### PR TITLE
Swap to local artifactory for pebble image

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/docker/pebble/PebbleContainer.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/docker/pebble/PebbleContainer.java
@@ -15,6 +15,9 @@ import static junit.framework.Assert.fail;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
+import componenttest.containers.ArtifactoryImageNameSubstitutor;
+import componenttest.containers.ExternalTestServiceDockerClientStrategy;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -97,10 +100,12 @@ public class PebbleContainer extends CAContainer {
 	 */
 	public PebbleContainer() {
 		super(new ImageFromDockerfile()
-				.withDockerfileFromBuilder(builder -> builder.from("letsencrypt/pebble")
+				.withDockerfileFromBuilder(builder -> builder
+						.from((ExternalTestServiceDockerClientStrategy.USE_REMOTE_DOCKER_HOST
+								? ArtifactoryImageNameSubstitutor.getPrivateRegistry() + "/"
+								: "") + "letsencrypt/pebble")
 						.copy("pebble-config.json", "/test/config/pebble-config.json").build())
-				.withFileFromFile("pebble-config.json", PEBBLE_CONFIG_JSON_FILE), 5002,
-				14000, 15000);
+				.withFileFromFile("pebble-config.json", PEBBLE_CONFIG_JSON_FILE), 5002, 14000, 15000);
 		challtestsrv.withStartupAttempts(20);
 		challtestsrv.withStartupTimeout(Duration.ofSeconds(60));
 

--- a/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryImageNameSubstitutor.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryImageNameSubstitutor.java
@@ -64,7 +64,7 @@ public class ArtifactoryImageNameSubstitutor extends ImageNameSubstitutor {
         return isSynthetic;
     }
 
-    static String getPrivateRegistry() {
+    public static String getPrivateRegistry() {
         String artifactoryServer = System.getProperty("fat.test.artifactory.download.server");
         if (artifactoryServer == null || artifactoryServer.isEmpty() || artifactoryServer.startsWith("${"))
             throw new IllegalStateException("No private registry configured. System property 'fat.test.artifactory.download.server' was: " + artifactoryServer);


### PR DESCRIPTION
Need to swap our main Pebble image to pull from the local artifactory or we can hit the rate limits -- `Caused by: com.github.dockerjava.api.exception.DockerClientException: Could not build image: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit`

Some of the images are auto swapped when they run through `ArtifactoryImageNameSubstitutor.apply()`

```
[08/06/2021 15:33:38:645 CDT] 001 ArtifactoryImageNameSubstituto apply                          I Swapping docker image name from testcontainers/ryuk:0.3.1 --> wasliberty-docker-remote.artifactory.swg-devops.com/testcontainers/ryuk:0.3.1
[08/06/2021 15:33:42:815 CDT] 001 ArtifactoryImageNameSubstituto apply                          I Swapping docker image name from letsencrypt/pebble-challtestsrv:latest --> wasliberty-docker-remote.artifactory.swg-devops.com/letsencrypt/pebble-challtestsrv:latest
```

The main Pebble image build does not flow through the apply method. The Boulder image name is remapped for us as well.

Added a check that if we're remote, we should remap to the local artifactory.

For RTC 285604