### PR TITLE
Update ws-security saml.4 fat project to run with jakarta ee9 features

### DIFF
--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.4/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.4/bnd.bnd
@@ -21,8 +21,23 @@ src: \
 
 fat.project: true
 
-tested.features: jsp-2.3, jdbc-4.1, el-3.0, appsecurity-3.0, servlet-4.0, jaxb-2.3, cdi-2.0, jaxws-2.3
-
+tested.features:\
+  jdbc-4.1, \
+  jaxws-2.3, \
+  xmlWS-3.0, \
+  jaxb-2.3, \
+  xmlBinding-3.0, \
+  jsp-2.3, \
+  pages-3.0, \
+  servlet-4.0, \
+  servlet-5.0, \
+  appSecurity-3.0, \
+  appSecurity-4.0, \
+  cdi-2.0, \
+  cdi-3.0, \
+  el-3.0, \
+  expressionlanguage-4.0
+  
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)
 # For all project names that match the pattern "*_fat*", dependencies for junit,

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.4/build.gradle
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.4/build.gradle
@@ -36,6 +36,8 @@ dependencies {
                         
 }
 
+addRequiredLibraries.dependsOn addJakartaTransformer
+
 
 /*
  * This is where all application WARs will be built.

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken4/FATSuite.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken4/FATSuite.java
@@ -37,12 +37,9 @@ import componenttest.rules.repeater.RepeatTests;
  */
 public class FATSuite {
 
-	//The following repeats run Lite only for local testing
-    //@ClassRule
-    //public static RepeatTests r = RepeatTests.withoutModification().andWith(FeatureReplacementAction.EE8_FEATURES().removeFeature("jsp-2.2").removeFeature("jaxws-2.2").removeFeature("servlet-3.1").removeFeature("usr:wsseccbh-1.0").addFeature("jsp-2.3").addFeature("jaxws-2.3").addFeature("servlet-4.0").addFeature("usr:wsseccbh-2.0"));
-
+	//The following run EE7 and EE8 full fat and no EE9 lite fat
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(FeatureReplacementAction.EE8_FEATURES().removeFeature("jsp-2.2").removeFeature("jaxws-2.2").removeFeature("servlet-3.1").removeFeature("usr:wsseccbh-1.0").addFeature("jsp-2.3").addFeature("jaxws-2.3").addFeature("servlet-4.0").addFeature("usr:wsseccbh-2.0"));
+    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly().removeFeature("jsp-2.2").removeFeature("jaxws-2.2").removeFeature("servlet-3.1").removeFeature("usr:wsseccbh-1.0").addFeature("jsp-2.3").addFeature("jaxws-2.3").addFeature("servlet-4.0").addFeature("usr:wsseccbh-2.0")).andWith(FeatureReplacementAction.EE9_FEATURES());
 
 
 }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken4/TwoServerTests/CxfSAMLCaller2ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken4/TwoServerTests/CxfSAMLCaller2ServerTests.java
@@ -13,7 +13,6 @@ package com.ibm.ws.wssecurity.fat.cxf.samltoken4.TwoServerTests;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -29,7 +28,6 @@ import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
 import com.ibm.ws.wssecurity.fat.cxf.samltoken4.common.CxfSAMLCallerTests;
 
-import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import componenttest.annotation.SkipForRepeat;
 
 import componenttest.annotation.AllowedFFDC;
@@ -38,7 +36,12 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServerWrapper;
-import componenttest.topology.utils.HttpUtils;
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
+import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
+
 
 /**
  * In general, these tests perform a simple IdP initiated SAML Web SSO, using
@@ -52,6 +55,7 @@ import componenttest.topology.utils.HttpUtils;
  * 2.0 token in the HTTP POST request.
  */
 
+@SkipForRepeat({ EE9_FEATURES })
 @LibertyServerWrapper
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
@@ -98,9 +102,6 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
         msgUtils.printClassName(thisClass.toString());
         Log.info(thisClass, "setupBeforeTest", "Prep for test");
