### PR TITLE
Remove hidden character that causes compile failure in eclipse.

### DIFF
--- a/dev/com.ibm.ws.cdi.2.0.weld/src/com/ibm/ws/cdi/proxy/AbstractProxyServices.java
+++ b/dev/com.ibm.ws.cdi.2.0.weld/src/com/ibm/ws/cdi/proxy/AbstractProxyServices.java
@@ -128,7 +128,7 @@ public abstract class AbstractProxyServices implements ProxyServices {
 
 	@Override
 	@FFDCIgnore(ClassNotFoundException.class)
-	public Class<?> defineClass​(Class<?> originalClass, String className, byte[] classBytes, int off, int len, ProtectionDomain protectionDomain) throws ClassFormatError {
+	public Class<?> defineClass(Class<?> originalClass, String className, byte[] classBytes, int off, int len, ProtectionDomain protectionDomain) throws ClassFormatError {
 
 		ClassLoader loader = loaderMap.get(originalClass);
 		Object classLoaderLock = null;
@@ -168,7 +168,7 @@ public abstract class AbstractProxyServices implements ProxyServices {
 	}
 
 	@Override
-	public Class<?> loadClass​(Class<?> originalClass, String classBinaryName) throws ClassNotFoundException {
+	public Class<?> loadClass(Class<?> originalClass, String classBinaryName) throws ClassNotFoundException {
 		ClassLoader cl = loaderMap.get(originalClass);
 		return loadClass​(classBinaryName, cl);
 	}


### PR DESCRIPTION
- defineClass and loadClass both had a hidden character after the method name and before the parenthesis.