### PR TITLE
Update to use the new capabilities in MicroProfileAction

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
@@ -261,6 +261,34 @@ public class MicroProfileActions {
     private static final FeatureSet[] ALL_SETS_ARRAY = { MP10, MP12, MP13, MP14, MP20, MP21, MP22, MP30, MP32, MP33, MP40, MP41, MP50 };
     public static final Set<FeatureSet> ALL = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(ALL_SETS_ARRAY)));
 
+    private static final String[] STANDALONE8_FEATURES_ARRAY = { "mpContextPropagation-1.0",
+                                                                 "mpContextPropagation-1.2",
+                                                                 "mpGraphQL-1.0",
+                                                                 "mpLRA-1.0",
+                                                                 "mpLRACoordinator-1.0",
+                                                                 "mpReactiveMessaging-1.0",
+                                                                 "mpReactiveStreams-1.0" };
+
+    private static final String[] STANDALONE9_FEATURES_ARRAY = { "mpContextPropagation-1.3" };
+//                                                                 "mpGraphQL-2.0",
+//                                                                 "mpLRA-2.0",
+//                                                                 "mpLRACoordinator-2.0",
+//                                                                 "mpReactiveMessaging-3.0",
+//                                                                 "mpReactiveStreams-2.0" };
+
+    private static final Set<String> STANDALONE8_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(STANDALONE8_FEATURES_ARRAY)));
+    private static final Set<String> STANDALONE9_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(STANDALONE9_FEATURES_ARRAY)));
+
+    public static final String STANDALONE8_ID = EE8FeatureReplacementAction.ID + "_STANDALONE";
+    public static final String STANDALONE9_ID = JakartaEE9Action.ID + "_STANDALONE";
+
+    public static final FeatureSet MP_STANDALONE8 = new FeatureSet(STANDALONE8_ID, STANDALONE8_FEATURE_SET, EEVersion.EE8);
+    public static final FeatureSet MP_STANDALONE9 = new FeatureSet(STANDALONE9_ID, STANDALONE9_FEATURE_SET, EEVersion.EE9);
+
+    //All MicroProfile Standalone FeatureSets
+    private static final FeatureSet[] ALL_STANDALONE_SETS_ARRAY = { MP_STANDALONE8, MP_STANDALONE9 };
+    public static final Set<FeatureSet> STANDALONE_ALL = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(ALL_STANDALONE_SETS_ARRAY)));
+
     /**
      * Get a RepeatTests instance for all MP versions. The LATEST will be run in LITE mode. The others will be run in FULL.
      *

--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9FeatureCompatibilityTest.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9FeatureCompatibilityTest.java
@@ -48,7 +48,9 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.EE7FeatureReplacementAction;
 import componenttest.rules.repeater.EE8FeatureReplacementAction;
+import componenttest.rules.repeater.EERepeatTests.EEVersion;
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.FeatureSet;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.topology.impl.LibertyServer;
@@ -122,34 +124,18 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
         nonEE9JavaEEFeatures.remove("ejbTest-1.0");
         nonEE9JavaEEFeatures.remove("ejbTest-2.0");
 
-        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP10.getFeatures());
-        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP12.getFeatures());
-        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP13.getFeatures());
-        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP14.getFeatures());
-        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP20.getFeatures());
-        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP21.getFeatures());
-        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP22.getFeatures());
-        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP30.getFeatures());
-        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP32.getFeatures());
-        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP33.getFeatures());
-        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP40.getFeatures());
-        nonEE9MicroProfileFeatures.addAll(MicroProfileActions.MP41.getFeatures());
-
-        // Add the MP convenience features as well
-        String[] mpVersions = { "1.0", "1.2", "1.3", "1.4", "2.0", "2.1", "2.2", "3.0",
-                                "3.2", "3.3", "4.0", "4.1" };
-        for (String mpVersion : mpVersions) {
-            nonEE9MicroProfileFeatures.add("microProfile-" + mpVersion);
+        for (FeatureSet mpFeatureSet : MicroProfileActions.ALL) {
+            if (mpFeatureSet.getEEVersion() != EEVersion.EE9) {
+                nonEE9MicroProfileFeatures.addAll(mpFeatureSet.getFeatures());
+            }
         }
 
         // MP standalone features
-        nonEE9MicroProfileFeatures.add("mpContextPropagation-1.0");
-        nonEE9MicroProfileFeatures.add("mpContextPropagation-1.2");
-        nonEE9MicroProfileFeatures.add("mpGraphQL-1.0");
-        nonEE9MicroProfileFeatures.add("mpLRA-1.0");
-        nonEE9MicroProfileFeatures.add("mpLRACoordinator-1.0");
-        nonEE9MicroProfileFeatures.add("mpReactiveMessaging-1.0");
-        nonEE9MicroProfileFeatures.add("mpReactiveStreams-1.0");
+        for (FeatureSet mpFeatureSet : MicroProfileActions.STANDALONE_ALL) {
+            if (mpFeatureSet.getEEVersion() != EEVersion.EE9) {
+                nonEE9MicroProfileFeatures.addAll(mpFeatureSet.getFeatures());
+            }
+        }
 
         incompatibleValueAddFeatures.add("jwtSso-1.0"); // depends on mpJWT
         incompatibleValueAddFeatures.add("openid-2.0"); // stabilized


### PR DESCRIPTION
- This PR resolves a review comment from Tom Watson in PR #18272. It now incorporate the new capabilities introduced by Tom Evens in PR #18320
- Update to use the EEVersion state in the MP FeatureSets in order to not have to list each MicroProfile feature level.
- Add a new set of FeatureSets for the MP standalone features.