### PR TITLE
Fix simplicity auto-feature dependency validation

### DIFF
--- a/dev/build.example.testcontainers_fat/bnd.bnd
+++ b/dev/build.example.testcontainers_fat/bnd.bnd
@@ -36,6 +36,11 @@ fat.test.databases: true
 # you may need to run ./gradlew --stop to get a new gradle daemon
 # it has been my experience that these properties are likely to be cached. 
 
+# Define additional tested features that are NOT present in any XML files in this bucket.
+# In this case, servlet-5.0 is added programmatically at runtime by the RepeatTests rule.
+tested.features: \
+	servlet-5.0
+
 # io.openliberty.org.testcontainers bundle should have all compile time
 # dependences you need for a testcontainer enabled fat project.
 # If you are creating a fat test that needs a module not currenlty in the

--- a/dev/com.ibm.ws.app.manager.wab.installer_fat/bnd.bnd
+++ b/dev/com.ibm.ws.app.manager.wab.installer_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ fat.project: true
 
 -sub: *.bnd
 
-tested.features: product1:product1, product2:product2, servlet-5.0
+tested.features: product1:product1, product2:product2, servlet-3.1, servlet-5.0
 
 -buildpath: \
 	com.ibm.websphere.appserver.spi.kernel.service,\

--- a/dev/com.ibm.ws.cdi.2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.2.0_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2020 IBM Corporation and others.
+# Copyright (c) 2017, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@ tested.features:\
 	appsecurity-4.0,\
 	servlet-5.0,\
 	concurrent-2.0,\
+	connectors-2.0,\
 	pages-3.0,\
 	enterpriseBeansLite-4.0,\
 	componenttest-2.0

--- a/dev/com.ibm.ws.cdi.annotations_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.annotations_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -18,9 +18,10 @@ src: \
 	
 tested.features:\
 	cdi-2.0,\
-        servlet-4.0,\
-        servlet-5.0,\
-        cdi-3.0
+	connectors-2.0,\
+	servlet-4.0,\
+	servlet-5.0,\
+	cdi-3.0
 	
 	
 test.project: true

--- a/dev/com.ibm.ws.cdi.api_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.api_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2020 IBM Corporation and others.
+# Copyright (c) 2018, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -28,6 +28,7 @@ tested.features:\
         jsf-2.3,\
         expressionLanguage-4.0,\
         pages-3.0,\
+        connectors-2.0,\
         concurrent-2.0
 
 test.project: true

--- a/dev/com.ibm.ws.cdi.beansxml.implicit_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.beansxml.implicit_fat/bnd.bnd
@@ -19,16 +19,17 @@ src: \
 
 tested.features:\
 	cdi-2.0,\
-        servlet-4.0,\
-        cdi-3.0,\
-        servlet-5.0,\
-        expressionLanguage-4.0,\
-        pages-3.0,\
-        enterprisebeanslite-4.0,\
-        enterprisebeans-4.0,\
-        enterprisebeansremote-4.0,\
-        enterprisebeanshome-4.0,\
-        enterprisebeanspersistenttimer-4.0
+	servlet-4.0,\
+	cdi-3.0,\
+	connectors-2.0,\
+	servlet-5.0,\
+	expressionLanguage-4.0,\
+	pages-3.0,\
+	enterprisebeanslite-4.0,\
+	enterprisebeans-4.0,\
+	enterprisebeansremote-4.0,\
+	enterprisebeanshome-4.0,\
+	enterprisebeanspersistenttimer-4.0
 
 	
 test.project: true

--- a/dev/com.ibm.ws.cdi.beansxml_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.beansxml_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -19,9 +19,10 @@ src: \
 
 tested.features:\
 	cdi-2.0,\
-        servlet-4.0,\
-        cdi-3.0,\
-        servlet-5.0
+	servlet-4.0,\
+	cdi-3.0,\
+	connectors-2.0,\
+	servlet-5.0
                 
 	
 test.project: true

--- a/dev/com.ibm.ws.cdi.extension_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.extension_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -38,14 +38,15 @@ tested.features:\
 	servlet-4.0,\
 	beanValidation-2.0,\
 	jsf-2.3,\
-        cdi-3.0,\
-        servlet-5.0,\
-        expressionLanguage-4.0,\
-        pages-3.0,\
-        enterprisebeanslite-4.0,\
-        cdi.internals-3.0,\
-        beanvalidation-3.0,\
-        faces-3.0
+	cdi-3.0,\
+	connectors-2.0,\
+	servlet-5.0,\
+	expressionLanguage-4.0,\
+	pages-3.0,\
+	enterprisebeanslite-4.0,\
+	cdi.internals-3.0,\
+	beanvalidation-3.0,\
+	faces-3.0
 	
 test.project: true
 

--- a/dev/com.ibm.ws.cdi.jee_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.jee_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -29,17 +29,19 @@ src: \
 	
 tested.features:\
 	cdi-2.0,\
-        servlet-4.0,\
-        jdbc-4.2,\
-        jpa-2.2,\
-        beanValidation-2.0,\
-        jaxrs-2.1,\
-        jsf-2.3,\
-        restfulwsclient-3.0,\
-        restfulws-3.0,\
-        jsonp-2.0,\
-        faces-3.0
-	
+	servlet-4.0,\
+	servlet-5.0,\
+	jdbc-4.2,\
+	jpa-2.2,\
+	beanValidation-2.0,\
+	jaxrs-2.1,\
+	jsf-2.3,\
+	connectors-2.0,\
+	mdb-4.0,\
+	restfulwsclient-3.0,\
+	restfulws-3.0,\
+	jsonp-2.0,\
+	faces-3.0
 	
 test.project: true
 

--- a/dev/com.ibm.ws.cdi.jndi_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.jndi_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 201* IBM Corporation and others.
+# Copyright (c) 2017, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ tested.features:\
 	servlet-4.0,\
 	webprofile-8.0,\
 	cdi-3.0,\
+	connectors-2.0,\
 	expressionLanguage-4.0,\
 	pages-3.0,\
 	servlet-5.0,\

--- a/dev/com.ibm.ws.cdi.lifecycle_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.lifecycle_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -36,7 +36,8 @@ tested.features: \
 	jsf-2.3,\
 	servlet-5.0,\
 	faces-3.0,\
-	cdi-3.0
+	cdi-3.0,\
+	connectors-2.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.ejb.3.2;version=latest,\

