### PR TITLE
Fix NPE in JAXRS metric with improper jwt

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/restmetrics/src/com/ibm/ws/jaxrs/fat/restmetrics/MetricsTestMonitorFilter.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/restmetrics/src/com/ibm/ws/jaxrs/fat/restmetrics/MetricsTestMonitorFilter.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.restmetrics;
+
+import java.io.IOException;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.annotation.Priority;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Monitor Class for RESTful Resource Methods.
+ */
+@Provider
+@Priority(1)
+public class MetricsTestMonitorFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+    @PostConstruct
+    public void postConstruct() {
+    }
+
+    @PreDestroy
+    public void preDestroy() {
+    }
+
+    /**
+     * Method : filter(ContainerRequestContext)
+     *
+     * @param reqCtx = Container request context
+     *
+     *            This method will be called whenever a request arrives for a
+     *            RESTful resource method.
+     *            All it does is save the current time so that the response
+     *            time can be calculated later.
+     *
+     */
+    @Override
+    public void filter(ContainerRequestContext reqCtx) throws IOException {
+        System.out.println("ContainerRequestContext.filter() has been invoked for path: " + reqCtx.getUriInfo().getPath());
+
+        if (reqCtx.getUriInfo().getPath().contains("abortTest")) {
+            System.out.println("ContainerRequestContext.filter() aborted.");
+            reqCtx.abortWith(Response.ok().build());
+        }
+
+
+    }
+
+    /**
+     * Method : filter(ContainerRequestContext, ContainerResponseContext)
+     *
+     * @param reqCtx = Container request context
+     * @param respCtx = Container response context
+     *
+     *            This method will be called whenever a response arrives from a
+     *            RESTful resource method.
+     *            It will calculate the cumulative response time for the resource
+     *            method and store the result in the REST_Stats MXBean.
+     *
+     */
+     @Override
+     public void filter(ContainerRequestContext reqCtx, ContainerResponseContext respCtx) throws IOException {
+         System.out.println("ContainerResponseContext.filter() has been invoked for path: " + reqCtx.getUriInfo().getPath());
+     }
+  }
+

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/restmetrics/src/com/ibm/ws/jaxrs/fat/restmetrics/RestMetricsApplication.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/restmetrics/src/com/ibm/ws/jaxrs/fat/restmetrics/RestMetricsApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ public class RestMetricsApplication extends Application {
     @Override
     public Set<Class<?>> getClasses() {
         Set<Class<?>> classes = new HashSet<Class<?>>();
+        classes.add(MetricsTestMonitorFilter.class);
         classes.add(RestMetricsResource.class);
         classes.add(MetricsCheckedExceptionMapper.class);
         classes.add(MetricsUncheckedExceptionMapper.class);

--- a/dev/com.ibm.ws.jaxrs.2.x.monitor/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.x.monitor/bnd.bnd
@@ -63,6 +63,7 @@ Liberty-Monitoring-Components:
 	com.ibm.ws.container.service;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
 	com.ibm.wsspi.org.osgi.service.component.annotations,\
+	com.ibm.ws.logging.core,\
 	com.ibm.ws.jaxrs.2.0.common
 
 jakartaeeMe: true


### PR DESCRIPTION
In the missing-jwt case the LibertyAuthFilter(ContainerRequestFilter) filter method is aborting and generating the expected 401.  As a result all other ContainerRequestFilters, including the JaxRsMonitorFilter are not run.  However, per design, the ContainerResponseFilters do run.  The JaxRsMonitorFilter (ContainerResponseFilter) relies on values set by the corresponding ContainerRequestFilter, but since that was not run an NPE results.   

This PR addresses this situation by detecting that the JaxRsMonitorFilter ContainerRequestFilter method has not been run and exits.   This PR also adds a testcase to ensure that metrics are not collected for the aborted method.

Fixes #18299