### PR TITLE
Update FeatureList for Java 17

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
+++ b/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
@@ -88,7 +88,7 @@ public class FeatureList {
             addJVM(possibleJavaVersions, "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
             addJVM(possibleJavaVersions, "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
             addJVM(possibleJavaVersions, "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
-            addJVM(possibleJavaVersions, "15", "14", "13", "12", "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
+            addJVM(possibleJavaVersions, "17", "16", "15", "14", "13", "12", "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
 
             List<GenericMetadata> mostGeneralRange = ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=1.7))\"");
 
@@ -100,7 +100,7 @@ public class FeatureList {
             eeToCapability.put("JavaSE-1.7", mostGeneralRange);
             eeToCapability.put("JavaSE-1.8", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=1.8))\""));
             eeToCapability.put("JavaSE-11", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=11))\""));
-            eeToCapability.put("JavaSE-15", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=15))\""));
+            eeToCapability.put("JavaSE-17", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=17))\""));
         }
 
         gaBuild = isGABuild();

--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/internal/EsaResourceImpl.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/internal/EsaResourceImpl.java
@@ -232,8 +232,9 @@ public class EsaResourceImpl extends RepositoryResourceImpl implements EsaResour
             return;
         }
 
-        String minJava11 = "Java SE 11, Java SE 15";
-        String minJava8 = "Java SE 8, Java SE 11, Java SE 15";
+        String minJava17 = "Java SE 17";
+        String minJava11 = "Java SE 11, Java SE 17";
+        String minJava8 = "Java SE 8, Java SE 11, Java SE 17";
 
         // The min version should have been validated when the ESA was constructed
         // so checking for the version string should be safe
@@ -247,6 +248,18 @@ public class EsaResourceImpl extends RepositoryResourceImpl implements EsaResour
             // If a feature requires a min of Java 9/10/11, state Java 11 is required because
             // Liberty does not officially support Java 9 or 10
             reqs.setVersionDisplayString(minJava11);
+            return;
+        }
+
+        if (minVersion.startsWith("12.") ||
+            minVersion.startsWith("13.") ||
+            minVersion.startsWith("14.") ||
+            minVersion.startsWith("15.") ||
+            minVersion.startsWith("16.") ||
+            minVersion.startsWith("17.")) {
+            // If a feature requires a min of Java 12/13/14/15/16/17, state Java 17 is required because
+            // Liberty does not officially support Java 12-16
+            reqs.setVersionDisplayString(minJava17);
             return;
         }
 


### PR DESCRIPTION
Update FeatureList and EsaResourceImpl to replace the previously supported non-LTS (non-long term support) release of Java 15 with the LTS release of Java 17.

Previous version for reference -> https://github.com/OpenLiberty/open-liberty/pull/13782