### PR TITLE
Update Eclipse Java Compiler (ECJ) to 3.26.0

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1714,7 +1714,7 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>ecj</artifactId>
-      <version>3.22.0</version>
+      <version>3.26.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -338,7 +338,7 @@ org.codehaus.woodstox:woodstox-core-asl:4.2.0
 org.cryptacular:cryptacular:1.2.4
 org.eclipse.birt.runtime.3_7_1:org.apache.xml.serializer:2.7.1
 org.eclipse.birt.runtime:org.w3c.css.sac:1.3.1.v200903091627
-org.eclipse.jdt:ecj:3.22.0
+org.eclipse.jdt:ecj:3.26.0
 org.eclipse.jetty.websocket:javax-websocket-client-impl:9.2.2.v20140723
 org.eclipse.jetty.websocket:javax-websocket-client-impl:9.4.39.v20210325
 org.eclipse.jetty.websocket:websocket-api:9.2.2.v20140723

--- a/dev/com.ibm.ws.org.eclipse.jdt.core/bnd.bnd
+++ b/dev/com.ibm.ws.org.eclipse.jdt.core/bnd.bnd
@@ -13,10 +13,10 @@ bVersion=1.0
 
 Bundle-Name: JDT Compiler
 Bundle-SymbolicName: com.ibm.ws.org.eclipse.jdt.core
-Bundle-Description: Eclipse Java Compiler (ECJ) from the Java Development Tools (JDT) Project. Version 3.22.0: June, 2020 
+Bundle-Description: Eclipse Java Compiler (ECJ) from the Java Development Tools (JDT) Project. Version 3.26.0: June, 2021
 
 Import-Package: !*
    
-Export-Package: org.eclipse.jdt.*;version=3.22.0;usage=JSP
+Export-Package: org.eclipse.jdt.*;version=3.26.0;usage=JSP
 
--buildpath: org.eclipse.jdt:ecj;strategy=exact;version=3.22.0
+-buildpath: org.eclipse.jdt:ecj;strategy=exact;version=3.26.0


### PR DESCRIPTION
Update to  #18043

3.26.0 originally indicated it might not have been Java 8 compliant since Eclipse moved to JDK 11.  However, it requires further testing to verify if it can actually work on Java 8. 

Version 4.20 (Same as 3.26) is supposed by Tomcat 9/10 which requires Java 8 as the minimum. We should be fine upgrading here. 