--- a/dev/com.ibm.ws.cdi.third.party_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.third.party_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -21,16 +21,17 @@ src: \
 	test-applications/deltaspikeTest.war/src
 	
 tested.features:\
-        cdi-2.0,\
-        servlet-4.0,\
-        jdbc-4.2,\
-        jpa-2.2,\
-        cdi-3.0,\
-        expressionLanguage-4.0,\
-        pages-3.0,\
-        servlet-5.0,\
-        persistencecontainer-3.0,\
-        persistence-3.0
+	cdi-2.0,\
+	servlet-4.0,\
+	jdbc-4.2,\
+	jpa-2.2,\
+	cdi-3.0,\
+	connectors-2.0,\
+	expressionLanguage-4.0,\
+	pages-3.0,\
+	servlet-5.0,\
+	persistencecontainer-3.0,\
+	persistence-3.0
 	
 test.project: true
 

--- a/dev/com.ibm.ws.cdi.visibility_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.visibility_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -68,19 +68,20 @@ test.project: true
 
 tested.features:\
 	cdi-2.0,\
-        servlet-4.0,\
-        servlet-5.0,\
-        cdi-3.0,\
-        restfulwsclient-3.0,\
-        restfulws-3.0,\
-        jsonp-2.0,\
-        appclientsupport-2.0,\
-        enterprisebeans-4.0,\
-        enterprisebeansremote-4.0,\
-        jdbc-4.2,\
-        enterprisebeanshome-4.0,\
-        enterprisebeanslite-4.0,\
-        enterprisebeanspersistenttimer-4.0
+	servlet-4.0,\
+	servlet-5.0,\
+	cdi-3.0,\
+	connectors-2.0,\
+	restfulwsclient-3.0,\
+	restfulws-3.0,\
+	jsonp-2.0,\
+	appclientsupport-2.0,\
+	enterprisebeans-4.0,\
+	enterprisebeansremote-4.0,\
+	jdbc-4.2,\
+	enterprisebeanshome-4.0,\
+	enterprisebeanslite-4.0,\
+	enterprisebeanspersistenttimer-4.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.ejb.3.2;version=latest,\

--- a/dev/com.ibm.ws.concurrent.persistent_fat/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/bnd.bnd
@@ -20,7 +20,7 @@ src: \
 fat.project: true
 fat.test.databases: true
 
-tested.features: servlet-5.0,concurrent-2.0,jdbc-4.2
+tested.features: servlet-5.0,concurrent-2.0,jdbc-4.2,connectors-2.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.concurrent.persistent_fat_feature/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_feature/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019,2020 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -17,6 +17,11 @@ src: \
 	test-bundles/userFeature/src
 
 fat.project: true
+
+# Define additional tested features that are NOT present in any XML files in this bucket.
+# In this case, jndi-1.0 is added by a test feature.
+tested.features: \
+	jndi-1.0
 
 -buildpath: \
 	com.ibm.websphere.org.osgi.core;version=latest,\

--- a/dev/com.ibm.ws.ejbcontainer.injection_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.injection_fat/bnd.bnd
@@ -48,6 +48,7 @@ tested.features: \
 	jdbc-4.0,\
 	jdbc-4.2,\
 	mdb-3.2,\
+	mdb-4.0,\
 	wasJmsClient-2.0,\
 	wasJmsServer-1.0,\
 	messagingClient-3.0,\

