### PR TITLE
Stop using java.vendor to detect IBM Java class libraries

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
@@ -54,7 +54,6 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.service.util.JavaInfo;
-import com.ibm.ws.kernel.service.util.JavaInfo.Vendor;
 import com.ibm.ws.resource.ResourceRefInfo;
 import com.ibm.ws.rsadapter.AdapterUtil;
 import com.ibm.ws.rsadapter.impl.WSManagedConnectionFactoryImpl.KerbUsage;
@@ -885,7 +884,7 @@ public class OracleHelper extends DatabaseHelper {
 
     @FFDCIgnore(Exception.class)
     private void checkIBMJava8() throws ResourceException {
-        if (JavaInfo.majorVersion() == 8 && JavaInfo.vendor() == Vendor.IBM) {
+        if (JavaInfo.isAvailable("com.ibm.security.auth.module.Krb5LoginModule")) {
             // The Oracle JDBC driver prior to 21c does not support kerberos authentication on IBM JDK 8 because
             // it has dependencies to the internal Sun security APIs which don't exist in IBM JDK 8
             boolean ibmJdkSupported;

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/CpuInfo.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/CpuInfo.java
@@ -27,7 +27,6 @@ import javax.management.ObjectName;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.FFDCFilter;
-import com.ibm.ws.kernel.service.util.JavaInfo.Vendor;
 
 /**
  * API for getting cpu info about the system
@@ -253,7 +252,7 @@ public class CpuInfo {
             return new NullCpuInfoAccessor();
         }
         try {
-            if (JavaInfo.isAccessible("com.ibm.lang.management.OperatingSystemMXBean")) {
+            if (JavaInfo.isAvailable("com.ibm.lang.management.OperatingSystemMXBean")) {
                 return new IBMJavaCpuInfoAccessor(mbean);
             }
             return new ModernJavaCpuInfoAccessor(mbean);

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/CpuInfo.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/CpuInfo.java
@@ -253,7 +253,7 @@ public class CpuInfo {
             return new NullCpuInfoAccessor();
         }
         try {
-            if (JavaInfo.vendor() == Vendor.IBM) {
+            if (JavaInfo.isAccessible("com.ibm.lang.management.OperatingSystemMXBean")) {
                 return new IBMJavaCpuInfoAccessor(mbean);
             }
             return new ModernJavaCpuInfoAccessor(mbean);

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/JavaInfo.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/JavaInfo.java
@@ -13,6 +13,8 @@ package com.ibm.ws.kernel.service.util;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
 /**
  * API for reading information related to the JDK
  */
@@ -154,11 +156,13 @@ public class JavaInfo {
     public static boolean isAvailable(String className) {
         return AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
             @Override
+            @FFDCIgnore(ClassNotFoundException.class)
             public Boolean run() {
                 try {
                     Class.forName(className);
                     return true;
                 } catch (ClassNotFoundException e) {
+                    //No FFDC needed
                     return false;
                 }
             }
@@ -171,7 +175,7 @@ public class JavaInfo {
      * Instead if there are behaviour differences between JVMs a test should be performed
      * to detect the actual capability used before making a decision. For example if there
      * is a different class on one JVM that needs to be used vs another an attempt should
-     * be made to load the class and take the code path. 
+     * be made to load the class and take the code path.
      *
      * <p>This method is intended to only be used for debug purposes.</p>
      *

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/JavaInfo.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/JavaInfo.java
@@ -141,6 +141,42 @@ public class JavaInfo {
         return instance().MICRO;
     }
 
+    /**
+     * In rare cases where different behaviour is performed based on the JVM vendor
+     * this method should be used to test for a unique JVM class provided by the
+     * vendor rather than using the vendor method. For example if on JVM provides a
+     * different Kerberos login module testing for that login module being loadable
+     * before configuring to use it is preferable to using the vendor data.
+     *
+     * @param className the name of a class in the JVM to test for
+     * @return true if the class is available, false otherwise.
+     */
+    public static boolean isAvailable(String className) {
+        return AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+            @Override
+            public Boolean run() {
+                try {
+                    Class.forName(className);
+                    return true;
+                } catch (ClassNotFoundException e) {
+                    return false;
+                }
+            }
+        });
+    }
+
+    @Deprecated
+    /**
+     * This method should not be used to change behaviour based on the Java vendor.
+     * Instead if there are behaviour differences between JVMs a test should be performed
+     * to detect the actual capability used before making a decision. For example if there
+     * is a different class on one JVM that needs to be used vs another an attempt should
+     * be made to load the class and take the code path. 
+     *
+     * <p>This method is intended to only be used for debug purposes.</p>
+     *
+     * @return the detected vendor of the JVM
+     */
     public static Vendor vendor() {
         return instance().VENDOR;
     }

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/MemoryInformation.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/MemoryInformation.java
@@ -31,7 +31,6 @@ import javax.management.ObjectName;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
-import com.ibm.ws.kernel.service.util.JavaInfo.Vendor;
 
 /**
  * Provides information about the memory of the underlying operating system.
@@ -896,7 +895,7 @@ public class MemoryInformation {
         try {
             ensureInitializedMBean();
 
-            if (JavaInfo.vendor() == Vendor.IBM) {
+            if (JavaInfo.isAvailable("com.ibm.security.auth.module.Krb5LoginModule")) {
                 return (Long) mBeanServer.getAttribute(osObjectName, "TotalPhysicalMemory");
             } else {
                 return (Long) mBeanServer.getAttribute(osObjectName, "TotalPhysicalMemorySize");

--- a/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/internal/JAASLoginModuleConfigImpl.java
+++ b/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/internal/JAASLoginModuleConfigImpl.java
@@ -43,7 +43,6 @@ import com.ibm.ws.container.service.app.deploy.NestedConfigHelper;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.boot.security.LoginModuleProxy;
 import com.ibm.ws.kernel.service.util.JavaInfo;
-import com.ibm.ws.kernel.service.util.JavaInfo.Vendor;
 import com.ibm.ws.security.jaas.common.JAASLoginModuleConfig;
 import com.ibm.ws.security.jaas.common.modules.WSLoginModuleProxy;
 import com.ibm.wsspi.adaptable.module.Container;
@@ -407,7 +406,7 @@ public class JAASLoginModuleConfigImpl implements JAASLoginModuleConfig {
     }
 
     private static boolean isIBMJdk18() {
-        return (JavaInfo.vendor() == Vendor.IBM && JavaInfo.majorVersion() == 8);
+        return JavaInfo.isAvailable("com.ibm.security.auth.module.Krb5LoginModule");
     }
 
 }

--- a/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/Krb5LoginModuleWrapper.java
+++ b/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/Krb5LoginModuleWrapper.java
@@ -25,7 +25,6 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.service.util.JavaInfo;
-import com.ibm.ws.kernel.service.util.JavaInfo.Vendor;
 
 public class Krb5LoginModuleWrapper implements LoginModule {
     private static final TraceComponent tc = Tr.register(Krb5LoginModuleWrapper.class);
@@ -46,8 +45,7 @@ public class Krb5LoginModuleWrapper implements LoginModule {
     }
 
     // Cannot rely purely on JavaInfo.vendor() because IBM JDK 8 for Mac OS reports vendor = Oracle and only has some IBM API available
-    private static final boolean isIBMJdk8 = JavaInfo.majorVersion() <= 8 &&
-                                             (JavaInfo.vendor() == Vendor.IBM || isIBMLoginModuleAvailable());
+    private static final boolean isIBMJdk8 = isIBMLoginModuleAvailable();
 
     public CallbackHandler callbackHandler;
     public Subject subject;

--- a/dev/com.ibm.ws.security/src/com/ibm/ws/security/krb5/Krb5Common.java
+++ b/dev/com.ibm.ws.security/src/com/ibm/ws/security/krb5/Krb5Common.java
@@ -22,7 +22,6 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.kernel.service.util.JavaInfo;
-import com.ibm.ws.kernel.service.util.JavaInfo.Vendor;
 
 /**
  * Krb5Common
@@ -36,16 +35,10 @@ public class Krb5Common {
     static public Oid KRB5_MECH_OID;
 
     // Is IBM JDK 1.8
-    static public boolean isIBMJdk18 = (JavaInfo.vendor() == Vendor.IBM && JavaInfo.majorVersion() == 8);
-
-    // Is Oracle JDK
-    static public boolean isOracleJdk = (JavaInfo.vendor() == Vendor.ORACLE);
-
-    // Is IBM, Oracle and Open JDK 11 or higher
-    static private boolean isJdk11OrUp = JavaInfo.majorVersion() >= 11;
+    static public boolean isIBMJdk18 = JavaInfo.isAvailable("com.ibm.security.auth.module.Krb5LoginModule");
 
     // SPNEGO support IBM JDK 8 and lower and JDK 11 and higher
-    static public boolean isOtherSupportJDKs = isOracleJdk || isJdk11OrUp;
+    static public boolean isOtherSupportJDKs = JavaInfo.isAvailable("com.sun.security.auth.module.Krb5LoginModule");;
 
     // Kerberos KDC host name
     static public final String KRB5_KDC = "java.security.krb5.kdc";

--- a/dev/com.ibm.ws.security/src/com/ibm/ws/security/krb5/Krb5Common.java
+++ b/dev/com.ibm.ws.security/src/com/ibm/ws/security/krb5/Krb5Common.java
@@ -38,7 +38,7 @@ public class Krb5Common {
     static public boolean isIBMJdk18 = JavaInfo.isAvailable("com.ibm.security.auth.module.Krb5LoginModule");
 
     // SPNEGO support IBM JDK 8 and lower and JDK 11 and higher
-    static public boolean isOtherSupportJDKs = JavaInfo.isAvailable("com.sun.security.auth.module.Krb5LoginModule");;
+    static public boolean isOtherSupportJDKs = JavaInfo.isAvailable("com.sun.security.auth.module.Krb5LoginModule");
 
     // Kerberos KDC host name
     static public final String KRB5_KDC = "java.security.krb5.kdc";

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
@@ -87,7 +87,6 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.service.util.JavaInfo;
-import com.ibm.ws.kernel.service.util.JavaInfo.Vendor;
 import com.ibm.ws.webcontainer.httpsession.SessionManager;
 import com.ibm.ws.webcontainer.osgi.DynamicVirtualHost;
 import com.ibm.ws.webcontainer.osgi.DynamicVirtualHostManager;
@@ -162,12 +161,8 @@ public class PluginGenerator {
     private static final boolean CHANGE_TRANSFORMER;
 
     static {
-        if (!JavaInfo.vendor().equals(Vendor.IBM)) {
-            CHANGE_TRANSFORMER = false;
-        } else {
-            int majorVersion = JavaInfo.majorVersion();
-            CHANGE_TRANSFORMER = majorVersion == 8;
-        }
+        // Question, could we remove this?
+        CHANGE_TRANSFORMER = JavaInfo.isAvailable("org.apache.xalan.processor.TransformerFactoryImpl");
     }
 
     /**

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/JavaInfo.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/JavaInfo.java
@@ -16,6 +16,9 @@ import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.Map;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
 import com.ibm.websphere.simplicity.log.Log;
 
 /**
@@ -126,7 +129,7 @@ public class JavaInfo {
         String vendor = System.getProperty("java.vendor").toLowerCase();
         if (vendor.contains("openj9"))
             VENDOR = Vendor.OPENJ9;
-        else if (vendor.contains("ibm") || vendor.contains("j9"))
+        else if (detectIBMJava())
             VENDOR = Vendor.IBM;
         else if (vendor.contains("oracle"))
             VENDOR = Vendor.SUN_ORACLE;
@@ -176,6 +179,20 @@ public class JavaInfo {
         FIXPACK = fp;
 
         Log.info(c, "<init>", this.toString());
+    }
+
+    private static boolean detectIBMJava() {
+        return AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+            @Override
+            public Boolean run() {
+                try {
+                    Class.forName("com.ibm.security.auth.module.Krb5LoginModule");
+                    return true;
+                } catch (ClassNotFoundException e) {
+                    return false;
+                }
+            }
+        });        
     }
 
     public int majorVersion() {


### PR DESCRIPTION
There is some brittle code that uses the java.vendor code to work out if the JVM contains IBM vs OpenJDK class libraries which isn't always correct. 