### PR TITLE
wsscxf saml.5 fat remove split

### DIFF
--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken5/OneServerTests/CxfSAMLAsymSignEnc1ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken5/OneServerTests/CxfSAMLAsymSignEnc1ServerTests.java
@@ -13,6 +13,8 @@ package com.ibm.ws.wssecurity.fat.cxf.samltoken5.OneServerTests;
 
 import java.util.ArrayList;
 import java.util.List;
+//issue 18363
+import java.util.Set;
 
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -87,5 +89,13 @@ public class CxfSAMLAsymSignEnc1ServerTests extends CxfSAMLAsymSignEncTests {
         testSettings.setSpTargetApp(testSAMLServer.getHttpString() + "/samlcxfclient/CxfSamlSvcClient");
         testSettings.setSamlTokenValidationData(testSettings.getIdpUserName(), testSettings.getSamlTokenValidationData().getIssuer(), testSettings.getSamlTokenValidationData().getInResponseTo(), testSettings.getSamlTokenValidationData().getMessageID(), testSettings.getSamlTokenValidationData().getEncryptionKeyUser(), testSettings.getSamlTokenValidationData().getRecipient(), testSettings.getSamlTokenValidationData().getEncryptAlg());
 
+        //issue 18363
+        Set<String> features = testSAMLServer.getServer().getServerConfiguration().getFeatureManager().getFeatures();
+        if (features.contains("jaxws-2.2")) {
+            setFeatureVersion("EE7");
+        } else if (features.contains("jaxws-2.3")) {
+            setFeatureVersion("EE8");
+        } // End of 18363
+        
      }
 }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken5/OneServerTests/CxfSAMLSymSignEnc1ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken5/OneServerTests/CxfSAMLSymSignEnc1ServerTests.java
@@ -15,6 +15,8 @@ import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 
 import java.util.ArrayList;
 import java.util.List;
+//issue 18363
+import java.util.Set;
 
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -88,6 +90,13 @@ public class CxfSAMLSymSignEnc1ServerTests extends CxfSAMLSymSignEncTests {
         testSettings.setSpTargetApp(testSAMLServer.getHttpString() + "/samlcxfclient/CxfSamlSvcClient");
         testSettings.setSamlTokenValidationData(testSettings.getIdpUserName(), testSettings.getSamlTokenValidationData().getIssuer(), testSettings.getSamlTokenValidationData().getInResponseTo(), testSettings.getSamlTokenValidationData().getMessageID(), testSettings.getSamlTokenValidationData().getEncryptionKeyUser(), testSettings.getSamlTokenValidationData().getRecipient(), testSettings.getSamlTokenValidationData().getEncryptAlg());
 
-                
+        //issue 18363
+        Set<String> features = testSAMLServer.getServer().getServerConfiguration().getFeatureManager().getFeatures();
+        if (features.contains("jaxws-2.2")) {
+            setFeatureVersion("EE7");
+        } else if (features.contains("jaxws-2.3")) {
+            setFeatureVersion("EE8");
+        } // End of 18363
+        
     }
 }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken5/TwoServerTests/CxfSAMLAsymSignEnc2ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken5/TwoServerTests/CxfSAMLAsymSignEnc2ServerTests.java
@@ -15,6 +15,8 @@ import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 
 import java.util.ArrayList;
 import java.util.List;
