### PR TITLE
wsscxf fat remove split

### DIFF
--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerUNTTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerUNTTests.java
@@ -82,8 +82,7 @@ public class CxfCallerUNTTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             errMsgVersion = "EE7";
-        }
-        if ((features.contains("jaxws-2.3")) || (features.contains("xmlWS-3.0"))) {
+        } else if ((features.contains("jaxws-2.3")) || (features.contains("xmlWS-3.0"))) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerUNTTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerUNTTests.java
@@ -243,8 +243,7 @@ public class CxfCallerUNTTests {
                         "UrnCallerToken04", //String strServicePort
                         "test4", // Expecting User ID
                         "test4", // Password
-                        errMsgVersion //2/2021
-            );
+                        errMsgVersion);
         } catch (Exception e) {
             throw e;
         }
@@ -284,7 +283,7 @@ public class CxfCallerUNTTests {
                        "",
                        untID,
                        untPassword,
-                       null); //2/2021
+                       null);
 
         return;
     }
@@ -403,7 +402,7 @@ public class CxfCallerUNTTests {
                                   String strBadOrGood,
                                   String untID,
                                   String untPassword,
-                                  String errMsgVersion) throws Exception { //2/2021
+                                  String errMsgVersion) throws Exception {
         try {
 
             WebRequest request = null;
@@ -467,7 +466,6 @@ public class CxfCallerUNTTests {
             e.printStackTrace(System.out);
         }
 
-        //2/2021
         server.deleteFileFromLibertyInstallRoot("usr/extension/lib/bundles/com.ibm.ws.wssecurity.example.cbh.jar");
         server.deleteFileFromLibertyInstallRoot("usr/extension/lib/features/wsseccbh-1.0.mf");
         server.deleteFileFromLibertyInstallRoot("usr/extension/lib/bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerUNTTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerUNTTests.java
@@ -33,11 +33,9 @@ import com.meterware.httpunit.WebConversation;
 import com.meterware.httpunit.WebRequest;
 import com.meterware.httpunit.WebResponse;
 
-import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 
@@ -80,12 +78,12 @@ public class CxfCallerUNTTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             errMsgVersion = "EE7";
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if ((features.contains("jaxws-2.3")) || (features.contains("xmlWS-3.0"))) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -131,7 +129,6 @@ public class CxfCallerUNTTests {
      *
      */
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     @Test
     public void testCxfCallerHttpPolicy() throws Exception {
 
@@ -163,7 +160,6 @@ public class CxfCallerUNTTests {
      *
      */
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     @Test
     public void testCxfCallerHttpsPolicy() throws Exception {
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerX509AsymTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerX509AsymTests.java
@@ -32,13 +32,11 @@ import com.meterware.httpunit.WebConversation;
 import com.meterware.httpunit.WebRequest;
 import com.meterware.httpunit.WebResponse;
 
-import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.EE8FeatureReplacementAction;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 
@@ -83,13 +81,13 @@ public class CxfCallerX509AsymTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             errMsgVersion = "EE7";
             errMsgVersionInX509 = "EE7";
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -136,7 +134,6 @@ public class CxfCallerX509AsymTests {
      *
      */
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCallerX509TokenPolicy() throws Exception {
 
@@ -168,7 +165,6 @@ public class CxfCallerX509AsymTests {
      *
      */
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCallerX509TransportEndorsingPolicy() throws Exception {
 
@@ -200,7 +196,6 @@ public class CxfCallerX509AsymTests {
      *
      */
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCallerHttpPolicyInX509() throws Exception {
 
@@ -232,7 +227,6 @@ public class CxfCallerX509AsymTests {
      *
      */
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCxfCallerHttpsPolicyInx509() throws Exception {
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerX509AsymTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerX509AsymTests.java
@@ -86,8 +86,7 @@ public class CxfCallerX509AsymTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             errMsgVersion = "EE7";
             errMsgVersionInX509 = "EE7";
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerX509SymTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerX509SymTests.java
@@ -80,11 +80,11 @@ public class CxfCallerX509SymTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerX509SymTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerX509SymTests.java
@@ -83,8 +83,7 @@ public class CxfCallerX509SymTests {
         if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfBspTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfBspTests.java
@@ -75,8 +75,7 @@ public class CxfBspTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_bsp.xml");
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_bsp_wss4j.xml");
@@ -117,19 +116,18 @@ public class CxfBspTests {
 
         String vendorName = System.getProperty("java.vendor");
         Log.info(thisClass, thisMethod, "JDK Vendor Name is: " + vendorName);
-        //7/2021
+
         String javaVersion = System.getProperty("java.version");
         Log.info(thisClass, thisMethod, "JDK Version is: " + javaVersion);
 
         ibmJDK = true;
-        //7/2027
         if ((vendorName.contains("IBM")) & (javaVersion.contains("1.8.0"))) {
             Log.info(thisClass, thisMethod, "Using an IBM JDK 8");
         } else {
             Log.info(thisClass, thisMethod, "Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - certain tests should not run!  WE WILL BE SKIPPING SOME TESTS");
             System.err.println("Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - certain tests should not run!");
             ibmJDK = false;
-        } // End 7/2021
+        }
 
         return;
     }
@@ -138,7 +136,6 @@ public class CxfBspTests {
     public void testEcho11Service() throws Exception {
         String thisMethod = "testEcho11Service";
         if (!ibmJDK) {
-            //7/2021
             Log.info(thisClass, thisMethod, "Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!  SKIPPING TEST");
             System.err.println("Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!");
             return;
@@ -168,7 +165,6 @@ public class CxfBspTests {
     public void testEcho12Service() throws Exception {
         String thisMethod = "testEcho12Service";
         if (!ibmJDK) {
-            //7/2021
             Log.info(thisClass, thisMethod, "Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!  SKIPPING TEST");
             System.err.println("Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!");
             return;
@@ -198,7 +194,6 @@ public class CxfBspTests {
     public void testEcho13Service() throws Exception {
         String thisMethod = "testEcho13Service";
         if (!ibmJDK) {
-            //7/2021
             Log.info(thisClass, thisMethod, "Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!  SKIPPING TEST");
             System.err.println("Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!");
             return;
@@ -228,7 +223,6 @@ public class CxfBspTests {
     public void testEcho14Service() throws Exception {
         String thisMethod = "testEcho14Service";
         if (!ibmJDK) {
-            //7/2021
             Log.info(thisClass, thisMethod, "Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!  SKIPPING TEST");
             System.err.println("Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!");
             return;

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfBspTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfBspTests.java
@@ -32,13 +32,11 @@ import com.meterware.httpunit.WebConversation;
 import com.meterware.httpunit.WebRequest;
 import com.meterware.httpunit.WebResponse;
 
-import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.EE8FeatureReplacementAction;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 
@@ -73,12 +71,12 @@ public class CxfBspTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_bsp.xml");
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_bsp_wss4j.xml");
@@ -136,7 +134,6 @@ public class CxfBspTests {
         return;
     }
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testEcho11Service() throws Exception {
         String thisMethod = "testEcho11Service";
@@ -167,7 +164,6 @@ public class CxfBspTests {
         return;
     }
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testEcho12Service() throws Exception {
         String thisMethod = "testEcho12Service";
@@ -198,7 +194,6 @@ public class CxfBspTests {
         return;
     }
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testEcho13Service() throws Exception {
         String thisMethod = "testEcho13Service";
@@ -229,7 +224,6 @@ public class CxfBspTests {
         return;
     }
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testEcho14Service() throws Exception {
         String thisMethod = "testEcho14Service";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfInteropX509Tests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfInteropX509Tests.java
@@ -117,19 +117,18 @@ public class CxfInteropX509Tests {
 
         String vendorName = System.getProperty("java.vendor");
         Log.info(thisClass, thisMethod, "JDK Vendor Name is: " + vendorName);
-        //7/2021
+
         String javaVersion = System.getProperty("java.version");
         Log.info(thisClass, thisMethod, "JDK Version is: " + javaVersion);
 
         ibmJDK = true;
-        //7/2027
         if ((vendorName.contains("IBM")) & (javaVersion.contains("1.8.0"))) {
             Log.info(thisClass, thisMethod, "Using an IBM JDK 8");
         } else {
             Log.info(thisClass, thisMethod, "Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - certain tests should not run!  WE WILL BE SKIPPING SOME TESTS");
             System.err.println("Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - certain tests should not run!");
             ibmJDK = false;
-        } // End 7/2021
+        }
 
         return;
     }
@@ -138,7 +137,6 @@ public class CxfInteropX509Tests {
     public void testEcho21Service() throws Exception {
         String thisMethod = "testEcho21Service";
         if (!ibmJDK) {
-            //7/2021
             Log.info(thisClass, thisMethod, "Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!  SKIPPING TEST");
             System.err.println("Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!");
             return;
@@ -168,7 +166,6 @@ public class CxfInteropX509Tests {
     public void testEcho22Service() throws Exception {
         String thisMethod = "testEcho22Service";
         if (!ibmJDK) {
-            //7/2021
             Log.info(thisClass, thisMethod, "Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!  SKIPPING TEST");
             System.err.println("Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!");
             return;
@@ -198,7 +195,6 @@ public class CxfInteropX509Tests {
     public void testEcho23Service() throws Exception {
         String thisMethod = "testEcho23Service";
         if (!ibmJDK) {
-            //7/2021
             Log.info(thisClass, thisMethod, "Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!  SKIPPING TEST");
             System.err.println("Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!");
             return;

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfInteropX509Tests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfInteropX509Tests.java
@@ -32,13 +32,11 @@ import com.meterware.httpunit.WebConversation;
 import com.meterware.httpunit.WebRequest;
 import com.meterware.httpunit.WebResponse;
 
-import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.EE8FeatureReplacementAction;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 
@@ -73,12 +71,12 @@ public class CxfInteropX509Tests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_x509.xml");
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_x509_wss4j.xml");
@@ -136,7 +134,6 @@ public class CxfInteropX509Tests {
         return;
     }
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testEcho21Service() throws Exception {
         String thisMethod = "testEcho21Service";
@@ -167,7 +164,6 @@ public class CxfInteropX509Tests {
         return;
     }
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testEcho22Service() throws Exception {
         String thisMethod = "testEcho22Service";
@@ -198,7 +194,6 @@ public class CxfInteropX509Tests {
         return;
     }
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testEcho23Service() throws Exception {
         String thisMethod = "testEcho23Service";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfSampleTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfSampleTests.java
@@ -90,7 +90,6 @@ public class CxfSampleTests {
         ShrinkHelper.defaultDropinApp(server, "WSSampleSei", "com.ibm.was.wssample.sei.echo");
         ShrinkHelper.defaultDropinApp(server, "webcontentprovider", "com.ibm.was.cxfsample.sei.echo");
 
-        //7/2021
         //JakartaEE9 transforms the sample client applications which exist at '<server>/apps/<appname>'.
         if (JakartaEE9Action.isActive()) {
             Path webcontent_archive = Paths.get(server.getServerRoot() + File.separatorChar + "apps" + File.separatorChar + "webcontent");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfSampleTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfSampleTests.java
@@ -36,7 +36,6 @@ import com.meterware.httpunit.WebConversation;
 import com.meterware.httpunit.WebRequest;
 import com.meterware.httpunit.WebResponse;
 
-import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
@@ -76,12 +75,12 @@ public class CxfSampleTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_asym.xml");
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if ((features.contains("jaxws-2.3")) || (features.contains("xmlWS-3.0"))) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_asym_wss4j.xml");
@@ -180,7 +179,6 @@ public class CxfSampleTests {
         return;
     }
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     @Test
     public void testEchoService() throws Exception {
         String thisMethod = "testEchoService";
@@ -205,7 +203,6 @@ public class CxfSampleTests {
         return;
     }
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     @Test
     public void testEcho4Service() throws Exception {
         String thisMethod = "testEcho4Service";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfSymSampleTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfSymSampleTests.java
@@ -36,7 +36,6 @@ import com.meterware.httpunit.WebConversation;
 import com.meterware.httpunit.WebRequest;
 import com.meterware.httpunit.WebResponse;
 
-import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
@@ -74,12 +73,12 @@ public class CxfSymSampleTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha384.xml");
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if ((features.contains("jaxws-2.3")) || (features.contains("xmlWS-3.0"))) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha384_wss4j.xml");
@@ -150,7 +149,6 @@ public class CxfSymSampleTests {
         return;
     }
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     @Test
     public void testEcho1Service() throws Exception {
         String thisMethod = "testEcho1Service";
@@ -175,7 +173,6 @@ public class CxfSymSampleTests {
         return;
     }
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     @Test
     public void testEcho2Service() throws Exception {
         String thisMethod = "testEcho2Service";
@@ -200,7 +197,6 @@ public class CxfSymSampleTests {
         return;
     }
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     @Test
     public void testEcho3Service() throws Exception {
         String thisMethod = "testEcho3Service";
@@ -225,7 +221,6 @@ public class CxfSymSampleTests {
         return;
     }
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     @Test
     public void testEcho5Service() throws Exception {
         String thisMethod = "testEcho5Service";
@@ -250,7 +245,6 @@ public class CxfSymSampleTests {
         return;
     }
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
     @Test
     public void testEcho6Service() throws Exception {
         String thisMethod = "testEcho6Service";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfSymSampleTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfSymSampleTests.java
@@ -88,7 +88,6 @@ public class CxfSymSampleTests {
         ShrinkHelper.defaultDropinApp(server, "WSSampleSei", "com.ibm.was.wssample.sei.echo");
         ShrinkHelper.defaultDropinApp(server, "webcontentprovider", "com.ibm.was.cxfsample.sei.echo");
 
-        //7/2021
         //JakartaEE9 transforms the sample client applications which exist at '<server>/apps/<appname>'.
         if (JakartaEE9Action.isActive()) {
             Path webcontent_archive = Paths.get(server.getServerRoot() + File.separatorChar + "apps" + File.separatorChar + "webcontent");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfDeriveKeyTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfDeriveKeyTests.java
@@ -60,8 +60,7 @@ public class CxfDeriveKeyTests extends CommonTests {
         if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfDeriveKeyTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfDeriveKeyTests.java
@@ -57,11 +57,11 @@ public class CxfDeriveKeyTests extends CommonTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
@@ -87,7 +87,6 @@ public class CxfDeriveKeyTests extends CommonTests {
      *
      */
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCXFDeriveKey1() throws Exception {
 
@@ -133,7 +132,7 @@ public class CxfDeriveKeyTests extends CommonTests {
      */
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFDeriveKey1WrongPw() throws Exception {
 
         String thisMethod = "testCXFDeriveKey1WrongPw";
@@ -179,7 +178,6 @@ public class CxfDeriveKeyTests extends CommonTests {
 
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFDeriveKey1ClMissingPToken() throws Exception {
 
         String thisMethod = "testCXFDeriveKey1ClMissingPToken";
@@ -224,7 +222,6 @@ public class CxfDeriveKeyTests extends CommonTests {
      */
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFDeriveKey1X509NotUNT() throws Exception {
 
         String thisMethod = "testCXFDeriveKey1X509NotUNT";
@@ -267,7 +264,6 @@ public class CxfDeriveKeyTests extends CommonTests {
      *
      */
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCXFDeriveKey2() throws Exception {
 
@@ -314,7 +310,6 @@ public class CxfDeriveKeyTests extends CommonTests {
 
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFDeriveKey2ClMissingReqDerivedKeys() throws Exception {
 
         String thisMethod = "testCXFDeriveKey2ClMissingReqDerivedKeys";
@@ -361,7 +356,6 @@ public class CxfDeriveKeyTests extends CommonTests {
      */
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFDeriveKey1ReqDerivedKeysOnlyInClient() throws Exception {
 
         String thisMethod = "testCXFDeriveKey1ReqDerivedKeysOnlyInClient";
@@ -405,7 +399,6 @@ public class CxfDeriveKeyTests extends CommonTests {
      *
      */
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCXFDeriveKey3() throws Exception {
 
@@ -451,7 +444,7 @@ public class CxfDeriveKeyTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFDeriveKey4() throws Exception {
 
         String thisMethod = "testCXFDeriveKey4";
@@ -542,7 +535,6 @@ public class CxfDeriveKeyTests extends CommonTests {
      *
      */
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCXFDeriveKey4ClAddEncrypted() throws Exception {
 
@@ -589,7 +581,6 @@ public class CxfDeriveKeyTests extends CommonTests {
      *
      */
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCXFDeriveKey4ClAddSigned() throws Exception {
 
@@ -636,7 +627,6 @@ public class CxfDeriveKeyTests extends CommonTests {
      *
      */
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCXFDeriveKey4ClAddSignedEncrypted() throws Exception {
 
@@ -681,7 +671,6 @@ public class CxfDeriveKeyTests extends CommonTests {
      *
      */
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCXFDeriveKey5() throws Exception {
 
@@ -726,7 +715,6 @@ public class CxfDeriveKeyTests extends CommonTests {
      *
      */
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCXFDeriveKey5AddEncrypted() throws Exception {
 
@@ -772,7 +760,7 @@ public class CxfDeriveKeyTests extends CommonTests {
      *
      */
     @Test
-    @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException", "java.net.MalformedURLException" })
+    @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" })
     public void testCXFDeriveKey5MissingSigned() throws Exception {
 
         String thisMethod = "testCXFDeriveKey5MissingSigned";
@@ -818,7 +806,6 @@ public class CxfDeriveKeyTests extends CommonTests {
      */
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFDeriveKey5MissingSignedAddEncrypted() throws Exception {
 
         String thisMethod = "testCXFDeriveKey5MissingSignedAddEncrypted";
@@ -863,7 +850,6 @@ public class CxfDeriveKeyTests extends CommonTests {
      *
      */
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCXFDeriveKey6() throws Exception {
 
@@ -908,7 +894,6 @@ public class CxfDeriveKeyTests extends CommonTests {
      *
      */
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCXFDeriveKey6AddSigned() throws Exception {
 
@@ -955,7 +940,6 @@ public class CxfDeriveKeyTests extends CommonTests {
      */
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFDeriveKey6MissingEncrypted() throws Exception {
 
         String thisMethod = "testCXFDeriveKey6MissingEncrypted";
@@ -1002,7 +986,6 @@ public class CxfDeriveKeyTests extends CommonTests {
      */
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFDeriveKey6MissingEncryptedAddSigned() throws Exception {
 
         String thisMethod = "testCXFDeriveKey6MissingEncryptedAddSigned";
@@ -1047,7 +1030,6 @@ public class CxfDeriveKeyTests extends CommonTests {
      *
      */
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCXFDeriveKey7() throws Exception {
 
@@ -1093,7 +1075,6 @@ public class CxfDeriveKeyTests extends CommonTests {
      */
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFDeriveKey7MissingEncrypted() throws Exception {
 
         String thisMethod = "testCXFDeriveKey7MissingEncrypted";
@@ -1185,7 +1166,6 @@ public class CxfDeriveKeyTests extends CommonTests {
      */
     @Test
     @AllowedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFDeriveKey7MissingSignedEncrypted() throws Exception {
 
         String thisMethod = "testCXFDeriveKey7MissingSignedEncrypted";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfPasswordDigestTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfPasswordDigestTests.java
@@ -100,8 +100,7 @@ public class CxfPasswordDigestTests extends CommonTests {
             pwdCBHVersion = "EE7";
             //issue 18363
             featureVersion = "EE7";
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             pwdCBHVersion = "EE8";
             //issue 18363
             featureVersion = "EE8";
@@ -399,10 +398,9 @@ public class CxfPasswordDigestTests extends CommonTests {
     public void testPWDigestCXFSvcClientaltCallback() throws Exception {
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback_wss4j.xml");
         } //End of issue 18363
 
@@ -410,10 +408,9 @@ public class CxfPasswordDigestTests extends CommonTests {
                     "This is WSSECFVT CXF Web Service (Password Digest)", "The " + testName.getMethodName() + " test failed - did not receive the correct response", pwdCBHVersion);
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
         } //End of issue 18363
 
@@ -425,10 +422,9 @@ public class CxfPasswordDigestTests extends CommonTests {
     public void testPWDigestCXFSvcClientaltCallbackSSL() throws Exception {
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback_wss4j.xml");
         } //End of issue 18363
 
@@ -437,10 +433,9 @@ public class CxfPasswordDigestTests extends CommonTests {
                     "The " + testName.getMethodName() + " test failed - did not receive the correct response", pwdCBHVersion);
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
         } //End of issue 18363
 
@@ -511,10 +506,9 @@ public class CxfPasswordDigestTests extends CommonTests {
     public void testPWDigestCXFSvcClientClCallbackInServerXml() throws Exception {
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback_wss4j.xml");
         } //End of issue 18363
 
@@ -523,10 +517,9 @@ public class CxfPasswordDigestTests extends CommonTests {
                     "The " + testName.getMethodName() + " test failed - did not receive the correct response");
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
         } //End of issue 18363
 
@@ -538,10 +531,9 @@ public class CxfPasswordDigestTests extends CommonTests {
     public void testPWDigestCXFSvcClientClCallbackInServerXmlSSL() throws Exception {
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback_wss4j.xml");
         } //End of issue 18363
 
@@ -550,10 +542,9 @@ public class CxfPasswordDigestTests extends CommonTests {
                     "The " + testName.getMethodName() + " test failed - did not receive the correct response");
 
         //issue 18363
-        if (featureVersion == "EE7") {
+        if (featureVersion.equals("EE7")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-        }
-        if (featureVersion == "EE8") {
+        } else if (featureVersion.equals("EE8")) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
         } //End of issue 18363
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfPasswordDigestTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfPasswordDigestTests.java
@@ -151,7 +151,6 @@ public class CxfPasswordDigestTests extends CommonTests {
      *
      */
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testPWDigestCXFSvcClientSpecifyUserSSL() throws Exception {
 
@@ -185,7 +184,6 @@ public class CxfPasswordDigestTests extends CommonTests {
      *
      */
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testPWDigestCXFSvcClientDefaultUserSSL() throws Exception {
 
@@ -203,7 +201,6 @@ public class CxfPasswordDigestTests extends CommonTests {
 
     }
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testPWDigestCXFSvcClientNoIdValidPwSSL() throws Exception {
 
@@ -325,7 +322,6 @@ public class CxfPasswordDigestTests extends CommonTests {
 
     }
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testPWDigestCXFSvcClientCreatedSSL() throws Exception {
 
@@ -342,7 +338,6 @@ public class CxfPasswordDigestTests extends CommonTests {
 
     }
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testPWDigestCXFSvcClientNonceCreatedSSL() throws Exception {
 
@@ -361,7 +356,6 @@ public class CxfPasswordDigestTests extends CommonTests {
 
     }
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testPWDigestCXFSvcClientNonceSSL() throws Exception {
 
@@ -427,9 +421,7 @@ public class CxfPasswordDigestTests extends CommonTests {
 
     }
 
-    //issue 18363
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testPWDigestCXFSvcClientaltCallbackSSL() throws Exception {
 
         //issue 18363
@@ -470,7 +462,7 @@ public class CxfPasswordDigestTests extends CommonTests {
     @Test
     @AllowedFFDC(value = { "java.io.IOException" }, repeatAction = { EmptyAction.ID, EE8FeatureReplacementAction.ID })
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testPWDigestCXFSvcClientaltCallbackBadUserSSL() throws Exception {
 
         genericTest(testName.getMethodName(), clientHttpsUrl, httpsPortNumber, "altCallback2", "UsrTokenPWDigestWebSvcSSL",
@@ -543,7 +535,6 @@ public class CxfPasswordDigestTests extends CommonTests {
     }
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testPWDigestCXFSvcClientClCallbackInServerXmlSSL() throws Exception {
 
         //issue 18363

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfPasswordDigestTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfPasswordDigestTests.java
@@ -13,7 +13,6 @@ package com.ibm.ws.wssecurity.fat.cxf.usernametoken;
 
 import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
-import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -61,6 +60,8 @@ public class CxfPasswordDigestTests extends CommonTests {
     private static String httpsPortNumber = "";
 
     private static String pwdCBHVersion = "";
+    //issue 18363
+    private static String featureVersion = "";
 
     static String strJksLocation = "./securitykeys/sslClientDefault.jks";
 
@@ -97,9 +98,13 @@ public class CxfPasswordDigestTests extends CommonTests {
         //The PWDigestCallbackHandler version doesn't use this flag but determined by the server.xml/server_wss4j.xml/server_withClCallback.xml/server_withClCallback_wss4j.xml
         if (features.contains("jaxws-2.2")) {
             pwdCBHVersion = "EE7";
+            //issue 18363
+            featureVersion = "EE7";
         }
         if (features.contains("jaxws-2.3")) {
             pwdCBHVersion = "EE8";
+            //issue 18363
+            featureVersion = "EE8";
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
         }
 
@@ -395,68 +400,57 @@ public class CxfPasswordDigestTests extends CommonTests {
 
     }
 
+    //issue 18363
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testPWDigestCXFSvcClientaltCallbackEE7Only() throws Exception {
+    public void testPWDigestCXFSvcClientaltCallback() throws Exception {
 
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback_wss4j.xml");
+        } //End of issue 18363
 
         genericTest(testName.getMethodName(), clientHttpUrl, "", "altCallback1", "UsrTokenPWDigestWebSvc",
                     "This is WSSECFVT CXF Web Service (Password Digest)", "The " + testName.getMethodName() + " test failed - did not receive the correct response", pwdCBHVersion);
 
-        //Added to resolve RTC 285305
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        } //End of issue 18363
 
         return;
 
     }
 
+    //issue 18363
     @Test
-    @SkipForRepeat({ NO_MODIFICATION })
-    public void testPWDigestCXFSvcClientaltCallbackEE8Only() throws Exception {
-
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback_wss4j.xml");
-
-        genericTest(testName.getMethodName(), clientHttpUrl, "", "altCallback1", "UsrTokenPWDigestWebSvc",
-                    "This is WSSECFVT CXF Web Service (Password Digest)", "The " + testName.getMethodName() + " test failed - did not receive the correct response", pwdCBHVersion);
-
-        //Added to resolve RTC 285305
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
-
-        return;
-
-    }
-
-    @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testPWDigestCXFSvcClientaltCallbackSSLEE7Only() throws Exception {
-
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback.xml");
-
-        genericTest(testName.getMethodName(), clientHttpsUrl, httpsPortNumber, "altCallback1", "UsrTokenPWDigestWebSvcSSL",
-                    "This is WSSECFVT CXF Web Service with SSL (Password Digest)",
-                    "The " + testName.getMethodName() + " test failed - did not receive the correct response", pwdCBHVersion);
-
-        //Added to resolve RTC 285305
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-
-        return;
-
-    }
-
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
-    public void testPWDigestCXFSvcClientaltCallbackSSLEE8Only() throws Exception {
+    public void testPWDigestCXFSvcClientaltCallbackSSL() throws Exception {
 
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback_wss4j.xml");
+        } //End of issue 18363
 
         genericTest(testName.getMethodName(), clientHttpsUrl, httpsPortNumber, "altCallback1", "UsrTokenPWDigestWebSvcSSL",
                     "This is WSSECFVT CXF Web Service with SSL (Password Digest)",
                     "The " + testName.getMethodName() + " test failed - did not receive the correct response", pwdCBHVersion);
 
-        //Added to resolve RTC 285305
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        } //End of issue 18363
 
         return;
 
@@ -520,70 +514,57 @@ public class CxfPasswordDigestTests extends CommonTests {
 
     }
 
+    //issue 18363
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testPWDigestCXFSvcClientClCallbackInServerXmlEE7Only() throws Exception {
+    public void testPWDigestCXFSvcClientClCallbackInServerXml() throws Exception {
 
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback_wss4j.xml");
+        } //End of issue 18363
 
         genericTest(testName.getMethodName(), clientHttpUrl, "", "user88", "UsrTokenPWDigestWebSvc",
                     "This is WSSECFVT CXF Web Service (Password Digest)",
                     "The " + testName.getMethodName() + " test failed - did not receive the correct response");
 
-        //Added to resolve RTC 285305
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        } //End of issue 18363
 
         return;
 
     }
 
     @Test
-    @SkipForRepeat({ NO_MODIFICATION })
-    public void testPWDigestCXFSvcClientClCallbackInServerXmlEE8Only() throws Exception {
-
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback_wss4j.xml");
-
-        genericTest(testName.getMethodName(), clientHttpUrl, "", "user88", "UsrTokenPWDigestWebSvc",
-                    "This is WSSECFVT CXF Web Service (Password Digest)",
-                    "The " + testName.getMethodName() + " test failed - did not receive the correct response");
-
-        //Added to resolve RTC 285305
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
-
-        return;
-
-    }
-
-    @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testPWDigestCXFSvcClientClCallbackInServerXmlSSLEE7Only() throws Exception {
-
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback.xml");
-
-        genericTest(testName.getMethodName(), clientHttpUrl, httpsPortNumber, "user88", "UsrTokenPWDigestWebSvcSSL",
-                    "This is WSSECFVT CXF Web Service with SSL (Password Digest)",
-                    "The " + testName.getMethodName() + " test failed - did not receive the correct response");
-
-        //Added to resolve RTC 285305
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-
-        return;
-
-    }
-
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
-    public void testPWDigestCXFSvcClientClCallbackInServerXmlSSLEE8Only() throws Exception {
+    public void testPWDigestCXFSvcClientClCallbackInServerXmlSSL() throws Exception {
 
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_withClCallback_wss4j.xml");
+        } //End of issue 18363
 
         genericTest(testName.getMethodName(), clientHttpUrl, httpsPortNumber, "user88", "UsrTokenPWDigestWebSvcSSL",
                     "This is WSSECFVT CXF Web Service with SSL (Password Digest)",
                     "The " + testName.getMethodName() + " test failed - did not receive the correct response");
 
-        //Added to resolve RTC 285305
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        //issue 18363
+        if (featureVersion == "EE7") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+        }
+        if (featureVersion == "EE8") {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        } //End of issue 18363
 
         return;
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfSSLUNTBasicTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfSSLUNTBasicTests.java
@@ -49,7 +49,7 @@ public class CxfSSLUNTBasicTests extends SSLTestCommon {
      *
      */
     @Test
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testUntWssecSvcClientSSL() throws Exception {
 
         genericTest("testUntWssecSvcClientSSL", untSSLClientUrl,
@@ -171,7 +171,7 @@ public class CxfSSLUNTBasicTests extends SSLTestCommon {
      *
      */
     @Test
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testUntWssecSvcClientSSLManaged() throws Exception {
 
         genericTest("testUntWssecSvcClientSSLManaged", untSSLClientUrl,

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfSSLUNTNonceTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfSSLUNTNonceTests.java
@@ -45,7 +45,7 @@ public class CxfSSLUNTNonceTests extends SSLTestCommon {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { JakartaEE9Action.ID })
     public void testCxfUntNonceOnlySSL() throws Exception {
 
         genericTest("testCxfUntNonceOnlySSL", untSSLClientUrl,
@@ -68,7 +68,7 @@ public class CxfSSLUNTNonceTests extends SSLTestCommon {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { JakartaEE9Action.ID })
     public void testCxfUntNonceAndCreatedSSL() throws Exception {
 
         genericTest("testCxfUntNonceAndCreatedSSL", untSSLClientUrl,
@@ -92,7 +92,7 @@ public class CxfSSLUNTNonceTests extends SSLTestCommon {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { JakartaEE9Action.ID })
     public void testCxfUntNonceAndCreatedNoIdSSL() throws Exception {
 
         genericTest("testCxfUntNonceAndCreatedNoIdSSL", untSSLClientUrl,
@@ -163,7 +163,7 @@ public class CxfSSLUNTNonceTests extends SSLTestCommon {
     }
 
     @Test
-    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException", "java.net.MalformedURLException" },
+    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException", "java.util.MissingResourceException" },
                  repeatAction = { JakartaEE9Action.ID })
     public void testCxfUntOldExtFutureTimestampSSL() throws Exception {
 
@@ -194,7 +194,7 @@ public class CxfSSLUNTNonceTests extends SSLTestCommon {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { JakartaEE9Action.ID })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { JakartaEE9Action.ID })
     public void testCxfUntReqTimestampSSL() throws Exception {
 
         genericTest("testCxfUntReqTimestampSSL", untSSLClientUrl,

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfSSLUNTNonceTimeOutTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfSSLUNTNonceTimeOutTests.java
@@ -58,8 +58,7 @@ public class CxfSSLUNTNonceTimeOutTests extends SSLTestCommon {
                            File.separator +
                            server.getPathToAutoFVTNamedServer() +
                            "server_customize.xml";
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             copyFromFile = System.getProperty("user.dir") +
                            File.separator +
                            server.getPathToAutoFVTNamedServer() +

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfWssTemplatesTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfWssTemplatesTests.java
@@ -196,8 +196,7 @@ public class CxfWssTemplatesTests extends CommonTests {
         //issue 18363
         if ("EE7".equals(getFeatureVersion())) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym.xml");
-        }
-        if ("EE8".equals(getFeatureVersion())) {
+        } else if ("EE8".equals(getFeatureVersion())) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym_wss4j.xml");
         } //End of 18363
 
@@ -228,8 +227,7 @@ public class CxfWssTemplatesTests extends CommonTests {
         //issue 18363
         if ("EE7".equals(getFeatureVersion())) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-        }
-        if ("EE8".equals(getFeatureVersion())) {
+        } else if ("EE8".equals(getFeatureVersion())) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
         } //End of 18363
 
@@ -254,8 +252,7 @@ public class CxfWssTemplatesTests extends CommonTests {
         //issue 18363
         if ("EE7".equals(getFeatureVersion())) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym.xml");
-        }
-        if ("EE8".equals(getFeatureVersion())) {
+        } else if ("EE8".equals(getFeatureVersion())) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym_wss4j.xml");
         } //End of 18363
 
@@ -286,8 +283,7 @@ public class CxfWssTemplatesTests extends CommonTests {
         //issue 18363
         if ("EE7".equals(getFeatureVersion())) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-        }
-        if ("EE8".equals(getFeatureVersion())) {
+        } else if ("EE8".equals(getFeatureVersion())) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
         } //End of 18363
 
@@ -319,8 +315,7 @@ public class CxfWssTemplatesTests extends CommonTests {
         //issue 18363
         if ("EE7".equals(getFeatureVersion())) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym.xml");
-        }
-        if ("EE8".equals(getFeatureVersion())) {
+        } else if ("EE8".equals(getFeatureVersion())) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym_wss4j.xml");
         } //End of 18363
 
@@ -351,8 +346,7 @@ public class CxfWssTemplatesTests extends CommonTests {
         //issue 18363
         if ("EE7".equals(getFeatureVersion())) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-        }
-        if ("EE8".equals(getFeatureVersion())) {
+        } else if ("EE8".equals(getFeatureVersion())) {
             reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
         } //End of 18363
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfWssTemplatesTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfWssTemplatesTests.java
@@ -11,9 +11,7 @@
 
 package com.ibm.ws.wssecurity.fat.cxf.usernametoken;
 
-import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
-import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 
 import java.io.File;
 
@@ -35,6 +33,18 @@ import componenttest.rules.repeater.EE8FeatureReplacementAction;
 public class CxfWssTemplatesTests extends CommonTests {
 
 //    static private UpdateWSDLPortNum newWsdl = null;
+
+    //issue 18363
+    static private String featureVersion = "";
+
+    //issue 18363
+    public static String getFeatureVersion() {
+        return featureVersion;
+    }
+
+    public static void setFeatureVersion(String version) {
+        featureVersion = version;
+    } //End of issue 18363
 
     /**
      * TestDescription:
@@ -182,47 +192,20 @@ public class CxfWssTemplatesTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testCXFUsernameTokenAsEndorsingAndX509SymmetricEE7Only() throws Exception {
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym.xml");
-        genericTest(
-                    // test name for logging
-                    "testCXFUsernameTokenAsEndorsingAndX509SymmetricEE7Only",
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "WSSTemplatesService3",
-                    // wsdl that the svc client code should use
-                    "",
-                    // wsdl port that svc client code should use
-                    "WSSTemplate3",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Response: This is WSSTemplateWebSvc3 Web Service.",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a successful message from the server.");
-
-        //Added to resolve RTC 285305
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-
-    }
-
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
-    public void testCXFUsernameTokenAsEndorsingAndX509SymmetricEE8Only() throws Exception {
+    public void testCXFUsernameTokenAsEndorsingAndX509Symmetric() throws Exception {
 
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym_wss4j.xml");
+        //issue 18363
+        if ("EE7".equals(getFeatureVersion())) {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym.xml");
+        }
+        if ("EE8".equals(getFeatureVersion())) {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym_wss4j.xml");
+        } //End of 18363
+
         genericTest(
                     // test name for logging
-                    "testCXFUsernameTokenAsEndorsingAndX509SymmetricEE8Only",
+                    "testCXFUsernameTokenAsEndorsingAndX509Symmetric",
                     // Svc Client Url that generic test code should use
                     clientHttpUrl,
                     // Port that svc client code should use
@@ -244,8 +227,13 @@ public class CxfWssTemplatesTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test expected a successful message from the server.");
 
-        //Added to resolve RTC 285305
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        //issue 18363
+        if ("EE7".equals(getFeatureVersion())) {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+        }
+        if ("EE8".equals(getFeatureVersion())) {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        } //End of 18363
 
     }
 
@@ -263,46 +251,20 @@ public class CxfWssTemplatesTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testCXFX509SymmetricAndEndorsingEE7Only() throws Exception {
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym.xml");
-        genericTest(
-                    // test name for logging
-                    "testCXFX509SymmetricAndEndorsingEE7Only",
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "WSSTemplatesService5",
-                    // wsdl that the svc client code should use
-                    "",
-                    // wsdl port that svc client code should use
-                    "WSSTemplate5",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Response: This is WSSTemplateWebSvc5 Web Service.",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a successful message from the server.");
-
-        //Added to resolve RTC 285305
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-
-    }
-
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
-    public void testCXFX509SymmetricAndEndorsingEE8Only() throws Exception {
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym_wss4j.xml");
+    public void testCXFX509SymmetricAndEndorsing() throws Exception {
+
+        //issue 18363
+        if ("EE7".equals(getFeatureVersion())) {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym.xml");
+        }
+        if ("EE8".equals(getFeatureVersion())) {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym_wss4j.xml");
+        } //End of 18363
+
         genericTest(
                     // test name for logging
-                    "testCXFX509SymmetricAndEndorsingEE8Only",
+                    "testCXFX509SymmetricAndEndorsing",
                     // Svc Client Url that generic test code should use
                     clientHttpUrl,
                     // Port that svc client code should use
@@ -324,8 +286,13 @@ public class CxfWssTemplatesTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test expected a successful message from the server.");
 
-        //Added to resolve RTC 285305
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        //issue 18363
+        if ("EE7".equals(getFeatureVersion())) {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+        }
+        if ("EE8".equals(getFeatureVersion())) {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        } //End of 18363
 
     }
 
@@ -350,47 +317,20 @@ public class CxfWssTemplatesTests extends CommonTests {
      */
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES })
-    public void testCXFX509SymmetricForMessageAndUntForClientEE7Only() throws Exception {
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym.xml");
-        genericTest(
-                    // test name for logging
-                    "testCXFX509SymmetricForMessageAndUntForClientEE7Only",
-                    // Svc Client Url that generic test code should use
-                    clientHttpUrl,
-                    // Port that svc client code should use
-                    "",
-                    // user that svc client code should use
-                    "user1",
-                    // pw that svc client code should use
-                    "security",
-                    // wsdl sevice that svc client code should use
-                    "WSSTemplatesService6",
-                    // wsdl that the svc client code should use
-                    "",
-                    // wsdl port that svc client code should use
-                    "WSSTemplate6",
-                    // msg to send from svc client to server
-                    "",
-                    // expected response from server
-                    "Response: This is WSSTemplateWebSvc6 Web Service.",
-                    // msg to issue if do NOT get the expected result
-                    "The test expected a successful message from the server.");
-
-        //Added to resolve RTC 285305
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
-
-    }
-
     @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @Test
-    @SkipForRepeat({ NO_MODIFICATION })
-    public void testCXFX509SymmetricForMessageAndUntForClientEE8Only() throws Exception {
+    public void testCXFX509SymmetricForMessageAndUntForClient() throws Exception {
 
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym_wss4j.xml");
+        //issue 18363
+        if ("EE7".equals(getFeatureVersion())) {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym.xml");
+        }
+        if ("EE8".equals(getFeatureVersion())) {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sym_wss4j.xml");
+        } //End of 18363
+
         genericTest(
                     // test name for logging
-                    "testCXFX509SymmetricForMessageAndUntForClientEE8Only",
+                    "testCXFX509SymmetricForMessageAndUntForClient",
                     // Svc Client Url that generic test code should use
                     clientHttpUrl,
                     // Port that svc client code should use
@@ -412,8 +352,13 @@ public class CxfWssTemplatesTests extends CommonTests {
                     // msg to issue if do NOT get the expected result
                     "The test expected a successful message from the server.");
 
-        //Added to resolve RTC 285305
-        reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        //issue 18363
+        if ("EE7".equals(getFeatureVersion())) {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server.xml");
+        }
+        if ("EE8".equals(getFeatureVersion())) {
+            reconfigServer(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+        } //End of 18363
 
     }
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfWssTemplatesTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfWssTemplatesTests.java
@@ -63,7 +63,7 @@ public class CxfWssTemplatesTests extends CommonTests {
      * Verify that the Web service is invoked successfully. This is a positive scenario.
      */
     @Test
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFUserNameTokenPasswordHashOverSSL() throws Exception {
 
         genericTest(
@@ -104,7 +104,7 @@ public class CxfWssTemplatesTests extends CommonTests {
      * Verify that the Web service is invoked successfully. This is a positive scenario.
      */
     @Test
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFUserNameTokenPasswordTextOverSSL() throws Exception {
         genericTest(
                     // test name for logging
@@ -146,7 +146,6 @@ public class CxfWssTemplatesTests extends CommonTests {
      * Verify that the Web service is invoked successfully. This is a positive scenario.
      */
 
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void testCXFAsymmetricX509MutualAuthenticationWithUnt() throws Exception {
         genericTest(
@@ -192,7 +191,6 @@ public class CxfWssTemplatesTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFUsernameTokenAsEndorsingAndX509Symmetric() throws Exception {
 
         //issue 18363
@@ -251,7 +249,6 @@ public class CxfWssTemplatesTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFX509SymmetricAndEndorsing() throws Exception {
 
         //issue 18363
@@ -317,7 +314,6 @@ public class CxfWssTemplatesTests extends CommonTests {
      */
 
     @Test
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     public void testCXFX509SymmetricForMessageAndUntForClient() throws Exception {
 
         //issue 18363

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/wsstemplates/CxfWssTemplatesTestsWithExternalPolicy.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/wsstemplates/CxfWssTemplatesTestsWithExternalPolicy.java
@@ -54,11 +54,15 @@ public class CxfWssTemplatesTestsWithExternalPolicy extends CxfWssTemplatesTests
         if (features.contains("usr:wsseccbh-1.0")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
+            //issue 18363
+            setFeatureVersion("EE7");
         }
         if (features.contains("usr:wsseccbh-2.0")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+            //issue 18363
+            setFeatureVersion("EE8");
         }
 
         ShrinkHelper.defaultDropinApp(server, "wsstemplatesclientwithep", "com.ibm.ws.wssecurity.fat.wsstemplatesclientwithep", "test.wssecfvt.wsstemplates",

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/wsstemplates/CxfWssTemplatesTestsWithExternalPolicy.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/wsstemplates/CxfWssTemplatesTestsWithExternalPolicy.java
@@ -51,13 +51,13 @@ public class CxfWssTemplatesTestsWithExternalPolicy extends CxfWssTemplatesTests
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             //issue 18363
             setFeatureVersion("EE7");
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/wsstemplates/CxfWssTemplatesTestsWithExternalPolicy.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/wsstemplates/CxfWssTemplatesTestsWithExternalPolicy.java
@@ -56,8 +56,7 @@ public class CxfWssTemplatesTestsWithExternalPolicy extends CxfWssTemplatesTests
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             //issue 18363
             setFeatureVersion("EE7");
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/wsstemplates/CxfWssTemplatesTestsWithWSDL.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/wsstemplates/CxfWssTemplatesTestsWithWSDL.java
@@ -55,8 +55,7 @@ public class CxfWssTemplatesTestsWithWSDL extends CxfWssTemplatesTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             //issue 18363
             setFeatureVersion("EE7");
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/wsstemplates/CxfWssTemplatesTestsWithWSDL.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/wsstemplates/CxfWssTemplatesTestsWithWSDL.java
@@ -50,13 +50,13 @@ public class CxfWssTemplatesTestsWithWSDL extends CxfWssTemplatesTests {
 
         ServerConfiguration config = server.getServerConfiguration();
         Set<String> features = config.getFeatureManager().getFeatures();
-        if (features.contains("usr:wsseccbh-1.0")) {
+        if (features.contains("jaxws-2.2")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
             //issue 18363
             setFeatureVersion("EE7");
         }
-        if (features.contains("usr:wsseccbh-2.0")) {
+        if (features.contains("jaxws-2.3")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/wsstemplates/CxfWssTemplatesTestsWithWSDL.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/wsstemplates/CxfWssTemplatesTestsWithWSDL.java
@@ -53,11 +53,15 @@ public class CxfWssTemplatesTestsWithWSDL extends CxfWssTemplatesTests {
         if (features.contains("usr:wsseccbh-1.0")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbh.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-1.0.mf");
+            //issue 18363
+            setFeatureVersion("EE7");
         }
         if (features.contains("usr:wsseccbh-2.0")) {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
+            //issue 18363
+            setFeatureVersion("EE8");
         }
 
         ShrinkHelper.defaultDropinApp(server, "wsstemplatesclient", "com.ibm.ws.wssecurity.fat.wsstemplatesclient", "test.wssecfvt.wsstemplates",


### PR DESCRIPTION
Update com.ibm.ws.wssecurity_fat.wsscxf to remove the split (EE7Only/EE8Only) and use the feature version as conditional check.