### PR TITLE
wsscxf.saml fat remove split

### DIFF
--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken/OneServerTests/CxfSAMLBasic1ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken/OneServerTests/CxfSAMLBasic1ServerTests.java
@@ -176,7 +176,7 @@ public class CxfSAMLBasic1ServerTests extends CxfSAMLBasicTests {
      */
     
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @AllowedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @AllowedFFDC(value = { "java.util.MissingResourceException", "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
     public void CxfSAMLBasicTests_wantAssertionsSignedTrue_missingSignature() throws Exception {
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken/OneServerTests/CxfSAMLBasic1ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken/OneServerTests/CxfSAMLBasic1ServerTests.java
@@ -103,8 +103,7 @@ public class CxfSAMLBasic1ServerTests extends CxfSAMLBasicTests {
         Set<String> features = testSAMLServer.getServer().getServerConfiguration().getFeatureManager().getFeatures(); 
 		if (features.contains("jaxws-2.2")) {
             setFeatureVersion("EE7");
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             setFeatureVersion("EE8");
         } // End of 18363
 		
@@ -133,8 +132,7 @@ public class CxfSAMLBasic1ServerTests extends CxfSAMLBasicTests {
     	//issue 18363
 		if ("EE7".equals(getFeatureVersion())) {
         	testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_clockskew.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-		}
-        if ("EE8".equals(getFeatureVersion())) {
+		} else if ("EE8".equals(getFeatureVersion())) {
         	testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_clockskew_ee8.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 		} //End of 18363
         
@@ -154,8 +152,7 @@ public class CxfSAMLBasic1ServerTests extends CxfSAMLBasicTests {
             List<validationData> expectations = helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_GENERAL_FAILURE_MSG);
             expectations = helpers.addMessageExpectation(testSAMLServer, expectations, SAMLConstants.INVOKE_ACS_WITH_SAML_RESPONSE, SAMLConstants.SAML_MESSAGES_LOG, SAMLConstants.STRING_CONTAINS, "Did NOT fail because the clocks were out of sync.", SAMLMessageConstants.CWWKW0217E_CLOCK_SKEW_ERROR);
             genericSAML(_testName, webClient, updatedTestSettings, standardFlow, expectations);
-        }
-        if ("EE8".equals(getFeatureVersion())) {
+        } else if ("EE8".equals(getFeatureVersion())) {
             String CXF_SAML_TOKEN_GENERAL_FAILURE_MSG = "SAML token security failure"; //@AV999 TODO select the message depending on the runtime
             List<validationData> expectations = helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_GENERAL_FAILURE_MSG);
             expectations = helpers.addMessageExpectation(testSAMLServer, expectations, SAMLConstants.INVOKE_ACS_WITH_SAML_RESPONSE, SAMLConstants.SAML_MESSAGES_LOG, SAMLConstants.STRING_CONTAINS, "Did NOT fail because the clocks were out of sync.", SAMLMessageConstants.CWWKW0217E_CLOCK_SKEW_ERROR);
@@ -186,8 +183,7 @@ public class CxfSAMLBasic1ServerTests extends CxfSAMLBasicTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
         	testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_samlWantAssertionsSigned.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        }
-        if ("EE8".equals(getFeatureVersion())) {
+        } else if ("EE8".equals(getFeatureVersion())) {
         	testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_samlWantAssertionsSigned_ee8.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
         } //End of 18363
         
@@ -209,8 +205,7 @@ public class CxfSAMLBasic1ServerTests extends CxfSAMLBasicTests {
             List<validationData> expectations = helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_GENERAL_FAILURE_MSG);
             expectations = helpers.addMessageExpectation(testSAMLServer, expectations, SAMLConstants.INVOKE_ACS_WITH_SAML_RESPONSE, SAMLConstants.SAML_TRACE_LOG, SAMLConstants.STRING_CONTAINS, "Did NOT fail because the assertion did NOT require a signature.", "verifySubjectConfirmationMethod A Bearer Assertion was not signed");
             genericSAML(_testName, webClient, updatedTestSettings, standardFlow, expectations);
-        }
-        if ("EE8".equals(getFeatureVersion())) {
+        } else if ("EE8".equals(getFeatureVersion())) {
         	String CXF_SAML_TOKEN_GENERAL_FAILURE_MSG = "SAML token security failure";
             List<validationData> expectations = helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_GENERAL_FAILURE_MSG);
             expectations = helpers.addMessageExpectation(testSAMLServer, expectations, SAMLConstants.INVOKE_ACS_WITH_SAML_RESPONSE, SAMLConstants.SAML_TRACE_LOG, SAMLConstants.STRING_CONTAINS, "Did NOT fail because the assertion did NOT require a signature.", "verifySubjectConfirmationMethod A Bearer Assertion was not signed");
@@ -240,8 +235,7 @@ public class CxfSAMLBasic1ServerTests extends CxfSAMLBasicTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
         	testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_audienceRestrictions_multiple_valid.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        }
-    	if ("EE8".equals(getFeatureVersion())) {
+        } else if ("EE8".equals(getFeatureVersion())) {
         	testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_audienceRestrictions_multiple_valid_ee8.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
         } //End of 18363
         
@@ -264,8 +258,7 @@ public class CxfSAMLBasic1ServerTests extends CxfSAMLBasicTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
     		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_audienceRestrictions_multiple_invalid.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	}	
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_audienceRestrictions_multiple_invalid_ee8.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
     	}// End of 18363	
     	
