### PR TITLE
Update ws-security saml.2 fat project to run with jakarta ee9 features

### DIFF
--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/bnd.bnd
@@ -21,7 +21,25 @@ src: \
 
 fat.project: true
 
-tested.features: jsp-2.3, jdbc-4.1, el-3.0, appsecurity-3.0, servlet-4.0, jaxb-2.3, cdi-2.0, jaxws-2.3
+#tested.features: jsp-2.3, jdbc-4.1, el-3.0, appsecurity-3.0, servlet-4.0, jaxb-2.3, cdi-2.0, jaxws-2.3
+
+tested.features:\
+  jdbc-4.1, \
+  jaxws-2.3, \
+  xmlWS-3.0, \
+  jaxb-2.3, \
+  xmlBinding-3.0, \
+  jsp-2.3, \
+  pages-3.0, \
+  servlet-4.0, \
+  servlet-5.0, \
+  appSecurity-3.0, \
+  appSecurity-4.0, \
+  cdi-2.0, \
+  cdi-3.0, \
+  el-3.0, \
+  expressionlanguage-4.0
+  
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/build.gradle
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/build.gradle
@@ -36,6 +36,7 @@ dependencies {
                         
 }
 
+addRequiredLibraries.dependsOn addJakartaTransformer
 
 /*
  * This is where all application WARs will be built.

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/FATSuite.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/FATSuite.java
@@ -36,13 +36,9 @@ import componenttest.rules.repeater.RepeatTests;
  * Purpose: This suite collects and runs all known good test suites.
  */
 public class FATSuite {
-
-	//The following repeats run Lite only for local testing
-    //@ClassRule
-    //public static RepeatTests r = RepeatTests.withoutModification().andWith(FeatureReplacementAction.EE8_FEATURES().removeFeature("jsp-2.2").removeFeature("jaxws-2.2").removeFeature("servlet-3.1").removeFeature("usr:wsseccbh-1.0").addFeature("jsp-2.3").addFeature("jaxws-2.3").addFeature("servlet-4.0").addFeature("usr:wsseccbh-2.0"));
-
+	
+	//The following run EE7 and EE8 full fat and EE9 lite fat
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(FeatureReplacementAction.EE8_FEATURES().removeFeature("jsp-2.2").removeFeature("jaxws-2.2").removeFeature("servlet-3.1").removeFeature("usr:wsseccbh-1.0").addFeature("jsp-2.3").addFeature("jaxws-2.3").addFeature("servlet-4.0").addFeature("usr:wsseccbh-2.0"));
-
+    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly().removeFeature("jsp-2.2").removeFeature("jaxws-2.2").removeFeature("servlet-3.1").removeFeature("usr:wsseccbh-1.0").addFeature("jsp-2.3").addFeature("jaxws-2.3").addFeature("servlet-4.0").addFeature("usr:wsseccbh-2.0")).andWith(FeatureReplacementAction.EE9_FEATURES().removeFeature("jsp-2.3").removeFeature("jaxws-2.3").removeFeature("servlet-4.0").addFeature("pages-3.0").addFeature("xmlWS-3.0").addFeature("servlet-5.0"));
 
 }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/FATSuite.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/FATSuite.java
@@ -39,6 +39,6 @@ public class FATSuite {
 	
 	//The following run EE7 and EE8 full fat and EE9 lite fat
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly().removeFeature("jsp-2.2").removeFeature("jaxws-2.2").removeFeature("servlet-3.1").removeFeature("usr:wsseccbh-1.0").addFeature("jsp-2.3").addFeature("jaxws-2.3").addFeature("servlet-4.0").addFeature("usr:wsseccbh-2.0")).andWith(FeatureReplacementAction.EE9_FEATURES().removeFeature("jsp-2.3").removeFeature("jaxws-2.3").removeFeature("servlet-4.0").addFeature("pages-3.0").addFeature("xmlWS-3.0").addFeature("servlet-5.0"));
+    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly().removeFeature("jsp-2.2").removeFeature("jaxws-2.2").removeFeature("servlet-3.1").removeFeature("usr:wsseccbh-1.0").addFeature("jsp-2.3").addFeature("jaxws-2.3").addFeature("servlet-4.0").addFeature("usr:wsseccbh-2.0")).andWith(FeatureReplacementAction.EE9_FEATURES().removeFeature("jsp-2.3").removeFeature("jaxws-2.3").removeFeature("servlet-4.0").removeFeature("usr:wsseccbh-1.0").addFeature("pages-3.0").addFeature("xmlWS-3.0").addFeature("servlet-5.0").addFeature("usr:wsseccbh-2.0"));
 
 }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/OneServerTests/CxfSAMLCaller1ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/OneServerTests/CxfSAMLCaller1ServerTests.java
