### PR TITLE
14901-Allow-variable-resolution-in-server-env

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -734,23 +734,51 @@ mergeJVMOptions()
 ## readServerEnv: Read server.env file and export environment variables.
 readServerEnv()
 {
+  # By default, we do not attempt to resolve variables in server.env
+  variableResolutionEnabled=0
   if [ -f "$1" ]; then
     saveIFS=$IFS
     IFS=$newline
     for line in `readNativeFile "$1" '[#_A-Za-z=]' | tr -d '\r'`; do
       case $line in
-      \#*);;
+
+      \#*)
+           # line is a comment.
+           # A comment line enables variable resolution if it contains the keyword,
+           # "enable_variable_resolution", and nothing else (ignoring case and white space).
+           # If found, we use the source command ( . ) which performs all of the server.env
+           # variable assignments while resolving any variable references.
+           if [ $variableResolutionEnabled = 0  ] && [ $(echo $line | grep -i "enable_variable_resolution") ]
+           then
+              processedLine=$(echo $line | tr -d '[:blank:]' | tr '[:upper:]' '[:lower:]')
+              if [ "#enable_variable_resolution" = $processedLine ]
+              then
+                 eval ". $1"
+                 variableResolutionEnabled=1
+              fi
+           fi ;;
       *=*)
         # Only accept alphanumeric variable names to avoid eval complexities.
         if var=`safeEcho "$line" | sed -e 's/^\([a-zA-Z0-9_][a-zA-Z0-9_]*\)=.*/\1/'`; then
            case $var in
-	   *=*)
+           *=*)
                SERVER_ENV_SETUP_FAILURE="${var} ${SERVER_ENV_SETUP_FAILURE}" ;;
            *)
-              extractValueAndEscapeForEval "${line}"
-              eval "${var}=${escapeForEvalResult}; export ${var}" ;;
-	   esac
-        fi
+              # if variable resolution is enabled, then we have already "sourced" the entire file.  As a result
+              # all of the variables in server.env have already been defined as shell variables.  To make them
+              # accessible to child processes, they need to be exported.
+              if [ $variableResolutionEnabled = 1 ]
+              then
+                 eval "export ${var}"
+              else
+                 # Variable resolution is not enabled.  Just set the variable to whatever is on the right side 
+                 # of the assignment and export it.  If a later line enables variable resolution, the source
+                 # command will reassign the variable (which is already exported) to the resolved value.
+                 extractValueAndEscapeForEval "${line}"
+                 eval "${var}=${escapeForEvalResult}; export ${var}"
+              fi
+           esac
+        fi ;;
       esac
     done
     IFS=$saveIFS


### PR DESCRIPTION
Resolves issue #14901 - Shell variable support in server.env

Note this issue, as written, is about **shell** variable support specifically, **not environment** variables. The difference between the two is that shell variables are not inherited by child processes and environment variables are. 

The server script is normally started in a new shell and does not inherit or have access to any variables defined in the parent shell.   For example, if you have the script named echoA.sh with contents:

   `echo $A`

and then you enter the commands:

A=45
./echoA.sh

The output is empty, because the echoA.sh script is started in a new shell.  If you enter the command "export A" before running the script, the output will be "45" since the new shell will have access to the **environment** variable A.

You can, however, execute the server script in the same shell by "sourcing" the script.  To do this you enter a period followed by a space before the script.  For example:

. ./echoA.sh

The output is then 45, because the script is run in the same shell.   There is nothing that can be done in the server script to support shell variables specifically.  It is how the server script is invoked that will determine that.

Another alternative is to assign any shell variables you need on the same line when invoking the script.  These variables belong to the new shell; not the parent shell.  For example

A=45 ./echoA.sh

Now, with that out of the way, the real issue is about variable resolution in the server.env.   Today, the server script reads the server.env file line by line and assigns and exports the variables (The server.env file is basically a properties file with an assignment statement on each line.)  The server script makes no attempt to resolve any variables that might be on the right hand side of the assignment statement.  Thus, in the assignment A=$B, the value of A is literally $B, not the value of B.    This issue is about resolving the variables on the right side of the assignment statements.

For backward compatibility, the new function is not enabled by default.   It must be explicitly enabled by adding the following comment near the top of the file:

`#   enable_variable_resolution`

Enabling variable resolution allows the assignment statements in server.env to refer to variables which will be resolved, for example

```
http_port = 9083
url = http://${HOSTNAME}:${http_port}
```

In this example, http_port is assigned a value.  On the next line  the environment variable HOSTNAME, and the shell variable http_port are resolved in the assignment of the url variable. The variables "http_port" and "url" are then exported by the server script and can be used in server.xml.

Note this is a linux-only issue as variables in server.env are already resolved on Windows.  This fact is not documented anywhere, and since the %var% syntax does not work, it is probably not a very well known capability.   To use variable expansion in the server.env file on Windows, you have to use delayed expansion syntax; for example !var!.

### Implementation notes
I first attempted to parse server.env statements looking for $var or ${var} syntax which might contain single or double quotes which could be odd in number.  I believe I found a way to do that in bash, but we don't want to restrict the capability to bash. 

A much easier way to do it is to source the server.env file.  This does all of the assignments and the variable resolution in one statement.   However, that does not eliminate the need to read the server.env file.  It still needs to be read for 2 reasons.  First, it must look for the enabling comment, and second, it must export each of the variables to make them available to the JVM.

There are some limitations to the source command.  It does not handle an odd number of quotation marks.  An odd number of quotation marks causes the source command to fail and the server script immediately terminates.  To use an odd number of quotes, inner quotation marks must be escaped with a backslash "\\".   This is one reason variable resolution is not enabled by default, as it could potentially cause the server script to fail for existing users.  The other reason is if someone is using a variable syntax on the right side of an assignment, but does not want the variable resolved.

