### PR TITLE
Update Imports for ECJ & Other Revisions

### DIFF
--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     binaries "commons-io:commons-io:2.8.0"
     binaries "commons-lang:commons-lang:2.4"
     binaries "org.apache.commons:commons-math:2.2"
-    binaries "org.eclipse.jdt.core.compiler:ecj:4.3.1"
+    binaries "org.eclipse.jdt:ecj:3.22.0"
     binaries "org.ow2.asm:asm-all:5.2"
     binaries "org.jsoup:jsoup:1.7.2"
     binaries "com.ibm.ws.javax.j2ee:servlet:3.1"

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -338,7 +338,6 @@ org.codehaus.woodstox:woodstox-core-asl:4.2.0
 org.cryptacular:cryptacular:1.2.4
 org.eclipse.birt.runtime.3_7_1:org.apache.xml.serializer:2.7.1
 org.eclipse.birt.runtime:org.w3c.css.sac:1.3.1.v200903091627
-org.eclipse.jdt.core.compiler:ecj:4.3.1
 org.eclipse.jdt:ecj:3.22.0
 org.eclipse.jetty.websocket:javax-websocket-client-impl:9.2.2.v20140723
 org.eclipse.jetty.websocket:javax-websocket-client-impl:9.4.39.v20210325

--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -58,7 +58,6 @@ com.ibm.ws.org.codehaus.jackson:jackson-mapper-asl:1.6.2.1
 com.ibm.ws.org.codehaus.jackson:jackson-mapper-asl:1.9.13
 com.ibm.ws.org.codehaus.jackson:jackson-xc:1.6.2.1
 com.ibm.ws.org.codehaus.jackson:jackson-xc:1.9.13
-com.ibm.ws.org.eclipse.jdt.core.compiler:ecj:4.4.2
 com.ibm.ws.org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.1.20200728.204607-6
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.antlr:2.6.8.WAS-ce829af
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.asm:2.6.8.WAS-ce829af

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.2/com.ibm.websphere.appserver.jsp-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.2/com.ibm.websphere.appserver.jsp-2.2.feature
@@ -38,7 +38,7 @@ Subsystem-Name: JavaServer Pages 2.2
   com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1", \
   com.ibm.websphere.appserver.eeCompatible-6.0, \
   com.ibm.websphere.appserver.javax.el-2.2
--bundles=com.ibm.ws.org.eclipse.jdt.core.3.22.0, \
+-bundles=com.ibm.ws.org.eclipse.jdt.core, \
  com.ibm.ws.jsp.factories, \
  com.ibm.websphere.javaee.jstl.1.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:jstl:1.2", \
  com.ibm.ws.jsp.jasper, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.3/com.ibm.websphere.appserver.jsp-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.3/com.ibm.websphere.appserver.jsp-2.3.feature
@@ -38,7 +38,7 @@ Subsystem-Name: JavaServer Pages 2.3
   com.ibm.websphere.appserver.eeCompatible-7.0; ibm.tolerates:="6.0,8.0", \
   com.ibm.websphere.appserver.el-3.0, \
   com.ibm.websphere.appserver.javax.el-3.0
--bundles=com.ibm.ws.org.eclipse.jdt.core.3.22.0, \
+-bundles=com.ibm.ws.org.eclipse.jdt.core, \
  com.ibm.websphere.javaee.jstl.1.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:jstl:1.2", \
  com.ibm.ws.jsp.2.3, \
  com.ibm.ws.jsp, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/pages-3.0/io.openliberty.pages-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/pages-3.0/io.openliberty.pages-3.0.feature
@@ -37,7 +37,7 @@ Subsystem-Name: Jakarta Server Pages 3.0
   com.ibm.websphere.appserver.eeCompatible-9.0, \
   io.openliberty.jakarta.pages-3.0, \
   io.openliberty.expressionLanguage-4.0
--bundles=com.ibm.ws.org.eclipse.jdt.core.3.22.0, \
+-bundles=com.ibm.ws.org.eclipse.jdt.core, \
  io.openliberty.jakarta.jstl.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api:2.0.0", \
  com.ibm.ws.jsp.2.3.jakarta, \
  com.ibm.ws.jsp.jakarta, \

--- a/dev/com.ibm.ws.jsp.2.3/bnd.bnd
+++ b/dev/com.ibm.ws.jsp.2.3/bnd.bnd
@@ -79,12 +79,12 @@ Import-Package: \
    org.apache.el.lang; version="3.0.0", \
    org.apache.el.parser; version="3.0.0", \
    org.apache.el.util; version="3.0.0", \
