### PR TITLE
Update JavaInfo.isAvailable method

### DIFF
--- a/dev/com.ibm.ws.java11_fat/fat/src/com/ibm/ws/java11_fat/JavaInfoTest.java
+++ b/dev/com.ibm.ws.java11_fat/fat/src/com/ibm/ws/java11_fat/JavaInfoTest.java
@@ -124,4 +124,33 @@ public class JavaInfoTest extends FATServletClient {
         assertEquals(sr, fatJavaInfo.serviceRelease());
     }
 
+    /**
+     * This test validates that classes are available using the JavaInfo.isSystemClassAvailable
+     * method. To validate this function, the test uses a Class.forName. Java classes
+     * should be found by isAvailable. Application classes should not be found.
+     */
+    @Test
+    public void verifyIsAvailable() {
+        String[] classesToTest = { "com.ibm.security.auth.module.Krb5LoginModule",
+                                   "com.ibm.lang.management.OperatingSystemMXBean",
+                                   "com.sun.security.auth.module.Krb5LoginModule",
+                                   "org.apache.xalan.processor.TransformerFactoryImpl",
+                                   "com.ibm.xtq.xslt.jaxp.compiler.TransformerFactoryImpl",
+                                   "org.xml.sax.ext.LexicalHandler"
+        };
+
+        for (String className : classesToTest) {
+            assertEquals(className, isAvailable(className), JavaInfo.isSystemClassAvailable(className));
+        }
+    }
+
+    private static boolean isAvailable(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            //No FFDC needed
+            return false;
+        }
+    }
 }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
@@ -933,7 +933,7 @@ public class OracleHelper extends DatabaseHelper {
 
     @FFDCIgnore(Exception.class)
     private void assertIBMKerberosSupported() throws ResourceException {
-        if (JavaInfo.isAvailable("com.ibm.security.auth.module.Krb5LoginModule")) {
+        if (JavaInfo.isSystemClassAvailable("com.ibm.security.auth.module.Krb5LoginModule")) {
             // The Oracle JDBC driver prior to 21c does not support kerberos authentication on IBM JDK 8 because
             // it has dependencies to the internal Sun security APIs which don't exist in IBM JDK 8
             boolean ibmJdkSupported;

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/CpuInfo.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/CpuInfo.java
@@ -252,7 +252,7 @@ public class CpuInfo {
             return new NullCpuInfoAccessor();
         }
         try {
-            if (JavaInfo.isAvailable("com.ibm.lang.management.OperatingSystemMXBean")) {
+            if (JavaInfo.isSystemClassAvailable("com.ibm.lang.management.OperatingSystemMXBean")) {
                 return new IBMJavaCpuInfoAccessor(mbean);
             }
             return new ModernJavaCpuInfoAccessor(mbean);

--- a/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/internal/JAASLoginModuleConfigImpl.java
+++ b/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/internal/JAASLoginModuleConfigImpl.java
@@ -196,7 +196,7 @@ public class JAASLoginModuleConfigImpl implements JAASLoginModuleConfig {
             try {
                 //If the IBM Krb5LoginModule class is available then try to load the target class
                 //OR, if it isn't available, only try to load the target class if it isn't the IBM Krb5LoginModule
-                if (JavaInfo.isAvailable(IBM_KRB5_LOGIN_MODULE) || !IBM_KRB5_LOGIN_MODULE.equalsIgnoreCase(target)) {
+                if (JavaInfo.isSystemClassAvailable(IBM_KRB5_LOGIN_MODULE) || !IBM_KRB5_LOGIN_MODULE.equalsIgnoreCase(target)) {
                     cl = Class.forName(target, false, loader);
                 }
             } catch (ClassNotFoundException e) {

--- a/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/Krb5LoginModuleWrapper.java
+++ b/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/Krb5LoginModuleWrapper.java
@@ -33,7 +33,7 @@ public class Krb5LoginModuleWrapper implements LoginModule {
     public static final String COM_SUN_SECURITY_AUTH_MODULE_KRB5LOGINMODULE = "com.sun.security.auth.module.Krb5LoginModule";
     public static final String COM_SUN_SECURITY_JGSS_KRB5_INITIATE = "com.sun.security.jgss.krb5.initiate";
     public static final String COM_SUN_SECURITY_JGSS_KRB5_ACCEPT = "com.sun.security.jgss.krb5.accept";
-    public static final boolean IBM_KRB5_LOGIN_MODULE_AVAILABLE = JavaInfo.isAvailable(COM_IBM_SECURITY_AUTH_MODULE_KRB5LOGINMODULE);
+    public static final boolean IBM_KRB5_LOGIN_MODULE_AVAILABLE = JavaInfo.isSystemClassAvailable(COM_IBM_SECURITY_AUTH_MODULE_KRB5LOGINMODULE);
 
     public CallbackHandler callbackHandler;
     public Subject subject;

--- a/dev/com.ibm.ws.security/src/com/ibm/ws/security/krb5/Krb5Common.java
+++ b/dev/com.ibm.ws.security/src/com/ibm/ws/security/krb5/Krb5Common.java
@@ -34,9 +34,9 @@ public class Krb5Common {
     // Kerberos mechanism OID
     static public Oid KRB5_MECH_OID;
 
-    static public boolean IBM_KRB5_LOGIN_MODULE_AVAILABLE = JavaInfo.isAvailable("com.ibm.security.auth.module.Krb5LoginModule");
+    static public boolean IBM_KRB5_LOGIN_MODULE_AVAILABLE = JavaInfo.isSystemClassAvailable("com.ibm.security.auth.module.Krb5LoginModule");
 
-    static public boolean OTHER_KRB5_LOGIN_MODULE_AVAILABLE = JavaInfo.isAvailable("com.sun.security.auth.module.Krb5LoginModule");
+    static public boolean OTHER_KRB5_LOGIN_MODULE_AVAILABLE = JavaInfo.isSystemClassAvailable("com.sun.security.auth.module.Krb5LoginModule");
 
     // Kerberos KDC host name
     static public final String KRB5_KDC = "java.security.krb5.kdc";

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
@@ -890,9 +890,9 @@ public class PluginGenerator {
 
         //The IBM XLTXEJ Compiled Transformer (some versions of IBM Java 8) does not work properly
         //If it is present then try to use the Apache Xalan Interpretive processor instead
-        boolean useApacheXalanTransformer = JavaInfo.isAvailable(IBM_XLTXEJ_COMPILED_TRANSFORMER_FACTORY_CLASS_NAME) &&
-                                    JavaInfo.isAvailable(XALAN_TRANSFORMER_FACTORY_CLASS_NAME) &&
-                                    JavaInfo.isAvailable(SAX_LEXICAL_HANDLER_CLASS_NAME);
+        boolean useApacheXalanTransformer = JavaInfo.isSystemClassAvailable(IBM_XLTXEJ_COMPILED_TRANSFORMER_FACTORY_CLASS_NAME) &&
+                                    JavaInfo.isSystemClassAvailable(XALAN_TRANSFORMER_FACTORY_CLASS_NAME) &&
+                                    JavaInfo.isSystemClassAvailable(SAX_LEXICAL_HANDLER_CLASS_NAME);
 
         if (useApacheXalanTransformer) {
 


### PR DESCRIPTION
Follow on work from #18392 and #18173

- Change method name to isSystemClassAvailable
- Change to have a cache to avoid doing a ClassLoader lookup.  Most beneficial when it is not found.
- Add a test case to show that the isSystemClassAvailable works