### PR TITLE
Fix Krb5LoginModule not being found on Java 11 and above.

### DIFF
--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/JavaInfo.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/JavaInfo.java
@@ -159,8 +159,11 @@ public class JavaInfo {
             @FFDCIgnore(ClassNotFoundException.class)
             public Boolean run() {
                 try {
-                    // passing null to only look at the system classloader
-                    Class.forName(className, false, null);
+                    // Using ClassLoader.findSystemClass() instead of
+                    // Class.forName(className, false, null) because Class.forName with a null
+                    // ClassLoader only looks at the boot ClassLoader with Java 9 and above
+                    // which doesn't look at all the modules available to the findSystemClass.
+                    systemClassAccessor.getSystemClass(className);
                     return true;
                 } catch (ClassNotFoundException e) {
                     //No FFDC needed
@@ -168,6 +171,14 @@ public class JavaInfo {
                 }
             }
         });
+    }
+
+    private static final SystemClassAccessor systemClassAccessor = new SystemClassAccessor();
+
+    private static final class SystemClassAccessor extends ClassLoader {
+        public Class<?> getSystemClass(String className) throws ClassNotFoundException {
+            return findSystemClass(className);
+        }
     }
 
     @Deprecated


### PR DESCRIPTION
- Update JavaInfo to use findSystemClass instead of Class.forName with a null ClassLoader.

This fixes a regression introduced with PR #18173.  This PR puts the code back to the way it was originally before a code review caused the code to be modified.   I have validated that this approach works where the other one does not with some Java versions.

Fixes #18393 