### PR TITLE
Removed HPEL debug trace log level check

### DIFF
--- a/dev/com.ibm.ws.logging.hpel/src/com/ibm/ws/logging/hpel/impl/LogRepositoryBaseImpl.java
+++ b/dev/com.ibm.ws.logging.hpel/src/com/ibm/ws/logging/hpel/impl/LogRepositoryBaseImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2012 IBM Corporation and others.
+ * Copyright (c) 2009, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,8 +36,8 @@ import com.ibm.ws.logging.hpel.LogRepositoryBase;
 public abstract class LogRepositoryBaseImpl implements LogRepositoryBase {
     /** Formatters used for logs in the repository. First in the list is the latest */
     public final static LogRecordSerializer[] KNOWN_FORMATTERS = new LogRecordSerializer[] {
-                                                                                            new BinaryLogRecordSerializerVersion2Impl(),
-                                                                                            new BinaryLogRecordSerializerImpl()
+                                                                                             new BinaryLogRecordSerializerVersion2Impl(),
+                                                                                             new BinaryLogRecordSerializerImpl()
     };
     /** Default repository location when its 'type' is not specified */
     public final static String DEFAULT_LOCATION = "logdata";
@@ -64,7 +64,6 @@ public abstract class LogRepositoryBaseImpl implements LogRepositoryBase {
     private static String thisClass = LogRepositoryBaseImpl.class.getName();
     // Unique logger as it does usepParentHandlers=false to avoid getting back into logging (and thus
     // risking recursion and stack overflow). No RBundle as only used for trace and write to sep file
-    // To get this trace output, must include com.ibm.ws.logging.hpel.impl.*=fine in traceSpec
     private static final int ONE_MEG = 1024 * 1024;
     private static Logger debugLogger = Logger.getLogger("com.ibm.hpel.debug"); // 682032 for debugAllowed
     private static final boolean debugAllowed = "true".equalsIgnoreCase(getSystemProperty("com.ibm.ws.logging.hpel.debug"));
@@ -100,7 +99,7 @@ public abstract class LogRepositoryBaseImpl implements LogRepositoryBase {
 
     /**
      * creates LogRepositoryBase instance. This one is generally for reading, as writing will also pass in process-specific info
-     * 
+     *
      * @param repositoryLocation the location of repository log files.
      */
     protected LogRepositoryBaseImpl(File repositoryLocation) {
@@ -135,8 +134,8 @@ public abstract class LogRepositoryBaseImpl implements LogRepositoryBase {
     /**
      * Creates lock file to be used as a pattern for instance repository.
      * Should be called only by parent's manager on start up.
-     * 
-     * @param pid process ID of the parent.
+     *
+     * @param pid   process ID of the parent.
      * @param label label of the parent.
      * @throws IOException if there's a problem to create lock file.
      */
@@ -172,9 +171,9 @@ public abstract class LogRepositoryBaseImpl implements LogRepositoryBase {
     /**
      * creates instance directory to use for log files. Both parent and children
      * need to use it when figuring out the log repository location.
-     * 
+     *
      * @param timestamp time on the first record to be stored.
-     * @param pid process ID of the parent
+     * @param pid       process ID of the parent
      * @return parent's directory (kids need to create directories under it) or
      *         <code>null</code> if directory can't be created or found due to race
      *         condition. In the later case user need to wait and try again.
@@ -201,10 +200,8 @@ public abstract class LogRepositoryBaseImpl implements LogRepositoryBase {
             return instanceDir;
         }
         // PM99024 , Code fix when .lock file removed
-        if (flag == true)
-        {
-            if (debugLogger.isLoggable(Level.FINE) && isDebugEnabled())
-            {
+        if (flag == true) {
+            if (isDebugEnabled()) {
                 debugLogger.logp(Level.FINE, thisClass, "makingLogDirectory", "no lock files found , creating folder with XXXXXX label");
             }
             instanceDir = new File(repositoryLocation, getLogDirectoryName(timestamp, pid, "XXXXXXX"));
@@ -223,17 +220,17 @@ public abstract class LogRepositoryBaseImpl implements LogRepositoryBase {
         if (lockFiles.length != 1 || !pid.equals(parseProcessID(lockFiles[0].getName()))) {
             // Use System.err to report that condition since logger is not ready yet.
             if (lockFiles.length < 1) {
-                if (debugLogger.isLoggable(Level.FINE) && isDebugEnabled())
+                if (isDebugEnabled())
                     debugLogger.logp(Level.FINE, thisClass, "makingLogDirectory", "no lock files found.");
             } else if (lockFiles.length > 1) {
                 StringBuilder sb = new StringBuilder();
                 for (File lock : lockFiles) {
                     sb.append(lock.getName()).append(" ");
                 }
-                if (debugLogger.isLoggable(Level.FINE) && isDebugEnabled())
+                if (isDebugEnabled())
                     debugLogger.logp(Level.FINE, thisClass, "makeLogDirectory", "too many lock files found: " + sb.toString());
             } else {
-                if (debugLogger.isLoggable(Level.FINE) && isDebugEnabled())
+                if (isDebugEnabled())
                     debugLogger.logp(Level.FINE, thisClass, "makeLogDirectory", "found stale lock file " + lockFiles[0].getName() + " but was expecting one generated by process "
                                                                                 + pid);
             }
@@ -244,7 +241,7 @@ public abstract class LogRepositoryBaseImpl implements LogRepositoryBase {
         // If somebody else deleted lock file right under our nose, need to wait until that somebody
         //    creates the right directory.
         if (!AccessHelper.deleteFile(lockFiles[0])) {
-            if (debugLogger.isLoggable(Level.FINE) && isDebugEnabled())
+            if (isDebugEnabled())
                 debugLogger.logp(Level.FINE, thisClass, "makeLogDirectory", "failed to delete found lock file " + lockFiles[0].getName() + ". Assume it was deleted already");
             return null;
         }
@@ -259,15 +256,14 @@ public abstract class LogRepositoryBaseImpl implements LogRepositoryBase {
     }
 
     //Method for forcefully creating Instance Directory , pass flag as true
-    protected File makeLogDirectory(long timestamp, final String pid)
-    {
+    protected File makeLogDirectory(long timestamp, final String pid) {
 
         return makeLogDirectory(timestamp, pid, false);
     }
 
     /**
      * calculates repository file name.
-     * 
+     *
      * @param timestamp the time in 'millis' of the first record in the file.
      * @return the file according to repository pattern
      */
@@ -282,7 +278,7 @@ public abstract class LogRepositoryBaseImpl implements LogRepositoryBase {
 
     /**
      * Retrieves the timestamp from the name of the file.
-     * 
+     *
      * @param file to retrieve timestamp from.
      * @return timestamp in millis or -1 if name's pattern does not correspond
      *         to the one used for files in the repository.
@@ -308,10 +304,10 @@ public abstract class LogRepositoryBaseImpl implements LogRepositoryBase {
 
     /**
      * returns sub-directory name to be used for instances and sub-processes
-     * 
+     *
      * @param timestamp time of the instance start. It should be negative for sub-processes
-     * @param pid process Id of the instance or sub-process. It cannot be null or empty.
-     * @param label additional identification to use on the sub-directory.
+     * @param pid       process Id of the instance or sub-process. It cannot be null or empty.
+     * @param label     additional identification to use on the sub-directory.
      * @return string representing requested sub-directory.
      */
     public String getLogDirectoryName(long timestamp, String pid, String label) {
@@ -335,7 +331,7 @@ public abstract class LogRepositoryBaseImpl implements LogRepositoryBase {
 
     /**
      * Returns the list of files in the repository.
-     * 
+     *
      * @return array of File instances representing files in the repository.
      */
     protected File[] listRepositoryFiles() {
@@ -427,9 +423,9 @@ public abstract class LogRepositoryBaseImpl implements LogRepositoryBase {
 
     /**
      * Retrieves the timestamp out of the directory name.
-     * 
+     *
      * example: directory file name for a serverinstance would be <repos_timestamp>_<pid>-<label>
-     * 
+     *
      * returned would be <repos_timestamp>
      */
     public static long parseTimeStamp(String fileName) {
@@ -490,7 +486,7 @@ public abstract class LogRepositoryBaseImpl implements LogRepositoryBase {
 
     /**
      * Retrieves the PID out of the directory name. (Qualifier 2)
-     * 
+     *
      * @param fileName
      * @return
      */
@@ -521,7 +517,7 @@ public abstract class LogRepositoryBaseImpl implements LogRepositoryBase {
 
     /**
      * Retrieves the label out of the directory name (Qualifier 3)
-     * 
+     *
      * @param fileName
      * @return
      */
@@ -535,7 +531,7 @@ public abstract class LogRepositoryBaseImpl implements LogRepositoryBase {
 
     /**
      * Retrieves the PID and label combined out of the directory name.
-     * 
+     *
      * @param fileName
      * @return
      */
@@ -556,7 +552,7 @@ public abstract class LogRepositoryBaseImpl implements LogRepositoryBase {
 
     /**
      * Returns the list of server instance directories in the repository.
-     * 
+     *
      * @return array of File instances representing files in the repository.
      */
     protected File[] listRepositoryDirs() {
@@ -572,13 +568,13 @@ public abstract class LogRepositoryBaseImpl implements LogRepositoryBase {
     }
 
     public void setLogEventNotifier(LogEventNotifier logEventNotifier) {
-        if (debugLogger.isLoggable(Level.FINE) && isDebugEnabled())
+        if (isDebugEnabled())
             debugLogger.logp(Level.FINE, thisClass, "setLogEventNotifier", "LEN: " + logEventNotifier);
         this.logEventNotifier = logEventNotifier;
     }
 
     public LogEventNotifier getLogEventNotifier() {
-        if (debugLogger.isLoggable(Level.FINE) && isDebugEnabled())
+        if (isDebugEnabled())
             debugLogger.logp(Level.FINE, thisClass, "getLogEventNotifier", "getLEN: " + logEventNotifier);
         return logEventNotifier;
     }
@@ -587,7 +583,7 @@ public abstract class LogRepositoryBaseImpl implements LogRepositoryBase {
      * determine if the logger is ready. This logger does not get set up since it has a separate
      * file handler (avoiding logging thru the normal channels as that would cause recursion). So
      * this check is done regularly as it can start dynamically
-     * 
+     *
      * @return determination as to whether or not file was created and file handler is in place
      */
     public static boolean isDebugEnabled() {
@@ -639,13 +635,14 @@ public abstract class LogRepositoryBaseImpl implements LogRepositoryBase {
         fHandler.setFormatter(new SimpleFormatter());
         LogRepositoryBaseImpl.debugLogger.addHandler(fHandler);
         LogRepositoryBaseImpl.debugLogger.setUseParentHandlers(false);
+        LogRepositoryBaseImpl.debugLogger.setLevel(Level.FINE); // Ensure the Log level is FINE, so the debug messages are logged accordingly.
         debugEnabled = true;
         return true;
     }
 
     /**
      * for classes in logging (which cannot log into the normal space, retrieve the special logger
-     * 
+     *
      * @return the specific logger that classes logging but not in normal flow will use
      */
     public static Logger getLogger() {
@@ -655,10 +652,11 @@ public abstract class LogRepositoryBaseImpl implements LogRepositoryBase {
     /**
      * take action on notification of trace or log file deletion or rolling. This is the dummy version as nonRuntime
      * managers need not implement this method, and subManagers who are unaware of file management cannot implement it
-     * 
+     *
      * @param eventType Type of event (delete or roll). It is assumed that the manager already knows what type of
-     *            logging it is working with (log vs trace).
+     *                      logging it is working with (log vs trace).
      */
-    public void notifyOfFileAction(String eventType) {}
+    public void notifyOfFileAction(String eventType) {
+    }
 
 }

--- a/dev/com.ibm.ws.logging.hpel/src/com/ibm/ws/logging/hpel/impl/LogRepositoryManagerImpl.java
+++ b/dev/com.ibm.ws.logging.hpel/src/com/ibm/ws/logging/hpel/impl/LogRepositoryManagerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2013 IBM Corporation and others.
+ * Copyright (c) 2009, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,727 +30,727 @@ import com.ibm.ws.logging.hpel.LogRepositoryManager;
  * the repository according to its maximum size and a minimum log record retention time.
  */
 public class LogRepositoryManagerImpl extends LogRepositoryBaseImpl implements LogRepositoryManager {
-	private static class EventContents {
-		public String eventType ;
-		public String repositoryType ;
-		public Date dateOldestLogRecord ;
-		public EventContents(String eventType, String repositoryType, Date dateOldestRecord) {
-			this.eventType = eventType ;
-			this.repositoryType = repositoryType ;
-			this.dateOldestLogRecord = dateOldestRecord ;
-		}
-	}
+        private static class EventContents {
+                public String eventType ;
+                public String repositoryType ;
+                public Date dateOldestLogRecord ;
+                public EventContents(String eventType, String repositoryType, Date dateOldestRecord) {
+                        this.eventType = eventType ;
+                        this.repositoryType = repositoryType ;
+                        this.dateOldestLogRecord = dateOldestRecord ;
+                }
+        }
 
-	// Assume there's no space constrains by default.
-	private long maxLogFileSize = MAX_LOG_FILE_SIZE;
-	private long maxRepositorySize = -1;
-	private final String svPid;
+        // Assume there's no space constrains by default.
+        private long maxLogFileSize = MAX_LOG_FILE_SIZE;
+        private long maxRepositorySize = -1;
+        private final String svPid;
 
-	private static String thisClass = LogRepositoryManagerImpl.class.getName() ;
-	private static Logger debugLogger = LogRepositoryBaseImpl.getLogger() ; 
-		// Assume there's no time constrains by default.
-	private TimerThread timer = null;
-	
-	private File ivSubDirectory = null;		// F017049-16879.3 Need to construct this based on pids, labels, and child processes
-	private final HashMap<String, FileDetails> activeFilesMap = new HashMap<String, FileDetails>() ;
-	// Contains count of both files and subdirectories.
-	private final HashMap<File, Integer> parentFilesMap = new HashMap<File, Integer>() ;
-	private String repositoryType = null ;
-	private boolean okToNotify = true ;		// Do not send notify until a roll is complete
-	private static ArrayList<EventContents>notificationQueue = 
-		new ArrayList<EventContents>() ;
-	
-	/**
-	 * Creates LogRepositoryManager instance maintaining files in the given location
-	 * for the specified process.
-	 * 
-	 * @param directory the location of all repository files.
-	 * @param pid the identifier of the process writing into this repository.
-	 * @param label additional identifier of the writing process.
-	 * @param useDirTree value <code>true</code> means we need to use instance directories with children
-	 * 		subdirectories in them; <code>false</code> means everything need to be stored in the root
-	 * 		directory.
-	 */
-	public LogRepositoryManagerImpl(File directory, String pid, String label, boolean useDirTree) {
-		super(directory);
-		if (!AccessHelper.canMakeDirectories(directory)) {
-			throw new IllegalArgumentException("Specified location can't be used as a log repository: " + directory);
-		}
-		
-		//On iSeries platforms, the pid will be a qualified combination of job number, user, and jobname with a
-		//qualifier of /.  The job number is a unique number assigned by the iSeries system that is always 6 digits.
-		//Since job number is unique and numeric, we will strip off the rest and treat the job number as a pid value.
-		int index = pid.indexOf("/");
-		if(index > -1 ){
-			pid = pid.substring(0, index);			
-		}
-		svPid = pid;
-		if (useDirTree) {
-			try {
-				createLockFile(pid, label);
-			} catch (IOException ex) {
-				throw new IllegalArgumentException("Specified location can't be used as a log repository: " + directory, ex);
-			}
-		} else {
-			ivSubDirectory = directory;
-		}
-	}
-	
-	/**
-	 * stop logging and thus stop the timer retention thread
-	 */
-	public synchronized void stop() {
-		if (timer != null) {
-			timer.keepRunning = false;
-			timer.interrupt();
-			timer = null;
-		}
-		// Remove this manager from the space alert list
-		LogRepositorySpaceAlert.getInstance().removeRepositoryInfo(this);
-	}
+        private static String thisClass = LogRepositoryManagerImpl.class.getName() ;
+        private static Logger debugLogger = LogRepositoryBaseImpl.getLogger() ; 
+                // Assume there's no time constrains by default.
+        private TimerThread timer = null;
+        
+        private File ivSubDirectory = null;             // F017049-16879.3 Need to construct this based on pids, labels, and child processes
+        private final HashMap<String, FileDetails> activeFilesMap = new HashMap<String, FileDetails>() ;
+        // Contains count of both files and subdirectories.
+        private final HashMap<File, Integer> parentFilesMap = new HashMap<File, Integer>() ;
+        private String repositoryType = null ;
+        private boolean okToNotify = true ;             // Do not send notify until a roll is complete
+        private static ArrayList<EventContents>notificationQueue = 
+                new ArrayList<EventContents>() ;
+        
+        /**
+         * Creates LogRepositoryManager instance maintaining files in the given location
+         * for the specified process.
+         * 
+         * @param directory the location of all repository files.
+         * @param pid the identifier of the process writing into this repository.
+         * @param label additional identifier of the writing process.
+         * @param useDirTree value <code>true</code> means we need to use instance directories with children
+         *              subdirectories in them; <code>false</code> means everything need to be stored in the root
+         *              directory.
+         */
+        public LogRepositoryManagerImpl(File directory, String pid, String label, boolean useDirTree) {
+                super(directory);
+                if (!AccessHelper.canMakeDirectories(directory)) {
+                        throw new IllegalArgumentException("Specified location can't be used as a log repository: " + directory);
+                }
+                
+                //On iSeries platforms, the pid will be a qualified combination of job number, user, and jobname with a
+                //qualifier of /.  The job number is a unique number assigned by the iSeries system that is always 6 digits.
+                //Since job number is unique and numeric, we will strip off the rest and treat the job number as a pid value.
+                int index = pid.indexOf("/");
+                if(index > -1 ){
+                        pid = pid.substring(0, index);                  
+                }
+                svPid = pid;
+                if (useDirTree) {
+                        try {
+                                createLockFile(pid, label);
+                        } catch (IOException ex) {
+                                throw new IllegalArgumentException("Specified location can't be used as a log repository: " + directory, ex);
+                        }
+                } else {
+                        ivSubDirectory = directory;
+                }
+        }
+        
+        /**
+         * stop logging and thus stop the timer retention thread
+         */
+        public synchronized void stop() {
+                if (timer != null) {
+                        timer.keepRunning = false;
+                        timer.interrupt();
+                        timer = null;
+                }
+                // Remove this manager from the space alert list
+                LogRepositorySpaceAlert.getInstance().removeRepositoryInfo(this);
+        }
 
-	/**
-	 * Configures constrain parameters of the repository.
-	 * 
-	 * @param maxRepositorySize maximum in bytes of the total sum of repository file sizes the manager should maintain.
-	 * 			This limit is ignored if <code>maxRepositorySize</code> is less than or equal to zero.
-	 * @param retentionTime the minimum time in milliseconds log records should be kept in the repository.
-	 * 			This limit is ignored if <code>retentionTime</code> is less than or equal to zero.
-	 */
-	public synchronized void configure(long maxRepositorySize, long retentionTime) {
-		if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-			debugLogger.logp(Level.FINE, thisClass, "configure", "Log Records for Manager managing type: "+managedType+
-				" for pid: "+svPid+" maxRepSz: "+maxRepositorySize+" retentionTm: "+retentionTime) ;
-		}
-		// Check only if reducing repository size
-		boolean checkSpaceNow = maxRepositorySize > 0 && (this.maxRepositorySize <= 0 || maxRepositorySize < this.maxRepositorySize);
-		
-		this.maxLogFileSize = calculateFileSplit(maxRepositorySize);
-		this.maxRepositorySize = maxRepositorySize;
-		
-		if (checkSpaceNow) {
-			checkSpaceConstrain(maxLogFileSize);
-		}
-		
-		if (timer == null) {
-			if (retentionTime > 0) {
-				timer = new TimerThread(retentionTime);
-				timer.start();
-			}
-		} else {
-			if (retentionTime <= 0) {
-				stop();
-			} else if (retentionTime != timer.retentionTime) {
-				timer.retentionTime = retentionTime;
-				timer.interrupt();
-			}
-		}
-	}
-	
-	private final static long MIN_LOG_FILE_SIZE = 1024 * 1024; // 1MB
-	private final static long MAX_LOG_FILE_SIZE = 5 * 1024 * 1024; // 5MB
-	private final static long MIN_REPOSITORY_SIZE = 10 * 1024 * 1024; // 10MB
-	private final static int SPLIT_RATIO = 20; // ratio of the repository size to the max file size
-	
-	/**
-	 * calculates maximum size of repository files based on the required maximum limit
-	 * on total size of the repository.
-	 * 
-	 * @param repositorySize space constrain on the repository.
-	 * @return size constrain of an individual file in the repository.
-	 */
-	protected static long calculateFileSplit(long repositorySize) {
-		if (repositorySize <= 0) {
-			return MAX_LOG_FILE_SIZE;
-		}
-		if (repositorySize < MIN_REPOSITORY_SIZE) {
-			throw new IllegalArgumentException("Specified repository size is too small");
-		}
-		
-		long result = repositorySize / SPLIT_RATIO;
-		
-		if (result < MIN_LOG_FILE_SIZE) {
-			result = MIN_LOG_FILE_SIZE;
-		} else if (result > MAX_LOG_FILE_SIZE) {
-			result = MAX_LOG_FILE_SIZE;
-		}
-		
-		return result;
-	}
-	
-	private static class FileDetails {
-		final File file;
-		final long timestamp;
-		long size;
-		String pid;
-		FileDetails(File file, long timestamp, long size, String pid) {
-			this.file = file;
-			this.size = size;
-			this.timestamp = timestamp;
-			this.pid = pid;
-		}
-	}
+        /**
+         * Configures constrain parameters of the repository.
+         * 
+         * @param maxRepositorySize maximum in bytes of the total sum of repository file sizes the manager should maintain.
+         *                      This limit is ignored if <code>maxRepositorySize</code> is less than or equal to zero.
+         * @param retentionTime the minimum time in milliseconds log records should be kept in the repository.
+         *                      This limit is ignored if <code>retentionTime</code> is less than or equal to zero.
+         */
+        public synchronized void configure(long maxRepositorySize, long retentionTime) {
+                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                        debugLogger.logp(Level.FINE, thisClass, "configure", "Log Records for Manager managing type: "+managedType+
+                                " for pid: "+svPid+" maxRepSz: "+maxRepositorySize+" retentionTm: "+retentionTime) ;
+                }
+                // Check only if reducing repository size
+                boolean checkSpaceNow = maxRepositorySize > 0 && (this.maxRepositorySize <= 0 || maxRepositorySize < this.maxRepositorySize);
+                
+                this.maxLogFileSize = calculateFileSplit(maxRepositorySize);
+                this.maxRepositorySize = maxRepositorySize;
+                
+                if (checkSpaceNow) {
+                        checkSpaceConstrain(maxLogFileSize);
+                }
+                
+                if (timer == null) {
+                        if (retentionTime > 0) {
+                                timer = new TimerThread(retentionTime);
+                                timer.start();
+                        }
+                } else {
+                        if (retentionTime <= 0) {
+                                stop();
+                        } else if (retentionTime != timer.retentionTime) {
+                                timer.retentionTime = retentionTime;
+                                timer.interrupt();
+                        }
+                }
+        }
+        
+        private final static long MIN_LOG_FILE_SIZE = 1024 * 1024; // 1MB
+        private final static long MAX_LOG_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+        private final static long MIN_REPOSITORY_SIZE = 10 * 1024 * 1024; // 10MB
+        private final static int SPLIT_RATIO = 20; // ratio of the repository size to the max file size
+        
+        /**
+         * calculates maximum size of repository files based on the required maximum limit
+         * on total size of the repository.
+         * 
+         * @param repositorySize space constrain on the repository.
+         * @return size constrain of an individual file in the repository.
+         */
+        protected static long calculateFileSplit(long repositorySize) {
+                if (repositorySize <= 0) {
+                        return MAX_LOG_FILE_SIZE;
+                }
+                if (repositorySize < MIN_REPOSITORY_SIZE) {
+                        throw new IllegalArgumentException("Specified repository size is too small");
+                }
+                
+                long result = repositorySize / SPLIT_RATIO;
+                
+                if (result < MIN_LOG_FILE_SIZE) {
+                        result = MIN_LOG_FILE_SIZE;
+                } else if (result > MAX_LOG_FILE_SIZE) {
+                        result = MAX_LOG_FILE_SIZE;
+                }
+                
+                return result;
+        }
+        
+        private static class FileDetails {
+                final File file;
+                final long timestamp;
+                long size;
+                String pid;
+                FileDetails(File file, long timestamp, long size, String pid) {
+                        this.file = file;
+                        this.size = size;
+                        this.timestamp = timestamp;
+                        this.pid = pid;
+                }
+        }
 
-	final LinkedList<FileDetails> fileList = new LinkedList<FileDetails>() ;
-	
-	long totalSize = -1L;
-	
-	/**
-	 * Initializes file list from the list of files in the repository.
-	 * This method should be called while holding a lock on fileList.
-	 * 
-	 * @param force indicator that the list should be initialized from the file
-	 * 		system even if it was initialized before.
-	 */
-	private void initFileList(boolean force) {
-		if (totalSize < 0 || force) {
-			fileList.clear();
-			parentFilesMap.clear();
-			totalSize = 0L;
-			File[] files = listRepositoryFiles();
-			if (files.length > 0) {
-				Arrays.sort(files, fileComparator);
-				for (File file: files) {
-					long size = AccessHelper.getFileLength(file);
-					// Intentional here to NOT add these files to activeFilesMap since they are legacy
-					fileList.add(new FileDetails(file, getLogFileTimestamp(file), size, null));
-					totalSize += size;
-					if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-						debugLogger.logp(Level.FINE, thisClass, "initFileList", "add: "+file.getPath()+" sz: "+size+
-							" listSz: "+fileList.size()+" new totalSz: "+totalSize);
-					}
-					incrementFileCount(file);
-				}
-				debugListLL("fileListPrePop") ;
-			}
-				
-			deleteEmptyRepositoryDirs();
+        final LinkedList<FileDetails> fileList = new LinkedList<FileDetails>() ;
+        
+        long totalSize = -1L;
+        
+        /**
+         * Initializes file list from the list of files in the repository.
+         * This method should be called while holding a lock on fileList.
+         * 
+         * @param force indicator that the list should be initialized from the file
+         *              system even if it was initialized before.
+         */
+        private void initFileList(boolean force) {
+                if (totalSize < 0 || force) {
+                        fileList.clear();
+                        parentFilesMap.clear();
+                        totalSize = 0L;
+                        File[] files = listRepositoryFiles();
+                        if (files.length > 0) {
+                                Arrays.sort(files, fileComparator);
+                                for (File file: files) {
+                                        long size = AccessHelper.getFileLength(file);
+                                        // Intentional here to NOT add these files to activeFilesMap since they are legacy
+                                        fileList.add(new FileDetails(file, getLogFileTimestamp(file), size, null));
+                                        totalSize += size;
+                                        if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                                                debugLogger.logp(Level.FINE, thisClass, "initFileList", "add: "+file.getPath()+" sz: "+size+
+                                                        " listSz: "+fileList.size()+" new totalSz: "+totalSize);
+                                        }
+                                        incrementFileCount(file);
+                                }
+                                debugListLL("fileListPrePop") ;
+                        }
+                                
+                        deleteEmptyRepositoryDirs();
 
-			if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()){
-				Iterator<File> parentKeys = parentFilesMap.keySet().iterator() ;
-				while (parentKeys.hasNext()) {
-					File parentNameKey = parentKeys.next() ;
-					Integer fileCount = parentFilesMap.get(parentNameKey) ;
-					debugLogger.logp(Level.FINE, thisClass, "initFileList", "  Directory: "+parentNameKey+" file count: "+ fileCount) ;									
-				}
-			}
-		}		
-	}
-	
-	/**
-	 * Deletes all empty server instance directories, including empty servant directories
-	 *
-	 */
-	protected void deleteEmptyRepositoryDirs() {
-		File[] directories = listRepositoryDirs();
-		
-		//determine if the server/controller instance directory is empty
-		for(int i = 0; i < directories.length; i++){
-			// This is a directory we should not delete
-			boolean currentDir = ivSubDirectory != null && ivSubDirectory.compareTo(directories[i])==0;
-			//if a server instance directory does not have a key in parentFilesMap, then it does not have any files 
-			if (debugLogger.isLoggable(Level.FINE) && isDebugEnabled())
-				debugLogger.logp(Level.FINE, thisClass, "deleteEmptyRepositoryDirs", "Instance directory name (controller): " + directories[i].getAbsolutePath());
-			
-			//now look for empty servant directories
-			File[] childFiles = AccessHelper.listFiles(directories[i], subprocFilter) ;
-			for (File curFile : childFiles) {
-				if (debugLogger.isLoggable(Level.FINE) && isDebugEnabled())
-					debugLogger.logp(Level.FINE, thisClass, "deleteEmptyRepositoryDirs", "Servant directory name: " + curFile.getAbsolutePath());
-				if (!currentDir && !parentFilesMap.containsKey(curFile)) {
-					if (debugLogger.isLoggable(Level.FINE) && isDebugEnabled())
-		    			debugLogger.logp(Level.FINE, thisClass, "deleteEmptyRepositoryDirs", "Found an empty servant directory:  " + curFile);
-					deleteDirectory(curFile);
-				} else {
-					incrementFileCount(curFile);
-				}
-			}
-			//delete directory if empty
-			if (!currentDir && !parentFilesMap.containsKey(directories[i])) {
-				if (debugLogger.isLoggable(Level.FINE) && isDebugEnabled())
-					debugLogger.logp(Level.FINE, thisClass, "listRepositoryFiles", "Found an empty directory:  " + directories[i]);
-				deleteDirectory(directories[i]);
-			}
-		}
-	}
-	
-	/**
-	 * Deletes the specified directory
-	 * @param the name of the directory to be deleted
-	 */
-	protected void deleteDirectory(File directoryName){
-		if (debugLogger.isLoggable(Level.FINE) && isDebugEnabled()) {
-			debugLogger.logp(Level.FINE, thisClass, "deleteDirectory", "empty directory "+((directoryName == null) ? "None":
-				directoryName.getPath()));
-		}		
-		if (AccessHelper.deleteFile(directoryName)) {  // If directory is empty, delete
-			if (debugLogger.isLoggable(Level.FINE) && isDebugEnabled()) {
-				debugLogger.logp(Level.FINE, thisClass, "deleteDirectory", "delete "+directoryName.getName());
-			}					
-		} else {
-			// Else the directory is not empty, and deletion fails
-			if (isDebugEnabled()) {
-				debugLogger.logp(Level.WARNING, thisClass, "deleteDirectory", "Failed to delete directory "+directoryName.getPath());
-			}
-		}
-	}
+                        if (LogRepositoryBaseImpl.isDebugEnabled()){
+                                Iterator<File> parentKeys = parentFilesMap.keySet().iterator() ;
+                                while (parentKeys.hasNext()) {
+                                        File parentNameKey = parentKeys.next() ;
+                                        Integer fileCount = parentFilesMap.get(parentNameKey) ;
+                                        debugLogger.logp(Level.FINE, thisClass, "initFileList", "  Directory: "+parentNameKey+" file count: "+ fileCount) ;                                                                     
+                                }
+                        }
+                }               
+        }
+        
+        /**
+         * Deletes all empty server instance directories, including empty servant directories
+         *
+         */
+        protected void deleteEmptyRepositoryDirs() {
+                File[] directories = listRepositoryDirs();
+                
+                //determine if the server/controller instance directory is empty
+                for(int i = 0; i < directories.length; i++){
+                        // This is a directory we should not delete
+                        boolean currentDir = ivSubDirectory != null && ivSubDirectory.compareTo(directories[i])==0;
+                        //if a server instance directory does not have a key in parentFilesMap, then it does not have any files 
+                        if (isDebugEnabled())
+                                debugLogger.logp(Level.FINE, thisClass, "deleteEmptyRepositoryDirs", "Instance directory name (controller): " + directories[i].getAbsolutePath());
+                        
+                        //now look for empty servant directories
+                        File[] childFiles = AccessHelper.listFiles(directories[i], subprocFilter) ;
+                        for (File curFile : childFiles) {
+                                if (isDebugEnabled())
+                                        debugLogger.logp(Level.FINE, thisClass, "deleteEmptyRepositoryDirs", "Servant directory name: " + curFile.getAbsolutePath());
+                                if (!currentDir && !parentFilesMap.containsKey(curFile)) {
+                                        if (isDebugEnabled())
+                                        debugLogger.logp(Level.FINE, thisClass, "deleteEmptyRepositoryDirs", "Found an empty servant directory:  " + curFile);
+                                        deleteDirectory(curFile);
+                                } else {
+                                        incrementFileCount(curFile);
+                                }
+                        }
+                        //delete directory if empty
+                        if (!currentDir && !parentFilesMap.containsKey(directories[i])) {
+                                if (isDebugEnabled())
+                                        debugLogger.logp(Level.FINE, thisClass, "listRepositoryFiles", "Found an empty directory:  " + directories[i]);
+                                deleteDirectory(directories[i]);
+                        }
+                }
+        }
+        
+        /**
+         * Deletes the specified directory
+         * @param the name of the directory to be deleted
+         */
+        protected void deleteDirectory(File directoryName){
+                if (isDebugEnabled()) {
+                        debugLogger.logp(Level.FINE, thisClass, "deleteDirectory", "empty directory "+((directoryName == null) ? "None":
+                                directoryName.getPath()));
+                }               
+                if (AccessHelper.deleteFile(directoryName)) {  // If directory is empty, delete
+                        if (isDebugEnabled()) {
+                                debugLogger.logp(Level.FINE, thisClass, "deleteDirectory", "delete "+directoryName.getName());
+                        }                                       
+                } else {
+                        // Else the directory is not empty, and deletion fails
+                        if (isDebugEnabled()) {
+                                debugLogger.logp(Level.WARNING, thisClass, "deleteDirectory", "Failed to delete directory "+directoryName.getPath());
+                        }
+                }
+        }
 
 
-	
-	private void incrementFileCount(File file){
-		File parentFile = file.getParentFile();
-		Integer filecount = parentFilesMap.get(parentFile);
-		if (filecount != null){
-			parentFilesMap.put(parentFile, filecount+1);
-		} else {
-			parentFilesMap.put(parentFile, 1);
-		}
-	}
-	
-	private void decrementFileCount(File file){
-		File parentFile = file.getParentFile();
-		Integer filecount = parentFilesMap.get(parentFile);
-		if (filecount != null){
-			if (filecount == 1) {
-				parentFilesMap.remove(parentFile);
-				deleteDirectory(parentFile);
-				decrementFileCount(parentFile);
-			} else {
-				parentFilesMap.put(parentFile, filecount-1);
-			}
-		}
-	}
-	
-	/*
-	 *  Make sure that repository has enough space for a new file
-	 */
-	private void checkSpaceConstrain(long logFileSize) {
-		long spaceNeeded;
-		if (maxRepositorySize > 0) {
-			synchronized(fileList) {
-				initFileList(false);
-				long purgeSize = totalSize + logFileSize - maxRepositorySize;
-				if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-					debugLogger.logp(Level.FINE, thisClass, "checkSpaceConstrain", "total: "+totalSize+
-					" maxLog: "+logFileSize+" maxRepos: "+maxRepositorySize) ;
-				}
-				if (purgeSize > 0) {
-					purgeOldFiles(purgeSize);
-				}
-				spaceNeeded = maxRepositorySize - totalSize;
-			}
-		} else {
-			spaceNeeded = MAX_LOG_FILE_SIZE; // If no limit ensure that at least one log file can be written
-		}
-		LogRepositorySpaceAlert.getInstance().setRepositoryInfo(this, repositoryLocation, spaceNeeded) ;
-	}
-	
-	/**
-	 * Removes old files from the repository. This method does not remove
-	 * the most recent file.
-	 * This method should be called while holding a lock on fileList.
-	 * 
-	 * @param total the amount in bytes of required free space.
-	 * @return <code>true</code> if at least one file was removed from the repository.
-	 */
-	private boolean purgeOldFiles(long total) {
-		boolean result = false;
-		// Should delete some files.
-		if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-			debugLogger.logp(Level.FINE, thisClass, "purgeOldFiles", "total: "+total+" listSz: "+fileList.size());
-		}
-		while(total > 0 && fileList.size() > 1) {
-			FileDetails details = purgeOldestFile();
-			if (details != null) {
-				if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-					debugLogger.logp(Level.FINE, thisClass, "purgeOldFiles", "Purged: "+details.file.getPath()+" sz: "+details.size);
-				}
-				total -= details.size;
-				result = true;
-			}
-		}
-		return result;
-	}
-	
-	/**
-	 * Removes the oldest file from the repository. This method has logic to avoid removing currently active files
-	 * This method should be called with a lock on filelist already attained	
-	 * 
-	 * @return instance representing the deleted file or <code>null</code> if
-	 * 		fileList was reinitinialized.
-	 */
-	private FileDetails purgeOldestFile() {
-		debugListLL("prepurgeOldestFile") ;
-		debugListHM("prepurgeOldestFile") ;
-		FileDetails  returnFD = getOldestInactive() ;
-		if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-			debugLogger.logp(Level.FINE, thisClass, "purgeOldestFile", "oldestInactive: "+((returnFD == null) ? "None":
-				returnFD.file.getPath()));
-		}
-		if (returnFD == null)
-			return null ;
-		if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-			debugLogger.logp(Level.FINE, thisClass, "purgeOldestFile", "fileList size before remove: "+fileList.size()) ;
-		}
-		
-		if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-			debugLogger.logp(Level.FINE, thisClass, "purgeOldestFile", "fileList size after remove: "+fileList.size()) ;
-		}
+        
+        private void incrementFileCount(File file){
+                File parentFile = file.getParentFile();
+                Integer filecount = parentFilesMap.get(parentFile);
+                if (filecount != null){
+                        parentFilesMap.put(parentFile, filecount+1);
+                } else {
+                        parentFilesMap.put(parentFile, 1);
+                }
+        }
+        
+        private void decrementFileCount(File file){
+                File parentFile = file.getParentFile();
+                Integer filecount = parentFilesMap.get(parentFile);
+                if (filecount != null){
+                        if (filecount == 1) {
+                                parentFilesMap.remove(parentFile);
+                                deleteDirectory(parentFile);
+                                decrementFileCount(parentFile);
+                        } else {
+                                parentFilesMap.put(parentFile, filecount-1);
+                        }
+                }
+        }
+        
+        /*
+         *  Make sure that repository has enough space for a new file
+         */
+        private void checkSpaceConstrain(long logFileSize) {
+                long spaceNeeded;
+                if (maxRepositorySize > 0) {
+                        synchronized(fileList) {
+                                initFileList(false);
+                                long purgeSize = totalSize + logFileSize - maxRepositorySize;
+                                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                                        debugLogger.logp(Level.FINE, thisClass, "checkSpaceConstrain", "total: "+totalSize+
+                                        " maxLog: "+logFileSize+" maxRepos: "+maxRepositorySize) ;
+                                }
+                                if (purgeSize > 0) {
+                                        purgeOldFiles(purgeSize);
+                                }
+                                spaceNeeded = maxRepositorySize - totalSize;
+                        }
+                } else {
+                        spaceNeeded = MAX_LOG_FILE_SIZE; // If no limit ensure that at least one log file can be written
+                }
+                LogRepositorySpaceAlert.getInstance().setRepositoryInfo(this, repositoryLocation, spaceNeeded) ;
+        }
+        
+        /**
+         * Removes old files from the repository. This method does not remove
+         * the most recent file.
+         * This method should be called while holding a lock on fileList.
+         * 
+         * @param total the amount in bytes of required free space.
+         * @return <code>true</code> if at least one file was removed from the repository.
+         */
+        private boolean purgeOldFiles(long total) {
+                boolean result = false;
+                // Should delete some files.
+                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                        debugLogger.logp(Level.FINE, thisClass, "purgeOldFiles", "total: "+total+" listSz: "+fileList.size());
+                }
+                while(total > 0 && fileList.size() > 1) {
+                        FileDetails details = purgeOldestFile();
+                        if (details != null) {
+                                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                                        debugLogger.logp(Level.FINE, thisClass, "purgeOldFiles", "Purged: "+details.file.getPath()+" sz: "+details.size);
+                                }
+                                total -= details.size;
+                                result = true;
+                        }
+                }
+                return result;
+        }
+        
+        /**
+         * Removes the oldest file from the repository. This method has logic to avoid removing currently active files
+         * This method should be called with a lock on filelist already attained        
+         * 
+         * @return instance representing the deleted file or <code>null</code> if
+         *              fileList was reinitinialized.
+         */
+        private FileDetails purgeOldestFile() {
+                debugListLL("prepurgeOldestFile") ;
+                debugListHM("prepurgeOldestFile") ;
+                FileDetails  returnFD = getOldestInactive() ;
+                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                        debugLogger.logp(Level.FINE, thisClass, "purgeOldestFile", "oldestInactive: "+((returnFD == null) ? "None":
+                                returnFD.file.getPath()));
+                }
+                if (returnFD == null)
+                        return null ;
+                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                        debugLogger.logp(Level.FINE, thisClass, "purgeOldestFile", "fileList size before remove: "+fileList.size()) ;
+                }
+                
+                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                        debugLogger.logp(Level.FINE, thisClass, "purgeOldestFile", "fileList size after remove: "+fileList.size()) ;
+                }
 
-		if (AccessHelper.deleteFile(returnFD.file)) {
-			fileList.remove(returnFD) ;
-			totalSize -= returnFD.size;
-			if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-				debugLogger.logp(Level.FINE, thisClass, "purgeOldestFile", "delete: "+returnFD.file.getName());
-			}
-			decrementFileCount(returnFD.file);
-			notifyOfFileAction(LogEventListener.EVENTTYPEDELETE) ;		// F004324
-		} else {
-			// Assume the list is out of sync.
-			if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-				debugLogger.logp(Level.FINE, thisClass, "purgeOldestFile", "Failed to delete file: "+returnFD.file.getPath());
-			}
-			initFileList(true);
-			returnFD = null;
-		}
-		debugListLL("postpurgeOldestFile") ;
-		return returnFD;
-	}
-	
-	private void debugListLL(String label) {
-		if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-			debugLogger.logp(Level.FINE, thisClass, "debugListLL", label+" w/fileList") ;
-			synchronized(fileList) {
-				for (FileDetails curFd : fileList) {
-					debugLogger.logp(Level.FINE, thisClass, "debugListLL", "  Sz: "+curFd.size+" Pid: "+curFd.pid+" Nm: "+curFd.file.getPath()) ;
-				}
-			}
-		}
-	}
+                if (AccessHelper.deleteFile(returnFD.file)) {
+                        fileList.remove(returnFD) ;
+                        totalSize -= returnFD.size;
+                        if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                                debugLogger.logp(Level.FINE, thisClass, "purgeOldestFile", "delete: "+returnFD.file.getName());
+                        }
+                        decrementFileCount(returnFD.file);
+                        notifyOfFileAction(LogEventListener.EVENTTYPEDELETE) ;          // F004324
+                } else {
+                        // Assume the list is out of sync.
+                        if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                                debugLogger.logp(Level.FINE, thisClass, "purgeOldestFile", "Failed to delete file: "+returnFD.file.getPath());
+                        }
+                        initFileList(true);
+                        returnFD = null;
+                }
+                debugListLL("postpurgeOldestFile") ;
+                return returnFD;
+        }
+        
+        private void debugListLL(String label) {
+                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                        debugLogger.logp(Level.FINE, thisClass, "debugListLL", label+" w/fileList") ;
+                        synchronized(fileList) {
+                                for (FileDetails curFd : fileList) {
+                                        debugLogger.logp(Level.FINE, thisClass, "debugListLL", "  Sz: "+curFd.size+" Pid: "+curFd.pid+" Nm: "+curFd.file.getPath()) ;
+                                }
+                        }
+                }
+        }
 
