### PR TITLE
remove the workaround in wss4j to load the gf jaxb ri classes

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/bus/LibertyApplicationBusFactory.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/bus/LibertyApplicationBusFactory.java
@@ -70,12 +70,7 @@ public class LibertyApplicationBusFactory extends CXFBusFactory {
         extensions.put(LibertyApplicationBus.Type.class, LibertyApplicationBus.Type.SERVER);
 
         final ClassLoader moduleClassLoader = moduleInfo.getClassLoader();
-        Object origTccl = THREAD_CONTEXT_ACCESSOR.pushContextClassLoaderForUnprivileged(moduleClassLoader);
-        try {
-            return createBus(extensions, properties, moduleClassLoader);
-        } finally {
-            THREAD_CONTEXT_ACCESSOR.popContextClassLoaderForUnprivileged(origTccl);
-        }
+        return createBus(extensions, properties, moduleClassLoader);
     }
 
     public LibertyApplicationBus createClientScopedBus(JaxWsModuleMetaData moduleMetaData) {
@@ -89,12 +84,7 @@ public class LibertyApplicationBusFactory extends CXFBusFactory {
         extensions.put(LibertyApplicationBus.Type.class, LibertyApplicationBus.Type.CLIENT);
 
         final ClassLoader moduleClassLoader = moduleInfo.getClassLoader();
-        Object origTccl = THREAD_CONTEXT_ACCESSOR.pushContextClassLoaderForUnprivileged(moduleClassLoader);
-        try {
-            return createBus(extensions, properties, moduleClassLoader);
-        } finally {
-            THREAD_CONTEXT_ACCESSOR.popContextClassLoaderForUnprivileged(origTccl);
-        }
+        return createBus(extensions, properties, moduleClassLoader);
     }
 
     @Override

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.stax.2.3.0/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.stax.2.3.0/bnd.bnd
@@ -20,5 +20,4 @@ instrument.classesExcludes: org/apache/wss4j/stax/setup/*.class
 	com.ibm.ws.org.apache.wss4j.ws.security.common.2.3.0;version=latest,\
 	com.ibm.ws.org.slf4j.api.1.7.7;version=latest,\
 	com.ibm.ws.org.apache.wss4j.bindings.2.3.0;version=latest,\
-	com.ibm.ws.org.apache.santuario.xmlsec.2.2.0;version=latest,\
-	io.openliberty.xmlBinding.3.0.internal.tools;version=latest
+	com.ibm.ws.org.apache.santuario.xmlsec.2.2.0;version=latest

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.stax.2.3.0/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.stax.2.3.0/bnd.overrides
@@ -21,10 +21,10 @@ Export-Package: \
  org.apache.wss4j.stax.*
 
 Import-Package: \
- org.glassfish.jaxb.runtime.v2;resolution:=optional,\
  *
 
 DynamicImport-Package: \
+ org.glassfish.jaxb.runtime.v2, \
  org.glassfish.jaxb.runtime.v2.*
 
 jakartaeeMe: true

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.stax.2.3.0/src/org/apache/wss4j/stax/setup/WSSec.java
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.stax.2.3.0/src/org/apache/wss4j/stax/setup/WSSec.java
@@ -60,24 +60,7 @@ public class WSSec {
 
     static {
         WSProviderConfig.init();
-        ClassLoader cl = null;
         try {
-            //Liberty code change start 
-            //TODO: look into why we are not finding this provider
-            ClassLoader jaxbimplcl = null;
-            try {
-                jaxbimplcl = org.glassfish.jaxb.runtime.v2.JAXBContextFactory.class.getClassLoader();
-            } catch (Throwable t) {
-                //ncdfe
-            }  
-            if (jaxbimplcl != null) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("setting the glassfish classes loader!");
-                }
-                cl = Thread.currentThread().getContextClassLoader();
-                Thread.currentThread().setContextClassLoader(jaxbimplcl);
-            }
-            //Liberty code change end
             Init.init(ClassLoaderUtils.getResource("wss/wss-config.xml", WSSec.class).toURI(), WSSec.class);
 
             WSSConstants.setJaxbContext(
@@ -101,14 +84,7 @@ public class WSSec {
         } catch (XMLSecurityException | JAXBException
             | SAXException | URISyntaxException e) {
             throw new RuntimeException(e.getMessage(), e);
-        } finally { //Liberty code change start
-            if (cl != null) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("setting back the original class loader!");
-                }
-                Thread.currentThread().setContextClassLoader(cl); 
-            }    
-        } //Liberty code change end
+        }
     }
 
     public static void init() {


### PR DESCRIPTION
Make an update to where we are creating  the liberty jax-ws cxf bus.
Remove the workaround in the wss4j
