### PR TITLE
Update MP JWT TCK to 1.2.2 version

### DIFF
--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.ibm.ws.microprofile.mpjwt12</groupId>
     <artifactId>tck.runner</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.2.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>MicroProfile MpJwt 1.2 TCK Runner</name>
 

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.ibm.ws.microprofile.mpjwt12</groupId>
     <artifactId>tck.runner.tck</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.2.2-SNAPSHOT</version>
     <name>MicroProfile JWT 1.2 TCK Runner TCK Module</name>
 
     <properties>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.jwt</groupId>
             <artifactId>microprofile-jwt-auth-api</artifactId>
-            <version>1.2</version>
+            <version>1.2.2</version>
         </dependency>
         
         <!--  impl -->
@@ -80,14 +80,14 @@
         <dependency>
             <groupId>org.eclipse.microprofile.jwt</groupId>
             <artifactId>microprofile-jwt-auth-tck</artifactId>
-            <version>1.2</version>
+            <version>1.2.2</version>
         </dependency>
        
         <!-- This is the actual MP-JWT TCK test classes -->
         <dependency>
             <groupId>org.eclipse.microprofile.jwt</groupId>
             <artifactId>microprofile-jwt-auth-tck</artifactId>
-            <version>1.2</version>
+            <version>1.2.2</version>
             <type>test-jar</type>        
            <!-- <systemPath>/Users/kristenclarke/MPJWT12/clone111020_RC212/microprofile-jwt-auth/tck/target/microprofile-jwt-auth-tck-1.2.RC2-SNAPSHOT-tests.jar</systemPath>  -->
             <!--  <scope>system</scope> -->


### PR DESCRIPTION
This PR is updating the MP JWT TCK version from 1.2 to 1.2.2.