### PR TITLE
wsscxf.saml.2 fat remove split

### DIFF
--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/OneServerTests/CxfSAMLCaller1ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/OneServerTests/CxfSAMLCaller1ServerTests.java
@@ -13,6 +13,7 @@ package com.ibm.ws.wssecurity.fat.cxf.samltoken2.OneServerTests;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -88,6 +89,17 @@ public class CxfSAMLCaller1ServerTests extends CxfSAMLCallerTests {
 
         testSAMLServer.addIgnoredServerExceptions(SAMLMessageConstants.CWWKS5207W_SAML_CONFIG_IGNORE_ATTRIBUTES, SAMLMessageConstants.CWWKG0101W_CONFIG_NOT_VISIBLE_TO_OTHER_BUNDLES, SAMLMessageConstants.CWWKF0001E_FEATURE_MISSING);
         
+        //issue 18363
+        Set<String> features = testSAMLServer.getServer().getServerConfiguration().getFeatureManager().getFeatures(); 
+		if (features.contains("jaxws-2.2")) {
+            setFeatureVersion("EE7");
+        }
+        if (features.contains("jaxws-2.3")) {
+            setFeatureVersion("EE8");
+        } 
+        if (features.contains("xmlWS-3.0")) {
+            setFeatureVersion("EE9");
+        }// End of 18363
         
     }
 }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/OneServerTests/CxfSAMLCaller1ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/OneServerTests/CxfSAMLCaller1ServerTests.java
@@ -93,11 +93,9 @@ public class CxfSAMLCaller1ServerTests extends CxfSAMLCallerTests {
         Set<String> features = testSAMLServer.getServer().getServerConfiguration().getFeatureManager().getFeatures(); 
 		if (features.contains("jaxws-2.2")) {
             setFeatureVersion("EE7");
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             setFeatureVersion("EE8");
-        } 
-        if (features.contains("xmlWS-3.0")) {
+        } else if (features.contains("xmlWS-3.0")) {
             setFeatureVersion("EE9");
         }// End of 18363
         

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/TwoServerTests/CxfSAMLCaller2ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/TwoServerTests/CxfSAMLCaller2ServerTests.java
@@ -27,18 +27,17 @@ import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
 import com.ibm.ws.wssecurity.fat.cxf.samltoken2.common.CxfSAMLCallerTests;
+//issue 18363
+import java.util.Set;
 
 import componenttest.annotation.SkipForRepeat;
-
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServerWrapper;
-import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
-import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.EE8FeatureReplacementAction;
 
@@ -148,6 +147,17 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
         testSAMLServer.addIgnoredServerExceptions(SAMLMessageConstants.CWWKS5207W_SAML_CONFIG_IGNORE_ATTRIBUTES, SAMLMessageConstants.CWWKG0101W_CONFIG_NOT_VISIBLE_TO_OTHER_BUNDLES, SAMLMessageConstants.CWWKF0001E_FEATURE_MISSING);
         testSAMLServer2.addIgnoredServerExceptions(SAMLMessageConstants.CWWKS5207W_SAML_CONFIG_IGNORE_ATTRIBUTES, SAMLMessageConstants.CWWKS5207W_SAML_CONFIG_IGNORE_ATTRIBUTES, SAMLMessageConstants.CWWKS3107W_GROUP_USER_MISMATCH, SAMLMessageConstants.CWWKW0232E_CANNOT_CREATE_SUBJECT_FOR_USER, SAMLMessageConstants.CWWKW0210E_CANNOT_CREATE_SUBJECT, SAMLMessageConstants.CWWKW0228E_SAML_ASSERTION_MISSING, SAMLMessageConstants.CWWKG0101W_CONFIG_NOT_VISIBLE_TO_OTHER_BUNDLES, SAMLMessageConstants.CWWKF0001E_FEATURE_MISSING);
        
+        //issue 18363
+        Set<String> features = testSAMLServer.getServer().getServerConfiguration().getFeatureManager().getFeatures(); 
+		if (features.contains("jaxws-2.2")) {
+            setFeatureVersion("EE7");
+        }
+        if (features.contains("jaxws-2.3")) {
+            setFeatureVersion("EE8");
+        }
+        if (features.contains("xmlWS-3.0")) {
+            setFeatureVersion("EE9");
+        }// End of 18363
         
     }
 
@@ -343,23 +353,19 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: An IPD group
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
-    @Test
-    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_identifiersGoodEE7Only() throws Exception {
-
-        generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_identifiersGood.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPGroups);
-
-    }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
-    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_identifiersGoodEE8Only() throws Exception {
+    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_identifiersGood() throws Exception {
 
-        generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_identifiersGood_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPGroups);
-
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+           generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_identifiersGood.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPGroups);
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+    		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_identifiersGood_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPGroups);
+    	} //End of 18363
     }
-
+ 
     /*
      * config settings:
      * mapToUserRegistry = Group
@@ -375,23 +381,19 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Default IDP Group
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
-    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_identifiersGoodEE7Only() throws Exception {
+    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_identifiersGood() throws Exception {
         
-    	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_identifiersGood.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPIdentifierGroup);
-
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_identifiersGood.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPIdentifierGroup);
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+    		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_identifiersGood_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPIdentifierGroup);
+    	} //End of 18363
     }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
-    @Test
-    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_identifiersGoodEE8Only() throws Exception {
-
-        generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_identifiersGood_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPIdentifierGroup);
-
-    }
-
+  
     /*
      * config settings:
      * mapToUserRegistry = Group
@@ -407,21 +409,17 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Default IDP Group
      */
    