-	private void debugListHM(String label) {
-		if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-			debugLogger.logp(Level.FINE, thisClass, "debugListHM", label+" hash") ;
-			synchronized(fileList) {
-				synchronized(activeFilesMap) {
-					Iterator<String> activeKeys = activeFilesMap.keySet().iterator() ;
-					while (activeKeys.hasNext()) {
-						String pidKey = activeKeys.next() ;
-						FileDetails thisFd = activeFilesMap.get(pidKey) ;
-						debugLogger.logp(Level.FINE, thisClass, "debugListHM", "  Pid: "+pidKey+" timestamp: "+thisFd.timestamp) ;
-					}
-				}
-			}
-		}
-	}
-	
-	public synchronized boolean purgeOldFiles() {
-		synchronized(fileList) {
-			initFileList(false);
-			return purgeOldFiles(maxLogFileSize);
-		}
-	}
+        private void debugListHM(String label) {
+                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                        debugLogger.logp(Level.FINE, thisClass, "debugListHM", label+" hash") ;
+                        synchronized(fileList) {
+                                synchronized(activeFilesMap) {
+                                        Iterator<String> activeKeys = activeFilesMap.keySet().iterator() ;
+                                        while (activeKeys.hasNext()) {
+                                                String pidKey = activeKeys.next() ;
+                                                FileDetails thisFd = activeFilesMap.get(pidKey) ;
+                                                debugLogger.logp(Level.FINE, thisClass, "debugListHM", "  Pid: "+pidKey+" timestamp: "+thisFd.timestamp) ;
+                                        }
+                                }
+                        }
+                }
+        }
+        
+        public synchronized boolean purgeOldFiles() {
+                synchronized(fileList) {
+                        initFileList(false);
+                        return purgeOldFiles(maxLogFileSize);
+                }
+        }
 
