### PR TITLE
wssecurity runtime with new prereq levels should support new config options

### DIFF
--- a/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/cxf/interceptor/WSSecurityLibertyPluginInterceptor.java
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/cxf/interceptor/WSSecurityLibertyPluginInterceptor.java
@@ -125,7 +125,8 @@ public class WSSecurityLibertyPluginInterceptor extends AbstractSoapInterceptor 
                 String key = keyIt.next();
                 if (message.getContextualProperty(key) == null) {
                     //check whether config has password
-                    if (WSSecurityConstants.CXF_SIG_PROPS.equals(key) || WSSecurityConstants.SEC_SIG_PROPS.equals(key)) {
+                    if ((WSSecurityConstants.CXF_SIG_PROPS.equals(key) || WSSecurityConstants.SEC_SIG_PROPS.equals(key)) && 
+                                    message.getContextualProperty(WSSecurityConstants.SEC_SIG_PROPS) == null ) {
                         Map<String, Object> tempMap = (Map<String, Object>) clientConfigMap.
                                         get(WSSecurityConstants.SEC_SIG_PROPS); //v3
                         if (tempMap == null) {
@@ -146,7 +147,8 @@ public class WSSecurityLibertyPluginInterceptor extends AbstractSoapInterceptor 
                             //message.setContextualProperty(WSSecurityConstants.CXF_SIG_CRYPTO, Utils.getCrypto(sigProps)); //@2020 TODO
                             SignatureAlgorithms.setAlgorithm(message, (String) tempMap.get(SIGNATURE_METHOD));
                         }
-                    } else if (WSSecurityConstants.CXF_ENC_PROPS.equals(key) || WSSecurityConstants.SEC_ENC_PROPS.equals(key)) {
+                    } else if ((WSSecurityConstants.CXF_ENC_PROPS.equals(key) || WSSecurityConstants.SEC_ENC_PROPS.equals(key)) && 
+                                    message.getContextualProperty(WSSecurityConstants.SEC_ENC_PROPS) == null ) {
                         Map<String, Object> tempMap = (Map<String, Object>) clientConfigMap.
                                         get(WSSecurityConstants.SEC_ENC_PROPS); //v3
                         if (tempMap == null) {
@@ -230,7 +232,8 @@ public class WSSecurityLibertyPluginInterceptor extends AbstractSoapInterceptor 
                 String key = keyIt.next();
 
                 //check whether config has password
-                if (WSSecurityConstants.CXF_SIG_PROPS.equals(key) || WSSecurityConstants.SEC_SIG_PROPS.equals(key)) {
+                if ((WSSecurityConstants.CXF_SIG_PROPS.equals(key) || WSSecurityConstants.SEC_SIG_PROPS.equals(key)) && 
+                                message.getContextualProperty(WSSecurityConstants.SEC_SIG_PROPS) == null ) {
                     Map<String, Object> tempMap = (Map<String, Object>) providerConfigMap.
                                     get(WSSecurityConstants.SEC_SIG_PROPS); //v3
                     if (tempMap == null) {
@@ -251,7 +254,8 @@ public class WSSecurityLibertyPluginInterceptor extends AbstractSoapInterceptor 
                         //message.setContextualProperty(WSSecurityConstants.CXF_SIG_CRYPTO, Utils.getCrypto(sigProps)); //@2020 TODO
                         SignatureAlgorithms.setAlgorithm(message, (String) tempMap.get(SIGNATURE_METHOD));
                     }
-                } else if (WSSecurityConstants.CXF_ENC_PROPS.equals(key) || WSSecurityConstants.SEC_ENC_PROPS.equals(key)) {
+                } else if ((WSSecurityConstants.CXF_ENC_PROPS.equals(key) || WSSecurityConstants.SEC_ENC_PROPS.equals(key)) && 
+                                message.getContextualProperty(WSSecurityConstants.SEC_ENC_PROPS) == null) {
                     Map<String, Object> tempMap = (Map<String, Object>) providerConfigMap.
                                     get(WSSecurityConstants.SEC_ENC_PROPS); //v3
                     if (tempMap == null) {

--- a/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/cxf/interceptor/WSSecurityLibertyPluginInterceptor.java
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/cxf/interceptor/WSSecurityLibertyPluginInterceptor.java
@@ -113,7 +113,7 @@ public class WSSecurityLibertyPluginInterceptor extends AbstractSoapInterceptor 
             Iterator<String> keyIt = client_config_keys.iterator();
             //check whether user name is specified via request context
             boolean user_id_exists = false;
-            if (message.getContextualProperty(WSSecurityConstants.CXF_USER_NAME) != null) {
+            if (message.getContextualProperty(WSSecurityConstants.CXF_USER_NAME) != null || message.getContextualProperty(WSSecurityConstants.SEC_USER_NAME) != null) {
                 user_id_exists = true;
 //                message.setContextualProperty(WSSecurityConstants.UPDATED_CXF_USER_NAME, message.getContextualProperty(WSSecurityConstants.CXF_USER_NAME));
 //                message.setContextualProperty(WSSecurityConstants.UPDATED_CXF_USER_PASSWORD, message.getContextualProperty(WSSecurityConstants.CXF_USER_PASSWORD));
@@ -125,9 +125,13 @@ public class WSSecurityLibertyPluginInterceptor extends AbstractSoapInterceptor 
                 String key = keyIt.next();
                 if (message.getContextualProperty(key) == null) {
                     //check whether config has password
-                    if (WSSecurityConstants.CXF_SIG_PROPS.equals(key)) {
+                    if (WSSecurityConstants.CXF_SIG_PROPS.equals(key) || WSSecurityConstants.SEC_SIG_PROPS.equals(key)) {
                         Map<String, Object> tempMap = (Map<String, Object>) clientConfigMap.
-                                        get(WSSecurityConstants.CXF_SIG_PROPS);
+                                        get(WSSecurityConstants.SEC_SIG_PROPS); //v3
+                        if (tempMap == null) {
+                            tempMap = (Map<String, Object>) clientConfigMap.
+                                            get(WSSecurityConstants.CXF_SIG_PROPS); //v3
+                        }
                         if (tempMap != null) {
                             Map<String, Object> sigPropsMap = new HashMap<String, Object>(tempMap);
                             Utils.modifyConfigMap(sigPropsMap);
@@ -142,9 +146,13 @@ public class WSSecurityLibertyPluginInterceptor extends AbstractSoapInterceptor 
                             //message.setContextualProperty(WSSecurityConstants.CXF_SIG_CRYPTO, Utils.getCrypto(sigProps)); //@2020 TODO
                             SignatureAlgorithms.setAlgorithm(message, (String) tempMap.get(SIGNATURE_METHOD));
                         }
-                    } else if (WSSecurityConstants.CXF_ENC_PROPS.equals(key)) {
+                    } else if (WSSecurityConstants.CXF_ENC_PROPS.equals(key) || WSSecurityConstants.SEC_ENC_PROPS.equals(key)) {
                         Map<String, Object> tempMap = (Map<String, Object>) clientConfigMap.
-                                        get(WSSecurityConstants.CXF_ENC_PROPS);
+                                        get(WSSecurityConstants.SEC_ENC_PROPS); //v3
+                        if (tempMap == null) {
+                            tempMap = (Map<String, Object>) clientConfigMap.
+                                            get(WSSecurityConstants.CXF_ENC_PROPS); //v3
+                        }
                         if (tempMap != null) {
                             Map<String, Object> encPropsMap = new HashMap<String, Object>(tempMap);
                             Utils.modifyConfigMap(encPropsMap);
@@ -153,12 +161,20 @@ public class WSSecurityLibertyPluginInterceptor extends AbstractSoapInterceptor 
                             message.setContextualProperty(key, encProps);
                             //message.setContextualProperty(WSSecurityConstants.CXF_ENC_CRYPTO, Utils.getCrypto(encProps)); //@2020 TODO
                         }
-                    } else if (WSSecurityConstants.CXF_USER_PASSWORD.equals(key)) {
+                    } else if (WSSecurityConstants.CXF_USER_PASSWORD.equals(key) || WSSecurityConstants.SEC_USER_PASSWORD.equals(key)) { //v3
                         //if user is specified via request context, 
                         //then don't bother checking for password in the server.xml
                         if (!user_id_exists) {
-                            String pwd = Utils.changePasswordType
-                                            ((SerializableProtectedString) clientConfigMap.get(WSSecurityConstants.CXF_USER_PASSWORD));
+                            String pwd = null;
+                            if (clientConfigMap.get(WSSecurityConstants.SEC_USER_PASSWORD) != null) {
+                                pwd = Utils.changePasswordType
+                                                ((SerializableProtectedString) clientConfigMap.get(WSSecurityConstants.SEC_USER_PASSWORD));
+                            } else if (clientConfigMap.get(WSSecurityConstants.CXF_USER_PASSWORD) != null) {
+                                pwd = Utils.changePasswordType
+                                                ((SerializableProtectedString) clientConfigMap.get(WSSecurityConstants.CXF_USER_PASSWORD));
+                            }
+//                            String pwd = Utils.changePasswordType
+//                                            ((SerializableProtectedString) clientConfigMap.get(WSSecurityConstants.CXF_USER_PASSWORD));
                             message.setContextualProperty(key, pwd);
                         }
 
@@ -214,9 +230,13 @@ public class WSSecurityLibertyPluginInterceptor extends AbstractSoapInterceptor 
                 String key = keyIt.next();
 
                 //check whether config has password
-                if (WSSecurityConstants.CXF_SIG_PROPS.equals(key)) {
+                if (WSSecurityConstants.CXF_SIG_PROPS.equals(key) || WSSecurityConstants.SEC_SIG_PROPS.equals(key)) {
                     Map<String, Object> tempMap = (Map<String, Object>) providerConfigMap.
-                                    get(WSSecurityConstants.CXF_SIG_PROPS);
+                                    get(WSSecurityConstants.SEC_SIG_PROPS); //v3
+                    if (tempMap == null) {
+                        tempMap = (Map<String, Object>) providerConfigMap.
+                                        get(WSSecurityConstants.CXF_SIG_PROPS); //v3
+                    }
                     if (tempMap != null) {
                         Map<String, Object> sigPropsMap = new HashMap<String, Object>(tempMap);
                         Utils.modifyConfigMap(sigPropsMap);
@@ -231,9 +251,13 @@ public class WSSecurityLibertyPluginInterceptor extends AbstractSoapInterceptor 
                         //message.setContextualProperty(WSSecurityConstants.CXF_SIG_CRYPTO, Utils.getCrypto(sigProps)); //@2020 TODO
                         SignatureAlgorithms.setAlgorithm(message, (String) tempMap.get(SIGNATURE_METHOD));
                     }
-                } else if (WSSecurityConstants.CXF_ENC_PROPS.equals(key)) {
+                } else if (WSSecurityConstants.CXF_ENC_PROPS.equals(key) || WSSecurityConstants.SEC_ENC_PROPS.equals(key)) {
                     Map<String, Object> tempMap = (Map<String, Object>) providerConfigMap.
-                                    get(WSSecurityConstants.CXF_ENC_PROPS);
+                                    get(WSSecurityConstants.SEC_ENC_PROPS); //v3
+                    if (tempMap == null) {
+                        tempMap = (Map<String, Object>) providerConfigMap.
+                                        get(WSSecurityConstants.CXF_ENC_PROPS); //v3
+                    }
                     if (tempMap != null) {
                         Map<String, Object> encPropsMap = new HashMap<String, Object>(tempMap);
                         Utils.modifyConfigMap(encPropsMap);
@@ -242,11 +266,11 @@ public class WSSecurityLibertyPluginInterceptor extends AbstractSoapInterceptor 
                         message.setContextualProperty(key, encProps);
                         //message.setContextualProperty(WSSecurityConstants.CXF_ENC_CRYPTO, Utils.getCrypto(encProps)); //@2020 TODO
                     }
-                } else if (WSSecurityConstants.CXF_USER_PASSWORD.equals(key)) {
+                } /*else if (WSSecurityConstants.CXF_USER_PASSWORD.equals(key)) {
                     String pwd = Utils.changePasswordType
                                     ((SerializableProtectedString) providerConfigMap.get(WSSecurityConstants.CXF_USER_PASSWORD));
                     message.setContextualProperty(key, pwd);
-                } else {
+                }*/ else {
                     //handle ws-security.cache.config.file property
                     if (WSSecurityConstants.CXF_NONCE_CACHE_CONFIG_FILE.equals(key)) {
                         //System.out.println("gkuo Liberty:get ws-security.cache.config.file:" + providerConfigMap.get(key));

--- a/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/cxf/validator/Utils.java
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/cxf/validator/Utils.java
@@ -132,15 +132,27 @@ public class Utils {
                             configMap.get(WSSecurityConstants.WSS4J_KEY_PASSWORD));
             configMap.put(WSSecurityConstants.WSS4J_KEY_PASSWORD, pwd);
         }
+        if (configMap.containsKey(WSSecurityConstants.WSS4J_2_KEY_PASSWORD)) {
+            String pwd = PasswordUtil.passwordDecode((String)configMap.get(WSSecurityConstants.WSS4J_2_KEY_PASSWORD));
+            configMap.put(WSSecurityConstants.WSS4J_2_KEY_PASSWORD, pwd);
+        }
         if (configMap.containsKey(WSSecurityConstants.WSS4J_KS_PASSWORD)) {
             String pwd = changePasswordType((SerializableProtectedString)
                             configMap.get(WSSecurityConstants.WSS4J_KS_PASSWORD));
             configMap.put(WSSecurityConstants.WSS4J_KS_PASSWORD, pwd);
         }
+        if (configMap.containsKey(WSSecurityConstants.WSS4J_2_KS_PASSWORD)) {
+            String pwd = PasswordUtil.passwordDecode((String)configMap.get(WSSecurityConstants.WSS4J_2_KS_PASSWORD));
+            configMap.put(WSSecurityConstants.WSS4J_2_KS_PASSWORD, pwd);
+        }
         if (configMap.containsKey(WSSecurityConstants.WSS4J_TS_PASSWORD)) {
             String pwd = changePasswordType((SerializableProtectedString)
                             configMap.get(WSSecurityConstants.WSS4J_TS_PASSWORD));
             configMap.put(WSSecurityConstants.WSS4J_TS_PASSWORD, pwd);
+        }
+        if (configMap.containsKey(WSSecurityConstants.WSS4J_2_TS_PASSWORD)) {
+            String pwd = PasswordUtil.passwordDecode((String)configMap.get(WSSecurityConstants.WSS4J_2_TS_PASSWORD));
+            configMap.put(WSSecurityConstants.WSS4J_2_TS_PASSWORD, pwd);
         }
     }
 

--- a/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityClientConfiguration.java
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityClientConfiguration.java
@@ -169,8 +169,15 @@ public class WSSecurityClientConfiguration implements ConfigurationListener {
                         for (String key : SPECIAL_CFG_KEYS) {
                             signaturePropertyMap.remove(key);
                         }
-                        //defaultConfigMap.put(WSSecurityConstants.SEC_SIG_PROPS, signaturePropertyMap);  //v3
-                        defaultConfigMap.put(WSSecurityConstants.CXF_SIG_PROPS, signaturePropertyMap);  //v3 - backward compatibility
+                        if (newConfigSpecified(signaturePropertyMap)) {
+                            signaturePropertyMap.remove(WSSecurityConstants.WSS4J_CRYPTO_PROVIDER); 
+                            signaturePropertyMap.putIfAbsent(WSSecurityConstants.WSS4J_2_CRYPTO_PROVIDER, WSSecurityConstants.WSS4J_2_CRYPTO_PROVIDER_NAME);
+                            defaultConfigMap.put(WSSecurityConstants.SEC_SIG_PROPS, signaturePropertyMap);  //v3
+                        } else {
+                            defaultConfigMap.put(WSSecurityConstants.CXF_SIG_PROPS, signaturePropertyMap);  //v3 - backward compatibility
+                        }
+                        
+                        
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                             Object sigProp = signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE) != null ? 
                                             signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE) : signaturePropertyMap.get(WSSecurityConstants.WSS4J_KS_TYPE);
@@ -208,8 +215,14 @@ public class WSSecurityClientConfiguration implements ConfigurationListener {
                         for (String key : SPECIAL_CFG_KEYS) {
                             encryptionPropertyMap.remove(key);
                         }
-                        //defaultConfigMap.put(WSSecurityConstants.SEC_ENC_PROPS, encryptionPropertyMap);  //v3
-                        defaultConfigMap.put(WSSecurityConstants.CXF_ENC_PROPS, encryptionPropertyMap);  //v3 - backward compatibility
+                        if (newConfigSpecified(encryptionPropertyMap)) {
+                            encryptionPropertyMap.remove(WSSecurityConstants.WSS4J_CRYPTO_PROVIDER); 
+                            encryptionPropertyMap.putIfAbsent(WSSecurityConstants.WSS4J_2_CRYPTO_PROVIDER, WSSecurityConstants.WSS4J_2_CRYPTO_PROVIDER_NAME);
+                            defaultConfigMap.put(WSSecurityConstants.SEC_ENC_PROPS, encryptionPropertyMap);  //v3
+                        } else {
+                            defaultConfigMap.put(WSSecurityConstants.CXF_ENC_PROPS, encryptionPropertyMap);  //v3 - backward compatibility
+                        }
+                        
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                             Object encProp = encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE) != null ? 
                                             encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE): encryptionPropertyMap.get(WSSecurityConstants.WSS4J_KS_TYPE);
@@ -268,6 +281,20 @@ public class WSSecurityClientConfiguration implements ConfigurationListener {
         }
     }
 
+
+    /**
+     * @param signature or encryption propertyMap
+     * @return
+     */
+    private boolean newConfigSpecified(Map<String, Object> propertyMap) {
+        Set <String> keys = propertyMap.keySet();
+        for (String key : keys) {
+            if (key.contains(WSSecurityConstants.WSS4J_2)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     /**
      * @return user name for this configuration.

--- a/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityClientConfiguration.java
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityClientConfiguration.java
@@ -169,18 +169,23 @@ public class WSSecurityClientConfiguration implements ConfigurationListener {
                         for (String key : SPECIAL_CFG_KEYS) {
                             signaturePropertyMap.remove(key);
                         }
-                        defaultConfigMap.put(WSSecurityConstants.CXF_SIG_PROPS, signaturePropertyMap);
+                        defaultConfigMap.put(WSSecurityConstants.SEC_SIG_PROPS, signaturePropertyMap);  //v3
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                            Tr.debug(tc, "signature configuration type = ", signaturePropertyMap.
-                                            get(WSSecurityConstants.WSS4J_KS_TYPE));
-                            Tr.debug(tc, "signature configuration alias = ", signaturePropertyMap.
-                                            get(WSSecurityConstants.WSS4J_KS_ALIAS));
-                            Tr.debug(tc, "signature configuration ks file = ", signaturePropertyMap.
-                                            get(WSSecurityConstants.WSS4J_KS_FILE));
-                            Tr.debug(tc, "signature configuration password = ", signaturePropertyMap.
-                                            get(WSSecurityConstants.WSS4J_KS_PASSWORD));
-                            Tr.debug(tc, "signature configuration provider = ", signaturePropertyMap.
-                                            get(WSSecurityConstants.WSS4J_CRYPTO_PROVIDER));
+                            Object sigProp = signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE) != null ? 
+                                            signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE) : signaturePropertyMap.get(WSSecurityConstants.WSS4J_KS_TYPE);
+                            Tr.debug(tc, "signature configuration type = ", sigProp );
+                            sigProp = signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_ALIAS) != null ? 
+                                            signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_ALIAS) : signaturePropertyMap.get(WSSecurityConstants.WSS4J_KS_ALIAS);
+                            Tr.debug(tc, "signature configuration alias = ", sigProp);
+                            sigProp = signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_FILE) != null ?
+                                            signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_FILE) : signaturePropertyMap.get(WSSecurityConstants.WSS4J_KS_FILE);
+                            Tr.debug(tc, "signature configuration ks file = ", sigProp);
+                            sigProp = signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_PASSWORD) != null ? 
+                                            signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_PASSWORD) : signaturePropertyMap.get(WSSecurityConstants.WSS4J_KS_PASSWORD);
+                            Tr.debug(tc, "signature configuration password = ", sigProp);
+                            sigProp = signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_CRYPTO_PROVIDER) != null ? 
+                                            signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_CRYPTO_PROVIDER) : signaturePropertyMap.get(WSSecurityConstants.WSS4J_CRYPTO_PROVIDER);
+                            Tr.debug(tc, "signature configuration provider = ", sigProp);
                         }
                     } else {
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -202,13 +207,23 @@ public class WSSecurityClientConfiguration implements ConfigurationListener {
                         for (String key : SPECIAL_CFG_KEYS) {
                             encryptionPropertyMap.remove(key);
                         }
-                        defaultConfigMap.put(WSSecurityConstants.CXF_ENC_PROPS, encryptionPropertyMap);
+                        defaultConfigMap.put(WSSecurityConstants.SEC_ENC_PROPS, encryptionPropertyMap);  //v3
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                            Tr.debug(tc, "encryption configuration type = ", encryptionPropertyMap.get(WSSecurityConstants.WSS4J_KS_TYPE));
-                            Tr.debug(tc, "encryption configuration alias = ", encryptionPropertyMap.get(WSSecurityConstants.WSS4J_KS_ALIAS));
-                            Tr.debug(tc, "encryption configuration ks file = ", encryptionPropertyMap.get(WSSecurityConstants.WSS4J_KS_FILE));
-                            Tr.debug(tc, "encryption configuration password = ", encryptionPropertyMap.get(WSSecurityConstants.WSS4J_KS_PASSWORD));
-                            Tr.debug(tc, "encryption configuration provider = ", encryptionPropertyMap.get(WSSecurityConstants.WSS4J_CRYPTO_PROVIDER));
+                            Object encProp = encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE) != null ? 
+                                            encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE): encryptionPropertyMap.get(WSSecurityConstants.WSS4J_KS_TYPE);
+                            Tr.debug(tc, "encryption configuration type = ", encProp);
+                            encProp = encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_ALIAS) != null ?
+                                            encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_ALIAS) : encryptionPropertyMap.get(WSSecurityConstants.WSS4J_KS_ALIAS);
+                            Tr.debug(tc, "encryption configuration alias = ", encProp);
+                            encProp = encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_FILE) != null ? 
+                                            encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_FILE) : encryptionPropertyMap.get(WSSecurityConstants.WSS4J_KS_FILE);
+                            Tr.debug(tc, "encryption configuration ks file = ", encProp);
+                            encProp = encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_PASSWORD) != null ?
+                                            encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_PASSWORD) : encryptionPropertyMap.get(WSSecurityConstants.WSS4J_KS_PASSWORD);
+                            Tr.debug(tc, "encryption configuration password = ", encProp);
+                            encProp = encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_CRYPTO_PROVIDER) != null ?
+                                            encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_CRYPTO_PROVIDER) : encryptionPropertyMap.get(WSSecurityConstants.WSS4J_CRYPTO_PROVIDER);
+                            Tr.debug(tc, "encryption configuration provider = ", encProp);
                         }
                     } else {
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -231,8 +246,8 @@ public class WSSecurityClientConfiguration implements ConfigurationListener {
                 Object entry_value = entry.getValue();//(String) properties.get(entry_key);
                 if (entry_value != null) {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                        Tr.debug(tc, "ws-security provider configuration entry key = ", entry_key);
-                        Tr.debug(tc, "ws-security provider configuration entry value = ", entry_value);
+                        Tr.debug(tc, "ws-security client configuration entry key = ", entry_key);
+                        Tr.debug(tc, "ws-security client configuration entry value = ", entry_value);
                     }
                     defaultConfigMap.put(entry_key, entry_value);
                     if (CXF_USER_NAME.equals(entry_key)) {

--- a/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityClientConfiguration.java
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityClientConfiguration.java
@@ -169,7 +169,8 @@ public class WSSecurityClientConfiguration implements ConfigurationListener {
                         for (String key : SPECIAL_CFG_KEYS) {
                             signaturePropertyMap.remove(key);
                         }
-                        defaultConfigMap.put(WSSecurityConstants.SEC_SIG_PROPS, signaturePropertyMap);  //v3
+                        //defaultConfigMap.put(WSSecurityConstants.SEC_SIG_PROPS, signaturePropertyMap);  //v3
+                        defaultConfigMap.put(WSSecurityConstants.CXF_SIG_PROPS, signaturePropertyMap);  //v3 - backward compatibility
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                             Object sigProp = signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE) != null ? 
                                             signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE) : signaturePropertyMap.get(WSSecurityConstants.WSS4J_KS_TYPE);
@@ -207,7 +208,8 @@ public class WSSecurityClientConfiguration implements ConfigurationListener {
                         for (String key : SPECIAL_CFG_KEYS) {
                             encryptionPropertyMap.remove(key);
                         }
-                        defaultConfigMap.put(WSSecurityConstants.SEC_ENC_PROPS, encryptionPropertyMap);  //v3
+                        //defaultConfigMap.put(WSSecurityConstants.SEC_ENC_PROPS, encryptionPropertyMap);  //v3
+                        defaultConfigMap.put(WSSecurityConstants.CXF_ENC_PROPS, encryptionPropertyMap);  //v3 - backward compatibility
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                             Object encProp = encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE) != null ? 
                                             encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE): encryptionPropertyMap.get(WSSecurityConstants.WSS4J_KS_TYPE);

--- a/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityConfiguration.java
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -297,128 +297,6 @@ public class WSSecurityConfiguration implements ConfigurationListener {
         return samlTokenConfigMap;
     }
 
-    ///**
-    // * @param properties
-    // * @throws Exception
-    // */
-    //private void processSamlTrustEngine() throws Exception {
-    //    // reset stored saml data
-    //    samlX509List = Collections.synchronizedList(new ArrayList<String>());
-    //    samlCrlList = Collections.synchronizedList(new ArrayList<String>());
-    //    isSamlTrustEngineEnabled = false;
-    //
-    //    String samlTrustEngine = (String) properties.get(KEY_samlTrustEngine);
-    //    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-    //        Tr.debug(tc, "samlTrustEngine pid:", samlTrustEngine);
-    //    }
-    //    if (samlTrustEngine == null || samlTrustEngine.isEmpty())
-    //        return;
-    //
-    //    isSamlTrustEngineEnabled = true;
-    //
-    //    processSamlTrustEngineData(samlTrustEngine);
-    //}
-
-    ///**
-    // * @param string
-    // * @throws Exception
-    // */
-    //private void processSamlTrustEngineData(String trustEngine) throws Exception {
-    //    Configuration config = null;
-    //    try {
-    //        config = configAdmin.getConfiguration(trustEngine);
-    //    } catch (IOException e) {
-    //        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-    //            Tr.debug(tc, "Invalid saml websso trust engine configuration", trustEngine);
-    //        }
-    //        return;
-    //    }
-    //    Dictionary<String, Object> trustEngineProps = config.getProperties();
-    //    trustAnchorName = (String) trustEngineProps.get(KEY_trustEngine_trustAnchor);
-    //    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-    //        Tr.debug(tc, "trustAnchor = " + trustAnchorName);
-    //    }
-    //
-    //    trustedIssuers = trim((String[]) trustEngineProps.get(KEY_trustedIssuers));
-    //    if (trustedIssuers != null) {
-    //        for (int iI = 0; iI < trustedIssuers.length; iI++) {
-    //            try {
-    //                trustedIssuers[iI] = URLDecoder.decode(trustedIssuers[iI], "UTF-8");
-    //                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-    //                    Tr.debug(tc, "trustedIssuer[" + iI + "] = " + trustedIssuers[iI]);
-    //                }
-    //            } catch (UnsupportedEncodingException e) {
-    //                throw new Exception(e); // handle the unexpected Exception
-    //            }
-    //        }
-    //    }
-    //
-    //    String[] certs = (String[]) trustEngineProps.get(KEY_trustEngine_x509cert);
-    //    if (certs == null || certs.length == 0) {
-    //        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-    //            Tr.debug(tc, "No X509Certificates were defined in the trust engine configuration. ");
-    //        }
-    //    }
-    //    else {
-    //        for (String certPid : certs) {
-    //            //pids.add(certPid); //TODO
-    //            Configuration certConfig = null;
-    //            try {
-    //                certConfig = configAdmin.getConfiguration(certPid);
-    //            } catch (IOException ioe) {
-    //                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-    //                    Tr.debug(tc, "Invalid X509 Certificate configuration", certPid);
-    //                }
-    //                continue;
-    //            }
-    //            if (certConfig == null || certConfig.getProperties() == null) {
-    //                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-    //                    Tr.debug(tc, "NULL X509 Certificate configuration", certPid);
-    //                }
-    //                continue;
-    //            }
-    //            String certPath = (String) certConfig.getProperties().get(KEY_trustEngine_path);
-    //            samlX509List.add(certPath);
-    //
-    //            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-    //                Tr.debug(tc, "Added x509 cert path: " + certPath);
-    //            }
-    //        }
-    //    }
-    //
-    //    String[] crls = (String[]) trustEngineProps.get(KEY_trustEngine_crl);
-    //    if (crls == null || crls.length == 0) {
-    //        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-    //            Tr.debug(tc, "No CRLs were defined in the trust engine configuration. ");
-    //        }
-    //    }
-    //    else {
-    //        for (String crlPid : crls) {
-    //            //pids.add(crlPid); //TODO
-    //            Configuration crlConfig = null;
-    //            try {
-    //                crlConfig = configAdmin.getConfiguration(crlPid);
-    //            } catch (IOException ioe) {
-    //                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-    //                    Tr.debug(tc, "Invalid CRL configuration", crlPid);
-    //                }
-    //                continue;
-    //            }
-    //            if (crlConfig == null || crlConfig.getProperties() == null) {
-    //                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-    //                    Tr.debug(tc, "NULL CRL configuration", crlPid);
-    //                }
-    //                continue;
-    //            }
-    //            String crlPath = (String) crlConfig.getProperties().get(KEY_trustEngine_path);
-    //            samlCrlList.add(crlPath);
-    //
-    //            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-    //                Tr.debug(tc, "Added crl path: " + crlPath);
-    //            }
-    //        }
-    //    }
-    //}
 
     /**
      */
@@ -449,13 +327,23 @@ public class WSSecurityConfiguration implements ConfigurationListener {
                             signaturePropertyMap.remove(key);
                         }
 
-                        defaultConfigMap.put(WSSecurityConstants.CXF_SIG_PROPS, signaturePropertyMap);
+                        defaultConfigMap.put(WSSecurityConstants.SEC_SIG_PROPS, signaturePropertyMap); //v3
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                            Tr.debug(tc, "signature configuration type = ", signaturePropertyMap.get(WSSecurityConstants.WSS4J_KS_TYPE));
-                            Tr.debug(tc, "signature configuration alias = ", signaturePropertyMap.get(WSSecurityConstants.WSS4J_KS_ALIAS));
-                            Tr.debug(tc, "signature configuration ks file = ", signaturePropertyMap.get(WSSecurityConstants.WSS4J_KS_FILE));
-                            Tr.debug(tc, "signature configuration password = ", signaturePropertyMap.get(WSSecurityConstants.WSS4J_KS_PASSWORD));
-                            Tr.debug(tc, "signature configuration provider = ", signaturePropertyMap.get(WSSecurityConstants.WSS4J_CRYPTO_PROVIDER));
+                            Object sigProp = signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE) != null ? 
+                                            signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE) : signaturePropertyMap.get(WSSecurityConstants.WSS4J_KS_TYPE);
+                            Tr.debug(tc, "signature configuration type = ", sigProp );
+                            sigProp = signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_ALIAS) != null ? 
+                                            signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_ALIAS) : signaturePropertyMap.get(WSSecurityConstants.WSS4J_KS_ALIAS);
+                            Tr.debug(tc, "signature configuration alias = ", sigProp);
+                            sigProp = signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_FILE) != null ?
+                                            signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_FILE) : signaturePropertyMap.get(WSSecurityConstants.WSS4J_KS_FILE);
+                            Tr.debug(tc, "signature configuration ks file = ", sigProp);
+                            sigProp = signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_PASSWORD) != null ? 
+                                            signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_PASSWORD) : signaturePropertyMap.get(WSSecurityConstants.WSS4J_KS_PASSWORD);
+                            Tr.debug(tc, "signature configuration password = ", sigProp);
+                            sigProp = signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_CRYPTO_PROVIDER) != null ? 
+                                            signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_CRYPTO_PROVIDER) : signaturePropertyMap.get(WSSecurityConstants.WSS4J_CRYPTO_PROVIDER);
+                            Tr.debug(tc, "signature configuration provider = ", sigProp);
                         }
                     } else {
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -479,13 +367,23 @@ public class WSSecurityConfiguration implements ConfigurationListener {
                         for (String key : SPECIAL_CFG_KEYS) {
                             encryptionPropertyMap.remove(key);
                         }
-                        defaultConfigMap.put(WSSecurityConstants.CXF_ENC_PROPS, encryptionPropertyMap);
+                        defaultConfigMap.put(WSSecurityConstants.SEC_ENC_PROPS, encryptionPropertyMap); //v3
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                            Tr.debug(tc, "encryption configuration type = ", encryptionPropertyMap.get(WSSecurityConstants.WSS4J_KS_TYPE));
-                            Tr.debug(tc, "encryption configuration alias = ", encryptionPropertyMap.get(WSSecurityConstants.WSS4J_KS_ALIAS));
-                            Tr.debug(tc, "encryption configuration ks file = ", encryptionPropertyMap.get(WSSecurityConstants.WSS4J_KS_FILE));
-                            Tr.debug(tc, "encryption configuration password = ", encryptionPropertyMap.get(WSSecurityConstants.WSS4J_KS_PASSWORD));
-                            Tr.debug(tc, "encryption configuration provider = ", encryptionPropertyMap.get(WSSecurityConstants.WSS4J_CRYPTO_PROVIDER));
+                            Object encProp = encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE) != null ? 
+                                            encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE): encryptionPropertyMap.get(WSSecurityConstants.WSS4J_KS_TYPE);
+                            Tr.debug(tc, "encryption configuration type = ", encProp);
+                            encProp = encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_ALIAS) != null ?
+                                            encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_ALIAS) : encryptionPropertyMap.get(WSSecurityConstants.WSS4J_KS_ALIAS);
+                            Tr.debug(tc, "encryption configuration alias = ", encProp);
+                            encProp = encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_FILE) != null ? 
+                                            encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_FILE) : encryptionPropertyMap.get(WSSecurityConstants.WSS4J_KS_FILE);
+                            Tr.debug(tc, "encryption configuration ks file = ", encProp);
+                            encProp = encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_PASSWORD) != null ?
+                                            encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_PASSWORD) : encryptionPropertyMap.get(WSSecurityConstants.WSS4J_KS_PASSWORD);
+                            Tr.debug(tc, "encryption configuration password = ", encProp);
+                            encProp = encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_CRYPTO_PROVIDER) != null ?
+                                            encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_CRYPTO_PROVIDER) : encryptionPropertyMap.get(WSSecurityConstants.WSS4J_CRYPTO_PROVIDER);
+                            Tr.debug(tc, "encryption configuration provider = ", encProp);
                         }
                     } else {
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -563,7 +461,7 @@ public class WSSecurityConfiguration implements ConfigurationListener {
                 }
                 if (entry_value != null) {
                     //handle ws-security.cache.config.file property
-                    if (WSSecurityConstants.CXF_NONCE_CACHE_CONFIG_FILE.equals(entry_key)) {
+                    if (WSSecurityConstants.CXF_NONCE_CACHE_CONFIG_FILE.equals(entry_key) || WSSecurityConstants.SEC_NONCE_CACHE_CONFIG_FILE.equals(entry_key)) {
                         String cache_file = (String) entry.getValue();
                         if (cache_file != null && !cache_file.isEmpty()) {
                             //Make sure that cache_file exists before prepending file:

--- a/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityConfiguration.java
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityConfiguration.java
@@ -326,9 +326,14 @@ public class WSSecurityConfiguration implements ConfigurationListener {
                         for (String key : SPECIAL_CFG_KEYS) {
                             signaturePropertyMap.remove(key);
                         }
+                        if (newConfigSpecified(signaturePropertyMap)) {
+                            signaturePropertyMap.remove(WSSecurityConstants.WSS4J_CRYPTO_PROVIDER); 
+                            signaturePropertyMap.putIfAbsent(WSSecurityConstants.WSS4J_2_CRYPTO_PROVIDER, WSSecurityConstants.WSS4J_2_CRYPTO_PROVIDER_NAME);
+                            defaultConfigMap.put(WSSecurityConstants.SEC_SIG_PROPS, signaturePropertyMap);  //v3
+                        } else {
+                            defaultConfigMap.put(WSSecurityConstants.CXF_SIG_PROPS, signaturePropertyMap);  //v3 - backward compatibility
+                        }
 
-                        //defaultConfigMap.put(WSSecurityConstants.SEC_SIG_PROPS, signaturePropertyMap); //v3
-                        defaultConfigMap.put(WSSecurityConstants.CXF_SIG_PROPS, signaturePropertyMap); //v3 - backward compatibility
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                             Object sigProp = signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE) != null ? 
                                             signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE) : signaturePropertyMap.get(WSSecurityConstants.WSS4J_KS_TYPE);
@@ -368,8 +373,14 @@ public class WSSecurityConfiguration implements ConfigurationListener {
                         for (String key : SPECIAL_CFG_KEYS) {
                             encryptionPropertyMap.remove(key);
                         }
-                        //defaultConfigMap.put(WSSecurityConstants.SEC_ENC_PROPS, encryptionPropertyMap); //v3
-                        defaultConfigMap.put(WSSecurityConstants.CXF_ENC_PROPS, encryptionPropertyMap); //v3 - backward compatibility
+                        if (newConfigSpecified(encryptionPropertyMap)) {
+                            encryptionPropertyMap.remove(WSSecurityConstants.WSS4J_CRYPTO_PROVIDER); 
+                            encryptionPropertyMap.putIfAbsent(WSSecurityConstants.WSS4J_2_CRYPTO_PROVIDER, WSSecurityConstants.WSS4J_2_CRYPTO_PROVIDER_NAME);
+                            defaultConfigMap.put(WSSecurityConstants.SEC_ENC_PROPS, encryptionPropertyMap);  //v3
+                        } else {
+                            defaultConfigMap.put(WSSecurityConstants.CXF_ENC_PROPS, encryptionPropertyMap);  //v3 - backward compatibility
+                        }
+
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                             Object encProp = encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE) != null ? 
                                             encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE): encryptionPropertyMap.get(WSSecurityConstants.WSS4J_KS_TYPE);
@@ -500,6 +511,21 @@ public class WSSecurityConfiguration implements ConfigurationListener {
     }
 
     //}
+    
+    /**
+     * @param signature or encryption propertyMap
+     * @return
+     */
+    private boolean newConfigSpecified(Map<String, Object> propertyMap) {
+        Set <String> keys = propertyMap.keySet();
+        for (String key : keys) {
+            if (key.contains(WSSecurityConstants.WSS4J_2)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 
     /**
      * @return callback class name for this configuration.

--- a/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityConfiguration.java
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityConfiguration.java
@@ -327,7 +327,8 @@ public class WSSecurityConfiguration implements ConfigurationListener {
                             signaturePropertyMap.remove(key);
                         }
 
-                        defaultConfigMap.put(WSSecurityConstants.SEC_SIG_PROPS, signaturePropertyMap); //v3
+                        //defaultConfigMap.put(WSSecurityConstants.SEC_SIG_PROPS, signaturePropertyMap); //v3
+                        defaultConfigMap.put(WSSecurityConstants.CXF_SIG_PROPS, signaturePropertyMap); //v3 - backward compatibility
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                             Object sigProp = signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE) != null ? 
                                             signaturePropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE) : signaturePropertyMap.get(WSSecurityConstants.WSS4J_KS_TYPE);
@@ -367,7 +368,8 @@ public class WSSecurityConfiguration implements ConfigurationListener {
                         for (String key : SPECIAL_CFG_KEYS) {
                             encryptionPropertyMap.remove(key);
                         }
-                        defaultConfigMap.put(WSSecurityConstants.SEC_ENC_PROPS, encryptionPropertyMap); //v3
+                        //defaultConfigMap.put(WSSecurityConstants.SEC_ENC_PROPS, encryptionPropertyMap); //v3
+                        defaultConfigMap.put(WSSecurityConstants.CXF_ENC_PROPS, encryptionPropertyMap); //v3 - backward compatibility
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                             Object encProp = encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE) != null ? 
                                             encryptionPropertyMap.get(WSSecurityConstants.WSS4J_2_KS_TYPE): encryptionPropertyMap.get(WSSecurityConstants.WSS4J_KS_TYPE);

--- a/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityConstants.java
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityConstants.java
@@ -57,6 +57,10 @@ public class WSSecurityConstants {
     
     public static final String SEC_SIG_PROPS = SEC + ".signature.properties"; //v3
     public static final String SEC_ENC_PROPS = SEC + ".encryption.properties";  //v3
+    
+    public static final String WSS4J_CRYPTO_PROVIDER_NAME = "org.apache.ws.security.components.crypto.Merlin"; // this default value specified in the metatype
+    public static final String WSS4J_2_CRYPTO_PROVIDER_NAME = "org.apache.wss4j.common.crypto.Merlin";
+    
     public static final String SEC_NONCE_CACHE_CONFIG_FILE = SEC + ".cache.config.file"; //v3 this is not nonce cache , security token cache that cxf maintains
 
     public static final String CXF_SAML_CALLBACK_HANDLER = WSSEC + ".saml-callback-handler";

--- a/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityConstants.java
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,19 +25,39 @@ public class WSSecurityConstants {
     public static final String CXF_USER_NAME = WSSEC + ".username";
     public static final String CXF_USER_PASSWORD = WSSEC + ".password";
     public static final String CXF_CBH = WSSEC + ".callback-handler";
+    
+    public static final String SEC_USER_NAME = SEC + ".username"; //v3
+    public static final String SEC_USER_PASSWORD = SEC + ".password"; //v3
+    public static final String SEC_CBH = SEC + ".callback-handler";  //v3
 
-    public static final String WSS4J_KS_TYPE = "org.apache.ws.security.crypto.merlin.keystore.type";
-    public static final String WSS4J_KS_PASSWORD = "org.apache.ws.security.crypto.merlin.keystore.password";
-    public static final String WSS4J_KEY_PASSWORD = "org.apache.ws.security.crypto.merlin.keystore.private.password";
-    public static final String WSS4J_KS_ALIAS = "org.apache.ws.security.crypto.merlin.keystore.alias";
-    public static final String WSS4J_KS_FILE = "org.apache.ws.security.crypto.merlin.keystore.file";
-    public static final String WSS4J_CRYPTO_PROVIDER = "org.apache.ws.security.crypto.provider";
+    public static final String WSS4J_1 = "org.apache.ws.security.crypto"; //v3
+    public static final String WSS4J_2 = "org.apache.wss4j.crypto";  //v3
+    
+    public static final String WSS4J_KS_TYPE = WSS4J_1 + ".merlin.keystore.type";
+    public static final String WSS4J_KS_PASSWORD = WSS4J_1 + ".merlin.keystore.password";
+    public static final String WSS4J_KEY_PASSWORD = WSS4J_1 + ".merlin.keystore.private.password";
+    public static final String WSS4J_KS_ALIAS = WSS4J_1 + ".merlin.keystore.alias";
+    public static final String WSS4J_KS_FILE = WSS4J_1 + ".merlin.keystore.file";
+    public static final String WSS4J_CRYPTO_PROVIDER = WSS4J_1 + ".provider";
 
-    public static final String WSS4J_TS_PASSWORD = "org.apache.ws.security.crypto.merlin.truststore.password";
+    public static final String WSS4J_TS_PASSWORD = WSS4J_1 + ".merlin.truststore.password";
+    
+    public static final String WSS4J_2_KS_TYPE = WSS4J_2 + ".merlin.keystore.type";
+    public static final String WSS4J_2_KS_PASSWORD = WSS4J_2 + ".merlin.keystore.password";
+    public static final String WSS4J_2_KEY_PASSWORD = WSS4J_2 + ".merlin.keystore.private.password";
+    public static final String WSS4J_2_KS_ALIAS = WSS4J_2 + ".merlin.keystore.alias";
+    public static final String WSS4J_2_KS_FILE = WSS4J_2 + ".merlin.keystore.file";
+    public static final String WSS4J_2_CRYPTO_PROVIDER = WSS4J_2 + ".provider";
+
+    public static final String WSS4J_2_TS_PASSWORD = WSS4J_2 + ".merlin.truststore.password";
 
     public static final String CXF_SIG_PROPS = WSSEC + ".signature.properties";
     public static final String CXF_ENC_PROPS = WSSEC + ".encryption.properties";
     public static final String CXF_NONCE_CACHE_CONFIG_FILE = WSSEC + ".cache.config.file";
+    
+    public static final String SEC_SIG_PROPS = SEC + ".signature.properties"; //v3
+    public static final String SEC_ENC_PROPS = SEC + ".encryption.properties";  //v3
+    public static final String SEC_NONCE_CACHE_CONFIG_FILE = SEC + ".cache.config.file"; //v3 this is not nonce cache , security token cache that cxf maintains
 
     public static final String CXF_SAML_CALLBACK_HANDLER = WSSEC + ".saml-callback-handler";
     public static final String DEFAULT_SAML_CALLBACK_HANDLER = "com.ibm.ws.wssecurity.callback.Saml20PropagationCallbackHandler";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.endsuptokens/server_asym_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.endsuptokens/server_asym_wss4j.xml
@@ -81,21 +81,21 @@
 	<!-- basicplcy.wssecfvt.test.CommonPasswordCallback -->
 	<wsSecurityClient
 		id="default"
-		ws-security.password="{xor}LDo8Ki02KyY="
-		ws-security.username="user1"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
+		security.password="{xor}LDo8Ki02KyY="
+		security.username="user1"
+		security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
 	
 		<signatureProperties
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="{xor}EzY9Oi0rJgdqb2YcMzY6MSs="
-			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/x509ClientDefault.jks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="{xor}EzY9Oi0rJgdqb2YcMzY6MSs="
+			org.apache.wss4j.crypto.merlin.keystore.alias="x509ClientDefault"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/x509ClientDefault.jks" />
 		<encryptionProperties
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="{xor}EzY9Oi0rJgdqb2YcMzY6MStt"
-			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerSecondCert"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/x509ClientSecond.jks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="{xor}EzY9Oi0rJgdqb2YcMzY6MStt"
+			org.apache.wss4j.crypto.merlin.keystore.alias="x509ServerSecondCert"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/x509ClientSecond.jks" />
 	</wsSecurityClient>
 
 	<wsSecurityProvider
@@ -104,15 +104,15 @@
 	>
 	
 		<signatureProperties
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="{xor}EzY9Oi0rJgdqb2YMOi0pOi1t"
-			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerSecond"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/x509ServerSecond.jks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="{xor}EzY9Oi0rJgdqb2YMOi0pOi1t"
+			org.apache.wss4j.crypto.merlin.keystore.alias="x509ServerSecond"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/x509ServerSecond.jks" />
 		<encryptionProperties
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="{xor}EzY9Oi0rJgdqb2YMOi0pOi0="
-			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefaultCert"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/x509ServerDefault.jks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="{xor}EzY9Oi0rJgdqb2YMOi0pOi0="
+			org.apache.wss4j.crypto.merlin.keystore.alias="x509ClientDefaultCert"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/x509ServerDefault.jks" />
 	</wsSecurityProvider>
 
     <include location="imports/java2Permissions.xml" />

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.endsuptokens/server_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.endsuptokens/server_wss4j.xml
@@ -12,7 +12,7 @@
 <server>
 	<featureManager>
 		<feature>ssl-1.0</feature>
-		<feature>usr:wsseccbh-1.0</feature>
+		<feature>usr:wsseccbh-2.0</feature>
 		<feature>servlet-3.1</feature>
 		<feature>appSecurity-2.0</feature>
 		<feature>jsp-2.2</feature>
@@ -81,19 +81,19 @@
 	<!-- basicplcy.wssecfvt.test.CommonPasswordCallback -->
 	<wsSecurityClient
 		id="default"
-		ws-security.encryption.username="x509ServerSecondCert"
-		ws-security.password="security"
-		ws-security.username="user1"
+		security.encryption.username="x509ServerSecondCert"
+		security.password="security"
+		security.username="user1"
 	>
 		<!-- **Do not need the private key password in Symmetric tests ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"> -->
 		<!-- signatureProperties **Do not need Signature properties in Symmetric 
-			org.apache.ws.security.crypto.merlin.keystore.type="jks" org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client" 
-			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault" org.apache.ws.security.crypto.merlin.file="${server.config.dir}/x509ClientDefault.jks"/ -->
+			org.apache.wss4j.crypto.merlin.keystore.type="jks" org.apache.wss4j.crypto.merlin.keystore.password="LibertyX509Client" 
+			org.apache.wss4j.crypto.merlin.keystore.alias="x509ClientDefault" org.apache.wss4j.crypto.merlin.file="${server.config.dir}/x509ClientDefault.jks"/ -->
 		<encryptionProperties
-			org.apache.ws.security.crypto.merlin.truststore.type="jks"
-			org.apache.ws.security.crypto.merlin.truststore.password="LibertyX509Client2"
-			org.apache.ws.security.crypto.merlin.truststore.file="${server.config.dir}/x509ClientSecond.jks"
-			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerSecondCert" />
+			org.apache.wss4j.crypto.merlin.truststore.type="jks"
+			org.apache.wss4j.crypto.merlin.truststore.password="LibertyX509Client2"
+			org.apache.wss4j.crypto.merlin.truststore.file="${server.config.dir}/x509ClientSecond.jks"
+			org.apache.wss4j.crypto.merlin.keystore.alias="x509ServerSecondCert" />
 		<!-- / -->
 		<!-- ** This works too, in case ws-security.encryption.username is not 
 			specified chc -->
@@ -102,18 +102,18 @@
 
 	<wsSecurityProvider
 		id="default"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
+		security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
 	
 		<!-- signatureProperties **Do not need Signature properties in Symmetric 
-			org.apache.ws.security.crypto.merlin.keystore.type="jks" org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server" 
-			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefaultCert" 
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/x509ServerDefault.jks"/ -->
+			org.apache.wss4j.crypto.merlin.keystore.type="jks" org.apache.wss4j.crypto.merlin.keystore.password="LibertyX509Server" 
+			org.apache.wss4j.crypto.merlin.keystore.alias="x509ClientDefaultCert" 
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/x509ServerDefault.jks"/ -->
 		<encryptionProperties
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server2"
-			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerSecond"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/x509ServerSecond.jks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="LibertyX509Server2"
+			org.apache.wss4j.crypto.merlin.keystore.alias="x509ServerSecond"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/x509ServerSecond.jks" />
 	</wsSecurityProvider>
 
     <include location="imports/java2Permissions.xml" />

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_2048_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_2048_wss4j.xml
@@ -46,32 +46,32 @@
 
 	<wsSecurityProvider
 		id="default"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
-		ws-security.signature.username="soapprovider"
+		security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
+		security.signature.username="soapprovider"
 	>
 	
 		<signatureProperties
 			signatureAlgorithm="sha256"
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="server"
-			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/dsig-receiver-2048.ks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="server"
+			org.apache.wss4j.crypto.merlin.keystore.alias="soapprovider"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/dsig-receiver-2048.ks" />
 	</wsSecurityProvider>
 
 	<wsSecurityClient
 		id="default"
-		ws-security.password="security"
-		ws-security.username="user1"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
-		ws-security.signature.username="soaprequester"
+		security.password="security"
+		security.username="user1"
+		security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
+		security.signature.username="soaprequester"
 	>
 	
 		<signatureProperties
 			signatureAlgorithm="sha256"
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="client"
-			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/dsig-sender-2048.ks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="client"
+			org.apache.wss4j.crypto.merlin.keystore.alias="soaprequester"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/dsig-sender-2048.ks" />
 
 	</wsSecurityClient>
 	

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_orig_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_orig_wss4j.xml
@@ -46,32 +46,32 @@
 
 	<wsSecurityProvider
 		id="default"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
-		ws-security.signature.username="soapprovider"
+		security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
+		security.signature.username="soapprovider"
 	>
 	
 		<signatureProperties
 			signatureAlgorithm="sha256"
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="server"
-			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/dsig-receiver.ks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="server"
+			org.apache.wss4j.crypto.merlin.keystore.alias="soapprovider"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/dsig-receiver.ks" />
 	</wsSecurityProvider>
 
 	<wsSecurityClient
 		id="default"
-		ws-security.password="security"
-		ws-security.username="user1"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
-		ws-security.signature.username="soaprequester"
+		security.password="security"
+		security.username="user1"
+		security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
+		security.signature.username="soaprequester"
 	>
 	
 		<signatureProperties
 			signatureAlgorithm="sha256"
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="client"
-			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/dsig-sender.ks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="client"
+			org.apache.wss4j.crypto.merlin.keystore.alias="soaprequester"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/dsig-sender.ks" />
 
 	</wsSecurityClient>
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_sha1_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_sha1_wss4j.xml
@@ -47,31 +47,31 @@
 
 	<wsSecurityProvider
 		id="default"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
-		ws-security.signature.username="soapprovider"
+		security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
+		security.signature.username="soapprovider"
 	>
 	
 		<signatureProperties
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="server"
-			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/dsig-receiver.ks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="server"
+			org.apache.wss4j.crypto.merlin.keystore.alias="soapprovider"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/dsig-receiver.ks" />
 	</wsSecurityProvider>
 
 	<wsSecurityClient
 		id="default"
-		ws-security.password="security"
-		ws-security.username="user1"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
-		ws-security.signature.username="soaprequester"
+		security.password="security"
+		security.username="user1"
+		security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
+		security.signature.username="soaprequester"
 	>
 	
 		<signatureProperties
 			signatureAlgorithm="sha256"
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="client"
-			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/dsig-sender.ks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="client"
+			org.apache.wss4j.crypto.merlin.keystore.alias="soaprequester"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/dsig-sender.ks" />
 
 	</wsSecurityClient>
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_sha2_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_sha2_wss4j.xml
@@ -46,32 +46,32 @@
 
 	<wsSecurityProvider
 		id="default"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
-		ws-security.signature.username="soapprovider"
+		security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
+		security.signature.username="soapprovider"
 		ws-security.return.security.error="true"
 	>
 	
 		<signatureProperties
 			signatureAlgorithm="sha256"
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="server"
-			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/dsig-receiver.ks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="server"
+			org.apache.wss4j.crypto.merlin.keystore.alias="soapprovider"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/dsig-receiver.ks" />
 	</wsSecurityProvider>
      
 	<wsSecurityClient
 		id="default"
-		ws-security.password="security"
-		ws-security.username="user1"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
-		ws-security.signature.username="soaprequester"
+		security.password="security"
+		security.username="user1"
+		security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
+		security.signature.username="soaprequester"
 	>
 	
 		<signatureProperties
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="client"
-			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/dsig-sender.ks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="client"
+			org.apache.wss4j.crypto.merlin.keystore.alias="soaprequester"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/dsig-sender.ks" />
 
 	</wsSecurityClient>
 	

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_sha384_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_sha384_wss4j.xml
@@ -49,32 +49,32 @@
 
 	<wsSecurityProvider
 		id="default"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
-		ws-security.signature.username="soapprovider"
+		security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
+		security.signature.username="soapprovider"
 	>
 	
 		<signatureProperties
 			signatureAlgorithm="sha384"
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="server"
-			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/dsig-receiver.ks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="server"
+			org.apache.wss4j.crypto.merlin.keystore.alias="soapprovider"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/dsig-receiver.ks" />
 	</wsSecurityProvider>
 
 	<wsSecurityClient
 		id="default"
-		ws-security.password="security"
-		ws-security.username="user1"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
-		ws-security.signature.username="soaprequester"
+		security.password="security"
+		security.username="user1"
+		security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
+		security.signature.username="soaprequester"
 	>
 	
 		<signatureProperties
 			signatureAlgorithm="sha384"
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="client"
-			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/dsig-sender.ks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="client"
+			org.apache.wss4j.crypto.merlin.keystore.alias="soaprequester"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/dsig-sender.ks" />
 
 	</wsSecurityClient>
     

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_sha3sym_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_sha3sym_wss4j.xml
@@ -24,10 +24,10 @@
 
 	<wsSecurityClient
 		id="default"
-		ws-security.encryption.username="x509ServerSecondCert"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
-		ws-security.password="security"
-		ws-security.username="user1"
+		security.encryption.username="x509ServerSecondCert"
+		security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
+		security.password="security"
+		security.username="user1"
 	>
 	
 		<!-- **Do not need the private key password in Symmetric tests ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"> 
@@ -36,38 +36,38 @@
 			EndorsingSupportingToken BAX35 -->
 		<signatureProperties
 			signatureAlgorithm="sha384"
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client"
-			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
-			org.apache.ws.security.crypto.merlin.truststore.alias="x509ServerDefaultCert"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/x509ClientDefault.jks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="LibertyX509Client"
+			org.apache.wss4j.crypto.merlin.keystore.alias="x509ClientDefault"
+			org.apache.wss4j.crypto.merlin.truststore.alias="x509ServerDefaultCert"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/x509ClientDefault.jks" />
 		<encryptionProperties
-			org.apache.ws.security.crypto.merlin.truststore.type="jks"
-			org.apache.ws.security.crypto.merlin.truststore.password="LibertyX509Client2"
-			org.apache.ws.security.crypto.merlin.truststore.file="${server.config.dir}/x509ClientSecond.jks" />
+			org.apache.wss4j.crypto.merlin.truststore.type="jks"
+			org.apache.wss4j.crypto.merlin.truststore.password="LibertyX509Client2"
+			org.apache.wss4j.crypto.merlin.truststore.file="${server.config.dir}/x509ClientSecond.jks" />
 		<!-- ** This works too, in case ws-security.encryption.username is not 
-			specified org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerSecondCert" -->
+			specified org.apache.wss4j.crypto.merlin.keystore.alias="x509ServerSecondCert" -->
 	</wsSecurityClient>
 
 	<wsSecurityProvider
 		id="default"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
+		security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
 	
 		<!-- **Do not need Signature properties in Symmetric. But put back for 
 			EndorsingSupportingToken BAX35 -->
 		<signatureProperties
 			signatureAlgorithm="sha384"
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server"
-			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerDefault"
-			org.apache.ws.security.crypto.merlin.truststore.alias="x509ClientDefaultCert"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/x509ServerDefault.jks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="LibertyX509Server"
+			org.apache.wss4j.crypto.merlin.keystore.alias="x509ServerDefault"
+			org.apache.wss4j.crypto.merlin.truststore.alias="x509ClientDefaultCert"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/x509ServerDefault.jks" />
 		<encryptionProperties
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server2"
-			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerSecond"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/x509ServerSecond.jks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="LibertyX509Server2"
+			org.apache.wss4j.crypto.merlin.keystore.alias="x509ServerSecond"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/x509ServerSecond.jks" />
 	</wsSecurityProvider>
 
     <include location="imports/java2Permissions.xml" />

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_sha512_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_sha512_wss4j.xml
@@ -46,32 +46,32 @@
 
 	<wsSecurityProvider
 		id="default"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
-		ws-security.signature.username="soapprovider"
+		security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
+		security.signature.username="soapprovider"
 	>
 	
 		<signatureProperties
 			signatureAlgorithm="sha512"
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="server"
-			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/dsig-receiver.ks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="server"
+			org.apache.wss4j.crypto.merlin.keystore.alias="soapprovider"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/dsig-receiver.ks" />
 	</wsSecurityProvider>
 
 	<wsSecurityClient
 		id="default"
-		ws-security.password="security"
-		ws-security.username="user1"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
-		ws-security.signature.username="soaprequester"
+		security.password="security"
+		security.username="user1"
+		security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
+		security.signature.username="soaprequester"
 	>
 	
 		<signatureProperties
 			signatureAlgorithm="sha512"
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="client"
-			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/dsig-sender.ks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="client"
+			org.apache.wss4j.crypto.merlin.keystore.alias="soaprequester"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/dsig-sender.ks" />
 
 	</wsSecurityClient>
     

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_sha5sym_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_sha5sym_wss4j.xml
@@ -27,10 +27,10 @@
 	<!-- basicplcy.wssecfvt.test.CommonPasswordCallback -->
 	<wsSecurityClient
 		id="default"
-		ws-security.encryption.username="x509ServerSecondCert"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
-		ws-security.password="security"
-		ws-security.username="user1"
+		security.encryption.username="x509ServerSecondCert"
+		security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
+		security.password="security"
+		security.username="user1"
 	>
 	
 		<!-- **Do not need the private key password in Symmetric tests ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"> 
@@ -39,38 +39,38 @@
 			EndorsingSupportingToken BAX35 -->
 		<signatureProperties
 			signatureAlgorithm="sha512"
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client"
-			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
-			org.apache.ws.security.crypto.merlin.truststore.alias="x509ServerDefaultCert"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/x509ClientDefault.jks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="LibertyX509Client"
+			org.apache.wss4j.crypto.merlin.keystore.alias="x509ClientDefault"
+			org.apache.wss4j.crypto.merlin.truststore.alias="x509ServerDefaultCert"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/x509ClientDefault.jks" />
 		<encryptionProperties
-			org.apache.ws.security.crypto.merlin.truststore.type="jks"
-			org.apache.ws.security.crypto.merlin.truststore.password="LibertyX509Client2"
-			org.apache.ws.security.crypto.merlin.truststore.file="${server.config.dir}/x509ClientSecond.jks" />
+			org.apache.wss4j.crypto.merlin.truststore.type="jks"
+			org.apache.wss4j.crypto.merlin.truststore.password="LibertyX509Client2"
+			org.apache.wss4j.crypto.merlin.truststore.file="${server.config.dir}/x509ClientSecond.jks" />
 		<!-- ** This works too, in case ws-security.encryption.username is not 
-			specified org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerSecondCert" -->
+			specified org.apache.wss4j.crypto.merlin.keystore.alias="x509ServerSecondCert" -->
 	</wsSecurityClient>
 
 	<wsSecurityProvider
 		id="default"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
+		security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
 	
 		<!-- **Do not need Signature properties in Symmetric. But put back for 
 			EndorsingSupportingToken BAX35 -->
 		<signatureProperties
 			signatureAlgorithm="sha512"
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server"
-			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerDefault"
-			org.apache.ws.security.crypto.merlin.truststore.alias="x509ClientDefaultCert"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/x509ServerDefault.jks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="LibertyX509Server"
+			org.apache.wss4j.crypto.merlin.keystore.alias="x509ServerDefault"
+			org.apache.wss4j.crypto.merlin.truststore.alias="x509ClientDefaultCert"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/x509ServerDefault.jks" />
 		<encryptionProperties
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server2"
-			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerSecond"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/x509ServerSecond.jks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="LibertyX509Server2"
+			org.apache.wss4j.crypto.merlin.keystore.alias="x509ServerSecond"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/x509ServerSecond.jks" />
 	</wsSecurityProvider>
 
     <include location="imports/java2Permissions.xml" />

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_wss4j.xml
@@ -46,30 +46,30 @@
 
 	<wsSecurityProvider
 		id="default"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
-		ws-security.signature.username="soapprovider"
+                security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
+		security.signature.username="soapprovider"
 	>
 		<signatureProperties
 			signatureAlgorithm="sha256"
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="server"
-			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/dsig-receiver.ks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="server"
+			org.apache.wss4j.crypto.merlin.keystore.alias="soapprovider"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/dsig-receiver.ks" />
 	</wsSecurityProvider>
      
 	<wsSecurityClient
 		id="default"
-		ws-security.password="security"
-		ws-security.username="user1"
-		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
-		ws-security.signature.username="soaprequester"
+		security.password="security"
+		security.username="user1"
+                security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
+		security.signature.username="soaprequester"
 	>
 		<signatureProperties
 			signatureAlgorithm="sha256"
-			org.apache.ws.security.crypto.merlin.keystore.type="jks"
-			org.apache.ws.security.crypto.merlin.keystore.password="client"
-			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"
-			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/dsig-sender.ks" />
+			org.apache.wss4j.crypto.merlin.keystore.type="jks"
+			org.apache.wss4j.crypto.merlin.keystore.password="client"
+			org.apache.wss4j.crypto.merlin.keystore.alias="soaprequester"
+			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/dsig-sender.ks" />
 
 	</wsSecurityClient>
 	<!-- this is in use by CxfSha2SigTests -->

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/endsuptokensclient/src/com/ibm/ws/wssecurity/fat/endsuptokensclient/CxfEndSupTokensSvcClient.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/endsuptokensclient/src/com/ibm/ws/wssecurity/fat/endsuptokensclient/CxfEndSupTokensSvcClient.java
@@ -239,9 +239,9 @@ public class CxfEndSupTokensSvcClient extends HttpServlet {
             Map<String, Object> requestContext = dispSOAPMsg.getRequestContext();
             if (id != null) {
                 System.out.println("Setting id: " + id + " with password: "
-                                   + pw);
-                requestContext.put("ws-security.username", id);
-                requestContext.put("ws-security.password", pw);
+                                   + pw + " with the new configuration names security.username and security.password");
+                requestContext.put("security.username", id); //v3 change
+                requestContext.put("security.password", pw); //v3 change
             }
 
             // may want to make this set the properties some times, and other

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken/OneServerTests/CxfSAMLBasic1ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken/OneServerTests/CxfSAMLBasic1ServerTests.java
@@ -206,7 +206,7 @@ public class CxfSAMLBasic1ServerTests extends CxfSAMLBasicTests {
     }
 
     @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "java.util.MissingResourceException","org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void CxfSAMLBasicTests_wantAssertionsSignedTrue_missingSignatureEE8Only() throws Exception {
 


### PR DESCRIPTION
CXF WS-Security 3.x updated the names of configuration properties such as 

 - ws-security.username and ws-security.password and ws-security.signature.username
 - to 
 - security-username, security.password, security.signature.username

and WSS4J 2.3.x updated the config such as 

- org.apache.ws.security.crypto.* 
- to
- org.apache.wss4j.crypto.*

The ws-security feature / runtime (with xmlWS-3.0 , jaxws-2.3) should work with either old or new properties.