@@ -281,8 +274,7 @@ public class CxfSAMLBasic1ServerTests extends CxfSAMLBasicTests {
             List<validationData> expectations = helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_GENERAL_FAILURE_MSG);     
             expectations = vData.addExpectation(expectations, SAMLConstants.INVOKE_ACS_WITH_SAML_RESPONSE, SAMLConstants.SAML_MESSAGES_LOG, SAMLConstants.STRING_CONTAINS, "Did NOT fail because the audienceRestrictions weren't satisfied.", null, audienceRestrictError);
             genericSAML(_testName, webClient, updatedTestSettings, standardFlow, expectations);
-        }
-        if ("EE8".equals(getFeatureVersion())) {
+        } else if ("EE8".equals(getFeatureVersion())) {
         	String CXF_SAML_TOKEN_GENERAL_FAILURE_MSG = "SAML token security failure";
             List<validationData> expectations = helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_GENERAL_FAILURE_MSG);         
             expectations = vData.addExpectation(expectations, SAMLConstants.INVOKE_ACS_WITH_SAML_RESPONSE, SAMLConstants.SAML_MESSAGES_LOG, SAMLConstants.STRING_CONTAINS, "Did NOT fail because the audienceRestrictions weren't satisfied.", null, audienceRestrictError);
@@ -297,8 +289,7 @@ public class CxfSAMLBasic1ServerTests extends CxfSAMLBasicTests {
     	//issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
     		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_audienceRestrictions_single_valid.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	}
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_audienceRestrictions_single_valid_ee8.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
     	} // End of 18363
     	