@@ -13,22 +13,22 @@ package com.ibm.ws.wssecurity.fat.cxf.samltoken2.OneServerTests;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import componenttest.custom.junit.runner.FATRunner;
 
-import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.wssecurity.fat.cxf.samltoken2.common.CxfSAMLCallerTests;
 
-import componenttest.custom.junit.runner.Mode;
-import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServerWrapper;
-import componenttest.topology.utils.HttpUtils;
+//import componenttest.topology.utils.HttpUtils;
+import componenttest.annotation.SkipForRepeat;
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
+import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
+
 
 /**
  * The testcases in this class were ported from tWAS' test SamlWebSSOTests.
@@ -46,6 +46,7 @@ import componenttest.topology.utils.HttpUtils;
  * 2.0 token in the HTTP POST request.
  */
 
+@SkipForRepeat({ NO_MODIFICATION, EE8_FEATURES })
 @LibertyServerWrapper
 @RunWith(FATRunner.class)
 public class CxfSAMLCaller1ServerTests extends CxfSAMLCallerTests {
@@ -89,7 +90,6 @@ public class CxfSAMLCaller1ServerTests extends CxfSAMLCallerTests {
         testSettings.setSpTargetApp(testSAMLServer.getHttpString() + "/samlcallerclient/CxfSamlCallerSvcClient");
         testSettings.setSamlTokenValidationData(testSettings.getIdpUserName(), testSettings.getSamlTokenValidationData().getIssuer(), testSettings.getSamlTokenValidationData().getInResponseTo(), testSettings.getSamlTokenValidationData().getMessageID(), testSettings.getSamlTokenValidationData().getEncryptionKeyUser(), testSettings.getSamlTokenValidationData().getRecipient(), SAMLConstants.AES256);
 
-        //3/2021 
         testSAMLServer.addIgnoredServerExceptions(SAMLMessageConstants.CWWKS5207W_SAML_CONFIG_IGNORE_ATTRIBUTES, SAMLMessageConstants.CWWKG0101W_CONFIG_NOT_VISIBLE_TO_OTHER_BUNDLES, SAMLMessageConstants.CWWKF0001E_FEATURE_MISSING);
         
         

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/OneServerTests/CxfSAMLCaller1ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/OneServerTests/CxfSAMLCaller1ServerTests.java
@@ -24,7 +24,6 @@ import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.wssecurity.fat.cxf.samltoken2.common.CxfSAMLCallerTests;
 
 import componenttest.topology.impl.LibertyServerWrapper;
-//import componenttest.topology.utils.HttpUtils;
 import componenttest.annotation.SkipForRepeat;
 import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
@@ -64,9 +63,6 @@ public class CxfSAMLCaller1ServerTests extends CxfSAMLCallerTests {
 
         msgUtils.printClassName(thisClass.toString());
         Log.info(thisClass, "setupBeforeTest", "Prep for test");
-
-        //1/26/2021
-        //HttpUtils.enableSSLv3();
 
         // add any additional messages that you want the "start" to wait for
         // we should wait for any providers that this test requires

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/TwoServerTests/CxfSAMLCaller2ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/TwoServerTests/CxfSAMLCaller2ServerTests.java
@@ -13,7 +13,6 @@ package com.ibm.ws.wssecurity.fat.cxf.samltoken2.TwoServerTests;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -29,7 +28,6 @@ import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
 import com.ibm.ws.wssecurity.fat.cxf.samltoken2.common.CxfSAMLCallerTests;
 
-import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import componenttest.annotation.SkipForRepeat;
 
 import componenttest.annotation.AllowedFFDC;
@@ -38,7 +36,12 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServerWrapper;
-import componenttest.topology.utils.HttpUtils;
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
+import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
+
 
 /**
  * In general, these tests perform a simple IdP initiated SAML Web SSO, using
@@ -52,6 +55,7 @@ import componenttest.topology.utils.HttpUtils;
  * 2.0 token in the HTTP POST request.
  */
 
+@SkipForRepeat({ EE9_FEATURES })
 @LibertyServerWrapper
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
@@ -99,9 +103,6 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
         msgUtils.printClassName(thisClass.toString());
         Log.info(thisClass, "setupBeforeTest", "Prep for test");
         
-        //1/26/2021
-        //HttpUtils.enableSSLv3();
-
         // add any additional messages that you want the "start" to wait for
         // we should wait for any providers that this test requires
         List<String> extraMsgs = new ArrayList<String>();
@@ -143,8 +144,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
         testSettings.setIdpUserPwd(userPass);
         testSettings.setSpTargetApp(testSAMLServer.getHttpString() + "/samlcallerclient/CxfSamlCallerSvcClient");
         testSettings.setSamlTokenValidationData(testSettings.getIdpUserName(), testSettings.getSamlTokenValidationData().getIssuer(), testSettings.getSamlTokenValidationData().getInResponseTo(), testSettings.getSamlTokenValidationData().getMessageID(), testSettings.getSamlTokenValidationData().getEncryptionKeyUser(), testSettings.getSamlTokenValidationData().getRecipient(), SAMLConstants.AES256);
-
-        //3/2021 
+ 
         testSAMLServer.addIgnoredServerExceptions(SAMLMessageConstants.CWWKS5207W_SAML_CONFIG_IGNORE_ATTRIBUTES, SAMLMessageConstants.CWWKG0101W_CONFIG_NOT_VISIBLE_TO_OTHER_BUNDLES, SAMLMessageConstants.CWWKF0001E_FEATURE_MISSING);
         testSAMLServer2.addIgnoredServerExceptions(SAMLMessageConstants.CWWKS5207W_SAML_CONFIG_IGNORE_ATTRIBUTES, SAMLMessageConstants.CWWKS5207W_SAML_CONFIG_IGNORE_ATTRIBUTES, SAMLMessageConstants.CWWKS3107W_GROUP_USER_MISMATCH, SAMLMessageConstants.CWWKW0232E_CANNOT_CREATE_SUBJECT_FOR_USER, SAMLMessageConstants.CWWKW0210E_CANNOT_CREATE_SUBJECT, SAMLMessageConstants.CWWKW0228E_SAML_ASSERTION_MISSING, SAMLMessageConstants.CWWKG0101W_CONFIG_NOT_VISIBLE_TO_OTHER_BUNDLES, SAMLMessageConstants.CWWKF0001E_FEATURE_MISSING);
        
@@ -272,7 +272,6 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
         // If set to true, the client will accept connections to any host, regardless of whether they have valid certificates or not.
         webClient.getOptions().setUseInsecureSSL(true); 
 
-        //3/2021
         String partToCheck = ".*pass:false::FatSamlC02aService.*SOAPFaultException.*An error happened processing a SAML Token: \"invalid user ID\"*";//@AV999 TODO set the message depending on the runtime
         
         String testMode = "negative";
@@ -344,22 +343,16 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: An IPD group
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    //Orig:
-    //public void testCxfCaller_mapToUserRegistry_Group_inRegistry_identifiersGood() throws Exception {
     public void testCxfCaller_mapToUserRegistry_Group_inRegistry_identifiersGoodEE7Only() throws Exception {
 
         generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_identifiersGood.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPGroups);
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    //@AllowedFFDC(value = { "java.util.MissingResourceException", "java.lang.ClassNotFoundException" }) //@AV999
-    //6/2021
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.lang.ClassNotFoundException", "java.security.PrivilegedActionException", "java.lang.NoSuchMethodException" })
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_Group_inRegistry_identifiersGoodEE8Only() throws Exception {
 
@@ -382,20 +375,16 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Default IDP Group
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    //Orig:
-    //public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_identifiersGood() throws Exception {
-    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_identifiersGood() throws Exception {
+    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_identifiersGoodEE7Only() throws Exception {
         
     	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_identifiersGood.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPIdentifierGroup);
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.lang.ClassNotFoundException"}) //@AV999
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
     public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_identifiersGoodEE8Only() throws Exception {
 
@@ -417,21 +406,17 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * User: test_userIdentifier
      * Group: Default IDP Group
      */
-    
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+   
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    //Orig:
-    //public void testCxfCaller_mapToUserRegistry_Group_groupNotInRegistry_identifiersGood() throws Exception {
     public void testCxfCaller_mapToUserRegistry_Group_groupNotInRegistry_identifiersGoodEE7Only() throws Exception {
         
     	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_groupNotInRegistry_identifiersGood.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) //@AV999
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_Group_groupNotInRegistry_identifiersGoodEE8Only() throws Exception {
 
@@ -454,20 +439,16 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Default IDP Group
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    //Orig:
-    //public void testCxfCaller_mapToUserRegistry_Group_group2InRegistry_identifiersGood() throws Exception {
     public void testCxfCaller_mapToUserRegistry_Group_group2InRegistry_identifiersGoodEE7Only() throws Exception {
         
     	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_group2InRegistry_identifiersGood.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) //@AV999
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
     public void testCxfCaller_mapToUserRegistry_Group_group2InRegistry_identifiersGoodEE8Only() throws Exception {
 
@@ -491,19 +472,15 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: null
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    //Orig:
-    //public void testCxfCaller_mapToUserRegistry_Group_inRegistry_identifiersOmitted() throws Exception {
     public void testCxfCaller_mapToUserRegistry_Group_inRegistry_identifiersOmittedEE7Only() throws Exception {
         generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_identifiersOmitted.xml", defaultServerCfgRealm, defaultIDPUser, defaultNullGroup);
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.lang.ClassNotFoundException" }) //@AV999
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_Group_inRegistry_identifiersOmittedEE8Only() throws Exception {
 
@@ -526,20 +503,16 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: null
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    //Orig:
-    //public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_identifiersOmitted() throws Exception {
     public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_identifiersOmittedEE7Only() throws Exception {
         
     	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_identifiersOmitted.xml", defaultServerCfgRealm, defaultIDPUser, defaultNullGroup);
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) //@AV999
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_identifiersOmittedEE8Only() throws Exception {
 
@@ -562,20 +535,16 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: null
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test 
-    //Orig:
-    //public void testCxfCaller_mapToUserRegistry_Group_inRegistry_groupIdentifierOmitted() throws Exception {
     public void testCxfCaller_mapToUserRegistry_Group_inRegistry_groupIdentifierOmittedEE7Only() throws Exception {
     	
     	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_groupIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) //@AV999
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
     public void testCxfCaller_mapToUserRegistry_Group_inRegistry_groupIdentifierOmittedEE8Only() throws Exception {
         generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_groupIdentifierOmitted_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
@@ -597,20 +566,16 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: null
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    //Orig:
-    //public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_groupIdentifierOmitted() throws Exception {
     public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_groupIdentifierOmittedEE7Only() throws Exception {
         
     	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_groupIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) //@AV999
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
     public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_groupIdentifierOmittedEE8Only() throws Exception {
 
@@ -633,20 +598,16 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Local server's group
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    //Orig:
-    //public void testCxfCaller_mapToUserRegistry_Group_inRegistry_realmIdentifierOmitted() throws Exception {
     public void testCxfCaller_mapToUserRegistry_Group_inRegistry_realmIdentifierOmittedEE7Only() throws Exception {
        
     	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_realmIdentifierOmitted.xml", defaultLocalRealm, defaultIDPIdentifierUser, defaultLocalGroups);
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) //@AV999
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
     public void testCxfCaller_mapToUserRegistry_Group_inRegistry_realmIdentifierOmittedEE8Only() throws Exception {
 
@@ -669,20 +630,16 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: null
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    //Orig:
-    //public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_realmIdentifierOmitted() throws Exception {
     public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_realmIdentifierOmittedEE7Only() throws Exception {
         
     	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_realmIdentifierOmitted.xml", defaultLocalRealm, defaultIDPIdentifierUser, defaultLocalGroups);
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) //@AV999
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
     public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_realmIdentifierOmittedEE8Only() throws Exception {
 
@@ -705,20 +662,16 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: An IPD group
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    //Orig:
-    //public void testCxfCaller_mapToUserRegistry_Group_inRegistry_userIdentifierOmitted() throws Exception {
     public void testCxfCaller_mapToUserRegistry_Group_inRegistry_userIdentifierOmittedEE7Only() throws Exception {
         
     	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_userIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPUser, defaultIDPGroups);
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) //@AV999
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
     public void testCxfCaller_mapToUserRegistry_Group_inRegistry_userIdentifierOmittedEE8Only() throws Exception {
 
@@ -741,20 +694,16 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Default IDP Group
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    //Orig:
-    //public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_userIdentifierOmitted() throws Exception {
     public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_userIdentifierOmittedEE7Only() throws Exception {
         
     	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_userIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPUser, defaultIDPGroups);
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) //@AV999
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
     public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_userIdentifierOmittedEE8Only() throws Exception {
 
@@ -777,20 +726,16 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: An IPD group
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    //Orig:
-    //public void testCxfCaller_mapToUserRegistry_Group_inRegistry_userUniqueIdentifierOmitted() throws Exception {
     public void testCxfCaller_mapToUserRegistry_Group_inRegistry_userUniqueIdentifierOmittedEE7Only() throws Exception {
         
     	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_userUniqueIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPGroups);
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) //@AV999
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_Group_inRegistry_userUniqueIdentifierOmittedEE8Only() throws Exception {
 
@@ -813,11 +758,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Default IDP Group
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    //Orig:
-    //public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_userUniqueIdentifierOmitted() throws Exception {
     public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_userUniqueIdentifierOmittedEE7Only() throws Exception {
         
     	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_userUniqueIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPGroups);
@@ -825,8 +767,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
     }
     
     //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) //@AV999
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_userUniqueIdentifierOmittedEE8Only() throws Exception {
 
@@ -850,20 +792,16 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Local Server groups
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    //Orig:
-    //public void testCxfCaller_mapToUserRegistry_Group_inRegistry_groupIdentifierBad() throws Exception {
     public void testCxfCaller_mapToUserRegistry_Group_inRegistry_groupIdentifierBadEE7Only() throws Exception {
         
     	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_groupIdentifierBad.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
 
     }
 
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) //@AV999
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_Group_inRegistry_groupIdentifierBadEE8Only() throws Exception {
 
@@ -888,21 +826,15 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: null
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    //Orig:
-    //public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_groupIdentifierBad() throws Exception {
     public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_groupIdentifierBadEE7Only() throws Exception {
         generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_groupIdentifierBad.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    //6/2021
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.lang.ClassNotFoundException"})
-    //@AllowedFFDC(value = { "java.util.MissingResourceException" }) //@AV999
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
     public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_groupIdentifierBadEE8Only() throws Exception {
 
@@ -923,22 +855,18 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Bad Attribute exception - looking for realmIdentifier in the message
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
-    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" })
+    @SkipForRepeat({ EE8_FEATURES })
+    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" }, repeatAction = { EmptyAction.ID })
     @Test
-    //Orig:
-    //public void testCxfCaller_mapToUserRegistry_Group_inRegistry_realmIdentifierBad() throws Exception {
     public void testCxfCaller_mapToUserRegistry_Group_inRegistry_realmIdentifierBadEE7Only() throws Exception {
         
     	badAttrValueTest("server_2_caller_mapToUserRegistry_Group_inRegistry_realmIdentifierBad.xml", realmIdentifierString);
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) //@AV999
-    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" })
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
+    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_Group_inRegistry_realmIdentifierBadEE8Only() throws Exception {
 
@@ -959,22 +887,18 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Bad Attribute exception - looking for realmIdentifier in the message
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
-    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" })
+    @SkipForRepeat({ EE8_FEATURES })
+    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" }, repeatAction = { EmptyAction.ID })
     @Test
-    //Orig:
-    //public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_realmIdentifierBad() throws Exception {
     public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_realmIdentifierBadEE7Only() throws Exception {
         
     	badAttrValueTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_realmIdentifierBad.xml", realmIdentifierString);
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) //@AV999
-    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" })
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_realmIdentifierBadEE8Only() throws Exception {
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/common/CxfSAMLCallerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/common/CxfSAMLCallerTests.java
@@ -21,13 +21,15 @@ import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
-import com.ibm.ws.wssecurity.fat.cxf.samltoken2.common.CXFSAMLCommonUtils;
 
-import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.AllowedFFDC;
-import componenttest.custom.junit.runner.Mode;
-import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServerWrapper;
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE9Action;
+
 
 /**
  * The testcases in this class were ported from tWAS' test SamlWebSSOTests.
@@ -71,6 +73,7 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
      * 
      */
     
+    //runs EE7 and EE8 from full fat; EE9 from lite fat (e.g., CxfSAMLCaller1ServerTests.java)
     //scenario 1 - done
     @Test
     public void testCxfCallerHttpPolicy() throws Exception {
@@ -92,10 +95,9 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
         updatedTestSettings.getCXFSettings().setTestMode(testMode);
         genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings));
     }
-    
-    //3/2021 to run with EE7
+   
     //scenario 2
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     @Test
     public void testCxfCallerHttpsPolicyEE7Only() throws Exception {
         
@@ -133,14 +135,12 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
 
     }
     
-    //3/2021 to run with EE8
+    //runs EE8 from full fat, EE9 from lite fat
     //scenario 2
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    //@AllowedFFDC(value = { "java.util.MissingResourceException", "java.lang.ClassNotFoundException", "java.net.MalformedURLException" }) //@AV999
-    //6/2021
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.lang.ClassNotFoundException", "java.net.MalformedURLException", "java.security.PrivilegedActionException", "java.lang.NoSuchMethodException" })
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID, JakartaEE9Action.ID })
     @Test
-    public void testCxfCallerHttpsPolicyEE8Only() throws Exception {
+    public void testCxfCallerHttpsPolicy() throws Exception {
         if (testSAMLServer2 == null) {
             //1 server reconfig
             testSAMLServer.reconfigServer(buildSPServerName("server_2in1_asymProtection_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
@@ -175,10 +175,8 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
 
     }
     
-
-    //3/2021 to run with EE7
     //scenario 3 - done
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     @Test
     public void testCxfCaller_WithRealmNameEE7Only() throws Exception {
         
@@ -216,12 +214,12 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
 
     }
     
-    //3/2021 to run with EE8
+    //runs EE8 from full fat, EE9 from lite fat
     //scenario 3 - done
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.lang.ClassNotFoundException" }) //@AV999
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID, JakartaEE9Action.ID })
     @Test
-    public void testCxfCaller_WithRealmNameEE8Only() throws Exception {
+    public void testCxfCaller_WithRealmName() throws Exception {
         if (testSAMLServer2 == null) {
             // 1 server reconfig
             testSAMLServer.reconfigServer(buildSPServerName("server_2in1_realmName_ee8.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
@@ -255,8 +253,7 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
 
     }
 
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     //scenario 5
     @Test
     public void testCxfCallerHttpsPolicy_IncludeTokenInSubjectIsFalseEE7Only() throws Exception {
@@ -289,12 +286,12 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
         
     }
     
-    //3/2021 to run with EE8
+    //runs EE8 from full fat, EE9 from lite fat
     //scenario 5
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException", "java.lang.ClassNotFoundException" })
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID, JakartaEE9Action.ID })
     @Test
-    public void testCxfCallerHttpsPolicy_IncludeTokenInSubjectIsFalseEE8Only() throws Exception {
+    public void testCxfCallerHttpsPolicy_IncludeTokenInSubjectIsFalse() throws Exception {
         if (testSAMLServer2 == null) {
             // 1 server reconfig
             testSAMLServer.reconfigServer(buildSPServerName("server_2in1_asymProtection_TokenInSubFalse_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/common/CxfSAMLCallerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/common/CxfSAMLCallerTests.java
@@ -118,11 +118,6 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
         String partToCheck = "pass:true::FatSamlC03Service";
         String testMode = "positive";
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-        
-        // Added to fix hostname mismatch to Common Name on the server certificate. This change ignore this check  
-        // If set to true, the client will accept connections to any host, regardless of whether they have valid certificates or not.
-        //6/2021 not needed now; the above SAMLCommonTestHelpers contains the same setting:
-        //webClient.getOptions().setUseInsecureSSL(true); 
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -159,11 +154,6 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
         String testMode = "positive";
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
         
-        // Added to fix hostname mismatch to Common Name on the server certificate. This change ignore this check  
-        // If set to true, the client will accept connections to any host, regardless of whether they have valid certificates or not.
-        //6/2021 not needed now; the above SAMLCommonTestHelpers contains the same setting:
-        //webClient.getOptions().setUseInsecureSSL(true); 
-
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
         updatedTestSettings.setCXFSettings("testCxfCallerHttpsPolicy", "cxf", servicePort, serviceSecurePort, userName, userPass, webServiceName,
@@ -198,11 +188,6 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
         String partToCheck = "pass:true::FatSamlC02Service";
         String testMode = "positive";
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        // Added to fix hostname mismatch to Common Name on the server certificate. This change ignore this check
-        // If set to true, the client will accept connections to any host, regardless of whether they have valid certificates or not.
-        //6/2021 not needed now; the above SAMLCommonTestHelpers contains the same setting:
-        //webClient.getOptions().setUseInsecureSSL(true); 
      
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -239,10 +224,6 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
         String testMode = "positive";
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
-        // Added to fix hostname mismatch to Common Name on the server certificate. This change ignore this check
-        // If set to true, the client will accept connections to any host, regardless of whether they have valid certificates or not.
-        webClient.getOptions().setUseInsecureSSL(true); 
-     
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
         updatedTestSettings.setCXFSettings("testCxfCaller_WithRealmName", "cxf", servicePort, serviceSecurePort, userName, userPass, webServiceName, webServicePort, "", "False", null, null);


### PR DESCRIPTION
update com.ibm.ws.wssecurity_fat.wsscxf.saml.2 with jakarta ee9