+//issue 18363
+import java.util.Set;
 
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -104,6 +106,13 @@ public class CxfSAMLAsymSignEnc2ServerTests extends CxfSAMLAsymSignEncTests {
         testSettings.setSpTargetApp(testSAMLServer.getHttpString() + "/samlcxfclient/CxfSamlSvcClient");
         testSettings.setSamlTokenValidationData(testSettings.getIdpUserName(), testSettings.getSamlTokenValidationData().getIssuer(), testSettings.getSamlTokenValidationData().getInResponseTo(), testSettings.getSamlTokenValidationData().getMessageID(), testSettings.getSamlTokenValidationData().getEncryptionKeyUser(), testSettings.getSamlTokenValidationData().getRecipient(), testSettings.getSamlTokenValidationData().getEncryptAlg());
 
+        //issue 18363
+        Set<String> features = testSAMLServer.getServer().getServerConfiguration().getFeatureManager().getFeatures();
+        if (features.contains("jaxws-2.2")) {
+            setFeatureVersion("EE7");
+        } else if (features.contains("jaxws-2.3")) {
+            setFeatureVersion("EE8");
+        } // End of 18363
                 
     }
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken5/TwoServerTests/CxfSAMLSymSignEnc2ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken5/TwoServerTests/CxfSAMLSymSignEnc2ServerTests.java
@@ -15,6 +15,8 @@ import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 
 import java.util.ArrayList;
 import java.util.List;
+//issue 18363
+import java.util.Set;
 
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -106,7 +108,14 @@ public class CxfSAMLSymSignEnc2ServerTests extends CxfSAMLSymSignEncTests {
         testSettings.setSpTargetApp(testSAMLServer.getHttpString() + "/samlcxfclient/CxfSamlSvcClient");
         testSettings.setSamlTokenValidationData(testSettings.getIdpUserName(), testSettings.getSamlTokenValidationData().getIssuer(), testSettings.getSamlTokenValidationData().getInResponseTo(), testSettings.getSamlTokenValidationData().getMessageID(), testSettings.getSamlTokenValidationData().getEncryptionKeyUser(), testSettings.getSamlTokenValidationData().getRecipient(), testSettings.getSamlTokenValidationData().getEncryptAlg());
 
-                
+        //issue 18363
+        Set<String> features = testSAMLServer.getServer().getServerConfiguration().getFeatureManager().getFeatures();
+        if (features.contains("jaxws-2.2")) {
+            setFeatureVersion("EE7");
+        } else if (features.contains("jaxws-2.3")) {
+            setFeatureVersion("EE8");
+        } // End of 18363
+        
     }
 
 }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken5/common/CxfSAMLAsymSignEncTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken5/common/CxfSAMLAsymSignEncTests.java
@@ -22,17 +22,13 @@ import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
 
 import componenttest.annotation.SkipForRepeat;
 
-import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServerWrapper;
-import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
-import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 import componenttest.rules.repeater.EmptyAction;
-import componenttest.rules.repeater.EE8FeatureReplacementAction;
 
 
 /**
@@ -61,7 +57,18 @@ public class CxfSAMLAsymSignEncTests extends SAMLCommonTest {
     protected static String servicePort = null;
     protected static String serviceSecurePort = null;
     protected static CXFSAMLCommonUtils commonUtils = new CXFSAMLCommonUtils();
+    //issue 18363
+    protected static String featureVersion = "";
 
+    //issue 18363
+    public static String getFeatureVersion() {
+        return featureVersion;
+    }
+    
+    public static void setFeatureVersion(String version) {
+        featureVersion = version;
+    } //End of issue 18363
+    
     /**
      * TestDescription:
      * 
@@ -76,34 +83,20 @@ public class CxfSAMLAsymSignEncTests extends SAMLCommonTest {
      * 
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    public void testSAMLCXFSignedSupportingTokens_AsymmmetricEE7Only() throws Exception {
-        
-    	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+    public void testSAMLCXFSignedSupportingTokens_Asymmmetric() throws Exception {
 
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLAsymSignService",
-                "SAMLAsymSignPort", "", "False", null, null);
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_ASYM_SIGN_SERVICE));
-
-    }
-
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @Test
-    public void testSAMLCXFSignedSupportingTokens_AsymmmetricEE8Only() throws Exception {
-
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-    		//2 servers reconfig
-    		testSAMLServer2.reconfigServer("server_2_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} 
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                //1 server reconfig
+    		    testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    } else {
+    		    //2 servers reconfig
+    		    testSAMLServer2.reconfigServer("server_2_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    		    testSAMLServer.reconfigServer("server_1_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    } 
+    	} //End of 18363   
     	
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
@@ -121,36 +114,22 @@ public class CxfSAMLAsymSignEncTests extends SAMLCommonTest {
      * The client uses a policy that does not specify that the request be signed
      * The test should fail since the policy can not be satisfied
      */
