### PR TITLE
grpc_fat SecureHelloWorldTest fix server.xml configuration

### DIFF
--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ClientHeaderPropagationTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ClientHeaderPropagationTests.java
@@ -93,6 +93,10 @@ public class ClientHeaderPropagationTests extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
+        // Setting serverConfigurationFile to null forces a server.xml update (when GrpcTestUtils.setServerConfiguration() is first called) on the repeat run
+        // If not set to null, test failures may occur (since the incorrect server.xml could be used)
+        serverConfigurationFile = null;
+
         // Stop the server
         if (GrpcServer != null && GrpcServer.isStarted()) {
             GrpcServer.stopServer();

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ClientInterceptorTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ClientInterceptorTests.java
@@ -106,6 +106,10 @@ public class ClientInterceptorTests extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
+        // Setting serverConfigurationFile to null forces a server.xml update (when GrpcTestUtils.setServerConfiguration() is first called) on the repeat run
+        // If not set to null, test failures may occur (since the incorrect server.xml could be used)
+        serverConfigurationFile = null;
+
         Exception excep = null;
         GrpcTestUtils.stopGrpcService(worldChannel);
 

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldCDITests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldCDITests.java
@@ -72,6 +72,10 @@ public class HelloWorldCDITests extends HelloWorldBasicTest {
 
     @AfterClass
     public static void tearDown() throws Exception {
+        // Setting serverConfigurationFile to null forces a server.xml update (when GrpcTestUtils.setServerConfiguration() is first called) on the repeat run
+        // If not set to null, test failures may occur (since the incorrect server.xml could be used)
+        serverConfigurationFile = null;
+
         if (helloWorldServer != null && helloWorldServer.isStarted()) {
             helloWorldServer.stopServer();
         }

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldTlsTest.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldTlsTest.java
@@ -76,6 +76,10 @@ public class HelloWorldTlsTest extends HelloWorldBasicTest {
 
     @AfterClass
     public static void tearDown() throws Exception {
+        // Setting serverConfigurationFile to null forces a server.xml update (when GrpcTestUtils.setServerConfiguration() is first called) on the repeat run
+        // If not set to null, test failures may occur (since the incorrect server.xml could be used)
+        serverConfigurationFile = null;
+
         // SRVE0777E: for testHelloWorldWithTlsInvalidClientTrustStore case
         // CWWKO0801E: for testHelloWorldWithTlsInvalidClientTrustStore case
         //     Unable to initialize SSL connection. Unauthorized access was denied or security settings have expired.

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/SecureHelloWorldTest.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/SecureHelloWorldTest.java
@@ -98,7 +98,6 @@ public class SecureHelloWorldTest extends HelloWorldBasicTest {
     @MinimumJavaLevel(javaLevel = 9)
     public void testSecureHelloWorldWithTls() throws Exception {
         serverConfigurationFile = GrpcTestUtils.setServerConfiguration(secureHelloWorldServer, serverConfigurationFile, DEFAULT_CONFIG_FILE, clientAppName, LOG);
-
         String response = runHelloWorldTlsTest();
         assertTrue("the gRPC request did not complete correctly", response.contains("us3r2"));
     }
@@ -112,13 +111,9 @@ public class SecureHelloWorldTest extends HelloWorldBasicTest {
     @Test
     @AllowedFFDC("io.grpc.StatusRuntimeException")
     public void testSecureHelloWorldWOTls() throws Exception {
-        Exception clientException = null;
-
-        // make a backup of the original configuration so we can restore it later
-        RemoteFile backup = new RemoteFile(secureHelloWorldServer.getMachine(), new File(secureHelloWorldServer.getServerRoot(), "server-backup.xml").getPath());
-        backup.copyFromSource(secureHelloWorldServer.getServerConfigurationFile());
-
+        // set <grpcClient ... usePlaintext="true" /> to disable the Liberty TLS config on the client
         serverConfigurationFile = GrpcTestUtils.setServerConfiguration(secureHelloWorldServer, serverConfigurationFile, SECURITY_PLAIN_TEXT, clientAppName, LOG);
+        Exception clientException = null;
         try {
             runHelloWorldTest();
         } catch (Exception e) {
@@ -126,8 +121,5 @@ public class SecureHelloWorldTest extends HelloWorldBasicTest {
             Log.info(c, name.getMethodName(), "exception caught: " + e);
         }
         assertTrue("An error is expected for this case", clientException != null);
-
-        // restore the original configuration
-        GrpcTestUtils.setServerConfiguration(secureHelloWorldServer, backup, clientAppName, LOG);
     }
 }

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/SecureHelloWorldTest.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/SecureHelloWorldTest.java
@@ -74,6 +74,10 @@ public class SecureHelloWorldTest extends HelloWorldBasicTest {
 
     @AfterClass
     public static void tearDown() throws Exception {
+        // Setting serverConfigurationFile to null forces a server.xml update (when GrpcTestUtils.setServerConfiguration() is first called) on the repeat run
+        // If not set to null, test failures may occur (since the incorrect server.xml could be used)
+        serverConfigurationFile = null;
+
         // SRVE0777E for testSecureHelloWorldWOTls case
         secureHelloWorldServer.stopServer("SRVE0777E", "CWWKE1102W", "CWWKE1107W", "CWWKE1106W");
     }

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ServiceConfigTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ServiceConfigTests.java
@@ -101,6 +101,10 @@ public class ServiceConfigTests extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
+        // Setting serverConfigurationFile to null forces a server.xml update (when GrpcTestUtils.setServerConfiguration() is first called) on the repeat run
+        // If not set to null, test failures may occur (since the incorrect server.xml could be used)
+        serverConfigurationFile = null;
+
         GrpcTestUtils.stopGrpcService(worldChannel);
         // The testInvalidMaxInboundMessageSize() test generates this log message, don't flag it as an error
         // CWWKT0203E: The maxInboundMessageSize -1 is not valid. Sizes must greater than 0.

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ServiceInterceptorTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ServiceInterceptorTests.java
@@ -90,6 +90,10 @@ public class ServiceInterceptorTests extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
+        // Setting serverConfigurationFile to null forces a server.xml update (when GrpcTestUtils.setServerConfiguration() is first called) on the repeat run
+        // If not set to null, test failures may occur (since the incorrect server.xml could be used)
+        serverConfigurationFile = null;
+
         GrpcTestUtils.stopGrpcService(worldChannel);
         grpcServer.stopServer("CWWKT0202W");
     }


### PR DESCRIPTION
The fix made in #14072 added logic to backup and then restore the original server.xml config that gets changed for `testSecureHelloWorldWithTls()`. That restore logic is unnecessary - the helper util `GrpcTestUtils.setServerConfiguration()` covers server.xml maintenance for all grpc_fat tests. The EE9 text re-execution logic added in #17568 causes `testSecureHelloWorldWithTls()` to get executed a second time, after the restore logic has run, so the correct server.xml is sometimes not set. 