### PR TITLE
Allow oracle JDBC driver to log to seperate file

### DIFF
--- a/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
+++ b/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
@@ -303,7 +303,7 @@ META_DATA_EXCEPTION.useraction=Verify that the metadata is enabled on the backen
 # Do not translate: java.util.Logging
 ORACLE_TRACE_PARSE_WARNING=DSRA7043W: A default value was used for the {0} system property because of the following parsing error: {1}
 ORACLE_TRACE_PARSE_WARNING.explanation=The system property strings for Oracle are parsed and passed to the java.util.logging library. If a property value cannot be parsed, a default value is used instead.
-ORACLE_TRACE_PARSE_WARNING.useraction=Examine the parsing error, and modify the system property. Additional documentation for valid logging properties are documented within the java.util.logging package.
+ORACLE_TRACE_PARSE_WARNING.useraction=Examine the parsing error and modify the system property. The valid logging properties are documented within the java.util.logging package.
 
 ORACLE_TRACE_ENABLE_INFO=DSRA7044I: Oracle JDBC driver tracing was enabled via the {0} system property. One or more of the [{1}] system properties that are required to separate Oracle log files are missing.
 ORACLE_TRACE_ENABLE_INFO.explanation=The Oracle JDBC debug driver uses the java.util.logging package for tracing. By default, the Oracle JDBC debug logs will be integrated into Liberty logs. To configure Oracle JDBC debug trace separation, all of the properties in this message must be configured as system properties.

--- a/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
+++ b/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
@@ -306,7 +306,7 @@ ORACLE_TRACE_PARSE_WARNING.explanation=The system property strings for Oracle ar
 ORACLE_TRACE_PARSE_WARNING.useraction=Examine the parsing error and modify the system property. The valid logging properties are documented within the java.util.logging package.
 
 ORACLE_TRACE_ENABLE_INFO=DSRA7044I: Oracle JDBC driver tracing was enabled via the {0} system property. One or more of the [{1}] system properties that are required to separate Oracle log files are missing.
-ORACLE_TRACE_ENABLE_INFO.explanation=The Oracle JDBC debug driver uses the java.util.logging package for tracing. By default, the Oracle JDBC debug logs will be integrated into Liberty logs. To configure Oracle JDBC debug trace separation, all of the properties in this message must be configured as system properties.
+ORACLE_TRACE_ENABLE_INFO.explanation=The Oracle JDBC debug driver uses the java.util.logging package for tracing. The Oracle JDBC debug logs are integrated into Liberty logs by default. To configure Oracle JDBC debug trace separation, all of the properties in this message must be configured as system properties.
 ORACLE_TRACE_ENABLE_INFO.useraction=If you want to configure separated Oracle JDBC log files, check your system properties and add the missing properties. Otherwise, you can ignore this message.
 
 # 7600-7606 deleted

--- a/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
+++ b/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
@@ -305,7 +305,7 @@ ORACLE_TRACE_PARSE_WARNING=DSRA7043W: A default value was used for the {0} syste
 ORACLE_TRACE_PARSE_WARNING.explanation=The system property strings for Oracle are parsed and passed to the java.util.logging library. If a property value cannot be parsed, a default value is used instead.
 ORACLE_TRACE_PARSE_WARNING.useraction=Examine the parsing error and modify the system property. The valid logging properties are documented within the java.util.logging package.
 
-ORACLE_TRACE_ENABLE_INFO=DSRA7044I: Oracle JDBC driver tracing was enabled via the {0} system property. One or more of the [{1}] system properties that are required to separate Oracle log files are missing.
+ORACLE_TRACE_ENABLE_INFO=DSRA7044I: Oracle JDBC driver tracing was enabled by the {0} system property. One or more of the [{1}] system properties that are required to separate Oracle log files are missing.
 ORACLE_TRACE_ENABLE_INFO.explanation=The Oracle JDBC debug driver uses the java.util.logging package for tracing. The Oracle JDBC debug logs are integrated into Liberty logs by default. To configure Oracle JDBC debug trace separation, all of the properties in this message must be configured as system properties.
 ORACLE_TRACE_ENABLE_INFO.useraction=If you want to configure separated Oracle JDBC log files, check your system properties and add the missing properties. Otherwise, you can ignore this message.
 

