### PR TITLE
exception replacement is broken in DataStoreAdapterException

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DatabaseHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DatabaseHelper.java
@@ -1522,25 +1522,18 @@ public class DatabaseHelper {
 
             return new ConnectionResults(pConn, null);
         } catch (PrivilegedActionException pae) {
-            FFDCFilter.processException(pae.getException(), getClass().getName(), "1298");
-
+            // FFDC covered by caller
             ResourceException resX = new DataStoreAdapterException("JAVAX_CONN_ERR", pae.getException(), DatabaseHelper.class, is2Phase ? "XAConnection" : "PooledConnection");
 
             if (tc.isEntryEnabled())
                 Tr.exit(this, tc, "getPooledConnection", "Exception");
             throw resX;
         } catch (ClassCastException castX) {
-            // There's a possibility this occurred because of an error in the JDBC driver
-            // itself.  The trace should allow us to determine this.
-            FFDCFilter.processException(castX, getClass().getName(), "1312");
-
-            if (tc.isDebugEnabled())
-                Tr.debug(this, tc, "Caught ClassCastException", castX);
-
+            // FFDC covered by caller
             ResourceException resX = new DataStoreAdapterException(castX.getMessage(), null, DatabaseHelper.class, is2Phase ? "NOT_A_2_PHASE_DS" : "NOT_A_1_PHASE_DS");
 
             if (tc.isEntryEnabled())
-                Tr.exit(this, tc, "getPooledConnection", "Exception");
+                Tr.exit(this, tc, "getPooledConnection", castX);
             throw resX;
         }
     }

--- a/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/ConfigTest.java
+++ b/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/ConfigTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1001,7 +1001,6 @@ public class ConfigTest extends FATServletClient {
      */
     @Test
     @ExpectedFFDC({ "com.ibm.ws.rsadapter.exceptions.DataStoreAdapterException",
-                    "java.sql.SQLException",
                     "java.sql.SQLNonTransientConnectionException",
                     "javax.resource.spi.ResourceAllocationException" })
     public void testConfigChangePurgePolicy() throws Throwable {

--- a/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HDXADataSource.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HDXADataSource.java
@@ -11,6 +11,7 @@
 package test.jdbc.heritage.driver;
 
 import java.sql.SQLException;
+import java.sql.SQLNonTransientException;
 
 import javax.sql.XAConnection;
 import javax.sql.XADataSource;
@@ -25,6 +26,9 @@ public class HDXADataSource extends HDDataSource implements XADataSource {
 
     @Override
     public XAConnection getXAConnection(String username, String password) throws SQLException {
+        if ("ConnectionRefused".equalsIgnoreCase(username))
+            throw new SQLNonTransientException("Connection Refused for Testing Purposes", "08001", 40000);
+
         return new HDConnection(this, super.getConnection(username, password));
     }
 }

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2019 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -112,8 +112,7 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
      * not get container managed authentication applied and therefore should not succeed.
      */
     @Test
-    @ExpectedFFDC({ "java.sql.SQLNonTransientConnectionException",
-                    "java.sql.SQLNonTransientException",
+    @ExpectedFFDC({ "java.sql.SQLNonTransientException",
                     "javax.resource.spi.SecurityException",
                     "javax.resource.spi.ResourceAllocationException" })
     public void testCustomLoginModuleDirectLookupInvalid() throws Exception {

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2019 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -122,8 +122,7 @@ public class ValidateDataSourceTest extends FATServletClient {
     }
 
     @Test
-    @ExpectedFFDC({ "java.sql.SQLNonTransientConnectionException",
-                    "java.sql.SQLNonTransientException",
+    @ExpectedFFDC({ "java.sql.SQLNonTransientException",
                     "javax.resource.spi.SecurityException",
                     "javax.resource.spi.ResourceAllocationException" })
     public void testAppAuthFails() throws Exception {
@@ -514,8 +513,10 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertTrue(err, stack.getString(2).startsWith("org.apache.derby."));
     }
 
-    @ExpectedFFDC(value = { "javax.resource.spi.SecurityException", "java.sql.SQLNonTransientException",
-                            "javax.resource.spi.ResourceAllocationException", "java.sql.SQLNonTransientConnectionException" })
+    @ExpectedFFDC(value = { "javax.resource.spi.SecurityException",
+                            "java.sql.SQLNonTransientException",
+                            "javax.resource.spi.ResourceAllocationException"
+    })
     @Test
     public void testWrongDefaultAuth() throws Exception {
         JsonObject json = new HttpsRequest(server, "/ibm/api/validation/dataSource/WrongDefaultAuth?auth=container")
@@ -542,8 +543,9 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertTrue(err, json.getString("message").contains("Invalid authentication"));
     }
 
-    @ExpectedFFDC(value = { "javax.resource.spi.SecurityException", "java.sql.SQLNonTransientException",
-                            "javax.resource.spi.ResourceAllocationException", "java.sql.SQLNonTransientConnectionException" })
+    @ExpectedFFDC(value = { "javax.resource.spi.SecurityException",
+                            "java.sql.SQLNonTransientException",
+                            "javax.resource.spi.ResourceAllocationException" })
     @Test
     public void testWrongProvidedAuth() throws Exception {
         JsonObject json = new HttpsRequest(server, "/ibm/api/validation/dataSource/DefaultDataSource?auth=container&authAlias=auth2")


### PR DESCRIPTION
Exception replacement isn't working for DataStoreAdapterException because of its inconsistent exception chaining between the cause and linked exceptions.  AdapterUtil.mapException expects to use setLinkedException to replace the chained exception, but the original cause is being used as the chained exception instead, causing the mapException result to be discarded.