### PR TITLE
Remove the mail-2.0 implementation from the API private feature

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.mail-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.mail-2.0.feature
@@ -8,8 +8,7 @@ IBM-Process-Types: client, \
 -features=com.ibm.websphere.appserver.eeCompatible-9.0, \
   io.openliberty.jakarta.activation-2.0
 -bundles=\
-  io.openliberty.jakarta.mail.2.0;location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.mail:jakarta.mail-api:2.0.0",\
-   io.openliberty.com.sun.mail.jakarta.mail.2.0
+  io.openliberty.jakarta.mail.2.0;location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.mail:jakarta.mail-api:2.0.0"
 kind=beta
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mail-2.0/io.openliberty.mail-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mail-2.0/io.openliberty.mail-2.0.feature
@@ -29,6 +29,7 @@ IBM-API-Package: \
   com.ibm.websphere.appserver.injection-2.0, \
   io.openliberty.jakarta.activation-2.0
 -bundles=\
+  io.openliberty.com.sun.mail.jakarta.mail.2.0, \
   io.openliberty.mail.2.0.internal, \
   com.ibm.ws.javamail.config
 -jars=io.openliberty.mail.2.0.thirdparty; location:=dev/api/third-party/; mavenCoordinates="com.sun.mail:jakarta.mail:2.0.0"


### PR DESCRIPTION
- Update to remove com.sun.mail implementation bundle from the io.openliberty.jakarta.mail-2.0 feature and include it with the mail-2.0 public feature.