### PR TITLE
Add transaction isolation config to Persistence Service

### DIFF
--- a/dev/com.ibm.ws.persistence/resources/com/ibm/wsspi/persistence/internal/PersistenceServiceMessages.nlsprops
+++ b/dev/com.ibm.ws.persistence/resources/com/ibm/wsspi/persistence/internal/PersistenceServiceMessages.nlsprops
@@ -89,3 +89,8 @@ PROVIDER_ERROR_CWWKD0292E=CWWKD0292E: {0}
 PROVIDER_ERROR_CWWKD0292E.explanation=The DatabaseStore has logged this error message.
 PROVIDER_ERROR_CWWKD0292E.useraction=Consult the DatabaseStore documentation.
 
+#-------------------------------------------------------------------------------
+UNSUPPORTED_ISOLATION_LEVEL_CWWKD0293E=CWWKD0293E: The configured transaction isolation level {0} is unsupported.
+UNSUPPORTED_ISOLATION_LEVEL_CWWKD0293E.explanation=The associated database driver does not support the requested isolation level.
+UNSUPPORTED_ISOLATION_LEVEL_CWWKD0293E.useraction=Change the isolation level before trying again.
+

--- a/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/DatabaseStore.java
+++ b/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/DatabaseStore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,23 +10,43 @@
  *******************************************************************************/
 package com.ibm.wsspi.persistence;
 
