### PR TITLE
Update batchManagement-1.0 to work with Jakarta EE9

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.batchManagement1.0-messaging3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.batchManagement1.0-messaging3.0.feature
@@ -1,9 +1,9 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=io.openliberty.batchManagement2.0-messaging3.0
+symbolicName=io.openliberty.batchManagement1.0-messaging3.0
 visibility=private
 IBM-Provision-Capability: \
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.messaging-3.0.internal))", \
- osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.batchManagement-2.0))"
+ osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.batchManagement-1.0))"
 -features=io.openliberty.mdb-4.0, \
   com.ibm.websphere.appserver.transaction-2.0
 -bundles=com.ibm.ws.jbatch.jms.jakarta

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.batchManagement1.0.javaee.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.batchManagement1.0.javaee.feature
@@ -1,0 +1,10 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName = io.openliberty.batchManagement1.0.javaee
+visibility = private
+IBM-Provision-Capability:\
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.batchManagement-1.0))",\
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.servlet-3.1)(osgi.identity=com.ibm.websphere.appserver.servlet-4.0)))"
+IBM-Install-Policy: when-satisfied
+-features=com.ibm.websphere.appserver.jsonp-1.0; ibm.tolerates:="1.1"
+kind=ga
+edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/javaBatch-1.0/com.ibm.websphere.appserver.adminCenter.tool.javaBatch-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/javaBatch-1.0/com.ibm.websphere.appserver.adminCenter.tool.javaBatch-1.0.feature
@@ -10,6 +10,6 @@ Subsystem-Icon: OSGI-INF/javaBatch_142.png, OSGI-INF/javaBatch_78.png; size=78, 
 kind=ga
 edition=base
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))",\
-  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.batchManagement-1.0)(osgi.identity=io.openliberty.batchManagement-2.0)))"
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.batchManagement-1.0))"
 IBM-Install-Policy: when-satisfied
 IBM-Feature-Version: 2

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.batchManagement1.0.internal.ee-7.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.batchManagement1.0.internal.ee-7.0.feature
@@ -1,0 +1,12 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.batchManagement1.0.internal.ee-7.0
+singleton=true
+WLP-DisableAllFeatures-OnConflict: false
+-features=com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
+  com.ibm.websphere.appserver.batch-1.0, \
+  com.ibm.websphere.appserver.transaction-1.2, \
+  com.ibm.websphere.appserver.jdbc-4.1; ibm.tolerates:="4.0,4.2,4.3"
+-bundles=com.ibm.ws.jbatch.joblog, \
+  com.ibm.ws.jbatch.rest
+kind=ga
+edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.batchManagement1.0.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.batchManagement1.0.internal.ee-9.0.feature
@@ -1,0 +1,12 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.batchManagement1.0.internal.ee-9.0
+singleton=true
+-features=com.ibm.websphere.appserver.servlet-5.0, \
+  io.openliberty.batch-2.0, \
+  com.ibm.websphere.appserver.transaction-2.0, \
+  com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:="4.3", \
+  io.openliberty.jsonp-2.0
+-bundles=com.ibm.ws.jbatch.joblog.jakarta, \
+  com.ibm.ws.jbatch.rest.jakarta
+kind=noship
+edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/batchManagement-1.0/com.ibm.websphere.appserver.batchManagement-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/batchManagement-1.0/com.ibm.websphere.appserver.batchManagement-1.0.feature
@@ -5,26 +5,18 @@ singleton:true
 visibility=public
 IBM-App-ForceRestart: uninstall, \
  install
-IBM-API-Package: javax.batch.api; type="spec", \
- javax.batch.api.chunk; type="spec", \
- javax.batch.api.chunk.listener; type="spec", \
- javax.batch.api.listener; type="spec", \
- javax.batch.api.partition; type="spec", \
- javax.batch.operations; type="spec", \
- javax.batch.runtime; type="spec", \
- javax.batch.runtime.context; type="spec"
 IBM-ShortName: batchManagement-1.0
 Subsystem-Name: Batch Management 1.0
 -features=com.ibm.websphere.appserver.restHandler-1.0, \
-  com.ibm.websphere.appserver.transaction-1.2, \
-  com.ibm.websphere.appserver.jsonp-1.0; ibm.tolerates:="1.1", \
-  com.ibm.websphere.appserver.batch-1.0, \
-  com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
+  com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0, 5.0", \
+  com.ibm.websphere.appserver.transaction-1.2; ibm.tolerates:="2.0", \
   com.ibm.websphere.appserver.jdbc-4.1; ibm.tolerates:="4.0,4.2,4.3", \
-  com.ibm.websphere.appserver.eeCompatible-7.0; ibm.tolerates:="8.0"
--bundles=com.ibm.ws.jbatch.joblog, \
-  com.ibm.ws.jbatch.rest
--jars=com.ibm.ws.jbatch.utility
+  com.ibm.websphere.appserver.eeCompatible-7.0; ibm.tolerates:="8.0,9.0", \
+  io.openliberty.batchManagement1.0.internal.ee-7.0; ibm.tolerates:="9.0"
+-jars=com.ibm.ws.jbatch.utility, \
+  com.ibm.websphere.javaee.batch.1.0; location:="dev/api/spec/", \
+  com.ibm.ws.org.glassfish.json.1.0, \
+  com.ibm.websphere.javaee.jsonp.1.0; location:="dev/api/spec/" 
 -files=bin/batchManager.bat, \
  bin/batchManager; ibm.file.encoding:=ebcdic, \
  bin/tools/ws-jbatchutil.jar

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE7FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE7FeatureReplacementAction.java
@@ -31,7 +31,6 @@ public class EE7FeatureReplacementAction extends FeatureReplacementAction {
                                                  "jpa-2.1",
                                                  "jpaContainer-2.1",
                                                  "batch-1.0",
-                                                 "batchManagement-1.0",
                                                  "beanValidation-1.1",
                                                  "jaxrs-2.0",
                                                  "jaxrsClient-2.0",

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE8FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE8FeatureReplacementAction.java
@@ -31,7 +31,6 @@ public class EE8FeatureReplacementAction extends FeatureReplacementAction {
                                                  "jpa-2.2",
                                                  "jpaContainer-2.2",
                                                  "batch-1.0",
-                                                 "batchManagement-1.0",
                                                  "beanValidation-2.0",
                                                  "jaxrs-2.1",
                                                  "jaxrsClient-2.1",

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE9Action.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE9Action.java
@@ -64,7 +64,6 @@ public class JakartaEE9Action extends FeatureReplacementAction {
                                                  "appAuthorization-2.0",
                                                  "appSecurity-4.0",
                                                  "batch-2.0",
-                                                 "batchManagement-2.0",
                                                  "beanValidation-3.0",
                                                  "cdi-3.0",
                                                  "concurrent-2.0",


### PR DESCRIPTION
- Previously we created a batchManager-2.0 for Jakarta EE 9 support.
- Instead we are changing to have batchManagement-1.0 do the right thing to support both Java EE 7, 8 and Jakarta EE 9 in one feature like the other value-add features.
