### PR TITLE
make public attribute includeCustomCacheKeyInSubject from spnego element 

### DIFF
--- a/dev/com.ibm.ws.security.spnego/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.spnego/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2014, 2020 IBM Corporation and others.
+# Copyright (c) 2014, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -57,6 +57,9 @@ trimKerberosRealmNameFromPrincipal.desc=Specifies whether SPNEGO removes the suf
 
 includeClientGSSCredentialInSubject=Add the client delegation credentials to subject
 includeClientGSSCredentialInSubject.desc=Specifies whether the client delegation credentials should be stored in a client subject.
+
+includeCustomCacheKeyInSubject=Add the custom cache key to subject
+includeCustomCacheKeyInSubject.desc=Specifies whether the custom cache key should be stored in a client subject and LTPA cookie.
 
 authFilterRef=Authentication Filter Reference
 authFilterRef$Ref=Authentication filter reference

--- a/dev/com.ibm.ws.security.spnego/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.spnego/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019, 2020 IBM Corporation and others.
+    Copyright (c) 2019, 2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -50,7 +50,7 @@
         <AD id="includeClientGSSCredentialInSubject" name="%includeClientGSSCredentialInSubject" description="%includeClientGSSCredentialInSubject.desc"
             required="false" type="Boolean" default="true" />     
 
-        <AD id="includeCustomCacheKeyInSubject" name="internal" description="internal use only"  
+        <AD id="includeCustomCacheKeyInSubject" name="%includeCustomCacheKeyInSubject" description="%includeCustomCacheKeyInSubject.desc"  
             required="false" type="Boolean" default="true"/>
 
         <AD id="allowLocalHost" name="internal" description="internal use only"


### PR DESCRIPTION
The <spnego includeCustomCacheKeyInSubject ... /> make this attribute public instead of internal. The default value stay the same as true. 