### PR TITLE
Fix listener destroy not call in the async error handling path

### DIFF
--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/WebContainerRequestState.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/WebContainerRequestState.java
@@ -110,7 +110,9 @@ public class WebContainerRequestState {
         if (_attributes==null) {
             _attributes=new HashMap();
         }
-        
+        if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) {  //306998.15
+            logger.logp(Level.FINE, CLASS_NAME,"setAttribute", " name --> " + string);
+        } 
         _attributes.put(string, obj);
     }
 	


### PR DESCRIPTION
fixes #18281

When the WC property deferServletRequestListenerDestroyOnError set to true AND there is an async dispatch error, listeners servlet request destroy is not invoked.