-	/**
-	 * add information about a new file being created by a subProcess in order to maintain retention information.  This is done for all
-	 * files created by each subProcess. If IPC facility is not ready, subProcess may have to create first, then notify when IPC is up.
-	 * @param spTimeStamp timestamp to associate with the file
-	 * @param spPid ProcessId of the process that is creating the file (initiator of this action)
-	 * @param spLabel Label to be used as part of the file name
-	 * @return the full path of the file subprocess need to use for log records
-	 */
-	public synchronized String addNewFileFromSubProcess(long spTimeStamp, String spPid, String spLabel) {
-		// TODO: It is theoretically possible that subProcess already created one of these (although it won't happen in our scenario.
-		// Consider either pulling actual pid from the files on initFileList or looking for the file here before adding it.  If found,
-		// adjust the pid to this pid.
-		checkSpaceConstrain(maxLogFileSize) ;
-		if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-			debugLogger.logp(Level.FINE, thisClass, "addNewFileFromSubProcess", "Tstamp: "+spTimeStamp+
-				" pid: "+spPid+" lbl: "+spLabel+" Max: "+maxLogFileSize);
-		}
-		
-		if (ivSubDirectory == null)
-			getControllingProcessDirectory(spTimeStamp, svPid) ;	// Note: passing, pid of this region, not sending child region
-		
-		if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-			debugLogger.logp(Level.FINE, thisClass, "addNewFileFromSubProcess", "Got ivSubDir: "+ivSubDirectory.getPath());
-		}
-		File servantDirectory = new File(ivSubDirectory, getLogDirectoryName(-1, spPid, spLabel)) ;
-		File servantFile = getLogFile(servantDirectory, spTimeStamp) ;
-		FileDetails thisFile = new FileDetails(servantFile, spTimeStamp, maxLogFileSize, spPid) ;
-		synchronized(fileList) {
-			initFileList(false) ;
-			fileList.add(thisFile) ;	// Not active as new one was created
-			incrementFileCount(servantFile);
-			synchronized(activeFilesMap) {	// In this block so that fileList always locked first
-				activeFilesMap.put(spPid, thisFile) ;
-			}
-		}
-		totalSize += maxLogFileSize ;
-		if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-			debugLogger.logp(Level.FINE, thisClass, "addNewFileFromSubProcess", "Added file: "+servantFile.getPath()+" sz:"+maxLogFileSize+" tstmp: "+spTimeStamp) ;
-			debugListLL("postAddFromSP") ;
-			debugListHM("postAddFromSP") ;
-		}
-		return servantFile.getPath() ;
-	}
+        /**
+         * add information about a new file being created by a subProcess in order to maintain retention information.  This is done for all
+         * files created by each subProcess. If IPC facility is not ready, subProcess may have to create first, then notify when IPC is up.
+         * @param spTimeStamp timestamp to associate with the file
+         * @param spPid ProcessId of the process that is creating the file (initiator of this action)
+         * @param spLabel Label to be used as part of the file name
+         * @return the full path of the file subprocess need to use for log records
+         */
+        public synchronized String addNewFileFromSubProcess(long spTimeStamp, String spPid, String spLabel) {
+                // TODO: It is theoretically possible that subProcess already created one of these (although it won't happen in our scenario.
+                // Consider either pulling actual pid from the files on initFileList or looking for the file here before adding it.  If found,
+                // adjust the pid to this pid.
+                checkSpaceConstrain(maxLogFileSize) ;
+                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                        debugLogger.logp(Level.FINE, thisClass, "addNewFileFromSubProcess", "Tstamp: "+spTimeStamp+
+                                " pid: "+spPid+" lbl: "+spLabel+" Max: "+maxLogFileSize);
+                }
+                
+                if (ivSubDirectory == null)
+                        getControllingProcessDirectory(spTimeStamp, svPid) ;    // Note: passing, pid of this region, not sending child region
+                
+                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                        debugLogger.logp(Level.FINE, thisClass, "addNewFileFromSubProcess", "Got ivSubDir: "+ivSubDirectory.getPath());
+                }
+                File servantDirectory = new File(ivSubDirectory, getLogDirectoryName(-1, spPid, spLabel)) ;
+                File servantFile = getLogFile(servantDirectory, spTimeStamp) ;
+                FileDetails thisFile = new FileDetails(servantFile, spTimeStamp, maxLogFileSize, spPid) ;
+                synchronized(fileList) {
+                        initFileList(false) ;
+                        fileList.add(thisFile) ;        // Not active as new one was created
+                        incrementFileCount(servantFile);
+                        synchronized(activeFilesMap) {  // In this block so that fileList always locked first
+                                activeFilesMap.put(spPid, thisFile) ;
+                        }
+                }
+                totalSize += maxLogFileSize ;
+                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                        debugLogger.logp(Level.FINE, thisClass, "addNewFileFromSubProcess", "Added file: "+servantFile.getPath()+" sz:"+maxLogFileSize+" tstmp: "+spTimeStamp) ;
+                        debugListLL("postAddFromSP") ;
+                        debugListHM("postAddFromSP") ;
+                }
+                return servantFile.getPath() ;
+        }
 