-    
-    @SkipForRepeat({ EE8_FEATURES })
+ 
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
-    public void testSAMLCXFSignedSupportingTokens_Asymmmetric_ClientNotSignedEE7Only() throws Exception {
-        
-    	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+    public void testSAMLCXFSignedSupportingTokens_Asymmmetric_ClientNotSigned() throws Exception {
 
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLAsymSignService",
-                "SAMLAsymSignPort", "", "False", null, commonUtils.processClientWsdl("ClientAsymOmitSign.wsdl", servicePort));
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_SERVICE_CLIENT_NOT_SIGN));
-
-    }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @Test
-    public void testSAMLCXFSignedSupportingTokens_Asymmmetric_ClientNotSignedEE8Only() throws Exception {
-
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-    		//2 servers reconfig
-    		testSAMLServer2.reconfigServer("server_2_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} 
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                //1 server reconfig
+    		    testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    } else {
+    		    //2 servers reconfig
+    		    testSAMLServer2.reconfigServer("server_2_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    		    testSAMLServer.reconfigServer("server_1_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    }
+    	} //End of 18363   
     	
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
@@ -159,39 +138,30 @@ public class CxfSAMLAsymSignEncTests extends SAMLCommonTest {
         updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLAsymSignService",
                 "SAMLAsymSignPort", "", "False", null, commonUtils.processClientWsdl("ClientAsymOmitSign.wsdl", servicePort));
 
-        //@AV999, the client sends a signed supporting token even though the policy says supporting token? is this just with saml token or any supporting token? TODO
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_ASYM_SIGN_SERVICE));
-
+        //issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    		genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_SERVICE_CLIENT_NOT_SIGN));
+    	} else if ("EE8".equals(getFeatureVersion())) {
+           //@AV999, the client sends a signed supporting token even though the policy says supporting token? is this just with saml token or any supporting token? TODO
+           genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_ASYM_SIGN_SERVICE));
+    	} //End of 18363
+    	
     }
