### PR TITLE
mpContextPropagation-1.3 TCK with mpConfig-3.0 for Jakarta EE 9

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/servers/tckServerForMPContextPropagation13/server.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/servers/tckServerForMPContextPropagation13/server.xml
@@ -14,7 +14,7 @@
         <feature>componenttest-2.0</feature>
         <feature>localConnector-1.0</feature>
         <feature>cdi-3.0</feature>
-        <!-- <feature>mpConfig-3.0</feature> TODO requires feature to be added -->
+        <feature>mpConfig-3.0</feature>
         <feature>mpContextPropagation-1.3</feature>
         <feature>arquillian-support-jakarta-2.0</feature>
     </featureManager>

--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -12,7 +12,7 @@
         <packages>
             <package name="org.eclipse.microprofile.context.tck.*"/>
         </packages>
-        <!-- TODO remove once mpConfig-3.0 feature supporting jakarta packages is added -->
+        <!-- This was used to exclude tests prior to mpConfig-3.0 being available
         <classes>
             <class name="org.eclipse.microprofile.context.tck.MPConfigTest">
                 <methods>
@@ -23,5 +23,6 @@
                 </methods>
             </class>
         </classes>
+        -->
     </test>
 </suite>


### PR DESCRIPTION
With mpConfig-3.0 available in pre-release form, we can enable TCK tests for mpContextPropagation-1.3 that require it.