### PR TITLE
Port BZ 64097: fix services lookup

### DIFF
--- a/dev/com.ibm.ws.el.3.0_fat/.classpath
+++ b/dev/com.ibm.ws.el.3.0_fat/.classpath
@@ -3,6 +3,7 @@
     <classpathentry kind="src" path="fat/src"/>
     <classpathentry kind="src" path="test-applications/TestEL3.0.war/src"/>
     <classpathentry kind="src" path="test-applications/TestVarargsMatching.war/src"/>
+    <classpathentry kind="src" path="test-applications/ELServicesLookup.war/src"/>
     <classpathentry kind="con" path="aQute.bnd.classpath.container"/>
     <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
     <classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.el.3.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.el.3.0_fat/bnd.bnd
@@ -14,7 +14,8 @@ bVersion=1.0
 src: \
     fat/src,\
     test-applications/TestEL3.0.war/src,\
-    test-applications/TestVarargsMatching.war/src
+    test-applications/TestVarargsMatching.war/src,\
+    test-applications/ELServicesLookup.war/src
 
 fat.project: true
 
@@ -29,4 +30,7 @@ tested.features:\
 # fattest.simplicity, and componenttest-1.0 will be automatically added to the buildpath
 -buildpath: \
     com.ibm.websphere.javaee.servlet.3.1;version=latest,\
-    com.ibm.websphere.javaee.el.3.0;version=latest
+    com.ibm.websphere.javaee.el.3.0;version=latest,\
+    org.apache.httpcomponents:httpclient;version=4.1.2,\
+    org.apache.httpcomponents:httpcore;version=4.1.2,\
+    httpunit:httpunit;version=1.5.4

--- a/dev/com.ibm.ws.el.3.0_fat/fat/src/com/ibm/ws/el/fat/ELUtils.java
+++ b/dev/com.ibm.ws.el.3.0_fat/fat/src/com/ibm/ws/el/fat/ELUtils.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.el.fat;
+
+import java.net.URL;
+
+import componenttest.topology.impl.LibertyServer;
+
+// Borrowed from JSPUtils.java
+public class ELUtils {
+    protected static final Class<?> c = ELUtils.class;
+
+    /**
+     * Construct a URL for a test case so a request can be made.
+     *
+     * @param server - The server that is under test, this is used to get the port and host name.
+     * @param contextRoot - The context root of the application
+     * @param path - Additional path information for the request.
+     * @return - A fully formed URL.
+     * @throws Exception
+     */
+    public static URL createHttpUrl(LibertyServer server, String contextRoot, String path) throws Exception {
+        return new URL(createHttpUrlString(server, contextRoot, path));
+    }
+
+    /**
+     * Construct a URL for a test case so a request can be made.
+     *
+     * @param server - The server that is under test, this is used to get the port and host name.
+     * @param contextRoot - The context root of the application
+     * @param path - Additional path information for the request.
+     * @return - A fully formed URL string.
+     * @throws Exception
+     */
+    public static String createHttpUrlString(LibertyServer server, String contextRoot, String path) {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("http://")
+                        .append(server.getHostname())
+                        .append(":")
+                        .append(server.getHttpDefaultPort())
+                        .append("/")
+                        .append(contextRoot)
+                        .append("/")
+                        .append(path);
+
+        return sb.toString();
+    }
+}

--- a/dev/com.ibm.ws.el.3.0_fat/fat/src/com/ibm/ws/el/fat/FATSuite.java
+++ b/dev/com.ibm.ws.el.3.0_fat/fat/src/com/ibm/ws/el/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ import com.ibm.ws.el.fat.tests.EL30CoercionRulesTest;
 import com.ibm.ws.el.fat.tests.EL30LambdaExpressionsTest;
 import com.ibm.ws.el.fat.tests.EL30ListCollectionObjectOperationsTest;
 import com.ibm.ws.el.fat.tests.EL30MethodExpressionInvocationsTest;
+import com.ibm.ws.el.fat.tests.EL30MiscTests;
 import com.ibm.ws.el.fat.tests.EL30OperatorPrecedenceTest;
 import com.ibm.ws.el.fat.tests.EL30OperatorsTest;
 import com.ibm.ws.el.fat.tests.EL30ReservedWordsTest;
@@ -31,6 +32,7 @@ import com.ibm.ws.fat.util.FatLogHandler;
 import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