-
-    @SkipForRepeat({ EE8_FEATURES })
-    @Test
-    public void testSAMLCXFEncryptedSupportingTokens_AsymmmetricEE7Only() throws Exception {
-        
-    	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLAsymEncrService",
-                "SAMLAsymEncrPort", "", "False", null, null);
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_ASYM_ENCR_SERVICE));
-
-    }
-
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @Test
-    public void testSAMLCXFEncryptedSupportingTokens_AsymmmetricEE8Only() throws Exception {
     
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-    		//2 servers reconfig
-    		testSAMLServer2.reconfigServer("server_2_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} 
+    @Test
+    public void testSAMLCXFEncryptedSupportingTokens_Asymmmetric() throws Exception {
+    
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                //1 server reconfig
+    		    testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    } else {
+    		    //2 servers reconfig
+    		    testSAMLServer2.reconfigServer("server_2_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    		    testSAMLServer.reconfigServer("server_1_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    }
+    	} //End of 18363   
     	
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
@@ -209,36 +179,22 @@ public class CxfSAMLAsymSignEncTests extends SAMLCommonTest {
      * The client uses a policy that does not specify that the request be encrypted
      * The test should fail since the policy can not be satisfied
      */
-    
-    @SkipForRepeat({ EE8_FEATURES })
+
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
-    public void testSAMLCXFEncryptedSupportingTokens_Asymmmetric_ClientNotEncryptedEE7Only() throws Exception {
-        
-    	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+    public void testSAMLCXFEncryptedSupportingTokens_Asymmmetric_ClientNotEncrypted() throws Exception {
 
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLAsymEncrService",
-                "SAMLAsymEncrPort", "", "False", null, commonUtils.processClientWsdl("ClientAsymOmitEncr.wsdl", servicePort));
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_ENCR_SERVICE_CLIENT_NOT_ENCR));
-
-    }
-
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
-    @Test
-    public void testSAMLCXFEncryptedSupportingTokens_Asymmmetric_ClientNotEncryptedEE8Only() throws Exception {
-
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-    		//2 servers reconfig
-    	    testSAMLServer2.reconfigServer("server_2_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} 
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                //1 server reconfig
+    		    testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    } else {
+    		    //2 servers reconfig
+    	        testSAMLServer2.reconfigServer("server_2_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    		    testSAMLServer.reconfigServer("server_1_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    }
+    	}//End of 18363   
     	
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
@@ -251,34 +207,20 @@ public class CxfSAMLAsymSignEncTests extends SAMLCommonTest {
 
     }
     
-    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    public void testSAMLCXFSignedEncryptedSupportingTokens_AsymmmetricEE7Only() throws Exception {
-
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLAsymSignEncrService",
-                "SAMLAsymSignEncrPort", "", "False", null, null);
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_ASYM_SIGN_ENCR_SERVICE));
-
-    }
-
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @Test
-    public void testSAMLCXFSignedEncryptedSupportingTokens_AsymmmetricEE8Only() throws Exception {
+    public void testSAMLCXFSignedEncryptedSupportingTokens_Asymmmetric() throws Exception {
     	
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-    		//2 servers reconfig
-    	    testSAMLServer2.reconfigServer("server_2_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} 
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                //1 server reconfig
+    		    testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    } else {
+    		    //2 servers reconfig
+    	        testSAMLServer2.reconfigServer("server_2_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    		    testSAMLServer.reconfigServer("server_1_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    }
+    	}//End of 18363   
     	
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
@@ -297,34 +239,21 @@ public class CxfSAMLAsymSignEncTests extends SAMLCommonTest {
      * The test should fail since the policy can not be satisfied
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
-    public void testSAMLCXFSignedEncryptedSupportingTokens_Asymmmetric_ClientNotEncryptedEE7Only() throws Exception {
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+    public void testSAMLCXFSignedEncryptedSupportingTokens_Asymmmetric_ClientNotEncrypted() throws Exception {
 
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLAsymSignEncrService",
-                "SAMLAsymSignEncrPort", "", "False", null, commonUtils.processClientWsdl("ClientAsymOmitEncrKeepSign.wsdl", servicePort));
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
-
-    }
-
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @Test
-    public void testSAMLCXFSignedEncryptedSupportingTokens_Asymmmetric_ClientNotEncryptedEE8Only() throws Exception {
-
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-    		//2 servers reconfig
-    		testSAMLServer2.reconfigServer("server_2_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	}
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                //1 server reconfig
+    		    testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    } else {
+    		    //2 servers reconfig
+    		    testSAMLServer2.reconfigServer("server_2_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    		    testSAMLServer.reconfigServer("server_1_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    }
+    	}//End of 18363   
     	
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
@@ -343,35 +272,21 @@ public class CxfSAMLAsymSignEncTests extends SAMLCommonTest {
      * The test should fail since the policy can not be satisfied
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
-    public void testSAMLCXFSignedEncryptedSupportingTokens_Asymmmetric_ClientNotSignedEE7Only() throws Exception {
-        
-    	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+    public void testSAMLCXFSignedEncryptedSupportingTokens_Asymmmetric_ClientNotSigned() throws Exception {
 
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLAsymSignEncrService",
-                "SAMLAsymSignEncrPort", "", "False", null, commonUtils.processClientWsdl("ClientAsymOmitSignKeepEncr.wsdl", servicePort));
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
-
-    }
-
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @Test
-    public void testSAMLCXFSignedEncryptedSupportingTokens_Asymmmetric_ClientNotSignedEE8Only() throws Exception {
-
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-    		//2 servers reconfig
-    	    testSAMLServer2.reconfigServer("server_2_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} 
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                //1 server reconfig
+    		    testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    } else {
+    		    //2 servers reconfig
+    	        testSAMLServer2.reconfigServer("server_2_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    		    testSAMLServer.reconfigServer("server_1_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    }
+    	}//End of 18363   
     	
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
@@ -380,38 +295,30 @@ public class CxfSAMLAsymSignEncTests extends SAMLCommonTest {
         updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLAsymSignEncrService",
                 "SAMLAsymSignEncrPort", "", "False", null, commonUtils.processClientWsdl("ClientAsymOmitSignKeepEncr.wsdl", servicePort));
 
-        //@AV999 TODO need to check whether the new runtime is correct in implementing the policy
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_ASYM_SIGN_ENCR_SERVICE));
-
+        //issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    		genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
+    	} else if ("EE8".equals(getFeatureVersion())) {
+            //@AV999 TODO need to check whether the new runtime is correct in implementing the policy
+            genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_ASYM_SIGN_ENCR_SERVICE));
+    	}//End of 18363
+    	
     }
     