-   org.eclipse.jdt.core.compiler;version="3.10.2";usage="JSP", \
-   org.eclipse.jdt.internal.compiler;version="3.10.2";usage="JSP", \
-   org.eclipse.jdt.internal.compiler.classfmt;version="3.10.2";usage="JSP", \
-   org.eclipse.jdt.internal.compiler.env;version="3.10.2";usage="JSP", \
-   org.eclipse.jdt.internal.compiler.impl;version="3.10.2";usage="JSP", \
-   org.eclipse.jdt.internal.compiler.problem;version="3.10.2";usage="JSP", \
+   org.eclipse.jdt.core.compiler;usage="JSP", \
+   org.eclipse.jdt.internal.compiler;usage="JSP", \
+   org.eclipse.jdt.internal.compiler.classfmt;usage="JSP", \
+   org.eclipse.jdt.internal.compiler.env;usage="JSP", \
+   org.eclipse.jdt.internal.compiler.impl;usage="JSP", \
+   org.eclipse.jdt.internal.compiler.problem;usage="JSP", \
    sun.io;resolution:=optional, \
    *
    

--- a/dev/com.ibm.ws.jsp/bnd.bnd
+++ b/dev/com.ibm.ws.jsp/bnd.bnd
@@ -100,12 +100,12 @@ Import-Package: \
    org.apache.el.util;version="2.2", \
    org.apache.jasper.el;version="2.2", \
    io.openliberty.el.internal.cdi;version="2.2", \
-   org.eclipse.jdt.core.compiler;version="3.10.2";usage="JSP", \
-   org.eclipse.jdt.internal.compiler;version="3.10.2";usage="JSP", \
-   org.eclipse.jdt.internal.compiler.classfmt;version="3.10.2";usage="JSP", \
-   org.eclipse.jdt.internal.compiler.env;version="3.10.2";usage="JSP", \
-   org.eclipse.jdt.internal.compiler.impl;version="3.10.2";usage="JSP", \
-   org.eclipse.jdt.internal.compiler.problem;version="3.10.2";usage="JSP", \
+   org.eclipse.jdt.core.compiler;usage="JSP", \
+   org.eclipse.jdt.internal.compiler;usage="JSP", \
+   org.eclipse.jdt.internal.compiler.classfmt;usage="JSP", \
+   org.eclipse.jdt.internal.compiler.env;usage="JSP", \
+   org.eclipse.jdt.internal.compiler.impl;usage="JSP", \
+   org.eclipse.jdt.internal.compiler.problem;usage="JSP", \
    sun.io;resolution:=optional, \
    *
 

--- a/dev/com.ibm.ws.jsp/bnd.bnd
+++ b/dev/com.ibm.ws.jsp/bnd.bnd
@@ -133,7 +133,7 @@ instrument.classesExcludes: com/ibm/ws/jsp/resources/*.class
 
 -buildpath: \
 	lib/bsf.jar;version=file,\
-	com.ibm.ws.org.eclipse.jdt.core.3.22.0;version=latest,\
+	com.ibm.ws.org.eclipse.jdt.core;version=latest,\
 	com.ibm.websphere.javaee.el.2.2;version=latest,\
 	com.ibm.websphere.javaee.jsp.2.2;version=latest,\
 	com.ibm.ws.kernel.service,\

--- a/dev/com.ibm.ws.org.eclipse.jdt.core/bnd.bnd
+++ b/dev/com.ibm.ws.org.eclipse.jdt.core/bnd.bnd
@@ -12,8 +12,8 @@
 bVersion=1.0
 
 Bundle-Name: JDT Compiler
-Bundle-SymbolicName: com.ibm.ws.org.eclipse.jdt.core.3.22.0
-Bundle-Description: JDT Compiler, version 3.22.0 [4.16]
+Bundle-SymbolicName: com.ibm.ws.org.eclipse.jdt.core
+Bundle-Description: Eclipse Java Compiler (ECJ) from the Java Development Tools (JDT) Project. Version 3.22.0: June, 2020 
 
 Import-Package: !*
    


### PR DESCRIPTION
Version imports were missed in PR #18189 (for issue #18043) 

Builds were fine without this correction because 3.10.2 is meant as a minimum (see doc [here](http://docs.osgi.org/specification/osgi.core/7.0.0/framework.module.html#i3189032))

I spoke to Tom Watson, and he recommend getting rid of the versions since the `usage=JSP` is enough for these classes to resolve.

https://github.com/OpenLiberty/open-liberty/blob/c601cff369ee3031b4584c379d3cf872dfab00ae/dev/com.ibm.ws.org.eclipse.jdt.core/bnd.bnd#L20 

Otherwise, I followed up with Tom Watson's review comments (other than updating to the latest which is in PR #18218) 
