### PR TITLE
Issue #13717: EE 9 EJB 2x Exception FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/.classpath
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/.classpath
@@ -7,6 +7,8 @@
 	<classpathentry kind="src" path="test-applications/EJB31AppExMixWeb.war/src"/>
 	<classpathentry kind="src" path="test-applications/EJB31AppExXmlBean.jar/src"/>
 	<classpathentry kind="src" path="test-applications/EJB31AppExXmlWeb.war/src"/>
+	<classpathentry kind="src" path="test-applications/Exception2xBean.jar/src"/>
+	<classpathentry kind="src" path="test-applications/Exception2xWeb.war/src"/>
 	<classpathentry kind="src" path="test-applications/ExceptionBean.jar/src"/>
 	<classpathentry kind="src" path="test-applications/ExceptionWeb.war/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/bnd.bnd
@@ -19,6 +19,8 @@ src: \
 	test-applications/EJB31AppExMixWeb.war/src, \
 	test-applications/EJB31AppExXmlBean.jar/src, \
 	test-applications/EJB31AppExXmlWeb.war/src, \
+	test-applications/Exception2xBean.jar/src, \
+	test-applications/Exception2xWeb.war/src, \
 	test-applications/ExceptionBean.jar/src, \
 	test-applications/ExceptionWeb.war/src
 