--- a/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
+++ b/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2001, 2021 IBM Corporation and others.
+# Copyright (c) 2001, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -299,6 +299,16 @@ META_DATA_EXCEPTION.useraction=Verify that the metadata is enabled on the backen
 # 7019 deleted
 # 7020 reserved for other NLS file
 # 7021-7042 deleted
+
+# Do not translate: java.util.Logging
+ORACLE_TRACE_PARSE_WARNING=DSRA7043W: A default value was used for the {0} system property because of the following parsing error: {1}
+ORACLE_TRACE_PARSE_WARNING.explanation=The system property strings for Oracle are parsed and passed to the java.util.logging library. If a property value cannot be parsed, a default value is used instead.
+ORACLE_TRACE_PARSE_WARNING.useraction=Examine the parsing error, and modify the system property. Additional documentation for valid logging properties are documented within the java.util.logging package.
+
+ORACLE_TRACE_ENABLE_INFO=DSRA7044I: Oracle JDBC driver tracing was enabled via the {0} system property. One or more of the [{1}] system properties that are required to separate Oracle log files are missing.
+ORACLE_TRACE_ENABLE_INFO.explanation=The Oracle JDBC debug driver uses the java.util.logging package for tracing. By default, the Oracle JDBC debug logs will be integrated into Liberty logs. To configure Oracle JDBC debug trace separation, all of the properties in this message must be configured as system properties.
+ORACLE_TRACE_ENABLE_INFO.useraction=If you want to configure separated Oracle JDBC log files, check your system properties and add the missing properties. Otherwise, you can ignore this message.
+
 # 7600-7606 deleted
 
 # ----------------------------------------------------------------------------

