### PR TITLE
JakartaEE10Action for tests

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat/fat/src/com/ibm/ws/concurrent/fat/EEConcurrencySpecTest.java
+++ b/dev/com.ibm.ws.concurrent_fat/fat/src/com/ibm/ws/concurrent/fat/EEConcurrencySpecTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2020 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
@@ -42,7 +43,8 @@ public class EEConcurrencySpecTest extends FATServletClient {
     @ClassRule
     public static RepeatTests r = RepeatTests
                     .withoutModification()
-                    .andWith(new JakartaEE9Action());
+                    .andWith(new JakartaEE9Action())
+                    .andWith(new JakartaEE10Action()); // TODO This doesn't use real Jakarta EE 10 features yet
 
     @Server("concurrent.spec.fat")
     @TestServlet(servlet = EEConcurrencyTestServlet.class, path = APP_NAME)

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/ShrinkHelper.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/ShrinkHelper.java
@@ -34,6 +34,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyClient;
 import componenttest.topology.impl.LibertyServer;
@@ -251,6 +252,8 @@ public class ShrinkHelper {
             Log.info(ShrinkHelper.class, "exportArtifact", "Not exporting artifact because it already exists at " + outputFile.getAbsolutePath());
             if (JakartaEE9Action.isActive()) {
                 JakartaEE9Action.transformApp(outputFile.toPath());
+            } else if (JakartaEE10Action.isActive()) {
+                JakartaEE10Action.transformApp(outputFile.toPath());
             }
             return a;
         }
@@ -264,6 +267,8 @@ public class ShrinkHelper {
             Log.info(ShrinkHelper.class, "exportArtifact", a.toString(true));
         if (JakartaEE9Action.isActive()) {
             JakartaEE9Action.transformApp(outputFile.toPath());
+        } else if (JakartaEE10Action.isActive()) {
+            JakartaEE10Action.transformApp(outputFile.toPath());
         }
         return a;
     }

--- a/dev/fattest.simplicity/src/componenttest/annotation/SkipForRepeat.java
+++ b/dev/fattest.simplicity/src/componenttest/annotation/SkipForRepeat.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.lang.annotation.Target;
 import componenttest.rules.repeater.EE7FeatureReplacementAction;
 import componenttest.rules.repeater.EE8FeatureReplacementAction;
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 
 @Target({ ElementType.METHOD, ElementType.TYPE })
@@ -28,6 +29,7 @@ public @interface SkipForRepeat {
     public static final String EE7_FEATURES = EE7FeatureReplacementAction.ID;
     public static final String EE8_FEATURES = EE8FeatureReplacementAction.ID;
     public static final String EE9_FEATURES = JakartaEE9Action.ID;
+    public static final String EE10_FEATURES = JakartaEE10Action.ID;
 
     String[] value();
 

--- a/dev/fattest.simplicity/src/componenttest/custom/junit/runner/FATRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/custom/junit/runner/FATRunner.java
@@ -57,6 +57,7 @@ import componenttest.exception.TopologyException;
 import componenttest.logging.ffdc.IgnoredFFDCs;
 import componenttest.logging.ffdc.IgnoredFFDCs.IgnoredFFDC;
 import componenttest.rules.repeater.EE9PackageReplacementHelper;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
@@ -627,11 +628,11 @@ public class FATRunner extends BlockJUnit4ClassRunner {
 
         ArrayList<String> annotationListPerClass = new ArrayList<String>();
         ExpectedFFDC[] ffdcs = m.getMethod().getAnnotationsByType(ExpectedFFDC.class);
-        
+
         for (ExpectedFFDC ffdc : ffdcs) {
             if (ffdc != null) {
                 String[] exceptionClasses = ffdc.value();
-                if (JakartaEE9Action.isActive()) {
+                if (JakartaEE9Action.isActive() || JakartaEE10Action.isActive()) {
                     String[] jakarta9ReplacementExceptionClasses = new String[exceptionClasses.length];
                     System.arraycopy(exceptionClasses, 0, jakarta9ReplacementExceptionClasses, 0, exceptionClasses.length);
                     int index = 0;
@@ -685,7 +686,7 @@ public class FATRunner extends BlockJUnit4ClassRunner {
         for (AllowedFFDC ffdc : ffdcs) {
             if (ffdc != null) {
                 String[] exceptionClasses = ffdc.value();
-                if (JakartaEE9Action.isActive()) {
+                if (JakartaEE9Action.isActive() || JakartaEE10Action.isActive()) {
                     String[] jakarta9ReplacementExceptionClasses = new String[exceptionClasses.length];
                     System.arraycopy(exceptionClasses, 0, jakarta9ReplacementExceptionClasses, 0, exceptionClasses.length);
                     int index = 0;

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE6FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE6FeatureReplacementAction.java
@@ -45,6 +45,7 @@ public class EE6FeatureReplacementAction extends FeatureReplacementAction {
         removeFeatures(EE7FeatureReplacementAction.EE7_FEATURE_SET);
         removeFeatures(EE8FeatureReplacementAction.EE8_FEATURE_SET);
         removeFeatures(JakartaEE9Action.EE9_FEATURE_SET);
+        removeFeatures(JakartaEE10Action.EE10_FEATURE_SET);
         forceAddFeatures(false);
         withID(ID);
     }

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE7FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE7FeatureReplacementAction.java
@@ -67,6 +67,7 @@ public class EE7FeatureReplacementAction extends FeatureReplacementAction {
         removeFeatures(EE6FeatureReplacementAction.EE6_FEATURE_SET);
         removeFeatures(EE8FeatureReplacementAction.EE8_FEATURE_SET);
         removeFeatures(JakartaEE9Action.EE9_FEATURE_SET);
+        removeFeatures(JakartaEE10Action.EE10_FEATURE_SET);
         forceAddFeatures(false);
         withID(ID);
     }

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE8FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE8FeatureReplacementAction.java
@@ -70,6 +70,7 @@ public class EE8FeatureReplacementAction extends FeatureReplacementAction {
         removeFeatures(EE6FeatureReplacementAction.EE6_FEATURE_SET);
         removeFeatures(EE7FeatureReplacementAction.EE7_FEATURE_SET);
         removeFeatures(JakartaEE9Action.EE9_FEATURE_SET);
+        removeFeatures(JakartaEE10Action.EE10_FEATURE_SET);
         forceAddFeatures(false);
         withID(ID);
     }

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureReplacementAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -109,6 +109,13 @@ public class FeatureReplacementAction implements RepeatTestAction {
      */
     public static FeatureReplacementAction EE9_FEATURES() {
         return new JakartaEE9Action();
+    }
+
+    /**
+     * Remove the EE7, EE8, and EE9 features; replace them with the EE10 features
+     */
+    public static FeatureReplacementAction EE10_FEATURES() {
+        return new JakartaEE10Action();
     }
 
     private boolean forceAddFeatures = true;

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE10Action.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE10Action.java
@@ -1,0 +1,215 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package componenttest.rules.repeater;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.fat.util.SharedServer;
+
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.custom.junit.runner.RepeatTestFilter;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
+import componenttest.topology.utils.FileUtils;
+
+/**
+ * Test repeat action that will do 2 things:
+ * <ol>
+ * <li>Invoke the Jakarta transformer on all war/ear files under the autoFVT/publish/ folder</li>
+ * <li>Update all server.xml configs under the autoFVT/publish/ folder to use EE 10 features</li>
+ * </ol>
+ */
+public class JakartaEE10Action extends FeatureReplacementAction {
+    public static final String ID = "EE10_FEATURES";
+
+    // TODO This will eventually be a list of Jakarta EE 10 features.
+    // TODO Replace EE 9 features in the list below with EE 10 features when they are added.
+    //
+    // FAT tests use a mix of enabled features and not yet enabled
+    // features, which is necessary for the FATs to run.
+
+    static final String[] EE10_FEATURES_ARRAY = {
+                                                  "appClientSupport-2.0",
+                                                  "jakartaee-9.0",
+                                                  "webProfile-9.0",
+                                                  "jakartaeeClient-9.0",
+                                                  "componenttest-2.0", // replaces "componenttest-1.0"
+                                                  "txtest-2.0",
+                                                  "appAuthentication-2.0",
+                                                  "appAuthorization-2.0",
+                                                  "appSecurity-4.0",
+                                                  "batch-2.0",
+                                                  "beanValidation-3.0",
+                                                  "cdi-3.0",
+                                                  "concurrent-2.0",
+                                                  "connectors-2.0",
+                                                  "connectorsInboundSecurity-2.0",
+                                                  "expressionLanguage-4.0",
+                                                  "enterpriseBeans-4.0",
+                                                  "enterpriseBeansHome-4.0",
+                                                  "enterpriseBeansLite-4.0",
+                                                  "enterpriseBeansPersistentTimer-4.0",
+                                                  "enterpriseBeansRemote-4.0",
+                                                  "enterpriseBeansTest-2.0",
+                                                  "mail-2.0",
+                                                  "persistence-3.0",
+                                                  "persistenceContainer-3.0",
+                                                  "jsonp-2.0",
+                                                  "jsonb-2.0",
+                                                  "jsonpContainer-2.0",
+                                                  "jsonbContainer-2.0",
+                                                  "faces-3.0",
+                                                  "facesContainer-3.0",
+                                                  "pages-3.0",
+                                                  "managedBeans-2.0",
+                                                  "mdb-4.0",
+                                                  "messaging-3.0",
+                                                  "messagingClient-3.0",
+                                                  "messagingServer-3.0",
+                                                  "messagingSecurity-3.0",
+                                                  "restfulWS-3.0",
+                                                  "restfulWSClient-3.0",
+                                                  "servlet-5.0",
+                                                  "websocket-2.0",
+                                                  "xmlBinding-3.0",
+                                                  "xmlWS-3.0"
+    };
+
+    public static final Set<String> EE10_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE10_FEATURES_ARRAY)));
+
+    public JakartaEE10Action() {
+        // Remove the EE7 and EE8 features; replace them with the EE9 features
+        super(EE10_FEATURE_SET);
+        removeFeatures(EE6FeatureReplacementAction.EE6_FEATURE_SET);
+        removeFeatures(EE7FeatureReplacementAction.EE7_FEATURE_SET);
+        removeFeatures(EE8FeatureReplacementAction.EE8_FEATURE_SET);
+        removeFeatures(JakartaEE9Action.EE9_FEATURE_SET);
+        forceAddFeatures(false);
+        withID(ID);
+    }
+
+    @Override
+    public String toString() {
+        return "JakartaEE10 FAT repeat action";
+    }
+
+    //
+
+    @Override
+    public JakartaEE10Action addFeature(String addFeature) {
+        return (JakartaEE10Action) super.addFeature(addFeature);
+    }
+
+    @Override
+    public JakartaEE10Action fullFATOnly() {
+        return (JakartaEE10Action) super.fullFATOnly();
+    }
+
+    @Override
+    public JakartaEE10Action liteFATOnly() {
+        return (JakartaEE10Action) super.liteFATOnly();
+    }
+
+    @Override
+    public JakartaEE10Action withTestMode(TestMode mode) {
+        return (JakartaEE10Action) super.withTestMode(mode);
+    }
+
+    @Override
+    public JakartaEE10Action addFeatures(Set<String> addFeatures) {
+        return (JakartaEE10Action) super.addFeatures(addFeatures);
+    }
+
+    @Override
+    public JakartaEE10Action removeFeature(String removeFeature) {
+        return (JakartaEE10Action) super.removeFeature(removeFeature);
+    }
+
+    @Override
+    public JakartaEE10Action removeFeatures(Set<String> removeFeatures) {
+        return (JakartaEE10Action) super.removeFeatures(removeFeatures);
+    }
+
+    @Override
+    public JakartaEE10Action withMinJavaLevel(int javaLevel) {
+        return (JakartaEE10Action) super.withMinJavaLevel(javaLevel);
+    }
+
+    @Override
+    public JakartaEE10Action withID(String id) {
+        return (JakartaEE10Action) super.withID(id);
+    }
+
+    @Override
+    public JakartaEE10Action forServers(String... serverNames) {
+        return (JakartaEE10Action) super.forServers(serverNames);
+    }
+
+    @Override
+    public JakartaEE10Action forClients(String... clientNames) {
+        return (JakartaEE10Action) super.forClients(clientNames);
+    }
+
+    @Override
+    public void setup() throws Exception {
+        // Ensure all shared servers are stopped and applications are cleaned
+        LibertyServerFactory.tidyAllKnownServers(SharedServer.class.getCanonicalName());
+        LibertyServerFactory.recoverAllServers(SharedServer.class.getCanonicalName());
+        for (LibertyServer server : LibertyServerFactory.getKnownLibertyServers(SharedServer.class.getCanonicalName())) {
+            Path rootPath = Paths.get(server.getServerRoot());
+            FileUtils.recursiveDelete(rootPath.toFile());
+        }
+        ShrinkHelper.cleanAllExportedArchives();
+
+        // Transform server.xml's
+        super.setup();
+    }
+
+    public static boolean isActive() {
+        return RepeatTestFilter.isRepeatActionActive(ID);
+    }
+
+    /**
+     * Invoke the Jakarta transformer on an application (ear or war or jar).
+     *
+     * A backup of the original application is placed under "&lt;server&gt;/backup".
+     * ".jakarta" is appended to name the initially transformed application. However,
+     * that application is renamed to the initial application name.
+     *
+     * @param appPath The application path to be transformed to Jakarta
+     */
+    public static void transformApp(Path appPath) {
+        JakartaEE9Action.transformApp(appPath, null);
+    }
+
+    /**
+     * Invoke the Jakarta transformer on an application (ear or war or jar).
+     * to create a new transformed copy.
+     *
+     * If the destination Path is null, the application is transformed into
+     * the same file as the source. A backup of the original application is placed
+     * under "&lt;server&gt;/backup". The extension ".jakarta" is appended to
+     * name the initially transformed application. However,
+     * that application is renamed to the initial application name.
+     *
+     * @param appPath    The application path of file to be transformed to Jakarta
+     * @param newAppPath The application path of the transformed file (or <code>null<code>)
+     */
+    public static void transformApp(Path appPath, Path newAppPath) {
+        JakartaEE9Action.transformApp(appPath, newAppPath);
+    }
+}


### PR DESCRIPTION
Create the JakartaEE10Action for running FAT buckets against Jakarta EE 10 feature.
Because there aren't any Jakarta EE 10 features yet, it will start out as a copy of the Jakarta EE 9 features and be updated as Jakarta EE 10 features are added.
Enable one test bucket to run with the JakartaEE10Action, which again, to start out with just means running a second time with Jakarta EE 9.
With this in place, developers will be able to have existing test buckets run with experimental non-ship Jakarta EE 10 features that they create, to ensure that the experimental changes for new EE 10 features don't break existing capability.