### PR TITLE
wsscxf.saml.1 fat remove split

### DIFF
--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/OneServerTests/CxfSAMLWSSTemplates1ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/OneServerTests/CxfSAMLWSSTemplates1ServerTests.java
@@ -22,6 +22,9 @@ import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.wssecurity.fat.cxf.samltoken1.common.CxfSAMLWSSTemplatesTests;
 
+//issue 18363
+import java.util.Set;
+
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -94,7 +97,15 @@ public class CxfSAMLWSSTemplates1ServerTests extends CxfSAMLWSSTemplatesTests {
         testSettings.setSpTargetApp(testSAMLServer.getHttpString() + "/samlwsstemplatesclient/CxfWssSAMLTemplatesSvcClient");
         testSettings.setSamlTokenValidationData(testSettings.getIdpUserName(), testSettings.getSamlTokenValidationData().getIssuer(), testSettings.getSamlTokenValidationData().getInResponseTo(), testSettings.getSamlTokenValidationData().getMessageID(), testSettings.getSamlTokenValidationData().getEncryptionKeyUser(), testSettings.getSamlTokenValidationData().getRecipient(), testSettings.getSamlTokenValidationData().getEncryptAlg());
 
-                
+        //issue 18363
+        Set<String> features = testSAMLServer.getServer().getServerConfiguration().getFeatureManager().getFeatures();
+        if (features.contains("jaxws-2.2")) {
+            setFeatureVersion("EE7");
+        }
+        if (features.contains("jaxws-2.3")) {
+            setFeatureVersion("EE8");
+        } // End of 18363
+        
     }
 
 }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/OneServerTests/CxfSAMLWSSTemplates1ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/OneServerTests/CxfSAMLWSSTemplates1ServerTests.java