@@ -39,5 +41,7 @@ tested.features: \
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.ejb.3.2;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest, \
+	com.ibm.websphere.javaee.transaction.1.2;version=latest, \
+	com.ibm.ws.ejbcontainer.core; version=latest, \
 	com.ibm.ws.ejbcontainer.fat_tools; version=latest,\
 	io.openliberty.ejbcontainer.jakarta.fat_tools; version=latest

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/build.gradle
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/build.gradle
@@ -28,6 +28,8 @@ dependencies {
   enterpriseBeansTools 'test:io.openliberty.ejbcontainer.jakarta.fat_tools:1.+'
   // Dependencies needed for when running on Java 9 (EE-type APIs were removed from JDK)
   requiredLibs 'com.ibm.ws.org.apache.yoko:yoko-spec-corba:1.5.0.31ef0b15cf'
+  // Dependencies needed for InvalidTransactionLocalException
+  requiredLibs project(':com.ibm.ws.ejbcontainer.core')
 }
 
 task addEJBTools {

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/publish/servers/com.ibm.ws.ejbcontainer.exception.fat.ExceptionServer/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/publish/servers/com.ibm.ws.ejbcontainer.exception.fat.ExceptionServer/server.xml
@@ -11,9 +11,8 @@
 
     <iiopEndpoint id="defaultIiopEndpoint" iiopPort="${bvt.prop.IIOP}" iiopsPort="${bvt.prop.IIOP.secure}"/>
 
-    <!-- Yoko ORB bug; org.apache.yoko.rmispec.util.UtilLoader.loadServiceClass needs doPriv around getClassLoader -->	
     <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
-    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="line.separator" actions="read"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="*" actions="read"/>
     <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
-    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.util.PropertyPermission" name="line.separator" actions="read"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.util.PropertyPermission" name="*" actions="read"/>
 </server>

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xApp.ear/resources/META-INF/application.xml
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xApp.ear/resources/META-INF/application.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE application PUBLIC "-//Sun Microsystems, Inc.//DTD J2EE Application 1.3//EN" "http://java.sun.com/dtd/application_1_3.dtd">
+
+   <application id="Application_ID">
+      <display-name>Exception2xApp</display-name>
+      <module>
+        <web>
+          <web-uri>Exception2xWeb.war</web-uri>
+          <context-root>/Exception2xWeb</context-root>
+        </web>
+      </module>
+      <module>
+         <ejb>Exception2xBean.jar</ejb>
+      </module>
+
+   </application>

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xApp.ear/resources/META-INF/ibm-application-bnd.xmi
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xApp.ear/resources/META-INF/ibm-application-bnd.xmi
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<applicationbnd:ApplicationBinding xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:applicationbnd="applicationbnd.xmi" xmlns:application="application.xmi" xmi:id="Application_ID_Bnd">
+  <authorizationTable xmi:id="AuthorizationTable_1"/>
+  <application href="META-INF/application.xml#Application_ID"/>
+</applicationbnd:ApplicationBinding>

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xApp.ear/resources/META-INF/ibm-application-ext.xmi
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xApp.ear/resources/META-INF/ibm-application-ext.xmi
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<applicationext:ApplicationExtension xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:applicationext="applicationext.xmi" xmlns:application="application.xmi" xmi:id="Application_ID_Ext">
+  <application href="META-INF/application.xml#Application_ID"/>
+</applicationext:ApplicationExtension>

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xApp.ear/resources/META-INF/permissions.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+    version="7">
+
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>*</name>
+        <actions>read</actions>
+    </permission>
+    <permission>
+        <!-- Yoko ORB bug; org.apache.yoko.rmispec.util.UtilLoader.loadServiceClass needs doPriv -->
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>getClassLoader</name>
+    </permission>
+</permissions>

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/resources/META-INF/ejb-jar.xml
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/resources/META-INF/ejb-jar.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ejb-jar PUBLIC "-//Sun Microsystems, Inc.//DTD Enterprise JavaBeans 2.0//EN" "http://java.sun.com/dtd/ejb-jar_2_0.dtd">
+   <ejb-jar id="ejb-jar_ID">
+      <display-name>Exception2xBean</display-name>
+      <enterprise-beans>
+         <session id="Session_1">
+            <ejb-name>ExceptionEJB</ejb-name>
+            <home>com.ibm.ws.ejbcontainer.exception2x.ejb.TestExHome</home>
+            <remote>com.ibm.ws.ejbcontainer.exception2x.ejb.TestEx</remote>
+            <local-home>com.ibm.ws.ejbcontainer.exception2x.ejb.TestExLItfHome</local-home>
+            <local>com.ibm.ws.ejbcontainer.exception2x.ejb.TestExLItf</local>
+            <ejb-class>com.ibm.ws.ejbcontainer.exception2x.ejb.TestExBean</ejb-class>
+            <session-type>Stateful</session-type>
+            <transaction-type>Container</transaction-type>
+         </session>
+
+         <session id="Session_1043952615515">
+            <ejb-name>SFRaEJB</ejb-name>
+            <home>com.ibm.ws.ejbcontainer.exception2x.ejb.SFRaHome</home>
+            <remote>com.ibm.ws.ejbcontainer.exception2x.ejb.SFRa</remote>
+            <ejb-class>com.ibm.ws.ejbcontainer.exception2x.ejb.SFRaBean</ejb-class>
+            <session-type>Stateful</session-type>
+            <transaction-type>Container</transaction-type>
+            <env-entry>
+              <description>An env var to test the fix for PK17144</description>
+              <env-entry-name>PK17144</env-entry-name>
+              <env-entry-type>java.lang.String</env-entry-type>
+              <env-entry-value>PK17144_string</env-entry-value>
+            </env-entry>
+         </session>
+      </enterprise-beans>
+
+     <assembly-descriptor>
+    	<container-transaction>
+	        <method>
+	        	<ejb-name>SFRaEJB</ejb-name>
+	        	<method-name>echoRequired</method-name>
+	        </method>
+	        <trans-attribute>NotSupported</trans-attribute>
+        </container-transaction>
+        <container-transaction>
+	        <method>
+	        	<ejb-name>SFRaEJB</ejb-name>
+	        	<method-name>getPKey</method-name>
+	        </method>
+	        <trans-attribute>NotSupported</trans-attribute>
+        </container-transaction>
+        <container-transaction>
+	        <method>
+	        	<ejb-name>SFRaEJB</ejb-name>
+	        	<method-name>getIntValue</method-name>
+	        </method>
+	        <trans-attribute>NotSupported</trans-attribute>
+        </container-transaction>
+        <container-transaction>
+	        <method>
+	        	<ejb-name>SFRaEJB</ejb-name>
+	        	<method-name>getStringValue</method-name>
+	        </method>
+	        <trans-attribute>NotSupported</trans-attribute>
+	     </container-transaction>
+     </assembly-descriptor>
+   </ejb-jar>

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/resources/META-INF/ibm-ejb-jar-bnd.xmi
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/resources/META-INF/ibm-ejb-jar-bnd.xmi
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ejbbnd:EJBJarBinding xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ejbbnd="ejbbnd.xmi" xmlns:ejb="ejb.xmi" xmlns:commonbnd="commonbnd.xmi" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmi:id="ejb-jar_ID_Bnd">
+  <ejbJar href="META-INF/ejb-jar.xml#ejb-jar_ID"/>
+  <ejbBindings xmi:id="EnterpriseBeanBinding_1" jndiName="exception2x/ejb/TestExHome">
+    <enterpriseBean xmi:type="ejb:Session" href="META-INF/ejb-jar.xml#Session_1"/>
+  </ejbBindings>
+  <ejbBindings xmi:id="EnterpriseBeanBinding_1043952615515" jndiName="exception2x/ejb/SFRaHome">
+    <enterpriseBean xmi:type="ejb:Session" href="META-INF/ejb-jar.xml#Session_1043952615515"/>
+  </ejbBindings>
+</ejbbnd:EJBJarBinding>

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/resources/META-INF/ibm-ejb-jar-ext.xmi
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/resources/META-INF/ibm-ejb-jar-ext.xmi
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ejbext:EJBJarExtension xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ejbext="ejbext.xmi" xmlns:ejb="ejb.xmi" xmlns:commonext.localtran="commonext.localtran.xmi" xmi:id="EJBJarExtension_1">
+  <ejbExtensions xmi:type="ejbext:SessionExtension" xmi:id="SessionExtension_1" timeout="600">
+    <enterpriseBean xmi:type="ejb:Session" href="META-INF/ejb-jar.xml#Session_1"/>
+    <structure xmi:id="BeanStructure_1" inheritenceRoot="false"/>
+    <beanCache xmi:id="BeanCache_1" activateAt="TRANSACTION"/>
+    <localTransaction xmi:id="LocalTransaction_1" boundary="BeanMethod" resolver="Application" unresolvedAction="Rollback"/>
+  </ejbExtensions>
+  <ejbExtensions xmi:type="ejbext:SessionExtension" xmi:id="SessionExtension_1043952615515" timeout="600">
+    <enterpriseBean xmi:type="ejb:Session" href="META-INF/ejb-jar.xml#Session_1043952615515"/>
+    <structure xmi:id="BeanStructure_3" inheritenceRoot="false"/>
+    <beanCache xmi:id="BeanCache_3" activateAt="TRANSACTION"/>
+    <localTransaction xmi:id="LocalTransaction_3" boundary="BeanMethod" resolver="Application" unresolvedAction="Rollback"/>
+  </ejbExtensions>
+  <ejbJar href="META-INF/ejb-jar.xml#ejb-jar_ID"/>
+</ejbext:EJBJarExtension>

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/src/com/ibm/ws/ejbcontainer/exception2x/ejb/SFRa.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/src/com/ibm/ws/ejbcontainer/exception2x/ejb/SFRa.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2003, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.exception2x.ejb;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.EJBObject;
+
+/**
+ * Remote interface for Enterprise Bean: SFRa
+ */
+public interface SFRa extends EJBObject {
+    /**
+     * Pre-defined keys string for directing when the EJBs should throw a RuntimeException.
+     */
+    static final int Normal = 0;
+    static final int Create = 1;
+    static final int PostCreate = 2;
+    static final int Activate = 3;
+    static final int Passivate = 4;
+    static final int Load = 5;
+    static final int Store = 6;
+    static final int Remove = 7;
+
+    /**
+     * Get accessor for persistent attribute: pKey
+     */
+    public String getPKey() throws RemoteException;
+
+    /**
+     * Set accessor for persistent attribute: pKey
+     */
+    public void setPKey(String theKey) throws RemoteException;
+
+    /**
+     * Get accessor for persistent attribute: intValue
+     */
+    public int getIntValue() throws RemoteException;
+
+    /**
+     * Set accessor for persistent attribute: intValue
+     */
+    public void setIntValue(int intValue) throws RemoteException;
+
+    /**
+     * Get accessor for persistent attribute: stringValue
+     */
+    public String getStringValue() throws RemoteException;
+
+    /**
+     * Set accessor for persistent attribute: stringValue
+     */
+    public void setStringValue(String stringValue) throws RemoteException;
+
+    /**
+     * Echo the input string plus the key string
+     */
+    public String echoRequired(String str) throws RemoteException;
+}

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/src/com/ibm/ws/ejbcontainer/exception2x/ejb/SFRaBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/src/com/ibm/ws/ejbcontainer/exception2x/ejb/SFRaBean.java
@@ -1,0 +1,293 @@
+/*******************************************************************************
+ * Copyright (c) 2003, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.exception2x.ejb;
+
+import java.util.logging.Logger;
+
+import javax.ejb.CreateException;
+import javax.ejb.EJBException;
+import javax.ejb.SessionBean;
+import javax.ejb.SessionContext;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
+/**
+ * Bean implementation class for Enterprise Bean: SFRa
+ */
+public class SFRaBean implements SessionBean {
+    private static final long serialVersionUID = -686496765499777826L;
+
+    private static final String CLASS_NAME = SFRaBean.class.getName();
+    private static final Logger svLogger = Logger.getLogger(CLASS_NAME);
+    private static final String BeanName = "SFRa";
+
+    private SessionContext mySessionCtx;
+
+    public String pKey;
+    public int intValue;
+    public String stringValue;
+
+    /**
+     * getSessionContext
+     */
+    public SessionContext getSessionContext() {
+        printMsg("(getSessionContext)");
+        return mySessionCtx;
+    }
+
+    /**
+     * setSessionContext
+     */
+    @Override
+    public void setSessionContext(SessionContext ctx) {
+        printMsg("(setSessionContext)");
+        mySessionCtx = ctx;
+
+        // PK17144.1: EJB 2.1 Spec, section 7.6.1, table 2 states that this
+        // life cycle method should have access to java:comp/env....so lets try.
+        this.getJavaEnvValue("setSessionContext");
+    }
+
+    /**
+     * unsetSessionContext
+     */
+    public void unsetSessionContext() {
+        printMsg("(unsetSessionContext)");
+        mySessionCtx = null;
+    }
+
+    /**
+     * Get accessor for persistent attribute: pKey
+     */
+    public String getPKey() {
+        return pKey;
+    }
+
+    /**
+     * Set accessor for persistent attribute: pKey
+     */
+    public void setPKey(String pKey) {
+        this.pKey = pKey;
+    }
+
+    /**
+     * Get accessor for persistent attribute: intValue
+     */
+    public int getIntValue() {
+        return intValue;
+    }
+
+    /**
+     * Set accessor for persistent attribute: intValue
+     */
+    public void setIntValue(int intValue) {
+        this.intValue = intValue;
+    }
+
+    /**
+     * Get accessor for persistent attribute: stringValue
+     */
+    public String getStringValue() {
+        return stringValue;
+    }
+
+    /**
+     * Set accessor for persistent attribute: stringValue
+     */
+    public void setStringValue(String stringValue) {
+        this.stringValue = stringValue;
+    }
+
+    /**
+     * PK17144.1: This APAR was opened because a user tried to get some context out
+     * of java:comp/env during ejbPassivate in a Stateful Session Bean. This lookup failed.
+     * Therefore, I'm adding a test here to verify that with the fix to this APAR
+     * we can get at the java:comp/env context. This code is tested indirectly through
+     * the tests in this suite. In other words, the tests in this suite perform certain
+     * operations which, along with the fact that this bean has its "atActivate" field set
+     * to "TRANSACTION", will cause this bean to be passivated. If the following look up
+     * fails, an exception will be thrown. This exception may not be apparently obvious (i.e.
+     * it may not cause the test to fail immediately), but after this exception is thrown the
+     * bean should be destroyed and as such on subsequent accesses a "NoSuchObjectException"
+     * should be thrown which will cause the fvts to fail horribly.
+     * This method will be called by a number of the life cycle methods in this bean. Even
+     * though this APAR was specific to ejbPassivate, we might as well go the extra inch and
+     * verify that other life cycle methods can access java:comp/en as outlines in the
+     * EJB 2.1 Spec, section 7.6.1, table 2.
+     *
+     * @param method A string containing the life cycle method that calls this method.
+     */
+    public void getJavaEnvValue(String method) {
+        String str = null;
+        this.printMsg("getJavaEnvValue called by: " + method);
+        try {
+            InitialContext ic = new InitialContext();
+
+            // First, lets verify that we can get the default/root java:comp/env context (i.e.
+            // the bean's environment naming context).
+            try {
+                Context defaultCxt = (Context) ic.lookup("java:comp/env");
+                if (defaultCxt == null) {
+                    throw new EJBException("Test of java:comp/env failed when trying to get the default context, called by life cycle method: " + method);
+                }
+
+                str = (String) defaultCxt.lookup("PK17144");
+                if (str == null || !str.equals("PK17144_string")) {
+                    throw new EJBException("Test of java:comp/env failed using the default context." +
+                                           " The retrieved String value, \"" + str + "\", is incorrect.  Called by life cycle method: " + method);
+                }
+
+            } catch (Throwable t) {
+                printMsg("Got an exception when doing a java:comp/env lookup!  We should be able to"
+                         + " do a java:comp/env lookup in " + method + ".  See APAR PK17144.  Exception is: " + t);
+                throw new RuntimeException("Got an excpetion when doing a java:comp/env lookup!  We should be able to"
+                                           + " do a java:comp/env lookup in " + method + ".  See APAR PK17144.  Exception is: " + t);
+            }
+
+            // Second, verify that we can get an env variable by using fully qualified
+            // path names.
+            str = (String) ic.lookup("java:comp/env/PK17144");
+            if (str == null || !str.equals("PK17144_string")) {
+                throw new EJBException("Test of java:comp/env/PK17144 failed." +
+                                       " The retrieved String value, \"" + str + "\", is incorrect.  Called by life cycle method: " + method);
+            }
+            // OK, if here we should be satisfy that we can access java:comp/env from a
+            // life cycle method.
+        } catch (Throwable t) {
+            printMsg("Got an unexpected excpetion when doing the java:comp/env lookup test!  We should be able to"
+                     + " do a java:comp/env lookup from life cycle method: " + method + ".  See APAR PK17144.  Exception is: " + t);
+            t.printStackTrace();
+            throw new RuntimeException("Got an excpetion when doing the java:comp/env lookup test!  We should be able to"
+                                       + " do a java:comp/env lookup from life cycle method: " + method + ".  See APAR PK17144.", t);
+        }
+    }
+
+    /**
+    *
+    */
+    public void ejbCreate(String pKey, int intValue, String stringValue) throws CreateException {
+        printMsg("(ejbCreate) pKey = " + pKey);
+        printMsg("    intValue     = " + intValue);
+        printMsg("    stringValue  = " + stringValue);
+
+        setPKey(pKey);
+        setIntValue(intValue);
+        setStringValue(stringValue);
+
+        if (getIntValue() == SFRa.Create) {
+            printMsg("throw RuntimeException");
+            //            int a =1;
+            //            int b = 0;
+            //            int c = a/b;
+            throw new RuntimeException("SFRa.ejbCreate()");
+        }
+
+        // PK17144.1: EJB 2.1 Spec, section 7.6.1, table 2 states that this
+        // life cycle method should have access to java:comp/env....so lets try.
+        this.getJavaEnvValue("ejbCreate");
+    }
+
+    /**
+     * Insert the method's description here.
+     */
+    public void ejbPostCreate(String pKey, int intValue, String stringValue) throws CreateException {
+        printMsg("(ejbPostCreate):" + getIntValue());
+        if (getIntValue() == SFRa.PostCreate) {
+            printMsg("throw RuntimeException");
+            throw new RuntimeException("SFRa.ejbPostCreate()");
+        }
+    }
+
+    /**
+     * ejbActivate
+     */
+    @Override
+    public void ejbActivate() {
+        printMsg("(ejbActivate):" + getIntValue());
+        if (getIntValue() == SFRa.Activate) {
+            printMsg("throw RuntimeException");
+            throw new RuntimeException("SFRa.ejbActivate()");
+        }
+
+        // PK17144.1: EJB 2.1 Spec, section 7.6.1, table 2 states that this
+        // life cycle method should have access to java:comp/env....so lets try.
+        this.getJavaEnvValue("ejbActivate");
+    }
+
+    /**
+     * ejbPassivate
+     */
+    @Override
+    public void ejbPassivate() {
+        printMsg("(ejbPassivate):" + getIntValue());
+        if (getIntValue() == SFRa.Passivate) {
+            printMsg("throw RuntimeException");
+            throw new RuntimeException("SFRa.ejbPassivate()");
+        }
+
+        // PK17144.1: EJB 2.1 Spec, section 7.6.1, table 2 states that this
+        // life cycle method should have access to java:comp/env....so lets try.
+        this.getJavaEnvValue("ejbPassivate");
+    }
+
+    /**
+     * ejbLoad
+     */
+    public void ejbLoad() {
+        printMsg("(ejbLoad):" + getIntValue());
+        if (getIntValue() == SFRa.Load) {
+            printMsg("throw RuntimeException");
+            throw new RuntimeException("SFRa.ejbLoad()");
+        }
+    }
+
+    /**
+     * ejbStore
+     */
+    public void ejbStore() {
+        printMsg("(ejbStore):" + getIntValue());
+        if (getIntValue() == SFRa.Store) {
+            printMsg("throw RuntimeException");
+            throw new RuntimeException("SFRa.ejbStore()");
+        }
+    }
+
+    /**
+     * ejbRemove
+     */
+    @Override
+    public void ejbRemove() {
+        printMsg("(ejbRemove):" + getIntValue());
+        if (getIntValue() == SFRa.Remove) {
+            printMsg("throw RuntimeException");
+            throw new RuntimeException("SFRa.ejbRemove()");
+        }
+
+        // PK17144.1: EJB 2.1 Spec, section 7.6.1, table 2 states that this
+        // life cycle method should have access to java:comp/env....so lets try.
+        this.getJavaEnvValue("ejbRemove");
+    }
+
+    /**
+     * Insert the method's description here.
+     * Creation date: (09/21/2000 4:04:36 PM)
+     */
+    public void printMsg(String msg) {
+        svLogger.info("  " + BeanName + " : " + msg);
+    }
+
+    /**
+     * Echo the input string plus the key string
+     */
+    public String echoRequired(String str) {
+        return str + ":" + getPKey();
+    }
+}

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/src/com/ibm/ws/ejbcontainer/exception2x/ejb/SFRaHome.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/src/com/ibm/ws/ejbcontainer/exception2x/ejb/SFRaHome.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2003, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.exception2x.ejb;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.CreateException;
+import javax.ejb.EJBHome;
+
+/**
+ * Home interface for Enterprise Bean: SFRa
+ */
+public interface SFRaHome extends EJBHome {
+    /**
+     * Creates an instance from a key for Entity Bean: SFRa
+     */
+    public SFRa create(String pKey, int intValue, String stringValue) throws CreateException, RemoteException;
+}

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/src/com/ibm/ws/ejbcontainer/exception2x/ejb/TestEx.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/src/com/ibm/ws/ejbcontainer/exception2x/ejb/TestEx.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2003, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.exception2x.ejb;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.EJBObject;
+
+/**
+ * This is an Enterprise Java Bean Remote Interface
+ */
+public interface TestEx extends EJBObject {
+    public int addMore(int i) throws RemoteException;
+
+    public void throwRuntimeException(String s) throws RemoteException;
+
+    public void throwTransactionRequiredException(String s) throws RemoteException;
+
+    public void throwTransactionRolledbackException(String s) throws RemoteException;
+
+    public void throwInvalidTransactionException(String s) throws RemoteException;
+
+    public void throwAccessException(String s) throws RemoteException;
+
+    public void throwActivityRequiredException(String s) throws RemoteException;
+
+    public void throwInvalidActivityException(String s) throws RemoteException;
+
+    public void throwActivityCompletedException(String s) throws RemoteException;
+
+    public void throwNoSuchObjectException(String s) throws RemoteException;
+}

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/src/com/ibm/ws/ejbcontainer/exception2x/ejb/TestExBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/src/com/ibm/ws/ejbcontainer/exception2x/ejb/TestExBean.java
@@ -1,0 +1,263 @@
+/*******************************************************************************
+ * Copyright (c) 2003, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.exception2x.ejb;
+
+import java.rmi.AccessException;
+import java.rmi.NoSuchObjectException;
+import java.rmi.RemoteException;
+import java.util.logging.Logger;
+
+import javax.activity.ActivityCompletedException;
+import javax.activity.ActivityRequiredException;
+import javax.activity.InvalidActivityException;
+import javax.ejb.CreateException;
+import javax.ejb.RemoveException;
+import javax.ejb.SessionBean;
+import javax.ejb.SessionContext;
+import javax.transaction.InvalidTransactionException;
+import javax.transaction.TransactionRequiredException;
+import javax.transaction.TransactionRolledbackException;
+
+/**
+ * This is an Entity Bean class with CMP fields
+ */
+@SuppressWarnings({ "null", "serial", "unused" })
+public class TestExBean implements SessionBean {
+    private static final String CLASS_NAME = TestExBean.class.getName();
+    private static final Logger svLogger = Logger.getLogger(CLASS_NAME);
+
+    private SessionContext sessionContext = null;
+    public int i_value;
+
+    /**
+     * ejbActivate method comment
+     *
+     * @exception RemoteException The exception description.
+     */
+    @Override
+    public void ejbActivate() throws RemoteException {
+    }
+
+    /**
+     * ejbCreate method
+     *
+     * @param value int
+     * @exception CreateException The exception description.
+     */
+    public void ejbCreate(int value) throws CreateException {
+        i_value = value;
+    }
+
+    /**
+     * ejbCreate method
+     *
+     * @param argId int
+     * @param d1 int
+     * @exception CreateException The exception description.
+     */
+    public void ejbCreate(int argId, int d1) throws CreateException {
+        ejbCreate(argId);
+        throw new NullPointerException("ejbCreate throwing NPE.");
+    }
+
+    /**
+     * ejbPassivate method comment
+     *
+     * @exception RemoteException The exception description.
+     */
+    @Override
+    public void ejbPassivate() throws RemoteException {
+    }
+
+    /**
+     * ejbRemove method comment
+     *
+     * @exception RemoteException The exception description.
+     * @exception RemoveException The exception description.
+     */
+    @Override
+    public void ejbRemove() throws RemoteException {
+    }
+
+    /**
+     * getSessionContext method comment
+     *
+     * @return SessionContext
+     */
+    public SessionContext getSessionContext() {
+        return sessionContext;
+    }
+
+    /**
+     * setSessionContext method comment
+     *
+     * @param ctx SessionContext
+     * @exception RemoteException The exception description.
+     */
+    @Override
+    public void setSessionContext(SessionContext ctx) throws RemoteException {
+        sessionContext = ctx;
+    }
+
+    /**
+     * unsetSessionContext method comment
+     *
+     * @exception RemoteException The exception description.
+     */
+    public void unsetSessionContext() throws RemoteException {
+        sessionContext = null;
+    }
+
+    /*
+     * -----
+     */
+    public int addMore(int moreValue) {
+        return i_value + moreValue;
+    }
+
+    /*
+     * -----
+     */
+    public void ejbHomeMyHomeMethod(int value) throws RemoteException {
+        // do something with value
+        svLogger.info("I am in myHomeMethod(" + value + ")");
+    }
+
+    /**
+     * throwNoSuchObjectException method comment
+     *
+     * @exception NoSuchObjectException
+     */
+    public void throwNoSuchObjectException(String s) throws RemoteException {
+        throw new NoSuchObjectException(s);
+    }
+
+    /**
+     * throwRuntimeException method comment
+     *
+     * @exception RuntimeException
+     */
+    public void throwRuntimeException(String s) throws RemoteException {
+        throw new RuntimeException(s);
+    }
+
+    /**
+     * throwTransactionRequiredException method comment
+     *
+     * @exception TransactionRequiredException
+     */
+    public void throwTransactionRequiredException(String s) throws RemoteException {
+        try {
+            Object o = null;
+            String x = o.toString();
+        } catch (NullPointerException npe) {
+            TransactionRequiredException ex = new TransactionRequiredException(s);
+            ex.detail = npe;
+            throw ex;
+        }
+    }
+
+    /**
+     * throwTransactionRolledbackException method comment
+     *
+     * @exception TransactionRolledbackException
+     */
+    public void throwTransactionRolledbackException(String s) throws RemoteException {
+        try {
+            Object o = null;
+            String x = o.toString();
+        } catch (NullPointerException npe) {
+            TransactionRolledbackException ex = new TransactionRolledbackException(s);
+            ex.detail = npe;
+            throw ex;
+        }
+    }
+
+    /**
+     * throwInvalidTransactionException method comment
+     *
+     * @exception InvalidTransactionException
+     */
+    public void throwInvalidTransactionException(String s) throws RemoteException {
+        try {
+            Object o = null;
+            String x = o.toString();
+        } catch (NullPointerException npe) {
+            InvalidTransactionException ex = new InvalidTransactionException(s);
+            ex.detail = npe;
+            throw ex;
+        }
+    }
+
+    /**
+     * throwAccessException method comment
+     *
+     * @exception AccessException
+     */
+    public void throwAccessException(String s) throws RemoteException {
+        try {
+            Object o = null;
+            String x = o.toString();
+        } catch (NullPointerException npe) {
+            AccessException ex = new AccessException(s);
+            ex.detail = npe;
+            throw ex;
+        }
+    }
+
+    /**
+     * throwActivityRequiredException method comment
+     *
+     * @exception ActivityRequiredException
+     */
+    public void throwActivityRequiredException(String s) throws RemoteException {
+        try {
+            Object o = null;
+            String x = o.toString();
+        } catch (NullPointerException npe) {
+            ActivityRequiredException ex = new ActivityRequiredException(s);
+            ex.detail = npe;
+            throw ex;
+        }
+    }
+
+    /**
+     * throwInvalidActivityException method comment
+     *
+     * @exception InvalidActivityException
+     */
+    public void throwInvalidActivityException(String s) throws RemoteException {
+        try {
+            Object o = null;
+            String x = o.toString();
+        } catch (NullPointerException npe) {
+            InvalidActivityException ex = new InvalidActivityException(s);
+            ex.detail = npe;
+            throw ex;
+        }
+    }
+
+    /**
+     * throwActivityCompletedException method comment
+     *
+     * @exception ActivityCompletedException
+     */
+    public void throwActivityCompletedException(String s) throws RemoteException {
+        try {
+            Object o = null;
+            String x = o.toString();
+        } catch (NullPointerException npe) {
+            ActivityCompletedException ex = new ActivityCompletedException(s);
+            ex.detail = npe;
+            throw ex;
+        }
+    }
+}

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/src/com/ibm/ws/ejbcontainer/exception2x/ejb/TestExHome.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/src/com/ibm/ws/ejbcontainer/exception2x/ejb/TestExHome.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2003, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.exception2x.ejb;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.CreateException;
+import javax.ejb.EJBHome;
+
+/**
+ * This is a Home interface for the Entity Bean
+ */
+public interface TestExHome extends EJBHome {
+    public TestEx create(int value) throws CreateException, RemoteException;
+
+    /**
+     * This create method will throw a NullPointerException during ejbCreate
+     */
+    public TestEx create(int value, int dummy) throws CreateException, RemoteException;
+}

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/src/com/ibm/ws/ejbcontainer/exception2x/ejb/TestExLItf.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/src/com/ibm/ws/ejbcontainer/exception2x/ejb/TestExLItf.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2003, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.exception2x.ejb;
+
+import javax.ejb.EJBLocalObject;
+
+/**
+ * This is an Enterprise Java Bean Local Interface
+ */
+public interface TestExLItf extends EJBLocalObject {
+    public int addMore(int i);
+
+    public void throwRuntimeException(String s);
+
+    public void throwTransactionRequiredException(String s);
+
+    public void throwTransactionRolledbackException(String s);
+
+    public void throwInvalidTransactionException(String s);
+
+    public void throwAccessException(String s);
+
+    public void throwActivityRequiredException(String s);
+
+    public void throwInvalidActivityException(String s);
+
+    public void throwActivityCompletedException(String s);
+
+    public void throwNoSuchObjectException(String s);
+}

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/src/com/ibm/ws/ejbcontainer/exception2x/ejb/TestExLItfHome.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xBean.jar/src/com/ibm/ws/ejbcontainer/exception2x/ejb/TestExLItfHome.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2003, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.exception2x.ejb;
+
+import javax.ejb.CreateException;
+import javax.ejb.EJBLocalHome;
+
+/**
+ * This is a Local Home interface for the Entity Bean
+ */
+public interface TestExLItfHome extends EJBLocalHome {
+    public TestExLItf create(int value) throws CreateException;
+
+    /**
+     * This create method will throw a NullPointerException during ejbCreate
+     */
+    public TestExLItf create(int value, int dummy) throws CreateException;
+}

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xWeb.war/resources/WEB-INF/ibm-web-bnd.xmi
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xWeb.war/resources/WEB-INF/ibm-web-bnd.xmi
@@ -1,0 +1,3 @@
+<webappbnd:WebAppBinding xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:webappbnd="webappbnd.xmi" xmlns:webapplication="webapplication.xmi" xmi:id="WebAppBinding_1" virtualHostName="default_host">
+	<webapp href="WEB-INF/web.xml#WebApp"/>
+</webappbnd:WebAppBinding>

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xWeb.war/resources/WEB-INF/ibm-web-ext.xmi
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xWeb.war/resources/WEB-INF/ibm-web-ext.xmi
@@ -1,0 +1,9 @@
+<webappext:WebAppExtension xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:webappext="webappext.xmi" xmlns:webapplication="webapplication.xmi" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmi:id="WebAppExtension_1"
+  reloadInterval="3"
+  reloadingEnabled="true"
+  additionalClassPath=""
+  fileServingEnabled="true"
+  directoryBrowsingEnabled="false"
+  serveServletsByClassnameEnabled="true">
+	<webApp href="WEB-INF/web.xml#WebApp"/>
+</webappext:WebAppExtension>

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xWeb.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xWeb.war/resources/WEB-INF/web.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
+<web-app id="WebApp">
+	<display-name>Exception2xWeb</display-name>
+	<servlet>
+		<servlet-name>Exception2xServlet</servlet-name>
+		<servlet-class>com.ibm.ws.ejbcontainer.exception2x.web.Exception2xServlet</servlet-class>
+	</servlet>
+	<servlet-mapping>
+		<servlet-name>Exception2xServlet</servlet-name>
+		<url-pattern>/Exception2xServlet</url-pattern>
+	</servlet-mapping>
+	<servlet>
+		<servlet-name>LifecycleMethod2xServlet</servlet-name>
+		<servlet-class>com.ibm.ws.ejbcontainer.exception2x.web.LifecycleMethod2xServlet</servlet-class>
+	</servlet>
+	<servlet-mapping>
+		<servlet-name>LifecycleMethod2xServlet</servlet-name>
+		<url-pattern>/LifecycleMethod2xServlet</url-pattern>
+	</servlet-mapping>
+</web-app>

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xWeb.war/src/com/ibm/ws/ejbcontainer/exception2x/web/Exception2xServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xWeb.war/src/com/ibm/ws/ejbcontainer/exception2x/web/Exception2xServlet.java
@@ -1,0 +1,550 @@
+/*******************************************************************************
+ * Copyright (c) 2003, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.exception2x.web;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.InvocationTargetException;
+import java.rmi.AccessException;
+import java.rmi.NoSuchObjectException;
+import java.rmi.RemoteException;
+import java.rmi.ServerException;
+import java.util.logging.Logger;
+
+import javax.activity.ActivityCompletedException;
+import javax.activity.ActivityRequiredException;
+import javax.activity.InvalidActivityException;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.ejb.AccessLocalException;
+import javax.ejb.EJBException;
+import javax.ejb.NoSuchObjectLocalException;
+import javax.ejb.TransactionRequiredLocalException;
+import javax.ejb.TransactionRolledbackLocalException;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.rmi.PortableRemoteObject;
+import javax.servlet.annotation.WebServlet;
+import javax.transaction.InvalidTransactionException;
+import javax.transaction.TransactionRequiredException;
+import javax.transaction.TransactionRolledbackException;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.omg.CORBA.portable.UnknownException;
+
+import com.ibm.ejs.container.InvalidTransactionLocalException;
+import com.ibm.ws.ejbcontainer.exception2x.ejb.TestEx;
+import com.ibm.ws.ejbcontainer.exception2x.ejb.TestExHome;
+import com.ibm.ws.ejbcontainer.exception2x.ejb.TestExLItf;
+import com.ibm.ws.ejbcontainer.exception2x.ejb.TestExLItfHome;
+
+import componenttest.annotation.ExpectedFFDC;
+import componenttest.app.FATServlet;
+
+/**
+ * <dl>
+ * <dt>Test Name:
+ * <dd>Exception2xTest
+ *
+ * <dt>Test Descriptions:
+ * <dd>Exception test for EJB 2.x beans.
+ *
+ * <dt>Command options:
+ * <dd>None
+ * <TABLE width="100%">
+ * <COL span="1" width="25%" align="left"> <COL span="1" align="left">
+ * <TBODY>
+ * <TR> <TH>Option</TH> <TH>Description</TH> </TR>
+ * <TR> <TD>-option 1</TD>
+ * <TD>Option 1 descriptions.</TD>
+ * </TR>
+ * </TBODY>
+ * </TABLE>
+ *
+ * <dt>Test Matrix:
+ * <dd>
+ * </dl>
+ */
+@SuppressWarnings("serial")
+@WebServlet("/Exception2xServlet")
+public class Exception2xServlet extends FATServlet {
+    private static final String CLASS_NAME = Exception2xServlet.class.getName();
+    private static final Logger svLogger = Logger.getLogger(CLASS_NAME);
+
+    protected static TestExHome beanHome;
+    protected static TestExLItfHome beanLocalHome;
+
+    private static TestEx beanRef = null;
+    private static TestExLItf beanLocalRef = null;
+
+    @PostConstruct
+    private void initializeBeans() {
+        try {
+            beanHome = (TestExHome) PortableRemoteObject.narrow(new InitialContext().lookup("java:app/Exception2xBean/ExceptionEJB!com.ibm.ws.ejbcontainer.exception2x.ejb.TestExHome"),
+                                                                TestExHome.class);
+            beanLocalHome = (TestExLItfHome) new InitialContext().lookup("java:app/Exception2xBean/ExceptionEJB!com.ibm.ws.ejbcontainer.exception2x.ejb.TestExLItfHome");
+
+            // create EJB instance
+            svLogger.info("Create EJB instance");
+            beanRef = beanHome.create(1);
+
+            // create Local EJB instance
+            svLogger.info("Create EJB instance");
+            beanLocalRef = beanLocalHome.create(2);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @PreDestroy
+    private void removeBeans() {
+        try {
+            if (beanRef != null) {
+                beanRef.remove();
+            }
+
+            if (beanLocalRef != null) {
+                beanLocalRef.remove();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * @testName: test1
+     *
+     * @assertion: An EJB method can throw a runtimeException. When that happens
+     *             the client should receive a ServerException with a UncheckedException
+     *             nested inside and the RuntimeException nested inside that.
+     * @test_Strategy: Call the bean method that throws the RuntimeException.
+     */
+    @Test
+    @ExpectedFFDC({ "java.lang.RuntimeException" })
+    public void testRemoteRuntimeException() throws Exception {
+        try {
+            beanRef.throwRuntimeException("test1");
+            fail("Expected RuntimeException not thrown.");
+        } catch (ServerException e) {
+            svLogger.info("Expected ServerException caught = " + e);
+        } finally {
+            // recreate EJB instance
+            svLogger.info("Recreate EJB instance");
+            beanRef = beanHome.create(1);
+        }
+    }
+
+    /**
+     * @testName: test2
+     * @assertion: An EJB method can throw a TransactionRequiredException().
+     *             When that happens the client should receive a TransactionRequiredException().
+     * @test_Strategy: Call the bean method that throws the TransactionRequiredException().
+     */
+    @Test
+    @ExpectedFFDC({ "javax.transaction.TransactionRequiredException" })
+    public void testRemoteTransactionRequiredException() throws Exception {
+        try {
+            beanRef.throwTransactionRequiredException("test2");
+            fail("Expected TransactionRequiredException not thrown.");
+        } catch (TransactionRequiredException e) {
+            svLogger.info("Expected TransactionRequiredException caught : " + e);
+        } finally {
+            // recreate EJB instance
+            svLogger.info("Recreate EJB instance");
+            beanRef = beanHome.create(1);
+        }
+    }
+
+    /**
+     * @testName: test3
+     * @assertion: An EJB method can throw a TransactionRolledbackException.
+     *             When that happens the client should receive a TransactionRolledbackException.
+     * @test_Strategy: Call the bean method that throws the TransactionRolledbackException.
+     */
+    @Test
+    @ExpectedFFDC({ "javax.transaction.TransactionRolledbackException" })
+    public void testRemoteTransactionRolledbackException() throws Exception {
+        try {
+            beanRef.throwTransactionRolledbackException("test3");
+            fail("Expected TransactionRolledbackException not thrown.");
+        } catch (TransactionRolledbackException e) {
+            svLogger.info("Expected TransactionRolledbackException caught : " + e);
+        } finally {
+            // recreate EJB instance
+            svLogger.info("Recreate EJB instance");
+            beanRef = beanHome.create(1);
+        }
+    }
+
+    /**
+     * @testName: test4
+     * @assertion: An EJB method can throw a InvalidTransactionException.
+     *             When that happens the client should receive a InvalidTransactionException.
+     * @test_Strategy: Call the bean method that throws the InvalidTransactionException.
+     */
+    @Test
+    @ExpectedFFDC({ "javax.transaction.InvalidTransactionException" })
+    public void testRemoteInvalidTransactionException() throws Exception {
+        try {
+            beanRef.throwInvalidTransactionException("test4");
+            fail("Expected InvalidTransactionException not thrown.");
+        } catch (InvalidTransactionException e) {
+            svLogger.info("Expected InvalidTransactionException caught : " + e);
+        } finally {
+            // recreate EJB instance
+            svLogger.info("Recreate EJB instance");
+            beanRef = beanHome.create(1);
+        }
+    }
+
+    /**
+     * @testName: test5
+     * @assertion: An EJB method can throw a AccessException.
+     *             When that happens the client should receive a AccessException.
+     * @test_Strategy: Call the bean method that throws the AccessException.
+     */
+    @Test
+    @ExpectedFFDC({ "java.rmi.AccessException" })
+    public void testRemoteAccessException() throws Exception {
+        try {
+            beanRef.throwAccessException("test4");
+            fail("Expected AccessException not thrown.");
+        } catch (AccessException e) {
+            svLogger.info("Expected AccessException caught : " + e);
+        } finally {
+            // recreate EJB instance
+            svLogger.info("Recreate EJB instance");
+            beanRef = beanHome.create(1);
+        }
+    }
+
+    /**
+     * @testName: test1
+     * @assertion: An EJB method can throw an ActivityRequiredException.
+     *             When that happens the client should receive a ActivityRequiredException.
+     * @test_Strategy: Call the bean method that throws the ActivityRequiredException.
+     */
+    @Ignore
+    @Test
+    public void testRemoteActivityRequiredException() throws Exception {
+        try {
+            beanRef.throwActivityRequiredException("test6");
+            fail("Expected ActivityRequiredException not thrown.");
+        } catch (ActivityRequiredException e) {
+            svLogger.info("Expected ActivityRequiredException caught : " + e);
+        }
+    }
+
+    /**
+     * @testName: test7
+     * @assertion: An EJB method can throw an InvalidActivityException..
+     *             When that happens the client should receive a InvalidActivityException.
+     * @test_Strategy: Call the bean method that throws the InvalidActivityException.
+     */
+    @Ignore
+    @Test
+    public void testRemoteInvalidActivityException() throws Exception {
+        try {
+            beanRef.throwInvalidActivityException("test7");
+            fail("Expected InvalidActivityException not thrown.");
+        } catch (InvalidActivityException e) {
+            svLogger.info("Expected InvalidActivityException caught : " + e);
+        }
+    }
+
+    /**
+     * @testName: test8
+     * @assertion: An EJB method can throw an ActivityCompletedException.
+     *             When that happens the client should receive a ActivityCompletedException.
+     * @test_Strategy: Call the bean method that throws the ActivityCompletedException.
+     */
+    @Ignore
+    @Test
+    public void testRemoteActivityCompletedException() throws Exception {
+        try {
+            beanRef.throwActivityCompletedException("test8");
+            fail("Expected ActivityCompletedException not thrown.");
+        } catch (ActivityCompletedException e) {
+            svLogger.info("Expected ActivityCompletedException caught : " + e);
+        }
+    }
+
+    /**
+     * @testName: test9
+     * @assertion: An EJB method can throw a NoSuchObjectException.
+     *             When that happens the client should receive a NoSuchObjectException.
+     * @test_Strategy: Call the bean method that throws the NoSuchObjectException.
+     */
+    @Test
+    @ExpectedFFDC({ "java.rmi.NoSuchObjectException" })
+    public void testRemoteNoSuchObjectException() throws Exception {
+        try {
+            beanRef.throwNoSuchObjectException("test9");
+            fail("Expected NoSuchObjectException not thrown.");
+        } catch (NoSuchObjectException e) {
+            svLogger.info("Expected NoSuchObjectException caught : " + e);
+        } finally {
+            // recreate EJB instance
+            svLogger.info("Recreate EJB instance");
+            beanRef = beanHome.create(1);
+        }
+    }
+
+    /**
+     * @testName: test18
+     * @assertion: A Local EJB method can throw a RuntimeException.
+     *             When that happens the client should receive an EJBException.
+     * @test_Strategy: Call the bean method that throws the RuntimeException.
+     */
+    @Test
+    @ExpectedFFDC({ "java.lang.RuntimeException" })
+    public void testLocalRuntimeException() throws Exception {
+        try {
+            beanLocalRef.throwRuntimeException("test18");
+            fail("Expected EJBException not thrown.");
+        } catch (EJBException e) {
+            svLogger.info("Expected EJBException caught : " + e);
+        } finally {
+            // recreate local EJB instance
+            svLogger.info("Recreate local EJB instance");
+            beanLocalRef = beanLocalHome.create(2);
+        }
+    }
+
+    /**
+     * @testName: test19
+     * @assertion: A Local EJB method can throw a TransactionRequiredException.
+     *             When that happens the client should receive a TransactionRequiredLocalException.
+     * @test_Strategy: Call the bean method that throws the TransactionRequiredException.
+     */
+    @Test
+    @ExpectedFFDC({ "javax.transaction.TransactionRequiredException" })
+    public void testLocalTransactionRequiredLocalException() throws Exception {
+        try {
+            beanLocalRef.throwTransactionRequiredException("test19");
+            fail("Expected TransactionRequiredException not thrown.");
+        } catch (TransactionRequiredLocalException e) {
+            svLogger.info("Expected TransactionRequiredLocalException caught : " + e);
+        } finally {
+            // recreate local EJB instance
+            svLogger.info("Recreate local EJB instance");
+            beanLocalRef = beanLocalHome.create(2);
+        }
+    }
+
+    /**
+     * @testName: test20
+     * @assertion: A Local EJB method can throw a TransactionRolledbackException.
+     *             When that happens the client should receive a TransactionRolledbackLocalException.
+     * @test_Strategy: Call the bean method that throws the TransactionRolledbackException.
+     */
+    @Test
+    @ExpectedFFDC({ "javax.transaction.TransactionRolledbackException" })
+    public void testLocalTransactionRolledbackLocalException() throws Exception {
+        try {
+            beanLocalRef.throwTransactionRolledbackException("test20");
+            fail("Expected TransactionRolledbackLocalException not thrown.");
+        } catch (TransactionRolledbackLocalException e) {
+            svLogger.info("Expected TransactionRolledbackLocalException caught : " + e);
+        } finally {
+            // recreate local EJB instance
+            svLogger.info("Recreate local EJB instance");
+            beanLocalRef = beanLocalHome.create(2);
+        }
+    }
+
+    /**
+     * @testName: test21
+     * @assertion: A Local EJB method can throw a InvalidTransactionException.
+     *             When that happens the client should receive a InvalidTransactionLocalException.
+     * @test_Strategy: Call the bean method that throws the InvalidTransactionException.
+     */
+    @Test
+    @ExpectedFFDC({ "javax.transaction.InvalidTransactionException" })
+    public void testLocalInvalidTransactionLocalException() throws Exception {
+        try {
+            beanLocalRef.throwInvalidTransactionException("test21");
+            fail("Expected InvalidTransactionLocalException not thrown.");
+        } catch (InvalidTransactionLocalException e) {
+            svLogger.info("Expected InvalidTransactionLocalException caught : " + e);
+        } finally {
+            // recreate local EJB instance
+            svLogger.info("Recreate local EJB instance");
+            beanLocalRef = beanLocalHome.create(2);
+        }
+    }
+
+    /**
+     * @testName: test22
+     * @assertion: A Local EJB method can throw a AccessException.
+     *             When that happens the client should receive a AccessLocalException.
+     * @test_Strategy: Call the bean method that throws the AccessException.
+     */
+    @Test
+    @ExpectedFFDC({ "java.rmi.AccessException" })
+    public void testLocalAccessLocalException() throws Exception {
+        try {
+            beanLocalRef.throwAccessException("test22");
+            fail("Expected AccessLocalException not thrown.");
+        } catch (AccessLocalException e) {
+            svLogger.info("Expected AccessLocalException caught : " + e);
+        } finally {
+            // recreate local EJB instance
+            svLogger.info("Recreate local EJB instance");
+            beanLocalRef = beanLocalHome.create(2);
+        }
+    }
+
+    /**
+     * @testName: test23
+     * @assertion: A local EJB method can throw a ActivityRequiredException.
+     *             When that happens the client should receive a ActivityRequiredLocalException.
+     * @test_Strategy: Call the bean method that throws the ActivityRequiredException.
+     */
+    @Ignore
+    @Test
+    public void testLocalActivityRequiredLocalException() throws Exception {
+//        try {
+        beanLocalRef.throwActivityRequiredException("test23");
+        fail("Expected ActivityRequiredLocalException not thrown.");
+//        } catch (ActivityRequiredLocalException e) {
+//            svLogger.info("Expected ActivityRequiredLocalException caught : " + e);
+//        }
+    }
+
+    /**
+     * @testName: test24
+     * @assertion: A Local EJB method can throw a InvalidActivityException.
+     *             When that happens the client should receive a InvalidActivityLocalException.
+     * @test_Strategy: Call the bean method that throws the InvalidActivityException.
+     */
+    @Ignore
+    @Test
+    public void testLocalInvalidActivityLocalException() throws Exception {
+//        try {
+        beanLocalRef.throwInvalidActivityException("test24");
+        fail("Expected InvalidActivityLocalException not thrown.");
+//        } catch (InvalidActivityLocalException e) {
+//            svLogger.info("Expected InvalidActivityLocalException caught : " + e);
+//        }
+    }
+
+    /**
+     * @testName: test25
+     * @assertion: A Local EJB method can throw a ActivityCompletedException.
+     *             When that happens the client should receive a ActivityCompletedLocalException.
+     * @test_Strategy: Call the bean method that throws the ActivityCompletedException.
+     */
+    @Ignore
+    @Test
+    public void testLocalActivityCompletedLocalException() throws Exception {
+//        try {
+        beanLocalRef.throwActivityCompletedException("test25");
+        fail("Expected ActivityCompletedLocalException not thrown.");
+//        } catch (ActivityCompletedLocalException e) {
+//            svLogger.info("Expected ActivityCompletedLocalException caught : " + e);
+//        }
+    }
+
+    /**
+     * @testName: test26
+     * @assertion: A Local EJB method can throw a NoSuchObjectException.
+     *             When that happens the client should receive a NoSuchObjectLocalException.
+     * @test_Strategy: Call the bean method that throws the NoSuchObjectException.
+     */
+    @Test
+    @ExpectedFFDC({ "java.rmi.NoSuchObjectException" })
+    public void testLocalNoSuchObjectLocalException() throws Exception {
+        try {
+            beanLocalRef.throwNoSuchObjectException("test26");
+            fail("Expected NoSuchObjectLocalException not thrown.");
+        } catch (NoSuchObjectLocalException e) {
+            svLogger.info("Expected NoSuchObjectLocalException caught : " + e);
+        } finally {
+            // recreate local EJB instance
+            svLogger.info("Recreate local EJB instance");
+            beanLocalRef = beanLocalHome.create(2);
+        }
+    }
+
+    /**
+     * @testName: test35
+     * @assertion: A call to create on local home can result in a unchecked exception
+     *             occurring when ejbCreate is called. When that happens the client should
+     *             receive a EJBException that wrappers the unchecked exception that occurred.
+     * @test_Strategy: Call the create method on local home interface that causes
+     *                 ejbCreate to throw a NullPointerException.
+     */
+    @Test
+    @ExpectedFFDC({ "javax.ejb.EJBException", "com.ibm.ws.LocalTransaction.RolledbackException" })
+    public void testLocalEjbCreateNullPointerException() throws Exception {
+        try {
+            beanLocalHome.create(35, 1);
+            fail("No exception occured, one was expected.");
+        } catch (EJBException e) {
+            Exception ex = e.getCausedByException();
+            assertNotNull("EJBException wrappers unchecked exception", ex);
+            assertTrue("NPE was thrown", ex instanceof NullPointerException);
+        }
+    }
+
+    /**
+     * @testName: test37
+     * @assertion: A call to create on remote home can result in a unchecked exception
+     *             occurring when ejbCreate is called. When that happens the client should
+     *             receive a RemoteException that wrappers the unchecked exception that occurred.
+     * @test_Strategy: Call the create method on remote home interface that causes
+     *                 ejbCreate to throw a NullPointerException.
+     */
+    @Test
+    @ExpectedFFDC({ "com.ibm.ejs.container.CreateFailureException", "com.ibm.ws.LocalTransaction.RolledbackException" })
+    public void testRemoteEjbCreateNullPointerException() throws Exception {
+        try {
+            beanHome.create(37, 1);
+            fail("No exception occured, one was expected.");
+        } catch (RemoteException e) {
+            Throwable t = findRootThrowable(e);
+            assertNotNull("RemoteException wrappers unchecked exception", t);
+            assertTrue("NPE was thrown", t instanceof NullPointerException);
+        }
+    }
+
+    /**
+     * Return root cause of a remote exception.
+     */
+    private Throwable findRootThrowable(RemoteException t) {
+        Throwable root = null;
+        Throwable next = t;
+
+        while (next != null) {
+            root = next;
+
+            if (root instanceof RemoteException) {
+                next = ((RemoteException) root).detail;
+            } else if (root instanceof EJBException) {
+                next = ((EJBException) root).getCausedByException();
+            } else if (root instanceof NamingException) {
+                next = ((NamingException) root).getRootCause();
+            } else if (root instanceof InvocationTargetException) {
+                next = ((InvocationTargetException) root).getTargetException();
+            } else if (root instanceof UnknownException) {
+                next = ((UnknownException) root).originalEx;
+            } else {
+                next = null;
+            }
+        }
+
+        return root;
+    }
+}

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xWeb.war/src/com/ibm/ws/ejbcontainer/exception2x/web/LifecycleMethod2xServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/Exception2xWeb.war/src/com/ibm/ws/ejbcontainer/exception2x/web/LifecycleMethod2xServlet.java
@@ -1,0 +1,245 @@
+/*******************************************************************************
+ * Copyright (c) 2003, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.exception2x.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.rmi.RemoteException;
+import java.util.logging.Logger;
+
+import javax.annotation.PostConstruct;
+import javax.naming.InitialContext;
+import javax.rmi.PortableRemoteObject;
+import javax.servlet.annotation.WebServlet;
+import javax.transaction.UserTransaction;
+
+import org.junit.Test;
+
+import com.ibm.websphere.ejbcontainer.test.tools.FATHelper;
+import com.ibm.ws.ejbcontainer.exception2x.ejb.SFRa;
+import com.ibm.ws.ejbcontainer.exception2x.ejb.SFRaHome;
+
+import componenttest.annotation.ExpectedFFDC;
+import componenttest.app.FATServlet;
+
+/**
+ * <dl>
+ * <dt>Test Name:
+ * <dd>WWSTestEjbMthd_SFRTTest
+ *
+ * <dt>Test Descriptions:
+ * <dd>EJB Container Exception on EJB.ejbMethods tests:
+ *
+ * <dt>Command options:
+ * <dd>
+ * <TABLE width="100%">
+ * <COL span="1" width="25%" align="left"> <COL span="1" align="left">
+ * <TBODY>
+ * <TR> <TH>Option</TH> <TH>Description</TH> </TR>
+ * <TR> <TD>None</TD>
+ * <TD></TD>
+ * </TR>
+ * </TBODY>
+ * </TABLE>
+ *
+ * <dt>Test Matrix:
+ * <dd>
+ * <br>Sub-tests
+ * <ul>
+ * <li>ejbMthd_normal - No Exception
+ * <li>ejbMthd_create - Exception on ejbCreate
+ * <li>ejbMthd_postCreate - Exception on ejbPostCreate
+ * <li>ejbMthd_Remove - Exception on ejbRemove
+ * <li>PQ70353 - Run regression test, which includes all of the above tests.
+ * </ul>
+ * <br>Data Sources
+ * </dl>
+ */
+@SuppressWarnings("serial")
+@WebServlet("/LifecycleMethod2xServlet")
+public class LifecycleMethod2xServlet extends FATServlet {
+    private static final String CLASS_NAME = LifecycleMethod2xServlet.class.getName();
+    private static final Logger svLogger = Logger.getLogger(CLASS_NAME);
+
+    private static SFRaHome fhome1;
+
+    private static final String fksNormal = Integer.toString(SFRa.Normal);
+    private static SFRa fejbNormal;
+    private static final String fksCreate = Integer.toString(SFRa.Create);
+    private static SFRa fejbCreate;
+    private static final String fksPostCreate = Integer.toString(SFRa.PostCreate);
+    private static SFRa fejbPostCreate;
+    private static final String fksRemove = Integer.toString(SFRa.Remove);
+    private static SFRa fejbRemove;
+
+    @PostConstruct
+    private void initializeHome() {
+        try {
+            fhome1 = (SFRaHome) PortableRemoteObject.narrow(new InitialContext().lookup("java:app/Exception2xBean/SFRaEJB"), SFRaHome.class);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    //
+    // ejbMthd_normal - Normal call, no exception
+    //
+    @Test
+    public void testNormal() throws Exception {
+        svLogger.info("-----> ejbMthd_normal - Normal call, no exception - started.");
+        String pKey = "ejbMthd_normal_Key";
+        fejbNormal = null;
+        UserTransaction ut = null;
+        try {
+            fejbNormal = fhome1.create(fksNormal, SFRa.Normal, fksNormal);
+            assertNotNull("      Created ejb instance - normally", fejbNormal);
+
+            ut = FATHelper.lookupUserTransaction();
+            assertNotNull("      Get UserTransaction", ut);
+            ut.begin();
+
+            String echoString = fejbNormal.echoRequired(pKey);
+            assertEquals("      test echoRequired(" + pKey + ").", echoString, pKey + ":" + fksNormal);
+            assertEquals("      test getPKey().", fejbNormal.getPKey(), fksNormal);
+            assertEquals("      test getIntValue().", fejbNormal.getIntValue(), SFRa.Normal);
+            assertEquals("      test getStringValue().", fejbNormal.getStringValue(), fksNormal);
+        } finally {
+            FATHelper.cleanupUserTransaction(ut);
+            if (fejbNormal != null) {
+                fejbNormal.remove();
+                fejbNormal = null;
+            }
+        }
+        svLogger.info("<----- ejbMthd_normal - Normal call, no exception - ended.");
+    }
+
+    //
+    // ejbMthd_create - Exception thrown on ejbCreate
+    //
+    @Test
+    @ExpectedFFDC({ "com.ibm.ejs.container.CreateFailureException", "com.ibm.ws.LocalTransaction.RolledbackException" })
+    public void testCreate() throws Exception {
+        svLogger.info("-----> ejbMthd_create - Exception thrown on ejbCreate - started.");
+        String pKey = "ejbMthd_create_Key";
+        fejbNormal = null;
+        fejbCreate = null;
+        UserTransaction ut = null;
+        try {
+            fejbNormal = fhome1.create(pKey, SFRa.Normal, pKey);
+            assertNotNull("      Created ejb instance - normally", fejbNormal);
+            fejbCreate = fhome1.create(fksCreate, SFRa.Create, fksCreate);
+            fail("      Unexpected return from successfull create.");
+        } catch (RemoteException rex) {
+            String exString = rex.toString();
+            svLogger.info("      Caught expected " + rex.getClass().getName());
+            assertContains("      Check for CreateFailureException.", "com.ibm.ejs.container.CreateFailureException", exString);
+
+            ut = FATHelper.lookupUserTransaction();
+            assertNotNull("      Get UserTransaction", ut);
+            ut.begin();
+
+            String echoString = fejbNormal.echoRequired(pKey);
+            assertEquals("      test echoRequired( " + pKey + " ).", echoString, pKey + ":" + pKey);
+            assertEquals("      test getPKey().", fejbNormal.getPKey(), pKey);
+            assertEquals("      test getIntValue().", fejbNormal.getIntValue(), SFRa.Normal);
+            assertEquals("      test getStringValue().", fejbNormal.getStringValue(), pKey);
+        } finally {
+            FATHelper.cleanupUserTransaction(ut);
+
+            if (fejbNormal != null) {
+                fejbNormal.remove();
+                fejbNormal = null;
+            }
+
+            if (fejbCreate != null) {
+                fejbCreate.remove();
+                fejbCreate = null;
+            }
+        }
+        svLogger.info("<----- ejbMthd_create - Exception thrown on ejbCreate - ended.");
+    }
+
+    //
+    // ejbMthd_postCreate - Exception thrown on ejbPostCreate
+    //
+    @Test
+    public void testPostCreate() throws Exception {
+        svLogger.info("-----> ejbMthd_postCreate - Exception thrown on ejbPostCreate - started.");
+        String pKey = "ejbMthd_postCreate_Key";
+        fejbNormal = null;
+        fejbPostCreate = null;
+        UserTransaction ut = null;
+        try {
+            fejbNormal = fhome1.create(pKey, SFRa.Normal, pKey);
+            assertNotNull("      Created ejb instance - normally", fejbNormal);
+            fejbPostCreate = fhome1.create(fksPostCreate, SFRa.PostCreate, fksPostCreate);
+            assertNotNull("      Created ejb instance - normally", fejbPostCreate);
+            ut = FATHelper.lookupUserTransaction();
+            assertNotNull("      Get UserTransaction", ut);
+            ut.begin();
+
+            String echoString = fejbNormal.echoRequired(pKey);
+            assertEquals("      test normal.echoRequired( " + pKey + " ).", echoString, pKey + ":" + pKey);
+            assertEquals("      test getPKey().", fejbNormal.getPKey(), pKey);
+            assertEquals("      test getIntValue().", fejbNormal.getIntValue(), SFRa.Normal);
+            assertEquals("      test getStringValue().", fejbNormal.getStringValue(), pKey);
+
+            echoString = fejbPostCreate.echoRequired(pKey);
+            assertEquals("      test postCreate.echoRequired( " + pKey + " ).", echoString, pKey + ":" + fksPostCreate);
+            assertEquals("      test getPKey().", fejbPostCreate.getPKey(), fksPostCreate);
+            assertEquals("      test getIntValue().", fejbPostCreate.getIntValue(), SFRa.PostCreate);
+            assertEquals("      test getStringValue().", fejbPostCreate.getStringValue(), fksPostCreate);
+        } finally {
+            FATHelper.cleanupUserTransaction(ut);
+            if (fejbNormal != null) {
+                fejbNormal.remove();
+                fejbNormal = null;
+            }
+            if (fejbPostCreate != null) {
+                fejbPostCreate.remove();
+                fejbPostCreate = null;
+            }
+        }
+        svLogger.info("<----- ejbMthd_postCreate - Exception thrown on ejbPostCreate - ended.");
+    }
+
+    //
+    // ejbMthd_remove - Exception thrown on ejbRemove
+    //
+    @Test
+    @ExpectedFFDC({ "java.lang.RuntimeException" })
+    public void testRemove() throws Exception {
+        svLogger.info("-----> ejbMthd_remove - Exception thrown on ejbRemove - started.");
+        String pKey = "ejbMthd_Remove_Key";
+        fejbRemove = null;
+        try {
+            fejbRemove = fhome1.create(pKey, SFRa.Remove, fksRemove);
+            assertNotNull("      Created ejb instance - normally", fejbRemove);
+            fejbRemove.remove();
+            svLogger.info("      Return successfully from remove().");
+            fejbRemove = null;
+        } finally {
+            if (fejbRemove != null) {
+                fejbRemove.remove();
+                fejbRemove = null;
+            }
+        }
+        svLogger.info("<----- ejbMthd_remove - Exception thrown on ejbRemove - ended.");
+    }
+
+    private static void assertContains(String message, String expected, String actual) {
+        if (actual == null || actual.indexOf(expected) == -1) {
+            fail("String \"" + actual + "\" does not contain \"" + expected + "\"");
+        }
+    }
+}


### PR DESCRIPTION
New EJB FAT that covers exception handling in EJB 2.x modules.
Will run for Java EE 7 & 8 as well as Jakarta 9.

for #13717 