### PR TITLE
Check for null BundleContext

### DIFF
--- a/dev/com.ibm.ws.app.manager.wab/src/com/ibm/ws/app/manager/wab/internal/WAB.java
+++ b/dev/com.ibm.ws.app.manager.wab/src/com/ibm/ws/app/manager/wab/internal/WAB.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corporation and others.
+ * Copyright (c) 2012, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.servlet.ServletContext;
 
 import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceRegistration;
@@ -474,13 +475,18 @@ class WAB implements BundleTrackerCustomizer<WAB> {
 
     private ServiceRegistration<ServletContext> scReg = null;
 
-    void registerServletContext(ServletContext sc) {
+    @FFDCIgnore(IllegalStateException.class)
+    void registerServletContext(ServletContext sc, BundleContext bc) {
         //Register the ServletContext in the service registry
         Dictionary<String, Object> scRegProps = new Hashtable<String, Object>(3);
         scRegProps.put("osgi.web.symbolicname", wabBundleSymbolicName);
         scRegProps.put("osgi.web.version", wabBundleVersion);
         scRegProps.put("osgi.web.contextpath", wabContextPath);
-        scReg = wabBundle.getBundleContext().registerService(ServletContext.class, sc, scRegProps);
+        try {
+            scReg = bc.registerService(ServletContext.class, sc, scRegProps);
+        } catch (IllegalStateException e) {
+            // ignore, but is likely stopped
+        }
     }
 
     @FFDCIgnore(IllegalStateException.class)

--- a/dev/com.ibm.ws.app.manager.wab/src/com/ibm/ws/app/manager/wab/internal/WABInstaller.java
+++ b/dev/com.ibm.ws.app.manager.wab/src/com/ibm/ws/app/manager/wab/internal/WABInstaller.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 IBM Corporation and others.
+ * Copyright (c) 2011, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1464,6 +1464,9 @@ public class WABInstaller implements EventHandler, ExtensionFactory, RuntimeUpda
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                         Tr.debug(tc, "Found WAB matching context path", iServletContext.getContextPath());
                     BundleContext wabBC = wab.getBundle().getBundleContext();
+                    if (wabBC == null) {
+                        return null;
+                    }
                     //Register the BundleContext as an attribute on the ServletContext
                     iServletContext.setAttribute("osgi-bundlecontext", wabBC);
                     // For Spring DM based applications register BundleContext under attribute that
@@ -1483,7 +1486,7 @@ public class WABInstaller implements EventHandler, ExtensionFactory, RuntimeUpda
                     esc.addMappingFilter("/*", fc);
                     //iServletContext.addFilter("/*", new OsgiDirectoryProtectionFilter());
                     //Register the ServletContext in the service registry
-                    wab.registerServletContext(iServletContext);
+                    wab.registerServletContext(iServletContext, wabBC);
                 }
                 return null;
             } else {


### PR DESCRIPTION
The bundle could be stopped or uninstalled which makes the
BundleContext be null.  We should handle this and carry on.
