### PR TITLE
CRIU: Fix .pid file on restore. Block restore when server running.

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -26,6 +26,10 @@
 #              background via the start action. 
 #              The default value is console.log
 #
+# CRIU_LOG_LEVEL - Set the log level of criu restore operation.
+#TODO need to reflect this to criu checkpoint
+#                  Set to 1-4 with 4 being max verbosity. Two "2" is the default.
+#
 # PID_DIR    - The directory that should be used for server pid file(s).
 #              The default value is ${WLP_OUTPUT_DIR}/.pid
 #
@@ -58,6 +62,10 @@
 # WLP_DEBUG_REMOTE - Whether to allow remote debugging or not. This can be set
 #              to y to allow remote debugging. By default, this value is not
 #              defined, which does not allow remote debugging on newer JDK/JREs.
+#
+# WLP_IN_CONTAINER - Set to true to signal that the script is being invoked from
+#              a container. If true, certain code will be optimized out where it 
+#              does not make sense to be run in container.
 #
 # WLP_SKIP_UMASK -  Skip setting the umask value to allow the default value 
 #              to be used.
@@ -390,7 +398,6 @@ serverStatus()
     if serverPIDStatus && $1; then
       return 0
     fi
-
     # The workarea suggests a started server.  Either the script started a
     # server process that ended before removing .sCommand, or the server was
     # started without using the script (so the PID file was never created).
@@ -864,7 +871,6 @@ javaCmd()
       CHECKPOINT_AT="features"
     fi
     REMAINING_ARGS="$REMAINING_ARGS --internal-checkpoint-at=$CHECKPOINT_AT"
-    # TODO remove below option once JVM handles it automatically
     JVM_OPTIONS_QUOTED="$JVM_OPTIONS_QUOTED -XX:+EnableCRIUSupport"
   fi
   
@@ -915,6 +921,7 @@ javaCmd()
     rc=$?
     kill $TAIL_PID
     backupWorkarea
+    rm -f "${SERVER_OUTPUT_DIR}/workarea/.sCommand"
     return $rc
   else
     "${JAVA_CMD}" "$@"
@@ -1206,10 +1213,17 @@ criuRestore()
   fi 
 
   BACKGROUND_RESTORE=$1
+  if [ -z "${CRIU_LOG_LEVEL}" ]; then
+    CRIU_LOG_LEVEL=2
+  fi  
+
   if $BACKGROUND_RESTORE
   then
-    criu restore --file-locks --tcp-established --images-dir=${SERVER_OUTPUT_DIR}/workarea/checkpoint/image -d -j -v -o ${X_LOG_DIR}/checkpoint/restore.log
+    criu restore --file-locks --tcp-established --images-dir=${SERVER_OUTPUT_DIR}/workarea/checkpoint/image \
+      --shell-job --verbosity=${CRIU_LOG_LEVEL} --log-file ${X_LOG_DIR}/checkpoint/restore.log --pidfile ${X_PID_FILE} \
+      --restore-detached 
     rc=$?
+    PID=`cat ${X_PID_FILE}`
     if [ $rc = 0 ]; then
       # successful restore, not check server status
       JVM_OPTIONS_QUOTED=${SAVE_JVM_OPTIONS_QUOTED}
@@ -1217,7 +1231,6 @@ criuRestore()
       OPENJ9_JAVA_OPTIONS=${SAVE_OPENJ9_JAVA_OPTIONS}
 
       # Verify/wait for the process to start
-      # TODO figure out the PID restored
       javaCmd '' "${SERVER_NAME}" --pid="${PID}" --status:start
       rc=$?
       # write the pid file if return is OK or UNKNOWN
@@ -1234,7 +1247,8 @@ criuRestore()
     tail -s0.1 -f "${RESTORE_CONSOLE_LOG}" &
     TAIL_PID=$!
 
-    criu restore --file-locks --tcp-established --images-dir=${SERVER_OUTPUT_DIR}/workarea/checkpoint/image -j -v -o ${X_LOG_DIR}/checkpoint/restore.log
+    criu restore --file-locks --tcp-established --images-dir=${SERVER_OUTPUT_DIR}/workarea/checkpoint/image \
+      --shell-job --verbosity=${CRIU_LOG_LEVEL} --log-file ${X_LOG_DIR}/checkpoint/restore.log
     rc=$?
 
     kill $TAIL_PID
@@ -1308,7 +1322,7 @@ case "$ACTION" in
       exit $?
     fi
 
-    if restoreServer false "$@"
+    if  serverStatus false --status || restoreServer false "$@" 
     then
       exit 0
     fi
@@ -1373,14 +1387,9 @@ case "$ACTION" in
       exit $?
     fi
 
-    if restoreServer true "$@"
-    then
-      exit 0
-    fi
-
     if checkServer true
     then
-      # We can't start the server in the background if it is already running.
+      # We can't start or restore the server in the background if it is already running.
       serverStatus false --status:starting
       rc=$?
       case $rc in
@@ -1388,6 +1397,11 @@ case "$ACTION" in
         rc=1
         ;;
       "1" )
+        if restoreServer true "$@"
+        then
+          exit 0
+        fi
+
         serverWorkingDirectory
 
         mkdirs "${X_LOG_DIR}"

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -1255,7 +1255,13 @@ criuRestore()
   fi
 
   return $rc
+}         
+
+serverHasCheckpoint()
+{
+  [ -d "${SERVER_OUTPUT_DIR}/workarea/checkpoint/image" ]
 }
+
 ## restoreServer: restore a server from a checkpoint image if it exists
 ##
 
@@ -1263,7 +1269,7 @@ restoreServer()
 {
   BACKGROUND_RESTORE=$1
 
-  if [ "${ACTION}" = "checkpoint" ] || [ ! -d "${SERVER_OUTPUT_DIR}/workarea/checkpoint/image" ]; then
+  if [ "${ACTION}" = "checkpoint" ] || ! serverHasCheckpoint ; then
     return 1
   fi
 
@@ -1322,7 +1328,16 @@ case "$ACTION" in
       exit $?
     fi
 
-    if  serverStatus false --status || restoreServer false "$@" 
+    if serverHasCheckpoint && [ ${ACTION} != "checkpoint" ]; then
+      # Avoid call to restoreServer below if server already running.
+      # If there is no checkpoint, then maintain legacy behavior of 
+      # allowing server launch to check for already running instance.
+      if serverStatus false --status:starting; then
+        exit 0
+      fi  
+    fi
+                  
+    if restoreServer false "$@" 
     then
       exit 0
     fi


### PR DESCRIPTION
Fixes #18401 

 Blocks server start with restore and run with restore if server already running. Fixes problem with servername.pid file empty after restore.