### PR TITLE
Issue #17742: Revert FAT skips after Yoko Jakarta Support

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/test-applications/StatefulPassivationWeb.war/src/com/ibm/ejb2x/base/pitt/web/PassivationRegressionServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/test-applications/StatefulPassivationWeb.war/src/com/ibm/ejb2x/base/pitt/web/PassivationRegressionServlet.java
@@ -46,7 +46,6 @@ import com.ibm.ejb2x.base.pitt.ejb.StatelessSessionHome;
 import com.ibm.websphere.ejbcontainer.test.tools.FATHelper;
 
 import componenttest.annotation.ExpectedFFDC;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 /**
@@ -223,8 +222,6 @@ public class PassivationRegressionServlet extends FATServlet {
      * </ul>
      */
     @Test
-    // TODO: Remove Skip when #17742 is fixed
-    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     @ExpectedFFDC({ "org.omg.CORBA.OBJECT_NOT_EXIST", "java.lang.RuntimeException", "com.ibm.websphere.csi.CSITransactionRolledbackException" })
     public void testTXRequiredExceptionCommit() throws Exception {
         CMEntityHome cmHome = FATHelper.lookupRemoteBinding(CMENTITY_HOME, CMEntityHome.class);
@@ -282,8 +279,6 @@ public class PassivationRegressionServlet extends FATServlet {
      * </ul>
      */
     @Test
-    // TODO: Remove Skip when #17742 is fixed
-    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     @ExpectedFFDC({ "org.omg.CORBA.OBJECT_NOT_EXIST", "java.lang.RuntimeException", "com.ibm.websphere.csi.CSITransactionRolledbackException" })
     public void testTXRequiredException() throws Exception {
         CMEntityHome cmHome = FATHelper.lookupRemoteBinding(CMENTITY_HOME, CMEntityHome.class);
@@ -618,8 +613,6 @@ public class PassivationRegressionServlet extends FATServlet {
      * </ul>
      */
     @Test
-    // TODO: Remove Skip when #17742 is fixed
-    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     @ExpectedFFDC({ "com.ibm.websphere.csi.CSITransactionRolledbackException" })
     public void testBMTLeftOpenCausesRollback() throws Exception {
         CMEntityHome cmHome = FATHelper.lookupRemoteBinding(CMENTITY_HOME, CMEntityHome.class);

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/BasicRemote.war/src/com/ibm/ws/ejbcontainer/remote/fat/basic/BasicRemoteTestServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/BasicRemote.war/src/com/ibm/ws/ejbcontainer/remote/fat/basic/BasicRemoteTestServlet.java
@@ -36,7 +36,6 @@ import org.omg.CosNaming.NamingContext;
 import org.omg.CosNaming.NamingContextHelper;
 
 import componenttest.annotation.ExpectedFFDC;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 @WebServlet("/BasicRemoteTestServlet")
@@ -212,8 +211,6 @@ public class BasicRemoteTestServlet extends FATServlet {
     }
 
     @Test
-    // TODO: Remove Skip when #17742 is fixed
-    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     @ExpectedFFDC({
                     "java.lang.reflect.InvocationTargetException",
                     "com.ibm.ws.ejbcontainer.remote.fat.basic.TestRollbackException",

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/StatelessAnnWeb.war/src/com/ibm/ws/ejbcontainer/remote/ejb3session/sl/ann/web/TxAttrComp2Servlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/StatelessAnnWeb.war/src/com/ibm/ws/ejbcontainer/remote/ejb3session/sl/ann/web/TxAttrComp2Servlet.java
@@ -40,7 +40,6 @@ import com.ibm.ws.ejbcontainer.remote.ejb3session.sl.ann.ejb.TxAttrEJBLocal;
 import com.ibm.ws.ejbcontainer.remote.ejb3session.sl.ann.ejb.TxAttrEJBLocalHome;
 
 import componenttest.annotation.ExpectedFFDC;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 /**
@@ -327,8 +326,6 @@ public class TxAttrComp2Servlet extends FATServlet {
      * javax.transaction.TransactionRequiredException.
      */
     @Test
-    // TODO: Remove Skip when #17742 is fixed
-    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     @ExpectedFFDC({ "com.ibm.websphere.csi.CSITransactionRequiredException" })
     public void testMandatoryAttribThrowsExcp_TxAttrComp2() throws Exception {
         try {

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/StatelessAnnWeb.war/src/com/ibm/ws/ejbcontainer/remote/ejb3session/sl/ann/web/TxAttrCompView2Servlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/StatelessAnnWeb.war/src/com/ibm/ws/ejbcontainer/remote/ejb3session/sl/ann/web/TxAttrCompView2Servlet.java
@@ -40,7 +40,6 @@ import com.ibm.ws.ejbcontainer.remote.ejb3session.sl.ann.ejb.TxAttrEJBLocal;
 import com.ibm.ws.ejbcontainer.remote.ejb3session.sl.ann.ejb.TxAttrEJBLocalHome;
 
 import componenttest.annotation.ExpectedFFDC;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 /**
@@ -323,8 +322,6 @@ public class TxAttrCompView2Servlet extends FATServlet {
      * javax.transaction.TransactionRequiredException.
      */
     @Test
-    // TODO: Remove Skip when #17742 is fixed
-    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     @ExpectedFFDC({ "com.ibm.websphere.csi.CSITransactionRequiredException" })
     public void testMandatoryAttribThrowsExcp_TxAttrCompView2() throws Exception {
         try {


### PR DESCRIPTION
Now that the Yoko ORB supports Jakarta packaging, revert the changes
to some FAT that skipped tests for Jakarta EE 9 due to exceptions
not using the correct jakarta packages. The tests will now run
with Jakarta EE 9 features.

for #17742 