### PR TITLE
JSF faces-config parser shouldn't NPE on missing namespace

### DIFF
--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/jsf/FacesConfigDDParser.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/jsf/FacesConfigDDParser.java
@@ -90,9 +90,9 @@ final class FacesConfigDDParser extends DDParser {
                 version = 23;
                 return new FacesConfigType(getDeploymentDescriptorPath());
             }
-        } else if ("https://jakarta.ee/xml/ns/jakartaee".contentEquals(namespace)) {
+        } else if ("https://jakarta.ee/xml/ns/jakartaee".equals(namespace)) {
             // Don't allow a faces-config.xml with a version="3.0" if the faces-3.0 feature is not enabled.
-            if ((this.FacesBundleLoadedVersion >= 30) && "3.0".contentEquals(vers)) {
+            if ((this.FacesBundleLoadedVersion >= 30) && "3.0".equals(vers)) {
                 // Jakarta 9 only
                 version = 30;
                 return new FacesConfigType(getDeploymentDescriptorPath());

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22MiscellaneousTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22MiscellaneousTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020 IBM Corporation and others.
+ * Copyright (c) 2015, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -67,6 +67,8 @@ public class JSF22MiscellaneousTests {
 
         WebArchive SerializeWar = ShrinkHelper.buildDefaultApp("JSF22MiscellaneousSerialize.war", "");
 
+        WebArchive xmlnsWar = ShrinkHelper.buildDefaultApp("FacesConfigMissingXmlns.war", "");
+
         EnterpriseArchive JSF22MiscellaneousEar = ShrinkWrap.create(EnterpriseArchive.class, "JSF22Miscellaneous.ear");
 
         JSF22MiscellaneousWar.addAsLibraries(JSF22MiscellaneousJar);
@@ -77,6 +79,8 @@ public class JSF22MiscellaneousTests {
         ShrinkHelper.addDirectory(JSF22MiscellaneousEar, "test-applications" + "/JSF22Miscellaneous.ear" + "/resources");
 
         ShrinkHelper.exportDropinAppToServer(jsf22MiscellaneousServer, JSF22MiscellaneousEar);
+
+        ShrinkHelper.exportDropinAppToServer(jsf22MiscellaneousServer, xmlnsWar);
 
         ShrinkHelper.defaultDropinApp(jsf22MiscellaneousServer, "FunctionMapper.war", "com.ibm.ws.jsf23.fat.functionmapper");
 
@@ -459,6 +463,29 @@ public class JSF22MiscellaneousTests {
             page = page.getElementById("form1:button1").click();
 
             assertTrue("Function Mapper is null!", page.asText().contains("FunctionMapper Exists (Expecting true): true"));
+        }
+    }
+
+    /**
+     * Check to make sure that an app starts correctly when it has a faces-config.xml which is missing a "xmlns" declaration.
+     * 
+     * See https://github.com/OpenLiberty/open-liberty/issues/18155
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testFacesConfigMissingXmlns() throws Exception {
+        try (WebClient webClient = new WebClient()) {
+
+            String contextRoot = "FacesConfigMissingXmlns";
+            URL url = JSFUtils.createHttpUrl(jsf22MiscellaneousServer, contextRoot, "index.xhtml");
+            HtmlPage page = (HtmlPage) webClient.getPage(url);
+
+            if (page == null) {
+                Assert.fail("index.xhtml did not render properly.");
+            } else if (!page.asText().contains("Test Success")) {
+                Assert.fail("/FacesConfigMissingXmlns/index.xhtml did not contain \"Test Success\":\n" + page.asXml());
+            }
         }
     }
 }

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/FacesConfigMissingXmlns.war/resources/WEB-INF/faces-config.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/FacesConfigMissingXmlns.war/resources/WEB-INF/faces-config.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ -->
+ <!-- Note: expected declaration is missing: xmlns="http://xmlns.jcp.org/xml/ns/javaee"-->
+ <faces-config 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+    http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_2.xsd"
+    version="2.2">
+
+    <name>FacesConfigMissingXmlns</name>
+
+</faces-config>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/FacesConfigMissingXmlns.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/FacesConfigMissingXmlns.war/resources/WEB-INF/web.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ -->
+<web-app id="WebApp_ID" version="3.1" 
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+
+    <display-name>FacesConfigMissingXmlns</display-name>
+
+    <servlet>
+        <servlet-name>Faces Servlet</servlet-name>
+        <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>Faces Servlet</servlet-name>
+        <url-pattern>*.xhtml</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/FacesConfigMissingXmlns.war/resources/index.xhtml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/FacesConfigMissingXmlns.war/resources/index.xhtml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ -->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:h="http://xmlns.jcp.org/jsf/html">
+
+<h:head>
+	<title>FacesConfigMissingXmlns</title>
+</h:head>
+
+<h:body>
+	<h:outputText value="Test Success" />
+</h:body>
+</html>


### PR DESCRIPTION
For #18155