### PR TITLE
Update package server conflict logic

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -106,7 +106,15 @@ File mavenDir = new File(project.buildDir, 'maven')
 class PackageLibertyWithFeatures extends DefaultTask {
     Closure withFeatures
     Boolean completeFeatureList
-    Boolean packageServerConflict
+    // packageServerConflict does not need to be set unless the list of features includes conflicting features
+    //
+    // It can be set to "true" to mean that the feature resolution logic will ignore singletons when there 
+    // is a conflict.  A side effect of this is that if there is a conflict, the "preferred" version will 
+    // be chosen (the version before the list of tolerates) which can choose the wrong private features.
+    //
+    // To solve the issues with the use of a value of "true", this property can be set to a comma separated
+    // list of base symbolic names (the feature name without the hyphen and version number).
+    String packageServerConflict
     File outputTo
 
     @TaskAction
@@ -367,7 +375,7 @@ if (isAutomatedBuild && !isIFIXBuild) {
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
         withFeatures this.&webProfile8Features
-        packageServerConflict = true
+        packageServerConflict = "true"
         outputTo packageDir
         doLast {
             copy {
@@ -394,7 +402,7 @@ if (isAutomatedBuild && !isIFIXBuild) {
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
         withFeatures this.&javaee8Features
-        packageServerConflict = true
+        packageServerConflict = "true"
         outputTo packageDir
         doLast {
             copy {
@@ -417,6 +425,7 @@ if (isAutomatedBuild && !isIFIXBuild) {
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
         withFeatures this.&jakartaee9Features
+        packageServerConflict = "com.ibm.websphere.appserver.sessionStore"
         outputTo packageDir
         doLast {
             ["$packageDir/wlp/NOTICES", "$packageDir/wlp/README.TXT", "$packageDir/wlp/lib/versions/openliberty.properties"].each { path ->
@@ -440,7 +449,7 @@ if (isAutomatedBuild && !isIFIXBuild) {
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
         withFeatures this.&microProfile4Features
-        packageServerConflict = true
+        packageServerConflict = "com.ibm.websphere.appserver.microProfile,com.ibm.websphere.appserver.mpHealth,com.ibm.websphere.appserver.org.eclipse.microprofile.health"
         outputTo packageDir
         doLast {
             copy {

--- a/dev/build.image/profiles/jakartaee9/features.xml
+++ b/dev/build.image/profiles/jakartaee9/features.xml
@@ -1,5 +1,9 @@
 <feature>jakartaee-9.0</feature>
 <feature>jakartaeeClient-9.0</feature>
 <feature>appSecurityClient-1.0</feature>
+<feature>monitor-1.0</feature>
+<feature>ldapRegistry-3.0</feature>
 <feature>localConnector-1.0</feature>
 <feature>transportSecurity-1.0</feature>
+<feature>sessionCache-1.0</feature>
+<feature>sessionDatabase-1.0</feature>

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jcaJ2eeManagement-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jcaJ2eeManagement-1.0.feature
@@ -1,6 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.jcaJ2eeManagement-1.0
-singleton=true
 IBM-Provision-Capability: osgi.identity;filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.jca-1.7))", \
  osgi.identity;filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.j2eeManagement-1.1))"
 IBM-Install-Policy: when-satisfied

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jdbcJ2eeManagement-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jdbcJ2eeManagement-1.0.feature
@@ -1,6 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.jdbcJ2eeManagement-1.0
-singleton=true
 IBM-Provision-Capability: osgi.identity;filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.jdbc-4.1)(osgi.identity=com.ibm.websphere.appserver.jdbc-4.2)(osgi.identity=com.ibm.websphere.appserver.jdbc-4.3)))", \
  osgi.identity;filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.j2eeManagement-1.1))"
 IBM-Install-Policy: when-satisfied

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mongodb-2.0-ssl.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mongodb-2.0-ssl.feature
@@ -1,7 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mongodb-2.0-ssl
 visibility=private
-singleton=true
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mongodb-2.0))", \
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.ssl-1.0))"
 -bundles=com.ibm.ws.mongo.ssl

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpConfig1.1-cdi1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpConfig1.1-cdi1.2.feature
@@ -1,7 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mpConfig1.1-cdi1.2
 visibility=private
-singleton=true
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpConfig-1.1))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.cdi-1.2)(osgi.identity=com.ibm.websphere.appserver.cdi-2.0)))"

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpConfig1.2-cdi1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpConfig1.2-cdi1.2.feature
@@ -1,7 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mpConfig1.2-cdi1.2
 visibility=private
-singleton=true
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpConfig-1.2)(osgi.identity=com.ibm.websphere.appserver.mpConfig-1.3)))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.cdi-1.2)(osgi.identity=com.ibm.websphere.appserver.cdi-2.0)))"

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpConfig1.4-cdi1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpConfig1.4-cdi1.2.feature
@@ -1,7 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mpConfig1.4-cdi1.2
 visibility=private
