### PR TITLE
Avoid CWTE during oracle ucp testing

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ucp/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ucp/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2016, 2019 IBM Corporation and others.
+    Copyright (c) 2016, 2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -30,7 +30,7 @@
     
     <connectionManager id="conMgrUpdate" maxPoolSize="1" />
     
-    <connectionManager id="sharedConMgr" maxPoolSize="1" />
+    <connectionManager id="sharedConMgr" maxPoolSize="1" connectionTimeout="1m"/>
     
     <!-- This DataSource intentionally uses a connectionManagerRef -->
     <dataSource id="ucpDS" jndiName="jdbc/ucpDS" connectionManagerRef="conMgr" validationTimeout="20" >

--- a/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oracleucpfat/src/ucp/web/OracleUCPTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oracleucpfat/src/ucp/web/OracleUCPTestServlet.java
@@ -112,7 +112,7 @@ public class OracleUCPTestServlet extends FATServlet {
 
     /**
      * Checks to see if an ExecutionException was caused by a ConnectionWaitTimeoutException.
-     * If it was a junit failure is produced with a meaningful debug message for future servicability.
+     * If it was a ConnectionWaitTimeoutException, a junit failure is produced with a meaningful debug message for future serviceability.
      *
      * @param exception - ExecutionException from an async getConnection request.
      * @param jndiName  - jndiName of datasource involved in getConnectionRequest

--- a/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oracleucpfat/src/ucp/web/OracleUCPTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oracleucpfat/src/ucp/web/OracleUCPTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corporation and others.
+ * Copyright (c) 2016, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -108,6 +109,26 @@ public class OracleUCPTestServlet extends FATServlet {
 
     @Resource
     private UserTransaction tran;
+
+    /**
+     * Checks to see if an ExecutionException was caused by a ConnectionWaitTimeoutException.
+     * If it was a junit failure is produced with a meaningful debug message for future servicability.
+     *
+     * @param exception - ExecutionException from an async getConnection request.
+     * @param jndiName  - jndiName of datasource involved in getConnectionRequest
+     * @throws ExecutionException - If not caused by ConnectionWaitTimeoutException original ExecutionException is thrown
+     */
+    private static void checkForConnectionWaitTimeoutException(ExecutionException exception, String jndiName) throws ExecutionException {
+        Throwable cause = exception.getCause();
+        if (cause.getClass().getCanonicalName().equals("com.ibm.websphere.ce.cm.ConnectionWaitTimeoutException")) {
+            cause.printStackTrace(System.out);
+            fail("The task returned a ConnectionWaitTimeoutException. "
+                 + "Meaning that slow infrastructure caused the async getConnection call to run longer than the connectionTimeout. "
+                 + "Consider increasing the connectionTimeout for " + jndiName);
+        } else {
+            throw exception;
+        }
+    }
 
     /**
      * Basic test that we can get and use a connection when using Oracle UCP
@@ -344,6 +365,8 @@ public class OracleUCPTestServlet extends FATServlet {
                 fail("The task should not have completed, instead returned " + future.get(10, TimeUnit.SECONDS));
             } catch (TimeoutException ex) {
                 //expected
+            } catch (ExecutionException ee) {
+                checkForConnectionWaitTimeoutException(ee, "jdbc/ucpDS");
             }
 
             //Now try to close one of the connections, which should allow the other task to complete
@@ -398,6 +421,8 @@ public class OracleUCPTestServlet extends FATServlet {
                 fail("The task should not have completed, instead returned " + future.get(10, TimeUnit.SECONDS));
             } catch (TimeoutException ex) {
                 //expected
+            } catch (ExecutionException ee) {
+                checkForConnectionWaitTimeoutException(ee, "jdbc/ucpDSEmbeddedConMgr");
             }
 
             //Now try to close one of the connections, which should allow the other task to complete
@@ -435,6 +460,8 @@ public class OracleUCPTestServlet extends FATServlet {
                 fail("The task should not have completed, instead returned " + future.get(10, TimeUnit.SECONDS));
             } catch (TimeoutException ex) {
                 //expected
+            } catch (ExecutionException ee) {
+                checkForConnectionWaitTimeoutException(ee, "jdbc/oracleDS");
             }
 
             //Now try to close one of the connections, which should allow the other task to complete
@@ -683,6 +710,8 @@ public class OracleUCPTestServlet extends FATServlet {
                 fail("The task should not have completed, instead returned " + future.get(10, TimeUnit.SECONDS));
             } catch (TimeoutException ex) {
                 //expected
+            } catch (ExecutionException ee) {
+                checkForConnectionWaitTimeoutException(ee, "jdbc/oracleDS");
             }
 
             //Now try to close one of the connections, which should allow the other task to complete
@@ -715,6 +744,8 @@ public class OracleUCPTestServlet extends FATServlet {
                 fail("The task should not have completed, instead returned " + future.get(10, TimeUnit.SECONDS));
             } catch (TimeoutException ex) {
                 //expected
+            } catch (ExecutionException ee) {
+                checkForConnectionWaitTimeoutException(ee, "jdbc/oracleDS");
             }
 
             //Now try to close one of the connections, which should allow the other task to complete


### PR DESCRIPTION
When testing Oracle UCP we often make asynchronous getConnection requests to datasources.
When using the Liberty connection pool and it is full we will expect these getConnection requests to wait until a connection is available.  Whereas, when we are the Oracle connection pool we expect getConnection requests to bypass our connection pool.

In the case where we expect a thread to wait until a connection is available we can run into a situation when running on slow test infrastructure where the ExecutorService takes longer to timeout than the connectionTimeout of the datasource.
Resulting in a `ConnectionWaitTimeoutException` like this:

```
--- Start waiting for connection
[6/20/21, 23:51:09:957 UTC] 00000067 id=7583d6e8 com.ibm.ejs.j2c.FreePool                                     > createOrWaitForConnection Entry 

--- ExecutorService timeout reached (10 seconds) - However java still needs to resolve the finally block and call connection.close
[6/20/21, 23:51:19:954 UTC] 00000036 id=1a8e5c4e com.ibm.ws.rsadapter.jdbc.WSJdbcConnection                   > close Entry 

--- Something else slows down test system
[6/20/21, 23:51:39:959 UTC] 00000067 id=7583d6e8 com.ibm.ejs.j2c.FreePool                                     < queueRequest Exit 

--- OH NO!  connectionTimeout has been exceeded but we haven't removed the MCWrapper from the waiter pool
[6/20/21, 23:52:08:860 UTC] 00000036 id=1a8e5c4e com.ibm.ws.rsadapter.jdbc.WSJdbcConnection                   1 state --> CLOSED

--- Now we have to throw J2CA0045E
[6/20/21, 23:52:09:032 UTC] 00000067 id=00000000 com.ibm.ejs.j2c.FreePool                                     E J2CA0045E: Connection not available while invoking method createOrWaitForConnection for resource jdbc/oracleDS. Timed out waiting for 58,903 millisecond(s) with 0 remaining waiting requests and 1 current total connections used.
```

To avoid this I have increased the connectionTimeout of `jdbc/oracleDS` to 1 minute and introduced a new failure message if this happens to any of the other tests for future serviceability. 