-    @SkipForRepeat({ EE8_FEATURES })
-    @Test
-    public void testCxfCaller_mapToUserRegistry_Group_groupNotInRegistry_identifiersGoodEE7Only() throws Exception {
-        
-    	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_groupNotInRegistry_identifiersGood.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
-
-    }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
-    public void testCxfCaller_mapToUserRegistry_Group_groupNotInRegistry_identifiersGoodEE8Only() throws Exception {
-
-        generalPositiveTest("server_2_caller_mapToUserRegistry_Group_groupNotInRegistry_identifiersGood_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
-
+    public void testCxfCaller_mapToUserRegistry_Group_groupNotInRegistry_identifiersGood() throws Exception {
+    	
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_groupNotInRegistry_identifiersGood.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+    		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_groupNotInRegistry_identifiersGood_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
+    	} //End of 18363
     }
 
     /*
@@ -439,23 +437,19 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Default IDP Group
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
-    public void testCxfCaller_mapToUserRegistry_Group_group2InRegistry_identifiersGoodEE7Only() throws Exception {
+    public void testCxfCaller_mapToUserRegistry_Group_group2InRegistry_identifiersGood() throws Exception {
         
-    	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_group2InRegistry_identifiersGood.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
-
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_group2InRegistry_identifiersGood.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+    		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_group2InRegistry_identifiersGood_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
+    	}//End of 18363
     }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
-    @Test
-    public void testCxfCaller_mapToUserRegistry_Group_group2InRegistry_identifiersGoodEE8Only() throws Exception {
-
-        generalPositiveTest("server_2_caller_mapToUserRegistry_Group_group2InRegistry_identifiersGood_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
-
-    }
-
+ 
     /********** identifiers are Omitted **********/
     /*
      * config settings:
@@ -472,22 +466,19 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: null
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
-    @Test
-    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_identifiersOmittedEE7Only() throws Exception {
-        generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_identifiersOmitted.xml", defaultServerCfgRealm, defaultIDPUser, defaultNullGroup);
-
-    }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
-    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_identifiersOmittedEE8Only() throws Exception {
-
-        generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_identifiersOmitted_ee8.xml", defaultServerCfgRealm, defaultIDPUser, defaultNullGroup);
-
+    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_identifiersOmitted() throws Exception {
+        
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_identifiersOmitted.xml", defaultServerCfgRealm, defaultIDPUser, defaultNullGroup);
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {	
+    		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_identifiersOmitted_ee8.xml", defaultServerCfgRealm, defaultIDPUser, defaultNullGroup);
+    	}//End of 18363
     }
-
+ 
     /*
      * config settings:
      * mapToUserRegistry = Group
@@ -503,23 +494,19 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: null
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
-    @Test
-    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_identifiersOmittedEE7Only() throws Exception {
-        
-    	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_identifiersOmitted.xml", defaultServerCfgRealm, defaultIDPUser, defaultNullGroup);
-
-    }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
-    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_identifiersOmittedEE8Only() throws Exception {
-
-        generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_identifiersOmitted_ee8.xml", defaultServerCfgRealm, defaultIDPUser, defaultNullGroup);
-
+    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_identifiersOmitted() throws Exception {
+        
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_identifiersOmitted.xml", defaultServerCfgRealm, defaultIDPUser, defaultNullGroup);
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+    		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_identifiersOmitted_ee8.xml", defaultServerCfgRealm, defaultIDPUser, defaultNullGroup);
+    	} //End of 18363
     }
-
+ 
     /*
      * config settings:
      * mapToUserRegistry = Group
@@ -535,22 +522,19 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: null
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test 
-    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_groupIdentifierOmittedEE7Only() throws Exception {
+    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_groupIdentifierOmitted() throws Exception {
     	
-    	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_groupIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
-
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_groupIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+    		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_groupIdentifierOmitted_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
+    	}//End of 18363
     }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
-    @Test
-    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_groupIdentifierOmittedEE8Only() throws Exception {
-        generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_groupIdentifierOmitted_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
-
-    }
-
+  
     /*
      * config settings:
      * mapToUserRegistry = Group
@@ -566,23 +550,19 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: null
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
-    @Test
-    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_groupIdentifierOmittedEE7Only() throws Exception {
-        
-    	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_groupIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
-
-    }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
-    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_groupIdentifierOmittedEE8Only() throws Exception {
-
-        generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_groupIdentifierOmitted_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
-
+    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_groupIdentifierOmitted() throws Exception {
+        
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_groupIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+    		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_groupIdentifierOmitted_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
+    	}//End of 18363
     }
-
+ 
     /*
      * config settings:
      * mapToUserRegistry = Group
@@ -598,21 +578,17 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Local server's group
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
-    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_realmIdentifierOmittedEE7Only() throws Exception {
+    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_realmIdentifierOmitted() throws Exception {
        
-    	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_realmIdentifierOmitted.xml", defaultLocalRealm, defaultIDPIdentifierUser, defaultLocalGroups);
-
-    }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
-    @Test
-    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_realmIdentifierOmittedEE8Only() throws Exception {
-
-        generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_realmIdentifierOmitted_ee8.xml", defaultLocalRealm, defaultIDPIdentifierUser, defaultLocalGroups);
-
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_realmIdentifierOmitted.xml", defaultLocalRealm, defaultIDPIdentifierUser, defaultLocalGroups);
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+    		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_realmIdentifierOmitted_ee8.xml", defaultLocalRealm, defaultIDPIdentifierUser, defaultLocalGroups);
+    	}//End of 18363
     }
 
     /*
@@ -630,23 +606,19 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: null
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
-    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_realmIdentifierOmittedEE7Only() throws Exception {
+    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_realmIdentifierOmitted() throws Exception {
         
-    	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_realmIdentifierOmitted.xml", defaultLocalRealm, defaultIDPIdentifierUser, defaultLocalGroups);
-
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_realmIdentifierOmitted.xml", defaultLocalRealm, defaultIDPIdentifierUser, defaultLocalGroups);
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+    		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_realmIdentifierOmitted_ee8.xml", defaultLocalRealm, defaultIDPIdentifierUser, defaultLocalGroups);
+    	}//End of 18363
     }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
-    @Test
-    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_realmIdentifierOmittedEE8Only() throws Exception {
-
-        generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_realmIdentifierOmitted_ee8.xml", defaultLocalRealm, defaultIDPIdentifierUser, defaultLocalGroups);
-
-    }
-
+ 
     /*
      * config settings:
      * mapToUserRegistry = Group
@@ -662,23 +634,19 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: An IPD group
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
-    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_userIdentifierOmittedEE7Only() throws Exception {
+    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_userIdentifierOmitted() throws Exception {
         
-    	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_userIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPUser, defaultIDPGroups);
-
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_userIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPUser, defaultIDPGroups);
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+    		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_userIdentifierOmitted_ee8.xml", defaultIDPIdentifierRealm, defaultIDPUser, defaultIDPGroups);
+    	}//End of 18363
     }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
-    @Test
-    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_userIdentifierOmittedEE8Only() throws Exception {
-
-        generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_userIdentifierOmitted_ee8.xml", defaultIDPIdentifierRealm, defaultIDPUser, defaultIDPGroups);
-
-    }
-
+ 
     /*
      * config settings:
      * mapToUserRegistry = Group
@@ -694,23 +662,19 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Default IDP Group
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
-    @Test
-    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_userIdentifierOmittedEE7Only() throws Exception {
-        
-    	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_userIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPUser, defaultIDPGroups);
-
-    }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
-    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_userIdentifierOmittedEE8Only() throws Exception {
-
-        generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_userIdentifierOmitted_ee8.xml", defaultIDPIdentifierRealm, defaultIDPUser, defaultIDPGroups);
-
+    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_userIdentifierOmitted() throws Exception {
+        
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_userIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPUser, defaultIDPGroups);
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+    		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_userIdentifierOmitted_ee8.xml", defaultIDPIdentifierRealm, defaultIDPUser, defaultIDPGroups);
+    	}//End of 18363
     }
-
+ 
     /*
      * config settings:
      * mapToUserRegistry = Group
@@ -726,23 +690,19 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: An IPD group
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
-    @Test
-    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_userUniqueIdentifierOmittedEE7Only() throws Exception {
-        
-    	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_userUniqueIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPGroups);
-
-    }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
-    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_userUniqueIdentifierOmittedEE8Only() throws Exception {
-
-        generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_userUniqueIdentifierOmitted_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPGroups);
-
+    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_userUniqueIdentifierOmitted() throws Exception {
+        
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_userUniqueIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPGroups);
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+    		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_userUniqueIdentifierOmitted_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPGroups);
+    	}//End of 18363
     }
-
+ 
     /*
      * config settings:
      * mapToUserRegistry = Group
@@ -758,22 +718,17 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Default IDP Group
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
-    @Test
-    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_userUniqueIdentifierOmittedEE7Only() throws Exception {
-        
-    	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_userUniqueIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPGroups);
-
-    }
-    
-    //3/2021 to run with EE8
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
-    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_userUniqueIdentifierOmittedEE8Only() throws Exception {
-
-        generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_userUniqueIdentifierOmitted_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPGroups);
-
+    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_userUniqueIdentifierOmitted() throws Exception {
+        
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_userUniqueIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPGroups);
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+    		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_userUniqueIdentifierOmitted_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPGroups);
+    	}//End of 18363
     }
 
     /********** identifiers are Bad **********/
@@ -792,23 +747,18 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: Local Server groups
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
-    @Test
-    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_groupIdentifierBadEE7Only() throws Exception {
-        
-    	generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_groupIdentifierBad.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
-
-    }
-
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
-    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_groupIdentifierBadEE8Only() throws Exception {
-
-        generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_groupIdentifierBad_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
-
-    }
-            
+    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_groupIdentifierBad() throws Exception {
+        
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_groupIdentifierBad.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+    		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_groupIdentifierBad_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
+    	}//End of 18363
+    }         
    
 
     /*
@@ -826,20 +776,17 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Group: null
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
-    @Test
-    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_groupIdentifierBadEE7Only() throws Exception {
-        generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_groupIdentifierBad.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
-
-    }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @Test
-    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_groupIdentifierBadEE8Only() throws Exception {
-
-        generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_groupIdentifierBad_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
-
+    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_groupIdentifierBad() throws Exception {
+       
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_groupIdentifierBad.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+    		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_groupIdentifierBad_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
+    	}//End of 18363
     }
 
     /*
@@ -855,25 +802,21 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Bad Attribute exception - looking for realmIdentifier in the message
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
-    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" }, repeatAction = { EmptyAction.ID })
-    @Test
-    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_realmIdentifierBadEE7Only() throws Exception {
-        
-    	badAttrValueTest("server_2_caller_mapToUserRegistry_Group_inRegistry_realmIdentifierBad.xml", realmIdentifierString);
-
-    }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
     @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" }, repeatAction = { EmptyAction.ID })
     @Test
-    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_realmIdentifierBadEE8Only() throws Exception {
-
-        badAttrValueTest("server_2_caller_mapToUserRegistry_Group_inRegistry_realmIdentifierBad_ee8.xml", realmIdentifierString);
-
+    public void testCxfCaller_mapToUserRegistry_Group_inRegistry_realmIdentifierBad() throws Exception {
+        
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    	    badAttrValueTest("server_2_caller_mapToUserRegistry_Group_inRegistry_realmIdentifierBad.xml", realmIdentifierString);
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+    		badAttrValueTest("server_2_caller_mapToUserRegistry_Group_inRegistry_realmIdentifierBad_ee8.xml", realmIdentifierString);
+    	}//End of 18363
     }
-
+    
     /*
      * config settings:
      * mapToUserRegistry = Group
@@ -887,23 +830,19 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
      * Bad Attribute exception - looking for realmIdentifier in the message
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
-    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" }, repeatAction = { EmptyAction.ID })
-    @Test
-    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_realmIdentifierBadEE7Only() throws Exception {
-        
-    	badAttrValueTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_realmIdentifierBad.xml", realmIdentifierString);
-
-    }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
     @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @ExpectedFFDC(value = { "com.ibm.ws.wssecurity.caller.SamlCallerTokenException" }, repeatAction = { EmptyAction.ID })
     @Test
-    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_realmIdentifierBadEE8Only() throws Exception {
-
-        badAttrValueTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_realmIdentifierBad_ee8.xml", realmIdentifierString);
-
+    public void testCxfCaller_mapToUserRegistry_Group_notInRegistry_realmIdentifierBad() throws Exception {
+        
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    	    badAttrValueTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_realmIdentifierBad.xml", realmIdentifierString);
+    	}
+    	if ("EE8".equals(getFeatureVersion())) {
+    		badAttrValueTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_realmIdentifierBad_ee8.xml", realmIdentifierString);
+    	}//End of 18363
     }
- 
+  
 }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/TwoServerTests/CxfSAMLCaller2ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/TwoServerTests/CxfSAMLCaller2ServerTests.java
@@ -151,11 +151,9 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
         Set<String> features = testSAMLServer.getServer().getServerConfiguration().getFeatureManager().getFeatures(); 
 		if (features.contains("jaxws-2.2")) {
             setFeatureVersion("EE7");
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             setFeatureVersion("EE8");
-        }
-        if (features.contains("xmlWS-3.0")) {
+        } else if (features.contains("xmlWS-3.0")) {
             setFeatureVersion("EE9");
         }// End of 18363
         
@@ -360,8 +358,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
            generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_identifiersGood.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPGroups);
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_identifiersGood_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPGroups);
     	} //End of 18363
     }
@@ -388,8 +385,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
     	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_identifiersGood.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPIdentifierGroup);
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_identifiersGood_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPIdentifierGroup);
     	} //End of 18363
     }
@@ -416,8 +412,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
     	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_groupNotInRegistry_identifiersGood.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_groupNotInRegistry_identifiersGood_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
     	} //End of 18363
     }
@@ -444,8 +439,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
     	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_group2InRegistry_identifiersGood.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_group2InRegistry_identifiersGood_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
     	}//End of 18363
     }
@@ -473,8 +467,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
     	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_identifiersOmitted.xml", defaultServerCfgRealm, defaultIDPUser, defaultNullGroup);
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {	
+    	} else if ("EE8".equals(getFeatureVersion())) {	
     		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_identifiersOmitted_ee8.xml", defaultServerCfgRealm, defaultIDPUser, defaultNullGroup);
     	}//End of 18363
     }
@@ -501,8 +494,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
     	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_identifiersOmitted.xml", defaultServerCfgRealm, defaultIDPUser, defaultNullGroup);
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_identifiersOmitted_ee8.xml", defaultServerCfgRealm, defaultIDPUser, defaultNullGroup);
     	} //End of 18363
     }
@@ -529,8 +521,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
     	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_groupIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_groupIdentifierOmitted_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
     	}//End of 18363
     }
@@ -557,8 +548,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
     	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_groupIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_groupIdentifierOmitted_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
     	}//End of 18363
     }
@@ -585,8 +575,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
     	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_realmIdentifierOmitted.xml", defaultLocalRealm, defaultIDPIdentifierUser, defaultLocalGroups);
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_realmIdentifierOmitted_ee8.xml", defaultLocalRealm, defaultIDPIdentifierUser, defaultLocalGroups);
     	}//End of 18363
     }
@@ -613,8 +602,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
     	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_realmIdentifierOmitted.xml", defaultLocalRealm, defaultIDPIdentifierUser, defaultLocalGroups);
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_realmIdentifierOmitted_ee8.xml", defaultLocalRealm, defaultIDPIdentifierUser, defaultLocalGroups);
     	}//End of 18363
     }
@@ -641,8 +629,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
     	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_userIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPUser, defaultIDPGroups);
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_userIdentifierOmitted_ee8.xml", defaultIDPIdentifierRealm, defaultIDPUser, defaultIDPGroups);
     	}//End of 18363
     }
@@ -669,8 +656,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
     	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_userIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPUser, defaultIDPGroups);
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_userIdentifierOmitted_ee8.xml", defaultIDPIdentifierRealm, defaultIDPUser, defaultIDPGroups);
     	}//End of 18363
     }
@@ -697,8 +683,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
     	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_userUniqueIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPGroups);
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_userUniqueIdentifierOmitted_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPGroups);
     	}//End of 18363
     }
@@ -725,8 +710,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
     	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_userUniqueIdentifierOmitted.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPGroups);
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_userUniqueIdentifierOmitted_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultIDPGroups);
     	}//End of 18363
     }
@@ -754,8 +738,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
     	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_groupIdentifierBad.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_inRegistry_groupIdentifierBad_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
     	}//End of 18363
     }         
@@ -783,8 +766,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
     	    generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_groupIdentifierBad.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		generalPositiveTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_groupIdentifierBad_ee8.xml", defaultIDPIdentifierRealm, defaultIDPIdentifierUser, defaultNullGroup);
     	}//End of 18363
     }
@@ -811,8 +793,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
     	    badAttrValueTest("server_2_caller_mapToUserRegistry_Group_inRegistry_realmIdentifierBad.xml", realmIdentifierString);
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		badAttrValueTest("server_2_caller_mapToUserRegistry_Group_inRegistry_realmIdentifierBad_ee8.xml", realmIdentifierString);
     	}//End of 18363
     }
@@ -839,8 +820,7 @@ public class CxfSAMLCaller2ServerTests extends CxfSAMLCallerTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
     	    badAttrValueTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_realmIdentifierBad.xml", realmIdentifierString);
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		badAttrValueTest("server_2_caller_mapToUserRegistry_Group_notInRegistry_realmIdentifierBad_ee8.xml", realmIdentifierString);
     	}//End of 18363
     }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/common/CxfSAMLCallerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/common/CxfSAMLCallerTests.java
@@ -117,8 +117,7 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
                 testSAMLServer2.reconfigServer(buildSPServerName("server_2_caller_asymProtection.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
                 testSAMLServer.reconfigServer(buildSPServerName("server_1_asymProtection.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
             }
-    	}
-    	if (("EE8".equals(getFeatureVersion())) || ("EE9".equals(getFeatureVersion()))){
+    	} else if (("EE8".equals(getFeatureVersion())) || ("EE9".equals(getFeatureVersion()))){
     		if (testSAMLServer2 == null) {
                 //1 server reconfig
                 testSAMLServer.reconfigServer(buildSPServerName("server_2in1_asymProtection_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
@@ -165,8 +164,7 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
                 // shouldn't need to reconfig server 1 - we don't need to change anything there
                 //			testSAMLServer.reconfigServer(buildSPServerName("server_1_realmName.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
             }
-    	}
-    	if (("EE8".equals(getFeatureVersion())) || ("EE9".equals(getFeatureVersion()))){
+    	} else if (("EE8".equals(getFeatureVersion())) || ("EE9".equals(getFeatureVersion()))){
     		if (testSAMLServer2 == null) {
                 // 1 server reconfig
                 testSAMLServer.reconfigServer(buildSPServerName("server_2in1_realmName_ee8.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
@@ -212,8 +210,7 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
                 testSAMLServer2.reconfigServer(buildSPServerName("server_2_caller_asymProtection_TokenInSubFalse.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
                 testSAMLServer.reconfigServer(buildSPServerName("server_1_asymProtection.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
             }
-    	} 
-    	if (("EE8".equals(getFeatureVersion())) || ("EE9".equals(getFeatureVersion()))){
+    	} else if (("EE8".equals(getFeatureVersion())) || ("EE9".equals(getFeatureVersion()))){
     		if (testSAMLServer2 == null) {
                 // 1 server reconfig
                 testSAMLServer.reconfigServer(buildSPServerName("server_2in1_asymProtection_TokenInSubFalse_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/common/CxfSAMLCallerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken2/common/CxfSAMLCallerTests.java
@@ -14,7 +14,6 @@ package com.ibm.ws.wssecurity.fat.cxf.samltoken2.common;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.annotation.SkipForRepeat;
 
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
@@ -24,9 +23,6 @@ import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.topology.impl.LibertyServerWrapper;
-import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
-import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
-import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 import componenttest.rules.repeater.EE8FeatureReplacementAction;
 import componenttest.rules.repeater.JakartaEE9Action;
 
@@ -58,7 +54,18 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
     protected static String servicePort = null;
     protected static String serviceSecurePort = null;
     protected static CXFSAMLCommonUtils commonUtils = new CXFSAMLCommonUtils();
+    //issue 18363
+    protected static String featureVersion = "";
 
+    //issue 18363
+    public static String getFeatureVersion() {
+        return featureVersion;
+    }
+    
+    public static void setFeatureVersion(String version) {
+        featureVersion = version;
+    } //End of issue 18363
+    
     /**
      * TestDescription:
      * 
@@ -72,8 +79,7 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
      * Test should succeed in accessing the server side service.
      * 
      */
