### PR TITLE
Allow backslash in BasicRegistry entities

### DIFF
--- a/dev/com.ibm.ws.security.registry.basic/src/com/ibm/ws/security/registry/basic/internal/BasicRegistry.java
+++ b/dev/com.ibm.ws.security.registry.basic/src/com/ibm/ws/security/registry/basic/internal/BasicRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011,2020 IBM Corporation and others.
+ * Copyright (c) 2011,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -466,6 +466,7 @@ public class BasicRegistry implements UserRegistry {
      * <li>) -> \)</li>
      * <li>{ -> \{</li>
      * <li>} -> \}</li>
+     * <li>\ -> \\</li>
      * </ul>
      *
      * @param pattern
@@ -486,6 +487,7 @@ public class BasicRegistry implements UserRegistry {
          * in a regular expression.
          */
         pattern = pattern.replace("*", ".*");
+        pattern = pattern.replace("\\", "\\\\");
         pattern = pattern.replace("(", "\\(").replace(")", "\\)");
         pattern = pattern.replace("{", "\\{").replace("}", "\\}");
 
@@ -505,7 +507,7 @@ public class BasicRegistry implements UserRegistry {
      * @see #getUsers(String, int)
      * @see #getGroups(String, int)
      * @param pattern pattern to match
-     * @param limit limit of entries to return
+     * @param limit   limit of entries to return
      * @return a SearchResult object
      */
     private SearchResult searchMap(Map<String, ?> map, String pattern, int limit) {

--- a/dev/com.ibm.ws.security.registry.basic_fat/fat/src/com/ibm/ws/security/registry/basic/fat/FATTest.java
+++ b/dev/com.ibm.ws.security.registry.basic_fat/fat/src/com/ibm/ws/security/registry/basic/fat/FATTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011,2020 IBM Corporation and others.
+ * Copyright (c) 2011,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -264,6 +264,36 @@ public class FATTest {
 
         result = servlet.getGroups("*tractors)*", 0);
         assertEquals(1, result.getList().size());
+    }
+
+    /**
+     * Test user with backslash in name.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void getUsersWithSingleBackslash() throws Exception {
+        Log.info(c, "getUsersWithSingleBackslash", "Check getUsers with single backslash pattern");
+
+        setServerConfiguration(server, DEFAULT_CONFIG_FILE);
+
+        SearchResult result = servlet.getUsers("dan\\", 0);
+        assertEquals("Expected to find user \"dan\\\" with backslash in name.", 1, result.getList().size());
+    }
+
+    /**
+     * Test group with backslash in name.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void getGroupsWithSingleBackslash() throws Exception {
+        Log.info(c, "getGroupsWithSingleBackslash", "Check getGroups with single backslash pattern");
+
+        setServerConfiguration(server, DEFAULT_CONFIG_FILE);
+
+        SearchResult result = servlet.getGroups("*group3\\*", 0);
+        assertEquals("Expected to find group \"group3\\, backslash\" with backslash in name.", 1, result.getList().size());
     }
 
     /**

--- a/dev/com.ibm.ws.security.registry.basic_fat/publish/files/basic.server.xml.orig
+++ b/dev/com.ibm.ws.security.registry.basic_fat/publish/files/basic.server.xml.orig
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2018 IBM Corporation and others.
+    Copyright (c) 2018,2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@
         <user name="user2" password="{xor}Lz4sLCgwLTtubWw=" />
         <user name="bob (contractor)" password="bobspassword" />
         <user name="henry {contractor}" password="henryspassword" />
+        <user name="dan\" password="danspassword" />
         <group name="memberlessGroup" />
         <group name="adminGroup">
             <member name="admin"/>
@@ -37,6 +38,9 @@
         </group>
         <group name="group2 {contractors}">
             <member name="henry {contractor}" />
+        </group>
+        <group name="group3\, backslash">
+            <member name="dan\" />
         </group>
     </basicRegistry>
 

--- a/dev/com.ibm.ws.security.registry.basic_fat/publish/servers/com.ibm.ws.security.registry.basic.fat/server.xml
+++ b/dev/com.ibm.ws.security.registry.basic_fat/publish/servers/com.ibm.ws.security.registry.basic.fat/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2018 IBM Corporation and others.
+    Copyright (c) 2018,2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@
         <user name="user2" password="{xor}Lz4sLCgwLTtubWw=" />
         <user name="bob (contractor)" password="bobspassword" />
         <user name="henry {contractor}" password="henryspassword" />
+        <user name="dan\" password="danspassword" />
         <group name="memberlessGroup" />
         <group name="adminGroup">
             <member name="admin"/>
@@ -37,6 +38,9 @@
         </group>
         <group name="group2 {contractors}">
             <member name="henry {contractor}" />
+        </group>
+        <group name="group3\, backslash">
+            <member name="dan\" />
         </group>
     </basicRegistry>
 


### PR DESCRIPTION
The Basic Registry is not handling users/groups with backslashes properly. This can manifest in several scenarios, including LDAP entries with backslashes that cause the Basic Registry to throw exceptions and fail out if allowOperationsIfReposDown is not set to true or simply not finding the user/group because of incorrect pattern matching.