### PR TITLE
Disable access token cache for re-auth jaxrs tests

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/publish/files/serversettings/oidcClientReAuthnConfig.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/publish/files/serversettings/oidcClientReAuthnConfig.xml
@@ -36,6 +36,7 @@
 		tokenEndpointUrl="http://localhost:${bvt.prop.security_1_HTTP_default}/oidc/endpoint/OidcConfigSample_AccessTokenShortLifetime/token"
 		jwkEndpointUrl="${oidcJWKValidationURL_PT_ShortLifetime}"
 		signatureAlgorithm="${oidcSignAlg}"
+		accessTokenCacheEnabled="false"
 		authFilterRef="rp_accessTokenShortLifetime_reAuthnTrue_noCushion_Filter" />
 
 
@@ -61,6 +62,7 @@
 		tokenEndpointUrl="http://localhost:${bvt.prop.security_1_HTTP_default}/oidc/endpoint/OidcConfigSample_IDTokenShortLifetime/token"
 		jwkEndpointUrl="${oidcJWKValidationURL_ID_ShortLifetime}"
 		signatureAlgorithm="${oidcSignAlg}"
+		accessTokenCacheEnabled="false"
 		authFilterRef="rp_idTokenShortLifetime_reAuthnTrue_noCushion_Filter" />
 
 
@@ -86,6 +88,7 @@
 		tokenEndpointUrl="http://localhost:${bvt.prop.security_1_HTTP_default}/oidc/endpoint/OidcConfigSample_BothShortLifetime/token"
 		jwkEndpointUrl="${oidcJWKValidationURL_Both_ShortLifetime}"
 		signatureAlgorithm="${oidcSignAlg}"
+		accessTokenCacheEnabled="false"
 		authFilterRef="rp_bothShortLifetime_reAuthnTrue_noCushion_Filter" />
 
 
@@ -113,6 +116,7 @@
 		tokenEndpointUrl="http://localhost:${bvt.prop.security_1_HTTP_default}/oidc/endpoint/OidcConfigSample_AccessTokenShortLifetime/token"
 		jwkEndpointUrl="${oidcJWKValidationURL_PT_ShortLifetime}"
 		signatureAlgorithm="${oidcSignAlg}"
+		accessTokenCacheEnabled="false"
 		authFilterRef="rp_accessTokenShortLifetime_reAuthnFalse_noCushion_Filter" />
 
 
@@ -138,6 +142,7 @@
 		tokenEndpointUrl="http://localhost:${bvt.prop.security_1_HTTP_default}/oidc/endpoint/OidcConfigSample_IDTokenShortLifetime/token"
 		jwkEndpointUrl="${oidcJWKValidationURL_ID_ShortLifetime}"
 		signatureAlgorithm="${oidcSignAlg}"
+		accessTokenCacheEnabled="false"
 		authFilterRef="rp_idTokenShortLifetime_reAuthnFalse_noCushion_Filter" />
 
 
@@ -163,6 +168,7 @@
 		tokenEndpointUrl="http://localhost:${bvt.prop.security_1_HTTP_default}/oidc/endpoint/OidcConfigSample_BothShortLifetime/token"
 		jwkEndpointUrl="${oidcJWKValidationURL_Both_ShortLifetime}"
 		signatureAlgorithm="${oidcSignAlg}"
+		accessTokenCacheEnabled="false"
 		authFilterRef="rp_bothShortLifetime_reAuthnFalse_noCushion_Filter" />
 
 
@@ -192,6 +198,7 @@
 		tokenEndpointUrl="http://localhost:${bvt.prop.security_1_HTTP_default}/oidc/endpoint/OidcConfigSample_AccessTokenShortLifetime/token"
 		jwkEndpointUrl="${oidcJWKValidationURL_PT_ShortLifetime}"
 		signatureAlgorithm="${oidcSignAlg}"
+		accessTokenCacheEnabled="false"
 		authFilterRef="rp_accessTokenShortLifetime_reAuthnTrue_withCushion_Filter" />
 
 
@@ -217,6 +224,7 @@
 		tokenEndpointUrl="http://localhost:${bvt.prop.security_1_HTTP_default}/oidc/endpoint/OidcConfigSample_IDTokenShortLifetime/token"
 		jwkEndpointUrl="${oidcJWKValidationURL_ID_ShortLifetime}"
 		signatureAlgorithm="${oidcSignAlg}"
+		accessTokenCacheEnabled="false"
 		authFilterRef="rp_idTokenShortLifetime_reAuthnTrue_withCushion_Filter" />
 
 
@@ -242,6 +250,7 @@
 		tokenEndpointUrl="http://localhost:${bvt.prop.security_1_HTTP_default}/oidc/endpoint/OidcConfigSample_BothShortLifetime/token"
 		jwkEndpointUrl="${oidcJWKValidationURL_Both_ShortLifetime}"
 		signatureAlgorithm="${oidcSignAlg}"
+		accessTokenCacheEnabled="false"
 		authFilterRef="rp_bothShortLifetime_reAuthnTrue_withCushion_Filter" />
 
 
@@ -271,6 +280,7 @@
 		tokenEndpointUrl="http://localhost:${bvt.prop.security_1_HTTP_default}/oidc/endpoint/OidcConfigSample_AccessTokenShortLifetime/token"
 		jwkEndpointUrl="${oidcJWKValidationURL_PT_ShortLifetime}"
 		signatureAlgorithm="${oidcSignAlg}"
+		accessTokenCacheEnabled="false"
 		authFilterRef="rp_accessTokenShortLifetime_reAuthnFalse_withCushion_Filter" />
 
 
