### PR TITLE
Ensure consistent handling of Accept-Language header

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/client/src/com/ibm/ws/jaxrs/fat/client/echoapp/EchoResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/client/src/com/ibm/ws/jaxrs/fat/client/echoapp/EchoResource.java
@@ -11,6 +11,7 @@
 package com.ibm.ws.jaxrs.fat.client.echoapp;
 
 import java.util.List;
+import java.util.logging.Logger;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -29,6 +30,7 @@ import com.ibm.ws.jaxrs.fat.client.jaxb.Echo;
 
 @Path("/echoaccept")
 public class EchoResource {
+    private static Logger LOG = Logger.getLogger(EchoResource.class.getName());
 
     @Context
     HttpHeaders requestHeaders;
@@ -39,6 +41,7 @@ public class EchoResource {
         List<String> acceptHeader = requestHeaders.getRequestHeader(HttpHeaders.ACCEPT);
 
         if (acceptHeader != null) {
+            LOG.info(() -> "Accept: " + acceptHeader);
             for (String s : acceptHeader) {
                 sb.append(s);
             }
@@ -46,6 +49,7 @@ public class EchoResource {
 
         if (acceptHeader == null || acceptHeader.isEmpty()
             || MediaType.WILDCARD_TYPE.equals(requestHeaders.getAcceptableMediaTypes().get(0))) {
+            LOG.info(() -> "Nothing or */* from Accept header");
             return Response.ok(sb.toString()).type(MediaType.TEXT_PLAIN_TYPE).build();
         }
 
@@ -56,14 +60,17 @@ public class EchoResource {
                                                     MediaType.APPLICATION_JSON_TYPE).add().build());
         if (variant != null) {
             if (MediaType.APPLICATION_JSON_TYPE.isCompatible(variant.getMediaType())) {
+                LOG.info(() -> "Variant is compatible with application/json");
                 JSONObject jsonObject = new JSONObject();
                 jsonObject.put("value", sb.toString());
                 return Response.ok(jsonObject).type(MediaType.APPLICATION_JSON).build();
             } else if (MediaType.TEXT_XML_TYPE.isCompatible(variant.getMediaType())) {
+                LOG.info(() -> "Variant is compatible with text/xml");
                 Echo e = new Echo();
                 e.setValue(sb.toString());
                 return Response.ok(e).type(MediaType.TEXT_XML).build();
             }
+            LOG.info(() -> "Variant is not null, but not compatible with application/json nor text/xml");
         }
 
         return Response.ok(sb.toString()).type(MediaType.TEXT_PLAIN_TYPE).build();

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/.classpath
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="test-applications/acceptLanguage/src"/>
 	<classpathentry kind="src" path="test-applications/cdiApp/src"/>
 	<classpathentry kind="src" path="test-applications/classSubResApp/src"/>
 	<classpathentry kind="src" path="test-applications/formApp/src"/>

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/bnd.bnd
@@ -13,6 +13,7 @@ bVersion=1.0
 
 src: \
   fat/src,\
+  test-applications/acceptLanguage/src,\
   test-applications/cdiApp/src,\
   test-applications/classSubResApp/src,\
   test-applications/formApp/src,\

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/AcceptLanguageTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/AcceptLanguageTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs21.fat.extended;
+
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import jaxrs21.fat.acceptlanguage.AcceptLanguageTestServlet;
+
+@RunWith(FATRunner.class)
+public class AcceptLanguageTest extends FATServletClient {
+
+    private static final String appName = "acceptlanguage";
+
+    @Server("jaxrs21.fat.acceptlanguage")
+    @TestServlet(servlet = AcceptLanguageTestServlet.class, contextRoot = appName)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        WebArchive app = ShrinkHelper.buildDefaultApp(appName, "jaxrs21.fat.acceptlanguage");
+        ShrinkHelper.exportDropinAppToServer(server, app);
+        server.addInstalledAppForValidation(appName);
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        server.stopServer("CWWKW1002W");
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                
+                AcceptLanguageTest.class,
                 CDITest.class,
                 ClassSubResTest.class,
                 JsonbCharsetTest.class,

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.acceptlanguage/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.acceptlanguage/bootstrap.properties
@@ -1,0 +1,5 @@
+#com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs20.*=all:com.ibm.websphere.jaxrs20.*=all:org.apache.cxf.*=all:LogService=all
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+ds.loglevel=debug
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.acceptlanguage/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.acceptlanguage/server.xml
@@ -1,0 +1,10 @@
+<server>
+	<featureManager>
+		<feature>componenttest-1.0</feature>
+		<feature>jaxrs-2.1</feature>
+	</featureManager>
+
+	<include location="../fatTestPorts.xml"/>
+
+    <javaPermission className="java.util.PropertyPermission" name="bvt.prop.HTTP_default" actions="read"/>
+</server>

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/acceptLanguage/src/jaxrs21/fat/acceptlanguage/AcceptLanguageTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/acceptLanguage/src/jaxrs21/fat/acceptlanguage/AcceptLanguageTestServlet.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jaxrs21.fat.acceptlanguage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/CDITestServlet")
+public class AcceptLanguageTestServlet extends FATServlet {
+    private final static String FROM_HTTP_HEADERS = "fromHttpHeaders";
+    private final static String FROM_REQUEST_FILTER = "fromContainerRequestFilter";
+    private final static int HTTP_PORT = Integer.getInteger("bvt.prop.HTTP_default", 8010);
+
+    
+    @Test
+    public void testUnorderedButQualifiedList_httpHeaders() throws Exception {
+        assertThatURI(FROM_HTTP_HEADERS)
+            .withAcceptLanguageHeader("en-US;q=0.5, de;q=0.4, en;q=0.6, fr-CA;q=0.9, en-CA;q=0.7")
+            .returns("fr-CA,en-CA,en,en-US,de");
+    }
+    @Test
+    public void testUnorderedButQualifiedList_filterContext() throws Exception {
+        assertThatURI(FROM_HTTP_HEADERS)
+            .withAcceptLanguageHeader("en-US;q=0.5, de;q=0.4, en;q=0.6, fr-CA;q=0.9, en-CA;q=0.7")
+            .returns("fr-CA,en-CA,en,en-US,de");
+    }
+
+    @Test
+    public void testEmptyList_httpHeaders() throws Exception {
+        assertThatURI(FROM_HTTP_HEADERS)
+            .withAcceptLanguageHeader("")
+            .returns("und"); 
+        // per spec, should return Locale with * language (undefined) if unable to find valid language from header
+    }
+    @Test
+    public void testEmptyList_filterContext() throws Exception {
+        assertThatURI(FROM_REQUEST_FILTER)
+            .withAcceptLanguageHeader("")
+            .returns("und");
+        // per spec, should return Locale with * language (undefined) if unable to find valid language from header
+    }
+
+    @Test
+    public void testListWithEmptyEntry_httpHeaders() throws Exception {
+        assertThatURI(FROM_HTTP_HEADERS)
+            .withAcceptLanguageHeader("en;q=0.9, , es;q=0.7, fr;q=0.6")
+            .returns("und,en,es,fr");
+    }
+    @Test
+    public void testListWithEmptyEntry_filterContext() throws Exception {
+        assertThatURI(FROM_REQUEST_FILTER)
+            .withAcceptLanguageHeader("zh;q=0.7, jp;q=0.8, , ro;q=0.9, , en;q=0.1")
+            .returns("und,und,ro,jp,zh,en");
+    }
+
+    @Test
+    public void testListWithClearlyMadeUpEntries_httpHeaders() throws Exception {
+        assertThatURI(FROM_HTTP_HEADERS)
+            .withAcceptLanguageHeader("blah, boo, js, ewok")
+            .returns("blah,boo,js,ewok");
+    }
+    @Test
+    public void testListWithClearlyMadeUpEntries_filterContext() throws Exception {
+        assertThatURI(FROM_REQUEST_FILTER)
+            .withAcceptLanguageHeader("blah, boo, js, ewok")
+            .returns("blah,boo,js,ewok");
+    }
+
+    private static Tester assertThatURI(String path) throws Exception {
+        return new Tester(path);
+    }
+    
+    private static class Tester {
+        private String fullUri;
+        private String returnedValue;
+        
+        Tester(String path) {
+            fullUri = "http://localhost:" + HTTP_PORT + "/acceptlanguage/app/resource/" + path;
+        }
+        Tester withAcceptLanguageHeader(String headerValue) {
+            Client c = ClientBuilder.newClient();
+            try {
+                returnedValue = c.target(fullUri).request()
+                                 .header(HttpHeaders.ACCEPT_LANGUAGE, headerValue)
+                                 .get(String.class);
+            } catch (Throwable t) {
+                t.printStackTrace();
+                returnedValue = t.toString();
+            } finally {
+                c.close();
+            }
+            return this;
+        }
+        void returns(String expected) {
+            assertEquals(expected, returnedValue);
+        }
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/acceptLanguage/src/jaxrs21/fat/acceptlanguage/App.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/acceptLanguage/src/jaxrs21/fat/acceptlanguage/App.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jaxrs21.fat.acceptlanguage;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("app")
+public class App extends Application {
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/acceptLanguage/src/jaxrs21/fat/acceptlanguage/MyDynamicFeature.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/acceptLanguage/src/jaxrs21/fat/acceptlanguage/MyDynamicFeature.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jaxrs21.fat.acceptlanguage;
+
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class MyDynamicFeature implements DynamicFeature {
+
+    @Override
+    public void configure(ResourceInfo resInfo, FeatureContext context) {
+        if ("getAcceptableLanguagesFromRequestFilter".equals(resInfo.getResourceMethod().getName())) {
+            context.register(MyFilter.class);
+        }
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/acceptLanguage/src/jaxrs21/fat/acceptlanguage/MyFilter.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/acceptLanguage/src/jaxrs21/fat/acceptlanguage/MyFilter.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jaxrs21.fat.acceptlanguage;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Response;
+
+public class MyFilter implements ContainerRequestFilter {
+
+    @Override
+    public void filter(ContainerRequestContext ctx) throws IOException {
+        List<Locale> locales = ctx.getAcceptableLanguages();
+        String localesStr = locales.stream().map(Locale::toLanguageTag).collect(Collectors.joining(","));
+        ctx.abortWith(Response.ok(localesStr).build());
+    }
+
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/acceptLanguage/src/jaxrs21/fat/acceptlanguage/Resource.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/acceptLanguage/src/jaxrs21/fat/acceptlanguage/Resource.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jaxrs21.fat.acceptlanguage;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("resource")
+@Produces(MediaType.TEXT_PLAIN)
+public class Resource {
+
+    @Context
+    HttpHeaders headers;
+
+    @GET
+    @Path("fromHttpHeaders")
+    public Response getAcceptableLanguagesFromHttpHeaders() {
+        List<Locale> locales = headers.getAcceptableLanguages();
+        String localesStr = locales.stream().map(Locale::toLanguageTag).collect(Collectors.joining(","));
+        return Response.ok(localesStr).build();
+    }
+
+    @GET
+    @Path("fromContainerRequestFilter")
+    // this method should never be invoked because the filter should abort with the filter output before it gets here
+    public Response getAcceptableLanguagesFromRequestFilter() {
+        return Response.ok("Filter not invoked.").build();
+    }
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/impl/HttpHeadersImpl.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/impl/HttpHeadersImpl.java
@@ -1,0 +1,341 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.jaxrs.impl;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.apache.cxf.common.util.StringUtils;
+import org.apache.cxf.helpers.CastUtils;
+import org.apache.cxf.jaxrs.utils.ExceptionUtils;
+import org.apache.cxf.jaxrs.utils.HttpUtils;
+import org.apache.cxf.jaxrs.utils.JAXRSUtils;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageUtils;
+
+public class HttpHeadersImpl implements HttpHeaders {
+
+    static final String HEADER_SPLIT_PROPERTY =
+        "org.apache.cxf.http.header.split";
+    static final String COOKIE_SEPARATOR_PROPERTY =
+        "org.apache.cxf.http.cookie.separator";
+    private static final String COOKIE_SEPARATOR_CRLF = "crlf";
+    private static final String COOKIE_SEPARATOR_CRLF_EXPRESSION = "\r\n";
+    private static final Pattern COOKIE_SEPARATOR_CRLF_PATTERN =
+            Pattern.compile(COOKIE_SEPARATOR_CRLF_EXPRESSION);
+    private static final String DEFAULT_SEPARATOR = ",";
+    private static final String DEFAULT_COOKIE_SEPARATOR = ";";
+    private static final String DOLLAR_CHAR = "$";
+    private static final String COOKIE_VERSION_PARAM = DOLLAR_CHAR + "Version";
+    private static final String COOKIE_PATH_PARAM = DOLLAR_CHAR + "Path";
+    private static final String COOKIE_DOMAIN_PARAM = DOLLAR_CHAR + "Domain";
+
+    private static final String COMPLEX_HEADER_EXPRESSION =
+        "(([\\w]+=\"[^\"]*\")|([\\w]+=[\\w]+)|([\\w]+))(;(([\\w]+=\"[^\"]*\")|([\\w]+=[\\w]+)|([\\w]+)))?";
+    private static final Pattern COMPLEX_HEADER_PATTERN =
+        Pattern.compile(COMPLEX_HEADER_EXPRESSION);
+    private static final String QUOTE = "\"";
+    private static final Set<String> HEADERS_WITH_POSSIBLE_QUOTES;
+    static {
+        HEADERS_WITH_POSSIBLE_QUOTES = new HashSet<>();
+        HEADERS_WITH_POSSIBLE_QUOTES.add(HttpHeaders.CONTENT_TYPE);
+        HEADERS_WITH_POSSIBLE_QUOTES.add(HttpHeaders.CACHE_CONTROL);
+        HEADERS_WITH_POSSIBLE_QUOTES.add(HttpHeaders.ETAG);
+        HEADERS_WITH_POSSIBLE_QUOTES.add(HttpHeaders.IF_MATCH);
+        HEADERS_WITH_POSSIBLE_QUOTES.add(HttpHeaders.IF_NONE_MATCH);
+        HEADERS_WITH_POSSIBLE_QUOTES.add(HttpHeaders.COOKIE);
+        HEADERS_WITH_POSSIBLE_QUOTES.add(HttpHeaders.SET_COOKIE);
+    }
+
+
+    private Message message;
+    private Map<String, List<String>> headers;
+    public HttpHeadersImpl(Message message) {
+        this.message = message;
+        this.headers = CastUtils.cast((Map<?, ?>)message.get(Message.PROTOCOL_HEADERS));
+        if (headers == null) {
+            headers = Collections.emptyMap();
+        }
+    }
+
+    public List<MediaType> getAcceptableMediaTypes() {
+        List<String> lValues = headers.get(HttpHeaders.ACCEPT);
+        if (lValues == null || lValues.isEmpty() || lValues.get(0) == null) {
+            return Collections.singletonList(MediaType.WILDCARD_TYPE);
+        }
+        List<MediaType> mediaTypes = new LinkedList<>();
+        for (String value : lValues) {
+            mediaTypes.addAll(JAXRSUtils.parseMediaTypes(value));
+        }
+        sortMediaTypesUsingQualityFactor(mediaTypes);
+        return mediaTypes;
+    }
+
+    public Map<String, Cookie> getCookies() {
+        List<String> values = headers.get(HttpHeaders.COOKIE);
+        if (values == null || values.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, Cookie> cl = new HashMap<>();
+        for (String value : values) {
+            if (value == null) {
+                continue;
+            }
+
+
+            List<String> cs = getHeaderValues(HttpHeaders.COOKIE, value,
+                                              getCookieSeparator(value));
+            for (String c : cs) {
+                Cookie cookie = Cookie.valueOf(c);
+                cl.put(cookie.getName(), cookie);
+            }
+        }
+        return cl;
+    }
+
+    private String getCookieSeparator(String value) {
+        String separator = getCookieSeparatorFromProperty();
+        if (separator != null) {
+            return separator;
+        }
+        if (value.contains(DOLLAR_CHAR)
+            && (value.contains(COOKIE_VERSION_PARAM)
+                || value.contains(COOKIE_PATH_PARAM)
+                || value.contains(COOKIE_DOMAIN_PARAM))) {
+            return DEFAULT_SEPARATOR;
+        }
+
+        return DEFAULT_COOKIE_SEPARATOR;
+    }
+    private String getCookieSeparatorFromProperty() {
+        Object cookiePropValue = message.getContextualProperty(COOKIE_SEPARATOR_PROPERTY);
+        if (cookiePropValue != null) {
+            String separator = cookiePropValue.toString().trim();
+            if (COOKIE_SEPARATOR_CRLF.equals(separator)) {
+                return COOKIE_SEPARATOR_CRLF_EXPRESSION;
+            }
+            if (separator.length() != 1) {
+                throw ExceptionUtils.toInternalServerErrorException(null, null);
+            }
+            return separator;
+        }
+        return null;
+    }
+
+    public Locale getLanguage() {
+        List<String> values = getListValues(HttpHeaders.CONTENT_LANGUAGE);
+        return values.isEmpty() ? null : HttpUtils.getLocale(values.get(0).trim());
+    }
+
+    public MediaType getMediaType() {
+        List<String> values = getListValues(HttpHeaders.CONTENT_TYPE);
+        return values.isEmpty() ? null : JAXRSUtils.toMediaType(values.get(0));
+    }
+
+    public MultivaluedMap<String, String> getRequestHeaders() {
+        boolean splitIndividualValue
+            = MessageUtils.getContextualBoolean(message, HEADER_SPLIT_PROPERTY, false);
+        if (splitIndividualValue) {
+            Map<String, List<String>> newHeaders =
+                new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+            for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+                newHeaders.put(entry.getKey(), getRequestHeader(entry.getKey()));
+            }
+            return new MetadataMap<String, String>(Collections.unmodifiableMap(newHeaders), false);
+        }
+        return new MetadataMap<String, String>(Collections.unmodifiableMap(headers), false);
+    }
+
+    public List<Locale> getAcceptableLanguages() {
+        List<String> ls = getListValues(HttpHeaders.ACCEPT_LANGUAGE);
+        if (ls.isEmpty() // original check
+            || (ls.size() == 1 && (ls.get(0) == null || "".equals(ls.get(0).trim())))) { // Liberty change
+            return Collections.singletonList(new Locale("*"));
+        }
+        
+        List<Locale> newLs = new ArrayList<>();
+        Map<Locale, Float> prefs = new HashMap<>();
+        for (String l : ls) {
+            String[] pair = l.split(";");
+
+            Locale locale = HttpUtils.getLocale(pair[0].trim());
+
+            newLs.add(locale);
+            if (pair.length > 1) {
+                String[] pair2 = pair[1].split("=");
+                if (pair2.length > 1) {
+                    prefs.put(locale, JAXRSUtils.getMediaTypeQualityFactor(pair2[1].trim()));
+                } else {
+                    prefs.put(locale, 1F);
+                }
+            } else {
+                prefs.put(locale, 1F);
+            }
+        }
+        if (newLs.size() <= 1) {
+            return newLs;
+        }
+
+        Collections.sort(newLs, new AcceptLanguageComparator(prefs));
+        return newLs;
+
+    }
+
+    public List<String> getRequestHeader(String name) {
+        boolean splitIndividualValue
+            = MessageUtils.getContextualBoolean(message, HEADER_SPLIT_PROPERTY, false);
+
+        List<String> values = headers.get(name);
+        if (!splitIndividualValue
+            || values == null
+            || HttpUtils.isDateRelatedHeader(name)) {
+            return values;
+        }
+
+        List<String> ls = new LinkedList<>();
+        for (String value : values) {
+            if (value == null) {
+                continue;
+            }
+            String sep = HttpHeaders.COOKIE.equalsIgnoreCase(name) ? getCookieSeparator(value) : DEFAULT_SEPARATOR;
+            ls.addAll(getHeaderValues(name, value, sep));
+        }
+        return ls;
+    }
+
+    private List<String> getListValues(String headerName) {
+        List<String> values = headers.get(headerName);
+        if (values == null || values.isEmpty() || values.get(0) == null) {
+            return Collections.emptyList();
+        }
+        if (HttpUtils.isDateRelatedHeader(headerName)) {
+            return values;
+        }
+        List<String> actualValues = new LinkedList<>();
+        for (String v : values) {
+            actualValues.addAll(getHeaderValues(headerName, v));
+        }
+        return actualValues;
+    }
+
+    private List<String> getHeaderValues(String headerName, String originalValue) {
+        return getHeaderValues(headerName, originalValue, DEFAULT_SEPARATOR);
+    }
+
+    private static List<String> getHeaderValues(String headerName, String originalValue, String sep) {
+        if (!originalValue.contains(QUOTE)
+            || HEADERS_WITH_POSSIBLE_QUOTES.contains(headerName)) {
+            final String[] ls; 
+            if (COOKIE_SEPARATOR_CRLF_EXPRESSION != sep) {
+                ls = originalValue.split(sep);
+            } else {
+                ls = COOKIE_SEPARATOR_CRLF_PATTERN.split(originalValue);
+            }
+            if (ls.length == 1) {
+                return Collections.singletonList(ls[0].trim());
+            }
+            List<String> newValues = new ArrayList<>();
+            for (String v : ls) {
+                newValues.add(v.trim());
+            }
+            return newValues;
+        }
+        if (originalValue.startsWith("\"") && originalValue.endsWith("\"")) {
+            String actualValue = originalValue.length() == 2 ? ""
+                : originalValue.substring(1, originalValue.length() - 1);
+            return Collections.singletonList(actualValue);
+        }
+        List<String> values = new ArrayList<>(4);
+        Matcher m = COMPLEX_HEADER_PATTERN.matcher(originalValue);
+        while (m.find()) {
+            String val = m.group().trim();
+            if (val.length() > 0) {
+                values.add(val);
+            }
+        }
+        return values;
+    }
+
+    private static class AcceptLanguageComparator implements Comparator<Locale> {
+        private Map<Locale, Float> prefs;
+
+        AcceptLanguageComparator(Map<Locale, Float> prefs) {
+            this.prefs = prefs;
+        }
+
+        public int compare(Locale lang1, Locale lang2) {
+            float p1 = prefs.get(lang1);
+            float p2 = prefs.get(lang2);
+            return Float.compare(p1, p2) * -1;
+        }
+    }
+
+    private void sortMediaTypesUsingQualityFactor(List<MediaType> types) {
+        if (types.size() > 1) {
+            Collections.sort(types, new Comparator<MediaType>() {
+
+                public int compare(MediaType mt1, MediaType mt2) {
+                    return JAXRSUtils.compareMediaTypesQualityFactors(mt1, mt2);
+                }
+
+            });
+        }
+    }
+
+    public Date getDate() {
+        List<String> values = headers.get(HttpHeaders.DATE);
+        if (values == null || values.isEmpty() || StringUtils.isEmpty(values.get(0))) {
+            return null;
+        }
+        return HttpUtils.getHttpDate(values.get(0));
+    }
+
+    public String getHeaderString(String headerName) {
+        return HttpUtils.getHeaderString(headers.get(headerName));
+    }
+
+    public int getLength() {
+        List<String> values = headers.get(HttpHeaders.CONTENT_LENGTH);
+        if (values == null || values.size() != 1) {
+            return -1;
+        }
+        return HttpUtils.getContentLength(values.get(0));
+    }
+
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/HttpUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/HttpUtils.java
@@ -301,8 +301,12 @@ public final class HttpUtils {
 
     public static Locale getLocale(String value) {
         if (value == null) {
-            return null;
+            return new Locale("", ""); //Liberty change
         }
+        // Liberty change start
+        String[] languageLocale = value.split("-", 2);
+        return languageLocale.length > 1 ? new Locale(languageLocale[0], languageLocale[1]) : new Locale(languageLocale[0]);
+        /*
         String language = null;
         String locale = null;
         int index = value.indexOf('-');
@@ -321,7 +325,8 @@ public final class HttpUtils {
             return new Locale(language);
         }
         return new Locale(language, locale);
-
+        */
+        //Liberty change end
     }
 
     public static int getContentLength(String value) {

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/org/jboss/resteasy/specimpl/ResteasyHttpHeaders.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/org/jboss/resteasy/specimpl/ResteasyHttpHeaders.java
@@ -1,0 +1,212 @@
+package org.jboss.resteasy.specimpl;
+
+import org.jboss.resteasy.util.CookieParser;
+import org.jboss.resteasy.util.DateUtil;
+import org.jboss.resteasy.util.MediaTypeHelper;
+import org.jboss.resteasy.util.WeightedLanguage;
+
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class ResteasyHttpHeaders implements HttpHeaders
+{
+
+   private MultivaluedMap<String, String> requestHeaders;
+   private MultivaluedMap<String, String> unmodifiableRequestHeaders;
+   private Map<String, Cookie> cookies;
+
+   public ResteasyHttpHeaders(final MultivaluedMap<String, String> requestHeaders)
+   {
+      this(requestHeaders, new HashMap<String, Cookie>());
+   }
+
+   public ResteasyHttpHeaders(final MultivaluedMap<String, String> requestHeaders, final boolean eagerlyInitializeEntrySet)
+   {
+      this(requestHeaders, new HashMap<String, Cookie>(), eagerlyInitializeEntrySet);
+   }
+
+   public ResteasyHttpHeaders(final MultivaluedMap<String, String> requestHeaders, final Map<String, Cookie> cookies)
+   {
+      this(requestHeaders, cookies, true);
+   }
+
+   public ResteasyHttpHeaders(final MultivaluedMap<String, String> requestHeaders, final Map<String, Cookie> cookies, final boolean eagerlyInitializeEntrySet)
+   {
+      this.requestHeaders = requestHeaders;
+      this.unmodifiableRequestHeaders = new UnmodifiableMultivaluedMap<>(requestHeaders, eagerlyInitializeEntrySet);
+      this.cookies = (cookies == null ? new HashMap<>() : cookies);
+   }
+
+   @Override
+   public MultivaluedMap<String, String> getRequestHeaders()
+   {
+      return unmodifiableRequestHeaders;
+   }
+
+   public MultivaluedMap<String, String> getMutableHeaders()
+   {
+      return requestHeaders;
+   }
+
+   public void testParsing()
+   {
+      // test parsing should throw an exception on error
+      getAcceptableMediaTypes();
+      getMediaType();
+      getLanguage();
+      getAcceptableLanguages();
+
+   }
+
+   @Override
+   public List<String> getRequestHeader(String name)
+   {
+      List<String> vals = unmodifiableRequestHeaders.get(name);
+      return vals == null ? Collections.<String>emptyList() : vals;
+   }
+
+   @Override
+   public Map<String, Cookie> getCookies()
+   {
+      mergeCookies();
+      return Collections.unmodifiableMap(cookies);
+   }
+
+   public Map<String, Cookie> getMutableCookies()
+   {
+      mergeCookies();
+      return cookies;
+   }
+
+   public void setCookies(Map<String, Cookie> cookies)
+   {
+      this.cookies = cookies;
+   }
+
+   @Override
+   public Date getDate()
+   {
+      String date = requestHeaders.getFirst(DATE);
+      if (date == null) return null;
+      return DateUtil.parseDate(date);
+   }
+
+   @Override
+   public String getHeaderString(String name)
+   {
+      List<String> vals = requestHeaders.get(name);
+      if (vals == null) return null;
+      StringBuilder builder = new StringBuilder();
+      boolean first = true;
+      for (String val : vals)
+      {
+         if (first) first = false;
+         else builder.append(",");
+         builder.append(val);
+      }
+      return builder.toString();
+   }
+
+   @Override
+   public Locale getLanguage()
+   {
+      String obj = requestHeaders.getFirst(HttpHeaders.CONTENT_LANGUAGE);
+      if (obj == null) return null;
+      return new Locale(obj);
+   }
+
+   @Override
+   public int getLength()
+   {
+      String obj = requestHeaders.getFirst(HttpHeaders.CONTENT_LENGTH);
+      if (obj == null) return -1;
+      return Integer.parseInt(obj);
+   }
+
+   // because header string map is mutable, we only cache the parsed media type
+   // and still do hash lookup
+   private String cachedMediaTypeString;
+   private MediaType cachedMediaType;
+   @Override
+   public MediaType getMediaType()
+   {
+      String obj = requestHeaders.getFirst(HttpHeaders.CONTENT_TYPE);
+      if (obj == null) return null;
+      if (obj == cachedMediaTypeString) return cachedMediaType;
+      cachedMediaTypeString = obj;
+      cachedMediaType = MediaType.valueOf(obj);
+      return cachedMediaType;
+   }
+
+   @Override
+   public List<MediaType> getAcceptableMediaTypes()
+   {
+      List<String> vals = requestHeaders.get(ACCEPT);
+      if (vals == null || vals.isEmpty()) {
+         return Collections.singletonList(MediaType.WILDCARD_TYPE);
+      } else {
+         List<MediaType> list = new ArrayList<MediaType>();
+         for (String v : vals) {
+            StringTokenizer tokenizer = new StringTokenizer(v, ",");
+            while (tokenizer.hasMoreElements()) {
+               String item = tokenizer.nextToken().trim();
+               list.add(MediaType.valueOf(item));
+            }
+         }
+         MediaTypeHelper.sortByWeight(list);
+         return Collections.unmodifiableList(list);
+      }
+   }
+
+   @Override
+   public List<Locale> getAcceptableLanguages()
+   {
+      List<String> vals = requestHeaders.get(ACCEPT_LANGUAGE);
+      if (vals == null || vals.isEmpty()
+                      || (vals.size() == 1 && "".equals(vals.get(0).trim()))) { // liberty change
+         return Collections.singletonList(Locale.forLanguageTag("*"));
+      }
+      List<WeightedLanguage> languages = new ArrayList<WeightedLanguage>();
+      for (String v : vals) {
+         StringTokenizer tokenizer = new StringTokenizer(v, ",");
+         while (tokenizer.hasMoreElements()) {
+            String item = tokenizer.nextToken().trim();
+            languages.add(WeightedLanguage.parse(item));
+         }
+      }
+      Collections.sort(languages);
+      List<Locale> list = new ArrayList<Locale>(languages.size());
+      for (WeightedLanguage language : languages) list.add(language.getLocale());
+      return Collections.unmodifiableList(list);
+   }
+
+   private void mergeCookies()
+   {
+      List<String> cookieHeader = requestHeaders.get(HttpHeaders.COOKIE);
+      if (cookieHeader != null && !cookieHeader.isEmpty())
+      {
+         for (String s : cookieHeader)
+         {
+            List<Cookie> list = CookieParser.parseCookies(s);
+            for (Cookie cookie : list)
+            {
+               cookies.put(cookie.getName(), cookie);
+            }
+         }
+      }
+   }
+}


### PR DESCRIPTION
Specifically this fixes how JAX-RS 2.1 / CXF handles "blank" languages - these should be treated as "und" (undefined).