-        
-        //1/26/2021
-        //HttpUtils.enableSSLv3();
 
         // add any additional messages that you want the "start" to wait for
         // we should wait for any providers that this test requires
@@ -143,7 +144,6 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
         testSettings.setSpTargetApp(testSAMLServer.getHttpString() + "/samlcallerclient/CxfSamlCallerSvcClient");
         testSettings.setSamlTokenValidationData(testSettings.getIdpUserName(), testSettings.getSamlTokenValidationData().getIssuer(), testSettings.getSamlTokenValidationData().getInResponseTo(), testSettings.getSamlTokenValidationData().getMessageID(), testSettings.getSamlTokenValidationData().getEncryptionKeyUser(), testSettings.getSamlTokenValidationData().getRecipient(), SAMLConstants.AES256);
 
-        //3/2021 
         testSAMLServer.addIgnoredServerExceptions(SAMLMessageConstants.CWWKS5207W_SAML_CONFIG_IGNORE_ATTRIBUTES, SAMLMessageConstants.CWWKG0101W_CONFIG_NOT_VISIBLE_TO_OTHER_BUNDLES, SAMLMessageConstants.CWWKF0001E_FEATURE_MISSING);
         testSAMLServer2.addIgnoredServerExceptions(SAMLMessageConstants.CWWKS5207W_SAML_CONFIG_IGNORE_ATTRIBUTES, SAMLMessageConstants.CWWKS5207W_SAML_CONFIG_IGNORE_ATTRIBUTES, SAMLMessageConstants.CWWKS3107W_GROUP_USER_MISMATCH, SAMLMessageConstants.CWWKW0232E_CANNOT_CREATE_SUBJECT_FOR_USER, SAMLMessageConstants.CWWKW0210E_CANNOT_CREATE_SUBJECT, SAMLMessageConstants.CWWKW0228E_SAML_ASSERTION_MISSING, SAMLMessageConstants.CWWKG0101W_CONFIG_NOT_VISIBLE_TO_OTHER_BUNDLES, SAMLMessageConstants.CWWKF0001E_FEATURE_MISSING);
         
@@ -271,7 +271,6 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
         // If set to true, the client will accept connections to any host, regardless of whether they have valid certificates or not.
         webClient.getOptions().setUseInsecureSSL(true); 
 
-        //3/2021
         String partToCheck = ".*pass:false::FatSamlC02aService.*SOAPFaultException.*An error happened processing a SAML Token: \"invalid user ID\"*";//@AV999 TODO set the message depending on the runtime
         
         String testMode = "negative";
@@ -318,7 +317,6 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
 
-    //6/2021
     //This is the start test for saml.4
 
     
@@ -335,9 +333,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Bad Attribute exception - looking for userUniqueIdentifier in the message
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
-    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" })
+    @SkipForRepeat({ EE8_FEATURES })
+    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" }, repeatAction = { EmptyAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_No_inRegistry_userUniqueIdentifierBadEE7Only() throws Exception {
         