--- a/dev/com.ibm.ws.ejbcontainer.injection_fat/fat/src/com/ibm/ws/ejbcontainer/injection/fat/tests/InjectionMIXTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.injection_fat/fat/src/com/ibm/ws/ejbcontainer/injection/fat/tests/InjectionMIXTest.java
@@ -68,7 +68,7 @@ public class InjectionMIXTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("ejbcontainer.injection.ra.fat.MsgEndpointServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("ejbcontainer.injection.ra.fat.MsgEndpointServer")).andWith(RepeatWithCDI.WithRepeatWithCDI().forServers("ejbcontainer.injection.ra.fat.MsgEndpointServer")).andWith(FeatureReplacementAction.EE9_FEATURES().forServers("ejbcontainer.injection.ra.fat.MsgEndpointServer")).andWith(RepeatWithEE9CDI.EE9CDI_FEATURES().forServers("ejbcontainer.injection.ra.fat.MsgEndpointServer"));
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("ejbcontainer.injection.ra.fat.MsgEndpointServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("ejbcontainer.injection.ra.fat.MsgEndpointServer")).andWith(RepeatWithCDI.WithRepeatWithCDI().forServers("ejbcontainer.injection.ra.fat.MsgEndpointServer")).andWith(FeatureReplacementAction.EE9_FEATURES().forServers("ejbcontainer.injection.ra.fat.MsgEndpointServer")).andWith(RepeatWithEE9CDI.EE9CDI_FEATURES().fullFATOnly().forServers("ejbcontainer.injection.ra.fat.MsgEndpointServer"));
 
     @BeforeClass
     public static void beforeClass() throws Exception {

--- a/dev/com.ibm.ws.ejbcontainer.injection_fat/fat/src/com/ibm/ws/ejbcontainer/injection/fat/tests/InjectionMiscTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.injection_fat/fat/src/com/ibm/ws/ejbcontainer/injection/fat/tests/InjectionMiscTest.java
@@ -43,7 +43,7 @@ public class InjectionMiscTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.ejbcontainer.injection.fat.InjectionMiscServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.injection.fat.InjectionMiscServer")).andWith(FeatureReplacementAction.EE9_FEATURES().forServers("com.ibm.ws.ejbcontainer.injection.fat.InjectionMiscServer"));
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.injection.fat.InjectionMiscServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.injection.fat.InjectionMiscServer")).andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.injection.fat.InjectionMiscServer"));
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.ejbcontainer.injection_fat/fat/src/com/ibm/ws/ejbcontainer/injection/fat/tests/RemoteInjectionTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.injection_fat/fat/src/com/ibm/ws/ejbcontainer/injection/fat/tests/RemoteInjectionTest.java
@@ -44,7 +44,7 @@ public class RemoteInjectionTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.ejbcontainer.injection.fat.server")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.injection.fat.server")).andWith(FeatureReplacementAction.EE9_FEATURES().forServers("com.ibm.ws.ejbcontainer.injection.fat.server"));
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.injection.fat.server")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.injection.fat.server")).andWith(FeatureReplacementAction.EE9_FEATURES().forServers("com.ibm.ws.ejbcontainer.injection.fat.server"));
 
     @BeforeClass
     public static void beforeClass() throws Exception {

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019,2020 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -63,13 +63,20 @@ fat.project: true
 
 # These features get added programmatically
 tested.features: \
+  javaee-8.0,\
+  beanValidation-2.0,\
   jaxrs-2.1,\
   cdi-2.0,\
   restfulWS-3.0,\
   appsecurity-3.0,\
   jsonb-2.0,\
   appsecurity-4.0,\
-  expressionlanguage-4.0
+  enterpriseBeansLite-4.0,\
+  expressionlanguage-4.0,\
+  managedBeans-2.0,\
+  pages-3.0,\
+  xmlBinding-3.0,\
+  xmlWS-3.0
 
 -buildpath: \
   com.ibm.websphere.javaee.annotation.1.2,\

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.securityAnnotations/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.securityAnnotations/server.xml
@@ -4,6 +4,7 @@
         <feature>jaxrs-2.0</feature>
         <feature>appSecurity-2.0</feature>
         <feature>componenttest-1.0</feature>
+        <feature>timedexit-1.0</feature>
     </featureManager>
  
  	<basicRegistry id="basic" realm="WebRealm">

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.securityAnnotations_rolesAsGroups/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.securityAnnotations_rolesAsGroups/server.xml
@@ -3,7 +3,7 @@
         <feature>jaxrs-2.0</feature>
         <feature>appSecurity-2.0</feature>
         <feature>componenttest-1.0</feature>
-        
+        <feature>timedexit-1.0</feature>
     </featureManager>
  
  	<basicRegistry id="basic" realm="WebRealm">

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.securityContext/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.securityContext/server.xml
@@ -4,6 +4,7 @@
         <feature>jaxrs-2.0</feature>
         <feature>appSecurity-2.0</feature>
         <feature>componenttest-1.0</feature>
+        <feature>timedexit-1.0</feature>
     </featureManager>
  
  	<basicRegistry id="basic" realm="WebRealm">

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2018 IBM Corporation and others.
+# Copyright (c) 2017, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -27,9 +27,10 @@ fat.project: true
 tested.features: \
   restfulwsclient-3.0,\
   jsonb-2.0,\
-  restfulws-3.0,,\
+  restfulws-3.0,\
   cdi-3.0,\
-  jsonp-2.0
+  jsonp-2.0,\
+  xmlBinding-3.0
 
 
 -buildpath: \

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -57,6 +57,7 @@ tested.features: jaxws-2.3, \
   servlet-4.0, \
   cdi-2.0, \
   appSecurity-3.0, \
+  connectors-2.0,\
   enterpriseBeansLite-4.0, \
   pages-3.0, \
   servlet-5.0, \

--- a/dev/com.ibm.ws.jbatch.cdi_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jbatch.cdi_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -23,6 +23,7 @@ fat.project: true
 tested.features: \
     cdi-2.0,\
     servlet-4.0,\
+    servlet-5.0,\
     enterprisebeans-4.0,\
     xmlBinding-3.0,\
     batch-2.0,\

--- a/dev/com.ibm.ws.jca.1.7_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jca.1.7_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2020 IBM Corporation and others.
+# Copyright (c) 2018, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ src: \
 
 fat.project: true
 
-tested.features: connectors-2.0, jaxb-3.0, concurrent-2.0, messaging-3.0, enterprisebeanslite-4.0
+tested.features: connectors-2.0, jaxb-3.0, concurrent-2.0, messaging-3.0, enterprisebeanslite-4.0, servlet-5.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.connector.1.7;version=latest,\

--- a/dev/com.ibm.ws.jca_fat_configprops/bnd.bnd
+++ b/dev/com.ibm.ws.jca_fat_configprops/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -17,6 +17,11 @@ src: \
 	test-applications/fvtweb/src
 
 fat.project: true
+
+# Define additional tested features that are NOT present in any XML files in this bucket.
+tested.features:\
+	connectors-2.0,\
+	servlet-5.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\

--- a/dev/com.ibm.ws.jca_fat_derbyra/bnd.bnd
+++ b/dev/com.ibm.ws.jca_fat_derbyra/bnd.bnd
@@ -22,7 +22,7 @@ fat.project: true
 # In this case, Java EE 8 features are added programmatically at runtime by the RepeatTests rule.
 tested.features:\
 	appsecurity-3.0, servlet-4.0, enterprisebeans-4.0, concurrent-2.0, enterprisebeansremote-4.0, jdbc-4.2, enterprisebeanshome-4.0, enterprisebeanslite-4.0, enterprisebeanspersistenttimer-4.0,\
-	appsecurity-4.0, servlet-5.0, expressionlanguage-4.0, cdi-3.0
+	appsecurity-4.0, servlet-5.0, expressionlanguage-4.0, cdi-3.0, connectors-2.0
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.jca_fat_dynamicConfig/bnd.bnd
+++ b/dev/com.ibm.ws.jca_fat_dynamicConfig/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -17,6 +17,13 @@ src: \
 	test-resourceadapters/dcra/src
 
 fat.project: true
+
+# Define additional tested features that are NOT present in any XML files in this bucket.
+tested.features:\
+	connectors-2.0,\
+	mdb-3.2,\
+	mdb-4.0,\
+	servlet-5.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\

--- a/dev/com.ibm.ws.jca_fat_enterpriseApp/bnd.bnd
+++ b/dev/com.ibm.ws.jca_fat_enterpriseApp/bnd.bnd
@@ -21,8 +21,8 @@ fat.project: true
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, Java EE 8 features are added programatically at runtime by the RepeatTests rule.
 tested.features:\
-	appsecurity-3.0, servlet-4.0, cdi-2.0, jdbc-4.2, connectors-2.0, messaging-3.0,\
-	appsecurity-4.0, servlet-5.0, expressionlanguage-4.0, cdi-3.0, pages-3.0
+	appsecurity-3.0, servlet-4.0, cdi-2.0, mdb-3.2, jdbc-4.2, connectors-2.0, messaging-3.0,\
+	appsecurity-4.0, servlet-5.0, expressionlanguage-4.0, cdi-3.0, pages-3.0, mdb-4.0
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.jca_fat_errorpaths/bnd.bnd
+++ b/dev/com.ibm.ws.jca_fat_errorpaths/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,11 @@ src: \
 	test-resourceadapters/ErrorPathRA/src
 
 fat.project: true
+
+# Define additional tested features that are NOT present in any XML files in this bucket.
+tested.features:\
+	connectors-2.0,\
+	servlet-5.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.connector.1.7;version=latest,\

--- a/dev/com.ibm.ws.jca_fat_example_anno/bnd.bnd
+++ b/dev/com.ibm.ws.jca_fat_example_anno/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -17,6 +17,12 @@ src: \
 	test-resourceadapter/src
 
 fat.project: true
+
+# Define additional tested features that are NOT present in any XML files in this bucket.
+tested.features:\
+	connectors-2.0,\
+	mdb-4.0,\
+	servlet-5.0
 
 -buildpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.jdbc_fat_v41/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_v41/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2020 IBM Corporation and others.
+# Copyright (c) 2017, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ src: \
 
 fat.project: true
 
-tested.features: servlet-5.0
+tested.features: servlet-5.0, connectors-2.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\

--- a/dev/com.ibm.ws.kernel.feature_fat/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.feature_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -40,7 +40,7 @@ tested.features: needsNewEe-1.0, newEe-1.0, \
 	jaxrsClient-2.1, jaxws-2.2, jca-1.7, jcaInboundSecurity-1.0, jdbc-4.2, jms-2.0, jndi-1.0, \
 	jpa-2.2, jpaContainer-2.2, jpaContainer-2.1, jpa-2.1, persistenceContainer-3.0, jdbc-4.2, jsp-2.2, \
 	jsfContainer-2.3, jsf-2.3, jsonb-1.0, jsonp-1.1, jsp-2.3, \
-	managedBeans-1.0, mdb-3.2, \
+	managedBeans-1.0, mdb-3.2, mdb-4.0, \
 	servlet-5.0, ssl-1.0, \
 	wasJmsClient-2.0, wasJmsSecurity-1.0, wasJmsServer-1.0, webProfile-8.0, websocket-1.1, \
 	featuref-1.0, productauto:pfeaturen-1.0, productauto:pfeaturem-1.0, featuree-1.0, productauto:pfeaturel-1.0, featureg-1.0, productauto:pfeaturef-1.0, productauto:pfeatureg-1.0, productauto:pfeaturee-1.0, capabilityc-1.0, badpathtool-1.0, emptyiconheader-1.0, goldenpathtool-1.0, icondirectivestool-1.0, noheadertool-1.0, missingiconstool-1.0, jwt-1.0, servlet-3.1, \

--- a/dev/com.ibm.ws.messaging.open_jms20_fat/bnd.bnd
+++ b/dev/com.ibm.ws.messaging.open_jms20_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2020 IBM Corporation and others.
+# Copyright (c) 2018, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -40,6 +40,7 @@ tested.features:\
   messagingServer-3.0,\
   mdb-4.0,\
   messaging-3.0,\
+  connectors-2.0,\
   ejbLite-3.2,\
   enterprisebeanslite-4.0,\
   pages-3.0,\

--- a/dev/com.ibm.ws.messaging.open_jms20context_fat/bnd.bnd
+++ b/dev/com.ibm.ws.messaging.open_jms20context_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2020 IBM Corporation and others.
+# Copyright (c) 2018, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -22,6 +22,7 @@ src:\
 test.project: true
 
 tested.features:\
+  servlet-5.0,\
   wasJmsServer-1.0,\
   wasJmsClient-2.0,\
   messagingClient-3.0,\

--- a/dev/com.ibm.ws.microprofile.config.1.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2020 IBM Corporation and others.
+# Copyright (c) 2017, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -40,7 +40,8 @@ tested.features: mpConfig-1.1,\
                  mpConfig-2.0,\
                  cdi-1.2,\
                  cdi-2.0,\
-                 localconnector-1.0
+                 localconnector-1.0,\
+                 servlet-3.1
 
 -buildpath: \
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2020 IBM Corporation and others.
+# Copyright (c) 2017, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -27,7 +27,8 @@ tested.features: mpFaultTolerance-1.0,\
                  mpConfig-1.2,\
                  mpConfig-1.3,\
                  cdi-1.2,\
-                 cdi-2.0
+                 cdi-2.0,\
+                 servlet-3.1
 
 fat.project: true
 

--- a/dev/com.ibm.ws.rest.handler.config_fat/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.config_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2019 IBM Corporation and others.
+# Copyright (c) 2017, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -45,6 +45,7 @@ tested.features: componenttest-2.0,\
                  mpOpenApi-2.0,\
                  mpOpenApi-1.1,\
                  servlet-4.0,\
+                 servlet-5.0,\
                  mpConfig-2.0,\
                  jsonp-1.1,\
                  jaxrsclient-2.1,\

--- a/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2019 IBM Corporation and others.
+# Copyright (c) 2017, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ fat.project: true
 
 tested.features: mpOpenApi-2.0,\
                  servlet-4.0,\
+                 servlet-5.0,\
                  mpConfig-2.0,\
                  jsonp-1.1,\
                  jaxrsclient-2.1,\

--- a/dev/com.ibm.ws.security.acme_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.acme_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2020 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@ src: \
 	test-applications/slowapp.war/src
 
 fat.project: true
-tested.features: appsecurity-4.0, expressionlanguage-4.0, cdi-3.0
+tested.features: servlet-3.1, appsecurity-4.0, expressionlanguage-4.0, cdi-3.0
 
 # Uncomment to use remote docker host to simulate continuous build behavior.
 #fat.test.use.remote.docker: true

--- a/dev/com.ibm.ws.security.saml.sso_fat.endpoint.samlmetadata/bnd.bnd
+++ b/dev/com.ibm.ws.security.saml.sso_fat.endpoint.samlmetadata/bnd.bnd
@@ -17,7 +17,7 @@ src: \
 fat.project: true
 
 tested.features: samlweb-2.0, jdbc-4.0, jsp-2.3, servlet-4.0, el-3.0, \
-    appsecurity-4.0, expressionlanguage-4.0, cdi-3.0, pages-3.0
+    servlet-5.0, appsecurity-4.0, expressionlanguage-4.0, cdi-3.0, pages-3.0
 
 -buildpath: \
     fattest.simplicity;version=latest, \

--- a/dev/com.ibm.ws.session.cache_fat_config/bnd.bnd
+++ b/dev/com.ibm.ws.session.cache_fat_config/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ src: \
 fat.project: true
 
 tested.features: \
+  monitor-1.0,\
   servlet-5.0,\
   componenttest-2.0
 

--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/bnd.bnd
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -16,8 +16,10 @@ src: \
 	test-applications/sessionCacheConfigApp/src
 
 fat.project: true
-tested.features: cdi-2.0
 
+tested.features: \
+	cdi-2.0,\
+	monitor-1.0
 
 -buildpath: \
     com.ibm.websphere.javaee.jcache.1.1;version=latest,\

--- a/dev/com.ibm.ws.transaction.cloud_fat.db2.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.db2.1/bnd.bnd
@@ -23,6 +23,7 @@ fat.test.databases: true
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
 	servlet-4.0,\
+	servlet-5.0,\
 	cdi-2.0,\
 	cdi-3.0,\
 	jdbc-4.2

--- a/dev/com.ibm.ws.transaction.cloud_fat.db2.2/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.db2.2/bnd.bnd
@@ -23,6 +23,7 @@ fat.test.databases: true
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
 	servlet-4.0,\
+	servlet-5.0,\
 	cdi-2.0,\
 	cdi-3.0,\
 	jdbc-4.2

--- a/dev/com.ibm.ws.transaction.cloud_fat.derby.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.derby.1/bnd.bnd
@@ -23,6 +23,7 @@ fat.test.databases: true
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
 	servlet-4.0,\
+	servlet-5.0,\
 	cdi-2.0,\
 	cdi-3.0,\
 	jdbc-4.2

--- a/dev/com.ibm.ws.transaction.cloud_fat.derby.2/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.derby.2/bnd.bnd
@@ -23,6 +23,7 @@ fat.test.databases: true
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
 	servlet-4.0,\
+	servlet-5.0,\
 	cdi-2.0,\
 	cdi-3.0,\
 	jdbc-4.2

--- a/dev/com.ibm.ws.transaction.cloud_fat.oracle.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.oracle.1/bnd.bnd
@@ -23,6 +23,7 @@ fat.test.databases: true
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
 	servlet-4.0,\
+	servlet-5.0,\
 	cdi-2.0,\
 	cdi-3.0,\
 	jdbc-4.2

--- a/dev/com.ibm.ws.transaction.cloud_fat.oracle.2/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.oracle.2/bnd.bnd
@@ -23,6 +23,7 @@ fat.test.databases: true
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
 	servlet-4.0,\
+	servlet-5.0,\
 	cdi-2.0,\
 	cdi-3.0,\
 	jdbc-4.2

--- a/dev/com.ibm.ws.transaction.cloud_fat.postgresql.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.postgresql.1/bnd.bnd
@@ -23,6 +23,7 @@ fat.test.databases: true
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
 	servlet-4.0,\
+	servlet-5.0,\
 	cdi-2.0,\
 	cdi-3.0,\
 	jdbc-4.2

--- a/dev/com.ibm.ws.transaction.cloud_fat.postgresql.2/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.postgresql.2/bnd.bnd
@@ -23,6 +23,7 @@ fat.test.databases: true
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
 	servlet-4.0,\
+	servlet-5.0,\
 	cdi-2.0,\
 	cdi-3.0,\
 	jdbc-4.2

--- a/dev/com.ibm.ws.transaction.cloud_fat.sqlserver.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.sqlserver.1/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -23,6 +23,7 @@ fat.test.databases: true
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
 	servlet-4.0,\
+	servlet-5.0,\
 	cdi-2.0,\
 	cdi-3.0,\
 	jdbc-4.2

--- a/dev/com.ibm.ws.transaction.cloud_fat.sqlserver.2/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.sqlserver.2/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -23,6 +23,7 @@ fat.test.databases: true
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
 	servlet-4.0,\
+	servlet-5.0,\
 	cdi-2.0,\
 	cdi-3.0,\
 	jdbc-4.2

--- a/dev/com.ibm.ws.transaction.core_fat.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.1/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019,2020 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -40,6 +40,7 @@ tested.features:\
   jdbc-4.2,\
   jpa-2.2,\
   txtest-2.0,\
+  servlet-4.0,\
   servlet-5.0,\
   jdbc-4.3
 

--- a/dev/com.ibm.ws.transaction.core_fat.10/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.10/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019,2020 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -40,6 +40,7 @@ tested.features:\
   jdbc-4.2,\
   jpa-2.2,\
   txtest-2.0,\
+  servlet-4.0,\
   servlet-5.0,\
   jdbc-4.3
 

--- a/dev/com.ibm.ws.transaction.core_fat.2/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.2/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019,2020 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -40,6 +40,7 @@ tested.features:\
   jdbc-4.2,\
   jpa-2.2,\
   txtest-2.0,\
+  servlet-4.0,\
   servlet-5.0,\
   jdbc-4.3
 

--- a/dev/com.ibm.ws.transaction.core_fat.3/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.3/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019,2020 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -40,6 +40,7 @@ tested.features:\
   jdbc-4.2,\
   jpa-2.2,\
   txtest-2.0,\
+  servlet-4.0,\
   servlet-5.0,\
   jdbc-4.3
 

--- a/dev/com.ibm.ws.transaction.core_fat.4/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.4/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019,2020 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -40,6 +40,7 @@ tested.features:\
   jdbc-4.2,\
   jpa-2.2,\
   txtest-2.0,\
+  servlet-4.0,\
   servlet-5.0,\
   jdbc-4.3
 

--- a/dev/com.ibm.ws.transaction.core_fat.5/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.5/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019,2020 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -40,6 +40,7 @@ tested.features:\
   jdbc-4.2,\
   jpa-2.2,\
   txtest-2.0,\
+  servlet-4.0,\
   servlet-5.0,\
   jdbc-4.3
 

--- a/dev/com.ibm.ws.transaction.core_fat.6/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.6/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019,2020 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -40,6 +40,7 @@ tested.features:\
   jdbc-4.2,\
   jpa-2.2,\
   txtest-2.0,\
+  servlet-4.0,\
   servlet-5.0,\
   jdbc-4.3
 

--- a/dev/com.ibm.ws.transaction.core_fat.7/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.7/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019,2020 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -40,6 +40,7 @@ tested.features:\
   jdbc-4.2,\
   jpa-2.2,\
   txtest-2.0,\
+  servlet-4.0,\
   servlet-5.0,\
   jdbc-4.3
 

--- a/dev/com.ibm.ws.transaction.core_fat.8/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.8/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019,2020 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -40,6 +40,7 @@ tested.features:\
   jdbc-4.2,\
   jpa-2.2,\
   txtest-2.0,\
+  servlet-4.0,\
   servlet-5.0,\
   jdbc-4.3
 

--- a/dev/com.ibm.ws.transaction.core_fat.9/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.9/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019,2020 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -40,6 +40,7 @@ tested.features:\
   jdbc-4.2,\
   jpa-2.2,\
   txtest-2.0,\
+  servlet-4.0,\
   servlet-5.0,\
   jdbc-4.3
 

--- a/dev/com.ibm.ws.transaction.core_fat.startMultiEJB/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.startMultiEJB/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019,2020 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -25,6 +25,7 @@ tested.features:\
   jdbc-4.2,\
   servlet-3.1,\
   servlet-4.0,\
+  servlet-5.0,\
   enterprisebeanslite-4.0,\
   enterprisebeanspersistenttimer-4.0
   

--- a/dev/com.ibm.ws.wsat.common_fat/bnd.bnd
+++ b/dev/com.ibm.ws.wsat.common_fat/bnd.bnd
@@ -21,7 +21,7 @@ fat.project: true
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, Java EE 8 features are added programmatically at runtime by the RepeatTests rule.
 tested.features: \
-	servlet-4.0, jaxb-2.3, jaxws-2.3, xmlws-3.0
+	servlet-4.0, servlet-5.0, jaxb-2.3, jaxws-2.3, xmlws-3.0, connectors-2.0
 
 -buildpath: \
   com.ibm.websphere.javaee.jaxws.2.2;version=latest,\

--- a/dev/com.ibm.ws.wsat.concurrent_fat/bnd.bnd
+++ b/dev/com.ibm.ws.wsat.concurrent_fat/bnd.bnd
@@ -21,7 +21,7 @@ fat.project: true
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, Java EE 8 features are added programatically at runtime by the RepeatTests rule.
 tested.features: \
-	servlet-4.0,cdi-2.0,jaxb-2.3, jaxws-2.3,expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
+	servlet-4.0,servlet-5.0,cdi-2.0,jaxb-2.3, jaxws-2.3,expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0, connectors-2.0
 
 -buildpath: \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest, \

--- a/dev/com.ibm.ws.wsat.migration_fat.1/bnd.bnd
+++ b/dev/com.ibm.ws.wsat.migration_fat.1/bnd.bnd
@@ -24,7 +24,7 @@ fat.project: true
 # In this case, Java EE 8 features are added programatically at runtime by the RepeatTests rule.
 tested.features: \
 	servlet-4.0, cdi-2.0, jdbc-4.2, appsecurity-3.0, jaxrs-2.1, jpa-2.2, jaxb-2.3, jaxws-2.3, \
-	expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
+	servlet-5.0, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0, connectors-2.0
 
 -buildpath: \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest, \

--- a/dev/com.ibm.ws.wsat.migration_fat.2/bnd.bnd
+++ b/dev/com.ibm.ws.wsat.migration_fat.2/bnd.bnd
@@ -24,7 +24,7 @@ fat.project: true
 # In this case, Java EE 8 features are added programatically at runtime by the RepeatTests rule.
 tested.features: \
 	servlet-4.0, cdi-2.0, jdbc-4.2, appsecurity-3.0, jaxrs-2.1, jpa-2.2, jaxb-2.3, jaxws-2.3,\
-	expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
+	servlet-5.0, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0, connectors-2.0
 
 -buildpath: \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest, \

--- a/dev/com.ibm.ws.wsat.migration_fat.3/bnd.bnd
+++ b/dev/com.ibm.ws.wsat.migration_fat.3/bnd.bnd
@@ -24,7 +24,7 @@ fat.project: true
 # In this case, Java EE 8 features are added programatically at runtime by the RepeatTests rule.
 tested.features: \
 	servlet-4.0, cdi-2.0, jdbc-4.2, appsecurity-3.0, jaxrs-2.1, jpa-2.2, jaxb-2.3, jaxws-2.3,\
-	expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
+	servlet-5.0, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0, connectors-2.0
 
 -buildpath: \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest, \

--- a/dev/com.ibm.ws.wsat.migration_fat.4/bnd.bnd
+++ b/dev/com.ibm.ws.wsat.migration_fat.4/bnd.bnd
@@ -24,7 +24,7 @@ fat.project: true
 # In this case, Java EE 8 features are added programatically at runtime by the RepeatTests rule.
 tested.features: \
 	servlet-4.0, cdi-2.0, jdbc-4.2, appsecurity-3.0, jaxrs-2.1, jpa-2.2, jaxb-2.3, jaxws-2.3,\
-	expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
+	servlet-5.0, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0, connectors-2.0
 
 -buildpath: \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest, \

--- a/dev/com.ibm.ws.wsat.migration_fat.5/bnd.bnd
+++ b/dev/com.ibm.ws.wsat.migration_fat.5/bnd.bnd
@@ -24,7 +24,7 @@ fat.project: true
 # In this case, Java EE 8 features are added programatically at runtime by the RepeatTests rule.
 tested.features: \
 	servlet-4.0, cdi-2.0, jdbc-4.2, appsecurity-3.0, jaxrs-2.1, jpa-2.2, jaxb-2.3, jaxws-2.3,\
-	expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
+	servlet-5.0, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0, connectors-2.0
 
 -buildpath: \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest, \

--- a/dev/com.ibm.ws.wsat.recovery_fat.lps/bnd.bnd
+++ b/dev/com.ibm.ws.wsat.recovery_fat.lps/bnd.bnd
@@ -19,7 +19,7 @@ src: \
 fat.project: true
 
 tested.features: \
-	servlet-4.0, jaxb-2.3, jaxws-2.3, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
+	servlet-4.0, servlet-5.0, jaxb-2.3, jaxws-2.3, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0, connectors-2.0
 
 -buildpath: \
   com.ibm.tx.jta;version=latest,\

--- a/dev/com.ibm.ws.wsat.recovery_fat.multi.1/bnd.bnd
+++ b/dev/com.ibm.ws.wsat.recovery_fat.multi.1/bnd.bnd
@@ -19,7 +19,7 @@ src: \
 fat.project: true
 
 tested.features: \
-	servlet-4.0, jaxb-2.3, jaxws-2.3, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
+	servlet-4.0, servlet-5.0, jaxb-2.3, jaxws-2.3, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
 
 -buildpath: \
   com.ibm.tx.jta;version=latest,\

--- a/dev/com.ibm.ws.wsat.recovery_fat.multi.2/bnd.bnd
+++ b/dev/com.ibm.ws.wsat.recovery_fat.multi.2/bnd.bnd
@@ -19,7 +19,7 @@ src: \
 fat.project: true
 
 tested.features: \
-	servlet-4.0, jaxb-2.3, jaxws-2.3, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
+	servlet-4.0, servlet-5.0, jaxb-2.3, jaxws-2.3, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
 
 -buildpath: \
   com.ibm.tx.jta;version=latest,\

--- a/dev/com.ibm.ws.wsat.recovery_fat.multi.3/bnd.bnd
+++ b/dev/com.ibm.ws.wsat.recovery_fat.multi.3/bnd.bnd
@@ -19,7 +19,7 @@ src: \
 fat.project: true
 
 tested.features: \
-	servlet-4.0, jaxb-2.3, jaxws-2.3, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
+	servlet-4.0, servlet-5.0, jaxb-2.3, jaxws-2.3, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
 
 -buildpath: \
   com.ibm.tx.jta;version=latest,\

--- a/dev/com.ibm.ws.wsat.recovery_fat.multi.4/bnd.bnd
+++ b/dev/com.ibm.ws.wsat.recovery_fat.multi.4/bnd.bnd
@@ -19,7 +19,7 @@ src: \
 fat.project: true
 
 tested.features: \
-	servlet-4.0, jaxb-2.3, jaxws-2.3, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
+	servlet-4.0, servlet-5.0, jaxb-2.3, jaxws-2.3, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
 
 -buildpath: \
   com.ibm.tx.jta;version=latest,\

--- a/dev/com.ibm.ws.wsat.recovery_fat.single/bnd.bnd
+++ b/dev/com.ibm.ws.wsat.recovery_fat.single/bnd.bnd
@@ -19,7 +19,7 @@ src: \
 fat.project: true
 
 tested.features: \
-	servlet-4.0, jaxb-2.3, jaxws-2.3, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
+	servlet-4.0, servlet-5.0, jaxb-2.3, jaxws-2.3, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0, connectors-2.0
 
 -buildpath: \
   com.ibm.tx.jta;version=latest,\

--- a/dev/com.ibm.ws.wsat_fat.assertion/bnd.bnd
+++ b/dev/com.ibm.ws.wsat_fat.assertion/bnd.bnd
@@ -29,7 +29,7 @@ fat.project: true
 # In this case, Java EE 8 features are added programmatically at runtime by the RepeatTests rule.
 tested.features: \
 	servlet-4.0, cdi-2.0, jdbc-4.2, appsecurity-3.0, jaxrs-2.1, jpa-2.2, jaxb-2.3, jaxws-2.3,\
-	expressionlanguage-4.0, xmlws-3.0, cdi-3.0, enterprisebeanslite-4.0, pages-3.0
+	servlet-5.0, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, enterprisebeanslite-4.0, pages-3.0, connectors-2.0
 
 -buildpath: \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest, \

--- a/dev/com.ibm.ws.wsat_fat.db/bnd.bnd
+++ b/dev/com.ibm.ws.wsat_fat.db/bnd.bnd
@@ -29,7 +29,7 @@ fat.project: true
 # In this case, Java EE 8 features are added programmatically at runtime by the RepeatTests rule.
 tested.features: \
 	servlet-4.0, cdi-2.0, jdbc-4.2, appsecurity-3.0, jaxrs-2.1, jpa-2.2,jaxb-2.3,jaxws-2.3,\
-	expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
+	servlet-5.0, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0, connectors-2.0
 
 -buildpath: \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest, \

--- a/dev/com.ibm.ws.wsat_fat.db_optional/bnd.bnd
+++ b/dev/com.ibm.ws.wsat_fat.db_optional/bnd.bnd
@@ -29,7 +29,7 @@ fat.project: true
 # In this case, Java EE 8 features are added programmatically at runtime by the RepeatTests rule.
 tested.features: \
 	servlet-4.0, cdi-2.0, jdbc-4.2, appsecurity-3.0, jaxrs-2.1, jpa-2.2, jaxb-2.3, jaxws-2.3,\
-	expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
+	servlet-5.0, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0, connectors-2.0
 
 -buildpath: \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest, \

--- a/dev/com.ibm.ws.wsat_fat.dbs/bnd.bnd
+++ b/dev/com.ibm.ws.wsat_fat.dbs/bnd.bnd
@@ -29,7 +29,7 @@ fat.project: true
 # In this case, Java EE 8 features are added programmatically at runtime by the RepeatTests rule.
 tested.features: \
 	servlet-4.0, cdi-2.0, jdbc-4.2, appsecurity-3.0, jaxrs-2.1, jpa-2.2, jaxb-2.3, jaxws-2.3,\
-	expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
+	servlet-5.0, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0, connectors-2.0
 
 -buildpath: \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest, \

--- a/dev/com.ibm.ws.wsat_fat.dbs_optional/bnd.bnd
+++ b/dev/com.ibm.ws.wsat_fat.dbs_optional/bnd.bnd
@@ -29,7 +29,7 @@ fat.project: true
 # In this case, Java EE 8 features are added programmatically at runtime by the RepeatTests rule.
 tested.features: \
 	servlet-4.0, cdi-2.0, jdbc-4.2, appsecurity-3.0, jaxrs-2.1, jpa-2.2, jaxb-2.3, jaxws-2.3,\
-	expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
+	servlet-5.0, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0, connectors-2.0
 
 -buildpath: \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest, \

--- a/dev/com.ibm.ws.wsat_fat.multi/bnd.bnd
+++ b/dev/com.ibm.ws.wsat_fat.multi/bnd.bnd
@@ -29,7 +29,7 @@ fat.project: true
 # In this case, Java EE 8 features are added programmatically at runtime by the RepeatTests rule.
 tested.features: \
 	servlet-4.0, cdi-2.0, jdbc-4.2, appsecurity-3.0, jaxrs-2.1, jpa-2.2, jaxb-2.3, jaxws-2.3,\
-	expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
+	servlet-5.0, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0, connectors-2.0
 
 -buildpath: \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest, \

--- a/dev/com.ibm.ws.wsat_fat.ssl/bnd.bnd
+++ b/dev/com.ibm.ws.wsat_fat.ssl/bnd.bnd
@@ -29,7 +29,7 @@ fat.project: true
 # In this case, Java EE 8 features are added programmatically at runtime by the RepeatTests rule.
 tested.features: \
 	servlet-4.0, cdi-2.0, jdbc-4.2, appsecurity-3.0, jaxrs-2.1, jpa-2.2, jaxb-2.3, jaxws-2.3, \
-	appsecurity-4.0, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0
+	servlet-5.0, appsecurity-4.0, expressionlanguage-4.0, xmlws-3.0, cdi-3.0, pages-3.0, connectors-2.0
 
 -buildpath: \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest, \

--- a/dev/fattest.simplicity/src/componenttest/depchain/Feature.java
+++ b/dev/fattest.simplicity/src/componenttest/depchain/Feature.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package componenttest.depchain;
 
 import java.util.ArrayList;
@@ -10,8 +20,11 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import com.ibm.websphere.simplicity.log.Log;
+
 public class Feature {
     private static final Class<?> c = Feature.class;
+    public static final boolean DEBUG = false;
     private String shortName;
     private String symbolicName;
     private final List<String> enables = new ArrayList<String>();
@@ -56,7 +69,7 @@ public class Feature {
                 } else if ("include".equals(nodeName)) {
                     includes.add(child.getAttribute("symbolicName"));
                 } else if ("autoProvision".equals(nodeName)) {
-                    autoProvision.add(child.getAttribute("autoProvision"));
+                    autoProvision.add(content);
                 }
             }
         }