@@ -85,7 +85,6 @@ public class CxfSAMLWSSTemplates1ServerTests extends CxfSAMLWSSTemplatesTests {
 
         startSPWithIDPServer("com.ibm.ws.wssecurity_fat.saml.wssTemplates", "server_2_in_1.xml", SAMLConstants.SAML_SERVER_TYPE, extraMsgs, extraApps, true, SAMLConstants.EXAMPLE_CALLBACK, SAMLConstants.EXAMPLE_CALLBACK_FEATURE);
 
-        //3/2021
         testSAMLServer.addIgnoredServerExceptions(SAMLMessageConstants.CWWKS5207W_SAML_CONFIG_IGNORE_ATTRIBUTES, SAMLMessageConstants.CWWKG0101W_CONFIG_NOT_VISIBLE_TO_OTHER_BUNDLES, SAMLMessageConstants.CWWKF0001E_FEATURE_MISSING);
         
         servicePort = Integer.toString(testSAMLServer.getServerHttpPort());
@@ -101,8 +100,7 @@ public class CxfSAMLWSSTemplates1ServerTests extends CxfSAMLWSSTemplatesTests {
         Set<String> features = testSAMLServer.getServer().getServerConfiguration().getFeatureManager().getFeatures();
         if (features.contains("jaxws-2.2")) {
             setFeatureVersion("EE7");
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             setFeatureVersion("EE8");
         } // End of 18363
         

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/OneServerTests/CxfSSLSAMLBasic1ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/OneServerTests/CxfSSLSAMLBasic1ServerTests.java
@@ -22,6 +22,9 @@ import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.wssecurity.fat.cxf.samltoken1.common.CxfSSLSAMLBasicTests;
 
+//issue 18363
+import java.util.Set;
+
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -85,5 +88,14 @@ public class CxfSSLSAMLBasic1ServerTests extends CxfSSLSAMLBasicTests {
         testSettings.setSpTargetApp(testSAMLServer.getHttpsString() + "/samlcxfclient/CxfSamlSvcClient");
         testSettings.setSamlTokenValidationData(testSettings.getIdpUserName(), testSettings.getSamlTokenValidationData().getIssuer(), testSettings.getSamlTokenValidationData().getInResponseTo(), testSettings.getSamlTokenValidationData().getMessageID(), testSettings.getSamlTokenValidationData().getEncryptionKeyUser(), testSettings.getSamlTokenValidationData().getRecipient(), testSettings.getSamlTokenValidationData().getEncryptAlg());
 
+        //issue 18363
+        Set<String> features = testSAMLServer.getServer().getServerConfiguration().getFeatureManager().getFeatures();
+        if (features.contains("jaxws-2.2")) {
+            setFeatureVersion("EE7");
+        }
+        if (features.contains("jaxws-2.3")) {
+            setFeatureVersion("EE8");
+        }// End of 18363
+        
     }
 }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/OneServerTests/CxfSSLSAMLBasic1ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/OneServerTests/CxfSSLSAMLBasic1ServerTests.java
@@ -92,8 +92,7 @@ public class CxfSSLSAMLBasic1ServerTests extends CxfSSLSAMLBasicTests {
         Set<String> features = testSAMLServer.getServer().getServerConfiguration().getFeatureManager().getFeatures();
         if (features.contains("jaxws-2.2")) {
             setFeatureVersion("EE7");
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             setFeatureVersion("EE8");
         }// End of 18363
         

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/TwoServerTests/CxfSAMLWSSTemplates2ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/TwoServerTests/CxfSAMLWSSTemplates2ServerTests.java
@@ -108,8 +108,7 @@ public class CxfSAMLWSSTemplates2ServerTests extends CxfSAMLWSSTemplatesTests {
         Set<String> features = testSAMLServer.getServer().getServerConfiguration().getFeatureManager().getFeatures();
         if (features.contains("jaxws-2.2")) {
             setFeatureVersion("EE7");
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             setFeatureVersion("EE8");
         } // End of 18363
         

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/TwoServerTests/CxfSAMLWSSTemplates2ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/TwoServerTests/CxfSAMLWSSTemplates2ServerTests.java
@@ -21,6 +21,8 @@ import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.wssecurity.fat.cxf.samltoken1.common.CxfSAMLWSSTemplatesTests;
+//issue 18363
+import java.util.Set;
 
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
@@ -102,7 +104,15 @@ public class CxfSAMLWSSTemplates2ServerTests extends CxfSAMLWSSTemplatesTests {
         testSettings.setSpTargetApp(testSAMLServer.getHttpString() + "/samlwsstemplatesclient/CxfWssSAMLTemplatesSvcClient");
         testSettings.setSamlTokenValidationData(testSettings.getIdpUserName(), testSettings.getSamlTokenValidationData().getIssuer(), testSettings.getSamlTokenValidationData().getInResponseTo(), testSettings.getSamlTokenValidationData().getMessageID(), testSettings.getSamlTokenValidationData().getEncryptionKeyUser(), testSettings.getSamlTokenValidationData().getRecipient(), testSettings.getSamlTokenValidationData().getEncryptAlg());
 
-                
+        //issue 18363
+        Set<String> features = testSAMLServer.getServer().getServerConfiguration().getFeatureManager().getFeatures();
+        if (features.contains("jaxws-2.2")) {
+            setFeatureVersion("EE7");
+        }
+        if (features.contains("jaxws-2.3")) {
+            setFeatureVersion("EE8");
+        } // End of 18363
+        
     }
 
 }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/TwoServerTests/CxfSSLSAMLBasic2ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/TwoServerTests/CxfSSLSAMLBasic2ServerTests.java
@@ -22,6 +22,9 @@ import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.wssecurity.fat.cxf.samltoken1.common.CxfSSLSAMLBasicTests;
 
+//issue 18363
+import java.util.Set;
+
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServerWrapper;
 import componenttest.annotation.SkipForRepeat;
@@ -101,7 +104,6 @@ public class CxfSSLSAMLBasic2ServerTests extends CxfSSLSAMLBasicTests {
         testSettings.setIdpUserPwd("security");
         testSettings.setSpTargetApp(testSAMLServer.getHttpsString() + "/samlcxfclient/CxfSamlSvcClient");
         testSettings.setSamlTokenValidationData(testSettings.getIdpUserName(), testSettings.getSamlTokenValidationData().getIssuer(), testSettings.getSamlTokenValidationData().getInResponseTo(), testSettings.getSamlTokenValidationData().getMessageID(), testSettings.getSamlTokenValidationData().getEncryptionKeyUser(), testSettings.getSamlTokenValidationData().getRecipient(), testSettings.getSamlTokenValidationData().getEncryptAlg());
-
         
     }
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/common/CxfSAMLWSSTemplatesTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/common/CxfSAMLWSSTemplatesTests.java
@@ -28,8 +28,6 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServerWrapper;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
-import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
-import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 import componenttest.rules.repeater.EE8FeatureReplacementAction;
 import componenttest.rules.repeater.EmptyAction;
 
@@ -48,7 +46,18 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
     protected static String servicePort = null;
     protected static String serviceSecurePort = null;
     protected static String policyType = "wsdl";
+    //issue 18363
+    protected static String featureVersion = "";
 
+    //issue 18363
+    public static String getFeatureVersion() {
+        return featureVersion;
+    }
+    
+    public static void setFeatureVersion(String version) {
+        featureVersion = version;
+    } //End of issue 18363
+    
     /**
      * TestDescription:
      * Client matches server side policy (transport enabled)
@@ -56,33 +65,21 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
      * 
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
-    public void CxfSAMLWSSTemplatesTests_Saml20TokenOverSSLEE7Only() throws Exception {
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+    public void CxfSAMLWSSTemplatesTests_Saml20TokenOverSSL() throws Exception {
 
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setSpTargetApp(testSAMLServer.getHttpsString() + "/samlwsstemplatesclient/CxfWssSAMLTemplatesSvcClient");
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, serviceSecurePort, "user1", "user1pwd", "WSSTemplatesService2", "WSSTemplate2", "", "False", null, null);
-        updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_2));
-
-    }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @Test
-    public void CxfSAMLWSSTemplatesTests_Saml20TokenOverSSLEE8Only() throws Exception {
-
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-            //2 servers reconfig
-    		testSAMLServer2.reconfigServer("server_2_wsstemplate_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} 
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                //1 server reconfig
+    		    testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    } else {
+                //2 servers reconfig
+    		    testSAMLServer2.reconfigServer("server_2_wsstemplate_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    		    testSAMLServer.reconfigServer("server_1_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    } 
+    	} //End of 18363
     	
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
@@ -104,34 +101,20 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
      * 
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    public void CxfSAMLWSSTemplatesTests_Saml20TokenOverSSL_httpFromClientEE7Only() throws Exception {
-        
-    	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+    public void CxfSAMLWSSTemplatesTests_Saml20TokenOverSSL_httpFromClient() throws Exception {
 
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setSpTargetApp(testSAMLServer.getHttpsString() + "/samlwsstemplatesclient/CxfWssSAMLTemplatesSvcClient");
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "WSSTemplatesService2", "WSSTemplate2", "", "False", null, null);
-        updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
-        
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED));
-        
-    }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
-    @Test
-    public void CxfSAMLWSSTemplatesTests_Saml20TokenOverSSL_httpFromClientEE8Only() throws Exception {
-
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-    	    //2 servers reconfig
-    		testSAMLServer2.reconfigServer("server_2_wsstemplate_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} 
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                //1 server reconfig
+    		    testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        	} else {
+    	        //2 servers reconfig
+    		    testSAMLServer2.reconfigServer("server_2_wsstemplate_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    		    testSAMLServer.reconfigServer("server_1_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    } 
+    	} //End of 18363
     	
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
@@ -141,8 +124,15 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
         updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "WSSTemplatesService2", "WSSTemplate2", "", "False", null, null);
         updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
         
-        String CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED = "HttpsToken could not be asserted: Not an HTTPs connection"; //@AV999 new error message
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED));
+        //issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    		genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED));
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+            String CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED = "HttpsToken could not be asserted: Not an HTTPs connection"; //@AV999 new error message
+            genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED));
+    	} //End of 18363
+    	
     }
 
     /**
@@ -153,18 +143,31 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
      * Test should succeed in accessing the server side service.
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    public void CxfSAMLWSSTemplatesTests_AsymmetricX509MutualAuthenticationWithSamlEE7Only() throws Exception {
+    public void CxfSAMLWSSTemplatesTests_AsymmetricX509MutualAuthenticationWithSaml() throws Exception {
         
-    	if (testSAMLServer2 == null) {
-            // 1 server reconfig
-            testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        } else {
-            // 2 server reconfig
-            testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-            testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        }
+    	if ("EE7".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                // 1 server reconfig
+                testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            } else {
+                // 2 server reconfig
+                testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+                testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            }
+    	} //End of 18363
+    	
+    	if ("EE8".equals(getFeatureVersion())) {
+    		if (testSAMLServer2 == null) {
+                // 1 server reconfig
+                testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            } else {
+                // 2 server reconfig
+                testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+                testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            }
+    	} // End of 18363
+    	
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
@@ -175,31 +178,7 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
         genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_4));
 
     }
-
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @Test
-    public void CxfSAMLWSSTemplatesTests_AsymmetricX509MutualAuthenticationWithSamlEE8Only() throws Exception {
-
-        if (testSAMLServer2 == null) {
-            // 1 server reconfig
-            testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        } else {
-            // 2 server reconfig
-            testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-            testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        }
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "WSSTemplatesService4", "WSSTemplate4", "", "False", null, null);
-        updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_4));
-
-    }
-    
+ 
     /**
      * TestDescription:
      * This test uses a policy with Asymmetric X509 Policy with
@@ -208,19 +187,32 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
      * Test should fail to access the server side service.
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
-    public void CxfSAMLWSSTemplatesTests_AsymmetricX509MutualAuthenticationWithSaml_omitInitiatorTokenEE7Only() throws Exception {
+    public void CxfSAMLWSSTemplatesTests_AsymmetricX509MutualAuthenticationWithSaml_omitInitiatorToken() throws Exception {
     	
-        if (testSAMLServer2 == null) {
-            // 1 server reconfig
-            testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        } else {
-            // 2 server reconfig
-            testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-            testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        }
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+            if (testSAMLServer2 == null) {
+                // 1 server reconfig
+                testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            } else {
+                // 2 server reconfig
+                testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+                testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            } 
+    	}   	
+    	if ("EE8".equals(getFeatureVersion())) {
+    		if (testSAMLServer2 == null) {
+                // 1 server reconfig
+                testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            } else {
+                // 2 server reconfig
+                testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+                testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            }
+    	} //End of 18363
+    	
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
@@ -234,46 +226,20 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
 
         updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
         
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
-        
+        //issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+            genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+            if ("externalPolicy".equals(policyType)) { //@AV999 TODO in jaxws-2.3 , this is a successful scenario
+                genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_4)); //@AV999
+            } else {
+                String CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR = "These policy alternatives can not be satisfied:"; //@AV999, we need to use different error message depending on runtime
+                genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR)); //@AV999
+            }  
+    	} //End of 18363
     }
     
-    
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @Test 
-    public void CxfSAMLWSSTemplatesTests_AsymmetricX509MutualAuthenticationWithSaml_omitInitiatorTokenEE8Only() throws Exception {
-
-        if (testSAMLServer2 == null) {
-            // 1 server reconfig
-            testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        } else {
-            // 2 server reconfig
-            testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-            testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        }
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        if ("externalPolicy".equals(policyType)) {
-            updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "WSSTemplatesService4", "WSSTemplate4", "", "False", null, commonUtils.processClientWsdl("ClientAsymOmitInitiatorTokenWithEP.wsdl", servicePort));
-        }
-        else {
-            updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "WSSTemplatesService4", "WSSTemplate4", "", "False", null, commonUtils.processClientWsdl("ClientAsymOmitInitiatorToken.wsdl", servicePort));
-        }
-
-        updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
- 
-        if ("externalPolicy".equals(policyType)) { //@AV999 TODO in jaxws-2.3 , this is a successful scenario
-            genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_4)); //@AV999
-        } else {
-            String CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR = "These policy alternatives can not be satisfied:"; //@AV999, we need to use different error message depending on runtime
-            genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR)); //@AV999
-        }    
-    
-    }
-
     /**
      * TestDescription:
      * This test uses a policy with Asymmetric X509 Policy with
@@ -282,19 +248,32 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
      * Test should fail to access the server side service.
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
-    public void CxfSAMLWSSTemplatesTests_AsymmetricX509MutualAuthenticationWithSaml_omitRecipientTokenEE7Only() throws Exception {
+    public void CxfSAMLWSSTemplatesTests_AsymmetricX509MutualAuthenticationWithSaml_omitRecipientToken() throws Exception {
     	
-        if (testSAMLServer2 == null) {
-            // 1 server reconfig
-            testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        } else {
-            // 2 server reconfig
-            testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-            testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        }
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+            if (testSAMLServer2 == null) {
+                // 1 server reconfig
+                testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            } else {
+                // 2 server reconfig
+                testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+                testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            }
+    	} 
+    	if ("EE8".equals(getFeatureVersion())) {
+    		if (testSAMLServer2 == null) {
+                // 1 server reconfig
+                testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            } else {
+                // 2 server reconfig
+                testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+                testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            }
+    	} //End of 18363
+    	
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
@@ -305,46 +284,21 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
         else {
             updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "WSSTemplatesService4", "WSSTemplate4", "", "False", null, commonUtils.processClientWsdl("ClientAsymOmitRecipientToken.wsdl", servicePort));
         }
-        updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
-               
-    }
-    
-    
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
-    @Test
-    public void CxfSAMLWSSTemplatesTests_AsymmetricX509MutualAuthenticationWithSaml_omitRecipientTokenEE8Only() throws Exception {
-
-        if (testSAMLServer2 == null) {
-            // 1 server reconfig
-            testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        } else {
-            // 2 server reconfig
-            testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-            testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        }
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        if ("externalPolicy".equals(policyType)) {
-            updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "WSSTemplatesService4", "WSSTemplate4", "", "False", null, commonUtils.processClientWsdl("ClientAsymOmitRecipientTokenWithEP.wsdl", servicePort));
-        }
-        else {
-            updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "WSSTemplatesService4", "WSSTemplate4", "", "False", null, commonUtils.processClientWsdl("ClientAsymOmitRecipientToken.wsdl", servicePort));
-        }
-        updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
-
-        if ("externalPolicy".equals(policyType)) { //@AV999 TODO in jaxws-2.3 , this is a successful scenario
-            genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_4)); //@AV999
-        } else {
-            genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
-        } 
         
-    }
-    
+        updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
+
+        //issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+            genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+    		if ("externalPolicy".equals(policyType)) { //@AV999 TODO in jaxws-2.3 , this is a successful scenario
+                genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_4)); //@AV999
+            } else {
+                genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
+            } 
+    	} //End of 18363
+    }   
     
     /**
      * TestDescription:
@@ -353,10 +307,21 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
      * Test should succeed in accessing the server side service.
      */
    
-    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    public void CxfSAMLWSSTemplatesTests_X509SymmetricForMessageAndSamlForClientEE7Only() throws Exception {
+    public void CxfSAMLWSSTemplatesTests_X509SymmetricForMessageAndSamlForClient() throws Exception {
         
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    		if (testSAMLServer2 == null) {
+                //1 server reconfig
+        		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        	} else {
+                //2 servers reconfig
+        		testSAMLServer2.reconfigServer("server_2_wsstemplate_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        		testSAMLServer.reconfigServer("server_1_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        	} 
+    	} //End of 18363
+    	
     	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
@@ -367,31 +332,7 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
         genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_6));
 
     }
-
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
-    @Test
-    public void CxfSAMLWSSTemplatesTests_X509SymmetricForMessageAndSamlForClientEE8Only() throws Exception {
-
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-            //2 servers reconfig
-    		testSAMLServer2.reconfigServer("server_2_wsstemplate_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} 
-    	
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "WSSTemplatesService6", "WSSTemplate6", "", "False", null, null);
-        updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_6));
-
-    }
+    
     /**
      * TestDescription:
      * This test uses a policy with Symmetric X509 Message Policy and SAML.
@@ -399,10 +340,21 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
      * Test should fail to access the server side service.
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
-    public void CxfSAMLWSSTemplatesTests_X509SymmetricForMessageAndSamlForClient_omitProtectionPolicyEE7Only() throws Exception {
+    public void CxfSAMLWSSTemplatesTests_X509SymmetricForMessageAndSamlForClient_omitProtectionPolicy() throws Exception {
+    	
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    		if (testSAMLServer2 == null) {
+                //1 server reconfig
+        		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        	} else {
+                //2 servers reconfig
+        		testSAMLServer2.reconfigServer("server_2_wsstemplate_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        		testSAMLServer.reconfigServer("server_1_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        	} 
+    	} //End of 18363
     	
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
@@ -411,40 +363,19 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
         updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "WSSTemplatesService6", "WSSTemplate6", "", "False", null, commonUtils.processClientWsdl("ClientSymOmitProtectionPolicy.wsdl", servicePort));
         updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
 
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
-    }
-    
-    
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @Test
-    public void CxfSAMLWSSTemplatesTests_X509SymmetricForMessageAndSamlForClient_omitProtectionPolicyEE8Only() throws Exception {
-
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-            //2 servers reconfig
-    		testSAMLServer2.reconfigServer("server_2_wsstemplate_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} 
-    	
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "WSSTemplatesService6", "WSSTemplate6", "", "False", null, commonUtils.processClientWsdl("ClientSymOmitProtectionPolicy.wsdl", servicePort));
-        updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
-
-        
-        if ("externalPolicy".equals(policyType)) { //@AV999 , jaxws-2.3 this is failing at the client side
-            String CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR = "javax.xml.ws.soap.SOAPFaultException: javax.xml.crypto.dsig.TransformException: org.apache.wss4j.common.ext.WSSecurityException: Referenced Token ";
-            genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
-        } else {
+        //issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
             genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
-        } 
-        
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+    		if ("externalPolicy".equals(policyType)) { //@AV999 , jaxws-2.3 this is failing at the client side
+                String CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR = "javax.xml.ws.soap.SOAPFaultException: javax.xml.crypto.dsig.TransformException: org.apache.wss4j.common.ext.WSSecurityException: Referenced Token ";
+                genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
+            } else {
+                genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
+            } 
+    	} //End of 18363
+    	
     }
-    
 
 }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/common/CxfSAMLWSSTemplatesTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/common/CxfSAMLWSSTemplatesTests.java
@@ -127,8 +127,7 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
         //issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
     		genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED));
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
             String CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED = "HttpsToken could not be asserted: Not an HTTPs connection"; //@AV999 new error message
             genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED));
     	} //End of 18363
@@ -155,9 +154,7 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
                 testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
                 testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
             }
-    	} //End of 18363
-    	
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		if (testSAMLServer2 == null) {
                 // 1 server reconfig
                 testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
@@ -201,8 +198,7 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
                 testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
                 testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
             } 
-    	}   	
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		if (testSAMLServer2 == null) {
                 // 1 server reconfig
                 testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
@@ -229,8 +225,7 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
         //issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
             genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
             if ("externalPolicy".equals(policyType)) { //@AV999 TODO in jaxws-2.3 , this is a successful scenario
                 genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_4)); //@AV999
             } else {
@@ -262,8 +257,7 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
                 testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
                 testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
             }
-    	} 
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		if (testSAMLServer2 == null) {
                 // 1 server reconfig
                 testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
@@ -290,8 +284,7 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
         //issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
             genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		if ("externalPolicy".equals(policyType)) { //@AV999 TODO in jaxws-2.3 , this is a successful scenario
                 genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_4)); //@AV999
             } else {
@@ -366,8 +359,7 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
         //issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
             genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		if ("externalPolicy".equals(policyType)) { //@AV999 , jaxws-2.3 this is failing at the client side
                 String CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR = "javax.xml.ws.soap.SOAPFaultException: javax.xml.crypto.dsig.TransformException: org.apache.wss4j.common.ext.WSSecurityException: Referenced Token ";
                 genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/common/CxfSSLSAMLBasicTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/common/CxfSSLSAMLBasicTests.java
@@ -145,8 +145,7 @@ public class CxfSSLSAMLBasicTests extends SAMLCommonTest {
         //issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
             genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED));
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		String CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED = "HttpsToken could not be asserted: Not an HTTPs connection"; // @AV999 slightly different error with new runtime
             genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED));
     	} //End of 18363

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/common/CxfSSLSAMLBasicTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken1/common/CxfSSLSAMLBasicTests.java
@@ -56,6 +56,17 @@ public class CxfSSLSAMLBasicTests extends SAMLCommonTest {
     protected static String servicePort = null;
     protected static String serviceSecurePort = null;
     protected static CXFSAMLCommonUtils commonUtils = new CXFSAMLCommonUtils();
+    //issue 18363
+    protected static String featureVersion = "";
+
+    //issue 18363
+    public static String getFeatureVersion() {
+        return featureVersion;
+    }
+    
+    public static void setFeatureVersion(String version) {
+        featureVersion = version;
+    } //End of issue 18363
 
     /**
      * TestDescription:
@@ -68,36 +79,20 @@ public class CxfSSLSAMLBasicTests extends SAMLCommonTest {
      * Test should succeed in accessing the server side service.
      * 
      */