--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/FATSuite.java
@@ -33,6 +33,7 @@ import oracle.jdbc.pool.OracleDataSource;
 
 @RunWith(Suite.class)
 @SuiteClasses({
+                OracleCustomTrace.class,
                 OracleTest.class,
                 OracleTraceTest.class,
                 OracleUCPTest.class,

--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleCustomTrace.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleCustomTrace.java
@@ -1,0 +1,242 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jdbc.fat.oracle;
+
+import static componenttest.custom.junit.runner.Mode.TestMode.FULL;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testcontainers.containers.OracleContainer;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+@Mode(FULL)
+@RunWith(FATRunner.class)
+public class OracleCustomTrace extends FATServletClient {
+
+    public static final String JEE_APP = "oracletracefat";
+    public static final String SERVLET_NAME = "OracleTraceTestServlet";
+    private static final String SSL_PASSWORD = "{xor}Lz4sLCgwLTtubw==";
+
+    /**
+     * Oracle tracing properties that can be set
+     */
+    private static final String ORACLELOG_ENABLE_TRACE = "-Doracle.jdbc.Trace",
+                    ORACLELOG_FILENAME = "-DoracleLogFileName",
+                    ORACLELOG_PACKAGENAME = "-DoracleLogPackageName",
+                    ORACLELOG_FILE_SIZE_LIMIT = "-DoracleLogFileSizeLimit",
+                    ORACLELOG_FILE_COUNT = "-DoracleLogFileCount",
+                    ORACLELOG_FORMAT = "-DoracleLogFormat",
+                    ORACLELOG_TRACELEVEL = "-DoracleLogTraceLevel";
+
+    /**
+     * Set of logging property keys
+     */
+    private static final List<String> loggingPropKeys = Arrays.asList(ORACLELOG_FILENAME, ORACLELOG_PACKAGENAME,
+                                                                      ORACLELOG_FILE_SIZE_LIMIT, ORACLELOG_FILE_COUNT,
+                                                                      ORACLELOG_FORMAT, ORACLELOG_TRACELEVEL);
+
+    private static final OracleContainer oracle = FATSuite.getSharedOracleContainer();
+    private static final Map<String, String> TIME_ZONE_OPTION = Collections.singletonMap("-Doracle.jdbc.timezoneAsRegion", "false");
+    private static final Map<String, String> TRACE_OPTION = Collections.singletonMap("-Doracle.jdbc.Trace", "true");
+
+    private static Map<String, String> serverJvmOptClone;
+
+    @Server("com.ibm.ws.jdbc.fat.oracle.trace")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        serverJvmOptClone = server.getJvmOptionsAsMap();
+        ShrinkHelper.defaultApp(server, JEE_APP, "trace.web");
+        //Do not start server, tests will do that
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server.isStarted()) {
+            server.stopServer("DSRA7043W");
+        }
+    }
+
+    private void restartServerWithNewLogging(Map<String, String> jvmOpts) throws Exception {
+        if (server.isStarted()) {
+            server.stopServer("DSRA7043W");
+        }
+
+        server.addEnvVar("URL", oracle.getJdbcUrl());
+        server.addEnvVar("USER", oracle.getUsername());
+        server.addEnvVar("PASSWORD", oracle.getPassword());
+        server.addEnvVar("SSL_PASSWORD", SSL_PASSWORD);
+
+        server.setJvmOptions(Stream.of(serverJvmOptClone, jvmOpts, TIME_ZONE_OPTION, TRACE_OPTION)
+                        .flatMap(m -> m.entrySet().stream())
+                        .collect(Collectors.toMap(Entry::getKey, Entry::getValue, (existing, replacement) -> existing)));
+
+        server.startServer(getTestMethodSimpleName() + ".log");
+    }
+
+    private Map<String, List<String>> findLoggingStringInTrace() throws Exception {
+        Map<String, List<String>> results = new HashMap<>(6);
+        //NOTE: using mark, so order is important here
+        results.put(ORACLELOG_FILENAME, server.findStringsInLogsAndTraceUsingMark(Pattern.quote("ORACLELOG_FILENAME")));
+        results.put(ORACLELOG_PACKAGENAME, server.findStringsInLogsAndTraceUsingMark(Pattern.quote("ORACLELOG_PACKAGENAME")));
+        results.put(ORACLELOG_FILE_SIZE_LIMIT, server.findStringsInLogsAndTraceUsingMark(Pattern.quote("ORACLELOG_FILE_SIZE_LIMIT")));
+        results.put(ORACLELOG_FILE_COUNT, server.findStringsInLogsAndTraceUsingMark(Pattern.quote("ORACLELOG_FILE_COUNT")));
+        results.put(ORACLELOG_FORMAT, server.findStringsInLogsAndTraceUsingMark(Pattern.quote("ORACLELOG_FORMAT")));
+        results.put(ORACLELOG_TRACELEVEL, server.findStringsInLogsAndTraceUsingMark(Pattern.quote("ORACLELOG_TRACELEVEL")));
+
+        return results;
+    }
+
+    @Test
+    public void testOracleCustomLogging() throws Exception {
+        Map<String, String> expectedValues = new HashMap<String, String>() {
+            private static final long serialVersionUID = 1L;
+            {
+                put(ORACLELOG_ENABLE_TRACE, "true");
+                put(ORACLELOG_FILENAME, "logs/oracle.log");
+                put(ORACLELOG_PACKAGENAME, "oracle.jdbc");
+                put(ORACLELOG_FILE_SIZE_LIMIT, "1000");
+                put(ORACLELOG_FILE_COUNT, "2");
+                put(ORACLELOG_FORMAT, "XMLFormatter");
+                put(ORACLELOG_TRACELEVEL, "FINE");
+            }
+        };
+        restartServerWithNewLogging(expectedValues);
+
+        server.setTraceMarkToEndOfDefaultTrace();
+        runTestWithResponse(server, JEE_APP + "/" + SERVLET_NAME, "testOracleLogging&iteration=1");
+
+        Map<String, List<String>> actualValues = findLoggingStringInTrace();
+
+        loggingPropKeys.stream().forEach(key -> {
+            assertEquals("Failed to find " + key + " in logs and trace", 1, actualValues.get(key).size());
+            assertTrue("Failed to verify " + key + " in logs and trace", actualValues.get(key).get(0).contains(expectedValues.get(key)));
+        });
+
+        //Ensure two files were created and named correctly
+        File oracleLog1 = Paths.get(server.getLogsRoot() + "oracle.0.0.log").toFile();
+        File oracleLog2 = Paths.get(server.getLogsRoot() + "oracle.1.0.log").toFile();
+        assertTrue("Expected to find oracle log file at: " + oracleLog1.getPath(), oracleLog1.isFile());
+        assertTrue("Expected to find oracle log file at: " + oracleLog2.getPath(), oracleLog2.isFile());
+
+        //Read all bytes into string and ensure package name and trace level were set correctly
+        //TODO what if oracle retains lock on file? This did not happen when testing locally, but is possible.
+        String oracleLog1str = new String(Files.readAllBytes(oracleLog1.toPath()));
+        assertTrue("Expected oracle log file to be using the oracle.jdbc logger", oracleLog1str.contains("<logger>oracle.jdbc</logger>"));
+        assertTrue("Expected oracle log file to be using the FINE trace level", oracleLog1str.contains("<level>CONFIG</level>"));
+
+        //Use a second datasource and ensure we do not setup custom logging again
+        server.setTraceMarkToEndOfDefaultTrace();
+        runTestWithResponse(server, JEE_APP + "/" + SERVLET_NAME, "testOracleLoggingAgain&iteration=2");
+        List<String> unexpectedLines = server.findStringsInLogsAndTraceUsingMark(Pattern.quote("ORACLELOG"));
+        assertEquals("Found lines in trace that show oracle custom logging was done more than once", 0, unexpectedLines.size());
+    }
+
+    @Test
+    public void testOracleCustomLoggingParseErrors() throws Exception {
+        Map<String, String> erronousConfig = new HashMap<String, String>() {
+            private static final long serialVersionUID = 1L;
+            {
+                //Valid required config
+                put(ORACLELOG_ENABLE_TRACE, "true");
+                put(ORACLELOG_FILENAME, "logs/oracle.log");
+                put(ORACLELOG_PACKAGENAME, "oracle.jdbc");
+                //Expected validation/parsing errors
+                put(ORACLELOG_FILE_SIZE_LIMIT, "-1");
+                put(ORACLELOG_FILE_COUNT, "0");
+                put(ORACLELOG_FORMAT, "my.custom.format.Class");
+                put(ORACLELOG_TRACELEVEL, "DEBUG");
+            }
+        };
+
+        Map<String, String> expectedValues = new HashMap<String, String>() {
+            private static final long serialVersionUID = 1L;
+            {
+                put(ORACLELOG_ENABLE_TRACE, "true");
+                put(ORACLELOG_FILENAME, "logs/oracle.log");
+                put(ORACLELOG_PACKAGENAME, "oracle.jdbc");
+                put(ORACLELOG_FILE_SIZE_LIMIT, "0");
+                put(ORACLELOG_FILE_COUNT, "1");
+                put(ORACLELOG_FORMAT, "SimpleFormatter");
+                put(ORACLELOG_TRACELEVEL, "INFO");
+            }
+        };
+        restartServerWithNewLogging(erronousConfig);
+
+        server.setTraceMarkToEndOfDefaultTrace();
+        runTestWithResponse(server, JEE_APP + "/" + SERVLET_NAME, "testOracleLogging&iteration=3");
+
+        Map<String, List<String>> actualValues = findLoggingStringInTrace();
+
+        loggingPropKeys.stream().forEach(key -> {
+            assertEquals("Failed to find " + key + " in logs and trace", 1, actualValues.get(key).size());
+            assertTrue("Failed to verify " + key + " in logs and trace", actualValues.get(key).get(0).contains(expectedValues.get(key)));
+        });
+
+        List<String> expectedErrorLines = server.findStringsInLogsAndTraceUsingMark("DSRA7043W");
+        assertEquals("Expected number or warnings not found for invalid config", 8, expectedErrorLines.size());
+
+        //Ensure file was created
+        File oracleLog = Paths.get(server.getLogsRoot() + "oracle.0.0.log").toFile();
+        assertTrue("Expected to find oracle log file at: " + oracleLog.getPath(), oracleLog.isFile());
+
+        //Ideally, we would want to make an assertion that this file contains logs.
+        //However, we have no guarantee that the Oracle driver has removed it's lock on the log file.
+        //Instead, assume if a log file was created, then the oracle driver is logging to it.
+    }
+
+    @Test
+    public void testOracleCustomLoggingInsuffcientConfig() throws Exception {
+        Map<String, String> insufficentConfig = new HashMap<String, String>() {
+            private static final long serialVersionUID = 1L;
+            {
+                put(ORACLELOG_ENABLE_TRACE, "true");
+                put(ORACLELOG_FILENAME, "logs/oracle.log");
+            }
+        };
+
+        restartServerWithNewLogging(insufficentConfig);
+
+        server.setTraceMarkToEndOfDefaultTrace();
+        runTestWithResponse(server, JEE_APP + "/" + SERVLET_NAME, "testOracleLogging&iteration=4");
+
+        List<String> expectedInfoLine = server.findStringsInLogsAndTraceUsingMark("DSRA7044I");
+        assertEquals("Expected to be informed of insufficient config", 2, expectedInfoLine.size());
+
+        //Ensure file was NOT created
+        File oracleLog = Paths.get(server.getLogsRoot() + "oracle.0.0.log").toFile();
+        assertTrue("Did not expect to find oracle log file at: " + oracleLog.getPath(), !oracleLog.isFile());
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleTraceTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleTraceTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import org.junit.AfterClass;
@@ -45,22 +46,25 @@ public class OracleTraceTest extends FATServletClient {
     @TestServlet(servlet = OracleTraceTestServlet.class, path = JEE_APP + "/" + SERVLET_NAME)
     public static LibertyServer server;
 
-    public static final OracleContainer oracle = FATSuite.getSharedOracleContainer();
+    private static final OracleContainer oracle = FATSuite.getSharedOracleContainer();
 
     @BeforeClass
     public static void setUp() throws Exception {
 
-        // Set server environment variables
         server.addEnvVar("URL", oracle.getJdbcUrl());
         server.addEnvVar("USER", oracle.getUsername());
         server.addEnvVar("PASSWORD", oracle.getPassword());
         server.addEnvVar("SSL_PASSWORD", SSL_PASSWORD);
 
+        Map<String, String> jvmOps = server.getJvmOptionsAsMap();
+        jvmOps.put("-Doracle.jdbc.timezoneAsRegion", "false");
+        jvmOps.put("-Doracle.jdbc.Trace", "true");
+
         // Create a normal Java EE application and export to server
         ShrinkHelper.defaultApp(server, JEE_APP, "trace.web");
 
         // Start Server
-        server.startServer();
+        server.startServer(OracleTraceTest.class.getName() + ".log");
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.trace/bootstrap.properties
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.trace/bootstrap.properties
@@ -10,7 +10,7 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-com.ibm.ws.logging.trace.specification=*=info:RRA=all
+com.ibm.ws.logging.trace.specification=*=info:RRA=all:WAS.database=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 ds.loglevel=debug

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.trace/jvm.options
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.trace/jvm.options
@@ -1,1 +1,0 @@
--Doracle.jdbc.timezoneAsRegion=false

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.trace/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.trace/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -33,9 +33,17 @@
     	<properties.oracle URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}"/>
     </dataSource>
     
-    <!-- This datasource is not intended to actually make an SSL connection to the oracle backend, 
-    instead we are just creating this datasource to ensure that the passwords in the connectionProperties are hidden in trace.-->
+    <dataSource id="default-dup" jndiName="jdbc/default-dup">
+    	<jdbcDriver libraryRef="DBLib"/>
+    	<properties.oracle URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}"/>
+    </dataSource>
+    
+	<!--
+	This datasource is not intended to actually make an SSL connection to the oracle backend, 
+    instead we are just creating this datasource to ensure that the passwords in the connectionProperties are hidden in trace. 
+    -->
     <dataSource id="conn-prop-ds" jndiName="jdbc/conn-prop-ds">
+    	<jdbcDriver libraryRef="DBLib"/>
     	<properties.oracle URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}" 
     	connectionProperties="
 	    	oracle.net.ssl_version=1.2;
@@ -45,12 +53,12 @@
 	    	javax.net.ssl.keyStorePassword=${env.SSL_PASSWORD};
 	    	javax.net.ssl.trustStore= path-to-keystore/keystore.p12;
 	    	javax.net.ssl.trustStoreType=PKCS12;
-	    	javax.net.ssl.trustStorePassword=${env.SSL_PASSWORD}"
+	    	javax.net.ssl.trustStorePassword=${env.SSL_PASSWORD}"    		
 	    	/>
-    	<jdbcDriver libraryRef="DBLib"/>
     </dataSource>
     
     <dataSource id="conn-prop-ds-generic" jndiName="jdbc/conn-prop-ds-generic">
+    	<jdbcDriver libraryRef="DBLib"/>
     	<properties URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}"
     	connectionProperties="
 	    	oracle.net.ssl_version=1.2;
