### PR TITLE
Add Oracle row size limit property

### DIFF
--- a/dev/com.ibm.ws.session.db/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.session.db/resources/OSGI-INF/l10n/metatype.properties
@@ -75,6 +75,9 @@ use.invalidated.id.desc=Set this property to "true" to reuse the incoming identi
 use.oracle.blob=Use Binary Large Object (BLOB) for medium column
 use.oracle.blob.desc=Set this property to "true" to create the database table using the Binary Large Object (BLOB) data type for the medium column. This value increases performance of persistent sessions when Oracle databases are used. Due to an Oracle restriction, BLOB support requires use of the Oracle Call Interface (OCI) database driver for more than 4000 bytes of data. You must also ensure that a new sessions table is created before the server is restarted by dropping your old sessions table or by changing the datasource definition to reference a database that does not contain a sessions table.
 
+oracle.row.size.name=Oracle row size limit
+oracle.row.size.desc=Set megabyte-per-record limit. The default is 2-megabyte limit of stored data per record.
+
 skip.index.creation=Skip index creation
 skip.index.creation.desc=Set this property to "true" to disable index creation on server startup. This custom property should only be used if you want to manually create your own database indices for session persistence. However, it is recommended that you let session manager create database indices. Before enabling this property, make sure that the correct index does exist on your session database.
 

--- a/dev/com.ibm.ws.session.db/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.session.db/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2013 IBM Corporation and others.
+# Copyright (c) 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.session.db/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.session.db/resources/OSGI-INF/l10n/metatype.properties
@@ -76,7 +76,7 @@ use.oracle.blob=Use Binary Large Object (BLOB) for medium column
 use.oracle.blob.desc=Set this property to "true" to create the database table using the Binary Large Object (BLOB) data type for the medium column. This value increases performance of persistent sessions when Oracle databases are used. Due to an Oracle restriction, BLOB support requires use of the Oracle Call Interface (OCI) database driver for more than 4000 bytes of data. You must also ensure that a new sessions table is created before the server is restarted by dropping your old sessions table or by changing the datasource definition to reference a database that does not contain a sessions table.
 
 oracle.row.size.name=Oracle row size limit
-oracle.row.size.desc=Set megabyte-per-record limit. The default is 2-megabyte limit of stored data per record.
+oracle.row.size.desc=Set the limit of stored data per record, in megabytes. The default is 2 megabytes.
 
 skip.index.creation=Skip index creation
 skip.index.creation.desc=Set this property to "true" to disable index creation on server startup. This custom property should only be used if you want to manually create your own database indices for session persistence. However, it is recommended that you let session manager create database indices. Before enabling this property, make sure that the correct index does exist on your session database.

--- a/dev/com.ibm.ws.session.db/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.session.db/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2012, 2013 IBM Corporation and others.
+    Copyright (c) 2012, 2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.session.db/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.session.db/resources/OSGI-INF/metatype/metatype.xml
@@ -153,6 +153,11 @@
             description="%use.oracle.blob.desc" 
             ibmui:group="oracle"
             required="false" type="Boolean" default="false"/>
+        <AD id="rowSizeLimit" 
+            name="%oracle.row.size.name" 
+            description="%oracle.row.size.desc" 
+            ibmui:group="oracle"
+            required="false" type="Integer" default="2"/>            
     </OCD>
 
     <Designate pid="com.ibm.ws.session.db">

--- a/dev/com.ibm.ws.session.db/resources/com/ibm/ws/session/db/resources/WASSession.nlsprops
+++ b/dev/com.ibm.ws.session.db/resources/com/ibm/ws/session/db/resources/WASSession.nlsprops
@@ -156,9 +156,9 @@ DatabaseHashMap.selectNoUpdateError.explanation=An exception has been detected w
 DatabaseHashMap.selectNoUpdateError.useraction=If a SQLException has occurred then refer to the appropriate database documentation for your environment. Also, ensure that you have properly configured a data source for the Session Manager.
 
 # -------------------------------------------------------------------------------------------------