-    
-    @Mode(TestMode.LITE)
-    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
-    @Test
-    public void testSAMLCxfSvcClient_TransportEnabledEE7Only() throws Exception {
-
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, serviceSecurePort, "user1", "user1pwd", "SamlTokenTransportSecure",
-                "SamlTokenTransportSecurePort", "", "False", null, null);
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SSL_SAML_TOKEN_SERVICE));
-
-    }
-    
+ 
     @Mode(TestMode.LITE)
     @SkipForRepeat({ NO_MODIFICATION, EE8_FEATURES })
     @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { JakartaEE9Action.ID })
     @Test
-    public void testSAMLCxfSvcClient_TransportEnabledEE9Only() throws Exception {
-    		
-    	if (testSAMLServer2 == null) {
+    public void testSAMLCxfSvcClient_TransportEnabled() throws Exception {
+    	
+        if (testSAMLServer2 == null) {
             //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_ee8.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_ee8.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
     	} else {
     	    //2 servers reconfig
-    		testSAMLServer2.reconfigServer("server_2_ee8.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    testSAMLServer2.reconfigServer("server_2_ee8.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    testSAMLServer.reconfigServer("server_1_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
     	} 
     	
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
@@ -108,7 +103,7 @@ public class CxfSSLSAMLBasicTests extends SAMLCommonTest {
                 "SamlTokenTransportSecurePort", "", "False", null, null);
 
         genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SSL_SAML_TOKEN_SERVICE));
-
+    
     }
     
     /**
@@ -124,35 +119,21 @@ public class CxfSSLSAMLBasicTests extends SAMLCommonTest {
      */
     
     @Mode(TestMode.FULL)
-    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
+    @SkipForRepeat({ EE9_FEATURES })
     @Test
-    public void testSAMLCxfSvcClient_TransportEnabled_httpFromClientEE7Only() throws Exception {
+    public void testSAMLCxfSvcClient_TransportEnabled_httpFromClient() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "SamlTokenTransportSecure",
-                "SamlTokenTransportSecurePort", "", "False", null, null);
-
-        
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED));
-       
-    }
-
-    @Mode(TestMode.FULL)
-    @SkipForRepeat({ NO_MODIFICATION, EE9_FEATURES })
-    @Test
-    public void testSAMLCxfSvcClient_TransportEnabled_httpFromClientEE8Only() throws Exception {
-    	
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_ee8.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-    	    //2 servers reconfig
-    		testSAMLServer2.reconfigServer("server_2_ee8.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} 
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    		if (testSAMLServer2 == null) {
+                //1 server reconfig
+        		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_ee8.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        	} else {
+        	    //2 servers reconfig
+        		testSAMLServer2.reconfigServer("server_2_ee8.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        		testSAMLServer.reconfigServer("server_1_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        	} 
+    	} //End of 18363
     	
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
@@ -161,10 +142,16 @@ public class CxfSSLSAMLBasicTests extends SAMLCommonTest {
         updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "SamlTokenTransportSecure",
                 "SamlTokenTransportSecurePort", "", "False", null, null);
 
-        String CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED = "HttpsToken could not be asserted: Not an HTTPs connection"; // @AV999 slightly different error with new runtime
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED));
+        //issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+            genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED));
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+    		String CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED = "HttpsToken could not be asserted: Not an HTTPs connection"; // @AV999 slightly different error with new runtime
+            genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED));
+    	} //End of 18363
     }