-	/**
-	 * inactivate active file for a given process.  Should only be one file active for a process
-	 * @param spPid
-	 */
-	public void inactivateSubProcess(String spPid) {
-		synchronized (fileList) {		// always lock fileList first to avoid deadlock
-			synchronized(activeFilesMap) {		// Right into sync block because 99% case is that map contains pid
-				activeFilesMap.remove(spPid) ;
-			}
-		}
-		if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-			debugLogger.logp(Level.FINE, thisClass, "inactivateSubProcess", "Inactivated pid: "+spPid) ;
-		}
-	}
-	
-	private final static long FAILED_WAIT_TIME = 1000; // sleep for 1sec.
-	private final static long FAILED_MAX_COUNT = 5; // fall asleep 5 times.
-	
-	/*
-	 * Calculates location of the new file with provided timestamp.
-	 * It should be called with the instance lock taken.
-	 */
-	private File calculateLogFile(long timestamp) {
-		if (ivSubDirectory == null)
-			getControllingProcessDirectory(timestamp, svPid) ;
-		
-		return getLogFile(ivSubDirectory, timestamp);
-	}
-	
-	public synchronized File startNewFile(long timestamp) {
-		
-		okToNotify = false ;
-		checkSpaceConstrain(maxLogFileSize);
-		
-		File file = calculateLogFile(timestamp);
-		
-		File dir = file.getParentFile();
-		if (!AccessHelper.isDirectory(dir)) {
-			AccessHelper.makeDirectories(dir);
-		}
-		
-		FileDetails thisFile = new FileDetails(file, timestamp, 0, svPid);
-		synchronized(fileList) {
-			initFileList(false);
-			fileList.add(thisFile);
-			incrementFileCount(file);
-			synchronized(activeFilesMap) {		// This in this loop to make sure fileList always locked first
-				activeFilesMap.put(svPid, thisFile) ;
-			}
-		}
-		if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-			debugLogger.logp(Level.FINE, thisClass, "startNewFile", "Added file: "+file.getPath()+" sz: 0  tstmp: "+timestamp) ;
-			debugListLL("postAddLocal") ;
-			debugListHM("postAddLocal") ;
-		}
-		
-		if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-			debugLogger.logp(Level.FINE, thisClass, "startNewFile", "roll");
-		}
-		// F004324, NOT notifying of roll here. If caller used this for a roll, then caller must register the roll
-		okToNotify = true ;		// Callers can now send notifications. 
+        /**
+         * inactivate active file for a given process.  Should only be one file active for a process
+         * @param spPid
+         */
+        public void inactivateSubProcess(String spPid) {
+                synchronized (fileList) {               // always lock fileList first to avoid deadlock
+                        synchronized(activeFilesMap) {          // Right into sync block because 99% case is that map contains pid
+                                activeFilesMap.remove(spPid) ;
+                        }
+                }
+                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                        debugLogger.logp(Level.FINE, thisClass, "inactivateSubProcess", "Inactivated pid: "+spPid) ;
+                }
+        }
+        
+        private final static long FAILED_WAIT_TIME = 1000; // sleep for 1sec.
+        private final static long FAILED_MAX_COUNT = 5; // fall asleep 5 times.
+        
+        /*
+         * Calculates location of the new file with provided timestamp.
+         * It should be called with the instance lock taken.
+         */
+        private File calculateLogFile(long timestamp) {
+                if (ivSubDirectory == null)
+                        getControllingProcessDirectory(timestamp, svPid) ;
+                
+                return getLogFile(ivSubDirectory, timestamp);
+        }
+        
+        public synchronized File startNewFile(long timestamp) {
+                
+                okToNotify = false ;
+                checkSpaceConstrain(maxLogFileSize);
+                
+                File file = calculateLogFile(timestamp);
+                
+                File dir = file.getParentFile();
+                if (!AccessHelper.isDirectory(dir)) {
+                        AccessHelper.makeDirectories(dir);
+                }
+                
+                FileDetails thisFile = new FileDetails(file, timestamp, 0, svPid);
+                synchronized(fileList) {
+                        initFileList(false);
+                        fileList.add(thisFile);
+                        incrementFileCount(file);
+                        synchronized(activeFilesMap) {          // This in this loop to make sure fileList always locked first
+                                activeFilesMap.put(svPid, thisFile) ;
+                        }
+                }
+                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                        debugLogger.logp(Level.FINE, thisClass, "startNewFile", "Added file: "+file.getPath()+" sz: 0  tstmp: "+timestamp) ;
+                        debugListLL("postAddLocal") ;
+                        debugListHM("postAddLocal") ;
+                }
+                
+                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                        debugLogger.logp(Level.FINE, thisClass, "startNewFile", "roll");
+                }
+                // F004324, NOT notifying of roll here. If caller used this for a roll, then caller must register the roll
+                okToNotify = true ;             // Callers can now send notifications. 
 
