### PR TITLE
promote catalog persistence in collective to the current server version

### DIFF
--- a/dev/com.ibm.ws.ui/bnd.bnd
+++ b/dev/com.ibm.ws.ui/bnd.bnd
@@ -64,6 +64,7 @@ Include-Resource: \
   com.ibm.ws.ui.internal.v1.utils.FeatureToolService
 
 -buildpath: \
+  com.ibm.websphere.appserver.api.kernel.service;version=latest,\
 	com.ibm.websphere.appserver.spi.kernel.service;version=latest,\
 	com.ibm.websphere.appserver.spi.logging;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\

--- a/dev/com.ibm.ws.ui/resources/com/ibm/ws/ui/internal/resources/UIMessages.nlsprops
+++ b/dev/com.ibm.ws.ui/resources/com/ibm/ws/ui/internal/resources/UIMessages.nlsprops
@@ -317,3 +317,7 @@ TOOLBOX_FILE_PROMOTED_TO_ENCODED_NAME.useraction=No action is required.
 TOOL_DATA_PROMOTED_TO_ENCODED_NAME=CWWKX1069I: Tool {0} data for user {1} was loaded from the persisted storage using its old file name and has converted to its new file name.
 TOOL_DATA_PROMOTED_TO_ENCODED_NAME.explanation=The product loaded the tool data for the specified user and tool from persisted storage using its old file name and stored a copy into the new file name. The copy in the new file name will be loaded by subsequent access to persisted storage.
 TOOL_DATA_PROMOTED_TO_ENCODED_NAME.useraction=No action is required.
+
+CATALOG_FILE_PROMOTED_TO_CURRENT_VERSION=CWWKX1070I: The Admin Center default catalog was loaded from COLLECTIVE persistence created by an earlier server version. The catalog has reloaded using a copy from the current server version.
+CATALOG_FILE_PROMOTED_TO_CURRENT_VERSION.explanation=The product converted the Admin Center default catalog to the current server version. The copy in the COLLECTIVE persistence will be loaded by subsequent access to persisted storage.
+CATALOG_FILE_PROMOTED_TO_CURRENT_VERSION.useraction=No action is required.

--- a/dev/com.ibm.ws.ui/resources/com/ibm/ws/ui/internal/resources/UIMessages.nlsprops
+++ b/dev/com.ibm.ws.ui/resources/com/ibm/ws/ui/internal/resources/UIMessages.nlsprops
@@ -318,6 +318,6 @@ TOOL_DATA_PROMOTED_TO_ENCODED_NAME=CWWKX1069I: Tool {0} data for user {1} was lo
 TOOL_DATA_PROMOTED_TO_ENCODED_NAME.explanation=The product loaded the tool data for the specified user and tool from persisted storage using its old file name and stored a copy into the new file name. The copy in the new file name will be loaded by subsequent access to persisted storage.
 TOOL_DATA_PROMOTED_TO_ENCODED_NAME.useraction=No action is required.
 
-CATALOG_FILE_PROMOTED_TO_CURRENT_VERSION=CWWKX1070I: The Admin Center default catalog was loaded from COLLECTIVE persistence created by an earlier server version. The catalog has reloaded using a copy from the current server version.
-CATALOG_FILE_PROMOTED_TO_CURRENT_VERSION.explanation=The product converted the Admin Center default catalog to the current server version. The copy in the COLLECTIVE persistence will be loaded by subsequent access to persisted storage.
+CATALOG_FILE_PROMOTED_TO_CURRENT_VERSION=CWWKX1070I: The Admin Center default catalog was loaded from COLLECTIVE persistence that is created by an earlier server version. The catalog is reloaded by using a copy from the current server version.
+CATALOG_FILE_PROMOTED_TO_CURRENT_VERSION.explanation=The product converted the Admin Center default catalog to the current server version. The copy in the COLLECTIVE persistence is loaded by subsequent access to the persisted storage.
 CATALOG_FILE_PROMOTED_TO_CURRENT_VERSION.useraction=No action is required.

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/ICatalog.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/ICatalog.java
@@ -37,6 +37,11 @@ public interface ICatalog extends SelfValidatingPOJO {
     String METADATA_IS_DEFAULT = "isDefault";
 
     /**
+     * Metadata field (String): the version of server loaded for this catalog
+     */
+    String METADATA_SERVER_VERSION = "serverVersion";
+
+    /**
      * Retrieve the catalog metadata. The returned Map is a read-only
      * snapshot of the metadata at the time it was asked for.
      * 

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/ICatalog.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/ICatalog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/Catalog.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/Catalog.java
@@ -92,6 +92,8 @@ public class Catalog implements ICatalog {
         String version = getServerVersion();
         if (version != null) {
             _metadata.put(METADATA_SERVER_VERSION, version);
+        } else {
+            _metadata.put(METADATA_SERVER_VERSION, "unknown");
         }
     }
 

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/Catalog.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/Catalog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
This PR is to fix a bug in the collective catalog persistence file which contains a bookmark that was created by an earlier Open Liberty server but the bookmark was removed in the later Open Liberty server. To fix the problem, the catalog in the collective would be promoted to the current version if it was a default catalog created by an earlier server version.

https://github.com/OpenLiberty/open-liberty/issues/18282