### PR TITLE
Create Jakarta EE 9 feature compatibility test

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appClientSupport-1.0/com.ibm.websphere.appserver.appClientSupport-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appClientSupport-1.0/com.ibm.websphere.appserver.appClientSupport-1.0.feature
@@ -4,7 +4,9 @@ WLP-DisableAllFeatures-OnConflict: false
 visibility=public
 IBM-ShortName: appClientSupport-1.0
 Subsystem-Name: Application Client Support for Server 1.0
--features=com.ibm.websphere.appclient.appClient-1.0, \
+-features=\
+  com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0, 8.0", \
+  com.ibm.websphere.appclient.appClient-1.0, \
   com.ibm.websphere.appserver.injection-1.0, \
   com.ibm.websphere.appserver.clientContainerRemoteSupport-1.0
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/scim-2.0/com.ibm.websphere.appserver.scim-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/scim-2.0/com.ibm.websphere.appserver.scim-2.0.feature
@@ -4,7 +4,7 @@ visibility=public
 IBM-ShortName: scim-2.0
 Subsystem-Name: System for Cross-domain Identity Management 2.0
 -features=com.ibm.websphere.appserver.restHandler-1.0, \
-  com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0"
+  com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0"
 -bundles=com.ibm.ws.security.wim.scim.2.0, \
  io.openliberty.com.fasterxml.jackson
 kind=noship

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/sipServlet-1.1/com.ibm.websphere.appserver.sipServlet-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/sipServlet-1.1/com.ibm.websphere.appserver.sipServlet-1.1.feature
@@ -16,7 +16,9 @@ IBM-API-Package: javax.servlet.sip.annotation;  type="spec", \
  com.ibm.websphere.sip;  type="ibm-api"
 IBM-ShortName: sipServlet-1.1
 Subsystem-Name: SIP Servlet 1.1
--features=com.ibm.websphere.appserver.channelfw-1.0, \
+-features=\
+  com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0, 8.0", \
+  com.ibm.websphere.appserver.channelfw-1.0, \
   com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="3.0,4.0"
 -bundles=\
   com.ibm.websphere.javaee.jaxb.2.2; apiJar=false; require-java:="9"; location:="dev/api/spec/,lib/",\

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/wasJmsClient-2.0/com.ibm.websphere.appserver.wasJmsClient-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/wasJmsClient-2.0/com.ibm.websphere.appserver.wasJmsClient-2.0.feature
@@ -7,7 +7,9 @@ IBM-API-Package: javax.jms; version="2.0"; type="spec", \
  com.ibm.websphere.sib.api.jms; type="internal"
 IBM-ShortName: wasJmsClient-2.0
 Subsystem-Name: JMS 2.0 Client for Message Server
--features=com.ibm.websphere.appserver.channelfw-1.0, \
+-features=\
+  com.ibm.websphere.appserver.eeCompatible-7.0; ibm.tolerates:="6.0, 8.0", \
+  com.ibm.websphere.appserver.channelfw-1.0, \
   com.ibm.websphere.appserver.transaction-1.2, \
   com.ibm.websphere.appserver.internal.jms-2.0
 -bundles=com.ibm.ws.messaging.common, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/wasJmsSecurity-1.0/com.ibm.websphere.appserver.wasJmsSecurity-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/wasJmsSecurity-1.0/com.ibm.websphere.appserver.wasJmsSecurity-1.0.feature
@@ -4,7 +4,9 @@ WLP-DisableAllFeatures-OnConflict: false
 visibility=public
 IBM-ShortName: wasJmsSecurity-1.0
 Subsystem-Name: Message Server Security 1.0