+import java.util.Map;
+
 /**
  * Enables configuration of a database as a persistent store that can be shared by multiple components.
  */
 public interface DatabaseStore {
+
     /**
      * Create a persistence service unit for the specified entity classes.
      * The invoker of this method is responsible for closing the persistence service unit
      * and for participating in DDL generation.
-     * 
-     * The persistence service feature is currently not supported for informix.
-     * 
+     *
      * @param loader class loader for the entity classes.
      * @param entityClasses list of entity classes.
      * @return the persistence service unit.
      * @throws Exception if a failure occurs.
+     * @throws UnsupportedOperationException for Informix
      */
     PersistenceServiceUnit createPersistenceServiceUnit(ClassLoader loader, String... entityClassNames) throws Exception;
+
+    /**
+     * Create a persistence service unit for the specified entity classes.
+     * Allows the invoker to pass configuration properties.
+     * The invoker of this method is responsible for closing the persistence service unit
+     * and for participating in DDL generation.
+     *
+     * The persistence service feature is currently not supported for informix.
+     *
+     * @param loader class loader for the entity classes.
+     * @param properties map of configuration properties
+     * @param entityClasses list of entity classes.
+     * @return the persistence service unit.
+     * @throws Exception if a failure occurs.
+     * @throws UnsupportedOperationException for Informix
+     * @throws UnsupportedOperationException if a configuration property is not supported
+     */
+    PersistenceServiceUnit createPersistenceServiceUnit(ClassLoader loader, Map properties, String... entityClassNames) throws Exception;
 
     /**
      * Get the configured schema name.


### PR DESCRIPTION
#### Current persistence service failure:
```
org.postgresql.util.PSQLException: Cannot change transaction isolation level in the middle of a transaction.
at org.postgresql.jdbc.PgConnection.setTransactionIsolation(PgConnection.java:844)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.base/java.lang.reflect.Method.invoke(Method.java:566)
at org.postgresql.ds.PGPooledConnection$ConnectionHandler.invoke(PGPooledConnection.java:337)
at com.sun.proxy.$Proxy10.setTransactionIsolation(Unknown Source)
at com.ibm.ws.rsadapter.impl.WSRdbManagedConnectionImpl.setTransactionIsolation(WSRdbManagedConnectionImpl.java:3989)
at com.ibm.ws.rsadapter.impl.WSRdbManagedConnectionImpl.synchronizePropertiesWithCRI(WSRdbManagedConnectionImpl.java:2065)
at com.ibm.ws.rsadapter.impl.WSRdbManagedConnectionImpl.getConnection(WSRdbManagedConnectionImpl.java:2352)
at com.ibm.ejs.j2c.MCWrapper.getConnection(MCWrapper.java:1933)
at com.ibm.ejs.j2c.ConnectionManager.allocateConnection(ConnectionManager.java:318)
at com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource.getConnection(WSJdbcDataSource.java:140)
at com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource.getConnection(WSJdbcDataSource.java:114)
at org.eclipse.persistence.sessions.JNDIConnector.connect(JNDIConnector.java:135)
at com.ibm.wsspi.persistence.internal.eclipselink.WrappingConnector.connect(WrappingConnector.java:40)
at org.eclipse.persistence.sessions.DatasourceLogin.connectToDatasource(DatasourceLogin.java:162)
...
at org.eclipse.persistence.queries.ObjectLevelReadQuery.executeInUnitOfWork(ObjectLevelReadQuery.java:1230)
at org.eclipse.persistence.internal.sessions.UnitOfWorkImpl.internalExecuteQuery(UnitOfWorkImpl.java:2900)
at org.eclipse.persistence.internal.sessions.AbstractSession.executeQuery(AbstractSession.java:1866)
at org.eclipse.persistence.internal.sessions.AbstractSession.retryQuery(AbstractSession.java:1936)
at org.eclipse.persistence.sessions.server.ClientSession.retryQuery(ClientSession.java:698)
at org.eclipse.persistence.internal.sessions.UnitOfWorkImpl.retryQuery(UnitOfWorkImpl.java:5540)
at org.eclipse.persistence.internal.sessions.AbstractSession.executeQuery(AbstractSession.java:1902)
at org.eclipse.persistence.internal.sessions.AbstractSession.executeQuery(AbstractSession.java:1848)
at org.eclipse.persistence.internal.sessions.AbstractSession.executeQuery(AbstractSession.java:1813)
at org.eclipse.persistence.internal.jpa.QueryImpl.executeReadQuery(QueryImpl.java:258)
at org.eclipse.persistence.internal.jpa.QueryImpl.getResultList(QueryImpl.java:473)
at com.ibm.ws.concurrent.persistent.db.DatabaseTaskStore.findUnclaimedTasks(DatabaseTaskStore.java:796)
```

#### Explanation:

The Persistence Service first sets the Transaction Isolation to TRANSACTION_READ_UNCOMMITTED on EclipseLink's `org.eclipse.persistence.sessions.DatabaseLogin` API.

EclipseLink uses that isolation level to set the isolation level on the first connection: 
`org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor.checkTransactionIsolation()`

Then, that first query fails with an exception (table does not exist).

EclipseLink attempts to determine if the failure was due to a communication issue with the database. 
EclipseLink executes a "ping" query to determine if it was a communication failure: 
org.eclipse.persistence.internal.databaseaccess.DatabasePlatform.wasFailureCommunicationBased

EclipseLink determines that the failure was a communication issue because of the  `java.sql.SQLException` from the ping query: 
org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor.processExceptionForCommError

Then, EclipseLink sees that the query was a readQuery and a communication issue, so EclipseLink tries to retry executing the query: 
org.eclipse.persistence.internal.sessions.AbstractSession.executeQuery

In order to re-execute the query, EclipseLink tries to get a new connection from the datasource pool.

However, connection sharing is enabled, and connectionSharing=MatchOriginalRequest is used (by default), so the connection pool matches that same connection by its original request, and attempts to set the TRANSACTION_READ_COMMITTED isolation level that we are asking for before handing it back to. That is where it fails because PostgreSQL is very strict.

#### Solution:

One solution is to remove the `org.eclipse.persistence.sessions.DatabaseLogin` API call to set transaction isolation within EclipseLink and instead set the transaction isolation on the `javax.sql.DataSource` so that all Connections will be the expected isolation level.

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>