### PR TITLE
Fix WebSocket Quiesce Error During Concurrent Requests 

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/transport/access/TransportConstants.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/transport/access/TransportConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,5 +28,8 @@ public class TransportConstants {
     public static final String CLOSE_NON_UPGRADED_STREAMS = "CloseNonUpgradedStreams";
     public static final String UPGRADED_LISTENER = "UpgradedListener";
     public static final String CLOSE_UPGRADED_WEBCONNECTION = "CloseUpgradedWebConnection";
+
+    // for defect 276206
+    public static final String ON_CLOSE_COUNTDOWN_LATCH = "OnCloseCountDownLatch";
 
 }

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/osgi/srt/SRTConnectionContext31.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/osgi/srt/SRTConnectionContext31.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@
 package com.ibm.ws.webcontainer31.osgi.srt;
 
 import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
 
 import javax.servlet.http.HttpUpgradeHandler;
 
@@ -108,6 +109,7 @@ public class SRTConnectionContext31 extends com.ibm.ws.webcontainer.osgi.srt.SRT
                         connection.setDeviceConnLink(cldevice);  
                         vc.getStateMap().put(TransportConstants.UPGRADED_CONNECTION, "true");
                         vc.getStateMap().put(TransportConstants.UPGRADED_WEB_CONNECTION_OBJECT, connection);
+                        vc.getStateMap().put(TransportConstants.ON_CLOSE_COUNTDOWN_LATCH,  new CountDownLatch(1));
                         connection.setVirtualConnection(vc);
 
                         doInit = true;                            
@@ -135,6 +137,7 @@ public class SRTConnectionContext31 extends com.ibm.ws.webcontainer.osgi.srt.SRT
                             // remove the TransportConstants which if added for Upgrade previously
                             vc.getStateMap().put(TransportConstants.CLOSE_UPGRADED_WEBCONNECTION, null);
                             vc.getStateMap().put(TransportConstants.UPGRADED_LISTENER, null);
+                            vc.getStateMap().put(TransportConstants.ON_CLOSE_COUNTDOWN_LATCH, null);
                             
                             upgradedCon.setVirtualConnection(vc);
 


### PR DESCRIPTION
My attempt at addressing defect 276206. It still needs review from the team, but I think it's promising. 

#17599

Basically, my idea for the fix is to use a countdown latch which is created during the upgrade initialization.   HttpDispatcherLink.Close needs to countdown before HttpDispatcherLink.destroy can be called.  99% of the time HttpDispatcherLink.close is completes first, so there shouldn’t  be any impact for customers.  But in case there are these two concurrent requests (upgrade & close wsoc call), then it should wait at most 30 milliseconds for the close to complete first. 

I'm confident there needs to be a wait in any solution we provide in order to avoid this problem, so it would be best when the connection is closing. 

Part of the problem is that the 101 is send to the client first (via the finishKeepConnection call) before the web-socket initialization is fully complete (via handler.init). 

https://github.com/OpenLiberty/open-liberty/blob/5d81f9cbe0e1b3d1ac09f18d298e61d420d4a359/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/osgi/srt/SRTConnectionContext31.java#L155-L161

But once the client receives the 101, it is free to send out any wsoc request, including close which the server isn’t ready for since it is a bit slow on closing up the upgrade request.   It's better to have a wait on the close frame request, since timing is more important for opening connections. 

Based on the logs I looked at, the timing differences between the close & destroy ranged from 8 to 25 milliseconds.  30 should be fairly safe?   30 should greatly reduce the number of defect occurrences. 


