### PR TITLE
Retry updates for CustomStore MongoDB test support

### DIFF
--- a/dev/com.ibm.ws.security.oauth_test.custom_store/src/security/custom/store/CustomStoreSample.java
+++ b/dev/com.ibm.ws.security.oauth_test.custom_store/src/security/custom/store/CustomStoreSample.java
@@ -36,6 +36,7 @@ import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoCredential;
+import com.mongodb.MongoTimeoutException;
 import com.mongodb.ServerAddress;
 import com.mongodb.WriteResult;
 
@@ -635,7 +636,7 @@ public class CustomStoreSample implements OAuthStore {
         System.out.println("CustomStoreSample isNetworkFailure processing for " + e);
         Throwable causeBy = e;
         while (causeBy != null) {
-            if (causeBy instanceof IOException) {
+            if (causeBy instanceof IOException || causeBy instanceof MongoTimeoutException) {
                 System.out.println("Hit an IOException: " + causeBy);
                 return true;
             } else {


### PR DESCRIPTION
Based on some build failures, add in a retry when fetching user information in the `oAuth20MongoSetup` servlet. Added a helper method for getting the requested client, `getDBObject` for `getSecretType`, etc.  Also added `MongoTimeoutException` as a retryable exception.

RTC 285586 and 285560