### PR TITLE
disable instrumentation support for some utilities classes

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.rt.security.3.4.1/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.rt.security.3.4.1/bnd.bnd
@@ -19,7 +19,7 @@
     org/apache/cxf=${bin}/org/apache/cxf
 
 globalize: false
-instrument.ffdc: true
+instrument.ffdc: false
 
 -buildpath: \
 	org.apache.cxf:cxf-rt-security;strategy=exact;version=3.4.1, \

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.dom.2.3.0/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.dom.2.3.0/bnd.bnd
@@ -12,6 +12,7 @@
 -includeresource: \
    @${repo;org.apache.wss4j:wss4j-ws-security-dom;2.3.0}!/!META-INF/MANIFEST.MF|META-INF/maven/*, \
    org/apache/wss4j=${bin}/org/apache/wss4j
+instrument.classesExcludes: org/apache/wss4j/dom/util/*.class
 -buildpath: org.apache.wss4j:wss4j-ws-security-dom;version=2.3.0, \
             com.ibm.ws.org.apache.wss4j.ws.security.common.2.3.0;version=latest, \
             com.ibm.ws.org.slf4j.api.1.7.7;version=latest, \


### PR DESCRIPTION
we are filling up logs with not very useful ffdcs (depending on the java level, there are different cnfe logged). 

