### PR TITLE
Updates for WebContainer monitor logic and updates to Request timing fat

### DIFF
--- a/dev/com.ibm.ws.request.timing.monitor_fat/bnd.bnd
+++ b/dev/com.ibm.ws.request.timing.monitor_fat/bnd.bnd
@@ -26,7 +26,9 @@ tested.features: \
 	mpMetrics-2.3,\
 	mpMetrics-2.2,\
 	mpMetrics-2.0,\
-	cdi-1.2
+	cdi-1.2,\
+	appsecurity-4.0,\
+	cdi-3.0
 
 -buildpath: \
 	com.ibm.ws.request.timing;version=latest,\

--- a/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/FATSuite.java
+++ b/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/FATSuite.java
@@ -26,6 +26,6 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction("mpMetrics-3.0", "mpMetrics-2.3").withID("MPM23")).andWith(new FeatureReplacementAction("mpMetrics-2.3", "mpMetrics-2.2").withID("MPM22")).andWith(new FeatureReplacementAction("mpMetrics-2.2", "mpMetrics-2.0").withID("MPM20"));
+    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction("mpMetrics-3.0", "mpMetrics-2.3").withID("MPM23")).andWith(new FeatureReplacementAction("mpMetrics-2.3", "mpMetrics-2.2").withID("MPM22")).andWith(new FeatureReplacementAction("mpMetrics-2.2", "mpMetrics-2.0").withID("MPM20")).andWith(FeatureReplacementAction.EE9_FEATURES().removeFeature("mpMetrics-2.0"));
 
 }

--- a/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/RequestTimingEventTest.java
+++ b/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/RequestTimingEventTest.java
@@ -42,7 +42,6 @@ import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 
 /**
@@ -109,7 +108,7 @@ public class RequestTimingEventTest {
     static ObjectName ServletInstanceName;
 
     // Keeping a AtomicLong total count because of threads created
-    public static AtomicLong totalRequestCount = new AtomicLong();
+    public static final AtomicLong totalRequestCount = new AtomicLong();
     public static long mbeanServletActiveCount = 1;
 
     public final String TestRequestHandlerUrl = getURLString("TestRequestHandler", 0);
@@ -120,14 +119,9 @@ public class RequestTimingEventTest {
      */
     @BeforeClass
     public static void setUp() throws Exception {
+        totalRequestCount.set(0);
         ShrinkHelper.defaultApp(server, "RequestTimingWebApp", "com.ibm.ws.request.timing.app");
 
-        JavaInfo java = JavaInfo.forCurrentVM();
-        int javaMajorVersion = java.majorVersion();
-        if (javaMajorVersion != 8) {
-            Log.info(c, "setUp", " Java version = " + javaMajorVersion + " - It is higher than 8, adding --add-exports...");
-            server.copyFileToLibertyServerRoot("add-exports/jvm.options");
-        }
         server.startServer();
         setupTables();
     }
