### PR TITLE
Remove dependency on MP Config from JAX-RS 3.0

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/restfulWSClient-3.0/io.openliberty.restfulWSClient-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/restfulWSClient-3.0/io.openliberty.restfulWSClient-3.0.feature
@@ -45,8 +45,7 @@ Subsystem-Name: Jakarta RESTful Web Services 3.0 Client
   com.ibm.ws.org.apache.httpcomponents, \
   com.ibm.ws.org.jboss.logging, \
   io.openliberty.org.jboss.resteasy.common.jakarta, \
-  io.openliberty.restfulWS.internal.globalhandler.jakarta, \
-  com.ibm.websphere.org.eclipse.microprofile.config.1.4; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.config:microprofile-config-api:1.4"
+  io.openliberty.restfulWS.internal.globalhandler.jakarta
 kind=beta
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/io.openliberty.org.jboss.resteasy.common/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.common/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -128,6 +128,7 @@ Import-Package: \
   !com.sun.xml.bind.marshaller, \
   !org.apache.cxf.*, \
   !org.apache.james.mime4j.*, \
+  !org.eclipse.microprofile.config.*, \
   !org.jboss.resteasy.plugins.providers.jaxb, \
   !org.jboss.resteasy.plugins.providers.validator, \
   !sun.misc, \


### PR DESCRIPTION
RESTEasy made it's dependency on MicroProfile Config to be optional.  We don't want to use it in Liberty (we want to keep the config function isolated - allowing the server to be leaner), so we (JAX-RS / RESTful WS 3.0) need to explicitly exclude that dependency.