@@ -296,6 +306,7 @@
 		tokenEndpointUrl="http://localhost:${bvt.prop.security_1_HTTP_default}/oidc/endpoint/OidcConfigSample_IDTokenShortLifetime/token"
 		jwkEndpointUrl="${oidcJWKValidationURL_ID_ShortLifetime}"
 		signatureAlgorithm="${oidcSignAlg}"
+		accessTokenCacheEnabled="false"
 		authFilterRef="rp_idTokenShortLifetime_reAuthnFalse_withCushion_Filter" />
 
 
@@ -321,6 +332,7 @@
 		tokenEndpointUrl="http://localhost:${bvt.prop.security_1_HTTP_default}/oidc/endpoint/OidcConfigSample_BothShortLifetime/token"
 		jwkEndpointUrl="${oidcJWKValidationURL_Both_ShortLifetime}"
 		signatureAlgorithm="${oidcSignAlg}"
+		accessTokenCacheEnabled="false"
 		authFilterRef="rp_bothShortLifetime_reAuthnFalse_withCushion_Filter" />
 
 
@@ -349,6 +361,7 @@
 		tokenEndpointUrl="http://localhost:${bvt.prop.security_1_HTTP_default}/oidc/endpoint/OidcConfigSample_BothLongLifetime/token"
 		jwkEndpointUrl="${oidcJWKValidationURL_Both_LongLifetime}"
 		signatureAlgorithm="${oidcSignAlg}"
+		accessTokenCacheEnabled="false"
 		authFilterRef="rp_bothLongLifetime_reAuthnTrue_noCushion_Filter" />
 
 	<authFilter id="rp_bothLongLifetime_reAuthnFalse_noCushion_Filter">
@@ -373,6 +386,7 @@
 		tokenEndpointUrl="http://localhost:${bvt.prop.security_1_HTTP_default}/oidc/endpoint/OidcConfigSample_BothLongLifetime/token"
 		jwkEndpointUrl="${oidcJWKValidationURL_Both_LongLifetime}"
 		signatureAlgorithm="${oidcSignAlg}"
+		accessTokenCacheEnabled="false"
 		authFilterRef="rp_bothLongLifetime_reAuthnFalse_noCushion_Filter" />
 
 	<authFilter id="rp_bothLongLifetime_reAuthnTrue_withCushion_Filter">
@@ -397,6 +411,7 @@
 		tokenEndpointUrl="http://localhost:${bvt.prop.security_1_HTTP_default}/oidc/endpoint/OidcConfigSample_BothLongLifetime/token"
 		jwkEndpointUrl="${oidcJWKValidationURL_Both_LongLifetime}"
 		signatureAlgorithm="${oidcSignAlg}"
+		accessTokenCacheEnabled="false"
 		authFilterRef="rp_bothLongLifetime_reAuthnTrue_withCushion_Filter" />
 
 	<authFilter id="rp_bothLongLifetime_reAuthnFalse_withCushion_Filter">
@@ -421,6 +436,7 @@
 		tokenEndpointUrl="http://localhost:${bvt.prop.security_1_HTTP_default}/oidc/endpoint/OidcConfigSample_BothLongLifetime/token"
 		jwkEndpointUrl="${oidcJWKValidationURL_Both_LongLifetime}"
 		signatureAlgorithm="${oidcSignAlg}"
+		accessTokenCacheEnabled="false"
 		authFilterRef="rp_bothLongLifetime_reAuthnFalse_withCushion_Filter" />
 
 
@@ -451,6 +467,7 @@
 		tokenEndpointUrl="http://localhost:${bvt.prop.security_1_HTTP_default}/oidc/endpoint/OidcConfigSample_BothShortLifetime/token"
 		jwkEndpointUrl="${oidcJWKValidationURL_Both_ShortLifetime}"
 		signatureAlgorithm="${oidcSignAlg}"
+		accessTokenCacheEnabled="false"
 		authFilterRef="rp_disableLtpaCookieFalse_bothShortLifetime_reAuthnTrue_withCushion_Filter" />
 
 

--- a/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/publish/files/serversettings/oidcRSClientReAuthnConfig.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/publish/files/serversettings/oidcRSClientReAuthnConfig.xml
@@ -35,6 +35,7 @@
 		jwkEndpointUrl="${oidcJWKValidationURL_PT_ShortLifetime}"
 		signatureAlgorithm="${oidcSignAlg}"
 		clockSkew="2s"
+		accessTokenCacheEnabled="false"
 		authFilterRef="rs_accessTokenShortLifetime_Filter" />
 
 
@@ -63,6 +64,7 @@
 		jwkEndpointUrl="${oidcJWKValidationURL_ID_ShortLifetime}"
 		signatureAlgorithm="${oidcSignAlg}"
 		clockSkew="2s"
+		accessTokenCacheEnabled="false"
 		authFilterRef="rs_idTokenShortLifetime_Filter" />
 
 
@@ -91,6 +93,7 @@
 		jwkEndpointUrl="${oidcJWKValidationURL_Both_ShortLifetime}"
 		signatureAlgorithm="${oidcSignAlg}"
 		clockSkew="2s"
+		accessTokenCacheEnabled="false"
 		authFilterRef="rs_bothShortLifetime_Filter" />
 
 
@@ -119,6 +122,7 @@
 		jwkEndpointUrl="${oidcJWKValidationURL_Both_LongLifetime}"
 		signatureAlgorithm="${oidcSignAlg}"
 		clockSkew="2s"
+		accessTokenCacheEnabled="false"
 		authFilterRef="rs_bothLongLifetime_Filter" />
 
 </server>


### PR DESCRIPTION
We've recently added support for an inbound access token cache.  For the tests that are trying to test when we're required to re-authenticate, the new cache can cause problems.
We have tests that will validate the caching behavior - these tests need to focus on token lifetimes, so, we will disable the new cache.
