### PR TITLE
Update Eclipse Java Compiler (ECJ) to 3.22

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1717,9 +1717,9 @@
       <version>4.3.1</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jdt.core.compiler</groupId>
+      <groupId>org.eclipse.jdt</groupId>
       <artifactId>ecj</artifactId>
-      <version>4.4.2</version>
+      <version>3.22.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -339,7 +339,7 @@ org.cryptacular:cryptacular:1.2.4
 org.eclipse.birt.runtime.3_7_1:org.apache.xml.serializer:2.7.1
 org.eclipse.birt.runtime:org.w3c.css.sac:1.3.1.v200903091627
 org.eclipse.jdt.core.compiler:ecj:4.3.1
-org.eclipse.jdt.core.compiler:ecj:4.4.2
+org.eclipse.jdt:ecj:3.22.0
 org.eclipse.jetty.websocket:javax-websocket-client-impl:9.2.2.v20140723
 org.eclipse.jetty.websocket:javax-websocket-client-impl:9.4.39.v20210325
 org.eclipse.jetty.websocket:websocket-api:9.2.2.v20140723

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.2/com.ibm.websphere.appserver.jsp-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.2/com.ibm.websphere.appserver.jsp-2.2.feature
@@ -38,7 +38,7 @@ Subsystem-Name: JavaServer Pages 2.2
   com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1", \
   com.ibm.websphere.appserver.eeCompatible-6.0, \
   com.ibm.websphere.appserver.javax.el-2.2
--bundles=com.ibm.ws.org.eclipse.jdt.core.3.10.2.v20160712-0000, \
+-bundles=com.ibm.ws.org.eclipse.jdt.core.3.22.0, \
  com.ibm.ws.jsp.factories, \
  com.ibm.websphere.javaee.jstl.1.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:jstl:1.2", \
  com.ibm.ws.jsp.jasper, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.3/com.ibm.websphere.appserver.jsp-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.3/com.ibm.websphere.appserver.jsp-2.3.feature
@@ -38,7 +38,7 @@ Subsystem-Name: JavaServer Pages 2.3
   com.ibm.websphere.appserver.eeCompatible-7.0; ibm.tolerates:="6.0,8.0", \
   com.ibm.websphere.appserver.el-3.0, \
   com.ibm.websphere.appserver.javax.el-3.0
--bundles=com.ibm.ws.org.eclipse.jdt.core.3.10.2.v20160712-0000, \
+-bundles=com.ibm.ws.org.eclipse.jdt.core.3.22.0, \
  com.ibm.websphere.javaee.jstl.1.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:jstl:1.2", \
  com.ibm.ws.jsp.2.3, \
  com.ibm.ws.jsp, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/pages-3.0/io.openliberty.pages-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/pages-3.0/io.openliberty.pages-3.0.feature
@@ -37,7 +37,7 @@ Subsystem-Name: Jakarta Server Pages 3.0
   com.ibm.websphere.appserver.eeCompatible-9.0, \
   io.openliberty.jakarta.pages-3.0, \
   io.openliberty.expressionLanguage-4.0
--bundles=com.ibm.ws.org.eclipse.jdt.core.3.10.2.v20160712-0000, \
+-bundles=com.ibm.ws.org.eclipse.jdt.core.3.22.0, \
  io.openliberty.jakarta.jstl.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api:2.0.0", \
  com.ibm.ws.jsp.2.3.jakarta, \
  com.ibm.ws.jsp.jakarta, \

--- a/dev/com.ibm.ws.jsp/bnd.bnd
+++ b/dev/com.ibm.ws.jsp/bnd.bnd
@@ -133,7 +133,7 @@ instrument.classesExcludes: com/ibm/ws/jsp/resources/*.class
 
 -buildpath: \
 	lib/bsf.jar;version=file,\
-	com.ibm.ws.org.eclipse.jdt.core.3.10.2.v20160712-0000;version=latest,\
+	com.ibm.ws.org.eclipse.jdt.core.3.22.0;version=latest,\
 	com.ibm.websphere.javaee.el.2.2;version=latest,\
 	com.ibm.websphere.javaee.jsp.2.2;version=latest,\
 	com.ibm.ws.kernel.service,\

--- a/dev/com.ibm.ws.org.eclipse.jdt.core/bnd.bnd
+++ b/dev/com.ibm.ws.org.eclipse.jdt.core/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -12,11 +12,11 @@
 bVersion=1.0
 
 Bundle-Name: JDT Compiler
-Bundle-SymbolicName: com.ibm.ws.org.eclipse.jdt.core.3.10.2.v20160712-0000
-Bundle-Description: JDT Compiler, version 4.4.1
+Bundle-SymbolicName: com.ibm.ws.org.eclipse.jdt.core.3.22.0
+Bundle-Description: JDT Compiler, version 3.22.0 [4.16]
 
 Import-Package: !*
    
-Export-Package: org.eclipse.jdt.*;version=3.10.2;usage=JSP
+Export-Package: org.eclipse.jdt.*;version=3.22.0;usage=JSP
 
--buildpath: org.eclipse.jdt.core.compiler.batch;strategy=exact;version=3.10.2.v20160712-0000
+-buildpath: org.eclipse.jdt:ecj;strategy=exact;version=3.22.0


### PR DESCRIPTION
Fixes #18043 where` System.out` is not resolved in Jsp files. 


__________________________

We chose the 3.22 as is is the last release to be certified as Java 8 compatible. 

[Per the Eclipse Foundation](https://wiki.eclipse.org/Eclipse/Installation#Install_a_JVM) — Current releases of Eclipse require Java 11 JRE/JDK or newer.

The last release that required Java 8 was 4.16 (which is the same as the 3.22 release -- verified through md5).   Hence, the switch from the latest.
[Summary of units tests on various platforms can be seen here](http://archive.eclipse.org/eclipse/downloads/drops4/R-4.16-202006040540/) for 4.16/3.22.

_______________
Note: GroupID coordinates changes from `org.eclipse.jdt.core.compiler` to `org.eclipse.jdt`  Lastly, I believe the 4.x releases are meant to line up with Eclipse Platform releases which explains the version differences?