### PR TITLE
Remove trace clutter from doPriv and other trivial methods

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
@@ -90,6 +90,7 @@ public class ManagedExecutorServiceImpl implements ExecutorService, //
         // control issues since ForkJoinPool doesn't have doPriv calls for getting some properties
         AccessController.doPrivileged(new PrivilegedAction<Void>() {
             @Override
+            @Trivial
             public Void run() {
                 ForkJoinPool.commonPool();
                 return null;
@@ -417,15 +418,21 @@ public class ManagedExecutorServiceImpl implements ExecutorService, //
     }
 
     @Override
+    @Trivial
     public WSContextService getContextService() {
+        WSContextService contextSvc;
         if (mpContextService == null)
             try {
-                return contextSvcRef.getServiceWithException(); // doPriv is covered by AtomicServiceReference
+                contextSvc = contextSvcRef.getServiceWithException(); // doPriv is covered by AtomicServiceReference
             } catch (IllegalStateException x) {
                 throw new RejectedExecutionException(x);
             }
         else
-            return mpContextService;
+            contextSvc = mpContextService;
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "getContextService: " + contextSvc);
+        return contextSvc;
     }
 
     @Override
@@ -436,12 +443,21 @@ public class ManagedExecutorServiceImpl implements ExecutorService, //
     }
 
     @Override
+    @Trivial
     public PolicyExecutor getLongRunningPolicyExecutor() {
-        return longRunningPolicyExecutorRef.get();
+        PolicyExecutor executor = longRunningPolicyExecutorRef.get();
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "getLongRunningPolicyExecutor: " + executor);
+        return executor;
     }
 
     @Override
+    @Trivial
     public PolicyExecutor getNormalPolicyExecutor() {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "getNormalPolicyExecutor: " + policyExecutor);
+
         return policyExecutor;
     }
 


### PR DESCRIPTION
doPrivileged is cluttering up the ContextServiceImpl/ManagedExecutorServiceImpl trace with useless trace points for instantiating and running privileged actions such as the following,

```
[8/16/21, 9:07:53:835 CDT] 00000037 id=00000000 com.ibm.ws.concurrent.internal.ContextServiceImpl$5          > <init> Entry  
                                                                                                               com.ibm.ws.concurrent.internal.ContextServiceImpl@f1b4d61a
[8/16/21, 9:07:53:835 CDT] 00000037 id=cf402f83 com.ibm.ws.concurrent.internal.ContextServiceImpl$5          < <init> Exit  
                                                                                                               com.ibm.ws.concurrent.internal.ContextServiceImpl$5@cf402f83
[8/16/21, 9:07:53:835 CDT] 00000037 id=cf402f83 com.ibm.ws.concurrent.internal.ContextServiceImpl$5          > run Entry 
[8/16/21, 9:07:53:835 CDT] 00000037 id=cf402f83 com.ibm.ws.concurrent.internal.ContextServiceImpl$5          < run Exit  
                                                                                                               null
```

It also includes the following misleading/erroneous claim of an unrecognized configuration attribute that is actually a built-in setting for EE default resources,

```
[8/16/21, 14:15:14:107 CDT] 00000052 id=56fbfba5 com.ibm.ws.concurrent.internal.ContextServiceImpl            3 unrecognized attribute: javaCompDefaultName
```

And other trivial methods are taking up a lot of space in the trace logs making debugging more difficult.

This pull will pare down the trace to be more focused on what is useful and will aid in debugging.