@@ -321,8 +312,7 @@ public class CxfSAMLBasic1ServerTests extends CxfSAMLBasicTests {
 	    //issue 18363
     	if ("EE7".equals(getFeatureVersion())) {
     		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_audienceRestrictions_single_invalid.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	}	
-    	if ("EE8".equals(getFeatureVersion())) {
+    	} else if ("EE8".equals(getFeatureVersion())) {
     		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_audienceRestrictions_single_invalid_ee8.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
     	} //End of 18363
     	
@@ -338,8 +328,7 @@ public class CxfSAMLBasic1ServerTests extends CxfSAMLBasicTests {
             List<validationData> expectations = helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_GENERAL_FAILURE_MSG);
             expectations = vData.addExpectation(expectations, SAMLConstants.INVOKE_ACS_WITH_SAML_RESPONSE, SAMLConstants.SAML_MESSAGES_LOG, SAMLConstants.STRING_CONTAINS, "Did NOT fail because the audienceRestrictions weren't satisfied.", null, audienceRestrictError);
             genericSAML(_testName, webClient, updatedTestSettings, standardFlow, expectations);
-        }
-        if ("EE8".equals(getFeatureVersion())) {
+        } else if ("EE8".equals(getFeatureVersion())) {
         	String CXF_SAML_TOKEN_GENERAL_FAILURE_MSG = "SAML token security failure";
             List<validationData> expectations = helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_GENERAL_FAILURE_MSG);        
             expectations = vData.addExpectation(expectations, SAMLConstants.INVOKE_ACS_WITH_SAML_RESPONSE, SAMLConstants.SAML_MESSAGES_LOG, SAMLConstants.STRING_CONTAINS, "Did NOT fail because the audienceRestrictions weren't satisfied.", null, audienceRestrictError);

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken/TwoServerTests/CxfSAMLBasic2ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken/TwoServerTests/CxfSAMLBasic2ServerTests.java
@@ -16,13 +16,11 @@ import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.log.Log;
-import com.ibm.websphere.simplicity.config.ServerConfiguration;
 
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
@@ -30,10 +28,7 @@ import com.ibm.ws.wssecurity.fat.cxf.samltoken.common.CxfSAMLBasicTests;
 
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.custom.junit.runner.Mode;
-import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServerWrapper;
-import componenttest.topology.utils.HttpUtils;
 
 /**
  * The testcases in this class were ported from tWAS' test SamlWebSSOTests.

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken/TwoServerTests/CxfSAMLWSSTemplatesWithExternalPolicy2ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken/TwoServerTests/CxfSAMLWSSTemplatesWithExternalPolicy2ServerTests.java
@@ -20,8 +20,6 @@ import java.util.Set;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
-import com.ibm.websphere.simplicity.config.ServerConfiguration;
-
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
@@ -32,7 +30,6 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServerWrapper;
-import componenttest.topology.utils.HttpUtils;
 
 /**
  * The testcases in this class were ported from tWAS' test SamlWebSSOTests.
@@ -109,6 +106,14 @@ public class CxfSAMLWSSTemplatesWithExternalPolicy2ServerTests extends CxfSAMLWS
         
         testSettings.setSpTargetApp(testSAMLServer.getHttpString() + "/samlwsstemplatesclient/CxfWssSAMLTemplatesSvcClient");              testSettings.setSamlTokenValidationData(testSettings.getIdpUserName(), testSettings.getSamlTokenValidationData().getIssuer(), testSettings.getSamlTokenValidationData().getInResponseTo(), testSettings.getSamlTokenValidationData().getMessageID(), testSettings.getSamlTokenValidationData().getEncryptionKeyUser(), testSettings.getSamlTokenValidationData().getRecipient(), testSettings.getSamlTokenValidationData().getEncryptAlg());
         
+        //issue 18363
+        Set<String> features = testSAMLServer.getServer().getServerConfiguration().getFeatureManager().getFeatures();
+        if (features.contains("jaxws-2.2")) {
+            setFeatureVersion("EE7");
+        }
+        if (features.contains("jaxws-2.3")) {
+            setFeatureVersion("EE8");
+        } // End of 18363
         
     }
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken/TwoServerTests/CxfSAMLWSSTemplatesWithExternalPolicy2ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken/TwoServerTests/CxfSAMLWSSTemplatesWithExternalPolicy2ServerTests.java
@@ -110,8 +110,7 @@ public class CxfSAMLWSSTemplatesWithExternalPolicy2ServerTests extends CxfSAMLWS
         Set<String> features = testSAMLServer.getServer().getServerConfiguration().getFeatureManager().getFeatures();
         if (features.contains("jaxws-2.2")) {
             setFeatureVersion("EE7");
-        }
-        if (features.contains("jaxws-2.3")) {
+        } else if (features.contains("jaxws-2.3")) {
             setFeatureVersion("EE8");
         } // End of 18363
         

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken/common/CxfSAMLBasicTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken/common/CxfSAMLBasicTests.java
@@ -11,10 +11,9 @@
 
 package com.ibm.ws.wssecurity.fat.cxf.samltoken.common;
 
-import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
-
 import java.util.List;
 
 import org.junit.Test;
@@ -29,7 +28,6 @@ import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
 
-import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
@@ -63,7 +61,18 @@ public class CxfSAMLBasicTests extends SAMLCommonTest {
     protected static CXFSAMLCommonUtils commonUtils = new CXFSAMLCommonUtils();
     protected static String servicePort = null;
     protected static String serviceSecurePort = null;
+    //issue 18363
+    protected static String featureVersion = "";
 
+    //issue 18363
+    public static String getFeatureVersion() {
+        return featureVersion;
+    }
+    
+    public static void setFeatureVersion(String version) {
+        featureVersion = version;
+    } //End of issue 18363
+	
     /**
      * TestDescription:
      *
@@ -89,7 +98,7 @@ public class CxfSAMLBasicTests extends SAMLCommonTest {
         updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "SAMLSOAPService2", "SAMLSoapPort2", "", "False", null, null);
 
         genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings));
-
+		
     }
 
     /**
@@ -116,7 +125,7 @@ public class CxfSAMLBasicTests extends SAMLCommonTest {
         updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLSOAPService2", "SAMLSoapPort2", "", "False", null, null);
 
         genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings));
-
+        
     }
 
     /**
@@ -137,7 +146,7 @@ public class CxfSAMLBasicTests extends SAMLCommonTest {
     @SkipForRepeat({ EE9_FEATURES })
     @Test
     public void CxfSAMLBasicTests_validUserBadPw_test() throws Exception {
-
+ 
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
@@ -146,7 +155,7 @@ public class CxfSAMLBasicTests extends SAMLCommonTest {
 
         genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings));
         //		genericSAML(_testName, wc, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SERVICE_UNAUTHORIZED));
-
+        
     }
 
     /**
@@ -176,7 +185,7 @@ public class CxfSAMLBasicTests extends SAMLCommonTest {
 
         genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings));
         //		genericSAML(_testName, wc, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SERVICE_UNAUTHORIZED));
-
+        
     }
 
     /**
@@ -208,7 +217,7 @@ public class CxfSAMLBasicTests extends SAMLCommonTest {
         expectations = helpers.addMessageExpectation(testSAMLServer, expectations, SAMLConstants.INVOKE_ACS_WITH_SAML_RESPONSE, SAMLConstants.SAML_MESSAGES_LOG, SAMLConstants.STRING_CONTAINS, "Did not receive message that the SAML Token did not validate.", SAMLMessageConstants.CWWKS5048E_ERROR_VERIFYING_SIGNATURE);
 
         genericSAML(_testName, webClient, updatedTestSettings, standardFlow, expectations);
-
+		
     }
 
     /**
@@ -234,6 +243,7 @@ public class CxfSAMLBasicTests extends SAMLCommonTest {
         updatedTestSettings.setCXFSettings(_testName, null, servicePort, serviceSecurePort, "user1", "user1pwd", "SAMLSOAPService2", "SAMLSoapPort2", "", "False", null, commonUtils.processClientWsdl("ClientNotSamlTokenWebSvc.wsdl", servicePort));
 
         genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, expectedResponse));
-    }
+		
+	}
 
 }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken/common/CxfSAMLWSSTemplatesTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken/common/CxfSAMLWSSTemplatesTests.java
@@ -11,9 +11,7 @@
 
 package com.ibm.ws.wssecurity.fat.cxf.samltoken.common;
 
-import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
-import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -49,7 +47,18 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
     protected static String servicePort = null;
     protected static String serviceSecurePort = null;
     protected static String policyType = "wsdl";
+    //issue 18363
+    protected static String featureVersion = "";
 
+    //issue 18363
+    public static String getFeatureVersion() {
+        return featureVersion;
+    }
+    
+    public static void setFeatureVersion(String version) {
+        featureVersion = version;
+    } //End of issue 18363
+    
     /**
      * TestDescription:
      * Client matches server side policy (transport enabled)
@@ -57,35 +66,23 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
      * 
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
+    @AllowedFFDC(value = { "java.util.MissingResourceException" }, repeatAction = { EE8FeatureReplacementAction.ID })
     @Test
-    public void CxfSAMLWSSTemplatesTests_Saml20TokenOverSSLEE7Only() throws Exception {
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setSpTargetApp(testSAMLServer.getHttpsString() + "/samlwsstemplatesclient/CxfWssSAMLTemplatesSvcClient");
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, serviceSecurePort, "user1", "user1pwd", "WSSTemplatesService2", "WSSTemplate2", "", "False", null, null);
-        updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_2));
-
-    }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.util.MissingResourceException", "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @Test
-    public void CxfSAMLWSSTemplatesTests_Saml20TokenOverSSLEE8Only() throws Exception {
-
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-            //2 servers reconfig
-    		testSAMLServer2.reconfigServer("server_2_wsstemplate_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	}
+    public void CxfSAMLWSSTemplatesTests_Saml20TokenOverSSL() throws Exception {
+        
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    		if (testSAMLServer2 == null) {
+                //1 server reconfig
+        		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        	} else {
+                //2 servers reconfig
+        		testSAMLServer2.reconfigServer("server_2_wsstemplate_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        		testSAMLServer.reconfigServer("server_1_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        	}
+    	} //End of 18363
     	
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+    	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -95,7 +92,6 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
         genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_2));
 
     }
-    
 
     /**
      * TestDescription:
@@ -105,10 +101,21 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
      * 
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    public void CxfSAMLWSSTemplatesTests_Saml20TokenOverSSL_httpFromClientEE7Only() throws Exception {
+    public void CxfSAMLWSSTemplatesTests_Saml20TokenOverSSL_httpFromClient() throws Exception {
         
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    		if (testSAMLServer2 == null) {
+                //1 server reconfig
+        		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        	} else {
+        	    //2 servers reconfig
+        		testSAMLServer2.reconfigServer("server_2_wsstemplate_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        		testSAMLServer.reconfigServer("server_1_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        	}
+    	} // End of 18363
+    	
     	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
@@ -117,33 +124,14 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
         updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "WSSTemplatesService2", "WSSTemplate2", "", "False", null, null);
         updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
         
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED));
-        
-    }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
-    @Test
-    public void CxfSAMLWSSTemplatesTests_Saml20TokenOverSSL_httpFromClientEE8Only() throws Exception {
-
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-    	    //2 servers reconfig
-    		testSAMLServer2.reconfigServer("server_2_wsstemplate_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	}
-    	
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setSpTargetApp(testSAMLServer.getHttpsString() + "/samlwsstemplatesclient/CxfWssSAMLTemplatesSvcClient");
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "WSSTemplatesService2", "WSSTemplate2", "", "False", null, null);
-        updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
-        
-        String CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED = "HttpsToken could not be asserted: Not an HTTPs connection";
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED));
+        //issue 18363
+        if ("EE7".equals(getFeatureVersion())) {
+            genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED));
+        }
+        if ("EE8".equals(getFeatureVersion())) {
+        	String CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED = "HttpsToken could not be asserted: Not an HTTPs connection";
+            genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED));
+        } //End of 18363
     }
 
     /**
@@ -154,18 +142,32 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
      * Test should succeed in accessing the server side service.
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    public void CxfSAMLWSSTemplatesTests_AsymmetricX509MutualAuthenticationWithSamlEE7Only() throws Exception {
+    public void CxfSAMLWSSTemplatesTests_AsymmetricX509MutualAuthenticationWithSaml() throws Exception {
         
-    	if (testSAMLServer2 == null) {
-            // 1 server reconfig
-            testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        } else {
-            // 2 server reconfig
-            testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-            testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        }
+    	//issue 18363
+        if ("EE7".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                // 1 server reconfig
+                testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            } else {
+                // 2 server reconfig
+                testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+                testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            }
+        }    
+    	
+    	if ("EE8".equals(getFeatureVersion())) {
+    		if (testSAMLServer2 == null) {
+                // 1 server reconfig
+                testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            } else {
+                // 2 server reconfig
+                testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+                testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            }
+    	} //End of 18363
+    	
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
@@ -176,31 +178,7 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
         genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_4));
 
     }
-
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID }) //@AV999 TODO we should not see CNFE and MalformedURL
-    @Test
-    public void CxfSAMLWSSTemplatesTests_AsymmetricX509MutualAuthenticationWithSamlEE8Only() throws Exception {
-
-        if (testSAMLServer2 == null) {
-            // 1 server reconfig
-            testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        } else {
-            // 2 server reconfig
-            testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-            testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        }
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "WSSTemplatesService4", "WSSTemplate4", "", "False", null, null);
-        updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_4));
-
-    }
-    
+   
     /**
      * TestDescription:
      * This test uses a policy with Asymmetric X509 Policy with
@@ -209,19 +187,33 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
      * Test should fail to access the server side service.
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
-    public void CxfSAMLWSSTemplatesTests_AsymmetricX509MutualAuthenticationWithSaml_omitInitiatorTokenEE7Only() throws Exception {
+    public void CxfSAMLWSSTemplatesTests_AsymmetricX509MutualAuthenticationWithSaml_omitInitiatorToken() throws Exception {
     	
-        if (testSAMLServer2 == null) {
-            // 1 server reconfig
-            testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        } else {
-            // 2 server reconfig
-            testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-            testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	//issue 18363
+        if ("EE7".equals(getFeatureVersion())) {
+            if (testSAMLServer2 == null) {
+                // 1 server reconfig
+                testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            } else {
+                // 2 server reconfig
+                testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+                testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            }
         }
+        
+        if ("EE8".equals(getFeatureVersion())) {
+        	if (testSAMLServer2 == null) {
+                // 1 server reconfig
+                testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            } else {
+                // 2 server reconfig
+                testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+                testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            }
+        } // End of 18363
+        
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
@@ -235,46 +227,21 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
 
         updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
         
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
+        //issue 18363
+        if ("EE7".equals(getFeatureVersion())) {
+            genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
+        }
+        if ("EE8".equals(getFeatureVersion())) {
+        	if ("externalPolicy".equals(policyType)) { //@AV999 TODO in jaxws-2.3 , this is a successful scenario
+                genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_4));
+            } else {
+                String CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR = "These policy alternatives can not be satisfied:"; //@AV999, we need to use different error message depending on runtime
+                genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
+            }    
+        } //End of 18363
         
     }
     
-    
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @Test 
-    public void CxfSAMLWSSTemplatesTests_AsymmetricX509MutualAuthenticationWithSaml_omitInitiatorTokenEE8Only() throws Exception {
-
-        if (testSAMLServer2 == null) {
-            // 1 server reconfig
-            testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        } else {
-            // 2 server reconfig
-            testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-            testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        }
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        if ("externalPolicy".equals(policyType)) {
-            updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "WSSTemplatesService4", "WSSTemplate4", "", "False", null, commonUtils.processClientWsdl("ClientAsymOmitInitiatorTokenWithEP.wsdl", servicePort));
-        }
-        else {
-            updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "WSSTemplatesService4", "WSSTemplate4", "", "False", null, commonUtils.processClientWsdl("ClientAsymOmitInitiatorToken.wsdl", servicePort));
-        }
-
-        updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
-
-        if ("externalPolicy".equals(policyType)) { //@AV999 TODO in jaxws-2.3 , this is a successful scenario
-            genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_4));
-        } else {
-            String CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR = "These policy alternatives can not be satisfied:"; //@AV999, we need to use different error message depending on runtime
-            genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
-        }    
-    
-    }
-
     /**
      * TestDescription:
      * This test uses a policy with Asymmetric X509 Policy with
@@ -283,19 +250,33 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
      * Test should fail to access the server side service.
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
-    public void CxfSAMLWSSTemplatesTests_AsymmetricX509MutualAuthenticationWithSaml_omitRecipientTokenEE7Only() throws Exception {
+    public void CxfSAMLWSSTemplatesTests_AsymmetricX509MutualAuthenticationWithSaml_omitRecipientToken() throws Exception {
     	
-        if (testSAMLServer2 == null) {
-            // 1 server reconfig
-            testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        } else {
-            // 2 server reconfig
-            testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-            testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        }
+    	//issue 18363
+        if ("EE7".equals(getFeatureVersion())) {
+            if (testSAMLServer2 == null) {
+                // 1 server reconfig
+                testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            } else {
+                // 2 server reconfig
+                testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+                testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            }
+        }  
+        
+        if ("EE8".equals(getFeatureVersion())) {
+        	if (testSAMLServer2 == null) {
+                // 1 server reconfig
+                testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            } else {
+                // 2 server reconfig
+                testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+                testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+            }
+        } //End of 18363
+        
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
@@ -308,44 +289,19 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
         }
         updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
 
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
-               
-    }
-    
-    
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @Test
-    public void CxfSAMLWSSTemplatesTests_AsymmetricX509MutualAuthenticationWithSaml_omitRecipientTokenEE8Only() throws Exception {
-
-        if (testSAMLServer2 == null) {
-            // 1 server reconfig
-            testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        } else {
-            // 2 server reconfig
-            testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-            testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-        }
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        if ("externalPolicy".equals(policyType)) {
-            updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "WSSTemplatesService4", "WSSTemplate4", "", "False", null, commonUtils.processClientWsdl("ClientAsymOmitRecipientTokenWithEP.wsdl", servicePort));
-        }
-        else {
-            updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "WSSTemplatesService4", "WSSTemplate4", "", "False", null, commonUtils.processClientWsdl("ClientAsymOmitRecipientToken.wsdl", servicePort));
-        }
-        updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
-
-        if ("externalPolicy".equals(policyType)) { //@AV999 TODO in jaxws-2.3 , this is a successful scenario
-            genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_4));
-        } else {
+        //issue 18363
+        if ("EE7".equals(getFeatureVersion())) {
             genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
         }
+        if ("EE8".equals(getFeatureVersion())) {
+        	if ("externalPolicy".equals(policyType)) { //@AV999 TODO in jaxws-2.3 , this is a successful scenario
+                genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_4));
+            } else {
+                genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
+            }
+        } //End of 18363
         
     }
-    
     
     /**
      * TestDescription:
@@ -354,10 +310,21 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
      * Test should succeed in accessing the server side service.
      */
    
