### PR TITLE
Fix various missing tested.features

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_krb5/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ fat.project: true
 
 tested.features: \
   connectors-2.0, \
+  servlet-5.0, \
   xmlBinding-3.0
 
 # Uncomment to use remote docker host to simulate continuous build behavior.

--- a/dev/com.ibm.ws.logging.hpel_fat/bnd.bnd
+++ b/dev/com.ibm.ws.logging.hpel_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -18,6 +18,11 @@ src: \
 
 
 fat.project: true
+
+# Define additional tested features that are NOT present in any XML files in this bucket.
+# In this case, servlet-3.1 is added when running on open-liberty image.
+tested.features:\
+	servlet-3.1
 
 -buildpath: \
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\

--- a/dev/com.ibm.ws.logging.json_fat/bnd.bnd
+++ b/dev/com.ibm.ws.logging.json_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,11 @@ src: \
     test-applications/LogstashApp/src
 
 test.project: true
+
+# Define additional tested features that are NOT present in any XML files in this bucket.
+# In this case, servlet-3.1 is added when running on open-liberty image.
+tested.features:\
+	servlet-3.1
 
 -buildpath: \
     com.ibm.websphere.javaee.servlet.3.1;version=latest,\

--- a/dev/com.ibm.ws.logstash.collector_fat/bnd.bnd
+++ b/dev/com.ibm.ws.logstash.collector_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,11 @@ src: \
     test-applications/LogstashApp/src
 
 fat.project: true
+
+# Define additional tested features that are NOT present in any XML files in this bucket.
+# In this case, servlet-3.1 is added when running on open-liberty image.
+tested.features:\
+	servlet-3.1
 
 # Uncomment to use remote docker host to simulate continuous build behavior.
 #fat.test.use.remote.docker: true

--- a/dev/com.ibm.ws.request.probe.jdbc_fat/bnd.bnd
+++ b/dev/com.ibm.ws.request.probe.jdbc_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,11 @@ src: \
 	test-applications/jdbcTestPrj_All/src
 
 fat.project: true
+
+# Define additional tested features that are NOT present in any XML files in this bucket.
+# In this case, servlet-3.1 is added when running on open-liberty image.
+tested.features:\
+	servlet-3.1
 
 -buildpath: \
 	com.ibm.ws.request.probe.jdbc;version=latest,\

--- a/dev/com.ibm.ws.request.probe.servlet_fat/bnd.bnd
+++ b/dev/com.ibm.ws.request.probe.servlet_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,11 @@ src: \
 	test-applications/ServletTest/src
 
 fat.project: true
+
+# Define additional tested features that are NOT present in any XML files in this bucket.
+# In this case, servlet-3.1 is added when running on open-liberty image.
+tested.features:\
+	servlet-3.1
 
 -buildpath: \
 	com.ibm.ws.request.probe.servlet;version=latest,\

--- a/dev/com.ibm.ws.rest.handler.validator.cloudant_fat/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.validator.cloudant_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -25,4 +25,4 @@ fat.project: true
 	com.ibm.websphere.javaee.jsonp.1.0;version=latest,\
 	io.openliberty.org.testcontainers;version=latest
 
-tested.features: componenttest-2.0
+tested.features: componenttest-2.0, servlet-3.1

--- a/dev/com.ibm.ws.security.wim.core_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.wim.core_fat/bnd.bnd
@@ -16,7 +16,7 @@ src: \
 	fat/src
 
 fat.project: true
-tested.features: appsecurity-4.0, expressionlanguage-4.0, cdi-3.0
+tested.features: appsecurity-4.0, expressionlanguage-4.0, cdi-3.0, servlet-3.1
 
 -buildpath: \
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\

--- a/dev/com.ibm.ws.security.wim.scim.2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.wim.scim.2.0_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -17,6 +17,10 @@ src: \
 
 fat.project: true
 
+# Define additional tested features that are NOT present in any XML files in this bucket.
+# In this case, servlet-3.1 is added when running on open-liberty image.
+tested.features:\
+	servlet-3.1
 
 -buildpath: \
     io.openliberty.com.fasterxml.jackson;version=latest,\

--- a/dev/com.ibm.ws.transaction.DB2HADB_fat/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.DB2HADB_fat/bnd.bnd
@@ -21,7 +21,7 @@ src: \
 
 fat.project: true
 
-tested.features: cdi-3.0
+tested.features: cdi-3.0, servlet-5.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\

--- a/dev/com.ibm.ws.transaction.DerbyHADB_fat/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.DerbyHADB_fat/bnd.bnd
@@ -21,7 +21,7 @@ src: \
 
 fat.project: true
 
-tested.features: cdi-3.0
+tested.features: cdi-3.0, servlet-5.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\

--- a/dev/com.ibm.ws.transaction.OracleHADB_fat/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.OracleHADB_fat/bnd.bnd
@@ -21,7 +21,7 @@ src: \
 
 fat.project: true
 
-tested.features: cdi-3.0
+tested.features: cdi-3.0, servlet-5.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\

--- a/dev/com.ibm.ws.transaction.PostgresqlHADB_fat/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.PostgresqlHADB_fat/bnd.bnd
@@ -21,7 +21,7 @@ src: \
 
 fat.project: true
 
-tested.features: cdi-3.0
+tested.features: cdi-3.0, servlet-5.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\

--- a/dev/com.ibm.ws.transaction.SQLServerHADB_fat/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.SQLServerHADB_fat/bnd.bnd
@@ -22,7 +22,7 @@ src: \
 
 fat.project: true
 
-tested.features: cdi-3.0
+tested.features: cdi-3.0, servlet-5.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\


### PR DESCRIPTION
Fix a few soft merge conflicts with the simplicity feature dependency
checker fixes, and also account for running on open-liberty only images
where servlet-3.0 does not exist, so servlet-3.1 is used instead.
