### PR TITLE
Fix issues from recent merges

### DIFF
--- a/.github/test-categories/EJB_2
+++ b/.github/test-categories/EJB_2
@@ -9,3 +9,4 @@ com.ibm.ws.ejbcontainer.timer.persistent_fat
 com.ibm.ws.ejbcontainer.tx_fat
 com.ibm.ws.injection_fat
 com.ibm.ws.managedbeans_fat
+io.openliberty.ejbcontainer.v40_fat

--- a/.github/test-categories/JAXRS_3
+++ b/.github/test-categories/JAXRS_3
@@ -2,3 +2,4 @@ com.ibm.ws.jaxrs.2.0.cdi.1.2_fat
 com.ibm.ws.jaxrs.2.0.client_fat
 com.ibm.ws.jaxrs.2.0_fat
 com.ibm.ws.jaxrs.2.1.cdi.2.0_fat
+io.openliberty.restfulWS.3.0.cdi.3.0_fat

--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/.classpath
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/.classpath
@@ -5,6 +5,5 @@
 	<classpathentry kind="src" path="test-contextproviders/threadprioritycontext/src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-	<classpathentry kind="src" path="/com.ibm.ws.componenttest.2.0"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/io.openliberty.jakarta.pages.3.0/.classpath
+++ b/dev/io.openliberty.jakarta.pages.3.0/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-    <classpathentry kind="src" path="src"/>
     <classpathentry kind="con" path="aQute.bnd.classpath.container"/>
     <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
     <classpathentry kind="output" path="bin"/>

--- a/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/.project
+++ b/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/.project
@@ -10,8 +10,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
 	</natures>
 </projectDescription>


### PR DESCRIPTION
- Remove nonexistent src dir from .classpath for io.openliberty.jakarta.pages.3.0
- Rely only on bnd for classpath for com.ibm.ws.concurrent.mp_fat_jakarta
- Add bndtools command and nature to io.openliberty.restfulWS.3.0.cdi.3.0_fat .project file
- Add new FAT tests to Github build test-categories.