-    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    public void testSAMLCXFSignedEncryptedAsyncSupportingTokens_AsymmmetricEE7Only() throws Exception {
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+    public void testSAMLCXFSignedEncryptedAsyncSupportingTokens_Asymmmetric() throws Exception {
 
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLAsyncX509Service",
-                "SAMLAsyncX509Port", "", "False", null, null);
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_ASYNC_ENCR_SERVICE));
-
-    }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @Test
-    public void testSAMLCXFSignedEncryptedAsyncSupportingTokens_AsymmmetricEE8Only() throws Exception {
-
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-    		//2 servers reconfig
-    		testSAMLServer2.reconfigServer("server_2_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} 
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                //1 server reconfig
+    		    testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_AsymSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    } else {
+    		    //2 servers reconfig
+    		    testSAMLServer2.reconfigServer("server_2_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    		    testSAMLServer.reconfigServer("server_1_AsymSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    }
+    	}//End of 18363   
     	
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken5/common/CxfSAMLSymSignEncTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken5/common/CxfSAMLSymSignEncTests.java
@@ -20,18 +20,15 @@ import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
-import componenttest.annotation.AllowedFFDC;
+
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServerWrapper;
-import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
-import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 import componenttest.rules.repeater.EmptyAction;
-import componenttest.rules.repeater.EE8FeatureReplacementAction;
 
 /**
  * The testcases in this class were ported from tWAS' test SamlWebSSOTests.
@@ -59,7 +56,18 @@ public class CxfSAMLSymSignEncTests extends SAMLCommonTest {
     protected static String servicePort = null;
     protected static String serviceSecurePort = null;
     protected static CXFSAMLCommonUtils commonUtils = new CXFSAMLCommonUtils();
+    //issue 18363
+    protected static String featureVersion = "";
 
+    //issue 18363
+    public static String getFeatureVersion() {
+        return featureVersion;
+    }
+    
+    public static void setFeatureVersion(String version) {
+        featureVersion = version;
+    } //End of issue 18363
+    
     /**
      * TestDescription:
      * 
@@ -74,34 +82,20 @@ public class CxfSAMLSymSignEncTests extends SAMLCommonTest {
      * 
      */
     
-    @SkipForRepeat({ EE8_FEATURES })
     @Test
-    public void testSAMLCXFSignedSupportingTokens_SymmmetricEE7Only() throws Exception {
-    	
-    	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLSymSignService",
-                "SAMLSymSignPort", "", "False", null, null);
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_SERVICE));
-
-    }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
-    @Test
-    public void testSAMLCXFSignedSupportingTokens_SymmmetricEE8Only() throws Exception {
+    public void testSAMLCXFSignedSupportingTokens_Symmmetric() throws Exception {
         
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_symSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-            //2 servers reconfig
-    		testSAMLServer2.reconfigServer("server_2_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} 
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                //1 server reconfig
+    		    testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_symSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    } else {
+                //2 servers reconfig
+    		    testSAMLServer2.reconfigServer("server_2_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    		    testSAMLServer.reconfigServer("server_1_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    }
+    	}//End of 18363   
     	
     	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
@@ -120,37 +114,23 @@ public class CxfSAMLSymSignEncTests extends SAMLCommonTest {
      * The test should fail since the policy can not be satisfied */
     
     //3/2021 @AV999 - even though the client policy does not have SignedSupportingTokens, 
-    //the saml token is signed by default with the new runtime and making the request processing successful at the provider
-     
-    @SkipForRepeat({ EE8_FEATURES })
-    @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @Test   
-    public void testSAMLCXFSignedSupportingTokens_Symmmetric_ClientNotSignedEE7Only() throws Exception {
-    	
-    	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLSymSignService",
-                "SAMLSymSignPort", "", "False", null, commonUtils.processClientWsdl("ClientSymOmitSign.wsdl", servicePort));
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_SERVICE_CLIENT_NOT_SIGN));
-
-    }
+    //the saml token is signed by default with the new runtime and making the request processing successful at the provider   
     
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })
+    @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
-    public void testSAMLCXFSignedSupportingTokens_Symmmetric_ClientNotSignedEE8Only() throws Exception {
+    public void testSAMLCXFSignedSupportingTokens_Symmmetric_ClientNotSigned() throws Exception {
 
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_symSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-    		//2 servers reconfig
-    		testSAMLServer2.reconfigServer("server_2_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} 
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                //1 server reconfig
+    		    testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_symSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    } else {
+    		    //2 servers reconfig
+    		    testSAMLServer2.reconfigServer("server_2_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    		    testSAMLServer.reconfigServer("server_1_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    }
+    	}//End of 18363   
     	
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
@@ -159,14 +139,29 @@ public class CxfSAMLSymSignEncTests extends SAMLCommonTest {
         updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLSymSignService",
                 "SAMLSymSignPort", "", "False", null, commonUtils.processClientWsdl("ClientSymOmitSign.wsdl", servicePort));
 
-        //@AV999
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_SERVICE));
-        
-    }
-   
-    @SkipForRepeat({ EE8_FEATURES })
+        //issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    		genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_SERVICE_CLIENT_NOT_SIGN));
+    	} else if ("EE8".equals(getFeatureVersion())) {
+            genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_SERVICE));
+    	}//End of 18363
+    	
+    } 
+    
     @Test
