### PR TITLE
update wsscxf.1 FAT with conditional check for split

### DIFF
--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sha2sig/CxfSha2SigTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sha2sig/CxfSha2SigTests.java
@@ -11,9 +11,7 @@
 
 package com.ibm.ws.wssecurity.fat.cxf.sha2sig;
 
-import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
-import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 
 import java.io.File;
 import java.util.Set;
@@ -48,6 +46,8 @@ public class CxfSha2SigTests extends CommonTests {
     static final private String serverName = "com.ibm.ws.wssecurity_fat.sha2sig";
 
     static private final Class<?> thisClass = CxfSha2SigTests.class;
+    //issue 18363
+    private static String featureVersion = "";
 
     @Server(serverName)
     public static LibertyServer server;
@@ -60,11 +60,15 @@ public class CxfSha2SigTests extends CommonTests {
         if (features.contains("usr:wsseccbh-1.0")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
+            //issue 18363
+            featureVersion = "EE7";
         }
         if (features.contains("usr:wsseccbh-2.0")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+            //issue 18363
+            featureVersion = "EE8";
         }
 
         ShrinkHelper.defaultDropinApp(server, "sha2sigclient", "com.ibm.ws.wssecurity.fat.sha2sigclient", "test.wssecfvt.sha2sig", "test.wssecfvt.sha2sig.types");
@@ -88,45 +92,18 @@ public class CxfSha2SigTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testCxfSha2SignSoapBodyEE7Only() throws Exception {
-
-        String thisMethod = "testCxfSha2SignSoapBody";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "Sha2SigService1",
-                    // wsdl that the svc client code should use
-                    //newClientWsdl,
-                    "",
-                    // wsdl port that svc client code should use
-                    "UrnSha2Sig1",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Response: This is WSSECFVT SHA2 Web Service.",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
-
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCxfSha2SignSoapBodyEE8Only() throws Exception {
+    public void testCxfSha2SignSoapBody() throws Exception {
 
         String thisMethod = "testCxfSha2SignSoapBody";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+        } //End of issue 18363
+
         genericTest(
                     // test name for logging
                     thisMethod,
@@ -165,45 +142,18 @@ public class CxfSha2SigTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testCxfSha2DigestAlgorithmEE7Only() throws Exception {
-
-        String thisMethod = "testCxfSha2DigestAlgorithm";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "Sha2SigService2",
-                    // wsdl that the svc client code should use
-                    //newClientWsdl,
-                    "",
-                    // wsdl port that svc client code should use
-                    "UrnSha2Sig2",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "This is WSSECFVT SHA256 Digest Web Service.",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
-
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCxfSha2DigestAlgorithmEE8Only() throws Exception {
+    public void testCxfSha2DigestAlgorithm() throws Exception {
 
         String thisMethod = "testCxfSha2DigestAlgorithm";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+        } //End of issue 18363
+
         genericTest(
                     // test name for logging
                     thisMethod,
@@ -241,11 +191,18 @@ public class CxfSha2SigTests extends CommonTests {
      *
      */
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testCxfSha384SigAlgorithmEE7Only() throws Exception {
+    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    public void testCxfSha384SigAlgorithm() throws Exception {
 
         String thisMethod = "testTwasSha384SigAlgorithm";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha384.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha384.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha384_wss4j.xml");
+        } //End of issue 18363
+
         genericTest(
                     // test name for logging
                     thisMethod,
@@ -271,45 +228,13 @@ public class CxfSha2SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
 
-        //Added to resolve RTC 285315
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
-
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCxfSha384SigAlgorithmEE8Only() throws Exception {
-
-        String thisMethod = "testCxfSha384SigAlgorithm";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha384_wss4j.xml");
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "Sha2SigService3",
-                    // wsdl that the svc client code should use
-                    //newClientWsdl,
-                    "",
-                    // wsdl port that svc client code should use
-                    "UrnSha2Sig3",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Response: This is WSSECFVT SHA384 Web Service.",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
-
-        //Added to resolve RTC 285315
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+        } //End of issue 18363
 
     }
 
@@ -323,11 +248,18 @@ public class CxfSha2SigTests extends CommonTests {
      *
      */
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testCxfSha512SigAlgorithmEE7Only() throws Exception {
+    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    public void testCxfSha512SigAlgorithm() throws Exception {
 
         String thisMethod = "testTwasSha512SigAlgorithm";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha512.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha512.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha512_wss4j.xml");
+        } //End of issue 18363
+
         genericTest(
                     // test name for logging
                     thisMethod,
@@ -353,45 +285,13 @@ public class CxfSha2SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
 
-        //Added to resolve RTC 285315
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
-
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCxfSha512SigAlgorithmEE8Only() throws Exception {
-
-        String thisMethod = "testCxfSha512SigAlgorithm";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha512_wss4j.xml");
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "Sha2SigService4",
-                    // wsdl that the svc client code should use
-                    //newClientWsdl,
-                    "",
-                    // wsdl port that svc client code should use
-                    "UrnSha2Sig4",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Response: This is WSSECFVT SHA512 Web Service.",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
-
-        //Added to resolve RTC 285315
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+        } //End of issue 18363
 
     }
 
@@ -408,83 +308,76 @@ public class CxfSha2SigTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    public void testCxfSha1ToSha2SigAlgorithmEE7Only() throws Exception {
-
-        String thisMethod = "testCxfSha1ToSha2SigAlgorithm";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha2.xml");
-
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "Sha2SigService5",
-                    // wsdl that the svc client code should use
-                    // newClientWsdl,
-                    "",
-                    // wsdl port that svc client code should use
-                    "UrnSha2Sig5",
-                    // msg to send from svc client to server
-                    "",
-                    "Response: javax.xml.ws.soap.SOAPFaultException",
-                    // expected response from server
-                    //Orig:
-                    "The signature method does not match the requirement",
-
-                    // msg to issue if do NOT get the expected result
-                    "The test did not receive the expected exception from the server.");
-
-        //Added to resolve RTC 285315
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
-
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException", "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCxfSha1ToSha2SigAlgorithmEE8Only() throws Exception {
+    public void testCxfSha1ToSha2SigAlgorithm() throws Exception {
 
         String thisMethod = "testCxfSha1ToSha2SigAlgorithm";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha2_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha2.xml");
+            genericTest(
+                        // test name for logging
+                        thisMethod,
+                        // Svc Client Url that generic test code should use
+                        clientHttpUrl,
+                        // Port that svc client code should use
+                        "",
+                        // user that svc client code should use
+                        "user1",
+                        // pw that svc client code should use
+                        "security",
+                        // wsdl sevice that svc client code should use
+                        "Sha2SigService5",
+                        // wsdl that the svc client code should use
+                        // newClientWsdl,
+                        "",
+                        // wsdl port that svc client code should use
+                        "UrnSha2Sig5",
+                        // msg to send from svc client to server
+                        "",
+                        "Response: javax.xml.ws.soap.SOAPFaultException",
+                        // expected response from server
+                        "The signature method does not match the requirement",
+                        // msg to issue if do NOT get the expected result
+                        "The test did not receive the expected exception from the server.");
 
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "Sha2SigService5",
-                    // wsdl that the svc client code should use
-                    // newClientWsdl,
-                    "",
-                    // wsdl port that svc client code should use
-                    "UrnSha2Sig5",
-                    // msg to send from svc client to server
-                    "",
-                    "Response: javax.xml.ws.soap.SOAPFaultException",
-                    // expected response from server
-                    //2/2021
-                    "An error was discovered processing the <wsse:Security> header",
-                    // msg to issue if do NOT get the expected result
-                    "The test did not receive the expected exception from the server.");
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
 
-        //Added to resolve RTC 285315
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+        } //End of issue 18363
+
+        //issue 18363
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha2_wss4j.xml");
+            genericTest(
+                        // test name for logging
+                        thisMethod,
+                        // Svc Client Url that generic test code should use
+                        clientHttpUrl,
+                        // Port that svc client code should use
+                        "",
+                        // user that svc client code should use
+                        "user1",
+                        // pw that svc client code should use
+                        "security",
+                        // wsdl sevice that svc client code should use
+                        "Sha2SigService5",
+                        // wsdl that the svc client code should use
+                        // newClientWsdl,
+                        "",
+                        // wsdl port that svc client code should use
+                        "UrnSha2Sig5",
+                        // msg to send from svc client to server
+                        "",
+                        "Response: javax.xml.ws.soap.SOAPFaultException",
+                        // expected response from server
+                        "An error was discovered processing the <wsse:Security> header",
+                        // msg to issue if do NOT get the expected result
+                        "The test did not receive the expected exception from the server.");
+
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+
+        } //End of issue 18363
 
     }
 
@@ -500,11 +393,18 @@ public class CxfSha2SigTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testCxfSha256SigAlg2048KeylenEE7Only() throws Exception {
+    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    public void testCxfSha256SigAlg2048Keylen() throws Exception {
 
         String thisMethod = "testCxfSha256SigAlg2048Keylen";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_2048.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_2048.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_2048_wss4j.xml");
+        } //End of issue 18363
+
         genericTest(
                     // test name for logging
                     thisMethod,
@@ -530,45 +430,13 @@ public class CxfSha2SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test did not receive the expected exception from the server.");
 
-        //Added to resolve RTC 285315
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
-
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCxfSha256SigAlg2048KeylenEE8Only() throws Exception {
-
-        String thisMethod = "testCxfSha256SigAlg2048Keylen";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_2048_wss4j.xml");
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "Sha2SigService7",
-                    // wsdl that the svc client code should use
-                    //newClientWsdl,
-                    "",
-                    // wsdl port that svc client code should use
-                    "UrnSha2Sig7",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Response: This is WSSECFVT SHA2-2048 Web Service.",
-                    // msg to issue if do NOT get the expected result
-                    "The test did not receive the expected exception from the server.");
-
-        //Added to resolve RTC 285315
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+        } //End of issue 18363
 
     }
 
@@ -584,48 +452,18 @@ public class CxfSha2SigTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testCxfSha384SymBindingEE7Only() throws Exception {
-
-        String thisMethod = "testCxfSha384SymBinding";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha3sym.xml");
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "Sha2SigService8",
-                    // wsdl that the svc client code should use
-                    //newClientWsdl,
-                    "",
-                    // wsdl port that svc client code should use
-                    "UrnSha2Sig8",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Response: This is WSSECFVT SHA2 SYM Web Service.",
-                    // msg to issue if do NOT get the expected result
-                    "The test did not receive the expected exception from the server.");
-
-        //Added to resolve RTC 285315
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
-
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCxfSha384SymBindingEE8Only() throws Exception {
+    public void testCxfSha384SymBinding() throws Exception {
 
         String thisMethod = "testCxfSha384SymBinding";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha3sym_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha3sym.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha3sym_wss4j.xml");
+        } //End of issue 18363
+
         genericTest(
                     // test name for logging
                     thisMethod,
@@ -651,8 +489,13 @@ public class CxfSha2SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test did not receive the expected exception from the server.");
 
-        //Added to resolve RTC 285315
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+        } //End of issue 18363
 
     }
 
@@ -668,47 +511,17 @@ public class CxfSha2SigTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testCxfSha512SymBindingEE7Only() throws Exception {
-        String thisMethod = "testCxfSha512SymBinding";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha5sym.xml");
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "Sha2SigService8",
-                    // wsdl that the svc client code should use
-                    //newClientWsdl,
-                    "",
-                    // wsdl port that svc client code should use
-                    "UrnSha2Sig8",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Response: This is WSSECFVT SHA2 SYM Web Service.",
-                    // msg to issue if do NOT get the expected result
-                    "The test did not receive the expected exception from the server.");
-
-        //Added to resolve RTC 285315
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
-
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCxfSha512SymBindingEE8Only() throws Exception {
-
+    public void testCxfSha512SymBinding() throws Exception {
         String thisMethod = "testCxfSha512SymBinding";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha5sym_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha5sym.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha5sym_wss4j.xml");
+        } //End of issue 18363
+
         genericTest(
                     // test name for logging
                     thisMethod,
@@ -734,8 +547,13 @@ public class CxfSha2SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test did not receive the expected exception from the server.");
 
-        //Added to resolve RTC 285315
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+        } //End of issue 18363
 
     }
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sha2sig/CxfSha2SigTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sha2sig/CxfSha2SigTests.java
@@ -57,13 +57,13 @@ public class CxfSha2SigTests extends CommonTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             //issue 18363
             featureVersion = "EE7";
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -92,7 +92,6 @@ public class CxfSha2SigTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfSha2SignSoapBody() throws Exception {
 
         String thisMethod = "testCxfSha2SignSoapBody";
@@ -142,7 +141,6 @@ public class CxfSha2SigTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfSha2DigestAlgorithm() throws Exception {
 
         String thisMethod = "testCxfSha2DigestAlgorithm";
@@ -191,7 +189,6 @@ public class CxfSha2SigTests extends CommonTests {
      *
      */
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfSha384SigAlgorithm() throws Exception {
 
         String thisMethod = "testTwasSha384SigAlgorithm";
@@ -248,7 +245,6 @@ public class CxfSha2SigTests extends CommonTests {
      *
      */
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfSha512SigAlgorithm() throws Exception {
 
         String thisMethod = "testTwasSha512SigAlgorithm";
@@ -309,7 +305,7 @@ public class CxfSha2SigTests extends CommonTests {
 
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException", "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfSha1ToSha2SigAlgorithm() throws Exception {
 
         String thisMethod = "testCxfSha1ToSha2SigAlgorithm";
@@ -393,7 +389,6 @@ public class CxfSha2SigTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfSha256SigAlg2048Keylen() throws Exception {
 
         String thisMethod = "testCxfSha256SigAlg2048Keylen";
@@ -452,7 +447,6 @@ public class CxfSha2SigTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfSha384SymBinding() throws Exception {
 
         String thisMethod = "testCxfSha384SymBinding";
@@ -511,7 +505,6 @@ public class CxfSha2SigTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfSha512SymBinding() throws Exception {
         String thisMethod = "testCxfSha512SymBinding";
         //issue 18363

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sha2sig/CxfSha2SigTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sha2sig/CxfSha2SigTests.java
@@ -62,8 +62,7 @@ public class CxfSha2SigTests extends CommonTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             //issue 18363
             featureVersion = "EE7";
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -96,10 +95,9 @@ public class CxfSha2SigTests extends CommonTests {
 
         String thisMethod = "testCxfSha2SignSoapBody";
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
         } //End of issue 18363
 
@@ -145,10 +143,9 @@ public class CxfSha2SigTests extends CommonTests {
 
         String thisMethod = "testCxfSha2DigestAlgorithm";
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
         } //End of issue 18363
 
@@ -193,10 +190,9 @@ public class CxfSha2SigTests extends CommonTests {
 
         String thisMethod = "testTwasSha384SigAlgorithm";
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha384.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha384_wss4j.xml");
         } //End of issue 18363
 
@@ -226,10 +222,9 @@ public class CxfSha2SigTests extends CommonTests {
                     "The test expected a succesful message from the server.");
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
         } //End of issue 18363
 
@@ -249,10 +244,9 @@ public class CxfSha2SigTests extends CommonTests {
 
         String thisMethod = "testTwasSha512SigAlgorithm";
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha512.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha512_wss4j.xml");
         } //End of issue 18363
 
@@ -282,10 +276,9 @@ public class CxfSha2SigTests extends CommonTests {
                     "The test expected a succesful message from the server.");
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
         } //End of issue 18363
 
@@ -310,7 +303,7 @@ public class CxfSha2SigTests extends CommonTests {
 
         String thisMethod = "testCxfSha1ToSha2SigAlgorithm";
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha2.xml");
             genericTest(
                         // test name for logging
@@ -340,10 +333,7 @@ public class CxfSha2SigTests extends CommonTests {
 
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
 
-        } //End of issue 18363
-
-        //issue 18363
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha2_wss4j.xml");
             genericTest(
                         // test name for logging
@@ -393,10 +383,9 @@ public class CxfSha2SigTests extends CommonTests {
 
         String thisMethod = "testCxfSha256SigAlg2048Keylen";
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_2048.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_2048_wss4j.xml");
         } //End of issue 18363
 
@@ -426,10 +415,9 @@ public class CxfSha2SigTests extends CommonTests {
                     "The test did not receive the expected exception from the server.");
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
         } //End of issue 18363
 
@@ -451,10 +439,9 @@ public class CxfSha2SigTests extends CommonTests {
 
         String thisMethod = "testCxfSha384SymBinding";
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha3sym.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha3sym_wss4j.xml");
         } //End of issue 18363
 
@@ -484,10 +471,9 @@ public class CxfSha2SigTests extends CommonTests {
                     "The test did not receive the expected exception from the server.");
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
         } //End of issue 18363
 
@@ -508,10 +494,9 @@ public class CxfSha2SigTests extends CommonTests {
     public void testCxfSha512SymBinding() throws Exception {
         String thisMethod = "testCxfSha512SymBinding";
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha5sym.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha5sym_wss4j.xml");
         } //End of issue 18363
 
@@ -541,10 +526,9 @@ public class CxfSha2SigTests extends CommonTests {
                     "The test did not receive the expected exception from the server.");
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
         } //End of issue 18363
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/wss11enc/CxfWss11EncTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/wss11enc/CxfWss11EncTests.java
@@ -55,13 +55,13 @@ public class CxfWss11EncTests extends CommonTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             //issue 18363
             featureVersion = "EE7";
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -103,7 +103,6 @@ public class CxfWss11EncTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientEncryptHeaderNS1() throws Exception {
 
         //issue 18363
@@ -176,7 +175,6 @@ public class CxfWss11EncTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientEncryptHeaderNS2() throws Exception {
 
         //issue 18363
@@ -238,7 +236,6 @@ public class CxfWss11EncTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientEncryptHeaderAny() throws Exception {
 
         //issue 18363

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/wss11enc/CxfWss11EncTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/wss11enc/CxfWss11EncTests.java
@@ -11,9 +11,7 @@
 
 package com.ibm.ws.wssecurity.fat.cxf.wss11enc;
 
-import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
-import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 
 import java.io.File;
 import java.util.Set;
@@ -46,6 +44,8 @@ public class CxfWss11EncTests extends CommonTests {
     static private final Class<?> thisClass = CxfWss11EncTests.class;
     //static private UpdateWSDLPortNum newWsdl = null;
     static final private String serverName = "com.ibm.ws.wssecurity_fat.wss11enc";
+    //issue 18363
+    private static String featureVersion = "";
 
     @Server(serverName)
     public static LibertyServer server;
@@ -58,11 +58,15 @@ public class CxfWss11EncTests extends CommonTests {
         if (features.contains("usr:wsseccbh-1.0")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
+            //issue 18363
+            featureVersion = "EE7";
         }
         if (features.contains("usr:wsseccbh-2.0")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+            //issue 18363
+            featureVersion = "EE8";
         }
 
         ShrinkHelper.defaultDropinApp(server, "wss11encclient", "com.ibm.ws.wssecurity.fat.wss11encclient", "test.wssecfvt.wss11enc", "test.wssecfvt.wss11enc.types");
@@ -99,46 +103,20 @@ public class CxfWss11EncTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testCXFClientEncryptHeaderNS1EE7Only() throws Exception {
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_enchdr.xml");
-        genericTest(
-                    // test name for logging
-                    "testCXFClientEncryptHeaderNS1EE7Only",
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "WSS11EncService1",
-                    // wsdl that the svc client code should use
-                    "",
-                    // wsdl port that svc client code should use
-                    "WSS11Enc1",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Response: This is Wss11EncWebSvc1 Web Service.",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
-
-        //Added to resolve RTC 285315
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCXFClientEncryptHeaderNS1EE8Only() throws Exception {
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_enchdr_wss4j.xml");
+    public void testCXFClientEncryptHeaderNS1() throws Exception {
+
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_enchdr.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_enchdr_wss4j.xml");
+        } //End of issue 18363
+
         genericTest(
                     // test name for logging
-                    "testCXFClientEncryptHeaderNS1EE8Only",
+                    "testCXFClientEncryptHeaderNS1",
                     // Svc Client Url that generic test code should use
                     clientHttpUrl,
                     // Port that svc client code should use
@@ -160,8 +138,13 @@ public class CxfWss11EncTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
 
-        //Added to resolve RTC 285315
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        } //End of issue 18363
 
     }
 
@@ -193,42 +176,20 @@ public class CxfWss11EncTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testCXFClientEncryptHeaderNS2EE7Only() throws Exception {
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-        genericTest(
-                    // test name for logging
-                    "testCXFClientEncryptHeaderNS2EE7Only",
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "WSS11EncService1",
-                    // wsdl that the svc client code should use
-                    "",
-                    // wsdl port that svc client code should use
-                    "WSS11Enc1",
-                    // msg to send from svc client to server
-                    "multiHeaders",
-                    // expected response from server
-                    "Response: This is Wss11EncWebSvc1 Web Service.",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCXFClientEncryptHeaderNS2EE8Only() throws Exception {
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+    public void testCXFClientEncryptHeaderNS2() throws Exception {
+
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        } //End of issue 18363
+
         genericTest(
                     // test name for logging
-                    "testCXFClientEncryptHeaderNS2EE8Only",
+                    "testCXFClientEncryptHeaderNS2",
                     // Svc Client Url that generic test code should use
                     clientHttpUrl,
                     // Port that svc client code should use
@@ -277,42 +238,20 @@ public class CxfWss11EncTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testCXFClientEncryptHeaderAnyEE7Only() throws Exception {
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-        genericTest(
-                    // test name for logging
-                    "testCXFClientEncryptHeaderAnyEE7Only",
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "WSS11EncService2",
-                    // wsdl that the svc client code should use
-                    "",
-                    // wsdl port that svc client code should use
-                    "WSS11Enc2",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Response: This is Wss11EncWebSvc2 Web Service.",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCXFClientEncryptHeaderAnyEE8Only() throws Exception {
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+    public void testCXFClientEncryptHeaderAny() throws Exception {
+
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        } //End of issue 18363
+
         genericTest(
                     // test name for logging
-                    "testCXFClientEncryptHeaderAnyEE8Only",
+                    "testCXFClientEncryptHeaderAny",
                     // Svc Client Url that generic test code should use
                     clientHttpUrl,
                     // Port that svc client code should use

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/wss11enc/CxfWss11EncTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/wss11enc/CxfWss11EncTests.java
@@ -26,13 +26,11 @@ import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.wssecurity.fat.utils.common.CommonTests;
 import com.ibm.ws.wssecurity.fat.utils.common.PrepCommonSetup;
 
-import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.EE8FeatureReplacementAction;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 
@@ -60,8 +58,7 @@ public class CxfWss11EncTests extends CommonTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             //issue 18363
             featureVersion = "EE7";
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -106,10 +103,9 @@ public class CxfWss11EncTests extends CommonTests {
     public void testCXFClientEncryptHeaderNS1() throws Exception {
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_enchdr.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_enchdr_wss4j.xml");
         } //End of issue 18363
 
@@ -138,10 +134,9 @@ public class CxfWss11EncTests extends CommonTests {
                     "The test expected a succesful message from the server.");
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
         } //End of issue 18363
 
@@ -178,10 +173,9 @@ public class CxfWss11EncTests extends CommonTests {
     public void testCXFClientEncryptHeaderNS2() throws Exception {
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
         } //End of issue 18363
 
@@ -239,10 +233,9 @@ public class CxfWss11EncTests extends CommonTests {
     public void testCXFClientEncryptHeaderAny() throws Exception {
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
         } //End of issue 18363
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/wss11sig/CxfWss11SigTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/wss11sig/CxfWss11SigTests.java
@@ -11,9 +11,7 @@
 
 package com.ibm.ws.wssecurity.fat.cxf.wss11sig;
 
-import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
-import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 
 import java.io.File;
 import java.util.Set;
@@ -50,6 +48,8 @@ public class CxfWss11SigTests extends CommonTests {
     static private UpdateWSDLPortNum newWsdl = null;
     static private String newClientWsdl = null;
     static final private String serverName = "com.ibm.ws.wssecurity_fat.wss11sig";
+    //issue 18363
+    private static String featureVersion = "";
 
     @Server(serverName)
     public static LibertyServer server;
@@ -62,11 +62,15 @@ public class CxfWss11SigTests extends CommonTests {
         if (features.contains("usr:wsseccbh-1.0")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
+            //issue 18363
+            featureVersion = "EE7";
         }
         if (features.contains("usr:wsseccbh-2.0")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+            //issue 18363
+            featureVersion = "EE8";
         }
 
         ShrinkHelper.defaultDropinApp(server, "wss11sigclient", "com.ibm.ws.wssecurity.fat.wss11sigclient", "test.wssecfvt.wss11sig", "test.wssecfvt.wss11sig.types");
@@ -271,9 +275,9 @@ public class CxfWss11SigTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    public void testCXFClientBasicEncryptedElementMisMatchEE7Only() throws Exception {
+    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    public void testCXFClientBasicEncryptedElementMisMatch() throws Exception {
 
         String thisMethod = "testCXFClientBasicEncryptedElement";
         printMethodName(thisMethod, "Start Prep for " + thisMethod);
@@ -282,69 +286,61 @@ public class CxfWss11SigTests extends CommonTests {
         Log.info(thisClass, thisMethod, "Using " + newClientWsdl);
         printMethodName(thisMethod, "End Prep for " + thisMethod);
 
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "WSS11SigService6",
-                    // wsdl that the svc client code should use
-                    newClientWsdl,
-                    // wsdl port that svc client code should use
-                    "WSS11Sig6",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Body not SIGNED",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            genericTest(
+                        // test name for logging
+                        thisMethod,
+                        // Svc Client Url that generic test code should use
+                        clientHttpUrl,
+                        // Port that svc client code should use
+                        "",
+                        // user that svc client code should use
+                        "user1",
+                        // pw that svc client code should use
+                        "security",
+                        // wsdl sevice that svc client code should use
+                        "WSS11SigService6",
+                        // wsdl that the svc client code should use
+                        newClientWsdl,
+                        // wsdl port that svc client code should use
+                        "WSS11Sig6",
+                        // msg to send from svc client to server
+                        "",
+                        // expected response from server
+                        "Body not SIGNED",
+                        // msg to issue if do NOT get the expected result
+                        "The test expected a succesful message from the server.");
+        } //End of issue 18363
 
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCXFClientBasicEncryptedElementMisMatchEE8Only() throws Exception {
-
-        String thisMethod = "testCXFClientBasicEncryptedElementMisMatchEE8Only";
-        printMethodName(thisMethod, "Start Prep for " + thisMethod);
-        newClientWsdl = updateClientWsdl(defaultClientWsdlLoc + "WSS11Signature_Elements.wsdl",
-                                         defaultClientWsdlLoc + "WSS11Signature_ElementsUpdated.wsdl");
-        Log.info(thisClass, thisMethod, "Using " + newClientWsdl);
-        printMethodName(thisMethod, "End Prep for " + thisMethod);
-
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "WSS11SigService6",
-                    // wsdl that the svc client code should use
-                    newClientWsdl,
-                    // wsdl port that svc client code should use
-                    "WSS11Sig6",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    //messagetoexpect,
-                    "Soap Body is not SIGNED",
-                    //End
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
+        //issue 18363
+        if (featureVersion == "EE8") {
+            genericTest(
+                        // test name for logging
+                        thisMethod,
+                        // Svc Client Url that generic test code should use
+                        clientHttpUrl,
+                        // Port that svc client code should use
+                        "",
+                        // user that svc client code should use
+                        "user1",
+                        // pw that svc client code should use
+                        "security",
+                        // wsdl sevice that svc client code should use
+                        "WSS11SigService6",
+                        // wsdl that the svc client code should use
+                        newClientWsdl,
+                        // wsdl port that svc client code should use
+                        "WSS11Sig6",
+                        // msg to send from svc client to server
+                        "",
+                        // expected response from server
+                        //messagetoexpect,
+                        "Soap Body is not SIGNED",
+                        //End
+                        // msg to issue if do NOT get the expected result
+                        "The test expected a succesful message from the server.");
+        } //End of issue 18363
 
     }
 
@@ -364,11 +360,18 @@ public class CxfWss11SigTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testCXFClientBasicEncryptedElementEE7Only() throws Exception {
+    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    public void testCXFClientBasicEncryptedElement() throws Exception {
 
         String thisMethod = "testCXFClientBasicEncryptedElement";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_enchdr.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_enchdr.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_enchdr_wss4j.xml");
+        } //End of issue 18363
+
         genericTest(
                     // test name for logging
                     thisMethod,
@@ -393,42 +396,13 @@ public class CxfWss11SigTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
 
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
-
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCXFClientBasicEncryptedElementEE8Only() throws Exception {
-
-        String thisMethod = "testCXFClientBasicEncryptedElementEE8Only";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_enchdr_wss4j.xml");
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "WSS11SigService6a",
-                    // wsdl that the svc client code should use
-                    "",
-                    // wsdl port that svc client code should use
-                    "WSS11Sig6a",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Response: This is Wss11SigWebSvc6a Web Service.",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
-
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+        } //End of issue 18363
 
     }
 
@@ -446,9 +420,9 @@ public class CxfWss11SigTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    public void testCXFClientBasicSigSignedElementMisMatchEE7Only() throws Exception {
+    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    public void testCXFClientBasicSigSignedElementMisMatch() throws Exception {
 
         String thisMethod = "testCXFClientBasicSigSignedElement";
         printMethodName(thisMethod, "Start Prep for " + thisMethod);
@@ -457,69 +431,61 @@ public class CxfWss11SigTests extends CommonTests {
         Log.info(thisClass, thisMethod, "Using " + newClientWsdl);
         printMethodName(thisMethod, "End Prep for " + thisMethod);
 
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "WSS11SigService7",
-                    // wsdl that the svc client code should use
-                    newClientWsdl,
-                    // wsdl port that svc client code should use
-                    "WSS11Sig7",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Body not SIGNED",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+            genericTest(
+                        // test name for logging
+                        thisMethod,
+                        // Svc Client Url that generic test code should use
+                        clientHttpUrl,
+                        // Port that svc client code should use
+                        "",
+                        // user that svc client code should use
+                        "user1",
+                        // pw that svc client code should use
+                        "security",
+                        // wsdl sevice that svc client code should use
+                        "WSS11SigService7",
+                        // wsdl that the svc client code should use
+                        newClientWsdl,
+                        // wsdl port that svc client code should use
+                        "WSS11Sig7",
+                        // msg to send from svc client to server
+                        "",
+                        // expected response from server
+                        "Body not SIGNED",
+                        // msg to issue if do NOT get the expected result
+                        "The test expected a succesful message from the server.");
+        } //End of issue 18363
 
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCXFClientBasicSigSignedElementMisMatchEE8Only() throws Exception {
-
-        String thisMethod = "testCXFClientBasicSigSignedElementMisMatchEE8Only";
-        printMethodName(thisMethod, "Start Prep for " + thisMethod);
-        newClientWsdl = updateClientWsdl(defaultClientWsdlLoc + "WSS11Signature_Elements.wsdl",
-                                         defaultClientWsdlLoc + "WSS11Signature_ElementsUpdated.wsdl");
-        Log.info(thisClass, thisMethod, "Using " + newClientWsdl);
-        printMethodName(thisMethod, "End Prep for " + thisMethod);
-
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "WSS11SigService7",
-                    // wsdl that the svc client code should use
-                    newClientWsdl,
-                    // wsdl port that svc client code should use
-                    "WSS11Sig7",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Soap Body is not SIGNED",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
+        //issue 18363
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+            genericTest(
+                        // test name for logging
+                        thisMethod,
+                        // Svc Client Url that generic test code should use
+                        clientHttpUrl,
+                        // Port that svc client code should use
+                        "",
+                        // user that svc client code should use
+                        "user1",
+                        // pw that svc client code should use
+                        "security",
+                        // wsdl sevice that svc client code should use
+                        "WSS11SigService7",
+                        // wsdl that the svc client code should use
+                        newClientWsdl,
+                        // wsdl port that svc client code should use
+                        "WSS11Sig7",
+                        // msg to send from svc client to server
+                        "",
+                        // expected response from server
+                        "Soap Body is not SIGNED",
+                        // msg to issue if do NOT get the expected result
+                        "The test expected a succesful message from the server.");
+        } //End of issue 18363
 
     }
 
@@ -536,44 +502,18 @@ public class CxfWss11SigTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testCXFClientBasicSigSignedElementEE7Only() throws Exception {
-
-        String thisMethod = "testCXFClientBasicSigSignedElement";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "WSS11SigService7a",
-                    // wsdl that the svc client code should use
-                    "",
-                    // wsdl port that svc client code should use
-                    "WSS11Sig7a",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Response: This is Wss11SigWebSvc7a Web Service.",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
-
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCXFClientBasicSigSignedElementEE8Only() throws Exception {
+    public void testCXFClientBasicSigSignedElement() throws Exception {
 
         String thisMethod = "testCXFClientBasicSigSignedElement";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        } //End of issue 18363
+
         genericTest(
                     // test name for logging
                     thisMethod,
@@ -611,47 +551,8 @@ public class CxfWss11SigTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testCXFClientBasicSigClNoSignConfSrvNoSignNoConfEE7Only() throws Exception {
-
-        String thisMethod = "testCXFClientBasicSigClNoSignConfSrvNoSignNoConf";
-        printMethodName(thisMethod, "Start Prep for " + thisMethod);
-        newClientWsdl = updateClientWsdl(defaultClientWsdlLoc + "WSS11Signature_sigConfMissingInServer.wsdl",
-                                         defaultClientWsdlLoc + "WSS11Signature_sigConfMissingInServerUpdated.wsdl");
-        Log.info(thisClass, thisMethod, "Using " + newClientWsdl);
-        printMethodName(thisMethod, "End Prep for " + thisMethod);
-
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "WSS11SigService8",
-                    // wsdl that the svc client code should use
-                    newClientWsdl,
-                    // wsdl port that svc client code should use
-                    "WSS11Sig8",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Wss11: Signature Confirmation policy validation failed",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
-
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCXFClientBasicSigClNoSignConfSrvNoSignNoConfEE8Only() throws Exception {
+    public void testCXFClientBasicSigClNoSignConfSrvNoSignNoConf() throws Exception {
 
         String thisMethod = "testCXFClientBasicSigClNoSignConfSrvNoSignNoConf";
         printMethodName(thisMethod, "Start Prep for " + thisMethod);
@@ -660,7 +561,14 @@ public class CxfWss11SigTests extends CommonTests {
         Log.info(thisClass, thisMethod, "Using " + newClientWsdl);
         printMethodName(thisMethod, "End Prep for " + thisMethod);
 
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        } //End of issue 18363
+
         genericTest(
                     // test name for logging
                     thisMethod,

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/wss11sig/CxfWss11SigTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/wss11sig/CxfWss11SigTests.java
@@ -64,8 +64,7 @@ public class CxfWss11SigTests extends CommonTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             //issue 18363
             featureVersion = "EE7";
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -283,7 +282,7 @@ public class CxfWss11SigTests extends CommonTests {
         printMethodName(thisMethod, "End Prep for " + thisMethod);
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             genericTest(
                         // test name for logging
                         thisMethod,
@@ -307,10 +306,8 @@ public class CxfWss11SigTests extends CommonTests {
                         "Body not SIGNED",
                         // msg to issue if do NOT get the expected result
                         "The test expected a succesful message from the server.");
-        } //End of issue 18363
 
-        //issue 18363
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             genericTest(
                         // test name for logging
                         thisMethod,
@@ -360,10 +357,9 @@ public class CxfWss11SigTests extends CommonTests {
 
         String thisMethod = "testCXFClientBasicEncryptedElement";
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_enchdr.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_enchdr_wss4j.xml");
         } //End of issue 18363
 
@@ -392,10 +388,9 @@ public class CxfWss11SigTests extends CommonTests {
                     "The test expected a succesful message from the server.");
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
         } //End of issue 18363
 
@@ -426,7 +421,7 @@ public class CxfWss11SigTests extends CommonTests {
         printMethodName(thisMethod, "End Prep for " + thisMethod);
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
             genericTest(
                         // test name for logging
@@ -451,10 +446,8 @@ public class CxfWss11SigTests extends CommonTests {
                         "Body not SIGNED",
                         // msg to issue if do NOT get the expected result
                         "The test expected a succesful message from the server.");
-        } //End of issue 18363
 
-        //issue 18363
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
             genericTest(
                         // test name for logging
@@ -500,10 +493,9 @@ public class CxfWss11SigTests extends CommonTests {
 
         String thisMethod = "testCXFClientBasicSigSignedElement";
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
         } //End of issue 18363
 
@@ -554,10 +546,9 @@ public class CxfWss11SigTests extends CommonTests {
         printMethodName(thisMethod, "End Prep for " + thisMethod);
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
         } //End of issue 18363
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/wss11sig/CxfWss11SigTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/wss11sig/CxfWss11SigTests.java
@@ -59,13 +59,13 @@ public class CxfWss11SigTests extends CommonTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             //issue 18363
             featureVersion = "EE7";
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -93,7 +93,6 @@ public class CxfWss11SigTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientBasicSigConfirm() throws Exception {
 
         genericTest(
@@ -135,7 +134,6 @@ public class CxfWss11SigTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientBasicSigConfirmNoSig() throws Exception {
 
         genericTest(
@@ -178,7 +176,7 @@ public class CxfWss11SigTests extends CommonTests {
 
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientBasicSigClConfSrvNoConf() throws Exception {
 
         String thisMethod = "testCXFClientBasicSigClConfSrvNoConf";
@@ -226,7 +224,6 @@ public class CxfWss11SigTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientBasicSigClNoConfSrvConf() throws Exception {
 
         String thisMethod = "testCXFClientBasicSigClNoConfSrvConf";
@@ -276,7 +273,6 @@ public class CxfWss11SigTests extends CommonTests {
 
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientBasicEncryptedElementMisMatch() throws Exception {
 
         String thisMethod = "testCXFClientBasicEncryptedElement";
@@ -360,7 +356,6 @@ public class CxfWss11SigTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientBasicEncryptedElement() throws Exception {
 
         String thisMethod = "testCXFClientBasicEncryptedElement";
@@ -421,7 +416,6 @@ public class CxfWss11SigTests extends CommonTests {
 
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientBasicSigSignedElementMisMatch() throws Exception {
 
         String thisMethod = "testCXFClientBasicSigSignedElement";
@@ -502,7 +496,6 @@ public class CxfWss11SigTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientBasicSigSignedElement() throws Exception {
 
         String thisMethod = "testCXFClientBasicSigSignedElement";
@@ -551,7 +544,6 @@ public class CxfWss11SigTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientBasicSigClNoSignConfSrvNoSignNoConf() throws Exception {
 
         String thisMethod = "testCXFClientBasicSigClNoSignConfSrvNoSignNoConf";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfEndSupTokensAsymTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfEndSupTokensAsymTests.java
@@ -67,12 +67,11 @@ public class CxfEndSupTokensAsymTests extends CommonTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             commonSetUp(serverName, "server_asym.xml", true, "/endsuptokensclient/CxfEndSupTokensSvcClient");
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             commonSetUp(serverName, "server_asym_wss4j.xml", true, "/endsuptokensclient/CxfEndSupTokensSvcClient");
-            //copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+
         }
 
     }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfEndSupTokensAsymTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfEndSupTokensAsymTests.java
@@ -63,12 +63,12 @@ public class CxfEndSupTokensAsymTests extends CommonTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             commonSetUp(serverName, "server_asym.xml", true, "/endsuptokensclient/CxfEndSupTokensSvcClient");
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             commonSetUp(serverName, "server_asym_wss4j.xml", true, "/endsuptokensclient/CxfEndSupTokensSvcClient");
@@ -88,7 +88,7 @@ public class CxfEndSupTokensAsymTests extends CommonTests {
      *
      */
     @Test
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFEndSupTokens0() throws Exception {
 
         String thisMethod = "testCXFEndSupTokens0";
@@ -174,7 +174,7 @@ public class CxfEndSupTokensAsymTests extends CommonTests {
      *
      */
     @Test
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFEndSupTokens0Body() throws Exception {
 
         String thisMethod = "testCXFEndSupTokens0Body";
@@ -217,7 +217,7 @@ public class CxfEndSupTokensAsymTests extends CommonTests {
      *
      */
     @Test
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFEndSupTokens0BodyElement() throws Exception {
 
         String thisMethod = "testCXFEndSupTokens0BodyElement";
@@ -302,7 +302,7 @@ public class CxfEndSupTokensAsymTests extends CommonTests {
      *
      */
     @Test
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFEndSupTokens1() throws Exception {
 
         String thisMethod = "testCXFEndSupTokens1";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfEndSupTokensSym2Tests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfEndSupTokensSym2Tests.java
@@ -47,7 +47,7 @@ public class CxfEndSupTokensSym2Tests extends CommonTests {
         server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
         PrepCommonSetup serverObject = new PrepCommonSetup();
         serverObject.prepareSetup(server);
-        //orig from CL:
+
         commonSetUp(serverName, "server_sym2.xml", true,
                     "/endsuptokensclient/CxfEndSupTokensSvcClient");
     }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfEndSupTokensSymTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfEndSupTokensSymTests.java
@@ -34,7 +34,6 @@ import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.EE8FeatureReplacementAction;
 import componenttest.rules.repeater.EmptyAction;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
@@ -70,8 +69,7 @@ public class CxfEndSupTokensSymTests extends CommonTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             commonSetUp(serverName, "server_sym.xml", true,
                         "/endsuptokensclient/CxfEndSupTokensSvcClient");
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             commonSetUp(serverName, "server_sym_wss4j.xml", true,

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfEndSupTokensSymTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfEndSupTokensSymTests.java
@@ -65,13 +65,13 @@ public class CxfEndSupTokensSymTests extends CommonTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             commonSetUp(serverName, "server_sym.xml", true,
                         "/endsuptokensclient/CxfEndSupTokensSvcClient");
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             commonSetUp(serverName, "server_sym_wss4j.xml", true,
@@ -92,7 +92,6 @@ public class CxfEndSupTokensSymTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFEndSupTokens4() throws Exception {
 
         String thisMethod = "testCXFEndSupTokens4";
@@ -136,7 +135,6 @@ public class CxfEndSupTokensSymTests extends CommonTests {
      *
      */
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFEndSupTokens4ClAddEncrypted() throws Exception {
 
         String thisMethod = "testCXFEndSupTokens4ClAddEncrypted";
@@ -180,7 +178,6 @@ public class CxfEndSupTokensSymTests extends CommonTests {
      *
      */
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFEndSupTokens4ClAddSigned() throws Exception {
 
         String thisMethod = "testCXFEndSupTokens4ClAddSigned";
@@ -225,7 +222,6 @@ public class CxfEndSupTokensSymTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFEndSupTokens4ClAddSignedEncrypted() throws Exception {
 
         String thisMethod = "testCXFEndSupTokens4ClAddSignedEncrypted";
@@ -269,7 +265,6 @@ public class CxfEndSupTokensSymTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFEndSupTokens5() throws Exception {
 
         String thisMethod = "testCXFEndSupTokens5";
@@ -314,7 +309,6 @@ public class CxfEndSupTokensSymTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFEndSupTokens5AddEncrypted() throws Exception {
 
         String thisMethod = "testCXFEndSupTokens5AddEncrypted";
@@ -360,7 +354,6 @@ public class CxfEndSupTokensSymTests extends CommonTests {
      */
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFEndSupTokens5MissingSigned() throws Exception {
 
         String thisMethod = "testCXFEndSupTokens5MissingSigned";
@@ -406,7 +399,6 @@ public class CxfEndSupTokensSymTests extends CommonTests {
      */
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFEndSupTokens5MissingSignedAddEncrypted() throws Exception {
 
         String thisMethod = "testCXFEndSupTokens5MissingSignedAddEncrypted";
@@ -451,7 +443,6 @@ public class CxfEndSupTokensSymTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFEndSupTokens6() throws Exception {
 
         String thisMethod = "testCXFEndSupTokens6";
@@ -496,7 +487,6 @@ public class CxfEndSupTokensSymTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFEndSupTokens6AddSigned() throws Exception {
 
         String thisMethod = "testCXFEndSupTokens6AddSigned";
@@ -542,7 +532,6 @@ public class CxfEndSupTokensSymTests extends CommonTests {
      */
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFEndSupTokens6MissingEncrypted() throws Exception {
 
         String thisMethod = "testCXFEndSupTokens6MissingEncrypted";
@@ -588,7 +577,6 @@ public class CxfEndSupTokensSymTests extends CommonTests {
      */
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFEndSupTokens6MissingEncryptedAddSigned() throws Exception {
 
         String thisMethod = "testCXFEndSupTokens6MissingEncryptedAddSigned";
@@ -633,7 +621,6 @@ public class CxfEndSupTokensSymTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFEndSupTokens7() throws Exception {
 
         String thisMethod = "testCXFEndSupTokens7";
@@ -678,7 +665,6 @@ public class CxfEndSupTokensSymTests extends CommonTests {
      */
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFEndSupTokens7MissingEncrypted() throws Exception {
 
         String thisMethod = "testCXFEndSupTokens7MissingEncrypted";
@@ -770,7 +756,6 @@ public class CxfEndSupTokensSymTests extends CommonTests {
      */
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFEndSupTokens7MissingSignedEncrypted() throws Exception {
 
         String thisMethod = "testCXFEndSupTokens7MissingSignedEncrypted";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigSymSha2NegativeTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigSymSha2NegativeTests.java
@@ -88,8 +88,7 @@ public class CxfX509MigSymSha2NegativeTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badsha2.xml");
             errMsgVersion = "EE7";
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badsha2_wss4j.xml");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigSymSha2NegativeTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigSymSha2NegativeTests.java
@@ -83,13 +83,13 @@ public class CxfX509MigSymSha2NegativeTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badsha2.xml");
             errMsgVersion = "EE7";
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badsha2_wss4j.xml");
@@ -138,7 +138,7 @@ public class CxfX509MigSymSha2NegativeTests {
 
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfX509KeyIdMigSymServiceSha1ToSha512() throws Exception {
 
         String thisMethod = "testCxfX509KeyIdMigSymService";
@@ -173,7 +173,7 @@ public class CxfX509MigSymSha2NegativeTests {
 
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfX509KeyIdMigSymServiceHttpsSha1ToSha512() throws Exception {
 
         String thisMethod = "testCxfX509KeyIdMigSymService";
@@ -208,7 +208,7 @@ public class CxfX509MigSymSha2NegativeTests {
 
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfX509IssuerSerialMigSymServiceSha1ToSha512() throws Exception {
 
         String thisMethod = "testCxfX509IssuerSerialMigSymService";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigSymTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigSymTests.java
@@ -90,8 +90,7 @@ public class CxfX509MigSymTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha512.xml");
             errMsgVersion = "EE7";
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha512_wss4j.xml");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigSymTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigSymTests.java
@@ -85,13 +85,13 @@ public class CxfX509MigSymTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha512.xml");
             errMsgVersion = "EE7";
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha512_wss4j.xml");
@@ -285,7 +285,6 @@ public class CxfX509MigSymTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfX509KeyIdMigSymService() throws Exception {
 
         String thisMethod = "testCxfX509KeyIdMigSymService";
@@ -317,7 +316,6 @@ public class CxfX509MigSymTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfX509KeyIdMigSymServiceHttps() throws Exception {
 
         String thisMethod = "testCxfX509KeyIdMigSymService";
@@ -499,7 +497,6 @@ public class CxfX509MigSymTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfX509IssuerSerialMigSymService() throws Exception {
         String thisMethod = "testCxfX509IssuerSerialMigSymService";
         methodFull = "testCxfX509IssuerSerialMigSymService";
@@ -694,7 +691,6 @@ public class CxfX509MigSymTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfX509ProtectTokensMigSymService() throws Exception {
         String thisMethod = "testCxfX509ProtectTokensMigSymService";
         methodFull = "testCxfX509ProtectTokensMigSymService";
@@ -869,7 +865,6 @@ public class CxfX509MigSymTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfX509ThumbprintMigSymService() throws Exception {
         String thisMethod = "testCxfX509ThumbprintMigSymService";
         methodFull = "testCxfX509ThumbprintMigSymService";
@@ -1076,7 +1071,6 @@ public class CxfX509MigSymTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfX509KeyIdDerivedMigSymService() throws Exception {
         String thisMethod = "testCxfX509KeyIdDerivedMigSymService";
         methodFull = "testCxfX509KeyIdDerivedMigSymService";
@@ -1283,7 +1277,6 @@ public class CxfX509MigSymTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfX509ThumbprintDerivedMigSymService() throws Exception {
         String thisMethod = "testCxfX509ThumbprintDerivedMigSymService";
         methodFull = "testCxfX509ThumbprintDerivedMigSymService";
@@ -1324,7 +1317,6 @@ public class CxfX509MigSymTests {
      **/
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testX509KeyIdentifierUNTService() throws Exception {
         String thisMethod = "testX509KeyIdentifierUNTService";
         methodFull = "testX509KeyIdentifierUNTService";
@@ -1367,7 +1359,6 @@ public class CxfX509MigSymTests {
      **/
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testX509SignatureConfirmService() throws Exception {
         String thisMethod = "testX509SignatureConfirmService";
         methodFull = "testX509SignatureConfirmService";
@@ -1406,7 +1397,6 @@ public class CxfX509MigSymTests {
      **/
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testSymEncSignService() throws Exception {
         String thisMethod = "testSymEncSignService";
         methodFull = "testSymEncSignService";
@@ -1439,7 +1429,6 @@ public class CxfX509MigSymTests {
      **/
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testSymEncSignStrictService() throws Exception {
         String thisMethod = "testSymEncSignStrictService";
         methodFull = "testSymEncSignStrictService";
@@ -1470,7 +1459,7 @@ public class CxfX509MigSymTests {
      **/
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testBasic192Service() throws Exception {
         String thisMethod = "testBasic192Service";
         methodFull = "testBasic192Service";
@@ -1565,7 +1554,6 @@ public class CxfX509MigSymTests {
     // With SymmetricBinding
     //
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testSymmetricEndorsingUNTPolicy() throws Exception {
         String thisMethod = "testSymmetricEndorsingUNTPolicy";
         methodFull = "testSymmetricEndorsingUNTPolicy";
@@ -1597,7 +1585,6 @@ public class CxfX509MigSymTests {
     }
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testSymmetricEndorsingUNTPolicyHttps() throws Exception {
         String thisMethod = "testSymmetricEndorsingUNTPolicy";
         methodFull = "testSymmetricEndorsingUNTPolicyHttps";
@@ -1704,7 +1691,6 @@ public class CxfX509MigSymTests {
 
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testBadCxfX509KeyIdMigSymEncryptBeforeSigningService() throws Exception {
         String thisMethod = "testCxfX509KeyIdMigSymEncryptBeforeSigningService";
         methodFull = "testBadCxfX509KeyIdMigSymEncryptBeforeSigningService";
@@ -1736,7 +1722,6 @@ public class CxfX509MigSymTests {
 
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testBadCxfX509IssuerSerialMigSymNoEncryptSignatureService() throws Exception {
         String thisMethod = "testCxfX509IssuerSerialMigSymNoEncryptSignatureService";
         methodFull = "testBadCxfX509IssuerSerialMigSymNoEncryptSignatureService";
@@ -1768,7 +1753,6 @@ public class CxfX509MigSymTests {
 
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testBadCxfX509ProtectTokensMigSymService() throws Exception {
         String thisMethod = "testCxfX509ProtectTokensMigSymService";
         methodFull = "testBadCxfX509ProtectTokensMigSymService";
@@ -1832,7 +1816,6 @@ public class CxfX509MigSymTests {
 
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testBadCxfX509KeyIdDerivedMigSymService() throws Exception {
         String thisMethod = "testCxfX509KeyIdDerivedMigSymService";
         methodFull = "testBadCxfX509KeyIdDerivedMigSymService";
@@ -1864,7 +1847,6 @@ public class CxfX509MigSymTests {
 
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testBadCxfX509ThumbprintDerivedMigSymService() throws Exception {
         String thisMethod = "testCxfX509ThumbprintDerivedMigSymService";
         methodFull = "testBadCxfX509ThumbprintDerivedMigSymService";
@@ -1906,7 +1888,6 @@ public class CxfX509MigSymTests {
      **/
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testBadX509KeyIdentifierUNTService() throws Exception {
         String thisMethod = "testBadX509KeyIdentifierUNTService";
         methodFull = "testBadX509KeyIdentifierUNTService";
@@ -1950,7 +1931,6 @@ public class CxfX509MigSymTests {
      **/
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testBadX509SignatureConfirmService() throws Exception {
         String thisMethod = "testBadX509SignatureConfirmService";
         methodFull = "testBadX509SignatureConfirmService";
@@ -1993,7 +1973,7 @@ public class CxfX509MigSymTests {
      **/
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testBadSymEncSignService() throws Exception {
         String thisMethod = "testBadSymEncSignService";
         methodFull = "testBadSymEncSignService";
@@ -2026,7 +2006,6 @@ public class CxfX509MigSymTests {
      **/
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testBadSymEncSignStrictService() throws Exception {
         String thisMethod = "testBadSymEncSignStrictService";
         methodFull = "testBadSymEncSignStrictService";
@@ -2058,7 +2037,7 @@ public class CxfX509MigSymTests {
 
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testBadBasic192Service() throws Exception {
         String thisMethod = "testBadBasic192Service";
         methodFull = "testBadBasic192Service";
@@ -2101,7 +2080,7 @@ public class CxfX509MigSymTests {
     //  in tcpmon
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testBadInclusiveC14NService() throws Exception {
         String thisMethod = "testBadInclusiveC14NService";
         methodFull = "testBadInclusiveC14NService";
@@ -2144,7 +2123,6 @@ public class CxfX509MigSymTests {
     //
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testBadSymmetricEndorsingUNTPolicy() throws Exception {
         String thisMethod = "testBadSymmetricEndorsingUNTPolicy";
         methodFull = "testBadSymmetricEndorsingUNTPolicy";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigTests.java
@@ -89,8 +89,7 @@ public class CxfX509MigTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             errMsgVersion = "EE7";
-        }
-        if ((features.contains("jaxws-2.3")) || (features.contains("xmlWS-3.0"))) {
+        } else if ((features.contains("jaxws-2.3")) || (features.contains("xmlWS-3.0"))) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigTests.java
@@ -85,12 +85,12 @@ public class CxfX509MigTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             errMsgVersion = "EE7";
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if ((features.contains("jaxws-2.3")) || (features.contains("xmlWS-3.0"))) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -321,7 +321,6 @@ public class CxfX509MigTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     public void testCxfX509AsymIssuerSerialMigService() throws Exception {
         String thisMethod = "testCxfX509AsymIssuerSerialMigService";
         methodFull = "testCxfX509AsymIssuerSerialMigService";
@@ -514,7 +513,6 @@ public class CxfX509MigTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     public void testCxfX509AsymThumbprintMigService() throws Exception {
         String thisMethod = "testCxfX509AsymThumbprintMigService";
         methodFull = "testCxfX509AsymThumbprintMigService";
@@ -724,7 +722,6 @@ public class CxfX509MigTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     public void testCxfX509AsymProtectTokensMigService() throws Exception {
         String thisMethod = "testCxfX509AsymProtectTokensMigService";
         methodFull = "testCxfX509AsymProtectTokensMigService";
@@ -895,7 +892,6 @@ public class CxfX509MigTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     public void testCxfX509TransportEndrosingMigServiceHttps() throws Exception {
         String thisMethod = "testCxfX509TransportEndorsingMigService";
         methodFull = "testCxfX509TransportEndorsingMigServiceHttps";
@@ -1081,7 +1077,6 @@ public class CxfX509MigTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     public void testCxfX509TransportEndrosingSP11MigServiceHttps() throws Exception {
         String thisMethod = "testCxfX509TransportEndorsingSP11MigService";
         methodFull = "testCxfX509TransportEndorsingSP11MigServiceHttps";
@@ -1250,7 +1245,6 @@ public class CxfX509MigTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     public void testCxfX509TransportSignedEndrosingMigServiceHttps() throws Exception {
         String thisMethod = "testCxfX509TransportSignedEndorsingMigService";
         methodFull = "testCxfX509TransportSignedEndorsingMigServiceHttps";
@@ -1419,7 +1413,6 @@ public class CxfX509MigTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     public void testCxfX509TransportEndrosingEncryptedMigServiceHttps() throws Exception {
         String thisMethod = "testCxfX509TransportEndorsingEncryptedMigService";
         methodFull = "testCxfX509TransportEndorsingEncryptedMigServiceHttps";
@@ -1589,7 +1582,6 @@ public class CxfX509MigTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     public void testCxfX509TransportSignedEndrosingEncryptedMigServiceHttps() throws Exception {
         String thisMethod = "testCxfX509TransportSignedEndorsingEncryptedMigService";
         methodFull = "testCxfX509TransportSignedEndorsingEncryptedMigServiceHttps";
@@ -1816,7 +1808,6 @@ public class CxfX509MigTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     public void testCxfX509TransportSupportingSignedMigServiceHttps() throws Exception {
         String thisMethod = "testCxfX509TransportSupportingSignedMigService";
         methodFull = "testCxfX509TransportSupportingSignedMigServiceHttps";
@@ -2156,7 +2147,6 @@ public class CxfX509MigTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     public void testCxfX509AsymmetricSignatureMigService() throws Exception {
         String thisMethod = "testCxfX509AsymmetricSignatureMigService";
         methodFull = "testCxfX509AsymmetricSignatureMigService";
@@ -2188,7 +2178,7 @@ public class CxfX509MigTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException", "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { JakartaEE9Action.ID })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { JakartaEE9Action.ID })
     public void testCxfX509AsymmetricSignatureReplayMigService() throws Exception {
         // This is a negative test case.
         // It ought to fail at the second request.
@@ -2375,7 +2365,6 @@ public class CxfX509MigTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     public void testCxfX509AsymmetricSignatureSP11MigService() throws Exception {
         String thisMethod = "testCxfX509AsymmetricSignatureSP11MigService";
         methodFull = "testCxfX509AsymmetricSignatureSP11MigService";
@@ -2558,7 +2547,6 @@ public class CxfX509MigTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     public void testCxfX509AsymmetricEncryptionMigService() throws Exception {
         String thisMethod = "testCxfX509AsymmetricEncryptionMigService";
         methodFull = "testCxfX509AsymmetricEncryptionMigService";
@@ -2634,7 +2622,6 @@ public class CxfX509MigTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     public void testWsComplexService() throws Exception {
         String thisMethod = "testWsComplexService";
         methodFull = "testWsComplexService";
@@ -2665,7 +2652,6 @@ public class CxfX509MigTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     public void testWsComplexSP11Service() throws Exception {
         String thisMethod = "testWsComplexSP11Service";
         methodFull = "testWsComplexSP11Service";
@@ -2705,7 +2691,6 @@ public class CxfX509MigTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     public void testAsymmetricBasic256Service() throws Exception {
         String thisMethod = "testAsymmetricBasic256Service";
         methodFull = "testAsymmetricBasic256Service";
@@ -2751,7 +2736,6 @@ public class CxfX509MigTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     public void testAsymSignatureConfirmService() throws Exception {
         String thisMethod = "testAsymSignatureConfirmService";
         methodFull = "testAsymSignatureConfirmService";
@@ -2790,7 +2774,6 @@ public class CxfX509MigTests {
      **/
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     public void testAsymEncSignService() throws Exception {
         String thisMethod = "testAsymEncSignService";
         methodFull = "testAsymEncSignService";
@@ -2851,7 +2834,6 @@ public class CxfX509MigTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     public void testTripleDesService() throws Exception {
         String thisMethod = "testTripleDesService";
         methodFull = "testTripleDesService";
@@ -2884,7 +2866,6 @@ public class CxfX509MigTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     public void testBasic128Service() throws Exception {
         String thisMethod = "testBasic128Service";
         methodFull = "testBasic128Service";
@@ -3508,7 +3489,7 @@ public class CxfX509MigTests {
      * It expects to fail
      **/
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException", "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { JakartaEE9Action.ID })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { JakartaEE9Action.ID })
     public void testBadAsymEndSignService() throws Exception {
         String thisMethod = "testBadAsymEncSignService";
         methodFull = "testBadAsymEncSignService";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509ASyncTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509ASyncTests.java
@@ -58,12 +58,12 @@ public class CxfX509ASyncTests extends CommonTests {
         //6/2021 need to update CommonTest.java to get req parameter of CBHVersion; comment out for now
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             CBHVersion = "EE7";
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -100,7 +100,6 @@ public class CxfX509ASyncTests extends CommonTests {
     @Test
     //skip EE7 test
     //@SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfAsyncInvokeNonBlocking() throws Exception {
 
         Log.info(thisClass, "setup", "CBHVersion in test method: " + CBHVersion);
@@ -143,7 +142,6 @@ public class CxfX509ASyncTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfAsyncInvokeBlocking() throws Exception {
 
         genericAsyncTest(
@@ -185,7 +183,6 @@ public class CxfX509ASyncTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfAsyncInvokeWithHandler() throws Exception {
 
         genericAsyncTest(

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509ASyncTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509ASyncTests.java
@@ -28,13 +28,11 @@ import com.ibm.ws.wssecurity.fat.utils.common.CommonTests;
 import com.ibm.ws.wssecurity.fat.utils.common.PrepCommonSetup;
 import com.ibm.ws.wssecurity.fat.utils.common.UpdateWSDLPortNum;
 
-import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.EE8FeatureReplacementAction;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 
@@ -62,8 +60,7 @@ public class CxfX509ASyncTests extends CommonTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             CBHVersion = "EE7";
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -79,8 +76,6 @@ public class CxfX509ASyncTests extends CommonTests {
         clientHttpUrl = "http://localhost:" + portNumber +
                         "/x509aSyncclient/CxfX509AsyncSvcClient";
 
-        Log.info(thisClass, "setup", "CBHVersion in setup: " + CBHVersion);
-
     }
 
     // All tests are using the same server side methods - they just invoke the calls
@@ -95,11 +90,7 @@ public class CxfX509ASyncTests extends CommonTests {
      *
      */
 
-    //2/2021 this test failed with EE8, see https://github.com/OpenLiberty/open-liberty/issues/16071
-    //6/20201 disable the test
     @Test
-    //skip EE7 test
-    //@SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
     public void testCxfAsyncInvokeNonBlocking() throws Exception {
 
         Log.info(thisClass, "setup", "CBHVersion in test method: " + CBHVersion);

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509BasicTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509BasicTests.java
@@ -78,11 +78,11 @@ public class CxfX509BasicTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -125,7 +125,6 @@ public class CxfX509BasicTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfX509Service() throws Exception {
         String thisMethod = "testCxfX509Service";
 
@@ -154,7 +153,6 @@ public class CxfX509BasicTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfX509ServiceHttps() throws Exception {
 
         String thisMethod = "testCxfX509Service";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509BasicTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509BasicTests.java
@@ -32,13 +32,11 @@ import com.meterware.httpunit.WebConversation;
 import com.meterware.httpunit.WebRequest;
 import com.meterware.httpunit.WebResponse;
 
-import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.EE8FeatureReplacementAction;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 
@@ -81,8 +79,7 @@ public class CxfX509BasicTests {
         if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509CrlTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509CrlTests.java
@@ -64,8 +64,7 @@ public class CxfX509CrlTests extends CommonTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             //issue 18363
             featureVersion = "EE7";
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -105,10 +104,9 @@ public class CxfX509CrlTests extends CommonTests {
 
         String thisMethod = "testCXFClientCRLPNotInList";
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_certp.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_certp_wss4j.xml");
         } //End of issue 18363
 
@@ -138,10 +136,9 @@ public class CxfX509CrlTests extends CommonTests {
                     "The test expected a succesful message from the server.");
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
         } //End of issue 18363
 
@@ -166,10 +163,9 @@ public class CxfX509CrlTests extends CommonTests {
 
         String thisMethod = "testCXFClientCRLNInList";
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_certn.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_certn_wss4j.xml");
         } //End of issue 18363
 
@@ -201,12 +197,11 @@ public class CxfX509CrlTests extends CommonTests {
                     "The test expected a succesful message from the server.");
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
-        } //End of issue 18363
+        } //End of 18363
 
     }
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509CrlTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509CrlTests.java
@@ -59,13 +59,13 @@ public class CxfX509CrlTests extends CommonTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             //issue 18363
             featureVersion = "EE7";
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -101,7 +101,6 @@ public class CxfX509CrlTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientCRLPNotInList() throws Exception {
 
         String thisMethod = "testCXFClientCRLPNotInList";
@@ -163,7 +162,6 @@ public class CxfX509CrlTests extends CommonTests {
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientCRLNInList() throws Exception {
 
         String thisMethod = "testCXFClientCRLNInList";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509CrlTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509CrlTests.java
@@ -11,9 +11,7 @@
 
 package com.ibm.ws.wssecurity.fat.cxf.x509token;
 
-import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
-import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 
 import java.io.File;
 import java.util.Set;
@@ -49,6 +47,8 @@ public class CxfX509CrlTests extends CommonTests {
     //static private final Class<?> thisClass = CxfX509CrlTests.class;
 //    static private UpdateWSDLPortNum newWsdl = null;
     static final private String serverName = "com.ibm.ws.wssecurity_fat.x509crl";
+    //issue 18363
+    private static String featureVersion = "";
 
     @Server(serverName)
     public static LibertyServer server;
@@ -62,11 +62,15 @@ public class CxfX509CrlTests extends CommonTests {
         if (features.contains("usr:wsseccbh-1.0")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
+            //issue 18363
+            featureVersion = "EE7";
         }
         if (features.contains("usr:wsseccbh-2.0")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+            //issue 18363
+            featureVersion = "EE8";
         }
 
         WebArchive x509crlclient_war = ShrinkHelper.buildDefaultApp("x509crlclient", "com.ibm.ws.wssecurity.fat.x509crlclient", "test.wssecfvt.x509crl",
@@ -97,48 +101,18 @@ public class CxfX509CrlTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testCXFClientCRLPNotInListEE7Only() throws Exception {
-
-        String thisMethod = "testCXFClientCRLPNotInList";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_certp.xml");
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "X509CrlNotInListService",
-                    // wsdl that the svc client code should use
-                    //newClientWsdl,
-                    "",
-                    // wsdl port that svc client code should use
-                    "X509CrlNotInList",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Response: This is X509CrlNotInListService Web Service",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
-
-        //Added to resolve RTC 285315
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCXFClientCRLPNotInListEE8Only() throws Exception {
+    public void testCXFClientCRLPNotInList() throws Exception {
 
         String thisMethod = "testCXFClientCRLPNotInList";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_certp_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_certp.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_certp_wss4j.xml");
+        } //End of issue 18363
+
         genericTest(
                     // test name for logging
                     thisMethod,
@@ -164,8 +138,13 @@ public class CxfX509CrlTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
 
-        //Added to resolve RTC 285315
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        } //End of issue 18363
 
     }
 
@@ -182,52 +161,20 @@ public class CxfX509CrlTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    public void testCXFClientCRLNInListEE7Only() throws Exception {
-
-        String thisMethod = "testCXFClientCRLNInList";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_certn.xml");
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "X509CrlInListService",
-                    // wsdl that the svc client code should use
-                    //newClientWsdl,
-                    "",
-                    // wsdl port that svc client code should use
-                    "X509CrlInList",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "has been revoked",
-                    // additional string to check for - chc SUN doesn't say what alias has been revoked
-                    //"myx509certN",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
-
-        //Added to resolve RTC 285315
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
     @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCXFClientCRLNInListEE8Only() throws Exception {
+    public void testCXFClientCRLNInList() throws Exception {
 
         String thisMethod = "testCXFClientCRLNInList";
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_certn_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_certn.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_certn_wss4j.xml");
+        } //End of issue 18363
+
         genericTest(
                     // test name for logging
                     thisMethod,
@@ -255,8 +202,13 @@ public class CxfX509CrlTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test expected a succesful message from the server.");
 
-        //Added to resolve RTC 285315
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        } //End of issue 18363
 
     }
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509EncTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509EncTests.java
@@ -68,13 +68,13 @@ public class CxfX509EncTests extends CommonTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             //issue 18363
             featureVersion = "EE7";
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -104,7 +104,6 @@ public class CxfX509EncTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientEncryptUsernameToken() throws Exception {
 
         genericTest(
@@ -232,7 +231,6 @@ public class CxfX509EncTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientEncryptBodyAndUnt() throws Exception {
 
         genericTest(
@@ -273,7 +271,6 @@ public class CxfX509EncTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientEncryptUntNonce() throws Exception {
 
         genericTest(
@@ -313,7 +310,6 @@ public class CxfX509EncTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfClientEncryptSignature() throws Exception {
 
         genericTest(
@@ -403,7 +399,6 @@ public class CxfX509EncTests extends CommonTests {
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientWrongEncKeyAlgorithm() throws Exception {
 
         String thisMethod = "testCXFClientWrongEncKeyAlgorithm";
@@ -483,7 +478,6 @@ public class CxfX509EncTests extends CommonTests {
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientWrongDataEncAlgorithm() throws Exception {
 
         String thisMethod = "testCXFClientWrongDataEncAlgorithm";
@@ -561,7 +555,6 @@ public class CxfX509EncTests extends CommonTests {
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientWrongEncryptionKey() throws Exception {
 
         String thisMethod = "testCXFClientWrongEncryptionKey";
@@ -645,7 +638,6 @@ public class CxfX509EncTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFClientEncryptionBeforeSign() throws Exception {
 
         //issue 18363

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509EncTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509EncTests.java
@@ -11,9 +11,7 @@
 
 package com.ibm.ws.wssecurity.fat.cxf.x509token;
 
-import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
-import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 
 import java.io.File;
 import java.util.Set;
@@ -51,6 +49,8 @@ public class CxfX509EncTests extends CommonTests {
     static private UpdateWSDLPortNum newWsdl = null;
     static private String newClientWsdl = null;
     static final private String serverName = "com.ibm.ws.wssecurity_fat.x509enc";
+    //issue 18363
+    private static String featureVersion = "";
 
     @Server(serverName)
     public static LibertyServer server;
@@ -71,11 +71,15 @@ public class CxfX509EncTests extends CommonTests {
         if (features.contains("usr:wsseccbh-1.0")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
+            //issue 18363
+            featureVersion = "EE7";
         }
         if (features.contains("usr:wsseccbh-2.0")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+            //issue 18363
+            featureVersion = "EE8";
         }
 
         ShrinkHelper.defaultDropinApp(server, "x509encclient", "com.ibm.ws.wssecurity.fat.x509encclient", "test.wssecfvt.x509enc", "test.wssecfvt.x509enc.types");
@@ -397,47 +401,10 @@ public class CxfX509EncTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    public void testCXFClientWrongEncKeyAlgorithmEE7Only() throws Exception {
-
-        String thisMethod = "testCXFClientWrongEncKeyAlgorithm";
-        printMethodName(thisMethod, "Start Prep for " + thisMethod);
-        newClientWsdl = updateClientWsdl(defaultClientWsdlLoc + "X509XmlEnc2.wsdl",
-                                         defaultClientWsdlLoc + "X509XmlEnc2Updated.wsdl");
-        Log.info(thisClass, thisMethod, "Using " + newClientWsdl);
-        printMethodName(thisMethod, "End Prep for " + thisMethod);
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "X509XmlEncService7",
-                    // wsdl that the svc client code should use
-                    newClientWsdl,
-                    // wsdl port that svc client code should use
-                    "UrnX509Enc7",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "AsymmetricBinding: The Key transport method does not match the requirement",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
-
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
     @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCXFClientWrongEncKeyAlgorithmEE8Only() throws Exception {
+    public void testCXFClientWrongEncKeyAlgorithm() throws Exception {
 
         String thisMethod = "testCXFClientWrongEncKeyAlgorithm";
         printMethodName(thisMethod, "Start Prep for " + thisMethod);
@@ -445,29 +412,60 @@ public class CxfX509EncTests extends CommonTests {
                                          defaultClientWsdlLoc + "X509XmlEnc2Updated.wsdl");
         Log.info(thisClass, thisMethod, "Using " + newClientWsdl);
         printMethodName(thisMethod, "End Prep for " + thisMethod);
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "X509XmlEncService7",
-                    // wsdl that the svc client code should use
-                    newClientWsdl,
-                    // wsdl port that svc client code should use
-                    "UrnX509Enc7",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "An error was discovered processing the <wsse:Security> header",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
+
+        //issue 18363
+        if (featureVersion == "EE7") {
+            genericTest(
+                        // test name for logging
+                        thisMethod,
+                        // Svc Client Url that generic test code should use
+                        clientHttpUrl,
+                        // Port that svc client code should use
+                        "",
+                        // user that svc client code should use
+                        "user1",
+                        // pw that svc client code should use
+                        "security",
+                        // wsdl sevice that svc client code should use
+                        "X509XmlEncService7",
+                        // wsdl that the svc client code should use
+                        newClientWsdl,
+                        // wsdl port that svc client code should use
+                        "UrnX509Enc7",
+                        // msg to send from svc client to server
+                        "",
+                        // expected response from server
+                        "AsymmetricBinding: The Key transport method does not match the requirement",
+                        // msg to issue if do NOT get the expected result
+                        "The test expected a succesful message from the server.");
+        } //End of issue 18363
+
+        //issue 18363
+        if (featureVersion == "EE8") {
+            genericTest(
+                        // test name for logging
+                        thisMethod,
+                        // Svc Client Url that generic test code should use
+                        clientHttpUrl,
+                        // Port that svc client code should use
+                        "",
+                        // user that svc client code should use
+                        "user1",
+                        // pw that svc client code should use
+                        "security",
+                        // wsdl sevice that svc client code should use
+                        "X509XmlEncService7",
+                        // wsdl that the svc client code should use
+                        newClientWsdl,
+                        // wsdl port that svc client code should use
+                        "UrnX509Enc7",
+                        // msg to send from svc client to server
+                        "",
+                        // expected response from server
+                        "An error was discovered processing the <wsse:Security> header",
+                        // msg to issue if do NOT get the expected result
+                        "The test expected a succesful message from the server.");
+        } //End of issue 18363
 
     }
 
@@ -483,48 +481,10 @@ public class CxfX509EncTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    public void testCXFClientWrongDataEncAlgorithmEE7Only() throws Exception {
-
-        String thisMethod = "testCXFClientWrongDataEncAlgorithm";
-        printMethodName(thisMethod, "Start Prep for " + thisMethod);
-        newClientWsdl = updateClientWsdl(defaultClientWsdlLoc + "X509XmlEnc2.wsdl",
-                                         defaultClientWsdlLoc + "X509XmlEnc2Updated.wsdl");
-        Log.info(thisClass, thisMethod, "Using " + newClientWsdl);
-        printMethodName(thisMethod, "End Prep for " + thisMethod);
-        genericTest(
-                    // test name for logging
-                    "testCXFClientWrongDataEncAlgorithm",
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "X509XmlEncService8",
-                    // wsdl that the svc client code should use
-                    newClientWsdl,
-                    // wsdl port that svc client code should use
-                    "UrnX509Enc8",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    //Orig:
-                    "AsymmetricBinding: The encryption algorithm does not match the requirement",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
-
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
     @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCXFClientWrongDataEncAlgorithmEE8Only() throws Exception {
+    public void testCXFClientWrongDataEncAlgorithm() throws Exception {
 
         String thisMethod = "testCXFClientWrongDataEncAlgorithm";
         printMethodName(thisMethod, "Start Prep for " + thisMethod);
@@ -532,30 +492,59 @@ public class CxfX509EncTests extends CommonTests {
                                          defaultClientWsdlLoc + "X509XmlEnc2Updated.wsdl");
         Log.info(thisClass, thisMethod, "Using " + newClientWsdl);
         printMethodName(thisMethod, "End Prep for " + thisMethod);
-        genericTest(
-                    // test name for logging
-                    "testCXFClientWrongDataEncAlgorithm",
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "X509XmlEncService8",
-                    // wsdl that the svc client code should use
-                    newClientWsdl,
-                    // wsdl port that svc client code should use
-                    "UrnX509Enc8",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "An error was discovered processing the <wsse:Security> header",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            genericTest(
+                        // test name for logging
+                        "testCXFClientWrongDataEncAlgorithm",
+                        // Svc Client Url that generic test code should use
+                        clientHttpUrl,
+                        // Port that svc client code should use
+                        "",
+                        // user that svc client code should use
+                        "user1",
+                        // pw that svc client code should use
+                        "security",
+                        // wsdl sevice that svc client code should use
+                        "X509XmlEncService8",
+                        // wsdl that the svc client code should use
+                        newClientWsdl,
+                        // wsdl port that svc client code should use
+                        "UrnX509Enc8",
+                        // msg to send from svc client to server
+                        "",
+                        // expected response from server
+                        "AsymmetricBinding: The encryption algorithm does not match the requirement",
+                        // msg to issue if do NOT get the expected result
+                        "The test expected a succesful message from the server.");
+        } //End of issue 18363
 
+        //issue 18363
+        if (featureVersion == "EE8") {
+            genericTest(
+                        // test name for logging
+                        "testCXFClientWrongDataEncAlgorithm",
+                        // Svc Client Url that generic test code should use
+                        clientHttpUrl,
+                        // Port that svc client code should use
+                        "",
+                        // user that svc client code should use
+                        "user1",
+                        // pw that svc client code should use
+                        "security",
+                        // wsdl sevice that svc client code should use
+                        "X509XmlEncService8",
+                        // wsdl that the svc client code should use
+                        newClientWsdl,
+                        // wsdl port that svc client code should use
+                        "UrnX509Enc8",
+                        // msg to send from svc client to server
+                        "",
+                        // expected response from server
+                        "An error was discovered processing the <wsse:Security> header",
+                        // msg to issue if do NOT get the expected result
+                        "The test expected a succesful message from the server.");
+        } //End of issue 18363
     }
 
     /**
@@ -570,90 +559,77 @@ public class CxfX509EncTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    public void testCXFClientWrongEncryptionKeyEE7Only() throws Exception {
-
-        String thisMethod = "testCXFClientWrongEncryptionKey";
-        printMethodName(thisMethod, "Start Prep for " + thisMethod);
-
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wrongEnc.xml");
-
-        printMethodName(thisMethod, "End Prep for " + thisMethod);
-
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "X509XmlEncService9",
-                    // wsdl that the svc client code should use
-                    "",
-                    // wsdl port that svc client code should use
-                    "UrnX509Enc9",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "The signature or decryption was invalid",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected an exception from the server.");
-
-        printMethodName(thisMethod, "Start Cleanup for " + thisMethod);
-
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
-
-        printMethodName(thisMethod, "End Cleanup for " + thisMethod);
-
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
     @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCXFClientWrongEncryptionKeyEE8Only() throws Exception {
+    public void testCXFClientWrongEncryptionKey() throws Exception {
 
         String thisMethod = "testCXFClientWrongEncryptionKey";
         printMethodName(thisMethod, "Start Prep for " + thisMethod);
-
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wrongEnc_wss4j.xml");
-
         printMethodName(thisMethod, "End Prep for " + thisMethod);
 
-        genericTest(
-                    // test name for logging
-                    thisMethod,
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "X509XmlEncService9",
-                    // wsdl that the svc client code should use
-                    "",
-                    // wsdl port that svc client code should use
-                    "UrnX509Enc9",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Cannot find key for alias: [alice]",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected an exception from the server.");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wrongEnc.xml");
+            genericTest(
+                        // test name for logging
+                        thisMethod,
+                        // Svc Client Url that generic test code should use
+                        clientHttpUrl,
+                        // Port that svc client code should use
+                        "",
+                        // user that svc client code should use
+                        "user1",
+                        // pw that svc client code should use
+                        "security",
+                        // wsdl sevice that svc client code should use
+                        "X509XmlEncService9",
+                        // wsdl that the svc client code should use
+                        "",
+                        // wsdl port that svc client code should use
+                        "UrnX509Enc9",
+                        // msg to send from svc client to server
+                        "",
+                        // expected response from server
+                        "The signature or decryption was invalid",
+                        // msg to issue if do NOT get the expected result
+                        "The test expected an exception from the server.");
+
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+
+        } //End of issue 18363
+
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wrongEnc_wss4j.xml");
+            genericTest(
+                        // test name for logging
+                        thisMethod,
+                        // Svc Client Url that generic test code should use
+                        clientHttpUrl,
+                        // Port that svc client code should use
+                        "",
+                        // user that svc client code should use
+                        "user1",
+                        // pw that svc client code should use
+                        "security",
+                        // wsdl sevice that svc client code should use
+                        "X509XmlEncService9",
+                        // wsdl that the svc client code should use
+                        "",
+                        // wsdl port that svc client code should use
+                        "UrnX509Enc9",
+                        // msg to send from svc client to server
+                        "",
+                        // expected response from server
+                        "Cannot find key for alias: [alice]",
+                        // msg to issue if do NOT get the expected result
+                        "The test expected an exception from the server.");
+
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+
+        } //End of issue 18363
 
         printMethodName(thisMethod, "Start Cleanup for " + thisMethod);
-
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
-
         printMethodName(thisMethod, "End Cleanup for " + thisMethod);
 
     }
@@ -669,42 +645,17 @@ public class CxfX509EncTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testCXFClientEncryptionBeforeSignEE7Only() throws Exception {
-
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-        genericTest(
-                    // test name for logging
-                    "testCXFClientEncryptionBeforeSign",
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "X509XmlEncService10",
-                    // wsdl that the svc client code should use
-                    "",
-                    // wsdl port that svc client code should use
-                    "UrnX509Enc10",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Response: This is X509EncWebSvc10 Web Service",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
-
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCXFClientEncryptionBeforeSignEE8Only() throws Exception {
+    public void testCXFClientEncryptionBeforeSign() throws Exception {
 
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        } //End of issue 18363
+
         genericTest(
                     // test name for logging
                     "testCXFClientEncryptionBeforeSign",

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509EncTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509EncTests.java
@@ -73,8 +73,7 @@ public class CxfX509EncTests extends CommonTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             //issue 18363
             featureVersion = "EE7";
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -409,7 +408,7 @@ public class CxfX509EncTests extends CommonTests {
         printMethodName(thisMethod, "End Prep for " + thisMethod);
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             genericTest(
                         // test name for logging
                         thisMethod,
@@ -433,10 +432,8 @@ public class CxfX509EncTests extends CommonTests {
                         "AsymmetricBinding: The Key transport method does not match the requirement",
                         // msg to issue if do NOT get the expected result
                         "The test expected a succesful message from the server.");
-        } //End of issue 18363
 
-        //issue 18363
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             genericTest(
                         // test name for logging
                         thisMethod,
@@ -486,8 +483,9 @@ public class CxfX509EncTests extends CommonTests {
                                          defaultClientWsdlLoc + "X509XmlEnc2Updated.wsdl");
         Log.info(thisClass, thisMethod, "Using " + newClientWsdl);
         printMethodName(thisMethod, "End Prep for " + thisMethod);
+
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             genericTest(
                         // test name for logging
                         "testCXFClientWrongDataEncAlgorithm",
@@ -511,10 +509,8 @@ public class CxfX509EncTests extends CommonTests {
                         "AsymmetricBinding: The encryption algorithm does not match the requirement",
                         // msg to issue if do NOT get the expected result
                         "The test expected a succesful message from the server.");
-        } //End of issue 18363
 
-        //issue 18363
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             genericTest(
                         // test name for logging
                         "testCXFClientWrongDataEncAlgorithm",
@@ -562,7 +558,7 @@ public class CxfX509EncTests extends CommonTests {
         printMethodName(thisMethod, "End Prep for " + thisMethod);
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wrongEnc.xml");
             genericTest(
                         // test name for logging
@@ -590,9 +586,7 @@ public class CxfX509EncTests extends CommonTests {
 
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
 
-        } //End of issue 18363
-
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wrongEnc_wss4j.xml");
             genericTest(
                         // test name for logging
@@ -641,10 +635,9 @@ public class CxfX509EncTests extends CommonTests {
     public void testCXFClientEncryptionBeforeSign() throws Exception {
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
         } //End of issue 18363
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509ObjectTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509ObjectTests.java
@@ -33,13 +33,11 @@ import com.meterware.httpunit.WebConversation;
 import com.meterware.httpunit.WebRequest;
 import com.meterware.httpunit.WebResponse;
 
-import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.EE8FeatureReplacementAction;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 
@@ -80,8 +78,7 @@ public class CxfX509ObjectTests {
         if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509ObjectTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509ObjectTests.java
@@ -77,11 +77,11 @@ public class CxfX509ObjectTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -136,7 +136,6 @@ public class CxfX509ObjectTests {
     //Aruna is aware of the cause from feature definition API packages; waiting for the next stage of update to fix it
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfX509Service() throws Exception {
 
         String thisMethod = "testCxfX509Service";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509OverRideTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509OverRideTests.java
@@ -78,11 +78,11 @@ public class CxfX509OverRideTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -129,7 +129,6 @@ public class CxfX509OverRideTests {
     //
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfX509Service() throws Exception {
         String thisMethod = "testCxfX509Service";
 
@@ -157,7 +156,7 @@ public class CxfX509OverRideTests {
     @Test
     @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfX50NegativeService() throws Exception {
 
         String thisMethod = "testCxfX509Service";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509OverRideTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509OverRideTests.java
@@ -81,8 +81,7 @@ public class CxfX509OverRideTests {
         if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509SigTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509SigTests.java
@@ -60,13 +60,13 @@ public class CxfX509SigTests extends CommonTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             //issue 18363
             featureVersion = "EE7";
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -84,7 +84,6 @@ public class CxfX509SigTests extends CommonTests {
     }
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfClientSignSoapBody() throws Exception {
 
         genericTest(
@@ -179,7 +178,6 @@ public class CxfX509SigTests extends CommonTests {
 
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfClientTimestampMissing() throws Exception {
 
         newClientWsdl = updateClientWsdl(defaultClientWsdlLoc + "X509XmlSigClientTimestamps.wsdl",
@@ -245,7 +243,6 @@ public class CxfX509SigTests extends CommonTests {
     }
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfClientSignBodyUNTAndTs() throws Exception {
 
         genericTest(
@@ -444,7 +441,6 @@ public class CxfX509SigTests extends CommonTests {
 
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfClientBadSrvKeyStorePswd() throws Exception {
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509SigTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509SigTests.java
@@ -11,9 +11,7 @@
 
 package com.ibm.ws.wssecurity.fat.cxf.x509token;
 
-import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
-import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 
 import java.io.File;
 import java.util.Set;
@@ -51,6 +49,8 @@ public class CxfX509SigTests extends CommonTests {
     static private UpdateWSDLPortNum newWsdl = null;
     static private String newClientWsdl = null;
     static final private String serverName = "com.ibm.ws.wssecurity_fat.x509sig";
+    //issue 18363
+    private static String featureVersion = "";
 
     @Server(serverName)
     public static LibertyServer server;
@@ -63,11 +63,15 @@ public class CxfX509SigTests extends CommonTests {
         if (features.contains("usr:wsseccbh-1.0")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
+            //issue 18363
+            featureVersion = "EE7";
         }
         if (features.contains("usr:wsseccbh-2.0")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+            //issue 18363
+            featureVersion = "EE8";
         }
 
         ShrinkHelper.defaultDropinApp(server, "x509sigclient", "com.ibm.ws.wssecurity.fat.x509sigclient", "test.wssecfvt.x509sig", "test.wssecfvt.x509sig.types");
@@ -110,70 +114,66 @@ public class CxfX509SigTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    public void testCxfBodyNotSignedEE7Only() throws Exception {
+    public void testCxfBodyNotSigned() throws Exception {
 
         newClientWsdl = updateClientWsdl(defaultClientWsdlLoc + "X509XmlSigNoClientSig.wsdl",
                                          defaultClientWsdlLoc + "X509XmlSigNoClientSigUpdated.wsdl");
         Log.info(thisClass, "testCxfBodyNotSigned", "Using " + newClientWsdl);
-        genericTest(
-                    // test name for logging
-                    "testCxfBodyNotSignedEE7Only",
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "X509XmlSigService1",
-                    // wsdl that the svc client code should use
-                    newClientWsdl,
-                    // wsdl port that svc client code should use
-                    "UrnX509Sig",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    //Orig:
-                    "Body not SIGNED",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            genericTest(
+                        // test name for logging
+                        "testCxfBodyNotSigned",
+                        // Svc Client Url that generic test code should use
+                        clientHttpUrl,
+                        // Port that svc client code should use
+                        "",
+                        // user that svc client code should use
+                        "user1",
+                        // pw that svc client code should use
+                        "security",
+                        // wsdl sevice that svc client code should use
+                        "X509XmlSigService1",
+                        // wsdl that the svc client code should use
+                        newClientWsdl,
+                        // wsdl port that svc client code should use
+                        "UrnX509Sig",
+                        // msg to send from svc client to server
+                        "",
+                        // expected response from server
+                        //Orig:
+                        "Body not SIGNED",
+                        // msg to issue if do NOT get the expected result
+                        "The test expected a succesful message from the server.");
+        } // End of issue 18363
 
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
-    public void testCxfBodyNotSignedEE8Only() throws Exception {
-
-        newClientWsdl = updateClientWsdl(defaultClientWsdlLoc + "X509XmlSigNoClientSig.wsdl",
-                                         defaultClientWsdlLoc + "X509XmlSigNoClientSigUpdated.wsdl");
-        Log.info(thisClass, "testCxfBodyNotSigned", "Using " + newClientWsdl);
-        genericTest(
-                    // test name for logging
-                    "testCxfBodyNotSignedEE8Only",
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "X509XmlSigService1",
-                    // wsdl that the svc client code should use
-                    newClientWsdl,
-                    // wsdl port that svc client code should use
-                    "UrnX509Sig",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Soap Body is not SIGNED", //@AV999
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
+        //issue 18363
+        if (featureVersion == "EE8") {
+            genericTest(
+                        // test name for logging
+                        "testCxfBodyNotSigned",
+                        // Svc Client Url that generic test code should use
+                        clientHttpUrl,
+                        // Port that svc client code should use
+                        "",
+                        // user that svc client code should use
+                        "user1",
+                        // pw that svc client code should use
+                        "security",
+                        // wsdl sevice that svc client code should use
+                        "X509XmlSigService1",
+                        // wsdl that the svc client code should use
+                        newClientWsdl,
+                        // wsdl port that svc client code should use
+                        "UrnX509Sig",
+                        // msg to send from svc client to server
+                        "",
+                        // expected response from server
+                        "Soap Body is not SIGNED",
+                        // msg to issue if do NOT get the expected result
+                        "The test expected a succesful message from the server.");
+        } // End of issue 18363
 
     }
 
@@ -308,217 +308,205 @@ public class CxfX509SigTests extends CommonTests {
     }
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    public void testCxfClientSignWithExpKeyEE7Only() throws Exception {
+    public void testCxfClientSignWithExpKey() throws Exception {
 
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_expcert.xml");
+        // use server config with expired cert
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_expcert.xml");
+            genericTest(
+                        // test name for logging
+                        "testCxfClientSignWithExpKey",
+                        // Svc Client Url that generic test code should use
+                        clientHttpUrl,
+                        // Port that svc client code should use
+                        "",
+                        // user that svc client code should use
+                        "user1",
+                        // pw that svc client code should use
+                        "security",
+                        // wsdl service that svc client code should use
+                        "X509XmlSigService4",
+                        // wsdl that the svc client code should use
+                        "",
+                        // wsdl port that svc client code should use
+                        "UrnX509Sig4",
+                        // msg to send from svc client to server
+                        "",
+                        // expected response from server
+                        "cannot create instance",
+                        // msg to issue if do NOT get the expected result
+                        "The test expected a succesful message from the server.");
 
-        genericTest(
-                    // test name for logging
-                    "testCxfClientSignWithExpKeyEE7Only",
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "X509XmlSigService4",
-                    // wsdl that the svc client code should use
-                    "",
-                    // wsdl port that svc client code should use
-                    "UrnX509Sig4",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    //Orig:
-                    "cannot create instance",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+        } //End of issue 18363
 
-        //Added to resolve RTC 285315
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+        //issue 18363
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_expcert_wss4j.xml");
+            genericTest(
+                        // test name for logging
+                        "testCxfClientSignWithExpKey",
+                        // Svc Client Url that generic test code should use
+                        clientHttpUrl,
+                        // Port that svc client code should use
+                        "",
+                        // user that svc client code should use
+                        "user1",
+                        // pw that svc client code should use
+                        "security",
+                        // wsdl sevice that svc client code should use
+                        "X509XmlSigService4",
+                        // wsdl that the svc client code should use
+                        "",
+                        // wsdl port that svc client code should use
+                        "UrnX509Sig4",
+                        // msg to send from svc client to server
+                        "",
+                        // expected response from server
+                        "Cannot create Crypto class",
+                        // msg to issue if do NOT get the expected result
+                        "The test expected a succesful message from the server.");
 
-    }
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
 
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
-    public void testCxfClientSignWithExpKeyEE8Only() throws Exception {
-
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_expcert_wss4j.xml");
-
-        genericTest(
-                    // test name for logging
-                    "testCxfClientSignWithExpKeyEE8Only",
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "X509XmlSigService4",
-                    // wsdl that the svc client code should use
-                    "",
-                    // wsdl port that svc client code should use
-                    "UrnX509Sig4",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Cannot create Crypto class", //@AV999
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
-
-        //Added to resolve RTC 285315
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+        } //End of issue 18363
 
     }
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    public void testCxfClientBadClKeyStorePswdEE7Only() throws Exception {
+    public void testCxfClientBadClKeyStorePswd() throws Exception {
 
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badclpwd.xml");
+        // use server config with bad client pw
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badclpwd.xml");
+            genericTest(
+                        // test name for logging
+                        "testCxfClientBadClKeyStorePswd",
+                        // Svc Client Url that generic test code should use
+                        clientHttpUrl,
+                        // Port that svc client code should use
+                        "",
+                        // user that svc client code should use
+                        "user1",
+                        // pw that svc client code should use
+                        "security",
+                        // wsdl sevice that svc client code should use
+                        "X509XmlSigService1",
+                        // wsdl that the svc client code should use
+                        "",
+                        // wsdl port that svc client code should use
+                        "UrnX509Sig",
+                        // msg to send from svc client to server
+                        "",
+                        // expected response from server
+                        "cannot create instance",
+                        // msg to issue if do NOT get the expected result
+                        "The test expected a succesful message from the server.");
 
-        genericTest(
-                    // test name for logging
-                    "testCxfClientBadClKeyStorePswdEE7Only",
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "X509XmlSigService1",
-                    // wsdl that the svc client code should use
-                    "",
-                    // wsdl port that svc client code should use
-                    "UrnX509Sig",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    //Orig:
-                    "cannot create instance",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
 
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+        } //End of issue 18363
 
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badclpwd_wss4j.xml");
+            genericTest(
+                        // test name for logging
+                        "testCxfClientBadClKeyStorePswd",
+                        // Svc Client Url that generic test code should use
+                        clientHttpUrl,
+                        // Port that svc client code should use
+                        "",
+                        // user that svc client code should use
+                        "user1",
+                        // pw that svc client code should use
+                        "security",
+                        // wsdl sevice that svc client code should use
+                        "X509XmlSigService1",
+                        // wsdl that the svc client code should use
+                        "",
+                        // wsdl port that svc client code should use
+                        "UrnX509Sig",
+                        // msg to send from svc client to server
+                        "",
+                        // expected response from server
+                        "Cannot create Crypto class",
+                        // msg to issue if do NOT get the expected result
+                        "The test expected a succesful message from the server.");
+
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+
+        } //End of issue 18363
     }
 
     @Test
-    @SkipForRepeat({ NO_MODIFICATION })
-    public void testCxfClientBadClKeyStorePswdEE8Only() throws Exception {
-
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badclpwd_wss4j.xml");
-
-        genericTest(
-                    // test name for logging
-                    "testCxfClientBadClKeyStorePswdEE8Only",
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "X509XmlSigService1",
-                    // wsdl that the svc client code should use
-                    "",
-                    // wsdl port that svc client code should use
-                    "UrnX509Sig",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Cannot create Crypto class", //@AV999
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
-
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
-
-    }
-
-    @Test
-    @SkipForRepeat({ EE8_FEATURES })
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    public void testCxfClientBadSrvKeyStorePswdEE7Only() throws Exception {
-
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badsvrpwd.xml");
-
-        genericTest(
-                    // test name for logging
-                    "testCxfClientBadSrvKeyStorePswdEE7Only",
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "X509XmlSigService1",
-                    // wsdl that the svc client code should use
-                    "",
-                    // wsdl port that svc client code should use
-                    "UrnX509Sig",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    //Orig:
-                    "cannot create instance",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
-
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
-
-    }
-
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    public void testCxfClientBadSrvKeyStorePswdEE8Only() throws Exception {
+    public void testCxfClientBadSrvKeyStorePswd() throws Exception {
 
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badsvrpwd_wss4j.xml");
+        // use server config with bad server pw
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badsvrpwd.xml");
+            genericTest(
+                        // test name for logging
+                        "testCxfClientBadSrvKeyStorePswd",
+                        // Svc Client Url that generic test code should use
+                        clientHttpUrl,
+                        // Port that svc client code should use
+                        "",
+                        // user that svc client code should use
+                        "user1",
+                        // pw that svc client code should use
+                        "security",
+                        // wsdl sevice that svc client code should use
+                        "X509XmlSigService1",
+                        // wsdl that the svc client code should use
+                        "",
+                        // wsdl port that svc client code should use
+                        "UrnX509Sig",
+                        // msg to send from svc client to server
+                        "",
+                        // expected response from server
+                        "cannot create instance",
+                        // msg to issue if do NOT get the expected result
+                        "The test expected a succesful message from the server.");
 
-        genericTest(
-                    // test name for logging
-                    "testCxfClientBadSrvKeyStorePswdEE8Only",
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "X509XmlSigService1",
-                    // wsdl that the svc client code should use
-                    "",
-                    // wsdl port that svc client code should use
-                    "UrnX509Sig",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Cannot create Crypto class",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a succesful message from the server.");
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
+        }
 
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badsvrpwd_wss4j.xml");
+            genericTest(
+                        // test name for logging
+                        "testCxfClientBadSrvKeyStorePswd",
+                        // Svc Client Url that generic test code should use
+                        clientHttpUrl,
+                        // Port that svc client code should use
+                        "",
+                        // user that svc client code should use
+                        "user1",
+                        // pw that svc client code should use
+                        "security",
+                        // wsdl sevice that svc client code should use
+                        "X509XmlSigService1",
+                        // wsdl that the svc client code should use
+                        "",
+                        // wsdl port that svc client code should use
+                        "UrnX509Sig",
+                        // msg to send from svc client to server
+                        "",
+                        // expected response from server
+                        "Cannot create Crypto class",
+                        // msg to issue if do NOT get the expected result
+                        "The test expected a succesful message from the server.");
 
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig_wss4j.xml");
+        }
     }
 
     public String updateClientWsdl(String origClientWsdl,

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509SigTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509SigTests.java
@@ -65,8 +65,7 @@ public class CxfX509SigTests extends CommonTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             //issue 18363
             featureVersion = "EE7";
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -120,7 +119,7 @@ public class CxfX509SigTests extends CommonTests {
                                          defaultClientWsdlLoc + "X509XmlSigNoClientSigUpdated.wsdl");
         Log.info(thisClass, "testCxfBodyNotSigned", "Using " + newClientWsdl);
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             genericTest(
                         // test name for logging
                         "testCxfBodyNotSigned",
@@ -145,10 +144,8 @@ public class CxfX509SigTests extends CommonTests {
                         "Body not SIGNED",
                         // msg to issue if do NOT get the expected result
                         "The test expected a succesful message from the server.");
-        } // End of issue 18363
 
-        //issue 18363
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             genericTest(
                         // test name for logging
                         "testCxfBodyNotSigned",
@@ -310,7 +307,7 @@ public class CxfX509SigTests extends CommonTests {
 
         // use server config with expired cert
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_expcert.xml");
             genericTest(
                         // test name for logging
@@ -337,10 +334,8 @@ public class CxfX509SigTests extends CommonTests {
                         "The test expected a succesful message from the server.");
 
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
-        } //End of issue 18363
 
-        //issue 18363
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_expcert_wss4j.xml");
             genericTest(
                         // test name for logging
@@ -378,7 +373,7 @@ public class CxfX509SigTests extends CommonTests {
 
         // use server config with bad client pw
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badclpwd.xml");
             genericTest(
                         // test name for logging
@@ -406,9 +401,7 @@ public class CxfX509SigTests extends CommonTests {
 
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
 
-        } //End of issue 18363
-
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badclpwd_wss4j.xml");
             genericTest(
                         // test name for logging
@@ -446,7 +439,7 @@ public class CxfX509SigTests extends CommonTests {
 
         // use server config with bad server pw
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badsvrpwd.xml");
             genericTest(
                         // test name for logging
@@ -473,9 +466,8 @@ public class CxfX509SigTests extends CommonTests {
                         "The test expected a succesful message from the server.");
 
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_orig.xml");
-        }
 
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badsvrpwd_wss4j.xml");
             genericTest(
                         // test name for logging

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509StrTypeTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509StrTypeTests.java
@@ -62,14 +62,14 @@ public class CxfX509StrTypeTests extends CommonTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             commonSetUp(serverName, "server_enc.xml", false, "/x509sigclient/CxfX509SigSvcClient");
             //issue 18361
             featureVersion = "EE7";
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             commonSetUp(serverName, "server_enc_wss4j.xml", false, "/x509sigclient/CxfX509SigSvcClient");
@@ -89,7 +89,6 @@ public class CxfX509StrTypeTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfClientSignIssuerSerial() throws Exception {
 
         genericTest(
@@ -126,7 +125,6 @@ public class CxfX509StrTypeTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfClientSignThumbPrint() throws Exception {
 
         genericTest(

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509StrTypeTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509StrTypeTests.java
@@ -68,8 +68,7 @@ public class CxfX509StrTypeTests extends CommonTests {
             commonSetUp(serverName, "server_enc.xml", false, "/x509sigclient/CxfX509SigSvcClient");
             //issue 18361
             featureVersion = "EE7";
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             commonSetUp(serverName, "server_enc_wss4j.xml", false, "/x509sigclient/CxfX509SigSvcClient");
@@ -164,13 +163,12 @@ public class CxfX509StrTypeTests extends CommonTests {
     @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCxfClientKeysMismatch() throws Exception {
 
-        //issue 18361 - adding the conditional flag instead of originally split test methods
-        if (featureVersion == "EE7") {
+        //issue 18361, 18363
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badenc.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badenc_wss4j.xml");
-        } //End of issue 18361
+        } //End of issue 18361, 18363
 
         genericTest(
                     // test name for logging
@@ -196,13 +194,12 @@ public class CxfX509StrTypeTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test did not receive the expected exception from the server.");
 
-        //issue 18361 - adding the conditional flag instead of originally split test methods and replacing server_enc.xml/server_enc_wss4j.xml for server_orig.xml/server_orig_wss4j.xml
-        if (featureVersion == "EE7") {
+        //issue 18361, 18363
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_enc.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_enc_wss4j.xml");
-        } //End of issue 18361
+        } //End of issue 18361, 18363
 
     }
 


### PR DESCRIPTION
Update com.ibm.ws.wssecurity_fat.wsscxf.1 to use conditional check for EE7/EE8 tests instead of separate methods (EE7Only/EE8Only).