-		if (timer != null) {
-			// Let timer thread know about the new file.
-			timer.interrupt();
-		}
-		
-		return file;
-	}
-	
-	/**
-	 * get the directory of the controlling process (this process). Used for this process and for prefixing the paths of
-	 * child process files (this process does the naming for those files).
-	 * @param timestamp
-	 * @param pid
-	 */
-	private void getControllingProcessDirectory(long timestamp, String pid) {
-		int count = 0;
-		while (ivSubDirectory == null) {
-			ivSubDirectory = makeLogDirectory(timestamp, pid);
-			if (ivSubDirectory == null) {
-				if (++count > FAILED_MAX_COUNT) {
-					ivSubDirectory = makeLogDirectory(timestamp, pid,true);
-					if(ivSubDirectory==null){
-						if (debugLogger.isLoggable(Level.FINE) && isDebugEnabled())
-						{
-							debugLogger.logp(Level.FINE, thisClass, "UnableToMakeDirectory", "Unable to create instance directory forcefully , throwing Runtime Exception");
-						}
-					  throw new RuntimeException("Failed to create instance log repository. See SystemOut.log for details.");
-				    }
-				}
-				try {
-					Thread.sleep(FAILED_WAIT_TIME);
-				} catch (InterruptedException ex) {
-					// Ignore it, assume that we had enough sleep.
-				}
-			}
-		}
-	}
-	
-	public synchronized File checkForNewFile(long total, long timestamp) {
-		// Check if file rotation is necessary.
-		synchronized(activeFilesMap) {		// This is a quick read w/no fileList access
-			FileDetails pidCurrentFd = activeFilesMap.get(svPid) ; 
-			// File rotation is not necessary if size hasn't reached maxLogFileSize or
-			// if rotation would override currently active file.
-			if (total <= maxLogFileSize || pidCurrentFd.file.equals(calculateLogFile(timestamp))) {
-				pidCurrentFd.size = total;
+                if (timer != null) {
+                        // Let timer thread know about the new file.
+                        timer.interrupt();
+                }
+                
+                return file;
+        }
+        
+        /**
+         * get the directory of the controlling process (this process). Used for this process and for prefixing the paths of
+         * child process files (this process does the naming for those files).
+         * @param timestamp
+         * @param pid
+         */
+        private void getControllingProcessDirectory(long timestamp, String pid) {
+                int count = 0;
+                while (ivSubDirectory == null) {
+                        ivSubDirectory = makeLogDirectory(timestamp, pid);
+                        if (ivSubDirectory == null) {
+                                if (++count > FAILED_MAX_COUNT) {
+                                        ivSubDirectory = makeLogDirectory(timestamp, pid,true);
+                                        if(ivSubDirectory==null){
+                                                if (isDebugEnabled())
+                                                {
+                                                        debugLogger.logp(Level.FINE, thisClass, "UnableToMakeDirectory", "Unable to create instance directory forcefully , throwing Runtime Exception");
+                                                }
+                                          throw new RuntimeException("Failed to create instance log repository. See SystemOut.log for details.");
+                                    }
+                                }
+                                try {
+                                        Thread.sleep(FAILED_WAIT_TIME);
+                                } catch (InterruptedException ex) {
+                                        // Ignore it, assume that we had enough sleep.
+                                }
+                        }
+                }
+        }
+        
+        public synchronized File checkForNewFile(long total, long timestamp) {
+                // Check if file rotation is necessary.
+                synchronized(activeFilesMap) {          // This is a quick read w/no fileList access
+                        FileDetails pidCurrentFd = activeFilesMap.get(svPid) ; 
+                        // File rotation is not necessary if size hasn't reached maxLogFileSize or
+                        // if rotation would override currently active file.
+                        if (total <= maxLogFileSize || pidCurrentFd.file.equals(calculateLogFile(timestamp))) {
+                                pidCurrentFd.size = total;
                         // We exceeded the maximum log file size so guarantee we have enough space
                         if (total > maxLogFileSize) {
                             checkSpaceConstrain(total);
                          }
 
-				return null;
-			}
-			totalSize += pidCurrentFd.size ;
-		}
-		
-		return startNewFile(timestamp);
-	}
+                                return null;
+                        }
+                        totalSize += pidCurrentFd.size ;
+                }
+                
+                return startNewFile(timestamp);
+        }
 