-DatabaseHashMapMR.db2LongVarCharErr=SESN8558E: An attempt was made to write more than row size limit to the database column.
+DatabaseHashMapMR.db2LongVarCharErr=SESN8558E: An attempt was made to write more to the database column than is allowed by the value of the rowSizeLimit property.
 DatabaseHashMapMR.db2LongVarCharErr.explanation=The session data may be too large for the database column.
-DatabaseHashMapMR.db2LongVarCharErr.useraction=Reduce the size of this attribute before attempting to store it in the session or increase the rowSizeLimit property.
+DatabaseHashMapMR.db2LongVarCharErr.useraction=Reduce the size of this attribute before attempting to store it in the session or increase the value of the rowSizeLimit property.
 
 
 ControllerSession.Initialized=SESN0126I: {0} service has initialized successfully.

--- a/dev/com.ibm.ws.session.db/resources/com/ibm/ws/session/db/resources/WASSession.nlsprops
+++ b/dev/com.ibm.ws.session.db/resources/com/ibm/ws/session/db/resources/WASSession.nlsprops
@@ -156,9 +156,9 @@ DatabaseHashMap.selectNoUpdateError.explanation=An exception has been detected w
 DatabaseHashMap.selectNoUpdateError.useraction=If a SQLException has occurred then refer to the appropriate database documentation for your environment. Also, ensure that you have properly configured a data source for the Session Manager.
 
 # -------------------------------------------------------------------------------------------------
-DatabaseHashMapMR.db2LongVarCharErr=SESN8558E: An attempt was made to write more than 2M to the large column.
+DatabaseHashMapMR.db2LongVarCharErr=SESN8558E: An attempt was made to write more than row size limit to the database column.
 DatabaseHashMapMR.db2LongVarCharErr.explanation=The session data may be too large for the database column.
-DatabaseHashMapMR.db2LongVarCharErr.useraction=Reduce the size of this attribute before attempting to store it in the session.
+DatabaseHashMapMR.db2LongVarCharErr.useraction=Reduce the size of this attribute before attempting to store it in the session or increase the rowSizeLimit property.
 
 
 ControllerSession.Initialized=SESN0126I: {0} service has initialized successfully.