@@ -88,6 +101,9 @@ public class Feature {
             return isProvisioned;
         }
 
+        if (DEBUG)
+            Log.info(c, "isProvisioned", "autoProvision=" + autoProvision);
+
         // Must be an auto feature, check if required features are enabled
         for (String conditionFeature : autoProvision) {
             boolean anyOf = conditionFeature.contains("|");
@@ -98,11 +114,16 @@ public class Feature {
                     continue;
                 identity = identity.substring(0, trimAt);
                 if (Pattern.matches("[\\-\\w\\.]+", identity)) {
+                    if (DEBUG)
+                        Log.info(c, "isProvisioned", "Pattern Matched : " + identity);
                     boolean installed = installedFeatures.contains(identity.toLowerCase());
                     if (anyOf)
                         isProvisioned |= installed;
                     else
                         isProvisioned &= installed;
+                } else {
+                    if (DEBUG)
+                        Log.info(c, "isProvisioned", "Pattern Not Matched : " + identity);
                 }
             }
             if (!isProvisioned)

--- a/dev/fattest.simplicity/src/componenttest/depchain/FeatureDependencyProcessor.java
+++ b/dev/fattest.simplicity/src/componenttest/depchain/FeatureDependencyProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -63,7 +63,7 @@ public class FeatureDependencyProcessor {
         File featureListFile = FeatureList.get(server);
         Set<String> testedFeatures = getTestedFeatures(testedFeaturesFile, featureListFile);
 
-        if (testedFeatures.contains("ALL_FEATURES"))
+        if (testedFeatures.contains("all_features"))
             return;
 
         Set<String> untestedFeatures = new HashSet<String>();
@@ -113,11 +113,15 @@ public class FeatureDependencyProcessor {
         // Continue to iterate auto-feature resolution until no more features are enabled
         boolean featuresAdded = true;
         while (featuresAdded) {
+            featuresAdded = false;
             for (Feature f : featureMap.values()) {
                 if (DEBUG && f.getFeatureType() == Type.AUTO_FEATURE)
                     Log.info(c, m, "Found auto feature: " + f);
-                if (f.getFeatureType() == Type.AUTO_FEATURE && f.isProvisioned(featureMap, testedFeatures))
-                    featuresAdded = testedFeatures.addAll(getEnabledFeatures(f.getSymbolicName(), testedFeatures, featureMap));
+                if (f.getFeatureType() == Type.AUTO_FEATURE && f.isProvisioned(featureMap, testedFeatures)) {
+                    if (testedFeatures.addAll(getEnabledFeatures(f.getSymbolicName(), testedFeatures, featureMap))) {
+                        featuresAdded = true;
+                    }
+                }
             }
             if (DEBUG)
                 Log.info(c, m, "After auto-feature calculation: " + testedFeatures);

--- a/dev/io.openliberty.ws.global.handler.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.ws.global.handler.internal_fat/bnd.bnd
@@ -39,7 +39,7 @@ src: \
 fat.project: true
 
 tested.features=appSecurity-3.0, cdi-2.0, cdi-3.0, enterprisebeanslite-4.0, jaxrs-2.1, jaxrsClient-2.1, restfulWS-3.0, \
- restfulWSClient-3.0, jsonp-1.1, jsonp-2.0, servlet-4.0, servlet-5.0, xmlWS-3.0, appSecurity-4.0, expressionlanguage-4.0, pages-3.0
+ restfulWSClient-3.0, jsonp-1.1, jsonp-2.0, servlet-4.0, servlet-5.0, servlet-5.0, xmlWS-3.0, appSecurity-4.0, expressionlanguage-4.0, pages-3.0
 
 -buildpath: \
 	io.openliberty.jakarta.enterpriseBeans.4.0;version=latest,\

--- a/dev/io.openliberty.wsoc.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.wsoc.internal_fat/bnd.bnd
@@ -34,6 +34,7 @@ tested.features: \
     messagingclient-3.0, \
     enterprisebeanslite-4.0, \
     cdi-3.0, \
+    connectors-2.0, \
     appsecurity-4.0, \
     expressionlanguage-4.0
 


### PR DESCRIPTION
Simplicity Feature code has a bug and is not reading auto-feature
provisioning correctly, so assumes all auto-features are enabled.

Fix auto-feature dependency validation and update FAT to properly
report tested features.