### PR TITLE
run TCK against jakarta packages with local snapshot

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.contextpropagation-1.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.contextpropagation-1.3.feature
@@ -1,0 +1,10 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.org.eclipse.microprofile.contextpropagation-1.3
+singleton=true
+#-features=io.openliberty.mpCompatible-5.0
+# TODO use 1.3 instead of 1.2 once it exists
+-bundles=\
+ io.openliberty.org.eclipse.microprofile.contextpropagation.1.2; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.2"
+kind=noship
+edition=full
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation-1.3/com.ibm.websphere.appserver.mpContextPropagation-1.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation-1.3/com.ibm.websphere.appserver.mpContextPropagation-1.3.feature
@@ -1,0 +1,18 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=com.ibm.websphere.appserver.mpContextPropagation-1.3
+visibility=public
+singleton=true
+IBM-ShortName: mpContextPropagation-1.3
+Subsystem-Name: MicroProfile Context Propagation 1.3
+IBM-App-ForceRestart: install, uninstall
+IBM-API-Package: \
+  org.eclipse.microprofile.context; type="stable", \
+  org.eclipse.microprofile.context.spi; type="stable"
+# TODO add io.openliberty.mpCompatible-5.0
+-features=\
+  io.openliberty.org.eclipse.microprofile.contextpropagation-1.3, \
+  io.openliberty.concurrent-2.0
+-bundles=\
+  com.ibm.ws.microprofile.contextpropagation.1.0
+kind=noship
+edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation-1.3/resources/l10n/com.ibm.websphere.appserver.mpContextPropagation-1.3.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation-1.3/resources/l10n/com.ibm.websphere.appserver.mpContextPropagation-1.3.properties
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=This feature implements the MicroProfile Context Propagation 1.3 specification, which allows you to obtain class instances of CompletableFuture that are backed by an instance of ManagedExecutor and provides the ability to contextualize CompletableFuture actions.

--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/bnd.bnd
@@ -16,4 +16,4 @@ src: \
 
 fat.project: true
 
-tested.features=concurrent-1.0
+tested.features=concurrent-2.0

--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/fat/src/com/ibm/ws/concurrent/mp/v1_3/fat/tck/MPContextPropagationTCKLauncher.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/fat/src/com/ibm/ws/concurrent/mp/v1_3/fat/tck/MPContextPropagationTCKLauncher.java
@@ -43,8 +43,8 @@ public class MPContextPropagationTCKLauncher {
     })
     @Test
     public void launchMPContextPropagation_1_3_Tck() throws Exception {
-        // TODO use this to only test with local build
-        // if (FATRunner.FAT_TEST_LOCALRUN)
-        MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.concurrency.mp.1.3_fat_tck", this.getClass() + ":launchMPContextPropagationTck");
+        // TODO use this to only test with local build (when tckRunner/tck.pom.xml specifies a #.#-SNAPSHOT version)
+        if (FATRunner.FAT_TEST_LOCALRUN)
+            MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.concurrency.mp.1.3_fat_tck", this.getClass() + ":launchMPContextPropagationTck");
     }
 }

--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/servers/tckServerForMPContextPropagation13/server.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/servers/tckServerForMPContextPropagation13/server.xml
@@ -10,13 +10,13 @@
  -->
 <server>
     <featureManager>
-        <feature>servlet-4.0</feature>
-        <feature>componenttest-1.0</feature>
+        <feature>servlet-5.0</feature>
+        <feature>componenttest-2.0</feature>
         <feature>localConnector-1.0</feature>
-        <feature>cdi-2.0</feature>
-        <feature>mpConfig-2.0</feature>
-        <feature>mpContextPropagation-1.2</feature>
-        <feature>arquillian-support-1.0</feature>
+        <feature>cdi-3.0</feature>
+        <!-- <feature>mpConfig-3.0</feature> TODO requires feature to be added -->
+        <feature>mpContextPropagation-1.3</feature>
+        <feature>arquillian-support-jakarta-2.0</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml" />

--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/tckRunner/pom.xml
@@ -19,7 +19,7 @@
     <name>MicroProfile Context Propagation TCK Runner</name>
 
     <properties>
-        <arquillian.version>1.3.0.Final</arquillian.version>
+        <arquillian.version>1.7.0.Alpha10</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -33,14 +33,14 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>javax.enterprise</groupId>
-                <artifactId>cdi-api</artifactId>
-                <version>1.2</version>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>3.0.0</version>
             </dependency>
             <dependency>
 	            <groupId>jakarta.transaction</groupId>
 	            <artifactId>jakarta.transaction-api</artifactId>
-	            <version>1.3.3</version>
+	            <version>2.0.0</version>
 	            <scope>provided</scope>
             </dependency>
             <dependency>

--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,13 +18,13 @@
 
     <properties>
         <!-- Use the following to test a release (1.3) or release candidate (1.3-RC1) -->
-        <microprofile.context.propagation.version>1.2</microprofile.context.propagation.version>
+        <!-- <microprofile.context.propagation.version>1.3-RC1</microprofile.context.propagation.version>-->
 
         <!-- Use the following to test a local snaphost (1.3-SNAPSHOT) -->
         <!-- The test case launch must be guarded with "if (FATRunner.FAT_TEST_LOCALRUN)" of this option is delivered. -->
-        <!-- <microprofile.context.propagation.version>1.3-SNAPSHOT</microprofile.context.propagation.version> -->
+        <microprofile.context.propagation.version>1.3-SNAPSHOT</microprofile.context.propagation.version>
 
-        <arquillian.version>1.3.0.Final</arquillian.version>
+        <arquillian.version>1.7.0.Alpha10</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>
@@ -71,16 +71,16 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-            <version>2.0</version>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <version>3.0.0</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
-            <version>1.3.3</version>
+            <version>2.0.0</version>
             <scope>provided</scope>
         </dependency>
 
@@ -98,8 +98,8 @@
 
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
-            <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.5</version>
+            <artifactId>arquillian-liberty-managed-jakarta</artifactId>
+            <version>2.0.0</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Create non-ship MP Context Propagation 1.3 feature and update the TCK bucket to use a local snapshot of the MP Context Propagation 1.3 TCK.  After doing this, tests are passing at 86%, where some failures are expected due to the lack of a MicroProfile 5.0 MP Config feature that some of the TCK tests require.