### PR TITLE
if there is no cookie in the request, then set cookie name to blank

### DIFF
--- a/dev/com.ibm.ws.security.authentication.filter/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.authentication.filter/resources/OSGI-INF/l10n/metatype.properties
@@ -41,7 +41,7 @@ requestHeader=Request Header
 requestHeader.desc=Specifies the HTTP request header attribute name, for example, <requestHeader id="sample" name="email" value="Kevin@yahoo.com|Steven@gmail.com" matchType="contains"/>.
 
 cookie=Cookie
-cookie.desc=Specifies the name of the cookie that the client sends in the HTTP request, for example, <cookie id="sample" name="LtpaToken2" matchType="equals"/>.
+cookie.desc=Specifies the name of the cookie that the client sends in the HTTP request, for example, <cookie id="sample" name="LtpaToken2" matchType="equals"/>. If the cookie element is configured and there is no cookie in the HttpServletRequest, then the authentication filter sets the cookie name to blank.
 
 matchType= Match type
 matchType.desc=Specifies the match type.

--- a/dev/com.ibm.ws.security.authentication.filter/src/com/ibm/ws/security/authentication/filter/internal/CommonFilter.java
+++ b/dev/com.ibm.ws.security.authentication.filter/src/com/ibm/ws/security/authentication/filter/internal/CommonFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -349,6 +349,12 @@ public class CommonFilter {
                     HTTPheader = req.getApplicationName();
                 } else if (key.equals(AuthFilterConfig.KEY_COOKIE)) {
                     HTTPheader = req.getCookieName(key);
+                    if (HTTPheader == null) {
+                        HTTPheader = "";
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc, "No cookie in the ServletRequest so assigned the cookie name to BLANK");
+                        }
+                    }
                 } else if (cond instanceof NotContainsCondition) {
                     continue;
                 } else {


### PR DESCRIPTION
If the cookie element is configured and there is no cookie in the HttpServletRequest, the authentication filter code sets the cookie name to blank.