--- a/dev/com.ibm.ws.session.db/resources/com/ibm/ws/session/db/resources/WASSession.nlsprops
+++ b/dev/com.ibm.ws.session.db/resources/com/ibm/ws/session/db/resources/WASSession.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 1997, 2001 IBM Corporation and others.
+# Copyright (c) 1997, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.session.db/src/com/ibm/ws/session/store/db/DatabaseHashMap.java
+++ b/dev/com.ibm.ws.session.db/src/com/ibm/ws/session/store/db/DatabaseHashMap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2013 IBM Corporation and others.
+ * Copyright (c) 1997, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -94,7 +94,6 @@ public class DatabaseHashMap extends BackedHashMap {
 
     static final int SMALLCOL_SIZE_ORACLE = 2000;
     static final int MEDIUMCOL_SIZE_ORACLE = 2097152; /* 2M long raw */
-    static final int MEDIUMCOL_SIZE_ORACLE_MR = 10485760; /* 10M long raw */
     static final int LARGECOL_SIZE_ORACLE = 1; /* This shouldn't be used, maybe change this to a BLOB */
 
     static final int SMALLCOL_SIZE_SYBASE = 10485760; /* set to 10M since to force use of small column since no size is associated with a column */
@@ -313,7 +312,9 @@ public class DatabaseHashMap extends BackedHashMap {
                     mediumColSize = MEDIUMCOL_SIZE_ORACLE;                 
                     if (_smc.isUsingMultirow() && _smc.getRowSizeLimit()*1048576 > mediumColSize) {
                         mediumColSize = _smc.getRowSizeLimit()*1048576;
-                        LoggingUtil.SESSION_LOGGER_WAS.logp(Level.FINE, methodClassName, methodNames[INIT_DB_SETTINGS], "Oracle row size : " + mediumColSize);
+                        if (com.ibm.websphere.ras.TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_WAS.isLoggable(Level.FINE)) {
+                            LoggingUtil.SESSION_LOGGER_WAS.logp(Level.FINE, methodClassName, methodNames[INIT_DB_SETTINGS], "Oracle row size limit : " + mediumColSize);
+                        }
                     }                    
                     largeColSize = LARGECOL_SIZE_ORACLE;
                     usingOracle = true;

--- a/dev/com.ibm.ws.session.db/src/com/ibm/ws/session/store/db/DatabaseHashMap.java
+++ b/dev/com.ibm.ws.session.db/src/com/ibm/ws/session/store/db/DatabaseHashMap.java
@@ -310,15 +310,13 @@ public class DatabaseHashMap extends BackedHashMap {
                 int dbCode = DBPortability.getDBCode(dmd);
                 if (dbCode == DBPortability.ORACLE) {
                     smallColSize = SMALLCOL_SIZE_ORACLE;
-                    
-                    if (_smc.isUsingMultirow())
-                        mediumColSize = MEDIUMCOL_SIZE_ORACLE_MR;
-                    else
-                        mediumColSize = MEDIUMCOL_SIZE_ORACLE;
-                    
+                    mediumColSize = MEDIUMCOL_SIZE_ORACLE;                 
+                    if (_smc.isUsingMultirow() && _smc.getRowSizeLimit()*1048576 > mediumColSize) {
+                        mediumColSize = _smc.getRowSizeLimit()*1048576;
+                        LoggingUtil.SESSION_LOGGER_WAS.logp(Level.FINE, methodClassName, methodNames[INIT_DB_SETTINGS], "Oracle row size : " + mediumColSize);
+                    }                    
                     largeColSize = LARGECOL_SIZE_ORACLE;
                     usingOracle = true;
-
                 } else if (dbCode == DBPortability.SYBASE) {
                     smallColSize = SMALLCOL_SIZE_SYBASE;
                     mediumColSize = MEDIUMCOL_SIZE_SYBASE;

--- a/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionManagerConfig.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionManagerConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2020 IBM Corporation and others.
+ * Copyright (c) 1997, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionManagerConfig.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionManagerConfig.java
@@ -61,6 +61,7 @@ public class SessionManagerConfig implements Cloneable {
     private int rowSize = 4;
     private String tableSpaceName = null;
     private boolean usingMultirow = false;
+    private int rowSizeLimit  = 2;
 
     // Object which contains MTM settings
     private Object drsSettings;
@@ -570,6 +571,20 @@ public class SessionManagerConfig implements Cloneable {
         usingMultirow = b;
     }
 
+    /**
+     * @return the rowSizeLimit
+     */
+    public final int getRowSizeLimit() {
+        return rowSizeLimit;
+    }
+
+    /**
+     * @param rowSizeLimit the rowSizeLimit to set
+     */
+    public final void setRowSizeLimit(int rowSizeLimit) {
+        this.rowSizeLimit = rowSizeLimit;
+    }    
+    
     // drsSettings
     public final Object getDRSSettings() {
         return drsSettings;

--- a/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionProperties.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2020 IBM Corporation and others.
+ * Copyright (c) 1997, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionProperties.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionProperties.java
@@ -803,7 +803,11 @@ final public class SessionProperties {
         if (bValue != null) {
             smc.setUsingMultirow(bValue.booleanValue());
         }
-
+        s = "rowSizeLimit";
+        iValue = propertyToInteger(xtpProperties.get(s));
+        if (iValue != null) {
+            smc.setRowSizeLimit(iValue.intValue());
+        }
         // tuning parameters; currently from DatabaseStoreService
         s = "scheduleInvalidation";
         bValue = propertyToBoolean(xtpProperties.get(s));


### PR DESCRIPTION
Provide a new httpSessionDatabase property to configure Oracle row size limit, the default is 2-megabyte limit of stored data per row.

<httpSessionDatabase rowSizeLimit="2"/> 