-singleton=true
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpConfig-1.4))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.cdi-1.2)(osgi.identity=com.ibm.websphere.appserver.cdi-2.0)))"

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpFaultTolerance-metrics.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpFaultTolerance-metrics.feature
@@ -1,6 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mpFaultTolerance-metrics
-singleton=true
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpFaultTolerance-1.1)(osgi.identity=com.ibm.websphere.appserver.mpFaultTolerance-2.0)))", \
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-1.1))"
 IBM-Install-Policy: when-satisfied

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpFaultTolerance-metrics2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpFaultTolerance-metrics2.0.feature
@@ -1,6 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mpFaultTolerance-metrics2.0
-singleton=true
 IBM-Provision-Capability: \
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpFaultTolerance-1.1)(osgi.identity=com.ibm.websphere.appserver.mpFaultTolerance-2.0)(osgi.identity=com.ibm.websphere.appserver.mpFaultTolerance-2.1)))", \
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpMetrics-2.0)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-2.2)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-2.3)))"

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpFaultTolerance1.0-cdi1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpFaultTolerance1.0-cdi1.2.feature
@@ -1,7 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mpFaultTolerance1.0-cdi1.2
 visibility=private
-singleton=true
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpFaultTolerance-1.0))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.cdi-1.2)(osgi.identity=com.ibm.websphere.appserver.cdi-2.0)))"

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpFaultTolerance1.1-cdi1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpFaultTolerance1.1-cdi1.2.feature
@@ -1,7 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mpFaultTolerance1.1-cdi1.2
 visibility=private
-singleton=true
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpFaultTolerance-1.1))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.cdi-1.2)(osgi.identity=com.ibm.websphere.appserver.cdi-2.0)))"

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpGraphQL1.0-appSecurity3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpGraphQL1.0-appSecurity3.0.feature
@@ -1,7 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mpGraphQL1.0-appSecurity3.0
 visibility=private
-singleton=true
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpGraphQL-1.0))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.appSecurity-2.0)(osgi.identity=com.ibm.websphere.appserver.appSecurity-3.0)))"

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpGraphQL1.0-metrics2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpGraphQL1.0-metrics2.3.feature
@@ -1,7 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mpGraphQL1.0-metrics2.3
 visibility=private
-singleton=true
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpGraphQL-1.0))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-2.3))"

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpMetrics-2.0-monitor-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpMetrics-2.0-monitor-1.0.feature
@@ -1,7 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mpMetrics-2.0-monitor-1.0
 visibility=private
-singleton=true
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-2.0))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.monitor-1.0)))"

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpMetrics-2.2-monitor-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpMetrics-2.2-monitor-1.0.feature
@@ -1,7 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mpMetrics-2.2-monitor-1.0
 visibility=private
-singleton=true
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-2.2))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.monitor-1.0)))"

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpMetrics-2.3-monitor-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpMetrics-2.3-monitor-1.0.feature
@@ -1,7 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mpMetrics-2.3-monitor-1.0
 visibility=private
-singleton=true
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-2.3))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.monitor-1.0)))"

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpMetrics-monitor-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpMetrics-monitor-1.0.feature
@@ -1,7 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mpMetrics-monitor-1.0
 visibility=private
-singleton=true
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-1.1))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.monitor-1.0)))"

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpMetrics1.0-cdi1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpMetrics1.0-cdi1.2.feature
@@ -1,7 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mpMetrics1.0-cdi1.2
 visibility=private
