### PR TITLE
Added jdk.attach flag to java9.options for Dump actions

### DIFF
--- a/dev/com.ibm.ws.kernel.boot/publish/platform/java/java9.options
+++ b/dev/com.ibm.ws.kernel.boot/publish/platform/java/java9.options
@@ -10,6 +10,9 @@ java.naming/com.sun.jndi.url.ldap=ALL-UNNAMED
 # for Oracle Kerberos
 --add-exports
 java.security.jgss/sun.security.krb5.internal=ALL-UNNAMED
+# for Dump action: com.ibm.ws.kernel.boot.internal.commands.HotSpotJavaDumperImpl$VirtualMachine.remoteDataDump(HotSpotJavaDumperImpl.java:339)
+--add-exports
+jdk.attach/sun.tools.attach=ALL-UNNAMED
 ### Opens
 --add-opens
 java.base/java.util=ALL-UNNAMED

--- a/dev/com.ibm.ws.request.timing.hung_fat/fat/src/com/ibm/ws/request/timing/hung/fat/HungRequestEnableThreadDumps.java
+++ b/dev/com.ibm.ws.request.timing.hung_fat/fat/src/com/ibm/ws/request/timing/hung/fat/HungRequestEnableThreadDumps.java
@@ -34,7 +34,6 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 
 /**
@@ -53,13 +52,7 @@ public class HungRequestEnableThreadDumps {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        JavaInfo java = JavaInfo.forCurrentVM();
         ShrinkHelper.defaultDropinApp(server, "TestWebApp", "com.ibm.testwebapp");
-        int javaVersion = java.majorVersion();
-        if (javaVersion != 8) {
-            CommonTasks.writeLogMsg(Level.INFO, " Java version = " + javaVersion + " - It is higher than 8, adding --add-exports...");
-            server.copyFileToLibertyServerRoot("add-exports/jvm.options");
-        }
         CommonTasks.writeLogMsg(Level.INFO, " Starting server...");
         server.startServer();
     }

--- a/dev/com.ibm.ws.request.timing.hung_fat/fat/src/com/ibm/ws/request/timing/hung/fat/HungRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing.hung_fat/fat/src/com/ibm/ws/request/timing/hung/fat/HungRequestTiming.java
@@ -47,7 +47,6 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
@@ -65,13 +64,7 @@ public class HungRequestTiming {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        JavaInfo java = JavaInfo.forCurrentVM();
         ShrinkHelper.defaultDropinApp(server, "TestWebApp", "com.ibm.testwebapp");
-        int javaVersion = java.majorVersion();
-        if (javaVersion != 8) {
-            CommonTasks.writeLogMsg(Level.INFO, " Java version = " + javaVersion + " - It is higher than 8, adding --add-exports...");
-            server.copyFileToLibertyServerRoot("add-exports/jvm.options");
-        }
         CommonTasks.writeLogMsg(Level.INFO, " starting server...");
         server.startServer();
     }

--- a/dev/com.ibm.ws.request.timing.hung_fat/publish/files/add-exports/jvm.options
+++ b/dev/com.ibm.ws.request.timing.hung_fat/publish/files/add-exports/jvm.options
@@ -1,3 +1,0 @@
-# for dump action: com.ibm.ws.kernel.boot.internal.commands.HotSpotJavaDumperImpl$VirtualMachine.remoteDataDump(HotSpotJavaDumperImpl.java:342)
---add-exports
-jdk.attach/sun.tools.attach=ALL-UNNAMED

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/TimingRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/TimingRequestTiming.java
@@ -39,7 +39,6 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
@@ -61,13 +60,7 @@ public class TimingRequestTiming {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        JavaInfo java = JavaInfo.forCurrentVM();
         ShrinkHelper.defaultDropinApp(server, "jdbcTestPrj_3", "com.ibm.ws.request.timing");
-        int javaVersion = java.majorVersion();
-        if (javaVersion != 8) {
-            CommonTasks.writeLogMsg(Level.INFO, " Java version = " + javaVersion + " - It is higher than 8, adding --add-exports...");
-            server.copyFileToLibertyServerRoot("add-exports/jvm.options");
-        }
         CommonTasks.writeLogMsg(Level.INFO, " starting server...");
         server.startServer();
     }

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/add-exports/jvm.options
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/add-exports/jvm.options
@@ -1,3 +1,0 @@
-# for dump action: com.ibm.ws.kernel.boot.internal.commands.HotSpotJavaDumperImpl$VirtualMachine.remoteDataDump(HotSpotJavaDumperImpl.java:342)
---add-exports
-jdk.attach/sun.tools.attach=ALL-UNNAMED


### PR DESCRIPTION
fixes #18128
Globally, add the jdk.attach flag in OL kernel options file for Java9+, so it gets picked up by the OL runtime and customers do not need to apply it themselves, when our OL code is doing the Dump/Heap/Core actions (`com.ibm.ws.kernel.boot.internal.commands.HotSpotJavaDumperImpl$VirtualMachine.remoteDataDump`).

RTC defect: 285684
WS-CD Git Issue: 24555