### PR TITLE
Remove docker constraint for libhpike on ACME FATs

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/FATSuite.java
@@ -47,10 +47,5 @@ public class FATSuite {
     //switching between local and remote docker hosts.
     static {
         ExternalTestServiceDockerClientStrategy.setupTestcontainers();
-        
-        // Filter out any external docker servers in the 'libhpike' cluster
-        ExternalTestServiceDockerClientStrategy.serviceFilter = (svc) -> {
-                return !svc.getAddress().contains("libhpike-dockerengine");
-        };
     }
 }


### PR DESCRIPTION
Try removing the host constraint for libhpike docker servers for acme_fat. Previously the boulder image would time out while starting on this bank of servers. Locally, it worked for me. Remove the constraint and see what occurs -- `AcmeRevocationTest` which runs on FULL mode will fail if we can't start the boulder image.