+
 /**
  * EL 3.0 Tests
  *
@@ -57,7 +59,8 @@ import componenttest.rules.repeater.RepeatTests;
                 EL22OperatorsTest.class,
                 EL30OperatorsTest.class,
                 EL30MethodExpressionInvocationsTest.class,
-                EL30VarargsMethodMatchingTest.class
+                EL30VarargsMethodMatchingTest.class,
+                EL30MiscTests.class
 })
 public class FATSuite {
 

--- a/dev/com.ibm.ws.el.3.0_fat/fat/src/com/ibm/ws/el/fat/tests/EL30MiscTests.java
+++ b/dev/com.ibm.ws.el.3.0_fat/fat/src/com/ibm/ws/el/fat/tests/EL30MiscTests.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.el.fat.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.logging.Logger;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.ws.el.fat.ELUtils;
+import com.meterware.httpunit.GetMethodWebRequest;
+import com.meterware.httpunit.WebConversation;
+import com.meterware.httpunit.WebRequest;
+import com.meterware.httpunit.WebResponse;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * EL Misc Tests
+ */
+@Mode(TestMode.FULL)
+@RunWith(FATRunner.class)
+public class EL30MiscTests {
+
+    private static final Logger LOG = Logger.getLogger(EL30MiscTests.class.getName());
+
+    @Server("elMiscServer")
+    public static LibertyServer elServer;
+
+    private static final String ServiceLookup_AppName = "ELServicesLookup";
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        ShrinkHelper.defaultDropinApp(elServer, "ELServicesLookup.war", "com.ibm.ws.el30.fat.servicelookup");
+
+        elServer.startServer(EL30MiscTests.class.getSimpleName() + ".log");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        // Stop the server
+        if (elServer != null && elServer.isStarted()) {
+            elServer.stopServer();
+        }
+    }
+
+    /**
+     * Comments in the META-INF/services/javax.el.ExpressionFactory files should be ignored
+     *
+     * https://github.com/OpenLiberty/open-liberty/pull/18424
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testEL30ServiceLookup() throws Exception {
+        WebConversation wc = new WebConversation();
+
+        String url = ELUtils.createHttpUrlString(elServer, ServiceLookup_AppName, "TestServiceLookup");
+        LOG.info("url: " + url);
+
+        WebRequest request = new GetMethodWebRequest(url);
+        WebResponse response = wc.getResponse(request);
+        LOG.info("Servlet response : " + response.getText());
+
+        assertEquals("Expected " + 200 + " status code was not returned!",
+                     200, response.getResponseCode());
+        assertTrue("The response did not contain: Lookup works!", response.getText().contains("Lookup works!"));
+    }
+
+    /**
+     * Comments in the META-INF/services/javax.el.ExpressionFactory files should be ignored
+     *
+     * The BZ 64097 patch was applied to both EL-3.0 and th EL-2.2 API.
+     *
+     * This one tests the service look using the jsp-2.2 feature because it relies on the el 2.2 api. This test was placed here for two mains reasons:
+     * - There's no el 2.2 bucket.
+     * - This scenario tests EL, so we chose not to place this in the the jsp FATs.
+     * - We didn't want to duplicate the test application in multiple buckets
+     *
+     * https://github.com/OpenLiberty/open-liberty/pull/18424
+     *
+     * @throws Exception
+     */
+    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
+    @Test
+    public void testEL22ServiceLookup() throws Exception {
+
+
+        elServer.saveServerConfiguration();
+
+        ServerConfiguration configuration = elServer.getServerConfiguration();
+        LOG.info("Server configuration that was saved: " + configuration);
+
+        elServer.setMarkToEndOfLog();
+        elServer.setServerConfigurationFile("serverConfigs/jsp22server.xml");
+        elServer.waitForConfigUpdateInLogUsingMark(Collections.singleton(ServiceLookup_AppName), true, "CWWKT0016I:.*ELServicesLookup.*");
+
+        configuration = elServer.getServerConfiguration();
+        LOG.info("Updated server configuration: " + configuration);
+
+        try {    
+            WebConversation wc = new WebConversation();
+    
+            wc.setExceptionsThrownOnErrorStatus(false);
+    
+            String url = ELUtils.createHttpUrlString(elServer, ServiceLookup_AppName, "EL22Test.jsp");
+            LOG.info("url: " + url);
+    
+            WebRequest request = new GetMethodWebRequest(url);
+            WebResponse response = wc.getResponse(request);
+            LOG.info("Servlet response : " + response.getText());
+    
+            assertEquals("Expected " + 200 + " status code was not returned!",
+                         200, response.getResponseCode());
+            assertTrue("The response did not contain: Lookup works!", response.getText().contains("Lookup works!"));
+            
+        } finally {
+            elServer.setMarkToEndOfLog();
+            elServer.restoreServerConfiguration();
+            // Wait for the application that is still deployed to start.
+            elServer.waitForConfigUpdateInLogUsingMark(Collections.singleton(ServiceLookup_AppName), true, "CWWKT0016I:.*ELServicesLookup.*");
+        }
+    }
+}

--- a/dev/com.ibm.ws.el.3.0_fat/fat/src/com/ibm/ws/el/fat/tests/EL30VarargsMethodMatchingTest.java
+++ b/dev/com.ibm.ws.el.3.0_fat/fat/src/com/ibm/ws/el/fat/tests/EL30VarargsMethodMatchingTest.java
@@ -20,12 +20,15 @@ import com.ibm.ws.el30.fat.varargstest.EL30VarargsMethodMatchingServlet;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
 /**
  * Test EL 3.0 Method Matching when Varargs are used. See BZ 65358 
  */