-		// F004324 related methods
-	/**
-	 * register a logEventNotifier with this logging manager.  This instructs the manager that, on file actions, a
-	 * notification should be sent out (then the notifier is responsible for notifying all registered listeners).
-	 * The notifier can be null which means that it is functionally deRegistering itself as there are no more
-	 * listeners (ie: the last listener just deRegistered
-	 */
+                // F004324 related methods
+        /**
+         * register a logEventNotifier with this logging manager.  This instructs the manager that, on file actions, a
+         * notification should be sent out (then the notifier is responsible for notifying all registered listeners).
+         * The notifier can be null which means that it is functionally deRegistering itself as there are no more
+         * listeners (ie: the last listener just deRegistered
+         */
        @Override
-	public void setLogEventNotifier(LogEventNotifier logEventNotifier) {
-		if (logEventNotifier == null) 
+        public void setLogEventNotifier(LogEventNotifier logEventNotifier) {
+                if (logEventNotifier == null) 
                 return ;
-		if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-			debugLogger.logp(Level.FINE, thisClass, "setLogEventNotifier", "managedTp: "+managedType);
-		}
-		super.setLogEventNotifier(logEventNotifier) ;
-			// the return is the oldest since it is not pid-specific.  At this point, in child processes (servants), this does not work
-			// since child processes do not remove files
-		if (TRACETYPE.equals(managedType) || LOGTYPE.equals(managedType)) {		// Only for log and trace
-			repositoryType = (TRACETYPE.equals(managedType)) ?					// Set repository type
-				LogEventListener.REPOSITORYTYPETRACE : LogEventListener.REPOSITORYTYPELOG ;
-			logEventNotifier.setOldestDate(getOldestDate(), repositoryType) ;
-			if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-				debugLogger.logp(Level.FINE, thisClass, "setLogEventNotifier", "repTp: "+repositoryType+" oldDt: "+getOldestDate());
-			}
-		}
-	}
-	@Override
-	public void notifyOfFileAction(String eventType) {
-		if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-			debugLogger.logp(Level.FINE, thisClass, "notifyOfFileAction", "rTp: "+repositoryType+" EvtTp: "+eventType+
-				" listener: "+logEventNotifier+" Dt: "+getOldestDate()+" Ok to notify: "+okToNotify);
-		}
-		if (logEventNotifier != null) {
-			if (okToNotify) {
-				if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-					debugLogger.logp(Level.FINE, thisClass, "notifyOfFileAction", "clearing queue") ;
-				}
-				synchronized (notificationQueue) {
-					if (notificationQueue.size() > 0) {
-						for (EventContents eventContents : notificationQueue) {
-							logEventNotifier.recordFileAction(eventContents.eventType, eventContents.repositoryType, 
-								eventContents.dateOldestLogRecord) ;
-						}
-						notificationQueue.clear() ;
-					}
-				}
-				logEventNotifier.recordFileAction(eventType, repositoryType, getOldestDate()) ;
-			} else {
-				if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-					debugLogger.logp(Level.FINE, thisClass, "notifyOfFileAction", "queueing event") ;
-				}
-				synchronized (notificationQueue) {
-					notificationQueue.add(new EventContents(eventType, repositoryType, getOldestDate())) ;
-				}
-			}
-		}
-	}
+                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                        debugLogger.logp(Level.FINE, thisClass, "setLogEventNotifier", "managedTp: "+managedType);
+                }
+                super.setLogEventNotifier(logEventNotifier) ;
+                        // the return is the oldest since it is not pid-specific.  At this point, in child processes (servants), this does not work
+                        // since child processes do not remove files
+                if (TRACETYPE.equals(managedType) || LOGTYPE.equals(managedType)) {             // Only for log and trace
+                        repositoryType = (TRACETYPE.equals(managedType)) ?                                      // Set repository type
+                                LogEventListener.REPOSITORYTYPETRACE : LogEventListener.REPOSITORYTYPELOG ;
+                        logEventNotifier.setOldestDate(getOldestDate(), repositoryType) ;
+                        if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                                debugLogger.logp(Level.FINE, thisClass, "setLogEventNotifier", "repTp: "+repositoryType+" oldDt: "+getOldestDate());
+                        }
+                }
+        }
+        @Override
+        public void notifyOfFileAction(String eventType) {
+                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                        debugLogger.logp(Level.FINE, thisClass, "notifyOfFileAction", "rTp: "+repositoryType+" EvtTp: "+eventType+
+                                " listener: "+logEventNotifier+" Dt: "+getOldestDate()+" Ok to notify: "+okToNotify);
+                }
+                if (logEventNotifier != null) {
+                        if (okToNotify) {
+                                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                                        debugLogger.logp(Level.FINE, thisClass, "notifyOfFileAction", "clearing queue") ;
+                                }
+                                synchronized (notificationQueue) {
+                                        if (notificationQueue.size() > 0) {
+                                                for (EventContents eventContents : notificationQueue) {
+                                                        logEventNotifier.recordFileAction(eventContents.eventType, eventContents.repositoryType, 
+                                                                eventContents.dateOldestLogRecord) ;
+                                                }
+                                                notificationQueue.clear() ;
+                                        }
+                                }
+                                logEventNotifier.recordFileAction(eventType, repositoryType, getOldestDate()) ;
+                        } else {
+                                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                                        debugLogger.logp(Level.FINE, thisClass, "notifyOfFileAction", "queueing event") ;
+                                }
+                                synchronized (notificationQueue) {
+                                        notificationQueue.add(new EventContents(eventType, repositoryType, getOldestDate())) ;
+                                }
+                        }
+                }
+        }
 
-	/**
-	 * get oldest file in cache that is not currently in use by a pid (ie: current log/trace/textLog for some process)
-	 * This method assumes that fileList is already sync'd
-	 * @return a FileDetails object representing the oldest inactive file in repository (prime candidate for removal)
-	 */
-	private FileDetails getOldestInactive() {
-		for (FileDetails curFd : fileList) {
-			if (curFd.pid == null)
-				return curFd ;
-			synchronized(activeFilesMap) {
-				FileDetails cur4Pid = activeFilesMap.get(curFd.pid) ;
-				if ( cur4Pid == null || cur4Pid != curFd) {
-					return curFd ;
-				}
-			}
-		}
-		return null ;
-	}
+        /**
+         * get oldest file in cache that is not currently in use by a pid (ie: current log/trace/textLog for some process)
+         * This method assumes that fileList is already sync'd
+         * @return a FileDetails object representing the oldest inactive file in repository (prime candidate for removal)
+         */
+        private FileDetails getOldestInactive() {
+                for (FileDetails curFd : fileList) {
+                        if (curFd.pid == null)
+                                return curFd ;
+                        synchronized(activeFilesMap) {
+                                FileDetails cur4Pid = activeFilesMap.get(curFd.pid) ;
+                                if ( cur4Pid == null || cur4Pid != curFd) {
+                                        return curFd ;
+                                }
+                        }
+                }
+                return null ;
+        }
 
-	private Date getOldestDate() {
-		synchronized (fileList) {		// Capture oldest file in link list
-			if (fileList.size() < 1)	// If nothing in the FileList (no files of this type created yet) ... return current time
-				return null ;
-			FileDetails oldFd = fileList.element() ;
-			return new Date(oldFd.timestamp) ;
-		}
-	}
+        private Date getOldestDate() {
+                synchronized (fileList) {               // Capture oldest file in link list
+                        if (fileList.size() < 1)        // If nothing in the FileList (no files of this type created yet) ... return current time
+                                return null ;
+                        FileDetails oldFd = fileList.element() ;
+                        return new Date(oldFd.timestamp) ;
+                }
+        }
 