-    public void testSAMLCXFEncryptedSupportingTokens_SymmmetricEE7Only() throws Exception {
+    public void testSAMLCXFEncryptedSupportingTokens_Symmmetric() throws Exception {
+    
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                //1 server reconfig
+    		    testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_symSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    } else {
+    	        //2 servers reconfig
+    		    testSAMLServer2.reconfigServer("server_2_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    		    testSAMLServer.reconfigServer("server_1_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    }
+    	}//End of 18363   
     	
     	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
@@ -178,153 +173,87 @@ public class CxfSAMLSymSignEncTests extends SAMLCommonTest {
         genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_ENCR_SERVICE));
 
     }
+    
+    /*
+     * In the test, the server side policy requires that the request be encrypted.
+     * The client uses a policy that does not specify that the request be encrypted
+     * The test should fail since the policy can not be satisfied
+     */
+    
+    @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
+    @Test
+    public void testSAMLCXFEncryptedSupportingTokens_Symmmetric_ClientNotEncrypted() throws Exception {
+    	
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                //1 server reconfig
+    		    testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_symSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    } else {
+    	        //2 servers reconfig
+       	        testSAMLServer2.reconfigServer("server_2_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	        testSAMLServer.reconfigServer("server_1_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    }
+    	}//End of 18363   
+    	
+    	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+
+        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
+        updatedTestSettings.updatePartnerInSettings("sp1", true);
+        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLSymEncrService",
+                "SAMLSymEncrPort", "", "False", null, commonUtils.processClientWsdl("ClientSymOmitEncr.wsdl", servicePort));
+
+        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_ENCR_SERVICE_CLIENT_NOT_ENCR));
+
+    }
+    
+    @Test
+    public void testSAMLCXFSignedEncryptedSupportingTokens_Symmmetric() throws Exception {
+    	
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                //1 server reconfig
+    		    testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_symSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    } else {
+    	        //2 servers reconfig
+    		    testSAMLServer2.reconfigServer("server_2_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    		    testSAMLServer.reconfigServer("server_1_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    }
+    	}//End of 18363   
+    	
+    	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+
+        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
+        updatedTestSettings.updatePartnerInSettings("sp1", true);
+        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLSymSignEncrService",
+                "SAMLSymSignEncrPort", "", "False", null, null);
+
+        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE));
+
+    }
+    
+    /*
+     * In the test, the server side policy requires that the request be encrypted.
+     * The client uses a policy that does not specify that the request be encrypted
+     * The test should fail since the policy can not be satisfied
+     */
   
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
-    @Test
-    public void testSAMLCXFEncryptedSupportingTokens_SymmmetricEE8Only() throws Exception {
-    
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_symSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-    	    //2 servers reconfig
-    		testSAMLServer2.reconfigServer("server_2_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} 
-    	
-    	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLSymEncrService",
-                "SAMLSymEncrPort", "", "False", null, null);
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_ENCR_SERVICE));
-
-    }
-    
-    /*
-     * In the test, the server side policy requires that the request be encrypted.
-     * The client uses a policy that does not specify that the request be encrypted
-     * The test should fail since the policy can not be satisfied
-     */
-    
-    @SkipForRepeat({ EE8_FEATURES })
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
-    public void testSAMLCXFEncryptedSupportingTokens_Symmmetric_ClientNotEncryptedEE7Only() throws Exception {
-    	
-    	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLSymEncrService",
-                "SAMLSymEncrPort", "", "False", null, commonUtils.processClientWsdl("ClientSymOmitEncr.wsdl", servicePort));
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_ENCR_SERVICE_CLIENT_NOT_ENCR));
-
-    }
-
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })  
-    @Test
-    public void testSAMLCXFEncryptedSupportingTokens_Symmmetric_ClientNotEncryptedEE8Only() throws Exception {
-    	
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_symSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-    	    //2 servers reconfig
-    	testSAMLServer2.reconfigServer("server_2_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	testSAMLServer.reconfigServer("server_1_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} 
-    	
-    	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLSymEncrService",
-                "SAMLSymEncrPort", "", "False", null, commonUtils.processClientWsdl("ClientSymOmitEncr.wsdl", servicePort));
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_ENCR_SERVICE_CLIENT_NOT_ENCR));
-
-    }
+    public void testSAMLCXFSignedEncryptedSupportingTokens_Symmmetric_ClientNotEncrypted() throws Exception {
     
-    @SkipForRepeat({ EE8_FEATURES })
-    @Test
-    public void testSAMLCXFSignedEncryptedSupportingTokens_SymmmetricEE7Only() throws Exception {
-    	
-    	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLSymSignEncrService",
-                "SAMLSymSignEncrPort", "", "False", null, null);
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE));
-
-    }
-
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
-    @Test
-    public void testSAMLCXFSignedEncryptedSupportingTokens_SymmmetricEE8Only() throws Exception {
-    	
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_symSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-    	    //2 servers reconfig
-    		testSAMLServer2.reconfigServer("server_2_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} 
-    	
-    	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLSymSignEncrService",
-                "SAMLSymSignEncrPort", "", "False", null, null);
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE));
-
-    }
-    
-    /*
-     * In the test, the server side policy requires that the request be encrypted.
-     * The client uses a policy that does not specify that the request be encrypted
-     * The test should fail since the policy can not be satisfied
-     */
-    
-    @SkipForRepeat({ EE8_FEATURES })
-    @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
-    @Test
-    public void testSAMLCXFSignedEncryptedSupportingTokens_Symmmetric_ClientNotEncryptedEE7Only() throws Exception {
-    	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLSymSignEncrService",
-                "SAMLSymSignEncrPort", "", "False", null, commonUtils.processClientWsdl("ClientSymOmitEncrKeepSign.wsdl", servicePort));
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
-
-    }
-    
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID }) 
-    @Test
-    public void testSAMLCXFSignedEncryptedSupportingTokens_Symmmetric_ClientNotEncryptedEE8Only() throws Exception {
-    
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_symSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-    		//2 servers reconfig
-    		testSAMLServer2.reconfigServer("server_2_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} 
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                //1 server reconfig
+    		    testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_symSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    } else {
+    		    //2 servers reconfig
+    		    testSAMLServer2.reconfigServer("server_2_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    		    testSAMLServer.reconfigServer("server_1_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    }
+    	}//End of 18363   
     	
     	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
@@ -347,36 +276,22 @@ public class CxfSAMLSymSignEncTests extends SAMLCommonTest {
     //3/2021 @AV999 - client policy specifies EncryptedSupportingTokens, provider expects SignedEncryptedSupportingTokens. 
     //Looks like with the new runtime the saml tokens are signed by default.
     //This change causes the test to complete the message exchange successful between client and providers
-      
-    @SkipForRepeat({ EE8_FEATURES })
+    
     @ExpectedFFDC(value = { "org.apache.ws.security.WSSecurityException" }, repeatAction = { EmptyAction.ID })
     @Test
-    public void testSAMLCXFSignedEncryptedSupportingTokens_Symmmetric_ClientNotSignedEE7Only() throws Exception {
-    	
-    	WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+    public void testSAMLCXFSignedEncryptedSupportingTokens_Symmmetric_ClientNotSigned() throws Exception {
 
-        SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.updatePartnerInSettings("sp1", true);
-        updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLSymSignEncrService",
-                "SAMLSymSignEncrPort", "", "False", null, commonUtils.processClientWsdl("ClientSymOmitSignKeepEncr.wsdl", servicePort));
-
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
-        
-    }
-
-    @SkipForRepeat({ NO_MODIFICATION })
-    @AllowedFFDC(value = { "java.net.MalformedURLException" }, repeatAction = { EE8FeatureReplacementAction.ID })  
-    @Test
-    public void testSAMLCXFSignedEncryptedSupportingTokens_Symmmetric_ClientNotSignedEE8Only() throws Exception {
-
-    	if (testSAMLServer2 == null) {
-            //1 server reconfig
-    		testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_symSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} else {
-    		//2 servers reconfig
-    		testSAMLServer2.reconfigServer("server_2_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    		testSAMLServer.reconfigServer("server_1_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
-    	} 
+    	//issue 18363
+    	if ("EE8".equals(getFeatureVersion())) {
+    	    if (testSAMLServer2 == null) {
+                //1 server reconfig
+    		    testSAMLServer.reconfigServer(buildSPServerName("server_2_in_1_symSignEnc_wss4j.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    } else {
+    		    //2 servers reconfig
+    		    testSAMLServer2.reconfigServer("server_2_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    		    testSAMLServer.reconfigServer("server_1_symSignEnc_wss4j.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+    	    }
+    	}//End of 18363   
     	
         WebClient webClient = SAMLCommonTestHelpers.getWebClient();
 
@@ -385,8 +300,13 @@ public class CxfSAMLSymSignEncTests extends SAMLCommonTest {
         updatedTestSettings.setCXFSettings(_testName, null, servicePort, null, null, null, "SAMLSymSignEncrService",
                 "SAMLSymSignEncrPort", "", "False", null, commonUtils.processClientWsdl("ClientSymOmitSignKeepEncr.wsdl", servicePort));
       
-        genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE));
-
+        //issue 18363
+    	if ("EE7".equals(getFeatureVersion())) {
+    		genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE_CLIENT_NOT_SIGN_OR_ENCR));
+    	} else if ("EE8".equals(getFeatureVersion())) {
+            genericSAML(_testName, webClient, updatedTestSettings, standardFlow, helpers.setDefaultGoodSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_SYM_SIGN_ENCR_SERVICE));
+    	}//End of 18363
+    	
     }
   
 }


### PR DESCRIPTION
Update com.ibm.ws.wssecurity_fat.wsscxf.saml.5 to remove the split (EE7Only/EE8Only)