-    
+  
     /**
      * TestDescription:
      * 
@@ -177,32 +164,16 @@ public class CxfSSLSAMLBasicTests extends SAMLCommonTest {
      * "more secure" than the server
      * 
      */
-    
-    @Mode(TestMode.LITE)
-    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
-    @Test
-    public void testSAMLCxfSvcClient_TransportNotEnabled_httpsFromClientEE7Only() throws Exception {
-
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, serviceSecurePort, "user1", "user1pwd", "SAMLSOAPService2",
-                "SAMLSoapPort2", "", "False", null, null);
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings));
-
-    }
-
+ 
     @Mode(TestMode.LITE)
     @SkipForRepeat({ NO_MODIFICATION, EE8_FEATURES })
     @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { JakartaEE9Action.ID })
     @Test
-    public void testSAMLCxfSvcClient_TransportNotEnabled_httpsFromClientEE9Only() throws Exception {
+    public void testSAMLCxfSvcClient_TransportNotEnabled_httpsFromClient() throws Exception {
   
     	if (testSAMLServer2 == null) {
             //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_ee8.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_ee8.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
     	} else {
     	    //2 servers reconfig
     	    testSAMLServer2.reconfigServer("server_2_ee8.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
@@ -217,7 +188,7 @@ public class CxfSSLSAMLBasicTests extends SAMLCommonTest {
                 "SAMLSoapPort2", "", "False", null, null);
 
         genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings));
-
+    	
     }
     
 }


### PR DESCRIPTION
 Update com.ibm.ws.wssecurity_fat.wsscxf.saml.1 to remove the split (EE7Only/EE8Only)