### PR TITLE
Run completion listeners on disconnect instead of closing event source

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/SseClientBehaviorApp/src/jaxrs21sse/clientbehavior/SseClientBehaviorTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/SseClientBehaviorApp/src/jaxrs21sse/clientbehavior/SseClientBehaviorTestServlet.java
@@ -101,7 +101,9 @@ public class SseClientBehaviorTestServlet extends FATServlet {
 
             source.open();
             _log.info("client source open");
+            assertTrue("SseEventSource#isOpen unexpected returned false before confirmation of received event", source.isOpen());
             assertTrue("Completion listener runnable was not executed", executionLatch.await(30, TimeUnit.SECONDS));
+            assertTrue("SseEventSource#isOpen unexpected returned false after confirmation of received event", source.isOpen());
 
         } catch (InterruptedException e) {
             // falls through

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/org/jboss/resteasy/plugins/providers/sse/client/SseEventSourceImpl.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/org/jboss/resteasy/plugins/providers/sse/client/SseEventSourceImpl.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -43,6 +44,8 @@ public class SseEventSourceImpl implements SseEventSource
    }
 
    private final AtomicReference<State> state = new AtomicReference<>(State.PENDING);
+
+   private final AtomicBoolean completionListenersInvoked = new AtomicBoolean(false);
 
    private final List<Consumer<InboundSseEvent>> onEventConsumers = new CopyOnWriteArrayList<>();
 
@@ -252,6 +255,15 @@ public class SseEventSourceImpl implements SseEventSource
       }
    }
 
+   // Liberty change start
+   private void runCompletionListeners()
+   {
+       if (!completionListenersInvoked.getAndSet(true)) {
+           onCompleteConsumers.forEach(Runnable::run);
+       }
+   }
+   // Liberty change end
+
    private void internalClose()
    {
       if (state.getAndSet(State.CLOSED) == State.CLOSED)
@@ -273,7 +285,7 @@ public class SseEventSourceImpl implements SseEventSource
          }
       }
       sseEventSourceScheduler.shutdownNow();
-      onCompleteConsumers.forEach(Runnable::run);
+      runCompletionListeners();
    }
 
    private class EventHandler implements Runnable
@@ -351,7 +363,7 @@ public class SseEventSourceImpl implements SseEventSource
                */
                if (eventInput == null && !alwaysReconnect)
                {
-                  internalClose();
+                   runCompletionListeners(); // Liberty change - just run completion listeners instead of internalClose()
                   return;
                }
                //Liberty change end
@@ -399,9 +411,9 @@ public class SseEventSourceImpl implements SseEventSource
                break;
             }
             */
-            if (eventInput == null || eventInput.isClosed())
+            if (eventInput == null /*|| eventInput.isClosed()*/)
             {
-               internalClose();
+               runCompletionListeners(); // Liberty change - just run completion listeners instead of internalClose()
                break;
             }
             // Liberty change end
@@ -413,9 +425,9 @@ public class SseEventSourceImpl implements SseEventSource
                   onEvent(event);
                }
                //event sink closed
-               else if (!alwaysReconnect)
+               else if (!alwaysReconnect || eventInput.isClosed())
                {
-                  internalClose();
+                  runCompletionListeners(); // Liberty change - just run completion listeners instead of internalClose()
                   break;
                }
             }


### PR DESCRIPTION
Many SSE TCK test cases are failing because the `SseEventSource#isOpen` method in the client is returning false after the server has disconnected. The javadoc for `isOpen` says that it should return true until the user has called the `close` method. This change ensures that when the server ends the connection the client will invoke event and completion listeners, but will not close the event source until the user has called close.