### PR TITLE
Plugin generator java8

### DIFF
--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/JavaInfo.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/JavaInfo.java
@@ -195,6 +195,15 @@ public class JavaInfo {
     }
 
     /**
+     * For debug purposes only
+     *
+     * @return a String containing basic info about the JDK
+     */
+    public static String debugString() {
+        return "Vendor = " + vendor() + ", Version = " + majorVersion() + "." + minorVersion();
+    }
+
+    /**
      * @return the integer value of the string, or 0 if the string cannot be coerced to a string
      */
     private static int parseIntSafe(String str) {

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
@@ -23,7 +23,6 @@ import java.net.UnknownHostException;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.text.SimpleDateFormat;
@@ -44,6 +43,9 @@ import java.util.Set;
 
 import javax.servlet.SessionCookieConfig;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
@@ -51,13 +53,17 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
-import java.io.IOException;
-import java.io.StringReader;
-
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
-
+import org.apache.commons.io.FileUtils;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Comment;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.NodeList;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -67,27 +73,12 @@ import org.xml.sax.XMLReader;
 import org.xml.sax.ext.LexicalHandler;
 import org.xml.sax.helpers.DefaultHandler;
 
-import org.apache.commons.io.FileUtils;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.framework.ServiceReference;
-import org.w3c.dom.Attr;
-import org.w3c.dom.Comment;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.service.util.JavaInfo;
-import com.ibm.ws.kernel.service.util.JavaInfo.Vendor;
 import com.ibm.ws.webcontainer.httpsession.SessionManager;
 import com.ibm.ws.webcontainer.osgi.DynamicVirtualHost;
 import com.ibm.ws.webcontainer.osgi.DynamicVirtualHostManager;
@@ -138,10 +129,6 @@ public class PluginGenerator {
     private static final String HTTP_ALLOWED_ENDPOINT = "allowFromEndpointRef";
     private static final String LOCALHOST = "localhost";
 
-    private static final String TRANSFORMER_FACTORY_JVM_PROPERTY_NAME = "javax.xml.transform.TransformerFactory";
-
-    private static final Object transformerLock = new Object();
-
     protected enum Role {
         PRIMARY, SECONDARY
     }
@@ -159,17 +146,10 @@ public class PluginGenerator {
     private Integer previousConfigHash = null;
     private File cachedFile;
 
-    private static final boolean CHANGE_TRANSFORMER;
-
-    static {
-        if (!JavaInfo.vendor().equals(Vendor.IBM)) {
-            CHANGE_TRANSFORMER = false;
-        } else {
-            int majorVersion = JavaInfo.majorVersion();
-            CHANGE_TRANSFORMER = majorVersion == 8;
-        }
-    }
-
+    public static final String XALAN_TRANSFORMER_FACTORY_CLASS_NAME = "org.apache.xalan.processor.TransformerFactoryImpl";
+    public static final String IBM_XLTXEJ_COMPILED_TRANSFORMER_FACTORY_CLASS_NAME = "com.ibm.xtq.xslt.jaxp.compiler.TransformerFactoryImpl";
+    public static final String SAX_LEXICAL_HANDLER_CLASS_NAME = "org.xml.sax.ext.LexicalHandler";
+    
     /**
      * Constructor.
      *
@@ -229,9 +209,9 @@ public class PluginGenerator {
 
         // Because this method is synchronized there can become a queue of requests waiting which then don't get started
         // for a significant time period. As a result if the servers is now shutting down skip generation.
-        if (pcd == null || FrameworkState.isStopping() || container.isServerStopping()) {
+        if (pcd == null || FrameworkState.isStopping() || WebContainer.isServerStopping()) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
-                Tr.exit(tc, "generateXML", ((FrameworkState.isStopping() || container.isServerStopping()) ? "Server is stopping" : "pcd is null"));
+                Tr.exit(tc, "generateXML", ((FrameworkState.isStopping() || WebContainer.isServerStopping()) ? "Server is stopping" : "pcd is null"));
             }
             // add error message in next update
             return;
@@ -469,7 +449,7 @@ public class PluginGenerator {
             }
 
             // check to see if the server is shutting down; if it is, bail out. A final exit message will be logged in the finally().
-            if (pcd == null || FrameworkState.isStopping() || container.isServerStopping()) {
+            if (pcd == null || FrameworkState.isStopping() || WebContainer.isServerStopping()) {
                 return;
             }
 
@@ -492,7 +472,7 @@ public class PluginGenerator {
                 // create a server element for each server in the cluster
                 for (ServerData sd : scd.clusterServers) {
                     // check to see if the server is shutting down; if it is, bail out. A final exit message will be logged in the finally().
-                    if (pcd == null || FrameworkState.isStopping() || container.isServerStopping()) {
+                    if (pcd == null || FrameworkState.isStopping() || WebContainer.isServerStopping()) {
                         return;
                     }
 
@@ -750,7 +730,7 @@ public class PluginGenerator {
             // bunch of PMI stuff?
 
             // check to see if the server is shutting down; if it is, bail out. A final exit message will be logged in the finally().
-            if (pcd == null || FrameworkState.isStopping() || container.isServerStopping()) {
+            if (pcd == null || FrameworkState.isStopping() || WebContainer.isServerStopping()) {
                 return;
             }
 
@@ -846,9 +826,9 @@ public class PluginGenerator {
         } finally {
             try {
                 // check to see if the server is shutting down; if it is, bail out
-                if (pcd == null || FrameworkState.isStopping() || container.isServerStopping()) {
+                if (pcd == null || FrameworkState.isStopping() || WebContainer.isServerStopping()) {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
-                        Tr.exit(tc, "generateXML", ((FrameworkState.isStopping() || container.isServerStopping()) ? "Server is stopping" : "pcd is null"));
+                        Tr.exit(tc, "generateXML", ((FrameworkState.isStopping() || WebContainer.isServerStopping()) ? "Server is stopping" : "pcd is null"));
                     }
                     return;
                 }
@@ -885,85 +865,48 @@ public class PluginGenerator {
     }
 
     @FFDCIgnore(IOException.class)
-    public static void copyFile(File in, File out)
-                    throws IOException
-                {
-                    FileChannel inChannel = new
-                        FileInputStream(in).getChannel();
-                    FileChannel outChannel = new
-                        FileOutputStream(out).getChannel();
-                    try {
-                        inChannel.transferTo(0, inChannel.size(),
-                                outChannel);
-                    }
-                    catch (IOException e) {
-                        throw e;
-                    }
-                    finally {
-                        if (inChannel != null) inChannel.close();
-                        if (outChannel != null) outChannel.close();
-                    }
-                }
+    public static void copyFile(File in, File out) throws IOException {
+        FileChannel inChannel = new FileInputStream(in).getChannel();
+        FileChannel outChannel = new FileOutputStream(out).getChannel();
+        try {
+            inChannel.transferTo(0, inChannel.size(),
+                                 outChannel);
+        } catch (IOException e) {
+            throw e;
+        } finally {
+            if (inChannel != null)
+                inChannel.close();
+            if (outChannel != null)
+                outChannel.close();
+        }
+    }
 
-    private static TransformerFactory getTransformerFactory() {
+    public static TransformerFactory getTransformerFactory() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
-            Tr.entry(tc, "getTransformerFactory", "CHANGE_TRANSORMER = " + CHANGE_TRANSFORMER);
+            Tr.entry(tc, "getTransformerFactory");
         }
 
         TransformerFactory tf = null;
 
-        if (CHANGE_TRANSFORMER) {
+        //The IBM XLTXEJ Compiled Transformer (some versions of IBM Java 8) does not work properly
+        //If it is present then try to use the Apache Xalan Interpretive processor instead
+        boolean useApacheXalanTransformer = JavaInfo.isAvailable(IBM_XLTXEJ_COMPILED_TRANSFORMER_FACTORY_CLASS_NAME) &&
+                                    JavaInfo.isAvailable(XALAN_TRANSFORMER_FACTORY_CLASS_NAME) &&
+                                    JavaInfo.isAvailable(SAX_LEXICAL_HANDLER_CLASS_NAME);
 
-            // Synchronize setting and restoring the jvm property to prevent this sequence:
-            // 1. Thread 1 gets jvm property
-            // 2. Thread 1 sets jvm property
-            // 3. Thread 2 gets jvm property set by Thread 1
-            // 4. Thread 1 resets jvm property to value obtained at 1.
-            // 5. Thread 2 resets jvm property to value set by Thread 1.
-            synchronized (transformerLock) {
-
-                final String defaultTransformerFactory = getJVMProperty(TRANSFORMER_FACTORY_JVM_PROPERTY_NAME);
-
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "JDK = " + JavaInfo.vendor() + ", JDK level = " + JavaInfo.majorVersion() + "." + JavaInfo.minorVersion() + ", current TF jvm property value = "
-                                 + defaultTransformerFactory);
-                }
-
-                AccessController.doPrivileged(new PrivilegedAction<Object>() {
-                    @Override
-                    public Object run() {
-                        System.setProperty(TRANSFORMER_FACTORY_JVM_PROPERTY_NAME, "org.apache.xalan.processor.TransformerFactoryImpl");
-                        return null;
-                    }
-                });
-
-                tf = TransformerFactory.newInstance();
-
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "IBM JDK : Use transformer factory: " + tf.getClass().getName());
-                }
-
-                AccessController.doPrivileged(new PrivilegedAction<Object>() {
-                    @Override
-                    public Object run() {
-                        if (defaultTransformerFactory != null)
-                            System.setProperty(TRANSFORMER_FACTORY_JVM_PROPERTY_NAME, defaultTransformerFactory);
-                        else
-                            System.clearProperty(TRANSFORMER_FACTORY_JVM_PROPERTY_NAME);
-                        return null;
-                    }
-                });
-
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "IBM JDK : TF jvm property value restored: " + getJVMProperty(TRANSFORMER_FACTORY_JVM_PROPERTY_NAME));
-                }
-            }
-        } else {
-            tf = TransformerFactory.newInstance();
+        if (useApacheXalanTransformer) {
 
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "Not IBM JDK : Use transformer factory: " + tf.getClass().getName());
+                Tr.debug(tc, "JDK : Use transformer factory: " + XALAN_TRANSFORMER_FACTORY_CLASS_NAME);
             }
+
+            tf = TransformerFactory.newInstance(XALAN_TRANSFORMER_FACTORY_CLASS_NAME, ClassLoader.getSystemClassLoader());
+        } else {
+            tf = TransformerFactory.newInstance();
+        }
+        
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "JDK : Actual transformer factory: " + tf.getClass().getName());
         }
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
@@ -971,16 +914,6 @@ public class PluginGenerator {
         }
         return tf;
 
-    }
-
-    private static String getJVMProperty(final String propertyName) {
-        String propValue = AccessController.doPrivileged(new PrivilegedAction<String>() {
-            @Override
-            public String run() {
-                return System.getProperty(propertyName);
-            }
-        });
-        return propValue;
     }
 
     /**
@@ -1048,22 +981,6 @@ public class PluginGenerator {
             }
         }
         return currentHash;
-    }
-
-    /**
-     * Return the hash value stored in the cached document
-     */
-    private Integer getHashValue(Document doc) {
-        if (doc == null) {
-            return null;
-        }
-        Element root = doc.getDocumentElement();
-        String hash = root.getAttribute("ConfigHash");
-        if (hash != null)
-            return new Integer(hash);
-        return null;
-
-
     }
 
     Set<DynamicVirtualHost> processVirtualHosts(DynamicVirtualHostManager vhostMgr,
@@ -1371,7 +1288,7 @@ public class PluginGenerator {
         sd.nodeName = GeneratePluginConfig.DEFAULT_NODE_NAME;
 
         // check to see if the server is shutting down; if it is, bail out. A final exit message will be logged in the caller.
-        if (pcd == null || FrameworkState.isStopping() || container.isServerStopping()) {
+        if (pcd == null || FrameworkState.isStopping() || WebContainer.isServerStopping()) {
             return false;
         }
 
@@ -1421,8 +1338,6 @@ protected class XMLRootHandler extends DefaultHandler implements LexicalHandler 
                         super((String) null);
                 }
         }
-
-        private String hashValue = null;
 
         /**
          * This is the name of the top-level element found in the XML file. This


### PR DESCRIPTION
On some versions of IBM Java SDKs, the default Transformer Factory is com.ibm.xtq.xslt.jaxp.compiler.TransformerFactoryImpl. That is a compiler processor but we don't want to use that. We want to use the interpretive processor.

https://www.ibm.com/docs/en/sdk-java-technology/8?topic=guide-using-xml#xml_using__select_processor

> com.ibm.xtq.xslt.jaxp.compiler.TransformerFactoryImpl
>     Use the XL TXE-J compiler. This value is the default.
> org.apache.xalan.processor.TransformerFactoryImpl
>     Use the XSLT4J interpreter. 

Previously, the code would have looked at the JVM vendor and version to estabilsh if running on IBM Java 8. However, that approach can not be guaranteed to work in the future. So instead we look directly at which classes are available from the system classloader. If the IBM XSLT classes are not all available then we use the oracle/sun fallback processor, the same one which is defined as a fallback in the API.

This PR also contains a few minor cleanup items such as removing unused imports and code.