### PR TITLE
Issue 18083: Address review comments for rename, trace checks

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/ApacheDSandKDC.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/ApacheDSandKDC.java
@@ -80,6 +80,7 @@ public class ApacheDSandKDC {
 
     public static String BASE_DN = LdapKerberosUtils.BASE_DN; // default, override in extending class
 
+    /* The Domain needs to be capitalized for Kerberos, but not necessarily for LDAP. */
     public static String DOMAIN = LdapKerberosUtils.DOMAIN; // default, override in extending class
 
     public static String WHICH_FAT = "LDAP"; // default, override in extending class. options: {LDAP, SPNEGO}

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/CommonBindTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/CommonBindTest.java
@@ -164,11 +164,11 @@ public class CommonBindTest {
     }
 
     /**
-     * A series of "Basics" that all the variations of config should pass, good login, bad login, isvalid, getusers/getgroups.
+     * Variations that should pass for all Ldap bindAuth configs, good login, bad login, isvalid, getusers/getgroups.
      *
      * @throws Exception
      */
-    public void baselineTests() throws Exception {
+    public void baselineLoginAndGetTests() throws Exception {
         String methodName = "baselineTests";
         Log.info(c, methodName, "Checking good credentials");
         loginUser();
@@ -219,7 +219,7 @@ public class CommonBindTest {
     }
 
     /**
-     * Run a checkpassword on a basic user from the ApacheDS server.
+     * Run a checkpassword on a user from the ApacheDS server.
      *
      * @throws Exception
      */
@@ -229,7 +229,7 @@ public class CommonBindTest {
     }
 
     /**
-     * Run a checkpassword on a basic user from the ApacheDS server, but expect it to fail. This
+     * Run a checkpassword on a user from the ApacheDS server, but expect it to fail. This
      * could fail with a null user or an exception.
      */
     public void loginUserShouldFail() throws Exception {
@@ -246,20 +246,20 @@ public class CommonBindTest {
     }
 
     /**
-     * Run a checkpassword on a basic user from the UnboundID server.
+     * Run a checkpassword on a user from the UnboundID server.
      *
      * @throws Exception
      */
-    public void loginUserUnboundID() throws Exception {
+    public void assertLoginUserUnboundID() throws Exception {
         assertDNsEqual("Authentication should succeed for " + UNBOUNDID_USER,
                        UNBOUNDID_USER_DN, servlet.checkPassword(UNBOUNDID_USER, UNBOUNDID_PWD));
     }
 
     /**
-     * Run a checkpassword on a basic user from the UnboundID server, but expect it to fail. This
+     * Run a checkpassword on a user from the UnboundID server, but expect it to fail. This
      * could fail with a null user or an exception.
      */
-    public void loginUserShouldFailUnboundID() throws Exception {
+    public void assertLoginUserShouldFailUnboundID() throws Exception {
         try {
             String dnReturned = servlet.checkPassword(UNBOUNDID_USER, UNBOUNDID_USER);
             if (dnReturned == null) {
@@ -348,14 +348,14 @@ public class CommonBindTest {
         ApacheDSandKDC.stopAllServers();
 
         Log.info(c, testName.getMethodName(), "With allowOp=false, both registries should fail to login");
-        loginUserShouldFailUnboundID();
+        assertLoginUserShouldFailUnboundID();
         loginUserShouldFail();
 
         Log.info(c, testName.getMethodName(), "Start all of the ApacheDS servers");
         ApacheDSandKDC.startAllServers();
 
         Log.info(c, testName.getMethodName(), "After apacheDS restart, all logins should succeed.");
-        loginUserUnboundID();
+        assertLoginUserUnboundID();
         loginUser();
     }
 
@@ -380,13 +380,13 @@ public class CommonBindTest {
         // Stop ApacheDS, with default behavior, we should not fail on the other registry
         ApacheDSandKDC.stopAllServers();
 
-        loginUserUnboundID();
+        assertLoginUserUnboundID();
         loginUserShouldFail();
 
         // Start Apache DS, should succeed
         ApacheDSandKDC.startAllServers();
 
-        loginUserUnboundID();
+        assertLoginUserUnboundID();
         loginUser();
 
     }
@@ -401,7 +401,7 @@ public class CommonBindTest {
     }
 
     /**
-     * Return a basic LdapRegistry with the default ticketCacheFile, caches and context pool disabled
+     * Return an LdapRegistry element with the default ticketCacheFile, caches and context pool disabled
      *
      * @return
      */
@@ -410,7 +410,7 @@ public class CommonBindTest {
     }
 
     /**
-     * Return a basic LdapRegistry with the default ticketCacheFile, caches and context pool enabled
+     * Return an LdapRegistry element with the default ticketCacheFile, caches and context pool enabled
      *
      * @return
      */
@@ -419,7 +419,7 @@ public class CommonBindTest {
     }
 
     /**
-     * Return a basic LdapRegistry with the default ticketCacheFile, context pool enabled and caches disabled
+     * Return an LdapRegistry element with the default ticketCacheFile, context pool enabled and caches disabled
      *
      * @return
      */
@@ -428,21 +428,21 @@ public class CommonBindTest {
     }
 
     /**
-     * Return a basic LdapRegistry with the krb5Principal, ready to add a keytab to the Kerberos config, caches and context pool disabled
+     * Return an LdapRegistry element with the krb5Principal, ready to add a keytab to the Kerberos config, caches and context pool disabled
      *
      * @return
      */
     protected LdapRegistry getLdapRegistryForKeytab() {
-        return LdapKerberosUtils.getKrb5PrincipalNameWithoutContextPool(ldapServerHostName, LDAP_PORT);
+        return LdapKerberosUtils.getLdapRegistryWithKrb5EnabledWithoutContextPool(ldapServerHostName, LDAP_PORT);
     }
 
     /**
-     * Return a basic LdapRegistry with the krb5Principal, ready to add a keytab to the Kerberos config, caches and context pool disabled
+     * Return an LdapRegistry element with the krb5Principal, ready to add a keytab to the Kerberos config, caches and context pool disabled
      *
      * @return
      */
     protected LdapRegistry getLdapRegistryForKeytabWithContextPool() {
-        return LdapKerberosUtils.getKrb5PrincipalName(ldapServerHostName, LDAP_PORT, false, false);
+        return LdapKerberosUtils.getLdapRegistryWithKrb5Enabled(ldapServerHostName, LDAP_PORT, false, false);
     }
 
     /**
@@ -451,7 +451,7 @@ public class CommonBindTest {
      *
      * @throws Exception
      */
-    public void bodyOfRestartServer() throws Exception {
+    public void innerRestartApacheServersTest() throws Exception {
         loginUser();
 
         Log.info(c, testName.getMethodName(), "Stop all of the ApacheDS servers");

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/KeytabBindLongRunTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/KeytabBindLongRunTest.java
@@ -60,7 +60,7 @@ public class KeytabBindLongRunTest extends CommonBindTest {
         newServer.getLdapRegistries().add(ldap);
         updateConfigDynamically(server, newServer);
 
-        bodyOfRestartServer();
+        innerRestartApacheServersTest();
     }
 
     /**
@@ -80,6 +80,6 @@ public class KeytabBindLongRunTest extends CommonBindTest {
         newServer.getLdapRegistries().add(ldap);
         updateConfigDynamically(server, newServer);
 
-        bodyOfRestartServer();
+        innerRestartApacheServersTest();
     }
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/KeytabBindMultiRegistryTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/KeytabBindMultiRegistryTest.java
@@ -70,7 +70,7 @@ public class KeytabBindMultiRegistryTest extends CommonBindTest {
 
             Log.info(c, testName.getMethodName(), "Since allowOp=false, expected logins on both Ldap repos to fail");
             loginUserShouldFail();
-            loginUserShouldFailUnboundID();
+            assertLoginUserShouldFailUnboundID();
 
             Log.info(c, testName.getMethodName(), "Update to valid keytab");
             kerb.keytab = keytabFile;
@@ -78,7 +78,7 @@ public class KeytabBindMultiRegistryTest extends CommonBindTest {
 
             Log.info(c, testName.getMethodName(), "Both registries should login again successfully");
             loginUser();
-            loginUserUnboundID();
+            assertLoginUserUnboundID();
 
         } finally {
             stopUnboundIDLdapServer();
@@ -111,7 +111,7 @@ public class KeytabBindMultiRegistryTest extends CommonBindTest {
 
             Log.info(c, testName.getMethodName(), "Since allowOp=false, expected login to fail on the Keberos Ldap and succeed on the simple bind Ldap");
             loginUserShouldFail();
-            loginUserUnboundID();
+            assertLoginUserUnboundID();
 
             Log.info(c, testName.getMethodName(), "Update to valid keytab");
             kerb.keytab = keytabFile;
@@ -119,7 +119,7 @@ public class KeytabBindMultiRegistryTest extends CommonBindTest {
 
             Log.info(c, testName.getMethodName(), "Both registries should login successfully");
             loginUser();
-            loginUserUnboundID();
+            assertLoginUserUnboundID();
         } finally {
             stopUnboundIDLdapServer();
         }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/KeytabBindTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/KeytabBindTest.java
@@ -59,15 +59,17 @@ public class KeytabBindTest extends CommonBindTest {
      */
     @Test
     @CheckForLeakedPasswords(LdapKerberosUtils.BIND_PASSWORD)
-    public void basicLoginChecks() throws Exception {
-        Log.info(c, testName.getMethodName(), "Run basic login checks with a standard configuration");
+    public void loginChecks() throws Exception {
+        Log.info(c, testName.getMethodName(), "Run login checks with a standard configuration");
         ServerConfiguration newServer = emptyConfiguration.clone();
         LdapRegistry ldap = getLdapRegistryForKeytab();
         addKerberosConfigAndKeytab(newServer);
         newServer.getLdapRegistries().add(ldap);
         updateConfigDynamically(server, newServer);
 
-        baselineTests();
+        baselineLoginAndGetTests();
+
+        assertFalse("Should have run through setKerberosCredentials", server.findStringsInLogsAndTrace("setKerberosCredentials").isEmpty());
     }
 
     /**
@@ -78,15 +80,15 @@ public class KeytabBindTest extends CommonBindTest {
      */
     @Test
     @CheckForLeakedPasswords(LdapKerberosUtils.BIND_PASSWORD)
-    public void basicLoginChecksWithContextPool() throws Exception {
-        Log.info(c, testName.getMethodName(), "Run basic login checks with a standard configuration");
+    public void loginChecksWithContextPool() throws Exception {
+        Log.info(c, testName.getMethodName(), "Run login checks with a standard configuration");
         ServerConfiguration newServer = emptyConfiguration.clone();
         LdapRegistry ldap = getLdapRegistryForKeytabWithContextPool();
         addKerberosConfigAndKeytab(newServer);
         newServer.getLdapRegistries().add(ldap);
         updateConfigDynamically(server, newServer);
 
-        baselineTests();
+        baselineLoginAndGetTests();
     }
 
     /**
@@ -235,7 +237,7 @@ public class KeytabBindTest extends CommonBindTest {
     @CheckForLeakedPasswords(LdapKerberosUtils.BIND_PASSWORD)
     public void keytabDefinedInConfig() throws Exception {
         assumeTrue(FATRunner.FAT_TEST_LOCALRUN); // Remote build wasn't picking up the keytab set in the config, despite using the same keytab for all the other keytab tests
-        Log.info(c, testName.getMethodName(), "Run basic login checks with the keytab defined in the krb5config file");
+        Log.info(c, testName.getMethodName(), "Run login checks with the keytab defined in the krb5config file");
         ServerConfiguration newServer = emptyConfiguration.clone();
         LdapRegistry ldap = getLdapRegistryForKeytab();
         String altConfigFile = ApacheDSandKDC.createConfigFile("keyTabInConfig-", KDC_PORT, true, true);
@@ -244,7 +246,7 @@ public class KeytabBindTest extends CommonBindTest {
         newServer.getLdapRegistries().add(ldap);
         updateConfigDynamically(server, newServer);
 
-        baselineTests();
+        baselineLoginAndGetTests();
     }
 
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/Krb5ConfigTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/Krb5ConfigTest.java
@@ -59,7 +59,7 @@ public class Krb5ConfigTest extends CommonBindTest {
      */
     @Test
     @CheckForLeakedPasswords(LdapKerberosUtils.BIND_PASSWORD)
-    public void basicLoginChecksConfigJVM_TicketCache() throws Exception {
+    public void loginChecksConfigJVM_TicketCache() throws Exception {
         Log.info(c, testName.getMethodName(), "Run basic login checks with a standard configuration");
         ServerConfiguration newServer = emptyConfiguration.clone();
         LdapRegistry ldap = getLdapRegistryWithTicketCache();
@@ -67,7 +67,7 @@ public class Krb5ConfigTest extends CommonBindTest {
         newServer.getLdapRegistries().add(ldap);
         updateConfigDynamically(server, newServer);
 
-        baselineTests();
+        baselineLoginAndGetTests();
     }
 
     /**
@@ -79,7 +79,7 @@ public class Krb5ConfigTest extends CommonBindTest {
      */
     @Test
     @CheckForLeakedPasswords(LdapKerberosUtils.BIND_PASSWORD)
-    public void basicLoginChecksConfigJVM_keytab() throws Exception {
+    public void loginChecksConfigJVM_keytab() throws Exception {
         Log.info(c, testName.getMethodName(), "Run basic login checks with a standard configuration");
         ServerConfiguration newServer = emptyConfiguration.clone();
         LdapRegistry ldap = getLdapRegistryForKeytab();
@@ -87,7 +87,7 @@ public class Krb5ConfigTest extends CommonBindTest {
         newServer.getLdapRegistries().add(ldap);
         updateConfigDynamically(server, newServer);
 
-        baselineTests();
+        baselineLoginAndGetTests();
     }
 
     /**

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/LdapApacheDSandKDC.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/LdapApacheDSandKDC.java
@@ -52,7 +52,7 @@ public class LdapApacheDSandKDC extends ApacheDSandKDC {
 
         setupService();
 
-        addBasicUserAndGroup();
+        addApplicationUserAndGroup();
     }
 
     @AfterClass
@@ -64,8 +64,8 @@ public class LdapApacheDSandKDC extends ApacheDSandKDC {
      * Add a starter user and group for general servlet login and searches
      *
      */
-    public static void addBasicUserAndGroup() throws Exception {
-        Log.info(c, "addBasicUserAndGroup", "Adding basic user and group");
+    public static void addApplicationUserAndGroup() throws Exception {
+        Log.info(c, "addApplicationUserAndGroup", "Adding basic user and group");
         Entry entry = directoryService.newEntry(new Dn(vmmUser1DN));
         entry.add("objectclass", "inetorgperson");
         entry.add("uid", vmmUser1);
@@ -78,7 +78,7 @@ public class LdapApacheDSandKDC extends ApacheDSandKDC {
         entry.add("objectclass", "groupOfNames");
         entry.add("member", vmmUser1DN);
         session.add(entry);
-        Log.info(c, "addBasicUserAndGroup", "Adding basic user and group");
+        Log.info(c, "addApplicationUserAndGroup", "Adding basic user and group");
     }
 
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/SimpleBindTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/SimpleBindTest.java
@@ -56,19 +56,19 @@ public class SimpleBindTest extends CommonBindTest {
      */
     @Test
     @CheckForLeakedPasswords(LdapKerberosUtils.BIND_PASSWORD)
-    public void basicLoginChecksForSimple() throws Exception {
-        Log.info(c, testName.getMethodName(), "Run basic login checks with bindAuthMechanism set to simple");
+    public void loginChecksForSimple() throws Exception {
+        Log.info(c, testName.getMethodName(), "Run login checks with bindAuthMechanism set to simple");
 
         ServerConfiguration newServer = emptyConfiguration.clone();
         LdapRegistry ldap = getLdapRegistryWithSimpleBind();
         newServer.getLdapRegistries().add(ldap);
         updateConfigDynamically(server, newServer);
 
-        baselineTests();
+        baselineLoginAndGetTests();
     }
 
     /**
-     * et bindAuthMechanism to something invalid
+     * Set bindAuthMechanism to something invalid
      *
      * @throws Exception
      */
@@ -93,8 +93,8 @@ public class SimpleBindTest extends CommonBindTest {
      */
     @Test
     @CheckForLeakedPasswords(LdapKerberosUtils.BIND_PASSWORD)
-    public void basicLoginChecksSimple_withoutBindAuth() throws Exception {
-        Log.info(c, testName.getMethodName(), "Run basic login checks with no bindAuthMechanism set.");
+    public void loginChecksSimple_withoutBindAuth() throws Exception {
+        Log.info(c, testName.getMethodName(), "Run login checks with no bindAuthMechanism set.");
 
         ServerConfiguration newServer = emptyConfiguration.clone();
         LdapRegistry ldap = getLdapRegistryWithSimpleBind();
@@ -102,7 +102,7 @@ public class SimpleBindTest extends CommonBindTest {
         newServer.getLdapRegistries().add(ldap);
         updateConfigDynamically(server, newServer);
 
-        baselineTests();
+        baselineLoginAndGetTests();
     }
 
     /**
@@ -112,8 +112,8 @@ public class SimpleBindTest extends CommonBindTest {
      */
     @AllowedFFDC("javax.naming.NoPermissionException")
     @Test
-    public void basicLoginChecksNoneBindAuth() throws Exception {
-        Log.info(c, testName.getMethodName(), "Run basic login checks with bindAuthMech of none, with and without allowing anon access.");
+    public void loginChecksNoneBindAuth() throws Exception {
+        Log.info(c, testName.getMethodName(), "Run login checks with bindAuthMech of none, with and without allowing anon access.");
 
         DirectoryService ds = ApacheDSandKDC.getDirectoryService();
         assertNotNull("DirectoryService is null, cannot update anon access.", ds);
@@ -129,14 +129,14 @@ public class SimpleBindTest extends CommonBindTest {
             newServer.getLdapRegistries().add(ldap);
             updateConfigDynamically(server, newServer);
 
-            Log.info(c, testName.getMethodName(), "Basic login should be successful with bindAuth=none, allowed by DirectoryService.");
-            baselineTests();
+            Log.info(c, testName.getMethodName(), "Login should be successful with bindAuth=none, allowed by DirectoryService.");
+            baselineLoginAndGetTests();
         } finally {
             Log.info(c, testName.getMethodName(), "Updating DirectoryService to block anonymous bind.");
             ds.setAllowAnonymousAccess(false);
         }
 
-        Log.info(c, testName.getMethodName(), "Basic logins should fail with bindAuth=none, blocked by DirectoryService.");
+        Log.info(c, testName.getMethodName(), "Logins should fail with bindAuth=none, blocked by DirectoryService.");
         loginUserShouldFail();
     }
 
@@ -147,8 +147,8 @@ public class SimpleBindTest extends CommonBindTest {
      */
     @AllowedFFDC("javax.naming.NoPermissionException")
     @Test
-    public void basicLoginChecksNone_withoutBindAuth() throws Exception {
-        Log.info(c, testName.getMethodName(), "Run basic login checks with none implied, with allowing anon access.");
+    public void loginChecksNone_withoutBindAuth() throws Exception {
+        Log.info(c, testName.getMethodName(), "Run login checks with none implied, with allowing anon access.");
 
         DirectoryService ds = ApacheDSandKDC.getDirectoryService();
         assertNotNull("DirectoryService is null, cannot update anon access.", ds);
@@ -164,14 +164,14 @@ public class SimpleBindTest extends CommonBindTest {
             newServer.getLdapRegistries().add(ldap);
             updateConfigDynamically(server, newServer);
 
-            Log.info(c, testName.getMethodName(), "Basic login should be successful with bindAuth=none, allowed by DirectoryService.");
-            baselineTests();
+            Log.info(c, testName.getMethodName(), "Login should be successful with bindAuth=none, allowed by DirectoryService.");
+            baselineLoginAndGetTests();
         } finally {
             Log.info(c, testName.getMethodName(), "Updating DirectoryService to block anonymous bind.");
             ds.setAllowAnonymousAccess(false);
         }
 
-        Log.info(c, testName.getMethodName(), "Basic logins should fail with bindAuth=none, blocked by DirectoryService.");
+        Log.info(c, testName.getMethodName(), "Logins should fail with bindAuth=none, blocked by DirectoryService.");
         loginUserShouldFail();
     }
 
@@ -181,7 +181,7 @@ public class SimpleBindTest extends CommonBindTest {
      * @return
      */
     private LdapRegistry getLdapRegistryWithSimpleBind() {
-        return LdapKerberosUtils.getSimpleBind(ldapServerHostName, LDAP_PORT);
+        return LdapKerberosUtils.getLdapRegistryWithSimpleBind(ldapServerHostName, LDAP_PORT);
     }
 
     /**

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindLongRunTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindLongRunTest.java
@@ -64,7 +64,7 @@ public class TicketCacheBindLongRunTest extends CommonBindTest {
         newServer.getLdapRegistries().add(ldap);
         updateConfigDynamically(server, newServer);
 
-        bodyOfRestartServer();
+        innerRestartApacheServersTest();
     }
 
     /**
@@ -84,7 +84,7 @@ public class TicketCacheBindLongRunTest extends CommonBindTest {
         newServer.getLdapRegistries().add(ldap);
         updateConfigDynamically(server, newServer);
 
-        bodyOfRestartServer();
+        innerRestartApacheServersTest();
     }
 
     /**

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindMultiRegistryTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindMultiRegistryTest.java
@@ -71,7 +71,7 @@ public class TicketCacheBindMultiRegistryTest extends CommonBindTest {
 
             Log.info(c, testName.getMethodName(), "Since allowOp=false, expected logins on both Ldap repos to fail");
             loginUserShouldFail();
-            loginUserShouldFailUnboundID();
+            assertLoginUserShouldFailUnboundID();
 
             Log.info(c, testName.getMethodName(), "Update to valid TicketCache");
             resetTicketCache(ldap);
@@ -79,7 +79,7 @@ public class TicketCacheBindMultiRegistryTest extends CommonBindTest {
 
             Log.info(c, testName.getMethodName(), "Both registries should login again successfully");
             loginUser();
-            loginUserUnboundID();
+            assertLoginUserUnboundID();
         } finally {
             stopUnboundIDLdapServer();
         }
@@ -112,7 +112,7 @@ public class TicketCacheBindMultiRegistryTest extends CommonBindTest {
 
             Log.info(c, testName.getMethodName(), "Since allowOp=false, expected login to fail on the Keberos Ldap and succeed on the simple bind Ldap");
             loginUserShouldFail();
-            loginUserUnboundID();
+            assertLoginUserUnboundID();
 
             Log.info(c, testName.getMethodName(), "Update to valid TicketCache");
             resetTicketCache(ldap);
@@ -120,7 +120,7 @@ public class TicketCacheBindMultiRegistryTest extends CommonBindTest {
 
             Log.info(c, testName.getMethodName(), "Both registries should login successfully");
             loginUser();
-            loginUserUnboundID();
+            assertLoginUserUnboundID();
         } finally {
             stopUnboundIDLdapServer();
         }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindTest.java
@@ -66,7 +66,9 @@ public class TicketCacheBindTest extends CommonBindTest {
         newServer.getLdapRegistries().add(ldap);
         updateConfigDynamically(server, newServer);
 
-        baselineTests();
+        baselineLoginAndGetTests();
+
+        assertFalse("Should have run through setKerberosCredentials", server.findStringsInLogsAndTrace("setKerberosCredentials").isEmpty());
     }
 
     /**
@@ -84,7 +86,7 @@ public class TicketCacheBindTest extends CommonBindTest {
         newServer.getLdapRegistries().add(ldap);
         updateConfigDynamically(server, newServer);
 
-        baselineTests();
+        baselineLoginAndGetTests();
     }
 
     /**

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/utils/LdapKerberosUtils.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/utils/LdapKerberosUtils.java
@@ -83,7 +83,7 @@ public class LdapKerberosUtils {
     public static LdapRegistry getTicketCache(String hostname, int port, String ticketCacheFile, boolean disableContextPool, boolean disableCaches) {
         LdapRegistry ldap = new LdapRegistry();
 
-        getBasicsLdapRegistry(ldap, hostname, port, disableContextPool, disableCaches);
+        getLdapRegistryElement(ldap, hostname, port, disableContextPool, disableCaches);
         ldap.setBindAuthMechanism(ConfigConstants.CONFIG_BIND_AUTH_KRB5);
         ldap.setKrb5Principal(BIND_PRINCIPAL_NAME);
         ldap.setKrb5TicketCache(ticketCacheFile);
@@ -95,27 +95,27 @@ public class LdapKerberosUtils {
     }
 
     /**
-     * Get a basic LdapRegistry with Kerberos and krb5Principal name, contextpool and caches disables
+     * Get an LdapRegistry element with Kerberos enabled, krb5Principal name set, contextpool and caches disables
      *
      * @param hostname
      * @param port
      * @return
      */
-    public static LdapRegistry getKrb5PrincipalNameWithoutContextPool(String hostname, int port) {
-        return getKrb5PrincipalName(hostname, port, true, true);
+    public static LdapRegistry getLdapRegistryWithKrb5EnabledWithoutContextPool(String hostname, int port) {
+        return getLdapRegistryWithKrb5Enabled(hostname, port, true, true);
     }
 
     /**
-     * Get a basic LdapRegistry with Kerberos and krb5Principal name, contextpool and caches can be enabled or disabled
+     * Get an LdapRegistry element with Kerberos enabled and krb5Principal name, contextpool and caches can be enabled or disabled
      *
      * @param hostname
      * @param port
      * @param disableCaches
      * @return
      */
-    public static LdapRegistry getKrb5PrincipalName(String hostname, int port, boolean disableContextPool, boolean disableCaches) {
+    public static LdapRegistry getLdapRegistryWithKrb5Enabled(String hostname, int port, boolean disableContextPool, boolean disableCaches) {
         LdapRegistry ldap = new LdapRegistry();
-        getBasicsLdapRegistry(ldap, hostname, port, disableContextPool, disableCaches);
+        getLdapRegistryElement(ldap, hostname, port, disableContextPool, disableCaches);
         ldap.setBindAuthMechanism(ConfigConstants.CONFIG_BIND_AUTH_KRB5);
         ldap.setKrb5Principal(BIND_PRINCIPAL_NAME);
 
@@ -124,14 +124,14 @@ public class LdapKerberosUtils {
     }
 
     /**
-     * Get an LdapRegistry with simple bindAuthmech and Bind DN and Bind password with
+     * Get an LdapRegistry element with simple bindAuthmech and Bind DN and Bind password with
      * disabled Context Pool/Caches
      *
      * @param hostname
      * @param port
      * @return
      */
-    public static LdapRegistry getSimpleBind(String hostname, int port) {
+    public static LdapRegistry getLdapRegistryWithSimpleBind(String hostname, int port) {
         return getSimpleBind(hostname, port, true, true);
     }
 
@@ -147,7 +147,7 @@ public class LdapKerberosUtils {
     public static LdapRegistry getSimpleBind(String hostname, int port, boolean disableContextPool, boolean disableCaches) {
         LdapRegistry ldap = new LdapRegistry();
 
-        getBasicsLdapRegistry(ldap, hostname, port, disableContextPool, disableCaches);
+        getLdapRegistryElement(ldap, hostname, port, disableContextPool, disableCaches);
         ldap.setBindAuthMechanism(ConfigConstants.CONFIG_AUTHENTICATION_TYPE_SIMPLE);
         ldap.setBindDN(BIND_SIMPLE_DN);
         ldap.setBindPassword(BIND_PASSWORD);
@@ -178,14 +178,14 @@ public class LdapKerberosUtils {
     }
 
     /**
-     * Get a basic LdapRegistry with optionally disabled cache/contextPool, no bind credentials added
+     * Get an LdapRegistry element with optionally disabled cache/contextPool, no bind credentials added
      *
      * @param ldap
      * @param hostname
      * @param port
      * @param disableCaches
      */
-    public static void getBasicsLdapRegistry(LdapRegistry ldap, String hostname, int port, boolean disableContextPool, boolean disableCaches) {
+    public static void getLdapRegistryElement(LdapRegistry ldap, String hostname, int port, boolean disableContextPool, boolean disableCaches) {
         ldap.setId("LDAP1");
         ldap.setRealm("LDAPRealm");
         ldap.setHost(hostname);


### PR DESCRIPTION
Fixes #18083 

We did a team review/socialization on new testing for LDAP Kerberos. Address comments from review:

- Removed several references to `basic` to avoid confusion with `BasicRegistry`.
- Added a trace check on the basic keytab/ticketcache test to ensure we went through `setKerberos` path.
- Rename a few common methods for clarity