### PR TITLE
criu: "exec restore" checkpoint taken with "server run"

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -1385,7 +1385,7 @@ case "$ACTION" in
     if [ -f ${SERVER_OUTPUT_DIR}/workarea/checkpoint/startCommand ]; then
       criu restore --file-locks --tcp-established --images-dir=${SERVER_OUTPUT_DIR}/workarea/checkpoint/image -j -v -o ${X_LOG_DIR}/restore.log &
     else 
-      criu restore --file-locks --tcp-established --images-dir=${SERVER_OUTPUT_DIR}/workarea/checkpoint/image -j -v -o ${X_LOG_DIR}/restore.log
+      exec criu restore --file-locks --tcp-established --images-dir=${SERVER_OUTPUT_DIR}/workarea/checkpoint/image -j -v -o ${X_LOG_DIR}/restore.log
     fi
     rc=$?
     if [ $rc != 0 ]; then


### PR DESCRIPTION
Attempting to be consistent and invoke the restore as closely as possible to the way we invoked the upstream checkpoint operation.