@@ -414,7 +408,7 @@ public class RequestTimingEventTest {
      * allow a test to finish
      *
      * @param countToWaitFor
-     *                           Value looked for in CountDownLatch
+     *            Value looked for in CountDownLatch
      * @throws Exception
      */
     private void waitInServletForCountDownLatch(int countToWaitFor) throws Exception {
@@ -484,9 +478,9 @@ public class RequestTimingEventTest {
      * test
      *
      * @param th
-     *                    -- array of threads
+     *            -- array of threads
      * @param numReqs
-     *                    -- number of requests is the number of threads needed
+     *            -- number of requests is the number of threads needed
      */
     private void createRequestThreads(Thread[] th, int numReqs, String method) {
         // Send N servlet requests to server, last request used to terminate

--- a/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/RequestTimingMbeanTest.java
+++ b/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/RequestTimingMbeanTest.java
@@ -44,7 +44,6 @@ import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 
 /**
@@ -75,7 +74,7 @@ public class RequestTimingMbeanTest {
     static ObjectName ServletInstanceName;
 
     // Keeping a AtomicLong total count because of threads created
-    public static AtomicLong totalRequestCount = new AtomicLong();
+    public static final AtomicLong totalRequestCount = new AtomicLong();
     public static long mbeanServletActiveCount = 1;
 
     public final String TestRequestHandlerUrl = getURLString("TestRequestHandler", 0);
@@ -88,14 +87,8 @@ public class RequestTimingMbeanTest {
      */
     @BeforeClass
     public static void setUp() throws Exception {
+        totalRequestCount.set(0);
         ShrinkHelper.defaultDropinApp(server, "RequestTimingWebApp", "com.ibm.ws.request.timing.app");
-
-        JavaInfo java = JavaInfo.forCurrentVM();
-        int javaMajorVersion = java.majorVersion();
-        if (javaMajorVersion != 8) {
-            Log.info(c, "setUp", " Java version = " + javaMajorVersion + " - It is higher than 8, adding --add-exports...");
-            server.copyFileToLibertyServerRoot("add-exports/jvm.options");
-        }
 
         server.startServer();
     }
@@ -541,7 +534,7 @@ public class RequestTimingMbeanTest {
      * allow a test to finish
      *
      * @param countToWaitFor
-     *                           Value looked for in CountDownLatch
+     *            Value looked for in CountDownLatch
      * @throws Exception
      */
     private void waitInServletForCountDownLatch(int countToWaitFor) throws Exception {
@@ -615,13 +608,13 @@ public class RequestTimingMbeanTest {
      * test
      *
      * @param th
-     *                            -- array of threads
+     *            -- array of threads
      * @param numReqs
-     *                            -- number of requests is the number of threads needed
+     *            -- number of requests is the number of threads needed
      * @param servletTestName
-     *                            -- Used for request to servlet
+     *            -- Used for request to servlet
      * @param testMethodName
-     *                            -- Used for printing to logs
+     *            -- Used for printing to logs
      */
     private void createRequestThreads(Thread[] th, int numReqs) {
         // Send N servlet requests to server, last request used to terminate

--- a/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/RequestTimingMetricsTest.java
+++ b/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/RequestTimingMetricsTest.java
@@ -28,11 +28,12 @@ import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.request.timing.app.RequestTimingServlet;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.topology.impl.JavaInfo;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
 /**
@@ -48,6 +49,7 @@ import componenttest.topology.impl.LibertyServer;
  * request during the mbean call which happens inside the initial servlet call.
  */
 @RunWith(FATRunner.class)
+@SkipForRepeat(JakartaEE9Action.ID)
 public class RequestTimingMetricsTest {
 
     private static final Class<RequestTimingMetricsTest> c = RequestTimingMetricsTest.class;
@@ -71,13 +73,6 @@ public class RequestTimingMetricsTest {
         ShrinkHelper.defaultDropinApp(server, "RequestTimingWebApp", "com.ibm.ws.request.timing.app");
         totalRequestCount = new AtomicInteger();
         activeServletRequest = 1;
-
-        JavaInfo java = JavaInfo.forCurrentVM();
-        int javaMajorVersion = java.majorVersion();
-        if (javaMajorVersion != 8) {
-            Log.info(c, "setUp", " Java version = " + javaMajorVersion + " - It is higher than 8, adding --add-exports...");
-            server.copyFileToLibertyServerRoot("add-exports/jvm.options");
-        }
 
         server.startServer();
 
@@ -375,7 +370,7 @@ public class RequestTimingMetricsTest {
      * allow a test to finish
      *
      * @param countToWaitFor
-     *                           Value looked for in CountDownLatch
+     *            Value looked for in CountDownLatch
      * @throws Exception
      */
     private void waitInServletForCountDownLatch(int countToWaitFor) throws Exception {
@@ -457,13 +452,13 @@ public class RequestTimingMetricsTest {
      * test
      *
      * @param th
-     *                            -- array of threads
+     *            -- array of threads
      * @param numReqs
-     *                            -- number of requests is the number of threads needed
+     *            -- number of requests is the number of threads needed
      * @param servletTestName
-     *                            -- Used for request to servlet
+     *            -- Used for request to servlet
      * @param testMethodName
-     *                            -- Used for printing to logs
+     *            -- Used for printing to logs
      */
     private void createRequestThreads(Thread[] th, int numReqs) {
         // Send N servlet requests to server, last request used to terminate

--- a/dev/com.ibm.ws.request.timing.monitor_fat/publish/files/add-exports/jvm.options
+++ b/dev/com.ibm.ws.request.timing.monitor_fat/publish/files/add-exports/jvm.options
@@ -1,3 +1,0 @@
-# for dump action: com.ibm.ws.kernel.boot.internal.commands.HotSpotJavaDumperImpl$VirtualMachine.remoteDataDump(HotSpotJavaDumperImpl.java:342)
---add-exports
-jdk.attach/sun.tools.attach=ALL-UNNAMED

--- a/dev/wlp-jakartaee-transform/rules/jakarta-direct.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-direct.properties
@@ -171,3 +171,6 @@ javax.servlet.ServletContext=jakarta.servlet.ServletContext
 javax.ws.rs.Application=jakarta.ws.rs.Application
 javax.xml.bind.annotation.XmlEnum=jakarta.xml.bind.annotation.XmlEnum
 javax.ws.rs.ext.Providers=jakarta.ws.rs.ext.Providers
+
+#WebContainerMontior annotations
+javax.servlet.ServletRequest,javax.servlet.ServletResponse,com.ibm.ws.webcontainer.webapp.WebAppServletInvocationEvent=jakarta.servlet.ServletRequest,jakarta.servlet.ServletResponse,com.ibm.ws.webcontainer.webapp.WebAppServletInvocationEvent


### PR DESCRIPTION
- Update transformation rules to correctly transform arguments for WebContainer monitor code
- Update request timing to do repeat for Jakarta EE 9
- Remove --add-exports jvm options file for the test since it is now in java9.options for the server.