### PR TITLE
Remove service filters for testcontainer buckets

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/FATSuite.java
@@ -35,11 +35,6 @@ public class FATSuite {
     //switching between local and remote docker hosts.
     static {
         ExternalTestServiceDockerClientStrategy.setupTestcontainers();
-
-        // Filter out any external docker servers in the 'libhpike' cluster
-        ExternalTestServiceDockerClientStrategy.serviceFilter = (svc) -> {
-            return !svc.getAddress().contains("libhpike-dockerengine");
-        };
     }
 
     // Updated docker image to use TLS1.2 for secure communication

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/FATSuite.java
@@ -42,11 +42,6 @@ public class FATSuite {
     //switching between local and remote docker hosts.
     static {
         ExternalTestServiceDockerClientStrategy.setupTestcontainers();
-
-        // Filter out any external docker servers in the 'libhpike' cluster
-        ExternalTestServiceDockerClientStrategy.serviceFilter = (svc) -> {
-            return !svc.getAddress().contains("libhpike-dockerengine");
-        };
     }
 
     public static final boolean REUSE_CONTAINERS = FATRunner.FAT_TEST_LOCALRUN && !ExternalTestServiceDockerClientStrategy.USE_REMOTE_DOCKER_HOST;

--- a/dev/fattest.simplicity/src/componenttest/containers/ExternalTestServiceDockerClientStrategy.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/ExternalTestServiceDockerClientStrategy.java
@@ -47,6 +47,13 @@ public class ExternalTestServiceDockerClientStrategy extends DockerClientProvide
 
     private static final Class<?> c = ExternalTestServiceDockerClientStrategy.class;
 
+    @Deprecated
+    /**
+     * Use of a service filter should be used with extreme caution.
+     * There is a possibility of filtering out all available docker engines available to a build machine.
+     * Resulting in an unavoidable failed FAT bucket.
+     * If certain docker engines are performing poorly please raise an issue.
+     */
     public static Predicate<ExternalTestService> serviceFilter = null;
 
     /**


### PR DESCRIPTION
Remove service filtering for JDBC buckets to ensure that they do not accidentally filter out the only docker-engine machines they can run against. 