-singleton=true
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-1.0))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.cdi-1.2)(osgi.identity=com.ibm.websphere.appserver.cdi-2.0)))"

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpMetrics1.1-cdi1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpMetrics1.1-cdi1.2.feature
@@ -1,7 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mpMetrics1.1-cdi1.2
 visibility=private
-singleton=true
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-1.1))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.cdi-1.2)(osgi.identity=com.ibm.websphere.appserver.cdi-2.0)))"

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpMetrics2.0-cdi1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpMetrics2.0-cdi1.2.feature
@@ -1,7 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mpMetrics2.0-cdi1.2
 visibility=private
-singleton=true
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-2.0))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.cdi-1.2)(osgi.identity=com.ibm.websphere.appserver.cdi-2.0)))"

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpMetrics2.2-cdi1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpMetrics2.2-cdi1.2.feature
@@ -1,7 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mpMetrics2.2-cdi1.2
 visibility=private
-singleton=true
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-2.2))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.cdi-1.2)(osgi.identity=com.ibm.websphere.appserver.cdi-2.0)))"

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpOpenTracing1.3-mpRestClient1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpOpenTracing1.3-mpRestClient1.2.feature
@@ -1,7 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mpOpenTracing1.3-mpRestClient1.2
 visibility=private
-singleton=true
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpOpenTracing-1.3))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.2)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.3)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.4)))"

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpReactiveStreams1.0-cdi1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpReactiveStreams1.0-cdi1.2.feature
@@ -1,7 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mpReactiveStreams1.0-cdi1.2
 visibility=private
-singleton=true
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpReactiveStreams-1.0))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.cdi-1.2)(osgi.identity=com.ibm.websphere.appserver.cdi-2.0)))"

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpRestClient1.0-cdi1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpRestClient1.0-cdi1.2.feature
@@ -1,7 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mpRestClient1.0-cdi1.2
 visibility=private
-singleton=true
 IBM-API-Package: com.ibm.ws.microprofile.rest.client.cdi; type="internal"
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.0)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.1)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.2)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.3)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.4)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-2.0)))", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpFaultTolerance3.0-metrics.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpFaultTolerance3.0-metrics.feature
@@ -1,6 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.mpFaultTolerance3.0-metrics
-singleton=true
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpFaultTolerance-3.0))", \
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-3.0))"
 IBM-Install-Policy: when-satisfied

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpMetrics-3.0-monitor-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpMetrics-3.0-monitor-1.0.feature
@@ -1,7 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.mpMetrics-3.0-monitor-1.0
 visibility=private
-singleton=true
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-3.0))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.monitor-1.0)))"

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpOpenTracing2.0-mpRestClient2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpOpenTracing2.0-mpRestClient2.0.feature
@@ -1,7 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.mpOpenTracing2.0-mpRestClient2.0
 visibility=private
-singleton=true
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpOpenTracing-2.0))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-2.0))"

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
@@ -264,7 +264,7 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
     protected OnError onError;
 
     private final String CONFIG_PACKAGE_SERVER_CONFLICT = "package.server.conflict";
-    private Boolean packageServerConflict = Boolean.FALSE;
+    private Set<String> packageServerConflict = null;
 
     /** Cache for currently installed features (and for all information we know about features) */
     protected FeatureRepository featureRepository;
@@ -634,9 +634,21 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
         }
 
         onError = (OnError) configuration.get(OnErrorUtil.CFG_KEY_ON_ERROR);
