### PR TITLE
Revert change to IBM Java detection in PluginGenerator

### DIFF
--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
@@ -87,6 +87,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.service.util.JavaInfo;
+import com.ibm.ws.kernel.service.util.JavaInfo.Vendor;
 import com.ibm.ws.webcontainer.httpsession.SessionManager;
 import com.ibm.ws.webcontainer.osgi.DynamicVirtualHost;
 import com.ibm.ws.webcontainer.osgi.DynamicVirtualHostManager;
@@ -161,8 +162,12 @@ public class PluginGenerator {
     private static final boolean CHANGE_TRANSFORMER;
 
     static {
-        // Question, could we remove this?
-        CHANGE_TRANSFORMER = JavaInfo.isAvailable("org.apache.xalan.processor.TransformerFactoryImpl");
+        if (!JavaInfo.vendor().equals(Vendor.IBM)) {
+            CHANGE_TRANSFORMER = false;
+        } else {
+            int majorVersion = JavaInfo.majorVersion();
+            CHANGE_TRANSFORMER = majorVersion == 8;
+        }
     }
 
     /**


### PR DESCRIPTION
There's something wrong with this change which breaks when running on IBM Java 8.

I would guess that the xalan transformer is available and should be used but the implementation class isn't loadable by application code?