### PR TITLE
Include all resources from JavaMail-1.5 implementation

### DIFF
--- a/dev/com.ibm.ws.javamail/bnd.bnd
+++ b/dev/com.ibm.ws.javamail/bnd.bnd
@@ -38,7 +38,10 @@ Include-Resource: \
 ## I originally included the other files, but commented them out for now
 ## as I'm not entirely sure they are needed for the feature to work properly
 app-resources= \
-  META-INF/mailcap 
+  META-INF/javamail.default.address.map | \
+  META-INF/javamail.default.providers | \
+  META-INF/javamail.charset.map | \
+  META-INF/mailcap
 
 Private-Package: \
 	com.ibm.ws.javamail.internal.injection, \


### PR DESCRIPTION
This pull request back ports the same fix to JavaMail-1.6 to 1.5. Original fix is: #17673 