### PR TITLE
Allow new ffdc when cert is missing

### DIFF
--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/common/RSSamlBasicTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/common/RSSamlBasicTests.java
@@ -171,6 +171,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
      * @throws Exception
      */
     @AllowedFFDC(value = { "com.ibm.ws.security.saml.error.SamlException" })
+    @AllowedFFDC(value = { "com.ibm.wsspi.channelfw.exception.InvalidChainNameException" })
     @AllowedFFDC(value = { "org.opensaml.ws.security.SecurityPolicyException" }, repeatAction = {EmptyAction.ID})
     @AllowedFFDC(value = { "org.opensaml.messaging.handler.MessageHandlerException" }, repeatAction = {JakartaEE9Action.ID})
     @Mode(TestMode.LITE)


### PR DESCRIPTION
Allow an additional ffdc when a cert is missing from a test trust store