-    
-    //runs EE7 and EE8 from full fat; EE9 from lite fat (e.g., CxfSAMLCaller1ServerTests.java)
+   
     //scenario 1 - done
     @Test
     public void testCxfCallerHttpPolicy() throws Exception {
@@ -97,54 +103,32 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
     }
    
     //scenario 2
-    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
-    @Test
-    public void testCxfCallerHttpsPolicyEE7Only() throws Exception {
-        
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-            testSAMLServer.reconfigServer(buildSPServerName("server_2in1_asymProtection.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        } else {
-            //2 servers reconfig
-            testSAMLServer2.reconfigServer(buildSPServerName("server_2_caller_asymProtection.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-            testSAMLServer.reconfigServer(buildSPServerName("server_1_asymProtection.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        }
-
-        // Create the conversation object which will maintain state for us
-        String webServiceName = "FatSamlC03Service";
-        String webServicePort = "SamlCallerToken03";
-        String policyName = "CallerHttpsPolicy";
-        String titleToCheck = "CXF SAML Caller Service Client";
-        String partToCheck = "pass:true::FatSamlC03Service";
-        String testMode = "positive";
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings("testCxfCallerHttpsPolicy", "cxf", servicePort, serviceSecurePort, userName, userPass, webServiceName,
-                webServicePort, "", "False", null, null);
-        updatedTestSettings.getCXFSettings().setBodyPartToCheck(partToCheck);
-        updatedTestSettings.getCXFSettings().setTitleToCheck(titleToCheck);
-        updatedTestSettings.getCXFSettings().setTestMode(testMode);
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings));
-
-    }
-    
-    //runs EE8 from full fat, EE9 from lite fat
-    //scenario 2
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID, JakartaEE9Action.ID })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID, JakartaEE9Action.ID })
     @Test
     public void testCxfCallerHttpsPolicy() throws Exception {
-        if (testSAMLServer2 == null) {
-            //1 server reconfig
-            testSAMLServer.reconfigServer(buildSPServerName("server_2in1_asymProtection_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        } else {
-            //2 servers reconfig
-            testSAMLServer2.reconfigServer(buildSPServerName("server_2_caller_asymProtection_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-            testSAMLServer.reconfigServer(buildSPServerName("server_1_asymProtection_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        }
-
+        
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                //1 server reconfig
+                testSAMLServer.reconfigServer(buildSPServerName("server_2in1_asymProtection.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            } else {
+                //2 servers reconfig
+                testSAMLServer2.reconfigServer(buildSPServerName("server_2_caller_asymProtection.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+                testSAMLServer.reconfigServer(buildSPServerName("server_1_asymProtection.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            }
+    	}
+    	if (("EE8".equals(getFeatureVersion())) || ("EE9".equals(getFeatureVersion()))){
+    		if (testSAMLServer2 == null) {
+                //1 server reconfig
+                testSAMLServer.reconfigServer(buildSPServerName("server_2in1_asymProtection_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            } else {
+                //2 servers reconfig
+                testSAMLServer2.reconfigServer(buildSPServerName("server_2_caller_asymProtection_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+                testSAMLServer.reconfigServer(buildSPServerName("server_1_asymProtection_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            }
+    	} //End of 18363
+    	
         // Create the conversation object which will maintain state for us
         String webServiceName = "FatSamlC03Service";
         String webServicePort = "SamlCallerToken03";
@@ -153,7 +137,7 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
         String partToCheck = "pass:true::FatSamlC03Service";
         String testMode = "positive";
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-        
+
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
         updatedTestSettings.setCXFSettings("testCxfCallerHttpsPolicy", "cxf", servicePort, serviceSecurePort, userName, userPass, webServiceName,
@@ -164,22 +148,36 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
         genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings));
 
     }
-    
+ 
     //scenario 3 - done
-    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID, JakartaEE9Action.ID })
     @Test
-    public void testCxfCaller_WithRealmNameEE7Only() throws Exception {
+    public void testCxfCaller_WithRealmName() throws Exception {
         
-    	if (testSAMLServer2 == null) {
-            // 1 server reconfig
-            testSAMLServer.reconfigServer(buildSPServerName("server_2in1_realmName.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        } else {
-            // 2 server reconfig
-            testSAMLServer2.reconfigServer(buildSPServerName("server_2_caller_realmName.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-            // shouldn't need to reconfig server 1 - we don't need to change anything there
-            //			testSAMLServer.reconfigServer(buildSPServerName("server_1_realmName.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        }
-
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                // 1 server reconfig
+                testSAMLServer.reconfigServer(buildSPServerName("server_2in1_realmName.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            } else {
+                // 2 server reconfig
+                testSAMLServer2.reconfigServer(buildSPServerName("server_2_caller_realmName.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+                // shouldn't need to reconfig server 1 - we don't need to change anything there
+                //			testSAMLServer.reconfigServer(buildSPServerName("server_1_realmName.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            }
+    	}
+    	if (("EE8".equals(getFeatureVersion())) || ("EE9".equals(getFeatureVersion()))){
+    		if (testSAMLServer2 == null) {
+                // 1 server reconfig
+                testSAMLServer.reconfigServer(buildSPServerName("server_2in1_realmName_ee8.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            } else {
+                // 2 server reconfig
+                testSAMLServer2.reconfigServer(buildSPServerName("server_2_caller_realmName_ee8.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+                // shouldn't need to reconfig server 1 - we don't need to change anything there
+                //			testSAMLServer.reconfigServer(buildSPServerName("server_1_realmName.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            }
+    	}// End of 18363
+    	
         // Create the conversation object which will maintain state for us
         String webServiceName = "FatSamlC02Service";
         String webServicePort = "SamlCallerToken02";
@@ -198,90 +196,34 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
         genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings));
 
     }
-    
-    //runs EE8 from full fat, EE9 from lite fat
-    //scenario 3 - done
-    @SkipForRepeat({ NO_MODIFICATION })
+ 
     @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID, JakartaEE9Action.ID })
-    @Test
-    public void testCxfCaller_WithRealmName() throws Exception {
-        if (testSAMLServer2 == null) {
-            // 1 server reconfig
-            testSAMLServer.reconfigServer(buildSPServerName("server_2in1_realmName_ee8.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        } else {
-            // 2 server reconfig
-            testSAMLServer2.reconfigServer(buildSPServerName("server_2_caller_realmName_ee8.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-            // shouldn't need to reconfig server 1 - we don't need to change anything there
-            //			testSAMLServer.reconfigServer(buildSPServerName("server_1_realmName.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        }
-
-        // Create the conversation object which will maintain state for us
-        String webServiceName = "FatSamlC02Service";
-        String webServicePort = "SamlCallerToken02";
-        String policyName = "CallerHttpsPolicy";
-        String titleToCheck = "CXF SAML Caller Service Client";
-        String partToCheck = "pass:true::FatSamlC02Service";
-        String testMode = "positive";
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings("testCxfCaller_WithRealmName", "cxf", servicePort, serviceSecurePort, userName, userPass, webServiceName, webServicePort, "", "False", null, null);
-        updatedTestSettings.getCXFSettings().setBodyPartToCheck(partToCheck);
-        updatedTestSettings.getCXFSettings().setTitleToCheck(titleToCheck);
-        updatedTestSettings.getCXFSettings().setTestMode(testMode);
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings));
-
-    }
-
-    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     //scenario 5
-    @Test
-    public void testCxfCallerHttpsPolicy_IncludeTokenInSubjectIsFalseEE7Only() throws Exception {
-        
-    	if (testSAMLServer2 == null) {
-            // 1 server reconfig
-            testSAMLServer.reconfigServer(buildSPServerName("server_2in1_asymProtection_TokenInSubFalse.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        } else {
-            // 2 server reconfig
-            testSAMLServer2.reconfigServer(buildSPServerName("server_2_caller_asymProtection_TokenInSubFalse.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-            testSAMLServer.reconfigServer(buildSPServerName("server_1_asymProtection.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        }
-
-        // Create the conversation object which will maintain state for us
-        String webServiceName = "FatSamlC04Service";
-        String webServicePort = "SamlCallerToken04";
-        String policyName = "CallerHttpsPolicy";
-        String titleToCheck = "CXF SAML Caller Service Client";
-        String partToCheck = "pass:false::FatSamlC04Service";
-        String testMode = "positive";
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings("testCxfCallerHttpsPolicy_IncludeTokenInSubjectIsFalse", "cxf", servicePort, serviceSecurePort, userName, userPass, webServiceName, webServicePort, "", "False", null, null);
-        updatedTestSettings.getCXFSettings().setBodyPartToCheck(partToCheck);
-        updatedTestSettings.getCXFSettings().setTitleToCheck(titleToCheck);
-        updatedTestSettings.getCXFSettings().setTestMode(testMode);
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings));
-        
-    }
-    
-    //runs EE8 from full fat, EE9 from lite fat
-    //scenario 5
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID, JakartaEE9Action.ID })
     @Test
     public void testCxfCallerHttpsPolicy_IncludeTokenInSubjectIsFalse() throws Exception {
-        if (testSAMLServer2 == null) {
-            // 1 server reconfig
-            testSAMLServer.reconfigServer(buildSPServerName("server_2in1_asymProtection_TokenInSubFalse_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        } else {
-            // 2 server reconfig
-            testSAMLServer2.reconfigServer(buildSPServerName("server_2_caller_asymProtection_TokenInSubFalse_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-            testSAMLServer.reconfigServer(buildSPServerName("server_1_asymProtection_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        }
-
+        
+    	//issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                // 1 server reconfig
+                testSAMLServer.reconfigServer(buildSPServerName("server_2in1_asymProtection_TokenInSubFalse.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            } else {
+                // 2 server reconfig
+                testSAMLServer2.reconfigServer(buildSPServerName("server_2_caller_asymProtection_TokenInSubFalse.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+                testSAMLServer.reconfigServer(buildSPServerName("server_1_asymProtection.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            }
+    	} 
+    	if (("EE8".equals(getFeatureVersion())) || ("EE9".equals(getFeatureVersion()))){
+    		if (testSAMLServer2 == null) {
+                // 1 server reconfig
+                testSAMLServer.reconfigServer(buildSPServerName("server_2in1_asymProtection_TokenInSubFalse_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            } else {
+                // 2 server reconfig
+                testSAMLServer2.reconfigServer(buildSPServerName("server_2_caller_asymProtection_TokenInSubFalse_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+                testSAMLServer.reconfigServer(buildSPServerName("server_1_asymProtection_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            }
+    	}// End of 18363
+    	
         // Create the conversation object which will maintain state for us
         String webServiceName = "FatSamlC04Service";
         String webServicePort = "SamlCallerToken04";
@@ -300,5 +242,5 @@ public class CxfSAMLCallerTests extends SAMLCommonTest {
         genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings));
         
     }
-    
+ 
 }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/publish/servers/com.ibm.ws.wssecurity_fat.saml.2servers/configs/server_2_caller_mapToUserRegistry_Group_groupNotInRegistry_identifiersGood_ee8.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/publish/servers/com.ibm.ws.wssecurity_fat.saml.2servers/configs/server_2_caller_mapToUserRegistry_Group_groupNotInRegistry_identifiersGood_ee8.xml
@@ -35,7 +35,7 @@
 	<include location="imports/goodSSLSettings.xml" />
 	<include location="imports/samlcallertoken_testApp.xml" />
 	<include
-		location="imports/securityProviderWithCaller_mapToUserRegistry_Group_identifiersGood.xml" />
+		location="imports/securityProviderWithCaller_mapToUserRegistry_Group_identifiersGood_ee8.xml" />
     <include location="imports/java2Permissions.xml" />
 	
 </server>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/publish/servers/com.ibm.ws.wssecurity_fat.saml.2servers/configs/server_2_caller_mapToUserRegistry_Group_inRegistry_groupIdentifierOmitted_ee8.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/publish/servers/com.ibm.ws.wssecurity_fat.saml.2servers/configs/server_2_caller_mapToUserRegistry_Group_inRegistry_groupIdentifierOmitted_ee8.xml
@@ -35,7 +35,7 @@
 	<include location="imports/goodSSLSettings.xml" />
 	<include location="imports/samlcallertoken_testApp.xml" />
 	<include
-		location="imports/securityProviderWithCaller_mapToUserRegistry_Group_groupIdentifierOmitted.xml" />
+		location="imports/securityProviderWithCaller_mapToUserRegistry_Group_groupIdentifierOmitted_ee8.xml" />
     <include location="imports/java2Permissions.xml" />
     
 </server>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/publish/servers/com.ibm.ws.wssecurity_fat.saml.2servers/configs/server_2_caller_mapToUserRegistry_Group_inRegistry_realmIdentifierBad_ee8.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/publish/servers/com.ibm.ws.wssecurity_fat.saml.2servers/configs/server_2_caller_mapToUserRegistry_Group_inRegistry_realmIdentifierBad_ee8.xml
@@ -35,7 +35,7 @@
 	<include location="imports/goodSSLSettings.xml" />
 	<include location="imports/samlcallertoken_testApp.xml" />
 	<include
-		location="imports/securityProviderWithCaller_mapToUserRegistry_Group_realmIdentifierBad.xml" />
+		location="imports/securityProviderWithCaller_mapToUserRegistry_Group_realmIdentifierBad_ee8.xml" />
     <include location="imports/java2Permissions.xml" />
     
 </server>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/publish/servers/com.ibm.ws.wssecurity_fat.saml.2servers/configs/server_2_caller_mapToUserRegistry_Group_inRegistry_realmIdentifierOmitted_ee8.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/publish/servers/com.ibm.ws.wssecurity_fat.saml.2servers/configs/server_2_caller_mapToUserRegistry_Group_inRegistry_realmIdentifierOmitted_ee8.xml
@@ -35,7 +35,7 @@
 	<include location="imports/goodSSLSettings.xml" />
 	<include location="imports/samlcallertoken_testApp.xml" />
 	<include
-		location="imports/securityProviderWithCaller_mapToUserRegistry_Group_realmIdentifierOmitted.xml" />
+		location="imports/securityProviderWithCaller_mapToUserRegistry_Group_realmIdentifierOmitted_ee8.xml" />
     <include location="imports/java2Permissions.xml" />
 	
 </server>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/publish/servers/com.ibm.ws.wssecurity_fat.saml.2servers/configs/server_2_caller_mapToUserRegistry_Group_notInRegistry_groupIdentifierOmitted_ee8.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/publish/servers/com.ibm.ws.wssecurity_fat.saml.2servers/configs/server_2_caller_mapToUserRegistry_Group_notInRegistry_groupIdentifierOmitted_ee8.xml
@@ -35,7 +35,7 @@
 	<include location="imports/goodSSLSettings.xml" />
 	<include location="imports/samlcallertoken_testApp.xml" />
 	<include
-		location="imports/securityProviderWithCaller_mapToUserRegistry_Group_groupIdentifierOmitted.xml" />
+		location="imports/securityProviderWithCaller_mapToUserRegistry_Group_groupIdentifierOmitted_ee8.xml" />
     <include location="imports/java2Permissions.xml" />
 	
 </server>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/publish/servers/com.ibm.ws.wssecurity_fat.saml.2servers/configs/server_2_caller_mapToUserRegistry_Group_notInRegistry_identifiersOmitted_ee8.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/publish/servers/com.ibm.ws.wssecurity_fat.saml.2servers/configs/server_2_caller_mapToUserRegistry_Group_notInRegistry_identifiersOmitted_ee8.xml
@@ -35,7 +35,7 @@
 	<include location="imports/goodSSLSettings.xml" />
 	<include location="imports/samlcallertoken_testApp.xml" />
 	<include
-		location="imports/securityProviderWithCaller_mapToUserRegistry_Group_identifiersOmitted.xml" />
+		location="imports/securityProviderWithCaller_mapToUserRegistry_Group_identifiersOmitted_ee8.xml" />
     <include location="imports/java2Permissions.xml" />
 	
 </server>


### PR DESCRIPTION
Update com.ibm.ws.wssecurity_fat.wsscxf.saml.2 to remove the split (EE7Only/EE8Only)
