### PR TITLE
Fix missing tested.features in Security WIM FAT

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.file_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.wim.adapter.file_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,11 @@ src: \
 	fat/src
 
 fat.project: true
+
+# Define additional tested features that are NOT present in any XML files in this bucket.
+# In this case, servlet-3.1 is added when running on open-liberty image.
+tested.features:\
+	servlet-3.1
 
 -buildpath: \
 	com.ibm.ws.org.apache.directory.server;version=latest,\


### PR DESCRIPTION
Fix an open-liberty image conflict with the simplicity feature dependency
checker fix; account for running on open-liberty only images
where servlet-3.0 does not exist, so servlet-3.1 is used instead.

Note: servlet-3.1 either directly or indirectly via auto-features
enables distributedMap-1.0 and jndi-1.0, so those do not need to
be included in the test.features list.
