### PR TITLE
fix 285305,285315

### DIFF
--- a/dev/com.ibm.ws.wssecurity.fat.utils.common/fat/src/com/ibm/ws/wssecurity/fat/utils/common/CommonTests.java
+++ b/dev/com.ibm.ws.wssecurity.fat.utils.common/fat/src/com/ibm/ws/wssecurity/fat/utils/common/CommonTests.java
@@ -786,7 +786,8 @@ public class CommonTests {
     public void endTest() throws Exception {
 
         try {
-            restoreServer();
+            //Removed to resolve RTC 285305, 285315
+            //restoreServer();
             String _testName = testName.getMethodName();
             printMethodName(_testName, "Ending TEST ");
             System.out.println("----- End:  " + testName + "   ----------------------------------------------------");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sha2sig/CxfSha2SigTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sha2sig/CxfSha2SigTests.java
@@ -11,7 +11,9 @@
 
 package com.ibm.ws.wssecurity.fat.cxf.sha2sig;
 
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 
 import java.io.File;
 import java.util.Set;
@@ -84,8 +86,9 @@ public class CxfSha2SigTests extends CommonTests {
      * in this test. This is a positive scenario.
      *
      */
+
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testCxfSha2SignSoapBodyEE7Only() throws Exception {
 
         String thisMethod = "testCxfSha2SignSoapBody";
@@ -118,7 +121,7 @@ public class CxfSha2SigTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfSha2SignSoapBodyEE8Only() throws Exception {
 
@@ -160,8 +163,9 @@ public class CxfSha2SigTests extends CommonTests {
      * in the algorithm suite. This is a positive scenario.
      *
      */
+
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testCxfSha2DigestAlgorithmEE7Only() throws Exception {
 
         String thisMethod = "testCxfSha2DigestAlgorithm";
@@ -194,7 +198,7 @@ public class CxfSha2SigTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfSha2DigestAlgorithmEE8Only() throws Exception {
 
@@ -237,7 +241,7 @@ public class CxfSha2SigTests extends CommonTests {
      *
      */
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testCxfSha384SigAlgorithmEE7Only() throws Exception {
 
         String thisMethod = "testTwasSha384SigAlgorithm";
@@ -267,10 +271,13 @@ public class CxfSha2SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
 
+        //Added to resolve RTC 285315
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfSha384SigAlgorithmEE8Only() throws Exception {
 
@@ -301,6 +308,9 @@ public class CxfSha2SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
 
+        //Added to resolve RTC 285315
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+
     }
 
     /**
@@ -313,7 +323,7 @@ public class CxfSha2SigTests extends CommonTests {
      *
      */
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testCxfSha512SigAlgorithmEE7Only() throws Exception {
 
         String thisMethod = "testTwasSha512SigAlgorithm";
@@ -343,10 +353,13 @@ public class CxfSha2SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
 
+        //Added to resolve RTC 285315
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfSha512SigAlgorithmEE8Only() throws Exception {
 
@@ -377,6 +390,9 @@ public class CxfSha2SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
 
+        //Added to resolve RTC 285315
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+
     }
 
     /**
@@ -392,7 +408,7 @@ public class CxfSha2SigTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     public void testCxfSha1ToSha2SigAlgorithmEE7Only() throws Exception {
 
@@ -427,10 +443,13 @@ public class CxfSha2SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test did not receive the expected exception from the server.");
 
+        //Added to resolve RTC 285315
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException", "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfSha1ToSha2SigAlgorithmEE8Only() throws Exception {
 
@@ -464,6 +483,9 @@ public class CxfSha2SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test did not receive the expected exception from the server.");
 
+        //Added to resolve RTC 285315
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+
     }
 
     /**
@@ -478,7 +500,7 @@ public class CxfSha2SigTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testCxfSha256SigAlg2048KeylenEE7Only() throws Exception {
 
         String thisMethod = "testCxfSha256SigAlg2048Keylen";
@@ -508,10 +530,13 @@ public class CxfSha2SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test did not receive the expected exception from the server.");
 
+        //Added to resolve RTC 285315
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfSha256SigAlg2048KeylenEE8Only() throws Exception {
 
@@ -542,6 +567,9 @@ public class CxfSha2SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test did not receive the expected exception from the server.");
 
+        //Added to resolve RTC 285315
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+
     }
 
     /**
@@ -556,7 +584,7 @@ public class CxfSha2SigTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testCxfSha384SymBindingEE7Only() throws Exception {
 
         String thisMethod = "testCxfSha384SymBinding";
@@ -586,10 +614,13 @@ public class CxfSha2SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test did not receive the expected exception from the server.");
 
+        //Added to resolve RTC 285315
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfSha384SymBindingEE8Only() throws Exception {
 
@@ -620,6 +651,9 @@ public class CxfSha2SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test did not receive the expected exception from the server.");
 
+        //Added to resolve RTC 285315
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+
     }
 
     /**
@@ -634,7 +668,7 @@ public class CxfSha2SigTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testCxfSha512SymBindingEE7Only() throws Exception {
         String thisMethod = "testCxfSha512SymBinding";
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha5sym.xml");
@@ -663,10 +697,13 @@ public class CxfSha2SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test did not receive the expected exception from the server.");
 
+        //Added to resolve RTC 285315
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfSha512SymBindingEE8Only() throws Exception {
 
@@ -696,6 +733,9 @@ public class CxfSha2SigTests extends CommonTests {
                     "Response: This is WSSECFVT SHA2 SYM Web Service.",
                     // msg to issue if do NOT get the expected result
                     "The test did not receive the expected exception from the server.");
+
+        //Added to resolve RTC 285315
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
 
     }
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/wss11enc/CxfWss11EncTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/wss11enc/CxfWss11EncTests.java
@@ -11,7 +11,9 @@
 
 package com.ibm.ws.wssecurity.fat.cxf.wss11enc;
 
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 
 import java.io.File;
 import java.util.Set;
@@ -97,7 +99,7 @@ public class CxfWss11EncTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testCXFClientEncryptHeaderNS1EE7Only() throws Exception {
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_enchdr.xml");
         genericTest(
@@ -123,10 +125,14 @@ public class CxfWss11EncTests extends CommonTests {
                     "Response: This is Wss11EncWebSvc1 Web Service.",
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
+
+        //Added to resolve RTC 285315
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientEncryptHeaderNS1EE8Only() throws Exception {
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_enchdr_wss4j.xml");
@@ -153,6 +159,10 @@ public class CxfWss11EncTests extends CommonTests {
                     "Response: This is Wss11EncWebSvc1 Web Service.",
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
+
+        //Added to resolve RTC 285315
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+
     }
 
     /**
@@ -183,7 +193,7 @@ public class CxfWss11EncTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testCXFClientEncryptHeaderNS2EE7Only() throws Exception {
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
         genericTest(
@@ -212,7 +222,7 @@ public class CxfWss11EncTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientEncryptHeaderNS2EE8Only() throws Exception {
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -267,7 +277,7 @@ public class CxfWss11EncTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testCXFClientEncryptHeaderAnyEE7Only() throws Exception {
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
         genericTest(
@@ -296,7 +306,7 @@ public class CxfWss11EncTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientEncryptHeaderAnyEE8Only() throws Exception {
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/wss11sig/CxfWss11SigTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/wss11sig/CxfWss11SigTests.java
@@ -11,7 +11,9 @@
 
 package com.ibm.ws.wssecurity.fat.cxf.wss11sig;
 
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 
 import java.io.File;
 import java.util.Set;
@@ -269,7 +271,7 @@ public class CxfWss11SigTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     public void testCXFClientBasicEncryptedElementMisMatchEE7Only() throws Exception {
 
@@ -307,7 +309,7 @@ public class CxfWss11SigTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientBasicEncryptedElementMisMatchEE8Only() throws Exception {
 
@@ -362,7 +364,7 @@ public class CxfWss11SigTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testCXFClientBasicEncryptedElementEE7Only() throws Exception {
 
         String thisMethod = "testCXFClientBasicEncryptedElement";
@@ -396,7 +398,7 @@ public class CxfWss11SigTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientBasicEncryptedElementEE8Only() throws Exception {
 
@@ -444,7 +446,7 @@ public class CxfWss11SigTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     public void testCXFClientBasicSigSignedElementMisMatchEE7Only() throws Exception {
 
@@ -455,6 +457,7 @@ public class CxfWss11SigTests extends CommonTests {
         Log.info(thisClass, thisMethod, "Using " + newClientWsdl);
         printMethodName(thisMethod, "End Prep for " + thisMethod);
 
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
         genericTest(
                     // test name for logging
                     thisMethod,
@@ -482,7 +485,7 @@ public class CxfWss11SigTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientBasicSigSignedElementMisMatchEE8Only() throws Exception {
 
@@ -533,10 +536,11 @@ public class CxfWss11SigTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testCXFClientBasicSigSignedElementEE7Only() throws Exception {
 
         String thisMethod = "testCXFClientBasicSigSignedElement";
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
         genericTest(
                     // test name for logging
                     thisMethod,
@@ -564,7 +568,7 @@ public class CxfWss11SigTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientBasicSigSignedElementEE8Only() throws Exception {
 
@@ -607,7 +611,7 @@ public class CxfWss11SigTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testCXFClientBasicSigClNoSignConfSrvNoSignNoConfEE7Only() throws Exception {
 
         String thisMethod = "testCXFClientBasicSigClNoSignConfSrvNoSignNoConf";
@@ -616,6 +620,8 @@ public class CxfWss11SigTests extends CommonTests {
                                          defaultClientWsdlLoc + "WSS11Signature_sigConfMissingInServerUpdated.wsdl");
         Log.info(thisClass, thisMethod, "Using " + newClientWsdl);
         printMethodName(thisMethod, "End Prep for " + thisMethod);
+
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
         genericTest(
                     // test name for logging
                     thisMethod,
@@ -643,7 +649,7 @@ public class CxfWss11SigTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientBasicSigClNoSignConfSrvNoSignNoConfEE8Only() throws Exception {
 
@@ -653,6 +659,7 @@ public class CxfWss11SigTests extends CommonTests {
                                          defaultClientWsdlLoc + "WSS11Signature_sigConfMissingInServerUpdated.wsdl");
         Log.info(thisClass, thisMethod, "Using " + newClientWsdl);
         printMethodName(thisMethod, "End Prep for " + thisMethod);
+
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
         genericTest(
                     // test name for logging
@@ -711,7 +718,8 @@ public class CxfWss11SigTests extends CommonTests {
                 newWsdl = null;
                 newClientWsdl = null;
             }
-            restoreServer();
+            //Removed to resolve RTC 285315
+            //restoreServer();
         } catch (Exception e) {
             e.printStackTrace(System.out);
         }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfEndSupTokensSym2Tests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfEndSupTokensSym2Tests.java
@@ -34,14 +34,12 @@ public class CxfEndSupTokensSym2Tests extends CommonTests {
     static final private String serverName = "com.ibm.ws.wssecurity_fat.endsuptokens";
 //    static private String newClientWsdl = null;
 
-    //Added 11/2020
     @Server(serverName)
     public static LibertyServer server;
 
     @BeforeClass
     public static void setUp() throws Exception {
 
-        //Added 11/2020
         ShrinkHelper.defaultDropinApp(server, "endsuptokensclient", "com.ibm.ws.wssecurity.fat.endsuptokensclient", "test.wssecfvt.endsuptokens",
                                       "test.wssecfvt.endsuptokens.types");
         ShrinkHelper.defaultDropinApp(server, "endsuptokens", "com.ibm.ws.wssecurity.fat.endsuptokens");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfEndSupTokensSymTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfEndSupTokensSymTests.java
@@ -76,7 +76,6 @@ public class CxfEndSupTokensSymTests extends CommonTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             commonSetUp(serverName, "server_sym_wss4j.xml", true,
                         "/endsuptokensclient/CxfEndSupTokensSvcClient");
-            //copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
         }
 
     }
@@ -835,7 +834,8 @@ public class CxfEndSupTokensSymTests extends CommonTests {
                 newWsdl = null;
                 newClientWsdl = null;
             }
-            restoreServer();
+            //Removed to resolve RTC 285315
+            //restoreServer();
         } catch (Exception e) {
             e.printStackTrace(System.out);
         }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigSymTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigSymTests.java
@@ -300,7 +300,7 @@ public class CxfX509MigSymTests {
                         "", //String portNumberSecure
                         "FatBAX01Service", //String strServiceName,
                         "UrnX509Token01", //String strServicePort
-                        errMsgVersion //2/2021 CxfX509MigSvcClient
+                        errMsgVersion //CxfX509MigSvcClient
             );
         } catch (Exception e) {
             throw e;
@@ -332,7 +332,7 @@ public class CxfX509MigSymTests {
                         portNumberSecure, //String portNumberSecure
                         "FatBAX01Service", //String strServiceName,
                         "UrnX509Token01", //String strServicePort
-                        errMsgVersion //2/2021 CxfX509MigSvcClient
+                        errMsgVersion //CxfX509MigSvcClient
             );
         } catch (Exception e) {
             throw e;
@@ -513,7 +513,7 @@ public class CxfX509MigSymTests {
                         "", //String portNumberSecure
                         "FatBAX03Service", //String strServiceName,
                         "UrnX509Token03", //String strServicePort
-                        errMsgVersion //2/2021 CxfX509MigSvcClient
+                        errMsgVersion //CxfX509MigSvcClient
             );
         } catch (Exception e) {
             throw e;
@@ -1488,7 +1488,7 @@ public class CxfX509MigSymTests {
                             "", //String portNumberSecure
                             "FatBAX31Service", //String strServiceName,
                             "UrnX509Token31", //String strServicePort
-                            errMsgVersion //2/2021 CxfX509MigSvcClient
+                            errMsgVersion //CxfX509MigSvcClient
                 );
             } catch (Exception e) {
                 throw e;
@@ -1782,7 +1782,7 @@ public class CxfX509MigSymTests {
                            "", //String portNumberSecure
                            "FatBAX09Service", //String strServiceName,
                            "UrnX509Token09", //String strServicePort
-                           errMsgVersion //2/2021 CxfX509MigBadSvcClient
+                           errMsgVersion //CxfX509MigBadSvcClient
             );
         } catch (Exception e) {
             throw e;

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigTests.java
@@ -940,7 +940,7 @@ public class CxfX509MigTests {
                         "", //String portNumberSecure
                         "FatBAX11Service", //String strServiceName,
                         "UrnX509Token11", //String strServicePort
-                        errMsgVersion //2/2021 CxfX509MigSvcClient
+                        errMsgVersion //CxfX509MigSvcClient
             );
         } catch (Exception e) {
             throw e;
@@ -1095,7 +1095,7 @@ public class CxfX509MigTests {
                         portNumberSecure, //String portNumberSecure
                         "FatBAX11Service", //String strServiceName,
                         "UrnX509Token11", //String strServicePort
-                        errMsgVersion //2/2021 CxfX509MigSvcClient
+                        errMsgVersion //CxfX509MigSvcClient
             );
         } catch (Exception e) {
             throw e;
@@ -1295,7 +1295,7 @@ public class CxfX509MigTests {
                         "", //String portNumberSecure
                         "FatBAX13Service", //String strServiceName,
                         "UrnX509Token13", //String strServicePort
-                        errMsgVersion //2/2021 CxfX509MigBadSvcClient
+                        errMsgVersion //CxfX509MigBadSvcClient
             );
         } catch (Exception e) {
             throw e;
@@ -1860,7 +1860,7 @@ public class CxfX509MigTests {
                         "", //String portNumberSecure
                         "FatBAX16Service", //String strServiceName,
                         "UrnX509Token16", //String strServicePort
-                        errMsgVersion //2/2021 CxfX509MigBadSvcClient
+                        errMsgVersion //CxfX509MigBadSvcClient
             );
         } catch (Exception e) {
             throw e;
@@ -2206,7 +2206,7 @@ public class CxfX509MigTests {
                         "", //String portNumberSecure
                         "FatBAX17Service", //String strServiceName,
                         "UrnX509Token17", //String strServicePort
-                        errMsgVersion //2/2021 CxfX509MigSvcClient
+                        errMsgVersion //CxfX509MigSvcClient
             );
         } catch (Exception e) {
             throw e;
@@ -2938,7 +2938,7 @@ public class CxfX509MigTests {
                            "", //String portNumberSecure
                            "FatBAX02Service", //String strServiceName,
                            "UrnX509Token02", //String strServicePort
-                           errMsgVersion //2/2021 CxfX509MigBadSvcClient
+                           errMsgVersion //CxfX509MigBadSvcClient
             );
         } catch (Exception e) {
             throw e;
@@ -3002,7 +3002,7 @@ public class CxfX509MigTests {
                            "", //String portNumberSecure
                            "FatBAX08Service", //String strServiceName,
                            "UrnX509Token08", //String strServicePort
-                           errMsgVersion //2/2021 CxfX509MigBadSvcClient
+                           errMsgVersion //CxfX509MigBadSvcClient
             );
         } catch (Exception e) {
             throw e;
@@ -3033,7 +3033,7 @@ public class CxfX509MigTests {
                            portNumberSecure, //String portNumberSecure
                            "FatBAX10Service", //String strServiceName,
                            "UrnX509Token10", //String strServicePort
-                           errMsgVersion //2/2021  CxfX509MigBadSvcClient
+                           errMsgVersion //CxfX509MigBadSvcClient
             );
         } catch (Exception e) {
             throw e;
@@ -3123,7 +3123,7 @@ public class CxfX509MigTests {
                            portNumberSecure, //String portNumberSecure
                            "FatBAX13Service", //String strServiceName,
                            "UrnX509Token13", //String strServicePort
-                           errMsgVersion //2/2021 CxfX509MigBadSvcClient
+                           errMsgVersion //CxfX509MigBadSvcClient
             );
         } catch (Exception e) {
             throw e;
@@ -3212,7 +3212,7 @@ public class CxfX509MigTests {
                            portNumberSecure, //String portNumberSecure
                            "FatBAX16Service", //String strServiceName,
                            "UrnX509Token16", //String strServicePort
-                           errMsgVersion //2/2021 CxfX509MigBadSvcClient
+                           errMsgVersion //CxfX509MigBadSvcClient
             );
         } catch (Exception e) {
             throw e;
@@ -3350,7 +3350,7 @@ public class CxfX509MigTests {
                            "", //String portNumberSecure
                            "FatBAX21Service", //String strServiceName,
                            "UrnX509Token21", //String strServicePort
-                           errMsgVersion //2/2021 CxfX509MigBadSvcClient
+                           errMsgVersion //CxfX509MigBadSvcClient
             );
         } catch (Exception e) {
             throw e;

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509CrlTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509CrlTests.java
@@ -11,7 +11,9 @@
 
 package com.ibm.ws.wssecurity.fat.cxf.x509token;
 
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 
 import java.io.File;
 import java.util.Set;
@@ -95,7 +97,7 @@ public class CxfX509CrlTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testCXFClientCRLPNotInListEE7Only() throws Exception {
 
         String thisMethod = "testCXFClientCRLPNotInList";
@@ -125,10 +127,13 @@ public class CxfX509CrlTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
 
+        //Added to resolve RTC 285315
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientCRLPNotInListEE8Only() throws Exception {
 
@@ -159,6 +164,9 @@ public class CxfX509CrlTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
 
+        //Added to resolve RTC 285315
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+
     }
 
     /**
@@ -174,7 +182,7 @@ public class CxfX509CrlTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     public void testCXFClientCRLNInListEE7Only() throws Exception {
 
@@ -207,11 +215,14 @@ public class CxfX509CrlTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
 
+        //Added to resolve RTC 285315
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID }) //@AV999
+    @SkipForRepeat({ NO_MODIFICATION })
+    @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientCRLNInListEE8Only() throws Exception {
 
@@ -243,6 +254,9 @@ public class CxfX509CrlTests extends CommonTests {
                     //"myx509certN",
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
+
+        //Added to resolve RTC 285315
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
 
     }
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509EncTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509EncTests.java
@@ -11,7 +11,9 @@
 
 package com.ibm.ws.wssecurity.fat.cxf.x509token;
 
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 
 import java.io.File;
 import java.util.Set;
@@ -395,7 +397,7 @@ public class CxfX509EncTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     public void testCXFClientWrongEncKeyAlgorithmEE7Only() throws Exception {
 
@@ -432,8 +434,8 @@ public class CxfX509EncTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID }) //@AV999
+    @SkipForRepeat({ NO_MODIFICATION })
+    @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientWrongEncKeyAlgorithmEE8Only() throws Exception {
 
@@ -463,7 +465,7 @@ public class CxfX509EncTests extends CommonTests {
                     // msg to send from svc client to server
                     "",
                     // expected response from server
-                    "An error was discovered processing the <wsse:Security> header", //@AV999
+                    "An error was discovered processing the <wsse:Security> header",
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
 
@@ -481,7 +483,7 @@ public class CxfX509EncTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     public void testCXFClientWrongDataEncAlgorithmEE7Only() throws Exception {
 
@@ -519,8 +521,8 @@ public class CxfX509EncTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID }) //@AV999
+    @SkipForRepeat({ NO_MODIFICATION })
+    @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientWrongDataEncAlgorithmEE8Only() throws Exception {
 
@@ -550,7 +552,7 @@ public class CxfX509EncTests extends CommonTests {
                     // msg to send from svc client to server
                     "",
                     // expected response from server
-                    "An error was discovered processing the <wsse:Security> header", //@AV999
+                    "An error was discovered processing the <wsse:Security> header",
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
 
@@ -568,7 +570,7 @@ public class CxfX509EncTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     public void testCXFClientWrongEncryptionKeyEE7Only() throws Exception {
 
@@ -612,8 +614,8 @@ public class CxfX509EncTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID }) //@AV999
+    @SkipForRepeat({ NO_MODIFICATION })
+    @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientWrongEncryptionKeyEE8Only() throws Exception {
 
@@ -644,7 +646,7 @@ public class CxfX509EncTests extends CommonTests {
                     // msg to send from svc client to server
                     "",
                     // expected response from server
-                    "Cannot find key for alias: [alice]", //@AV999
+                    "Cannot find key for alias: [alice]",
                     // msg to issue if do NOT get the expected result
                     "The test expected an exception from the server.");
 
@@ -667,8 +669,10 @@ public class CxfX509EncTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testCXFClientEncryptionBeforeSignEE7Only() throws Exception {
+
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
         genericTest(
                     // test name for logging
                     "testCXFClientEncryptionBeforeSign",
@@ -696,7 +700,7 @@ public class CxfX509EncTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientEncryptionBeforeSignEE8Only() throws Exception {
 
@@ -758,7 +762,8 @@ public class CxfX509EncTests extends CommonTests {
                 newWsdl = null;
                 newClientWsdl = null;
             }
-            restoreServer();
+            //Removed to resolve RTC 285315
+            //restoreServer();
         } catch (Exception e) {
             e.printStackTrace(System.out);
         }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509OverRideTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509OverRideTests.java
@@ -157,30 +157,8 @@ public class CxfX509OverRideTests {
     @Test
     @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    public void testCxfX50NegativeServiceEE7Only() throws Exception {
-
-        String thisMethod = "testCxfX509Service";
-
-        try {
-            testRoutine(
-                        thisMethod, //String thisMethod,
-                        "negative", // testMode: positive, positive-1, negative, negative-1....
-                        portNumber, //String portNumber,
-                        "", //String portNumberSecure
-                        "FVTVersionBAXService", //String strServiceName,
-                        "UrnX509Token" //String strServicePort
-            );
-        } catch (Exception e) {
-            throw e;
-        }
-
-        return;
-    }
-
-    @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCxfX50NegativeServiceEE8Only() throws Exception {
+    @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    public void testCxfX50NegativeService() throws Exception {
 
         String thisMethod = "testCxfX509Service";
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509SigTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509SigTests.java
@@ -11,7 +11,9 @@
 
 package com.ibm.ws.wssecurity.fat.cxf.x509token;
 
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 
 import java.io.File;
 import java.util.Set;
@@ -108,7 +110,7 @@ public class CxfX509SigTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     public void testCxfBodyNotSignedEE7Only() throws Exception {
 
@@ -143,7 +145,7 @@ public class CxfX509SigTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     public void testCxfBodyNotSignedEE8Only() throws Exception {
 
         newClientWsdl = updateClientWsdl(defaultClientWsdlLoc + "X509XmlSigNoClientSig.wsdl",
@@ -306,12 +308,10 @@ public class CxfX509SigTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     public void testCxfClientSignWithExpKeyEE7Only() throws Exception {
 
-        // use server config with expired cert
-        //reconfigServer(server.getInstallRoot().replace('\\', '/') + "/usr/servers/" + serverName + "/server_expcert.xml") ;
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_expcert.xml");
 
         genericTest(
@@ -339,13 +339,15 @@ public class CxfX509SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
 
+        //Added to resolve RTC 285315
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     public void testCxfClientSignWithExpKeyEE8Only() throws Exception {
 
-        // use server config with expired cert
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_expcert_wss4j.xml");
 
         genericTest(
@@ -372,15 +374,16 @@ public class CxfX509SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
 
+        //Added to resolve RTC 285315
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     public void testCxfClientBadClKeyStorePswdEE7Only() throws Exception {
 
-        // use server config with bad client pw
-        //reconfigServer(server.getInstallRoot().replace('\\', '/') + "/usr/servers/" + serverName + "/server_badclpwd.xml") ;
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badclpwd.xml");
 
         genericTest(
@@ -408,17 +411,14 @@ public class CxfX509SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
 
-        // restore original server config
-        //reconfigServer(server.getInstallRoot().replace('\\', '/') + "/usr/servers/" + serverName + "/server_orig.xml") ;
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
 
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     public void testCxfClientBadClKeyStorePswdEE8Only() throws Exception {
 
-        // use server config with bad client pwd
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badclpwd_wss4j.xml");
 
         genericTest(
@@ -445,20 +445,15 @@ public class CxfX509SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
 
-        // restore original server config
-        //reconfigServer(server.getInstallRoot().replace('\\', '/') + "/usr/servers/" + serverName + "/server_orig.xml") ;
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
 
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     public void testCxfClientBadSrvKeyStorePswdEE7Only() throws Exception {
 
-        // use server config with bad server pw
-
-        //reconfigServer(server.getInstallRoot().replace('\\', '/') + "/usr/servers/" + serverName + "/server_badsvrpwd.xml") ;
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badsvrpwd.xml");
 
         genericTest(
@@ -486,18 +481,16 @@ public class CxfX509SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
 
-        // restore original server config
-        //reconfigServer(server.getInstallRoot().replace('\\', '/') + "/usr/servers/" + serverName + "/server_orig.xml") ;
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
 
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
+    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfClientBadSrvKeyStorePswdEE8Only() throws Exception {
 
-        // use server config with bad server pwd
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badsvrpwd_wss4j.xml");
 
         genericTest(
@@ -520,12 +513,10 @@ public class CxfX509SigTests extends CommonTests {
                     // msg to send from svc client to server
                     "",
                     // expected response from server
-                    "Cannot create Crypto class", //@AV999
+                    "Cannot create Crypto class",
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
 
-        // restore original server config
-        //reconfigServer(server.getInstallRoot().replace('\\', '/') + "/usr/servers/" + serverName + "/server_orig.xml") ;
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
 
     }
@@ -561,7 +552,8 @@ public class CxfX509SigTests extends CommonTests {
                 newWsdl = null;
                 newClientWsdl = null;
             }
-            restoreServer();
+            //Removed to resolve RTC 285315
+            //restoreServer();
         } catch (Exception e) {
             e.printStackTrace(System.out);
         }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509StrTypeTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509StrTypeTests.java
@@ -11,7 +11,9 @@
 
 package com.ibm.ws.wssecurity.fat.cxf.x509token;
 
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 
 import java.io.File;
 import java.util.Set;
@@ -84,9 +86,6 @@ public class CxfX509StrTypeTests extends CommonTests {
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfClientSignThumbPrint() throws Exception {
 
-        // use server config with encryption keystore files
-        //reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_enc.xml");
-
         genericTest(
                     // test name for logging
                     "testCxfClientSignThumbPrint",
@@ -123,9 +122,6 @@ public class CxfX509StrTypeTests extends CommonTests {
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfClientSignIssuerSerial() throws Exception {
 
-        // use server config with encryption keystore files
-        //reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_enc.xml");
-
         genericTest(
                     // test name for logging
                     "testCxfClientSignIssuerSerial",
@@ -160,11 +156,10 @@ public class CxfX509StrTypeTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     public void testCxfClientKeysMismatchEE7Only() throws Exception {
 
-        // use server config with encryption keystore files
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badenc.xml");
 
         genericTest(
@@ -191,17 +186,15 @@ public class CxfX509StrTypeTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test did not receive the expected exception from the server.");
 
-        // restore original server config
-        // reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
 
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID }) //@AV999
+    @SkipForRepeat({ NO_MODIFICATION })
+    @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfClientKeysMismatchEE8Only() throws Exception {
 
-        // use server config with encryption keystore files
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badenc_wss4j.xml");
 
         genericTest(
@@ -228,8 +221,7 @@ public class CxfX509StrTypeTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test did not receive the expected exception from the server.");
 
-        // restore original server config
-        // reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
 
     }
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/x509migbadclient/src/com/ibm/ws/wssecurity/fat/x509migbadclient/CxfX509MigBadSvcClient.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/x509migbadclient/src/com/ibm/ws/wssecurity/fat/x509migbadclient/CxfX509MigBadSvcClient.java
@@ -96,7 +96,6 @@ public class CxfX509MigBadSvcClient extends HttpServlet {
     String methodFull = null;
     SOAPMessage soapReq = null;
 
-    //2/2021
     String errMsgVersion = "";
 
     private StringReader reqMsg = null;
@@ -173,20 +172,17 @@ public class CxfX509MigBadSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testBadCxfX509AsymIssuerSerialMigService")) {
                 service = new FatBAX02Service();
                 strExpect = "LIBERTYFAT X509 bax02";
-                //2/2021
+
                 if (errMsgVersion.equals("EE7")) {
-                    //Orig:
                     strSubErrMsg = "Cannot encrypt data"; // Because we specify Basic256 in the client. It needs JDK un-restricted Security Policy
-                    //2/2021
                     System.out.println("From CxfX509MigBadSvcClient, unlimitCryptoKeyLength:" + unlimitCryptoKeyLength);
-                    //Orig:
                     if (unlimitCryptoKeyLength) {
                         strSubErrMsg = "These policy alternatives can not be satisfied";
                     }
                 }
                 if (errMsgVersion.equals("EE8")) {
                     strSubErrMsg = "An error was discovered processing the <wsse:Security> header";
-                } //End 2/2021
+                }
             } else if (thisMethod.equals("testCxfX509IssuerSerialMigSymNoEncryptSignatureService")) {
                 service = new FatBAX03Service();
                 strExpect = "LIBERTYFAT X509 bax03";
@@ -209,33 +205,33 @@ public class CxfX509MigBadSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testCxfX509AsymProtectTokensMigService")) {
                 service = new FatBAX08Service();
                 strExpect = "LIBERTYFAT X509 bax08";
-                //2/2021
+
                 if (errMsgVersion.equals("EE7")) {
                     strSubErrMsg = "EncryptedParts: {http://schemas.xmlsoap.org/soap/envelope/}Body not ENCRYPTED"; //
                 }
                 if (errMsgVersion.equals("EE8")) {
                     strSubErrMsg = "EncryptedParts: Soap Body is not ENCRYPTED";
-                } //End 2/2021
+                }
             } else if (thisMethod.equals("testCxfX509ProtectTokensMigSymService")) {
                 service = new FatBAX09Service();
                 strExpect = "LIBERTYFAT X509 bax09";
-                //2/2021
+
                 if (errMsgVersion.equals("EE7")) {
                     strSubErrMsg = "SignedParts: {http://schemas.xmlsoap.org/soap/envelope/}Body not SIGNED";
                 }
                 if (errMsgVersion.equals("EE8")) {
                     strSubErrMsg = "SignedParts: Soap Body is not SIGNED";
-                } //End 2/2021
+                }
             } else if (thisMethod.equals("testCxfX509TransportEndorsingMigService")) {
                 service = new FatBAX10Service();
                 strExpect = "LIBERTYFAT X509 bax10";
-                //2/2021
+
                 if (errMsgVersion.equals("EE7")) {
                     strSubErrMsg = "Signature creation failed"; //"Assertion of type {http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702}HttpsToken could not be asserted";
                 }
                 if (errMsgVersion.equals("EE8")) {
                     strSubErrMsg = "list of references must contain at least one entry";
-                } //End 2/2021
+                }
             } else if (thisMethod.equals("testCxfX509TransportEndorsingSP11MigService")) {
                 service = new FatBAX11Service();
                 strExpect = "LIBERTYFAT X509 bax11";
@@ -247,13 +243,13 @@ public class CxfX509MigBadSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testCxfX509TransportEndorsingEncryptedMigService")) {
                 service = new FatBAX13Service();
                 strExpect = "LIBERTYFAT X509 bax13";
-                //2/2021
+
                 if (errMsgVersion.equals("EE7")) {
                     strSubErrMsg = "Signature creation failed"; //"Assertion of type {http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702}HttpsToken could not be asserted";
                 }
                 if (errMsgVersion.equals("EE8")) {
                     strSubErrMsg = "list of references must contain at least one entry";
-                } //End 2/2021
+                }
             } else if (thisMethod.equals("testCxfX509TransportSignedEndorsingEncryptedMigService")) {
                 service = new FatBAX14Service();
                 strExpect = "LIBERTYFAT X509 bax14";
@@ -265,13 +261,13 @@ public class CxfX509MigBadSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testCxfX509TransportKVTMigService")) {
                 service = new FatBAX16Service();
                 strExpect = "LIBERTYFAT X509 bax16";
-                //2/2021
+
                 if (errMsgVersion.equals("EE7")) {
                     strSubErrMsg = "Signature creation failed"; // "Assertion of type {http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702}HttpsToken could not be asserted";
                 }
                 if (errMsgVersion.equals("EE8")) {
                     strSubErrMsg = "Received Timestamp does not match the requirements";
-                } //End 2/2021
+                }
             } else if (thisMethod.equals("testCxfX509AsymmetricSignatureMigService")) {
                 service = new FatBAX17Service();
                 strExpect = "LIBERTYFAT X509 bax17";
@@ -292,13 +288,13 @@ public class CxfX509MigBadSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testBadWsComplexService")) {
                 service = new FatBAX21Service();
                 strExpect = "LIBERTYFAT X509 bax21";
-                //2/2021
+
                 if (errMsgVersion.equals("EE7")) {
                     strSubErrMsg = "Not signed before encrypted";
                 }
                 if (errMsgVersion.equals("EE8")) {
                     strSubErrMsg = "Not encrypted before signed";
-                } //End 2/2021
+                }
             } else if (thisMethod.equals("testBadX509KeyIdentifierUNTService")) {
                 service = new FatBAX24Service();
                 strExpect = "LIBERTYFAT X509 bax24";
@@ -330,43 +326,43 @@ public class CxfX509MigBadSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testBadBasic192Service")) {
                 service = new FatBAX31Service();
                 strExpect = "LIBERTYFAT X509 bax31";
-                //2/2021
+
                 if (errMsgVersion.equals("EE7")) {
                     strSubErrMsg = "The symmetric key length does not match the requirement"; // Test basic128 against Basic192
                 }
                 if (errMsgVersion.equals("EE8")) {
                     strSubErrMsg = "An error was discovered processing the <wsse:Security> header";
-                } //End 2/2021
+                }
             } else if (thisMethod.equals("testBadTripleDesService")) {
                 service = new FatBAX32Service();
                 strExpect = "LIBERTYFAT X509 bax32";
-                //2/2021
+
                 if (errMsgVersion.equals("EE7")) {
                     strSubErrMsg = "AsymmetricBinding: The encryption algorithm does not match the requirement";
                 }
                 if (errMsgVersion.equals("EE8")) {
                     strSubErrMsg = "An error was discovered processing the <wsse:Security> header";
-                } //End 2/2201
+                }
             } else if (thisMethod.equals("testBadInclusiveC14NService")) {
                 service = new FatBAX33Service();
                 strExpect = "LIBERTYFAT X509 bax33";
-                //2/2021
+
                 if (errMsgVersion.equals("EE7")) {
                     strSubErrMsg = "SignedSupportingTokens: The received token does not match the signed supporting token requirement";
                 }
                 if (errMsgVersion.equals("EE8")) {
                     strSubErrMsg = "BSP:R5404: Any CANONICALIZATION_METHOD Algorithm attribute MUST have a value of \"http://www.w3.org/2001/10/xml-exc-c14n#\" indicating that it uses Exclusive C14N without comments for canonicalization";
-                } //End 2/2021
+                }
             } else if (thisMethod.equals("testBadBasic128Service")) {
                 service = new FatBAX34Service();
                 strExpect = "LIBERTYFAT X509 bax34";
-                //2/2021
+
                 if (errMsgVersion.equals("EE8")) {
                     //testMode = "negative";
                     //the test method runs on EE8 as negative test
                     //newErrMsg = "BSP:R5404: Any CANONICALIZATION_METHOD Algorithm attribute MUST have a value of \"http://www.w3.org/2001/10/xml-exc-c14n#\" indicating that it uses Exclusive C14N without comments for canonicalization";
                     strSubErrMsg = "BSP:R5404: Any CANONICALIZATION_METHOD Algorithm attribute MUST have a value of \"http://www.w3.org/2001/10/xml-exc-c14n#\" indicating that it uses Exclusive C14N without comments for canonicalization";
-                } //End 2/2021
+                }
             } else if (thisMethod.equals("testBadSymmetricEndorsingUNTPolicy")) {
                 service = new FatBAX35Service();
                 strExpect = "LIBERTYFAT X509 bax35";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/x509migclient/src/com/ibm/ws/wssecurity/fat/x509migclient/CxfX509MigSvcClient.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/x509migclient/src/com/ibm/ws/wssecurity/fat/x509migclient/CxfX509MigSvcClient.java
@@ -101,7 +101,6 @@ public class CxfX509MigSvcClient extends HttpServlet {
     String methodFull = null;
     SOAPMessage soapReq = null;
 
-    //2/2021
     String errMsgVersion = "";
 
     private StringReader reqMsg = null;
@@ -175,26 +174,26 @@ public class CxfX509MigSvcClient extends HttpServlet {
             if (thisMethod.equals("testCxfX509KeyIdMigSymService")) {
                 service = new FatBAX01Service(wsdlURL, serviceName);
                 strExpect = "LIBERTYFAT X509 bax01";
-                //2/2021
+
                 if (errMsgVersion.equals("EE7")) {
                     strSubErrMsg = "The signature method does not match the requirement";
                 }
                 if (errMsgVersion.equals("EE8")) {
                     strSubErrMsg = "An error was discovered processing the <wsse:Security> header";
-                } //End 2/2021
+                }
             } else if (thisMethod.equals("testCxfX509AsymIssuerSerialMigService")) {
                 service = new FatBAX02Service(wsdlURL, serviceName);
                 strExpect = "LIBERTYFAT X509 bax02";
             } else if (thisMethod.equals("testCxfX509IssuerSerialMigSymService")) {
                 service = new FatBAX03Service(wsdlURL, serviceName);
                 strExpect = "LIBERTYFAT X509 bax03";
-                //2/2201
+
                 if (errMsgVersion.equals("EE7")) {
                     strSubErrMsg = "The signature method does not match the requirement";
                 }
                 if (errMsgVersion.equals("EE8")) {
                     strSubErrMsg = "An error was discovered processing the <wsse:Security> header";
-                } //End 2/2201
+                }
             } else if (thisMethod.equals("testCxfX509ThumbprintMigSymService")) {
                 service = new FatBAX04Service(wsdlURL, serviceName);
                 strExpect = "LIBERTYFAT X509 bax04";
@@ -220,13 +219,13 @@ public class CxfX509MigSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testCxfX509TransportEndorsingSP11MigService")) {
                 service = new FatBAX11Service(wsdlURL, serviceName);
                 strExpect = "LIBERTYFAT X509 bax11";
-                //2/2021
+
                 if (errMsgVersion.equals("EE7")) {
                     strSubErrMsg = "Assertion of type {http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702}HttpsToken could not be asserted: HttpURLConnection is not a HttpsURLConnection";
                 }
                 if (errMsgVersion.equals("EE8")) {
                     strSubErrMsg = "Assertion of type {http://schemas.xmlsoap.org/ws/2005/07/securitypolicy}HttpsToken could not be asserted: Not an HTTPs connection";
-                } //End 2/2021
+                }
             } else if (thisMethod.equals("testCxfX509TransportSignedEndorsingMigService")) {
                 service = new FatBAX12Service(wsdlURL, serviceName);
                 strExpect = "LIBERTYFAT X509 bax12";
@@ -253,13 +252,13 @@ public class CxfX509MigSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testCxfX509AsymmetricSignatureReplayMigService")) {
                 service = new FatBAX17Service(wsdlURL, serviceName);
                 strExpect = "LIBERTYFAT X509 bax17";
-                //2/2021
+
                 if (errMsgVersion.equals("EE7")) {
                     strSubErrMsg = "An invalid security token was provided (WSSecurityEngine: Invalid timestamp {0})";
                 }
                 if (errMsgVersion.equals("EE8")) {
                     strSubErrMsg = "BSP:R3227: A SECURITY_HEADER MUST NOT contain more than one TIMESTAMP";
-                } //End 2/2021
+                }
             } else if (thisMethod.equals("testCxfX509AsymmetricSignatureSP11MigService")) {
                 service = new FatBAX18Service(wsdlURL, serviceName);
                 strExpect = "LIBERTYFAT X509 bax18";
@@ -303,20 +302,17 @@ public class CxfX509MigSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testBasic192Service")) {
                 service = new FatBAX31Service(wsdlURL, serviceName);
                 strExpect = "LIBERTYFAT X509 bax31";
-                //2/2021
+
                 if (errMsgVersion.equals("EE7")) {
-                    //Orig:
                     strSubErrMsg = "Cannot encrypt data";
-                    //2/2021
                     System.out.println("From CxfX509MigSvcClient, unlimitCryptoKeyLength:" + unlimitCryptoKeyLength);
-                    //Orig:
                     if (unlimitCryptoKeyLength) {
                         strSubErrMsg = "xenc:EncryptionMethod/@Algorithm is not supported: http://www.w3.org/2001/04/xmlenc#aes192-cbc";
                     }
                 }
                 if (errMsgVersion.equals("EE8")) {
                     strSubErrMsg = "BSP:R5620: Any ED_ENCRYPTION_METHOD Algorithm attribute MUST have a value of \"http://www.w3.org/2001/04/xmlenc#tripledes-cbc\", \"http://www.w3.org/2001/04/xmlenc#aes128-cbc\" or \"http://www.w3.org/2001/04/xmlenc#aes256-cbc\"";
-                } //End 2/2021
+                }
             } else if (thisMethod.equals("testTripleDesService")) {
                 service = new FatBAX32Service(wsdlURL, serviceName);
                 strExpect = "LIBERTYFAT X509 bax32";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerUNTTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerUNTTests.java
@@ -134,7 +134,7 @@ public class CxfCallerUNTTests {
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     @Test
     public void testCxfCallerHttpPolicy() throws Exception {
-        //UpdateServerXml.reconfigServer(server, System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+
         String thisMethod = "testCxfCallerHttpPolicy";
         methodFull = "testCxfCallerHttpPolicy";
 
@@ -166,7 +166,7 @@ public class CxfCallerUNTTests {
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     @Test
     public void testCxfCallerHttpsPolicy() throws Exception {
-        //UpdateServerXml.reconfigServer(server, System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+
         String thisMethod = "testCxfCallerHttpsPolicy";
         methodFull = "testCxfCallerHttpsPolicy";
 
@@ -197,7 +197,7 @@ public class CxfCallerUNTTests {
 
     @Test
     public void testCxfCallerNoPolicy() throws Exception {
-        //UpdateServerXml.reconfigServer(server, System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+
         String thisMethod = "testCxfCallerNoPolicy";
         methodFull = "testCxfCallerNoPolicy";
 
@@ -228,7 +228,7 @@ public class CxfCallerUNTTests {
 
     @Test
     public void testCxfCallerHttpsNoUntPolicy() throws Exception {
-        //UpdateServerXml.reconfigServer(server, System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+
         String thisMethod = "testCxfCallerHttpsNoUntPolicy";
         methodFull = "testCxfCallerHttpsNoUntPolicy";
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerX509AsymTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerX509AsymTests.java
@@ -171,8 +171,6 @@ public class CxfCallerX509AsymTests {
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCallerX509TransportEndorsingPolicy() throws Exception {
-        // In case, the sequence on test cases are random... then need to unmark next line
-        //UpdateServerXml.reconfigServer(server, System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_x509_asym.xml");
 
         String thisMethod = "testCxfCallerX509TransportEndorsingPolicy";
         methodFull = "testCxfCallerX509TransportEndorsingPolicy";
@@ -206,9 +204,6 @@ public class CxfCallerX509AsymTests {
     @Test
     public void testCxfCallerHttpPolicyInX509() throws Exception {
 
-        // In case, the sequence on test cases are random... then need to unmark next line
-        //UpdateServerXml.reconfigServer(server, System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_x509_asym.xml");
-
         String thisMethod = "testCxfCallerHttpPolicy";
         methodFull = "testCxfCallerHttpPolicyInx509";
 
@@ -241,9 +236,6 @@ public class CxfCallerX509AsymTests {
     @Test
     public void testCxfCallerHttpsPolicyInx509() throws Exception {
 
-        // In case, the sequence on test cases are random... then need to unmark next line
-        //UpdateServerXml.reconfigServer(server, System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_x509_asym.xml");
-
         String thisMethod = "testCxfCallerHttpsPolicy";
         methodFull = "testCxfCallerHttpsPolicyInX509";
 
@@ -275,9 +267,6 @@ public class CxfCallerX509AsymTests {
     @Test
     public void testCxfCallerNoPolicyInX509() throws Exception {
 
-        // In case, the sequence on test cases are random... then need to unmark next line
-        //UpdateServerXml.reconfigServer(server, System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_x509_asym.xml");
-
         String thisMethod = "testCxfCallerNoPolicy";
         methodFull = "testCxfCallerNoPolicyInX509";
 
@@ -308,9 +297,6 @@ public class CxfCallerX509AsymTests {
 
     @Test
     public void testCxfCallerHttpsNoUntPolicyInX509() throws Exception {
-
-        // In case, the sequence on test cases are random... then need to unmark next line
-        //UpdateServerXml.reconfigServer(server, System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_x509_asym.xml");
 
         String thisMethod = "testCxfCallerHttpsNoUntPolicy";
         methodFull = "testCxfCallerHttpsNoUntPolicyInX509";
@@ -620,7 +606,6 @@ public class CxfCallerX509AsymTests {
             e.printStackTrace(System.out);
         }
 
-        //2/2021
         server.deleteFileFromLibertyInstallRoot("usr/extension/lib/bundles/com.ibm.ws.wssecurity.example.cbh.jar");
         server.deleteFileFromLibertyInstallRoot("usr/extension/lib/features/wsseccbh-1.0.mf");
         server.deleteFileFromLibertyInstallRoot("usr/extension/lib/bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerX509SymTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerX509SymTests.java
@@ -164,7 +164,6 @@ public class CxfCallerX509SymTests {
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCallerSymmetricEndorsingPolicyHttps() throws Exception {
-        //UpdateServerXml.reconfigServer(server, System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_x509_sym.xml");
 
         String thisMethod = "testCxfCallerSymmetricEndorsingPolicy";
         methodFull = "testCxfCallerSymmetricEndorsingPolicyHttps";
@@ -197,7 +196,7 @@ public class CxfCallerX509SymTests {
     //@Test
     // This is not a valid test for now
     public void testCxfCallerSymmetricEndorsingTLSPolicy() throws Exception {
-        //UpdateServerXml.reconfigServer(server, System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_x509_sym.xml");
+
         String thisMethod = "testCxfCallerSymmetricEndorsingTLSPolicy";
         methodFull = "testCxfCallerSymmetricEndorsingTLSPolicy";
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfDeriveKeyTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfDeriveKeyTests.java
@@ -1250,7 +1250,8 @@ public class CxfDeriveKeyTests extends CommonTests {
                 newWsdl = null;
                 newClientWsdl = null;
             }
-            restoreServer();
+            //Removed to resolve RTC 285305
+            //restoreServer();
         } catch (Exception e) {
             e.printStackTrace(System.out);
         }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfPasswordDigestTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfPasswordDigestTests.java
@@ -11,7 +11,9 @@
 
 package com.ibm.ws.wssecurity.fat.cxf.usernametoken;
 
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -214,32 +216,10 @@ public class CxfPasswordDigestTests extends CommonTests {
 
     }
 
-    //2/2021
-    //The following 4 test methods:
-    //testPWDigestCXFSvcClientBadPWOnClientSSL
-    //testPWDigestCXFSvcClientBadPWOnBothSidesSSL
-    //testPWDigestCXFSvcMissingIdInCallbackSSL
-    //testPWDigestCXFSvcClientBadIdSSL
-    //can't work with the combined exceptions:
-    //@ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException", "org.apache.wss4j.common.ext.WSSecurityException" })
-    //EE7 test will fail with [An FFDC reporting org.apache.wss4j.common.ext.WSSecurityException was expected but none was found.]
-    //EE8 test will fail with [An FFDC reporting org.apache.ws.security.WSSecurityException was expected but none was found.]
-    //So split them for EE7only an EE8only respectively
-
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    public void testPWDigestCXFSvcClientBadPWOnClientSSLEE7Only() throws Exception {
-
-        genericTest(testName.getMethodName(), clientHttpsUrl, httpsPortNumber, "user5", "UsrTokenPWDigestWebSvcSSL",
-                    couldNotAuth, "Bad password specified by the client - Expected Exception \"");
-
-    }
-
-    @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
     @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testPWDigestCXFSvcClientBadPWOnClientSSLEE8Only() throws Exception {
+    public void testPWDigestCXFSvcClientBadPWOnClientSSL() throws Exception {
 
         genericTest(testName.getMethodName(), clientHttpsUrl, httpsPortNumber, "user5", "UsrTokenPWDigestWebSvcSSL",
                     couldNotAuth, "Bad password specified by the client - Expected Exception \"");
@@ -256,19 +236,10 @@ public class CxfPasswordDigestTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    public void testPWDigestCXFSvcClientBadPWOnBothSidesSSLEE7Only() throws Exception {
-
-        genericTest(testName.getMethodName(), clientHttpsUrl, httpsPortNumber, "user3", "UsrTokenPWDigestWebSvcSSL",
-                    couldNotAuth, "Bad password specified for user3 from the client and callback - Expected Exception \"");
-
-    }
-
-    @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
     @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testPWDigestCXFSvcClientBadPWOnBothSidesSSLEE8Only() throws Exception {
+    public void testPWDigestCXFSvcClientBadPWOnBothSidesSSL() throws Exception {
 
         genericTest(testName.getMethodName(), clientHttpsUrl, httpsPortNumber, "user3", "UsrTokenPWDigestWebSvcSSL",
                     couldNotAuth, "Bad password specified for user3 from the client and callback - Expected Exception \"");
@@ -312,21 +283,10 @@ public class CxfPasswordDigestTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
-    @AllowedFFDC(value = { "java.io.IOException" }, repeatAction = { EmptyAction.ID })
+    @AllowedFFDC(value = { "java.io.IOException" }, repeatAction = { EmptyAction.ID, EE8FeatureReplacementAction.ID })
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    public void testPWDigestCXFSvcMissingIdInCallbackSSLEE7Only() throws Exception {
-
-        genericTest(testName.getMethodName(), clientHttpsUrl, httpsPortNumber, "user4", "UsrTokenPWDigestWebSvcSSL",
-                    couldNotAuth, "Callback could not return a pw for user4 - Expected Exception \"");
-
-    }
-
-    @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.io.IOException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testPWDigestCXFSvcMissingIdInCallbackSSLEE8Only() throws Exception {
+    public void testPWDigestCXFSvcMissingIdInCallbackSSL() throws Exception {
 
         genericTest(testName.getMethodName(), clientHttpsUrl, httpsPortNumber, "user4", "UsrTokenPWDigestWebSvcSSL",
                     couldNotAuth, "Callback could not return a pw for user4 - Expected Exception \"");
@@ -343,19 +303,9 @@ public class CxfPasswordDigestTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    public void testPWDigestCXFSvcClientBadIdSSLEE7Only() throws Exception {
-
-        genericTest(testName.getMethodName(), clientHttpsUrl, httpsPortNumber, "user77", "UsrTokenPWDigestWebSvcSSL",
-                    couldNotAuth, "Bad password specified for user77 in the server callback - Expected Exception \"");
-
-    }
-
-    @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
     @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testPWDigestCXFSvcClientBadIdSSLEE8Only() throws Exception {
+    public void testPWDigestCXFSvcClientBadIdSSL() throws Exception {
 
         genericTest(testName.getMethodName(), clientHttpsUrl, httpsPortNumber, "user77", "UsrTokenPWDigestWebSvcSSL",
                     couldNotAuth, "Bad password specified for user77 in the server callback - Expected Exception \"");
@@ -446,42 +396,49 @@ public class CxfPasswordDigestTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testPWDigestCXFSvcClientaltCallbackEE7Only() throws Exception {
 
-        // reconfig server
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback.xml");
 
         genericTest(testName.getMethodName(), clientHttpUrl, "", "altCallback1", "UsrTokenPWDigestWebSvc",
                     "This is WSSECFVT CXF Web Service (Password Digest)", "The " + testName.getMethodName() + " test failed - did not receive the correct response", pwdCBHVersion);
 
+        //Added to resolve RTC 285305
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+
         return;
 
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     public void testPWDigestCXFSvcClientaltCallbackEE8Only() throws Exception {
 
-        // reconfig server
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback_wss4j.xml");
 
         genericTest(testName.getMethodName(), clientHttpUrl, "", "altCallback1", "UsrTokenPWDigestWebSvc",
                     "This is WSSECFVT CXF Web Service (Password Digest)", "The " + testName.getMethodName() + " test failed - did not receive the correct response", pwdCBHVersion);
+
+        //Added to resolve RTC 285305
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+
         return;
 
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testPWDigestCXFSvcClientaltCallbackSSLEE7Only() throws Exception {
 
-        // reconfig server
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback.xml");
 
         genericTest(testName.getMethodName(), clientHttpsUrl, httpsPortNumber, "altCallback1", "UsrTokenPWDigestWebSvcSSL",
                     "This is WSSECFVT CXF Web Service with SSL (Password Digest)",
                     "The " + testName.getMethodName() + " test failed - did not receive the correct response", pwdCBHVersion);
+
+        //Added to resolve RTC 285305
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
 
         return;
 
@@ -489,39 +446,26 @@ public class CxfPasswordDigestTests extends CommonTests {
 
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     public void testPWDigestCXFSvcClientaltCallbackSSLEE8Only() throws Exception {
 
-        // reconfig server
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback_wss4j.xml");
 
         genericTest(testName.getMethodName(), clientHttpsUrl, httpsPortNumber, "altCallback1", "UsrTokenPWDigestWebSvcSSL",
                     "This is WSSECFVT CXF Web Service with SSL (Password Digest)",
                     "The " + testName.getMethodName() + " test failed - did not receive the correct response", pwdCBHVersion);
 
-        return;
-
-    }
-
-    @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
-    @ExpectedFFDC(value = { "java.io.IOException" }, repeatAction = { EmptyAction.ID })
-    public void testPWDigestCXFSvcClientaltCallbackBadUserEE7Only() throws Exception {
-
-        genericTest(testName.getMethodName(), clientHttpUrl, "", "altCallback2", "UsrTokenPWDigestWebSvc",
-                    couldNotAuth, "The " + testName.getMethodName() + " test failed - did not receive the correct response", pwdCBHVersion);
-
-        return;
-
-    }
-
-    @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @ExpectedFFDC(value = { "java.io.IOException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testPWDigestCXFSvcClientaltCallbackBadUserEE8Only() throws Exception {
-
-        //2/2021
+        //Added to resolve RTC 285305
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+
+        return;
+
+    }
+
+    @Test
+    @ExpectedFFDC(value = { "java.io.IOException" }, repeatAction = { EmptyAction.ID, EE8FeatureReplacementAction.ID })
+    public void testPWDigestCXFSvcClientaltCallbackBadUser() throws Exception {
+
         genericTest(testName.getMethodName(), clientHttpUrl, "", "altCallback2", "UsrTokenPWDigestWebSvc",
                     couldNotAuth, "The " + testName.getMethodName() + " test failed - did not receive the correct response", pwdCBHVersion);
 
@@ -530,25 +474,11 @@ public class CxfPasswordDigestTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
-    @AllowedFFDC(value = { "java.io.IOException" }, repeatAction = { EmptyAction.ID })
+    @AllowedFFDC(value = { "java.io.IOException" }, repeatAction = { EmptyAction.ID, EE8FeatureReplacementAction.ID })
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    public void testPWDigestCXFSvcClientaltCallbackBadUserSSLEE7Only() throws Exception {
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    public void testPWDigestCXFSvcClientaltCallbackBadUserSSL() throws Exception {
 
-        genericTest(testName.getMethodName(), clientHttpsUrl, httpsPortNumber, "altCallback2", "UsrTokenPWDigestWebSvcSSL",
-                    couldNotAuth, "The " + testName.getMethodName() + " test failed - did not receive the correct response", pwdCBHVersion);
-
-        return;
-
-    }
-
-    @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.io.IOException", "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testPWDigestCXFSvcClientaltCallbackBadUserSSLEE8Only() throws Exception {
-
-        //2/2021
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
         genericTest(testName.getMethodName(), clientHttpsUrl, httpsPortNumber, "altCallback2", "UsrTokenPWDigestWebSvcSSL",
                     couldNotAuth, "The " + testName.getMethodName() + " test failed - did not receive the correct response", pwdCBHVersion);
 
@@ -591,45 +521,51 @@ public class CxfPasswordDigestTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testPWDigestCXFSvcClientClCallbackInServerXmlEE7Only() throws Exception {
 
-        // reconfig server
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback.xml");
 
         genericTest(testName.getMethodName(), clientHttpUrl, "", "user88", "UsrTokenPWDigestWebSvc",
                     "This is WSSECFVT CXF Web Service (Password Digest)",
                     "The " + testName.getMethodName() + " test failed - did not receive the correct response");
 
+        //Added to resolve RTC 285305
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+
         return;
 
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     public void testPWDigestCXFSvcClientClCallbackInServerXmlEE8Only() throws Exception {
 
-        // reconfig server
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback_wss4j.xml");
 
         genericTest(testName.getMethodName(), clientHttpUrl, "", "user88", "UsrTokenPWDigestWebSvc",
                     "This is WSSECFVT CXF Web Service (Password Digest)",
                     "The " + testName.getMethodName() + " test failed - did not receive the correct response");
 
+        //Added to resolve RTC 285305
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+
         return;
 
     }
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testPWDigestCXFSvcClientClCallbackInServerXmlSSLEE7Only() throws Exception {
 
-        // reconfig server
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback.xml");
 
         genericTest(testName.getMethodName(), clientHttpUrl, httpsPortNumber, "user88", "UsrTokenPWDigestWebSvcSSL",
                     "This is WSSECFVT CXF Web Service with SSL (Password Digest)",
                     "The " + testName.getMethodName() + " test failed - did not receive the correct response");
+
+        //Added to resolve RTC 285305
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
 
         return;
 
@@ -637,15 +573,17 @@ public class CxfPasswordDigestTests extends CommonTests {
 
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     public void testPWDigestCXFSvcClientClCallbackInServerXmlSSLEE8Only() throws Exception {
 
-        // reconfig server
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback_wss4j.xml");
 
         genericTest(testName.getMethodName(), clientHttpUrl, httpsPortNumber, "user88", "UsrTokenPWDigestWebSvcSSL",
                     "This is WSSECFVT CXF Web Service with SSL (Password Digest)",
                     "The " + testName.getMethodName() + " test failed - did not receive the correct response");
+
+        //Added to resolve RTC 285305
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
 
         return;
 
@@ -658,7 +596,6 @@ public class CxfPasswordDigestTests extends CommonTests {
                                                 defaultClientWsdlLoc + "UsrTokenPWDigestWebSvcNoHashUpdated.wsdl");
         Log.info(thisClass, "testPWDigestCXFSvcClientClNoHash", "Using " + newClientWsdl);
 
-        //2/2021
         genericTest(testName.getMethodName(), clientHttpUrl, "", "user1", "UsrTokenPWDigestWebSvc", newClientWsdl,
                     "[Password hashing policy not enforced]", "The " + testName.getMethodName() + " test failed - did not receive the correct response", pwdCBHVersion);
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfSSLUNTNonceTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfSSLUNTNonceTests.java
@@ -142,7 +142,7 @@ public class CxfSSLUNTNonceTests extends SSLTestCommon {
      *
      */
 
-    @Test
+    //@Test  //EE7 not needed
     @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     public void testCxfUntOldExtFutureTimestampSSLEE7Only() throws Exception {
@@ -165,7 +165,7 @@ public class CxfSSLUNTNonceTests extends SSLTestCommon {
     @Test
     @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException", "java.net.MalformedURLException" },
                  repeatAction = { JakartaEE9Action.ID })
-    public void testCxfUntOldExtFutureTimestampSSLEE9Only() throws Exception {
+    public void testCxfUntOldExtFutureTimestampSSL() throws Exception {
 
         genericTest(
                     "testCxfUntOldExtFutureTimestampSSLEE9Only",
@@ -216,7 +216,7 @@ public class CxfSSLUNTNonceTests extends SSLTestCommon {
      *
      */
 
-    @Test
+    //@Test  //EE7 not needed
     @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     public void testCxfUntReqTimestampMissingSSLEE7Only() throws Exception {
@@ -238,7 +238,7 @@ public class CxfSSLUNTNonceTests extends SSLTestCommon {
 
     @Test
     @AllowedFFDC(value = { "java.util.MissingResourceException", "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { JakartaEE9Action.ID })
-    public void testCxfUntReqTimestampMissingSSLEE9Only() throws Exception {
+    public void testCxfUntReqTimestampMissingSSL() throws Exception {
 
         genericTest(
                     "testCxfUntReqTimestampMissingSSLEE9Only",
@@ -311,7 +311,7 @@ public class CxfSSLUNTNonceTests extends SSLTestCommon {
      *
      */
 
-    @Test
+    //@Test //EE7 not needed
     @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     public void testCxfUntReplaySSLEE7Only() throws Exception {
@@ -324,11 +324,11 @@ public class CxfSSLUNTNonceTests extends SSLTestCommon {
 
     @Test
     @AllowedFFDC(value = { "java.util.MissingResourceException", "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { JakartaEE9Action.ID })
-    public void testCxfUntReplaySSLEE9Only() throws Exception {
+    public void testCxfUntReplaySSL() throws Exception {
 
         genericTest("testCxfUntReplaySSLEE9Only", untSSLClientUrl, portNumberSecure,
                     "user1", "security", "FVTVersionBA7Service", "UrnBasicPlcyBA7",
-                    "true", "", replayAttackNew, //@AV999
+                    "true", "", replayAttackNew,
                     "Second call to FVTVersionBA7Service should have failed");
     }
 
@@ -344,7 +344,7 @@ public class CxfSSLUNTNonceTests extends SSLTestCommon {
      *
      */
 
-    @Test
+    //@Test //EE7 not needed
     @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     public void testCxfUntHardcodedReplaySSLEE7Only() throws Exception {
@@ -357,7 +357,7 @@ public class CxfSSLUNTNonceTests extends SSLTestCommon {
 
     @Test
     @AllowedFFDC(value = { "java.util.MissingResourceException", "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { JakartaEE9Action.ID })
-    public void testCxfUntHardcodedReplaySSLEE9Only() throws Exception {
+    public void testCxfUntHardcodedReplaySSL() throws Exception {
 
         genericTest("testCxfUntHardcodedReplaySSLEE9Only", untSSLClientUrl, portNumberSecure,
                     "user1", "security", "FVTVersionBA7Service", "UrnBasicPlcyBA7",

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfSSLUNTNonceTimeOutTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfSSLUNTNonceTimeOutTests.java
@@ -103,15 +103,12 @@ public class CxfSSLUNTNonceTimeOutTests extends SSLTestCommon {
     @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfUntHardcodedReplayOneAndMoreMinutesSSL() throws Exception {
 
-        //reconfigAndRestartServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_customize.xml");
         genericTest("testCxfUntReplayOneAndMoreMinutesSSL", untSSLClientUrl, portNumberSecure,
                     "user1", "security", "FVTVersionBA7Service", "UrnBasicPlcyBA7",
                     "true", "",
                     "Response: WSSECFVT FVTVersion_ba07",
                     "The test expected a succesful message from the server.");
-        // Make sure the server.xml is set back to server_orig.xml
-        // This will be done by next test case: TwoAndMoreMinutes
-        // reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+
     }
 
     /**
@@ -131,14 +128,12 @@ public class CxfSSLUNTNonceTimeOutTests extends SSLTestCommon {
     @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     public void testCxfUntHardcodedReplayTwoAndMoreMinutesSSL() throws Exception {
-        // Make sure the server.xml is set to server_customize.xml
-        // This was done by previous test: OneAndMoreMinutes
-        //  reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_customize.xml");
+
         genericTest("testCxfUntReplayTwoAndMoreMinutesSSL", untSSLClientUrl, portNumberSecure,
                     "user1", "security", "FVTVersionBA6Service", "UrnBasicPlcyBA6",
                     "true", "", msgExpires,
                     "Second call to FVTVersionBA6Service should have failed");
-        //reconfigAndRestartServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+
     }
 
 }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfWssTemplatesTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfWssTemplatesTests.java
@@ -11,7 +11,9 @@
 
 package com.ibm.ws.wssecurity.fat.cxf.usernametoken;
 
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 
 import java.io.File;
 
@@ -53,7 +55,7 @@ public class CxfWssTemplatesTests extends CommonTests {
     @Test
     @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFUserNameTokenPasswordHashOverSSL() throws Exception {
-        // reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_enchdr.xml");
+
         genericTest(
                     // test name for logging
                     "testCXFUserNameTokenPasswordHashOverSSL",
@@ -180,7 +182,7 @@ public class CxfWssTemplatesTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testCXFUsernameTokenAsEndorsingAndX509SymmetricEE7Only() throws Exception {
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym.xml");
         genericTest(
@@ -206,11 +208,15 @@ public class CxfWssTemplatesTests extends CommonTests {
                     "Response: This is WSSTemplateWebSvc3 Web Service.",
                     // msg to issue if do NOT get the expected result
                     "The test expected a successful message from the server.");
+
+        //Added to resolve RTC 285305
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+
     }
 
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     public void testCXFUsernameTokenAsEndorsingAndX509SymmetricEE8Only() throws Exception {
 
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym_wss4j.xml");
@@ -237,6 +243,10 @@ public class CxfWssTemplatesTests extends CommonTests {
                     "Response: This is WSSTemplateWebSvc3 Web Service.",
                     // msg to issue if do NOT get the expected result
                     "The test expected a successful message from the server.");
+
+        //Added to resolve RTC 285305
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+
     }
 
     /**
@@ -253,7 +263,7 @@ public class CxfWssTemplatesTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testCXFX509SymmetricAndEndorsingEE7Only() throws Exception {
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym.xml");
         genericTest(
@@ -279,11 +289,15 @@ public class CxfWssTemplatesTests extends CommonTests {
                     "Response: This is WSSTemplateWebSvc5 Web Service.",
                     // msg to issue if do NOT get the expected result
                     "The test expected a successful message from the server.");
+
+        //Added to resolve RTC 285305
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+
     }
 
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     public void testCXFX509SymmetricAndEndorsingEE8Only() throws Exception {
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym_wss4j.xml");
         genericTest(
@@ -309,6 +323,10 @@ public class CxfWssTemplatesTests extends CommonTests {
                     "Response: This is WSSTemplateWebSvc5 Web Service.",
                     // msg to issue if do NOT get the expected result
                     "The test expected a successful message from the server.");
+
+        //Added to resolve RTC 285305
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+
     }
 
     /**
@@ -332,7 +350,7 @@ public class CxfWssTemplatesTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
+    @SkipForRepeat({ EE8_FEATURES })
     public void testCXFX509SymmetricForMessageAndUntForClientEE7Only() throws Exception {
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym.xml");
         genericTest(
@@ -358,11 +376,15 @@ public class CxfWssTemplatesTests extends CommonTests {
                     "Response: This is WSSTemplateWebSvc6 Web Service.",
                     // msg to issue if do NOT get the expected result
                     "The test expected a successful message from the server.");
+
+        //Added to resolve RTC 285305
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+
     }
 
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+    @SkipForRepeat({ NO_MODIFICATION })
     public void testCXFX509SymmetricForMessageAndUntForClientEE8Only() throws Exception {
 
         reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym_wss4j.xml");
@@ -389,6 +411,10 @@ public class CxfWssTemplatesTests extends CommonTests {
                     "Response: This is WSSTemplateWebSvc6 Web Service.",
                     // msg to issue if do NOT get the expected result
                     "The test expected a successful message from the server.");
+
+        //Added to resolve RTC 285305
+        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+
     }
 
 }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/SSLTestCommon.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/SSLTestCommon.java
@@ -50,7 +50,6 @@ import componenttest.topology.impl.LibertyServer;
 public class SSLTestCommon {
 
     static private final Class<?> thisClass = SSLTestCommon.class;
-    //Added 10/2020
     static final private String serverName = "com.ibm.ws.wssecurity_fat.ssl";
     @Server(serverName)
 
@@ -78,12 +77,10 @@ public class SSLTestCommon {
     final static String badHttpsToken = "HttpsToken could not be asserted";
     final static String badHttpsClientCert = "Could not send Message.";
     final static String replayAttack = "An error happened processing a Username Token \"A replay attack has been detected\"";
-    //2/2021
-    final static String replayAttackNew = "An error happened processing a Username Token: \"A replay attack has been detected\""; //@AV999
 
+    final static String replayAttackNew = "An error happened processing a Username Token: \"A replay attack has been detected\"";
     final static String timestampReqButMissing = "An invalid security token was provided (WSSecurityEngine: Invalid timestamp";
-    //2/2021
-    final static String morethanOneTimestamp = "BSP:R3227: A SECURITY_HEADER MUST NOT contain more than one TIMESTAMP"; //@AV999
+    final static String morethanOneTimestamp = "BSP:R3227: A SECURITY_HEADER MUST NOT contain more than one TIMESTAMP";
 
     // "RequireClientCertificate is set, but no local certificates were negotiated.";
 
@@ -106,7 +103,6 @@ public class SSLTestCommon {
     public static void setUp() throws Exception {
         //String thisMethod = "setup";
 
-        //Added 10/2020
         ShrinkHelper.defaultDropinApp(server, "untsslclient", "com.ibm.ws.wssecurity.fat.untsslclient", "fats.cxf.basicssl.wssec", "fats.cxf.basicssl.wssec.types");
         ShrinkHelper.defaultDropinApp(server, "untoken", "com.ibm.ws.wssecurity.fat.untoken");
 
@@ -115,9 +111,6 @@ public class SSLTestCommon {
 
     protected static void initServer() throws Exception {
         String thisMethod = "initServer";
-
-        //commented out 10/16/2020, it's deprecated in CL and does not exist in OL
-        //HttpUtils.enableSSLv3();
 
         Log.info(thisClass, "initServer", "before server.startServer() inside SSLTestCommon");
         server.startServer();// will check CWWKS0008I: The security service is ready.
@@ -292,7 +285,6 @@ public class SSLTestCommon {
         System.err.println("*****************************" + strMethod);
     }
 
-    //4/2021
     public static void copyServerXml(String copyFromFile) throws Exception {
 
         try {

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/publish/servers/com.ibm.ws.wssecurity_fat.pwdigest/server_withClCallback.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/publish/servers/com.ibm.ws.wssecurity_fat.pwdigest/server_withClCallback.xml
@@ -73,15 +73,6 @@
 	>
 	</wsSecurityProvider>
 
-        <!-- orig from CL
-	<wsSecurityClient
-		id="default"
-		ws-security.password="security"
-		ws-security.username="user22"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.fat.pwdigest.ClientPWDigestCallbackHandler"
-	>
-        -->
-        <!-- update to work on OL using client package -->
         <wsSecurityClient
 		id="default"
 		ws-security.password="security"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/publish/servers/com.ibm.ws.wssecurity_fat.pwdigest/server_withClCallback_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/publish/servers/com.ibm.ws.wssecurity_fat.pwdigest/server_withClCallback_wss4j.xml
@@ -73,25 +73,13 @@
 		ws-security.return.security.error="true"
 	>
 	</wsSecurityProvider>
-	<!-- 3/2021 added ws-security.return.security.error -->
-    <!-- 2/2021 EE8 callbackhandler -->
     
-        <!-- orig from CL
-	<wsSecurityClient
-		id="default"
-		ws-security.password="security"
-		ws-security.username="user22"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.fat.pwdigest.ClientPWDigestCallbackHandler"
-	>
-        -->
-        <!-- update to work on OL using client package -->
         <wsSecurityClient
 		id="default"
 		ws-security.password="security"
 		ws-security.username="user22"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.fat.pwdigestclient.ClientPWDigestCallbackHandlerWss4j"
 	>
-    <!-- 2/2021 EE8 callbackhandler -->
     
 	</wsSecurityClient>
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/publish/servers/com.ibm.ws.wssecurity_fat.pwdigest/server_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/publish/servers/com.ibm.ws.wssecurity_fat.pwdigest/server_wss4j.xml
@@ -70,8 +70,6 @@
 		ws-security.return.security.error="true"
 	>
 	</wsSecurityProvider>
-	<!-- 3/2021 added ws-security.return.security.error -->
-    <!-- 2/2021 EE8 callbackhandler -->
     
 	<wsSecurityClient
 		id="default"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/test-applications/pwdigest/src/com/ibm/ws/wssecurity/fat/pwdigest/PWDigestCallbackHandlerWss4j.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/test-applications/pwdigest/src/com/ibm/ws/wssecurity/fat/pwdigest/PWDigestCallbackHandlerWss4j.java
@@ -39,9 +39,9 @@ public class PWDigestCallbackHandlerWss4j implements CallbackHandler {
 
     @Override
     public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-        System.out.println("in Handle of server callback");
+        System.out.println("in Handle of server callback-wss4j");
         for (int i = 0; i < callbacks.length; i++) {
-            System.out.println("Server Callback processing");
+            System.out.println("Server Callback-wss4j processing");
             WSPasswordCallback pc = (WSPasswordCallback) callbacks[i];
 
             String pass = passwords.get(pc.getIdentifier());

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/test-applications/pwdigestclient/src/com/ibm/ws/wssecurity/fat/pwdigestclient/AltClientPWDigestCallbackHandlerWss4j.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/test-applications/pwdigestclient/src/com/ibm/ws/wssecurity/fat/pwdigestclient/AltClientPWDigestCallbackHandlerWss4j.java
@@ -32,9 +32,9 @@ public class AltClientPWDigestCallbackHandlerWss4j implements CallbackHandler {
 
     @Override
     public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-        System.out.println("in Handle of alternate client callback");
+        System.out.println("in Handle of alternate client callback-wss4j");
         for (int i = 0; i < callbacks.length; i++) {
-            System.out.println("Alternate Client Callback processing");
+            System.out.println("Alternate Client Callback-wss4j processing");
             WSPasswordCallback pc = (WSPasswordCallback) callbacks[i];
 
             String pass = passwords.get(pc.getIdentifier());

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/test-applications/pwdigestclient/src/com/ibm/ws/wssecurity/fat/pwdigestclient/ClientPWDigestCallbackHandlerWss4j.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/test-applications/pwdigestclient/src/com/ibm/ws/wssecurity/fat/pwdigestclient/ClientPWDigestCallbackHandlerWss4j.java
@@ -39,9 +39,9 @@ public class ClientPWDigestCallbackHandlerWss4j implements CallbackHandler {
 
     @Override
     public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-        System.out.println("in Handle of client callback");
+        System.out.println("in Handle of client callback-wss4j");
         for (int i = 0; i < callbacks.length; i++) {
-            System.out.println("Client Callback processing");
+            System.out.println("Client Callback-wss4j processing");
             WSPasswordCallback pc = (WSPasswordCallback) callbacks[i];
 
             String pass = passwords.get(pc.getIdentifier());

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/test-applications/pwdigestclient/src/com/ibm/ws/wssecurity/fat/pwdigestclient/CxfUntPWDigestSvcClient.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/test-applications/pwdigestclient/src/com/ibm/ws/wssecurity/fat/pwdigestclient/CxfUntPWDigestSvcClient.java
@@ -77,7 +77,6 @@ public class CxfUntPWDigestSvcClient extends HttpServlet {
         String clientWsdlFile = request.getParameter("clientWsdl");
         String theWsdl = request.getParameter("theWsdl");
 
-        //2/2021
         String pwdCBHVersion = request.getParameter("pwdCallBackhandlerVersion");
 
         // set default WSDL parms
@@ -187,7 +186,7 @@ public class CxfUntPWDigestSvcClient extends HttpServlet {
             Map<String, Object> requestContext = dispSOAPMsg.getRequestContext();
 
             System.out.println("setTheId: " + setTheId);
-            //2/2021
+
             System.out.println("pwdCBHVersion: " + pwdCBHVersion);
 
             // Set username token in reqcontext for non-ibm clients.
@@ -223,21 +222,11 @@ public class CxfUntPWDigestSvcClient extends HttpServlet {
             if (setTheId.equals("NoIdBadPw")) {
                 requestContext.put("ws-security.password", "BadPW22");
             }
-            /*
-             * orig from CL
-             * if (setTheId.equals("altCallback1")) {
-             * requestContext.put("ws-security.username", "user2");
-             * requestContext.put("ws-security.password", "security"); //@av
-             * requestContext
-             * .put("ws-security.callback-handler",
-             * "com.ibm.ws.wssecurity.fat.pwdigest.AltClientPWDigestCallbackHandler");
-             * }
-             */
-            //Added 11/2020 to use client package pwdigestclient.AltClientPWDigestCallbackHandler
+
             if (setTheId.equals("altCallback1")) {
                 requestContext.put("ws-security.username", "user2");
                 requestContext.put("ws-security.password", "security");
-                //2/2021
+
                 if (pwdCBHVersion.equals("EE7")) {
                     requestContext.put("ws-security.callback-handler",
                                        "com.ibm.ws.wssecurity.fat.pwdigestclient.AltClientPWDigestCallbackHandler");
@@ -245,19 +234,9 @@ public class CxfUntPWDigestSvcClient extends HttpServlet {
                 if (pwdCBHVersion.equals("EE8")) {
                     requestContext.put("ws-security.callback-handler",
                                        "com.ibm.ws.wssecurity.fat.pwdigestclient.AltClientPWDigestCallbackHandlerWss4j");
-                } //End 2/2021
+                }
             }
 
-            /*
-             * orig from CL
-             * if (setTheId.equals("altCallback2")) {
-             * requestContext.put("ws-security.username", "user4");
-             * requestContext
-             * .put("ws-security.callback-handler",
-             * "com.ibm.ws.wssecurity.fat.pwdigest.AltClientPWDigestCallbackHandler");
-             * }
-             */
-            //Added 11/2020 to use client package pwdigestclient.AltClientPWDigestCallbackHandler
             if (setTheId.equals("altCallback2")) {
                 requestContext.put("ws-security.username", "user4");
                 if (pwdCBHVersion.equals("EE7")) {
@@ -267,7 +246,7 @@ public class CxfUntPWDigestSvcClient extends HttpServlet {
                 if (pwdCBHVersion.equals("EE8")) {
                     requestContext.put("ws-security.callback-handler",
                                        "com.ibm.ws.wssecurity.fat.pwdigestclient.AltClientPWDigestCallbackHandlerWss4j");
-                } //End 2/2021
+                }
             }
 
             if (setTheId.equals("badCallback")) {


### PR DESCRIPTION
To fix RTC defects 285305, 285315, where the common issue is server config mis-matched when the test methods are executed in a random order.  The mis-match meant the EE8 required callbackhandler class is not available due to the restoreServer() restores to EE7 server.xml.

 Update 3 FAT: com.ibm.ws.wssecurity_fat.wsscxf, com.ibm.ws.wssecurity_fat.wsscxf.1, com.ibm.ws.wssecurity.fat.utils.common
1. Remove restoreServer() (invoked by endTest()) from CommonTest.java in com.ibm.ws.wssecurity.fat.utils.common project
2. Remove restoreServer() (invoked by endTest() from several test classes of 2 wsscxf fat projects
3. Add reconfigServer() to return to the original server config for the tests which contain reconfigServer() for initial server update 
4. Misc.: Add AllowedFDC (MalformedExc), remove comments, etc.