-    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    public void CxfSAMLWSSTemplatesTests_X509SymmetricForMessageAndSamlForClientEE7Only() throws Exception {
+    public void CxfSAMLWSSTemplatesTests_X509SymmetricForMessageAndSamlForClient() throws Exception {
         
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    		if (testSAMLServer2 == null) {
+                //1 server reconfig
+        		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        	} else {
+                //2 servers reconfig
+        		testSAMLServer2.reconfigServer("server_2_wsstemplate_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        		testSAMLServer.reconfigServer("server_1_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        	}
+    	} //End of 18363
+    	
     	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
@@ -369,30 +336,6 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
 
     }
 
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID }) //@AV999 TODO
-    @Test
-    public void CxfSAMLWSSTemplatesTests_X509SymmetricForMessageAndSamlForClientEE8Only() throws Exception {
-
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-            //2 servers reconfig
-    		testSAMLServer2.reconfigServer("server_2_wsstemplate_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	}
-    	
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "WSSTemplatesService6", "WSSTemplate6", "", "False", null, null);
-        updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_6));
-
-    }
     /**
      * TestDescription:
      * This test uses a policy with Symmetric X509 Message Policy and SAML.
@@ -400,10 +343,21 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
      * Test should fail to access the server side service.
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
-    public void CxfSAMLWSSTemplatesTests_X509SymmetricForMessageAndSamlForClient_omitProtectionPolicyEE7Only() throws Exception {
+    public void CxfSAMLWSSTemplatesTests_X509SymmetricForMessageAndSamlForClient_omitProtectionPolicy() throws Exception {
+    	
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    		if (testSAMLServer2 == null) {
+                //1 server reconfig
+        		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        	} else {
+                //2 servers reconfig
+        		testSAMLServer2.reconfigServer("server_2_wsstemplate_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        		testSAMLServer.reconfigServer("server_1_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+        	}
+    	} //End of 18363
     	
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
@@ -412,39 +366,19 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
         updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "WSSTemplatesService6", "WSSTemplate6", "", "False", null, commonUtils.processClientWsdl("ClientSymOmitProtectionPolicy.wsdl", servicePort));
         updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
 
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
-    }
-    
-    
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @Test
-    public void CxfSAMLWSSTemplatesTests_X509SymmetricForMessageAndSamlForClient_omitProtectionPolicyEE8Only() throws Exception {
-
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-            //2 servers reconfig
-    		testSAMLServer2.reconfigServer("server_2_wsstemplate_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	}
-    	
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, "user1", "user1pwd", "WSSTemplatesService6", "WSSTemplate6", "", "False", null, commonUtils.processClientWsdl("ClientSymOmitProtectionPolicy.wsdl", servicePort));
-        updatedTestSettings.getCXFSettings().setTitleToCheck(SAMLConstants.CXF_SAML_TOKEN_WSS_SERVLET);
-        
-        if ("externalPolicy".equals(policyType)) { //@AV999 , jaxws-2.3 this is failing at the client side
-            String CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR = "javax.xml.ws.soap.SOAPFaultException: javax.xml.crypto.dsig.TransformException: org.apache.wss4j.common.ext.WSSecurityException: Referenced Token ";
-            genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
-        } else {
+        //issue 18363
+        if ("EE7".equals(getFeatureVersion())) {
             genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
         }
+        if ("EE8".equals(getFeatureVersion())) {
+        	if ("externalPolicy".equals(policyType)) { //@AV999 , jaxws-2.3 this is failing at the client side
+                String CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR = "javax.xml.ws.soap.SOAPFaultException: javax.xml.crypto.dsig.TransformException: org.apache.wss4j.common.ext.WSSecurityException: Referenced Token ";
+                genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
+            } else {
+                genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
+            }
+        } //End of 18363
         
     }
-    
 
 }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken/common/CxfSAMLWSSTemplatesTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken/common/CxfSAMLWSSTemplatesTests.java
@@ -127,8 +127,7 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
         //issue 18363
         if ("EE7".equals(getFeatureVersion())) {
             genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED));
-        }
-        if ("EE8".equals(getFeatureVersion())) {
+        } else if ("EE8".equals(getFeatureVersion())) {
         	String CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED = "HttpsToken could not be asserted: Not an HTTPs connection";
             genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_SERVICE_HTTPS_NOT_USED));
         } //End of 18363
@@ -155,9 +154,7 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
                 testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
                 testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
             }
-        }    
-    	
-    	if ("EE8".equals(getFeatureVersion())) {
+        } else if ("EE8".equals(getFeatureVersion())) {
     		if (testSAMLServer2 == null) {
                 // 1 server reconfig
                 testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
@@ -201,9 +198,7 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
                 testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
                 testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
             }
-        }
-        
-        if ("EE8".equals(getFeatureVersion())) {
+        } else if ("EE8".equals(getFeatureVersion())) {
         	if (testSAMLServer2 == null) {
                 // 1 server reconfig
                 testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
@@ -230,8 +225,7 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
         //issue 18363
         if ("EE7".equals(getFeatureVersion())) {
             genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
-        }
-        if ("EE8".equals(getFeatureVersion())) {
+        } else if ("EE8".equals(getFeatureVersion())) {
         	if ("externalPolicy".equals(policyType)) { //@AV999 TODO in jaxws-2.3 , this is a successful scenario
                 genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_4));
             } else {
@@ -264,9 +258,7 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
                 testSAMLServer2.reconfigServer(buildSPServerName("server_2_wsstemplate_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
                 testSAMLServer.reconfigServer(buildSPServerName("server_1_AsymSignEnc.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
             }
-        }  
-        
-        if ("EE8".equals(getFeatureVersion())) {
+        } else if ("EE8".equals(getFeatureVersion())) {
         	if (testSAMLServer2 == null) {
                 // 1 server reconfig
                 testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
@@ -292,8 +284,7 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
         //issue 18363
         if ("EE7".equals(getFeatureVersion())) {
             genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
-        }
-        if ("EE8".equals(getFeatureVersion())) {
+        } else if ("EE8".equals(getFeatureVersion())) {
         	if ("externalPolicy".equals(policyType)) { //@AV999 TODO in jaxws-2.3 , this is a successful scenario
                 genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_WSS_TEMPLATE_SERVICE_4));
             } else {
@@ -369,8 +360,7 @@ public class CxfSAMLWSSTemplatesTests extends SAMLCommonTest {
         //issue 18363
         if ("EE7".equals(getFeatureVersion())) {
             genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
-        }
-        if ("EE8".equals(getFeatureVersion())) {
+        } else if ("EE8".equals(getFeatureVersion())) {
         	if ("externalPolicy".equals(policyType)) { //@AV999 , jaxws-2.3 this is failing at the client side
                 String CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR = "javax.xml.ws.soap.SOAPFaultException: javax.xml.crypto.dsig.TransformException: org.apache.wss4j.common.ext.WSSecurityException: Referenced Token ";
                 genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));


### PR DESCRIPTION
Update com.ibm.ws.wssecurity_fat.wsscxf.saml to remove the split (EE7Only/EE8Only)