-	/*
-	 * Thread maintaining <code>retentionTime</code> limitation.
-	 */
-	private class TimerThread extends Thread {
-		private final static long IDLE_SLEEP = 60 * 60 * 1000; // An hour
-		private long retentionTime;
-		private boolean keepRunning = true;
-		
-		TimerThread(long retentionTime) {
-			this.retentionTime = retentionTime;
-		}
+        /*
+         * Thread maintaining <code>retentionTime</code> limitation.
+         */
+        private class TimerThread extends Thread {
+                private final static long IDLE_SLEEP = 60 * 60 * 1000; // An hour
+                private long retentionTime;
+                private boolean keepRunning = true;
+                
+                TimerThread(long retentionTime) {
+                        this.retentionTime = retentionTime;
+                }
 
-		@Override
-		public void run() {
-			FileDetails target = null;
-			long sleepTime = IDLE_SLEEP;
-			while(keepRunning) {
-				synchronized(fileList) {
-					// Make sure the file list is initialized.
-					initFileList(false);
-					
-					// Delete only if there's more than one file in the repository
-					// and target is still the oldest file in the list.
-					if (fileList.size() > 1 && target == getOldestInactive()) {
-						purgeOldestFile();
-					}
-					
-					// Find the next target and the duration of sleep.
-					if (fileList.size() < 2) {
-						target = null;
-						sleepTime = IDLE_SLEEP;
-					} else {
-						target = getOldestInactive() ;
-						long current = System.currentTimeMillis();
-						sleepTime = target.timestamp + retentionTime - current;
-					}
-				}
-				
-				if (sleepTime > 0) {
-					try {
-						sleep(sleepTime);
-					} catch (InterruptedException ex) {
-						// We wake up too early. Need to check again if a file should be deleted.
-						target = null;
-					}
-				}
-			}
-		}
-		
-	}
+                @Override
+                public void run() {
+                        FileDetails target = null;
+                        long sleepTime = IDLE_SLEEP;
+                        while(keepRunning) {
+                                synchronized(fileList) {
+                                        // Make sure the file list is initialized.
+                                        initFileList(false);
+                                        
+                                        // Delete only if there's more than one file in the repository
+                                        // and target is still the oldest file in the list.
+                                        if (fileList.size() > 1 && target == getOldestInactive()) {
+                                                purgeOldestFile();
+                                        }
+                                        
+                                        // Find the next target and the duration of sleep.
+                                        if (fileList.size() < 2) {
+                                                target = null;
+                                                sleepTime = IDLE_SLEEP;
+                                        } else {
+                                                target = getOldestInactive() ;
+                                                long current = System.currentTimeMillis();
+                                                sleepTime = target.timestamp + retentionTime - current;
+                                        }
+                                }
+                                
+                                if (sleepTime > 0) {
+                                        try {
+                                                sleep(sleepTime);
+                                        } catch (InterruptedException ex) {
+                                                // We wake up too early. Need to check again if a file should be deleted.
+                                                target = null;
+                                        }
+                                }
+                        }
+                }
+                
+        }
 
 }

--- a/dev/com.ibm.ws.logging.hpel/src/com/ibm/ws/logging/hpel/impl/LogRepositorySubManagerImpl.java
+++ b/dev/com.ibm.ws.logging.hpel/src/com/ibm/ws/logging/hpel/impl/LogRepositorySubManagerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2011 IBM Corporation and others.
+ * Copyright (c) 2009, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.logging.Level;
-import java.util.logging.Logger; 	// MJC, this is for separate debugging
+import java.util.logging.Logger;        // MJC, this is for separate debugging
 
 import com.ibm.ws.logging.hpel.LogRepositoryManager;
 // import com.ibm.ws.logging.hpel.impl.LogRepositoryManagerImpl.FileDetails;
@@ -27,217 +27,217 @@ import com.ibm.ws.logging.hpel.LogRepositorySubProcessCommunication;
  */
 public class LogRepositorySubManagerImpl extends LogRepositoryBaseImpl implements LogRepositoryManager {
 
-	// These 4 constants should become part of the LogRepositoryManager interface.
-	private final static long MAX_LOG_FILE_SIZE = 5 * 1024 * 1024; // 5MB
-	
-	private String ivProcessLabel ;
-	private String ivSuperPid ;
-	private String ivPid ;
-				// 682033
-	private long ivMaxListSize = -1 ;
-	private ArrayList<File> createdFiles = new ArrayList<File>() ;
-				// 682033
-	
-	private static String thisClass = LogRepositorySubManagerImpl.class.getName() ;
-		// Unique logger as it does usepParentHandlers=false to avoid getting back into logging (and thus
-		// risking recursion and stack overflow). No RBundle as only used for trace and write to sep file
-		// To get this trace output, must include com.ibm.ws.logging.hpel.impl.*=fine in traceSpec
-	private static Logger debugLogger = LogRepositoryBaseImpl.getLogger() ;
-	
-	private File ivSubDirectory = null ;		// F017049-16879.3 Need to construct this based on pids, labels, and child processes
-			// Timestamps for file creations done before communication to the parent was established
-	private final HashSet<Long> unsentFileNotifications = new HashSet<Long>() ;
-	private boolean purgeFiles = false ;
+        // These 4 constants should become part of the LogRepositoryManager interface.
+        private final static long MAX_LOG_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+        
+        private String ivProcessLabel ;
+        private String ivSuperPid ;
+        private String ivPid ;
+                                // 682033
+        private long ivMaxListSize = -1 ;
+        private ArrayList<File> createdFiles = new ArrayList<File>() ;
+                                // 682033
+        
+        private static String thisClass = LogRepositorySubManagerImpl.class.getName() ;
+                // Unique logger as it does usepParentHandlers=false to avoid getting back into logging (and thus
+                // risking recursion and stack overflow). No RBundle as only used for trace and write to sep file
+                // To get this trace output, must include com.ibm.ws.logging.hpel.impl.*=fine in traceSpec
+        private static Logger debugLogger = LogRepositoryBaseImpl.getLogger() ;
+        
+        private File ivSubDirectory = null ;            // F017049-16879.3 Need to construct this based on pids, labels, and child processes
+                        // Timestamps for file creations done before communication to the parent was established
+        private final HashSet<Long> unsentFileNotifications = new HashSet<Long>() ;
+        private boolean purgeFiles = false ;
 
-	private LogRepositorySubProcessCommunication ivSubProcessCommAgent = null ;
+        private LogRepositorySubProcessCommunication ivSubProcessCommAgent = null ;
 
-	/**
-	 * construct the manager of logging for this subProcess or logical child process
-	 * @param directory Directory which is the base of all logging for the parent and child processes
-	 * @param pid process ID for this subProcess
-	 * @param label label to be used in naming files associated with this subProcess
-	 * @param superPid process ID of the logical parent process 
-	 */
-	 // TODO: Consider a getLocation so that LogRepositoryComponent can verify location chgd before constructing new manager
-	public LogRepositorySubManagerImpl(File directory, String pid, String label, String superPid) {
-		super(directory);
-		if (!AccessHelper.canMakeDirectories(directory)) {
-			throw new IllegalArgumentException("Specified location can't be used as a log repository: " + directory);
-		}
-		ivPid = pid ;
-		ivProcessLabel = label ;
-		ivSuperPid = superPid ;
-	}
+        /**
+         * construct the manager of logging for this subProcess or logical child process
+         * @param directory Directory which is the base of all logging for the parent and child processes
+         * @param pid process ID for this subProcess
+         * @param label label to be used in naming files associated with this subProcess
+         * @param superPid process ID of the logical parent process 
+         */
+         // TODO: Consider a getLocation so that LogRepositoryComponent can verify location chgd before constructing new manager
+        public LogRepositorySubManagerImpl(File directory, String pid, String label, String superPid) {
+                super(directory);
+                if (!AccessHelper.canMakeDirectories(directory)) {
+                        throw new IllegalArgumentException("Specified location can't be used as a log repository: " + directory);
+                }
+                ivPid = pid ;
+                ivProcessLabel = label ;
+                ivSuperPid = superPid ;
+        }
 
-	/**
-	 * set the interface that will be used to communicate to the parent process when files are created or when there needs to be
-	 * a request to purge additional files (F017049-22453)
-	 * @param subProcessCommAgent implementer of this interface will notify parent processes of key activities
-	 */
-	public synchronized void setSubProcessCommunicationAgent(LogRepositorySubProcessCommunication subProcessCommAgent) {
-		if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-			debugLogger.logp(Level.FINE, thisClass, "setSubProcessCommAg", "type: "+managedType+
-				" unSentSz: "+unsentFileNotifications.size()+" pid: "+ivPid+" parent pid: "+ivSuperPid);
-		}
-		ivSubProcessCommAgent = subProcessCommAgent ;
-	}
-	
-	// Assume there's no space constrains by default.
-	private long maxLogFileSize = MAX_LOG_FILE_SIZE;
-	
-	/**
-	 * Configures constrain parameters of the repository.
-	 * 
-	 * @param maxRepositorySize maximum in bytes of the total sum of repository file sizes the manager should maintain.
-	 * 			This limit is ignored if <code>maxRepositorySize</code> is less than or equal to zero.
-	 */
-	public synchronized void configure(long maxRepositorySize) {
-		this.maxLogFileSize = LogRepositoryManagerImpl.calculateFileSplit(maxRepositorySize);
-		ivMaxListSize = (maxRepositorySize < 0) ? -1 : maxRepositorySize / maxLogFileSize;
-		if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-			debugLogger.logp(Level.FINE, thisClass, "configure", "inMax: "+maxRepositorySize+" outMax: "+this.maxLogFileSize+" Tp: "+managedType+
-				" MaxFilesInList: "+ivMaxListSize);
-		}
-	}
-	
-	/* (non-Javadoc)
-	 * @see com.ibm.ws.logging.hpel.LogRepositoryManager#checkForNewFile(long, long)
-	 */
-	public synchronized File checkForNewFile(long total, long timestamp) {
-		// Check if file rotation is necessary.
-		if (total <= maxLogFileSize) {
-			return null;
-		} 
-		
-		return startNewFile(timestamp);
-	}
+        /**
+         * set the interface that will be used to communicate to the parent process when files are created or when there needs to be
+         * a request to purge additional files (F017049-22453)
+         * @param subProcessCommAgent implementer of this interface will notify parent processes of key activities
+         */
+        public synchronized void setSubProcessCommunicationAgent(LogRepositorySubProcessCommunication subProcessCommAgent) {
+                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                        debugLogger.logp(Level.FINE, thisClass, "setSubProcessCommAg", "type: "+managedType+
+                                " unSentSz: "+unsentFileNotifications.size()+" pid: "+ivPid+" parent pid: "+ivSuperPid);
+                }
+                ivSubProcessCommAgent = subProcessCommAgent ;
+        }
+        
+        // Assume there's no space constrains by default.
+        private long maxLogFileSize = MAX_LOG_FILE_SIZE;
+        
+        /**
+         * Configures constrain parameters of the repository.
+         * 
+         * @param maxRepositorySize maximum in bytes of the total sum of repository file sizes the manager should maintain.
+         *                      This limit is ignored if <code>maxRepositorySize</code> is less than or equal to zero.
+         */
+        public synchronized void configure(long maxRepositorySize) {
+                this.maxLogFileSize = LogRepositoryManagerImpl.calculateFileSplit(maxRepositorySize);
+                ivMaxListSize = (maxRepositorySize < 0) ? -1 : maxRepositorySize / maxLogFileSize;
+                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                        debugLogger.logp(Level.FINE, thisClass, "configure", "inMax: "+maxRepositorySize+" outMax: "+this.maxLogFileSize+" Tp: "+managedType+
+                                " MaxFilesInList: "+ivMaxListSize);
+                }
+        }
+        
+        /* (non-Javadoc)
+         * @see com.ibm.ws.logging.hpel.LogRepositoryManager#checkForNewFile(long, long)
+         */
+        public synchronized File checkForNewFile(long total, long timestamp) {
+                // Check if file rotation is necessary.
+                if (total <= maxLogFileSize) {
+                        return null;
+                } 
+                
+                return startNewFile(timestamp);
+        }
 
