### PR TITLE
add PrototypeTest for rapid prototyping with all of the FAT boilerplate already set up

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/.classpath
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/.classpath
@@ -25,6 +25,7 @@
 	<classpathentry kind="src" path="test-applications/options/src"/>
 	<classpathentry kind="src" path="test-applications/paramconverter/src"/>
 	<classpathentry kind="src" path="test-applications/params/src"/>
+	<classpathentry kind="src" path="test-applications/prototype/src"/>
 	<classpathentry kind="src" path="test-applications/providerAndResource/src"/>
 	<classpathentry kind="src" path="test-applications/providerCache/src"/>
 	<classpathentry kind="src" path="test-applications/providers/src"/>

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/bnd.bnd
@@ -37,6 +37,7 @@ src: \
   test-applications/paramconverter/src,\
   test-applications/options/src,\
   test-applications/params/src,\
+  test-applications/prototype/src,\
   test-applications/providerAndResource/src,\
   test-applications/providerCache/src,\
   test-applications/providers/src,\

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/build.gradle
@@ -17,6 +17,7 @@ configurations {
   jersey
   json
   httpclient
+  prototype
 }
 
 configurations.jersey {
@@ -111,6 +112,11 @@ task createWadlTempDir {
   }
 }
 
+task addPrototypeLibs(type: Copy) {
+  from configurations.prototype
+  into "${buildDir}/autoFVT/appLibs/prototype/"
+}
+
 addRequiredLibraries {
   dependsOn addCXF
   dependsOn addJackson1x
@@ -121,6 +127,7 @@ addRequiredLibraries {
   dependsOn addHttpClient
   dependsOn createWadlTempDir
   dependsOn addDerby
+  dependsOn addPrototypeLibs
 }
 
 addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/FATSuite.java
@@ -56,6 +56,7 @@ import componenttest.rules.repeater.RepeatTests;
                 OptionsTest.class,
                 ParamConverterTest.class,
                 ParamsTest.class,
+                PrototypeTest.class,
                 ProviderCacheTest.class,
                 ReaderWriterProvidersTest.class,
                 ResourceInfoTest.class,

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/PrototypeTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/PrototypeTest.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs20.fat;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.jaxrs.fat.prototype.PrototypeClientTestServlet;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+/*
+ * The purpose of this test is to provide an empty canvas for rapid/easy test experimentation,
+ * as well as providing and example of FAT best practices.
+ *
+ * This Test should never have any real tests, if you use this Test to create a test that should
+ * be added permanently, create a new FAT Test using this test as a template.
+ */
+@RunWith(FATRunner.class)
+public class PrototypeTest extends FATServletClient {
+
+    private static final String appName = "prototype";
+
+    // Third party libs are copied to ${buildDir}/autoFVT/appLibs/prototype in build.gradle
+    private static final String libs = "appLibs/prototype";
+
+    @Server("com.ibm.ws.jaxrs.fat.prototype")
+    @TestServlet(servlet = PrototypeClientTestServlet.class, contextRoot = appName)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        // Build an application and export it to the dropins directory
+        ShrinkHelper.defaultDropinApp(server, appName, "com.ibm.ws.jaxrs.fat.prototype");
+
+        // Build an application, add third party libs, and manuall export to the dropins directory
+//        WebArchive app = ShrinkHelper.buildDefaultApp(appName, "com.ibm.ws.jaxrs.fat.prototype");
+//        app.addAsLibraries(new File(libs).listFiles());
+//        ShrinkHelper.exportDropinAppToServer(server, app);
+//        server.addInstalledAppForValidation(appName);
+
+        // Make sure we don't fail because we try to start an
+        // already started server
+        try {
+            server.startServer("Prototype.log", true);
+        } catch (Exception e) {
+            System.out.println(e.toString());
+        }
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        if (server != null) {
+            server.stopServer("CWWKE1102W");  //ignore server quiesce timeouts due to slow test machines
+        }
+    }
+
+    @Before
+    public void beforeTest() {}
+
+    @After
+    public void afterTest() {}
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.prototype/.gitignore
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.prototype/.gitignore
@@ -1,0 +1,2 @@
+/apps
+/dropins

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.prototype/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.prototype/bootstrap.properties
@@ -1,0 +1,4 @@
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all:org.jboss.resteasy*=all
+com.ibm.ws.logging.max.file.size=0
+
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.prototype/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.prototype/server.xml
@@ -1,0 +1,9 @@
+<server>
+    <featureManager>
+        <feature>componenttest-1.0</feature>
+        <feature>jaxrs-2.0</feature>
+    </featureManager>
+
+  	<include location="../fatTestPorts.xml"/>
+  	<javaPermission className="java.util.PropertyPermission" name="bvt.prop.HTTP_default" actions="read"/>
+</server>

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/prototype/src/com/ibm/ws/jaxrs/fat/prototype/PrototypeApplication.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/prototype/src/com/ibm/ws/jaxrs/fat/prototype/PrototypeApplication.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.prototype;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class PrototypeApplication extends Application {
+
+//    @Override
+//    public Set<Class<?>> getClasses() {
+//        Set<Class<?>> classes = new HashSet<Class<?>>();
+//        classes.add(PrototypeResource.class);
+//        return classes;
+//        return Collections.singleton(PrototypeResource.class);
+//    }
+//
+//    @Override
+//    public Map<String, Object> getProperties() {
+//        Map<String, Object> properties = new HashMap<String, Object>();
+//        return properties;
+//        return Collections.singleton(props);
+//    }
+//
+//    @Override
+//    public Set<Object> getSingletons() {
+//        Set<Object> singletons = new HashSet<Object>();
+//        singletons.add(new PrototypeResource());
+//        return singletons;
+//        return Collections.singleton(new PrototypeResource());
+//    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/prototype/src/com/ibm/ws/jaxrs/fat/prototype/PrototypeClientTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/prototype/src/com/ibm/ws/jaxrs/fat/prototype/PrototypeClientTestServlet.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.prototype;
+
+
+import static org.junit.Assert.assertEquals;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/JaxrsPrototypeClientTestServlet")
+public class PrototypeClientTestServlet extends FATServlet {
+
+    private static final String URI_CONTEXT_ROOT = "http://localhost:" + Integer.getInteger("bvt.prop.HTTP_default") + "/prototype/";
+
+    private Client client;
+
+    @Override
+    public void before() throws ServletException {
+        client = ClientBuilder.newClient();
+    }
+
+    @Override
+    public void after() {
+        client.close();
+    }
+
+    @Test
+    public void testHelloWorld() {
+        Response response = client.target(URI_CONTEXT_ROOT)
+                        .path("echo")
+                        .request(MediaType.TEXT_PLAIN_TYPE)
+                        .get();
+        assertEquals(200, response.getStatus());
+        assertEquals("Hello World!", response.readEntity(String.class));
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/prototype/src/com/ibm/ws/jaxrs/fat/prototype/PrototypeResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/prototype/src/com/ibm/ws/jaxrs/fat/prototype/PrototypeResource.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.prototype;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/")
+public class PrototypeResource {
+
+    @GET
+    @Path("echo")
+    public String hello() {
+        return "Hello World!";
+    }
+}


### PR DESCRIPTION
Adding this test will make it significantly faster/easier to quickly test JAX-RS functionality in `jaxrs-2.0`, `jaxrs-2.1` and `restfulWS-3.0` by providing a blank canvas with all of the FAT boilerplate already set up.

We should never merge and "real" tests, and keep this test clean for rapid testing.