### PR TITLE
check the server status when a FAT test server fails to stop within the timeout.

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -2454,9 +2454,16 @@ public class LibertyServer implements LogMonitorClient {
 
             int serverStopRC = output.getReturnCode();
             if (serverStopRC != 0) {
-                throw new RuntimeException("Server stop failed with RC " + serverStopRC +
-                                           ".\nStdout:\n" + output.getStdout() +
-                                           "\nStderr:\n" + output.getStderr());
+                if (serverStopRC >= 20) {
+                    ProgramOutput serverStatusOutput = executeServerScript("status", null);
+                    int statusCode = serverStatusOutput.getReturnCode();
+                    Log.warning(c, method + " server status return code=" + statusCode);
+                    if (statusCode != 1) {
+                        throw new RuntimeException("Server stop failed with RC " + serverStopRC +
+                                                   ".\nStdout:\n" + output.getStdout() +
+                                                   "\nStderr:\n" + output.getStderr());
+                    }
+                }
             }
 
             // Now verify that the server is truly stopped by checking server status from the command line.


### PR DESCRIPTION
Only throw an exception if the status call returns anything other that 1

I've been seeing more and more tests fail because the server failed to stop within the 15 seconds (local, 30 seconds on remote builds) timeout.

This PR is the result of an old slack conversation I found and some experimenting.