+@Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
 public class EL30VarargsMethodMatchingTest extends FATServletClient {
 

--- a/dev/com.ibm.ws.el.3.0_fat/publish/files/serverConfigs/jsp22server.xml
+++ b/dev/com.ibm.ws.el.3.0_fat/publish/files/serverConfigs/jsp22server.xml
@@ -1,0 +1,21 @@
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Server for testing EL 2.2 (through jsp-2.2) in a stand alone environment">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>jsp-2.2</feature>
+        <feature>servlet-3.1</feature>
+        <feature>componenttest-1.0</feature>
+    </featureManager>
+
+</server>

--- a/dev/com.ibm.ws.el.3.0_fat/publish/servers/elMiscServer/.gitignore
+++ b/dev/com.ibm.ws.el.3.0_fat/publish/servers/elMiscServer/.gitignore
@@ -1,0 +1,1 @@
+/dropins

--- a/dev/com.ibm.ws.el.3.0_fat/publish/servers/elMiscServer/bootstrap.properties
+++ b/dev/com.ibm.ws.el.3.0_fat/publish/servers/elMiscServer/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+osgi.console=7777

--- a/dev/com.ibm.ws.el.3.0_fat/publish/servers/elMiscServer/server.xml
+++ b/dev/com.ibm.ws.el.3.0_fat/publish/servers/elMiscServer/server.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2015 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Server for testing EL">
+
+    <include location="../fatTestPorts.xml"/>
+
+
+    <!-- Used for EL30MiscTests -->
+    
+    <featureManager>
+        <feature>el-3.0</feature>
+        <feature>servlet-3.1</feature>
+        <feature>componenttest-1.0</feature>
+    </featureManager>
+
+</server>

--- a/dev/com.ibm.ws.el.3.0_fat/test-applications/ELServicesLookup.war/resources/EL22Test.jsp
+++ b/dev/com.ibm.ws.el.3.0_fat/test-applications/ELServicesLookup.war/resources/EL22Test.jsp
@@ -1,0 +1,11 @@
+<html>
+<title>Service Lookup Test for EL 2.2</title>
+<body>
+
+    <!-- The TestServiceLookupServlet uses "javax.el.ELProcessor" which is not availabe from the EL api in the jsp-2.2. 
+    This jsp needs to be used instead.  -->
+
+    Lookup works!
+    
+</body>
+</html>

--- a/dev/com.ibm.ws.el.3.0_fat/test-applications/ELServicesLookup.war/resources/META-INF/services/javax.el.ExpressionFactory
+++ b/dev/com.ibm.ws.el.3.0_fat/test-applications/ELServicesLookup.war/resources/META-INF/services/javax.el.ExpressionFactory
@@ -1,0 +1,2 @@
+# ExpressionFactory#getClassNameServices should ignore this comment -- OLGH18419 
+org.apache.el.ExpressionFactoryImpl

--- a/dev/com.ibm.ws.el.3.0_fat/test-applications/ELServicesLookup.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.el.3.0_fat/test-applications/ELServicesLookup.war/resources/WEB-INF/web.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<web-app
+    version="3.1"
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+
+  <display-name>EL30ServicesLookup</display-name>
+
+  <servlet>
+    <servlet-name>TestServiceLookupServlet</servlet-name>
+    <servlet-class>com.ibm.ws.el30.fat.servicelookup.TestServiceLookupServlet</servlet-class>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>TestServiceLookupServlet</servlet-name>
+    <url-pattern>TestServiceLookup</url-pattern>
+  </servlet-mapping>
+
+</web-app>

--- a/dev/com.ibm.ws.el.3.0_fat/test-applications/ELServicesLookup.war/src/com/ibm/ws/el30/fat/servicelookup/TestServiceLookupServlet.java
+++ b/dev/com.ibm.ws.el.3.0_fat/test-applications/ELServicesLookup.war/src/com/ibm/ws/el30/fat/servicelookup/TestServiceLookupServlet.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.el30.fat.servicelookup;
+
+import java.io.*;
+import javax.servlet.*;
+import javax.servlet.http.*;
+import javax.el.ELProcessor;
+
+public class TestServiceLookupServlet extends HttpServlet {
+ 
+   public void doGet(HttpServletRequest request, HttpServletResponse response)
+      throws ServletException, IOException {
+
+        response.setContentType("text/html");
+        PrintWriter out = response.getWriter();
+        try {
+            ELProcessor elp = new ELProcessor();
+            out.println("<h1>" + "Lookup works!" + "</h1>");
+        } catch(Exception e){
+            out.println("<p>" + e + "</p>");
+        }
+      
+   }
+
+}


### PR DESCRIPTION
Description: 

If META-INF/services/javax.el.ExpressionFactory does not contain a qualified class name in its first line (i.e. comments above the class name), then EL throws an exception. 

Fixes #18419 

Comments were not ignored with the previous lookup implementation. 


See original patch here: https://github.com/apache/tomcat/commit/31bce633bb5f90cf8d48074494e30254b939560d