-        packageServerConflict = (Boolean) configuration.get(CONFIG_PACKAGE_SERVER_CONFLICT);
-        if (packageServerConflict == null) {
-            packageServerConflict = Boolean.FALSE;
+        String packageServerConflictString = (String) configuration.get(CONFIG_PACKAGE_SERVER_CONFLICT);
+        if (packageServerConflictString != null) {
+            if (!packageServerConflictString.equalsIgnoreCase("false") && packageServerConflictString.length() != 0) {
+                packageServerConflict = new HashSet<>();
+                if (!packageServerConflictString.equalsIgnoreCase("true")) {
+                    int startingIndex = 0;
+                    int index = packageServerConflictString.indexOf(",");
+                    while (index != -1) {
+                        packageServerConflict.add(packageServerConflictString.substring(startingIndex, index).trim());
+                        startingIndex = index + 1;
+                        index = packageServerConflictString.indexOf(",", startingIndex);
+                    }
+                    packageServerConflict.add(packageServerConflictString.substring(startingIndex).trim());
+                }
+            }
         }
 
         String[] features = (String[]) configuration.get(CFG_KEY_ACTIVE_FEATURES);
@@ -1236,7 +1248,7 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
         Collection<String> restrictedRepoAccessAttempts = new ArrayList<String>();
         boolean allowMultipleVersions = false;
         boolean featureListIsComplete = false;
-        boolean currentPackageServerConflict = false;
+        Set<String> currentPackageServerConflict = null;
         if (ProvisioningMode.CONTENT_REQUEST == mode || ProvisioningMode.FEATURES_REQUEST == mode) {
             // allow multiple versions if in minify (TODO strange since we are minifying!)
             // For feature request using the minified approach but that could cause additional singletons to be provisioned.
@@ -1282,11 +1294,11 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
     }
 
     private Result callFeatureResolver(Repository restrictedRespository, Collection<ProvisioningFeatureDefinition> kernelFeatures, Set<String> rootFeatures,
-                                       boolean allowMultipleVersions, boolean currentPackageServerConflict) {
+                                       boolean allowMultipleVersions, Set<String> currentPackageServerConflict) {
 
         // short circuit if package server is expecting conflicts
-        if (currentPackageServerConflict) {
-            return featureResolver.resolveFeatures(restrictedRespository, kernelFeatures, rootFeatures, Collections.<String> emptySet(), true);
+        if (currentPackageServerConflict != null) {
+            return featureResolver.resolveFeatures(restrictedRespository, kernelFeatures, rootFeatures, Collections.<String> emptySet(), currentPackageServerConflict, EnumSet.allOf(ProcessType.class));
         }
         // resolve the features
         // TODO Note that we are just supporting all types at runtime right now.  In the future this may be restricted by the actual running process type

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/resolver/FeatureResolver.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/resolver/FeatureResolver.java
@@ -244,4 +244,19 @@ public interface FeatureResolver {
     public Result resolveFeatures(Repository repository, Collection<ProvisioningFeatureDefinition> kernelFeatures, Collection<String> rootFeatures, Set<String> preResolved,
                                   boolean allowMultipleVersions,
                                   EnumSet<ProcessType> supportedProcessTypes);
+
+    /**
+     * Resolves a collection of root features against a repository.
+     *
+     * @param repository              the feature repository to use
+     * @param kernelFeatures          the set of kernel features to use for auto-feature processing
+     * @param rootFeatures            the root features to resolve
+     * @param preResolved             the set of already resolved features to base the resolution delta off of
+     * @param allowedMultipleVersions the set that includes features that effectively ignore singletons (null means none, empty set means all)
+     * @param supportedProcessTypes   the supported process types to allow to be resolved
+     * @return the resolution result
+     */
+    public Result resolveFeatures(Repository repository, Collection<ProvisioningFeatureDefinition> kernelFeatures, Collection<String> rootFeatures, Set<String> preResolved,
+                                  Set<String> allowedMultipleVersions,
+                                  EnumSet<ProcessType> supportedProcessTypes);
 }

--- a/dev/com.ibm.ws.kernel.feature/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.kernel.feature/resources/OSGI-INF/metatype/metatype.xml
@@ -21,7 +21,7 @@
 		</AD> 
         <AD id="feature" name="%feature.name" description="%feature.desc" required="false" type="String" cardinality="2147483647"/>
         <AD id="package.server.conflict" name="internal" description="internal use only" 
-            type="Boolean" default="false" required="false"/>
+            type="String" default="false" required="false"/>
     </OCD>
   
     <Designate pid="com.ibm.ws.kernel.feature">


### PR DESCRIPTION
- Add the ability to pass in the list of features allowed to conflict instead of doing all features (old ability is still there and still used).
- Update auto features to not be marked as singletons and add a test to keep them not marked as singletons
- Update Jakarta EE 9 package to include sessionDatabase and sessionCache and other features to align with the other EE packages.