-	/**
-	 * close down this subManager as servant is going down.  If ORB agent is up, send any unsent file creation notifications
-	 * and then notify the controller that this servant is no longer active
-	 */
-	public void inactivateSubProcess() {
-		if (ivSubProcessCommAgent != null) {
-			sendNotifications() ;
-			ivSubProcessCommAgent.inactivateSubProcess(ivPid) ;
-		}
-	}
-	
-	/* (non-Javadoc)
-	 * @see com.ibm.ws.logging.hpel.LogRepositoryManager#purgeOldFiles()
-	 * This now does not do the purge, but notes the need.  This may be called with unwanted locks in place, so it will
-	 * queue for the purging to be done at a later tim
-	 */
-	public synchronized boolean purgeOldFiles() {	// 671059 for servants, this will return null
-		if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-			debugLogger.logp(Level.FINE, thisClass, "purgeOldFiles", "Comm: "+ivSubProcessCommAgent+" Tp: "+managedType);
-		}
-		purgeFiles = true ;
-		return false ;
-	}
+        /**
+         * close down this subManager as servant is going down.  If ORB agent is up, send any unsent file creation notifications
+         * and then notify the controller that this servant is no longer active
+         */
+        public void inactivateSubProcess() {
+                if (ivSubProcessCommAgent != null) {
+                        sendNotifications() ;
+                        ivSubProcessCommAgent.inactivateSubProcess(ivPid) ;
+                }
+        }
+        
+        /* (non-Javadoc)
+         * @see com.ibm.ws.logging.hpel.LogRepositoryManager#purgeOldFiles()
+         * This now does not do the purge, but notes the need.  This may be called with unwanted locks in place, so it will
+         * queue for the purging to be done at a later tim
+         */
+        public synchronized boolean purgeOldFiles() {   // 671059 for servants, this will return null
+                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                        debugLogger.logp(Level.FINE, thisClass, "purgeOldFiles", "Comm: "+ivSubProcessCommAgent+" Tp: "+managedType);
+                }
+                purgeFiles = true ;
+                return false ;
+        }
 
-	public boolean purgeOldFilesAsync() {
-		if (!purgeFiles)  return false ;
-		boolean wasAnyFileRemoved = false;
-		if (ivSubProcessCommAgent == null) 
-			return false ;
-		else {
-			wasAnyFileRemoved = ivSubProcessCommAgent.removeFiles(managedType) ;
-			purgeFiles = false ;
-		}
-		return wasAnyFileRemoved;
-	}
+        public boolean purgeOldFilesAsync() {
+                if (!purgeFiles)  return false ;
+                boolean wasAnyFileRemoved = false;
+                if (ivSubProcessCommAgent == null) 
+                        return false ;
+                else {
+                        wasAnyFileRemoved = ivSubProcessCommAgent.removeFiles(managedType) ;
+                        purgeFiles = false ;
+                }
+                return wasAnyFileRemoved;
+        }
 
-	private final static long FAILED_WAIT_TIME = 1000; // sleep for 1sec.
-	private final static long FAILED_MAX_COUNT = 5; // fall asleep 5 times.
-	
-	/* (non-Javadoc)
-	 * @see com.ibm.ws.logging.hpel.LogRepositoryManager#startNewFile(long)
-	 * Modification to this method to queue requests so that the ORB calls are made when the thread is not holding crucial locks
-	 */
-	public synchronized File startNewFile(long timestamp) {
-		if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-			debugLogger.logp(Level.FINE, thisClass, "startNewFile", "unsentEmpty: "+unsentFileNotifications.isEmpty()+
-				" tstamp: "+timestamp+" Tp: "+managedType+" subProcCommAgent: "+ivSubProcessCommAgent);
-		}
-		synchronized(unsentFileNotifications) {		// Do not make orb call while holding the LogRecordHandler
-			unsentFileNotifications.add(timestamp) ;		// 671059 queue up for later notification
-		}
-		File file = null ;
-		if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-			debugLogger.logp(Level.FINE, thisClass, "startNewFile", "Add tstamp: "+timestamp+
-				" is unsent entry: "+unsentFileNotifications.size()+" FileNm: "+"xx");
-		}
-		int count = 0;
-		while (ivSubDirectory == null) {
-			File parentDir = makeLogDirectory(timestamp, ivSuperPid);
-			if (parentDir == null) {
-				if (++count > FAILED_MAX_COUNT) {
-					throw new RuntimeException("Failed to create instance log repository. See SystemOut.log for details.");
-				}
-				try {
-					Thread.sleep(FAILED_WAIT_TIME);
-				} catch (InterruptedException ex) {
-					// Ignore it, assume that we had enough sleep.
-				}
-			} else {
-				ivSubDirectory = new File(parentDir, getLogDirectoryName(-1, ivPid, ivProcessLabel));
-			}
-		}
-		
-		file = getLogFile(ivSubDirectory, timestamp);
-			
-		File dir = file.getParentFile();
-		if (!AccessHelper.isDirectory(dir)) {
-			AccessHelper.makeDirectories(dir);
-		}
-		
-		// 682033 look at servant subDirectory and
-		if (ivMaxListSize >= 0) {
-			createdFiles.add(file);
-			if (createdFiles.size() > ivMaxListSize) {
-				AccessHelper.deleteFile(createdFiles.remove(0));
-			}
-		}
-		// End of 682033 logic
-		return file;
-	}
+        private final static long FAILED_WAIT_TIME = 1000; // sleep for 1sec.
+        private final static long FAILED_MAX_COUNT = 5; // fall asleep 5 times.
+        
+        /* (non-Javadoc)
+         * @see com.ibm.ws.logging.hpel.LogRepositoryManager#startNewFile(long)
+         * Modification to this method to queue requests so that the ORB calls are made when the thread is not holding crucial locks
+         */
+        public synchronized File startNewFile(long timestamp) {
+                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                        debugLogger.logp(Level.FINE, thisClass, "startNewFile", "unsentEmpty: "+unsentFileNotifications.isEmpty()+
+                                " tstamp: "+timestamp+" Tp: "+managedType+" subProcCommAgent: "+ivSubProcessCommAgent);
+                }
+                synchronized(unsentFileNotifications) {         // Do not make orb call while holding the LogRecordHandler
+                        unsentFileNotifications.add(timestamp) ;                // 671059 queue up for later notification
+                }
+                File file = null ;
+                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                        debugLogger.logp(Level.FINE, thisClass, "startNewFile", "Add tstamp: "+timestamp+
+                                " is unsent entry: "+unsentFileNotifications.size()+" FileNm: "+"xx");
+                }
+                int count = 0;
+                while (ivSubDirectory == null) {
+                        File parentDir = makeLogDirectory(timestamp, ivSuperPid);
+                        if (parentDir == null) {
+                                if (++count > FAILED_MAX_COUNT) {
+                                        throw new RuntimeException("Failed to create instance log repository. See SystemOut.log for details.");
+                                }
+                                try {
+                                        Thread.sleep(FAILED_WAIT_TIME);
+                                } catch (InterruptedException ex) {
+                                        // Ignore it, assume that we had enough sleep.
+                                }
+                        } else {
+                                ivSubDirectory = new File(parentDir, getLogDirectoryName(-1, ivPid, ivProcessLabel));
+                        }
+                }
+                
+                file = getLogFile(ivSubDirectory, timestamp);
+                        
+                File dir = file.getParentFile();
+                if (!AccessHelper.isDirectory(dir)) {
+                        AccessHelper.makeDirectories(dir);
+                }
+                
+                // 682033 look at servant subDirectory and
+                if (ivMaxListSize >= 0) {
+                        createdFiles.add(file);
+                        if (createdFiles.size() > ivMaxListSize) {
+                                AccessHelper.deleteFile(createdFiles.remove(0));
+                        }
+                }
+                // End of 682033 logic
+                return file;
+        }
 
-	/**
-	 * sent notifications of file creations to the controller.  This is here (the actual sending of the notifications) so
-	 * that the requests can be queued and the actual orb calls can be made at a time when the thread is not holding
-	 * critical locks
-	 */
-	public boolean sendNotifications() {
-		long [] fileCre8TimeStamps ;
-		synchronized(unsentFileNotifications) {
-			int unsentSize = unsentFileNotifications.size() ;
-			if (ivSubProcessCommAgent == null || unsentSize == 0) return false;		// Prepare to copy out notification tstamps
-			fileCre8TimeStamps = new long[unsentSize] ;
-			Iterator<Long> unsentIter = unsentFileNotifications.iterator() ;
-			int curIdx = 0 ;
-			while (unsentIter.hasNext()) {
-				fileCre8TimeStamps[curIdx++] = unsentIter.next() ;
-			}
-			unsentFileNotifications.clear() ;
-		}
-		synchronized (ivSubProcessCommAgent) {
-			for (long thisTstamp : fileCre8TimeStamps) {
-				String tempStr = ivSubProcessCommAgent.notifyOfFileCreation(managedType, thisTstamp, ivPid, ivProcessLabel) ;
-				if (debugLogger.isLoggable(Level.FINE) && LogRepositoryBaseImpl.isDebugEnabled()) {
-					debugLogger.logp(Level.FINE, thisClass, "setSubProcessCommAg", "Notifying of past timestamp: "+thisTstamp+
-						" got file: "+tempStr);
-				}
-			}
-		}
-		return true ;
-	}
-	
-	/* (non-Javadoc)
-	 * @see com.ibm.ws.logging.hpel.LogRepositoryManager#stop()
-	 */
-	public synchronized void stop() {
-		inactivateSubProcess() ;
-	}
-	
+        /**
+         * sent notifications of file creations to the controller.  This is here (the actual sending of the notifications) so
+         * that the requests can be queued and the actual orb calls can be made at a time when the thread is not holding
+         * critical locks
+         */
+        public boolean sendNotifications() {
+                long [] fileCre8TimeStamps ;
+                synchronized(unsentFileNotifications) {
+                        int unsentSize = unsentFileNotifications.size() ;
+                        if (ivSubProcessCommAgent == null || unsentSize == 0) return false;             // Prepare to copy out notification tstamps
+                        fileCre8TimeStamps = new long[unsentSize] ;
+                        Iterator<Long> unsentIter = unsentFileNotifications.iterator() ;
+                        int curIdx = 0 ;
+                        while (unsentIter.hasNext()) {
+                                fileCre8TimeStamps[curIdx++] = unsentIter.next() ;
+                        }
+                        unsentFileNotifications.clear() ;
+                }
+                synchronized (ivSubProcessCommAgent) {
+                        for (long thisTstamp : fileCre8TimeStamps) {
+                                String tempStr = ivSubProcessCommAgent.notifyOfFileCreation(managedType, thisTstamp, ivPid, ivProcessLabel) ;
+                                if (LogRepositoryBaseImpl.isDebugEnabled()) {
+                                        debugLogger.logp(Level.FINE, thisClass, "setSubProcessCommAg", "Notifying of past timestamp: "+thisTstamp+
+                                                " got file: "+tempStr);
+                                }
+                        }
+                }
+                return true ;
+        }
+        
+        /* (non-Javadoc)
+         * @see com.ibm.ws.logging.hpel.LogRepositoryManager#stop()
+         */
+        public synchronized void stop() {
+                inactivateSubProcess() ;
+        }
+        
 }


### PR DESCRIPTION
fixes #18182

- Removed the `debugLogger.isLoggable(Level.FINE)` extra check, to enable HPEL debug trace to be logged correctly.