@@ -345,11 +342,9 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
 
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    //6/2021
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.lang.ClassNotFoundException", "java.security.PrivilegedActionException", "java.lang.NoSuchMethodException" })
-    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" })
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_No_inRegistry_userUniqueIdentifierBadEE8Only() throws Exception {
 
@@ -370,9 +365,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Bad Attribute exception - looking for userUniqueIdentifier in the message
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
-    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" })
+    @SkipForRepeat({ EE8_FEATURES })
+    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" }, repeatAction = { EmptyAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_No_notInRegistry_userUniqueIdentifierBadEE7Only() throws Exception {
         
@@ -380,10 +374,9 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
 
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) 
-    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" })
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
+    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_No_notInRegistry_userUniqueIdentifierBadEE8Only() throws Exception {
 
@@ -408,8 +401,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Local user's group
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_inRegistry_identifiersGoodEE7Only() throws Exception {
         
@@ -417,10 +409,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
 
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    //6/2021
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.security.PrivilegedActionException", "java.lang.NoSuchMethodException" })
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_inRegistry_identifiersGoodEE8Only() throws Exception {
 
@@ -441,9 +431,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * EntryNotFoundException expectd
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
-    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException", "org.apache.ws.security.WSSecurityException" })
+    @SkipForRepeat({ EE8_FEATURES })
+    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException", "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_notInRegistry_identifiersGoodEE7Only() throws Exception {
         
@@ -451,14 +440,12 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException", "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException" })//@AV999
-    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException" })
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_notInRegistry_identifiersGoodEE8Only() throws Exception {
 
-        //notfoundExceptionTest("server_2_caller_mapToUserRegistry_User_notInRegistry_identifiersGood_ee8.xml");
     	notfoundExceptionTestEE8("server_2_caller_mapToUserRegistry_User_notInRegistry_identifiersGood_ee8.xml");
     	
     }
@@ -479,8 +466,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Local user's group
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_inRegistry_identifiersOmittedEE7Only() throws Exception {
         
@@ -488,9 +474,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
 
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) 
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
     public void testCxfCaller_mapToUserRegistry_User_inRegistry_identifiersOmittedEE8Only() throws Exception {
 
@@ -511,9 +496,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * EntryNotFoundException expected
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
-    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException", "org.apache.ws.security.WSSecurityException" })
+    @SkipForRepeat({ EE8_FEATURES })
+    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException", "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_notInRegistry_identifiersOmittedEE7Only() throws Exception {
         
@@ -521,14 +505,12 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
 
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException", "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException" })//@AV999
-    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException" })
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_notInRegistry_identifiersOmittedEE8Only() throws Exception {
 
-       //notfoundExceptionTest("server_2_caller_mapToUserRegistry_User_notInRegistry_identifiersOmitted_ee8.xml");
     	notfoundExceptionTestEE8("server_2_caller_mapToUserRegistry_User_notInRegistry_identifiersOmitted_ee8.xml");
     	
     }
@@ -548,8 +530,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Local server's group
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_inRegistry_groupIdentifierOmittedEE7Only() throws Exception {
         
@@ -557,9 +538,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) 
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
     public void testCxfCaller_mapToUserRegistry_User_inRegistry_groupIdentifierOmittedEE8Only() throws Exception {
 
@@ -580,9 +560,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * EntryNotFoundException expected
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
-    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException", "org.apache.ws.security.WSSecurityException" })
+    @SkipForRepeat({ EE8_FEATURES })
+    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException", "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_notInRegistry_groupIdentifierOmittedEE7Only() throws Exception {
         
@@ -590,14 +569,12 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException", "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException" })//@AV999
-    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException" })
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_notInRegistry_groupIdentifierOmittedEE8Only() throws Exception {
 
-        //notfoundExceptionTest("server_2_caller_mapToUserRegistry_User_notInRegistry_groupIdentifierOmitted_ee8.xml");
     	notfoundExceptionTestEE8("server_2_caller_mapToUserRegistry_User_notInRegistry_groupIdentifierOmitted_ee8.xml");
     	
     }
@@ -617,8 +594,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Local server's group
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_inRegistry_realmIdentifierOmittedEE7Only() throws Exception {
         
@@ -626,9 +602,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
 
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) 
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
     public void testCxfCaller_mapToUserRegistry_User_inRegistry_realmIdentifierOmittedEE8Only() throws Exception {
 
@@ -649,9 +624,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * EntryNotFoundException expected
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
-    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException", "org.apache.ws.security.WSSecurityException" })
+    @SkipForRepeat({ EE8_FEATURES })
+    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException", "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_notInRegistry_realmIdentifierOmittedEE7Only() throws Exception {
         
@@ -659,14 +633,12 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
    
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException", "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException" }) //@AV999
-    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException" })
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
+    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_notInRegistry_realmIdentifierOmittedEE8Only() throws Exception {
 
-        //notfoundExceptionTest("server_2_caller_mapToUserRegistry_User_notInRegistry_realmIdentifierOmitted_ee8.xml");
     	notfoundExceptionTestEE8("server_2_caller_mapToUserRegistry_User_notInRegistry_groupIdentifierOmitted_ee8.xml");
 
     }
@@ -686,8 +658,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Local Server's group
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_inRegistry_userIdentifierOmittedEE7Only() throws Exception {
         
@@ -695,9 +666,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) 
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
     public void testCxfCaller_mapToUserRegistry_User_inRegistry_userIdentifierOmittedEE8Only() throws Exception {
 
@@ -718,9 +688,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * EntryNotFoundException expected
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
-    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException", "org.apache.ws.security.WSSecurityException" })
+    @SkipForRepeat({ EE8_FEATURES })
+    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException", "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_notInRegistry_userIdentifierOmittedEE7Only() throws Exception {
        
@@ -728,14 +697,12 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException", "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException" })//@AV999
-    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException" })
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_notInRegistry_userIdentifierOmittedEE8Only() throws Exception {
 
-        //notfoundExceptionTest("server_2_caller_mapToUserRegistry_User_notInRegistry_userIdentifierOmitted_ee8.xml");
     	notfoundExceptionTestEE8("server_2_caller_mapToUserRegistry_User_notInRegistry_userIdentifierOmitted_ee8.xml");
     	
     }
@@ -755,8 +722,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Local Server's group
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_inRegistry_userUniqueIdentifierOmittedEE7Only() throws Exception {
         
@@ -764,9 +730,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) 
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
     public void testCxfCaller_mapToUserRegistry_User_inRegistry_userUniqueIdentifierOmittedEE8Only() throws Exception {
 
@@ -787,9 +752,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * EntryNotFoundException expected
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
-    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException", "org.apache.ws.security.WSSecurityException" })
+    @SkipForRepeat({ EE8_FEATURES })
+    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException", "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_notInRegistry_userUniqueIdentifierOmittedEE7Only() throws Exception {
        
@@ -797,14 +761,12 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException", "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException" })//@AV999
-    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException" })
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_notInRegistry_userUniqueIdentifierOmittedEE8Only() throws Exception {
 
-        //notfoundExceptionTest("server_2_caller_mapToUserRegistry_User_notInRegistry_userUniqueIdentifierOmitted_ee8.xml");
     	notfoundExceptionTestEE8("server_2_caller_mapToUserRegistry_User_notInRegistry_userUniqueIdentifierOmitted_ee8.xml");
 
     }
@@ -825,8 +787,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Local Server groups
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_inRegistry_groupIdentifierBadEE7Only() throws Exception {
        
@@ -834,9 +795,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
 
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.lang.ClassNotFoundException" })
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_inRegistry_groupIdentifierBadEE8Only() throws Exception {
 
@@ -857,9 +817,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * EntryNotFoundException expected
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
-    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException", "org.apache.ws.security.WSSecurityException" })
+    @SkipForRepeat({ EE8_FEATURES })
+    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException", "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_notInRegistry_groupIdentifierBadEE7Only() throws Exception {
         
@@ -867,14 +826,12 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
 
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException", "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException" })//@AV999
-    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException" }) 
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
     public void testCxfCaller_mapToUserRegistry_User_notInRegistry_groupIdentifierBadEE8Only() throws Exception {
 
-        //notfoundExceptionTest("server_2_caller_mapToUserRegistry_User_notInRegistry_groupIdentifierBad_ee8.xml");
     	notfoundExceptionTestEE8("server_2_caller_mapToUserRegistry_User_notInRegistry_groupIdentifierBad_ee8.xml");
     	
     }
@@ -894,8 +851,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Local Server groups
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_inRegistry_realmIdentifierBadEE7Only() throws Exception {
         
@@ -903,9 +859,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) 
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
     public void testCxfCaller_mapToUserRegistry_User_inRegistry_realmIdentifierBadEE8Only() throws Exception {
 
@@ -926,9 +881,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * EntryNotFoundException expected
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
-    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException", "org.apache.ws.security.WSSecurityException" })
+    @SkipForRepeat({ EE8_FEATURES })
+    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException", "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_notInRegistry_realmIdentifierBadEE7Only() throws Exception {
         
@@ -936,14 +890,12 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
 
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException", "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException" })//@AV999
-    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException" }) 
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
     public void testCxfCaller_mapToUserRegistry_User_notInRegistry_realmIdentifierBadEE8Only() throws Exception {
 
-        //notfoundExceptionTest("server_2_caller_mapToUserRegistry_User_notInRegistry_realmIdentifierBad_ee8.xml");
     	notfoundExceptionTestEE8("server_2_caller_mapToUserRegistry_User_notInRegistry_realmIdentifierBad_ee8.xml");
 
     }
@@ -961,9 +913,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Bad Attribute exception - looking for userIdentifier in the message
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
-    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" })
+    @SkipForRepeat({ EE8_FEATURES })
+    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" }, repeatAction = { EmptyAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_inRegistry_userIdentifierBadEE7Only() throws Exception {
         
@@ -971,10 +922,9 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
     
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" })
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) 
+    @SkipForRepeat({ NO_MODIFICATION })
+    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
     public void testCxfCaller_mapToUserRegistry_User_inRegistry_userIdentifierBadEE8Only() throws Exception {
 
@@ -994,9 +944,9 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Expected/checked values:
      * Bad Attribute exception - looking for userIdentifier in the message
      */
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
-    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" })
+   
+    @SkipForRepeat({ EE8_FEATURES })
+    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" }, repeatAction = { EmptyAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_notInRegistry_userIdentifierBadEE7Only() throws Exception {
         
@@ -1004,10 +954,9 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
 
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" })
-    @AllowedFFDC(value = { "java.util.MissingResourceException" })
+    @SkipForRepeat({ NO_MODIFICATION })
+    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_notInRegistry_userIdentifierBadEE8Only() throws Exception {
 
@@ -1030,8 +979,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Local Server groups
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_inRegistry_userUniqueIdentifierBadEE7Only() throws Exception {
         
@@ -1039,9 +987,8 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
 
     }
 
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }) 
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
     public void testCxfCaller_mapToUserRegistry_User_inRegistry_userUniqueIdentifierBadEE8Only() throws Exception {
 
@@ -1062,23 +1009,20 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * EntryNotFoundException expected
      */
     
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
-    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException", "org.apache.ws.security.WSSecurityException" })
+    @SkipForRepeat({ EE8_FEATURES })
+    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException", "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_notInRegistry_userUniqueIdentifierBadEE7Only() throws Exception {
         notfoundExceptionTest("server_2_caller_mapToUserRegistry_User_notInRegistry_userUniqueIdentifierBad.xml");
 
     }
 
-    //3/2021 to run with EE8
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException", "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException" })//@AV999
-    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException" })
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @ExpectedFFDC(value = { "com.ibm.ws.security.registry.EntryNotFoundException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCaller_mapToUserRegistry_User_notInRegistry_userUniqueIdentifierBadEE8Only() throws Exception {
 
-        //notfoundExceptionTest("server_2_caller_mapToUserRegistry_User_notInRegistry_userUniqueIdentifierBad_ee8.xml");
         notfoundExceptionTestEE8("server_2_caller_mapToUserRegistry_User_notInRegistry_userUniqueIdentifierBad_ee8.xml");
 
     }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken4/common/CxfSAMLCallerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken4/common/CxfSAMLCallerTests.java
@@ -24,11 +24,14 @@ import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
 
 import com.ibm.ws.wssecurity.fat.cxf.samltoken4.common.CXFSAMLCommonUtils;
 
-import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServerWrapper;
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
 
 /**
  * The testcases in this class were ported from tWAS' test SamlWebSSOTests.
@@ -46,6 +49,8 @@ import componenttest.topology.impl.LibertyServerWrapper;
  * 2.0 token in the HTTP POST request.
  */
 
+@SkipForRepeat({ EE9_FEATURES })
+@Mode(TestMode.FULL)
 @LibertyServerWrapper
 @RunWith(FATRunner.class)
 public class CxfSAMLCallerTests extends SAMLCommonTest {
@@ -94,9 +99,8 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
         genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings));
     }
     
-    //3/2021 to run with EE7
     //scenario 2
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
     public void testCxfCallerHttpsPolicyEE7Only() throws Exception {
         
@@ -118,11 +122,6 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
         String testMode = "positive";
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
         
-        // Added to fix hostname mismatch to Common Name on the server certificate. This change ignore this check  
-        // If set to true, the client will accept connections to any host, regardless of whether they have valid certificates or not.
-        //6/2021 not needed now; the above SAMLCommonTestHelpers contains the same setting:
-        //webClient.getOptions().setUseInsecureSSL(true); 
-
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
         updatedTestSettings.setCXFSettings("testCxfCallerHttpsPolicy", "cxf", servicePort, serviceSecurePort, userName, userPass, webServiceName,
@@ -134,11 +133,9 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
 
     }
     
-    //3/2021 to run with EE8
     //scenario 2
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    //6/2021
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.lang.ClassNotFoundException", "java.net.MalformedURLException", "java.security.PrivilegedActionException", "java.lang.NoSuchMethodException" })
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCallerHttpsPolicyEE8Only() throws Exception {
         if (testSAMLServer2 == null) {
@@ -159,11 +156,6 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
         String testMode = "positive";
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
         
-        // Added to fix hostname mismatch to Common Name on the server certificate. This change ignore this check  
-        // If set to true, the client will accept connections to any host, regardless of whether they have valid certificates or not.
-        //6/2021 not needed now; the above SAMLCommonTestHelpers contains the same setting:
-        //webClient.getOptions().setUseInsecureSSL(true); 
-
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
         updatedTestSettings.setCXFSettings("testCxfCallerHttpsPolicy", "cxf", servicePort, serviceSecurePort, userName, userPass, webServiceName,
@@ -176,9 +168,8 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
     }
     
 
-    //3/2021 to run with EE7
     //scenario 3 - done
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @Test
     public void testCxfCaller_WithRealmNameEE7Only() throws Exception {
         
@@ -200,11 +191,6 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
         String partToCheck = "pass:true::FatSamlC02Service";
         String testMode = "positive";
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        // Added to fix hostname mismatch to Common Name on the server certificate. This change ignore this check
-        // If set to true, the client will accept connections to any host, regardless of whether they have valid certificates or not.
-        //6/2021 not needed now; the above SAMLCommonTestHelpers contains the same setting:
-        //webClient.getOptions().setUseInsecureSSL(true); 
      
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -216,10 +202,9 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
 
     }
     
-    //3/2021 to run with EE8
     //scenario 3 - done
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.lang.ClassNotFoundException" }) 
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
     public void testCxfCaller_WithRealmNameEE8Only() throws Exception {
         if (testSAMLServer2 == null) {
@@ -241,10 +226,6 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
         String testMode = "positive";
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
-        // Added to fix hostname mismatch to Common Name on the server certificate. This change ignore this check
-        // If set to true, the client will accept connections to any host, regardless of whether they have valid certificates or not.
-        webClient.getOptions().setUseInsecureSSL(true); 
-     
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
         updatedTestSettings.setCXFSettings("testCxfCaller_WithRealmName", "cxf", servicePort, serviceSecurePort, userName, userPass, webServiceName, webServicePort, "", "False", null, null);
@@ -255,8 +236,7 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
 
     }
 
-    //3/2021 to run with EE7
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     //scenario 5
     @Test
     public void testCxfCallerHttpsPolicy_IncludeTokenInSubjectIsFalseEE7Only() throws Exception {
@@ -289,10 +269,9 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
         
     }
     
-    //3/2021 to run with EE8
     //scenario 5
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException", "java.lang.ClassNotFoundException" })
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCallerHttpsPolicy_IncludeTokenInSubjectIsFalseEE8Only() throws Exception {
         if (testSAMLServer2 == null) {


### PR DESCRIPTION
update com.ibm.ws.wssecurity_fat.wsscxf.saml.4 with jakarta ee9

