### PR TITLE
Fix build break caused by PR #18320

### DIFF
--- a/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
@@ -29,7 +29,10 @@ tested.features: mpOpenApi-2.0,\
                  componenttest-2.0,\
                  appSecurity-4.0,\
                  messaging-3.0,\
-                 connectors-2.0
+                 connectors-2.0,\
+                 appsecurity-3.0,\
+                 cdi-2.0,\
+                 el-3.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.2;version=latest,\


### PR DESCRIPTION
PR #18320 changed the definition of the MP repeat tests which now changes server configuratoins to run with appSecurity-3.0.  As a result, the com.ibm.ws.rest.handler.validator_fat tests now fails due to not having appSecurity-3.0 and its dependent public features in the tested.features list.