@@ -62,7 +70,6 @@
 	    	javax.net.ssl.trustStoreType=PKCS12;
 	    	javax.net.ssl.trustStorePassword=${env.SSL_PASSWORD}"
 	    	/>
-    	<jdbcDriver libraryRef="DBLib"/>
     </dataSource>
     
     <javaPermission codebase="${shared.resource.dir}/oracle/oracleunknown.jar" className="java.security.AllPermission"/>

--- a/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oracletracefat/src/trace/web/OracleTraceTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oracletracefat/src/trace/web/OracleTraceTestServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,6 +19,8 @@ import java.sql.SQLException;
 import javax.annotation.Resource;
 import javax.annotation.sql.DataSourceDefinition;
 import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 
 import org.junit.Test;
@@ -46,6 +48,12 @@ import componenttest.app.FATServlet;
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/OracleTraceTestServlet")
 public class OracleTraceTestServlet extends FATServlet {
+
+    @Resource //The default datasource
+    private DataSource ds;
+
+    @Resource(lookup = "jdbc/default-dup")
+    private DataSource ds_dup;
 
     @Resource(lookup = "jdbc/conn-prop-ds")
     private DataSource conn_prop_ds;
@@ -84,7 +92,6 @@ public class OracleTraceTestServlet extends FATServlet {
         insert(conn_prop_dsd, 3, "three");
     }
 
-    //started from test class and verifies info message is only logged once
     public void testReadOnlyInfo() throws Exception {
         try (Connection conn = conn_prop_ds.getConnection();
                         PreparedStatement ps = conn.prepareStatement("INSERT INTO MYTABLE VALUES(?,?)");) {
@@ -101,5 +108,21 @@ public class OracleTraceTestServlet extends FATServlet {
             ps.setString(2, "five");
             ps.executeUpdate();
         }
+    }
+
+    public void testOracleLogging(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        if (request.getParameter("iteration") == null) {
+            throw new RuntimeException("iteration null");
+        }
+        Integer iteration = Integer.parseInt(request.getParameter("iteration"));
+        insert(ds, 10 + iteration, "tens");
+    }
+
+    public void testOracleLoggingAgain(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        if (request.getParameter("iteration") == null) {
+            throw new RuntimeException("iteration null");
+        }
+        Integer iteration = Integer.parseInt(request.getParameter("iteration"));
+        insert(ds_dup, 10 + iteration, "tens");
     }
 }


### PR DESCRIPTION
Simple solution for the Oracle JDBC driver to log to a separate file, but likely not a final solution we want to provide to customers. Related to #18370 