### PR TITLE
Address some wsoc defects

### DIFF
--- a/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/endpoints/client/basic/BasicClientEP.java
+++ b/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/endpoints/client/basic/BasicClientEP.java
@@ -45,6 +45,7 @@ public class BasicClientEP implements TestHelper {
         @OnMessage
         public String echoText(String data) {
 
+            LOG.info("DEBUG: BasicClientEP$TestOnOpen.echoText Recieving data -> " + data);
             _wtr.addMessage(data);
 
             if (_wtr.limitReached()) {
@@ -60,6 +61,7 @@ public class BasicClientEP implements TestHelper {
         public void onOpen(Session sess) {
             try {
                 String s = _data[_counter++];
+                LOG.info("DEBUG: BasicClientEP$TestOnOpen.onOpen Sending data to Remote -> " + s);
                 sess.getBasicRemote().sendText(s);
             } catch (Exception e) {
                 _wtr.addExceptionAndTerminate("Error publishing initial message", e);
@@ -85,7 +87,7 @@ public class BasicClientEP implements TestHelper {
 
         @OnMessage
         public String echoText(String data) {
-
+            LOG.info("DEBUG: BasicClientEP$TestOnClose.echoText Recieving data -> " + data);
             _wtr.addMessage(data);
 
             if (_wtr.limitReached()) {
@@ -101,6 +103,7 @@ public class BasicClientEP implements TestHelper {
         public void onOpen(Session sess) {
             try {
                 String s = _data[_counter++];
+                LOG.info("DEBUG: BasicClientEP$TestOnClose.onOpen Sending data to Remote -> " + s);
                 sess.getBasicRemote().sendText(s);
             } catch (Exception e) {
                 _wtr.addExceptionAndTerminate("Error publishing initial message", e);
@@ -127,7 +130,7 @@ public class BasicClientEP implements TestHelper {
 
         @OnMessage
         public String echoText(String data) {
-            LOG.info("BasicClientEP.TestOnError.echoText() " + data);
+            LOG.info("DEBUG: BasicClientEP.TestOnError.echoText Recieving data -> " + data);
 
             _wtr.addMessage(data);
 
@@ -145,6 +148,7 @@ public class BasicClientEP implements TestHelper {
             try {
                 String s = _data[_counter++];
                 sess.getBasicRemote().sendText(s);
+                LOG.info("DEBUG: BasicClientEP.TestOnError.onOpen Sending data to Remote -> " + s);
             } catch (Exception e) {
                 _wtr.addExceptionAndTerminate("Error publishing initial message", e);
 

--- a/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/util/wsoc/MultiClientRunner.java
+++ b/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/util/wsoc/MultiClientRunner.java
@@ -142,6 +142,9 @@ public class MultiClientRunner {
                 }
             }
 
+            // Wait for onOpen call to complete on the other endpoint (_uri side)
+            java.lang.Thread.sleep(50);
+
             if (_publishTask != null) {
                 _publishTask.setMultiTestContext(mctr);
                 publishExecutor = Executors.newSingleThreadExecutor();

--- a/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/util/wsoc/WsocTestRunner.java
+++ b/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/util/wsoc/WsocTestRunner.java
@@ -112,7 +112,7 @@ public class WsocTestRunner {
         }
 
         // We've had some test failures that are not found in local env and some builds.  This short wait should flesh them out locally...
-        java.lang.Thread.sleep(50);
+        java.lang.Thread.sleep(250);
         if (sess.isOpen()) {
             LOG.info("Reached max messages or test timeout, closing wsoc session");
             if (!_wtr.getClosedAlready()) {

--- a/dev/io.openliberty.wsoc.internal_fat/publish/servers/basicTestServer/server.xml
+++ b/dev/io.openliberty.wsoc.internal_fat/publish/servers/basicTestServer/server.xml
@@ -30,8 +30,6 @@
 
     <wasJmsEndpoint host="localhost" wasJmsPort="${bvt.prop.jms}" wasJmsSSLPort="${bvt.prop.jms.ssl}" />
     
-    <logging maxFileSize="50" maxFiles="3" traceFileName="wsocTrace.log" traceSpecification="*=info:com.ibm.ws.webcontainer.*=all:com.ibm.wsspi.webcontainer.*=all:com.ibm.ws.webcontainer31.*=all:ChannelFramework=all:HTTPChannel=all:TCPChannel=all:websockets=all:com.ibm.ws.runtime.update.*=all"/> 
-   
     <javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
     <javaPermission className="java.lang.RuntimePermission" name="modifyThread"/>  
     <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/> 

--- a/dev/io.openliberty.wsoc.internal_fat/test-applications/basic.war/src/basic/war/PathParamBasicServerEP.java
+++ b/dev/io.openliberty.wsoc.internal_fat/test-applications/basic.war/src/basic/war/PathParamBasicServerEP.java
@@ -13,6 +13,8 @@ package basic.war;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
+
 
 import javax.websocket.CloseReason;
 import javax.websocket.EndpointConfig;
@@ -29,6 +31,8 @@ import javax.websocket.server.ServerEndpoint;
  */
 public class PathParamBasicServerEP {
 
+    private static final Logger LOG = Logger.getLogger(PathParamBasicServerEP.class.getName());
+
     public String onOpenParamValue;
     //declared as static to preserve the value from onClose() until next invocation on onMessage() in ErrorTest
     public static String onCloseParamValue;
@@ -39,6 +43,7 @@ public class PathParamBasicServerEP {
     public static class TestOnOpen extends PathParamBasicServerEP {
         @OnMessage
         public String echoText(Session sess, String text) {
+            LOG.info("DEBUG: PathParamBasicServerEP$TestOnOpen.echoText Recieved data -> " + text);
             String returnText = null;
             if (onOpenParamValue != null) {
                 returnText = text + "," + onOpenParamValue;
@@ -57,6 +62,7 @@ public class PathParamBasicServerEP {
                     returnText = returnText + "," + ltwo.get(0);
                 }
             }
+            LOG.info("DEBUG: PathParamBasicServerEP$TestOnOpen.echoText Sending data -> " + returnText);
             return returnText;
         }
 
@@ -64,6 +70,7 @@ public class PathParamBasicServerEP {
         public void onOpen(final Session session, EndpointConfig ec, @PathParam("Integer-var") Integer integerVar) {
             if (session != null && ec != null) { //if the session & EndpointConfig are declared, runtime should be passing them in
                 onOpenParamValue = integerVar.toString();
+                LOG.info("DEBUG: PathParamBasicServerEP$TestOnOpen.onOpen Set onOpenParamValue to  " + integerVar);
             }
         }
 
@@ -72,6 +79,7 @@ public class PathParamBasicServerEP {
             try {
                 if (session != null && reason != null) { //if the session & CloseReason are declared, runtime should be passing them in
                     onCloseParamValue = stringVar;
+                    LOG.info("DEBUG: PathParamBasicServerEP$TestOnOpen.onClose Set onCloseParamValue to  " + stringVar);
                     session.close();
                 }
             } catch (IOException e) {
@@ -142,10 +150,12 @@ public class PathParamBasicServerEP {
     public static class TestOnClose extends PathParamBasicServerEP {
         @OnMessage
         public String echoText(String text) {
+            LOG.info("DEBUG: PathParamBasicServerEP$TestOnClose.echoText Recieved data ->  " + text);
             String returnText = null;
             if (onCloseParamValue != null) {
                 returnText = text + "," + onCloseParamValue;
             }
+            LOG.info("DEBUG: PathParamBasicServerEP$TestOnClose.echoText Sending 'text,onCloseParamValue' ->  " + returnText);
             return returnText;
         }
 
@@ -153,6 +163,7 @@ public class PathParamBasicServerEP {
         public void onOpen(final Session session, EndpointConfig ec, @PathParam("Integer-var") Integer integerVar) {
             if (session != null && ec != null) { //if the session & EndpointConfig are declared, runtime should be passing them in
                 onOpenParamValue = integerVar.toString();
+                LOG.info("DEBUG: PathParamBasicServerEP$TestOnClose.onOpen Set onOpenParamValue to  " + integerVar);
             }
         }
 
@@ -161,6 +172,7 @@ public class PathParamBasicServerEP {
             try {
                 if (session != null && reason != null) { //if the session & CloseReason are declared, runtime should be passing them in
                     onCloseParamValue = stringVar;
+                    LOG.info("DEBUG: PathParamBasicServerEP$TestOnClose.onClose Set onCloseParamValue to  " + stringVar);
                     session.close();
                 }
             } catch (IOException e) {


### PR DESCRIPTION
1) Increasing the wait to allow connections to finish processing. This is a temporary solution for now, I would like to pursue #18376 later on.  (For defects 283549, 286074 )

2) Add logging to the `TestSSCPathParamOnOpenAndTestOnClose` endpoints since I'm not sure what exacting is occurring in Defect 283838.

3) Fix trace in basicTestServer 


