### PR TITLE
Only allow a single checkpoint to be called

### DIFF
--- a/dev/io.openliberty.checkpoint/test/io/openliberty/checkpoint/internal/CheckpointImplTest.java
+++ b/dev/io.openliberty.checkpoint/test/io/openliberty/checkpoint/internal/CheckpointImplTest.java
@@ -220,6 +220,7 @@ public class CheckpointImplTest {
         WsLocationAdmin locAdmin = (WsLocationAdmin) SharedLocationManager.createLocations(testbuildDir, "test1");
         CheckpointImpl checkpoint = new CheckpointImpl(createComponentContext(), criu, locAdmin);
         checkDirectory(Phase.FEATURES, checkpoint, criu, locAdmin);
+        checkpoint.resetCheckpointCalled();
         checkFailDump(Phase.FEATURES, checkpoint, criu, locAdmin);
     }
 
@@ -364,6 +365,22 @@ public class CheckpointImplTest {
         cl.successfulCompletion(createTestFuture(), Boolean.TRUE);
         assertEquals("Wrong phase.", Phase.FEATURES, factory.phase);
         assertTrue("Expected to have called criu", criu.imageDir.getAbsolutePath().contains(locAdmin.getServerName()));
+    }
+
+    @Test
+    public void testMultipleCheckpoints() {
+        TestCRIU criu = new TestCRIU();
+        TestCheckpointHookFactory factory = new TestCheckpointHookFactory();
+        WsLocationAdmin locAdmin = (WsLocationAdmin) SharedLocationManager.createLocations(testbuildDir, "test9");
+        CheckpointImpl checkpoint = new CheckpointImpl(createComponentContext1(true, false, factory), criu, locAdmin);
+        checkpoint.check();
+        assertTrue("Expected to have called checkpoint", checkpoint.checkpointCalledAlready());
+        checkpoint.check();
+        assertTrue("Expected to have called checkpoint", checkpoint.checkpointCalledAlready());
+        checkpoint.resetCheckpointCalled();
+        assertTrue("Expected to have reset checkpoint", !checkpoint.checkpointCalledAlready());
+        checkpoint.check();
+        assertTrue("Expected to have called checkpoint", checkpoint.checkpointCalledAlready());
     }
 
     private CompletionListener<Boolean> getCompletionListener() {


### PR DESCRIPTION
When doing a "features" checkpoint, then changing the location of the keyStore in the server.xml, and finally doing a restore, the restore portion fails trying to do another checkpoint due to the config change. Add a test to ensure we can only call checkpoint once.