### PR TITLE
Remove duplicate bundle from channelfw feature

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.channelfw-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.channelfw-1.0.feature
@@ -4,7 +4,7 @@ WLP-DisableAllFeatures-OnConflict: false
 IBM-API-Package: com.ibm.websphere.endpoint; type="ibm-api"
 IBM-Process-Types: server, \
  client
--bundles=com.ibm.ws.timer, \
+-bundles=\
  com.ibm.ws.channelfw, \
  com.ibm.ws.timer, \
  com.ibm.ws.wsbytebuffer


### PR DESCRIPTION
`com.ibm.websphere.appserver.channelfw-1.0.feature` has the bundle `com.ibm.ws.timer` defined twice. This isn't a functional problem, but the duplicate should be cleaned up. The duplicate was added in #17940, for #16439