--features=com.ibm.websphere.appserver.wasJmsServer-1.0, \
+-features=\
+  com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0, 8.0", \
+  com.ibm.websphere.appserver.wasJmsServer-1.0, \
   com.ibm.websphere.appserver.security-1.0, \
   com.ibm.websphere.appserver.transaction-1.1; ibm.tolerates:="1.2"
 -bundles=\

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/wasJmsServer-1.0/com.ibm.websphere.appserver.wasJmsServer-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/wasJmsServer-1.0/com.ibm.websphere.appserver.wasJmsServer-1.0.feature
@@ -5,7 +5,9 @@ visibility=public
 IBM-API-Package: com.ibm.websphere.messaging.mbean; type="ibm-api"
 IBM-ShortName: wasJmsServer-1.0
 Subsystem-Name: Message Server 1.0
--features=com.ibm.websphere.appserver.appLifecycle-1.0, \
+-features=\
+  com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0, 8.0", \
+  com.ibm.websphere.appserver.appLifecycle-1.0, \
   com.ibm.websphere.appserver.channelfw-1.0, \
   com.ibm.websphere.appserver.transaction-1.1; ibm.tolerates:="1.2"
 -bundles=com.ibm.ws.messaging.comms.server, \

--- a/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/FATTest.java
+++ b/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/FATTest.java
@@ -772,6 +772,8 @@ public class FATTest extends AbstractAppManagerTest {
             pathsToCleanup.add(server.getServerRoot() + "/apps");
             // Ignore expected NPE and unknown resource warning
             server.stopServer("CWWKZ0002E", "CWWKZ0014W", "CWWKZ0005E");
+            server.uninstallSystemFeature("test.app.notifications");
+            server.uninstallSystemBundle("test.app.notifications");
         }
     }
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/fat/src/com/ibm/ws/concurrent/persistent/fat/oneexec/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/fat/src/com/ibm/ws/concurrent/persistent/fat/oneexec/FATSuite.java
@@ -10,8 +10,10 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent.persistent.fat.oneexec;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -35,5 +37,13 @@ public class FATSuite {
         assertTrue("Helper feature should have been copied to lib/features.",
                    server.fileExistsInLibertyInstallRoot("lib/features/singletonTestFeature-1.0.mf"));
         server.copyFileToLibertyInstallRoot("lib/", "bundles/test.feature.ejb.singleton.jar");
+    }
+
+    @AfterClass
+    public static void afterSuite() throws Exception {
+        server.deleteFileFromLibertyInstallRoot("lib/features/singletonTestFeature-1.0.mf");
+        assertFalse("Helper feature should have been deleted from lib/features.",
+                   server.fileExistsInLibertyInstallRoot("lib/features/singletonTestFeature-1.0.mf"));
+        server.deleteFileFromLibertyInstallRoot("lib/test.feature.ejb.singleton.jar");
     }
 }

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE7FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE7FeatureReplacementAction.java
@@ -58,7 +58,10 @@ public class EE7FeatureReplacementAction extends FeatureReplacementAction {
                                                  "wasJmsClient-2.0",
                                                  "wasJmsServer-1.0",
                                                  "wasJmsSecurity-1.0",
-                                                 "jaxws-2.2" };
+                                                 "jaxws-2.2",
+                                                 "j2eeManagement-1.1",
+                                                 "jaspic-1.1",
+                                                 "jacc-1.5" };
 
     public static final Set<String> EE7_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE7_FEATURES_ARRAY)));
 

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE8FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE8FeatureReplacementAction.java
@@ -21,6 +21,7 @@ public class EE8FeatureReplacementAction extends FeatureReplacementAction {
 
     static final String[] EE8_FEATURES_ARRAY = { "appClientSupport-1.0",
                                                  "javaee-8.0",
+                                                 "jakartaee-8.0",
                                                  "webProfile-8.0",
                                                  "javaeeClient-8.0",
                                                  "servlet-4.0",
@@ -61,7 +62,10 @@ public class EE8FeatureReplacementAction extends FeatureReplacementAction {
                                                  "wasJmsClient-2.0",
                                                  "wasJmsServer-1.0",
                                                  "wasJmsSecurity-1.0",
-                                                 "jaxws-2.2" };
+                                                 "jaxws-2.2",
+                                                 "j2eeManagement-1.1",
+                                                 "jaspic-1.1",
+                                                 "jacc-1.5" };
 
     public static final Set<String> EE8_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE8_FEATURES_ARRAY)));
 

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureReplacementAction.java
@@ -574,7 +574,7 @@ public class FeatureReplacementAction implements RepeatTestAction {
      *
      * @return                     The replacement feature name. Null if no replacement is available.
      */
-    private static String getReplacementFeature(String originalFeature, Set<String> replacementFeatures, Set<String> alwaysAddFeatures) {
+    public static String getReplacementFeature(String originalFeature, Set<String> replacementFeatures, Set<String> alwaysAddFeatures) {
         String methodName = "getReplacementFeature";
         // Example: servlet-3.1 --> servlet-4.0
         int dashOffset = originalFeature.indexOf('-');

--- a/dev/io.openliberty.jakartaee9.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.jakartaee9.internal_fat/bnd.bnd
@@ -25,15 +25,20 @@ tested.features:\
 
 -buildpath: \
 	io.openliberty.jakarta.annotation.2.0;version=latest,\
-    io.openliberty.jakarta.cdi.3.0;version=latest,\
-    io.openliberty.jakarta.enterpriseBeans.4.0;version=latest,\
-    io.openliberty.jakarta.restfulWS.3.0;version=latest,\
-    io.openliberty.jakarta.faces.3.0;version=latest,\
-    io.openliberty.jakarta.jsonb.2.0;version=latest,\
-    io.openliberty.jakarta.jsonp.2.0;version=latest,\
-    io.openliberty.jakarta.persistence.3.0;version=latest,\
-    io.openliberty.jakarta.security.2.0;version=latest,\
-    io.openliberty.jakarta.servlet.5.0;version=latest,\
-    io.openliberty.jakarta.transaction.2.0;version=latest,\
-    io.openliberty.jakarta.validation.3.0;version=latest,\
-    com.ibm.ws.componenttest.2.0;version=latest
+	io.openliberty.jakarta.cdi.3.0;version=latest,\
+	io.openliberty.jakarta.enterpriseBeans.4.0;version=latest,\
+	io.openliberty.jakarta.restfulWS.3.0;version=latest,\
+	io.openliberty.jakarta.faces.3.0;version=latest,\
+	io.openliberty.jakarta.jsonb.2.0;version=latest,\
+	io.openliberty.jakarta.jsonp.2.0;version=latest,\
+	io.openliberty.jakarta.persistence.3.0;version=latest,\
+	io.openliberty.jakarta.security.2.0;version=latest,\
+	io.openliberty.jakarta.servlet.5.0;version=latest,\
+	io.openliberty.jakarta.transaction.2.0;version=latest,\
+	io.openliberty.jakarta.validation.3.0;version=latest,\
+	com.ibm.ws.componenttest.2.0;version=latest,\
+	com.ibm.ws.kernel.feature;version=latest,\
+	com.ibm.ws.kernel.boot;version=latest,\
+	com.ibm.ws.logging;version=latest,\
+    com.ibm.ws.org.apache.aries.util;version=latest, \
+	org.eclipse.osgi;version=latest

--- a/dev/io.openliberty.jakartaee9.internal_fat/build.gradle
+++ b/dev/io.openliberty.jakartaee9.internal_fat/build.gradle
@@ -9,4 +9,22 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-addRequiredLibraries.dependsOn addDerby
+configurations {
+  kernel
+}
+
+dependencies {
+  kernel project(':com.ibm.ws.kernel.feature'),
+    project(':com.ibm.ws.kernel.boot')
+}
+
+task addJunitdependencies(type: Copy) {
+  from configurations.kernel
+  into "${buildDir}/autoFVT/lib/"
+}
+
+addRequiredLibraries {
+  dependsOn addDerby
+  dependsOn addJunitdependencies
+}
+

--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9FeatureCompatibilityTest.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9FeatureCompatibilityTest.java
@@ -1,0 +1,407 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.jakartaee9.internal.tests;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.kernel.boot.cmdline.Utils;
+import com.ibm.ws.kernel.boot.internal.KernelUtils;
+import com.ibm.ws.kernel.feature.internal.FeatureResolverImpl;
+import com.ibm.ws.kernel.feature.internal.subsystem.FeatureRepository;
+import com.ibm.ws.kernel.feature.provisioning.ProvisioningFeatureDefinition;
+import com.ibm.ws.kernel.feature.resolver.FeatureResolver;
+import com.ibm.ws.kernel.feature.resolver.FeatureResolver.Chain;
+import com.ibm.ws.kernel.feature.resolver.FeatureResolver.Result;
+import com.ibm.ws.kernel.provisioning.BundleRepositoryRegistry;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE7FeatureReplacementAction;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+/**
+ * This test validates that all Open Liberty features that are expected to work
+ * with Jakarta EE 9 features resolve correctly compared to a Jakarta EE 9 feature.
+ *
+ * When a feature is expected to conflict with Jakarta EE 9 features, this test validates
+ * that the com.ibm.websphere.appserver.eeCompatible feature is one of the conflicts. This is
+ * important because there are messages that come up for eeCompatible conflicts to tell the
+ * customer that features are not compatible with Jakarta EE 9.
+ *
+ * As new value add features are added to Open Liberty this test will assume that they
+ * will support Jakarta EE 9. When Jakarta EE 10 is added there will need to be some additional
+ * logic to handle Jakarta EE 10 features as being expected to not run with EE 9 features.
+ */
+@SuppressWarnings("restriction")
+@RunWith(FATRunner.class)
+public class EE9FeatureCompatibilityTest extends FATServletClient {
+
+    private static final Class<?> c = EE9FeatureCompatibilityTest.class;
+
+    static final List<String> features = new ArrayList<>();
+
+    static final Set<String> nonEE9JavaEEFeatures = new HashSet<>();
+
+    static final Set<String> nonEE9MicroProfileFeatures = new HashSet<>();
+
+    static final Set<String> incompatibleValueAddFeatures = new HashSet<>();
+
+    static final String serverName = "jakartaee9.fat";
+    static final FeatureResolver resolver = new FeatureResolverImpl();
+    static FeatureRepository repository;
+
+    @Server("jakartaee9.fat")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        File featureDir = new File(server.getInstallRoot() + "/lib/features/");
+        // If there was a problem building projects before this test runs, "lib/features" won't exist
+        if (featureDir != null && featureDir.exists()) {
+            for (File feature : featureDir.listFiles()) {
+                if (feature.getName().startsWith("io.openliberty.") ||
+                    feature.getName().startsWith("com.ibm.")) {
+                    parseShortName(feature);
+                }
+            }
+        }
+
+        nonEE9JavaEEFeatures.addAll(EE7FeatureReplacementAction.EE7_FEATURE_SET);
+        nonEE9JavaEEFeatures.addAll(EE8FeatureReplacementAction.EE8_FEATURE_SET);
+
+        // appSecurity-1.0 is superceded by appSecurity-2.0 so it isn't in one of the replacement
+        // feature lists.  jaxb and jaxws 2.3 are EE related, but are noship features currently.
+        // jsp-2.2 is a EE6 feature that is included with open liberty.
+        // websocket-1.0 is a special case.  Part of EE7, but 1.1 is used by liberty.
+        nonEE9JavaEEFeatures.add("appSecurity-1.0");
+        nonEE9JavaEEFeatures.add("jaxb-2.3");
+        nonEE9JavaEEFeatures.add("jaxws-2.3");
+        nonEE9JavaEEFeatures.add("jsp-2.2");
+        nonEE9JavaEEFeatures.add("websocket-1.0");
+
+        // Remove test features that are in the FeatureReplacementActions
+        nonEE9JavaEEFeatures.remove("componenttest-1.0");
+        nonEE9JavaEEFeatures.remove("componenttest-2.0");
+        nonEE9JavaEEFeatures.remove("txtest-1.0");
+        nonEE9JavaEEFeatures.remove("txtest-2.0");
+        nonEE9JavaEEFeatures.remove("ejbTest-1.0");
+        nonEE9JavaEEFeatures.remove("ejbTest-2.0");
+
+        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP10.getFeatures());
+        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP12.getFeatures());
+        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP13.getFeatures());
+        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP14.getFeatures());
+        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP20.getFeatures());
+        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP21.getFeatures());
+        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP22.getFeatures());
+        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP30.getFeatures());
+        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP32.getFeatures());
+        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP33.getFeatures());
+        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP40.getFeatures());
+        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP41.getFeatures());
+
+        // Add the MP convenience features as well
+        String[] mpVersions = { "1.0", "1.2", "1.3", "1.4", "2.0", "2.1", "2.2", "3.0",
+                                "3.2", "3.3", "4.0", "4.1" };
+        for (String mpVersion : mpVersions) {
+            nonEE9MicroProfileFeatures.add("microProfile-" + mpVersion);
+        }
+
+        // MP standalone features
+        nonEE9MicroProfileFeatures.add("mpContextPropagation-1.0");
+        nonEE9MicroProfileFeatures.add("mpContextPropagation-1.2");
+        nonEE9MicroProfileFeatures.add("mpGraphQL-1.0");
+        nonEE9MicroProfileFeatures.add("mpLRA-1.0");
+        nonEE9MicroProfileFeatures.add("mpLRACoordinator-1.0");
+        nonEE9MicroProfileFeatures.add("mpReactiveMessaging-1.0");
+        nonEE9MicroProfileFeatures.add("mpReactiveStreams-1.0");
+
+        incompatibleValueAddFeatures.add("jwtSso-1.0"); // depends on mpJWT
+        incompatibleValueAddFeatures.add("openid-2.0"); // stabilized
+        incompatibleValueAddFeatures.add("openapi-3.1"); // depends on mpOpenAPI
+        incompatibleValueAddFeatures.add("opentracing-1.0"); // opentracing depends on mpConfig
+        incompatibleValueAddFeatures.add("opentracing-1.1");
+        incompatibleValueAddFeatures.add("opentracing-1.2");
+        incompatibleValueAddFeatures.add("opentracing-1.3");
+        incompatibleValueAddFeatures.add("opentracing-2.0");
+        incompatibleValueAddFeatures.add("sipServlet-1.1"); // purposely not supporting EE 9
+        incompatibleValueAddFeatures.add("springBoot-1.5"); // springBoot 3.0 will support EE 9
+        incompatibleValueAddFeatures.add("springBoot-2.0");
+
+        // The features set should contain all of the incompatible features.  If it doesn't
+        // something was removed or there is a typo.
+        for (String feature : nonEE9JavaEEFeatures) {
+            Assert.assertTrue(feature + " was not in the all features list", features.contains(feature));
+        }
+        for (String feature : nonEE9MicroProfileFeatures) {
+            Assert.assertTrue(feature + " was not in the all features list", features.contains(feature));
+        }
+        for (String feature : incompatibleValueAddFeatures) {
+            Assert.assertTrue(feature + " was not in the all features list", features.contains(feature));
+        }
+
+        File lib = new File(server.getInstallRoot(), "lib");
+
+        Utils.setInstallDir(lib.getParentFile());
+        KernelUtils.setBootStrapLibDir(lib);
+
+        BundleRepositoryRegistry.initializeDefaults(serverName, true);
+
+        repository = new FeatureRepository();
+        repository.init();
+    }
+
+    private static void parseShortName(File feature) throws IOException {
+        // Only scan *.mf files
+        if (feature.isDirectory() || !feature.getName().endsWith(".mf"))
+            return;
+
+        Scanner scanner = new Scanner(feature);
+        try {
+            String shortName = null;
+            while (scanner.hasNextLine()) {
+                String line = scanner.nextLine();
+                if (line.startsWith("IBM-ShortName:")) {
+                    shortName = line.substring("IBM-ShortName:".length()).trim();
+                } else if (line.contains("IBM-Test-Feature:") && line.contains("true")) {
+                    Log.info(c, "parseShortName", "Skipping test feature: " + feature.getName());
+                    return;
+                } else if (line.startsWith("Subsystem-SymbolicName:") && !line.contains("visibility:=public")) {
+                    Log.info(c, "parseShortName", "Skipping non-public feature: " + feature.getName());
+                    return;
+                } else if (line.startsWith("IBM-ProductID") && !line.contains("io.openliberty")) {
+                    Log.info(c, "parseShortName", "Skipping non Open Liberty feature: " + feature.getName());
+                    return;
+                }
+            }
+            // some test feature files do not have a short name and do not have IBM-Test-Feature set.
+            // We do not want those ones.
+            if (shortName != null) {
+                features.add(shortName);
+            }
+        } finally {
+            scanner.close();
+        }
+    }
+
+    @Test
+    public void testEE9FeatureConflictsEE8() throws Exception {
+        Set<String> ee8Features = new HashSet<>();
+        ee8Features.addAll(EE8FeatureReplacementAction.EE8_FEATURE_SET);
+        // remove test features from the list
+        ee8Features.remove("componenttest-1.0");
+        ee8Features.remove("txtest-1.0");
+        ee8Features.remove("ejbTest-1.0");
+
+        // j2eeManagement-1.1 was removed in Jakarta EE 9 so there is no replacement
+        ee8Features.remove("j2eeManagement-1.1");
+
+        // A couple of special cases that we want to make sure work.
+        ee8Features.add("jaxb-2.3");
+        ee8Features.add("jaxws-2.3");
+
+        // servlet long name is the same for EE9 so it will fail because the prefixes
+        // match and it is marked as a singleton.
+        ee8Features.remove("servlet-4.0");
+        testEE9FeatureRenameConflicts(ee8Features);
+    }
+
+    @Test
+    public void testEE9FeatureConflictsEE7() throws Exception {
+        Set<String> ee7Features = new HashSet<>();
+        ee7Features.addAll(EE7FeatureReplacementAction.EE7_FEATURE_SET);
+        // remove test features from the list
+        ee7Features.remove("componenttest-1.0");
+        ee7Features.remove("txtest-1.0");
+        ee7Features.remove("ejbTest-1.0");
+
+        // j2eeManagement-1.1 was removed in Jakarta EE 9 so there is no replacement
+        ee7Features.remove("j2eeManagement-1.1");
+
+        // A couple of special cases that we want to make sure work.
+        ee7Features.add("appSecurity-1.0");
+        ee7Features.add("websocket-1.0");
+
+        // servlet long name is the same for EE9 so it will fail because the prefixes
+        // match and it is marked as a singleton.
+        ee7Features.remove("servlet-3.1");
+        testEE9FeatureRenameConflicts(ee7Features);
+    }
+
+    private void testEE9FeatureRenameConflicts(Set<String> olderEEFeatureSet) throws Exception {
+
+        List<String> featuresToTest = new ArrayList<>(2);
+        featuresToTest.add("previous-ee-feature-name");
+        featuresToTest.add("ee9-feature-name");
+
+        List<String> errors = new ArrayList<>();
+        for (String feature : olderEEFeatureSet) {
+            String ee9FeatureName = FeatureReplacementAction.getReplacementFeature(feature, JakartaEE9Action.EE9_FEATURE_SET, Collections.<String> emptySet());
+            if (ee9FeatureName == null) {
+                errors.add("Did not find EE 9 replacement feature for " + feature + '\n');
+                continue;
+            }
+            featuresToTest.set(0, feature);
+            featuresToTest.set(1, ee9FeatureName);
+            Result result = resolver.resolveFeatures(repository, Collections.<ProvisioningFeatureDefinition> emptySet(), featuresToTest, Collections.<String> emptySet(), false);
+            Map<String, Collection<Chain>> conflicts = result.getConflicts();
+            if (conflicts.isEmpty()) {
+                errors.add("Did not get expected conflict for " + feature + '\n');
+            } else if (!conflicts.containsKey("com.ibm.websphere.appserver.eeCompatible")) {
+                errors.add("Expected a conflict for com.ibm.websphere.appserver.eeCompatible for " + feature + " " + conflicts.keySet() + '\n');
+            }
+        }
+
+        if (!errors.isEmpty()) {
+            Assert.fail("Found errors while checking EE9 features incompatibility with EE8 features:\n" + errors);
+        }
+    }
+
+    @Test
+    public void testJsonP20Feature() throws Exception {
+        // jsonp-2.0 will conflict with itself
+        testCompatibility("jsonp-2.0", Collections.singletonMap("jsonp-2.0", "io.openliberty.jsonp"));
+    }
+
+    @Test
+    public void testServlet50Feature() throws Exception {
+        Map<String, String> specialEE9Conflicts = new HashMap<>();
+        specialEE9Conflicts.put("servlet-5.0", "com.ibm.websphere.appserver.servlet");
+        specialEE9Conflicts.put("servlet-4.0", "com.ibm.websphere.appserver.servlet");
+        specialEE9Conflicts.put("servlet-3.1", "com.ibm.websphere.appserver.servlet");
+
+        testCompatibility("servlet-5.0", specialEE9Conflicts);
+    }
+
+    /**
+     * This test is marked as FULL FAT because it can take 10 to 30 minutes to run depending on
+     * the system. This puts it past the 5 minute expected limit for lite tests. The jsonp-2.0 test
+     * is a quick test to show that the basics work with feature resolution.
+     *
+     * @throws Exception
+     */
+    @Test
+    @Mode(TestMode.FULL)
+    public void testJakarta91ConvenienceFeature() throws Exception {
+        Map<String, String> specialEE9Conflicts = new HashMap<>();
+        // faces and facesContainer conflict with each other
+        specialEE9Conflicts.put("facesContainer-3.0", "io.openliberty.facesProvider");
+        // the jakartaee-9.1 convenience feature conflicts with itself and with 9.0
+        specialEE9Conflicts.put("jakartaee-9.0", "io.openliberty.jakartaee");
+        specialEE9Conflicts.put("jakartaee-9.1", "io.openliberty.jakartaee");
+        // the convenience feature depends on jdbc-4.2 and tolerates 4.3
+        specialEE9Conflicts.put("jdbc-4.0", "com.ibm.websphere.appserver.jdbc");
+        specialEE9Conflicts.put("jdbc-4.1", "com.ibm.websphere.appserver.jdbc");
+        // the webProfile-9.1 convenience feature conflicts with the 9.0 one
+        specialEE9Conflicts.put("webProfile-9.0", "io.openliberty.webProfile");
+
+        testCompatibility("jakartaee-9.1", specialEE9Conflicts);
+    }
+
+    private void testCompatibility(String featureName, Map<String, String> specialConflicts) throws Exception {
+        final List<String> errors = new CopyOnWriteArrayList<>();
+
+        int threadCount = Runtime.getRuntime().availableProcessors() - 1;
+        if (threadCount > 4) {
+            threadCount = 4;
+        }
+        if (threadCount <= 1) {
+            checkFeatures(featureName, new ArrayDeque<String>(features), specialConflicts, errors);
+        } else {
+            final ConcurrentLinkedQueue<String> featuresQueue = new ConcurrentLinkedQueue<>(features);
+            Thread[] threads = new Thread[threadCount];
+            for (int i = 0; i < threadCount; ++i) {
+                threads[i] = new Thread(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        checkFeatures(featureName, featuresQueue, specialConflicts, errors);
+                    }
+                });
+            }
+            for (Thread thread : threads) {
+                thread.start();
+            }
+            for (Thread thread : threads) {
+                thread.join();
+            }
+        }
+
+        if (!errors.isEmpty()) {
+            Assert.fail("Found errors while checking EE9 features compatibility:\n" + errors);
+        }
+    }
+
+    private void checkFeatures(String baseFeature, Queue<String> featureQueue, Map<String, String> specialConflicts,
+                               List<String> errors) {
+        List<String> featuresToTest = new ArrayList<>(2);
+        featuresToTest.add(baseFeature);
+        featuresToTest.add("tested-feature-name");
+
+        String feature;
+        while ((feature = featureQueue.poll()) != null) {
+            Log.info(c, "checkFeatures", "start testing: " + feature);
+            featuresToTest.set(1, feature);
+            boolean expectToConflict = nonEE9JavaEEFeatures.contains(feature) || nonEE9MicroProfileFeatures.contains(feature) || incompatibleValueAddFeatures.contains(feature);
+            Result result = resolver.resolveFeatures(repository, Collections.<ProvisioningFeatureDefinition> emptySet(), featuresToTest, Collections.<String> emptySet(), false);
+            Log.info(c, "checkFeatures", "finished testing: " + feature);
+            Map<String, Collection<Chain>> conflicts = result.getConflicts();
+            if (expectToConflict) {
+                if (conflicts.isEmpty()) {
+                    errors.add("Did not get expected conflict for " + feature + '\n');
+                } else {
+                    String specialConflict = specialConflicts.get(feature);
+                    if (specialConflict != null) {
+                        if (!conflicts.containsKey(specialConflict)) {
+                            errors.add("Got unexpected conflict for " + feature + " " + conflicts.keySet() + '\n');
+                        } else if (conflicts.containsKey("com.ibm.websphere.appserver.eeCompatible")) {
+                            errors.add("Got eeCompatible conflict in additional to special conflict for " + feature + " " + conflicts.keySet() + '\n');
+                        }
+                    } else if (!conflicts.containsKey("com.ibm.websphere.appserver.eeCompatible")) {
+                        errors.add("Expected a conflict for com.ibm.websphere.appserver.eeCompatible for " + feature + " " + conflicts.keySet() + '\n');
+                    }
+                }
+            } else if (!conflicts.isEmpty()) {
+                String specialConflict = specialConflicts.get(feature);
+                if (specialConflict == null || !conflicts.containsKey(specialConflict)) {
+                    errors.add("Got unexpected conflict for " + feature + " " + conflicts.keySet() + '\n');
+                }
+            }
+        }
+    }
+}

--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/FATSuite.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/FATSuite.java
@@ -16,7 +16,8 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                JakartaEE9Test.class
+                JakartaEE9Test.class,
+                EE9FeatureCompatibilityTest.class
 })
 public class FATSuite {
 }


### PR DESCRIPTION
- Create FAT test that validates that expected feature resolve with EE 9 features
- The FAT test also validates features that should not resolve with EE 9 features and validates they conflict on the eeCompatible feature
- Also the FAT test validates that EE7 and EE8 features will not start with EE9 features.  Some of the features have the same short name base, but different version number, but aren't singleton with each other because of the prefix change.  For example jsonp-1.0 and jsonp-2.0.  The test validates that they get conflicts instead of allowing them to start together.
- Update FeatureReplacementActions to have missing features in its list of EE features.
- Update features to have a dependency on eeCompatible so that the tests that should conflict, correctly conflict on the eeCompatible feature.
- Update scim-2.0 noship feature to work with Jakarta EE9.  The feature doesn't need any special transformation.  It just needs a tolerates on servlet-5.0.