### PR TITLE
Repeat JavaMail Tests for JavaMail-1.5

### DIFF
--- a/dev/com.ibm.ws.javamail.1.6_fat/bnd.bnd
+++ b/dev/com.ibm.ws.javamail.1.6_fat/bnd.bnd
@@ -19,6 +19,12 @@ src: \
 
 fat.project: true
 
+tested.features: javaMail-1.5, \
+  servlet-3.1, \
+  javaMail-1.6, \
+  servlet-4.0
+  
+
 -buildpath: \
   com.ibm.websphere.javaee.annotation.1.2;version=latest,\
   com.ibm.websphere.javaee.servlet.4.0;version=latest,\

--- a/dev/com.ibm.ws.javamail.1.6_fat/fat/src/com/ibm/ws/javamail/fat/FATSuite.java
+++ b/dev/com.ibm.ws.javamail.1.6_fat/fat/src/com/ibm/ws/javamail/fat/FATSuite.java
@@ -11,12 +11,15 @@
 package com.ibm.ws.javamail.fat;
 
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
@@ -36,4 +39,8 @@ public class FATSuite {
         ShrinkHelper.defaultApp(mailSesionServer, "TestingApp", "TestingApp.*");
 
     }
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.withoutModification().andWith(FeatureReplacementAction.EE8_FEATURES().withID("javaMail-1.6"));
+
 }

--- a/dev/com.ibm.ws.javamail.1.6_fat/fat/src/com/ibm/ws/javamail/fat/MailSessionInjectionTest.java
+++ b/dev/com.ibm.ws.javamail.1.6_fat/fat/src/com/ibm/ws/javamail/fat/MailSessionInjectionTest.java
@@ -47,6 +47,6 @@ public class MailSessionInjectionTest extends FATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         server.stopServer("J2CA0086W.*State:STATE_TRAN_WRAPPER_INUSE", // EXPECTED: One test intentionally leaves an open connection
-                          "CWWKG0007W"); // let Nathan handle this : The system could not delete C:\Users\IBM_ADMIN\Documents\workspace\build.image/wlp/usr/servers\com.ibm.ws.jca.fat\workarea\org.eclipse.osgi\9\data\configs\com.ibm.ws.jca.jmsConnectionFactory.properties_83!-723947066
+                          "CWWKG0007W", "CWWKE0921W", "CWWKE0912W"); // let Nathan handle this : The system could not delete C:\Users\IBM_ADMIN\Documents\workspace\build.image/wlp/usr/servers\com.ibm.ws.jca.fat\workarea\org.eclipse.osgi\9\data\configs\com.ibm.ws.jca.jmsConnectionFactory.properties_83!-723947066
     }
 }

--- a/dev/com.ibm.ws.javamail.1.6_fat/publish/servers/com.ibm.ws.javamail.fat/server.xml
+++ b/dev/com.ibm.ws.javamail.1.6_fat/publish/servers/com.ibm.ws.javamail.fat/server.xml
@@ -3,7 +3,7 @@
     <feature>componentTest-1.0</feature>
     <feature>servlet-4.0</feature>
     <feature>localConnector-1.0</feature>
-    <feature>javaMail-1.6</feature>
+    <feature>javaMail-1.5</feature>
     <feature>jndi-1.0</feature>
     <feature>ejbLite-3.2</feature>
   </featureManager>
@@ -13,6 +13,8 @@
   <variable name="onError" value="FAIL"/>
 
   <application type="ear" id="fvtapp" name="fvtapp" location="fvtapp.ear"/>
+  
+   <javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
 
   <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
   <!-- Needed due to missing doPriv in javax.mail.Session.loadFile(), and we have no idea of the actual base paths -->

--- a/dev/com.ibm.ws.javamail.1.6_fat/publish/servers/mailSessionTestServer/server.xml
+++ b/dev/com.ibm.ws.javamail.1.6_fat/publish/servers/mailSessionTestServer/server.xml
@@ -1,9 +1,9 @@
 <server>
   <featureManager>
     <feature>componentTest-1.0</feature>
-    <feature>servlet-4.0</feature>
+    <feature>servlet-3.1</feature>
     <feature>jndi-1.0</feature>
-    <feature>javaMail-1.6</feature>
+    <feature>javaMail-1.5</feature>
   </featureManager>
 
   <mailSession>

--- a/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionDefinitionInjectionBinding.java
+++ b/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionDefinitionInjectionBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015,2017
+ * Copyright (c) 2015,2021
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionDefinitionInjectionBinding.java
+++ b/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionDefinitionInjectionBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015,2017
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -48,6 +48,7 @@ public class MailSessionDefinitionInjectionBinding extends InjectionBinding<Mail
     private static final String KEY_TRANSPORT_PROTOCOL_CLASS_NAME = "transportProtocolClassName";
     private static final String KEY_HOST = "host";
     private static final String KEY_FROM = "from";
+    private static final String KEY_PROPERTY = "property";
 
     private String description;
     private boolean XMLDescription;
@@ -91,7 +92,7 @@ public class MailSessionDefinitionInjectionBinding extends InjectionBinding<Mail
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.wsspi.injectionengine.InjectionBinding#merge(java.lang.annotation.Annotation, java.lang.Class, java.lang.reflect.Member)
      */
     @Override
@@ -100,8 +101,7 @@ public class MailSessionDefinitionInjectionBinding extends InjectionBinding<Mail
         if (isTraceOn && tc.isEntryEnabled())
             Tr.entry(tc, "merge: name=" + getJndiName() + ", " + super.toStringSecure(annotation));
 
-        if (member != null)
-        {
+        if (member != null) {
             // MailSessionDefinition is a class-level annotation only.
             throw new IllegalArgumentException(member.toString());
         }
@@ -123,22 +123,20 @@ public class MailSessionDefinitionInjectionBinding extends InjectionBinding<Mail
             Tr.exit(tc, "merge");
     }
 
-    void resolve()
-                    throws InjectionException
-    {
+    void resolve() throws InjectionException {
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
         if (isTraceOn && tc.isEntryEnabled())
             Tr.entry(tc, "resolve");
 
         Map<String, Object> props = new HashMap<String, Object>();
 
-        if (properties != null)
-        {
-            for (Map.Entry<String, String> entry : properties.entrySet())
-            {
+        if (properties != null) {
+            int i = 0;
+            for (Map.Entry<String, String> entry : properties.entrySet()) {
                 String key = entry.getKey();
-
-                props.put(key, entry.getValue());
+                props.put(KEY_PROPERTY + "." + i + ".name", key);
+                props.put(KEY_PROPERTY + "." + i + ".value", entry.getValue());
+                i++;
             }
         }
 
@@ -159,17 +157,14 @@ public class MailSessionDefinitionInjectionBinding extends InjectionBinding<Mail
             Tr.exit(tc, "resolve");
     }
 
-    void mergeXML(MailSession mailSession)
-                    throws InjectionConfigurationException
-    {
+    void mergeXML(MailSession mailSession) throws InjectionConfigurationException {
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
         if (isTraceOn && tc.isEntryEnabled())
             Tr.entry(tc, "mergeXML: name=" + getJndiName() + ", " + mailSession.toString());
 
         List<Description> descriptionList = mailSession.getDescriptions();
 
-        if (descriptionList != null)
-        {
+        if (descriptionList != null) {
             Iterator<Description> iter = descriptionList.iterator();
             StringBuilder descSB = new StringBuilder();
             while (iter.hasNext()) {
@@ -181,58 +176,50 @@ public class MailSessionDefinitionInjectionBinding extends InjectionBinding<Mail
         }
 
         String fromValue = mailSession.getFrom();
-        if (fromValue != null)
-        {
+        if (fromValue != null) {
             from = mergeXMLValue(from, fromValue, "from", KEY_FROM, null);
             XMLFrom = true;
         }
 
         String hostValue = mailSession.getHost();
-        if (hostValue != null)
-        {
+        if (hostValue != null) {
             host = mergeXMLValue(host, hostValue, "host", KEY_HOST, null);
             XMLHost = true;
         }
 
         String userValue = mailSession.getUser();
-        if (userValue != null)
-        {
+        if (userValue != null) {
             user = mergeXMLValue(user, userValue, "user", KEY_USER, null);
             XMLUser = true;
         }
 
         String passwordValue = mailSession.getPassword();
-        if (passwordValue != null && password != null)
-        {
+        if (passwordValue != null && password != null) {
             password = (SerializableProtectedString) mergeXMLValue(password.getChars(), passwordValue, "password", KEY_PASSWORD, null);
             XMLPassword = true;
         }
 
         String storeProtocolValue = mailSession.getStoreProtocol();
-        if (storeProtocolValue != null)
-        {
+        if (storeProtocolValue != null) {
             storeProtocol = mergeXMLValue(storeProtocol, storeProtocolValue, "store-protocol", KEY_STORE_PROTOCOL, null);
             XMLStoreProtocol = true;
         }
 
         String storeProtocolClassNameValue = mailSession.getStoreProtocolClassName();
-        if (storeProtocolClassNameValue != null)
-        {
+        if (storeProtocolClassNameValue != null) {
             storeProtocolClassName = mergeXMLValue(storeProtocolClassName, storeProtocolClassNameValue, "store-protocol-class-name",
                                                    KEY_STORE_PROTOCOL_CLASS_NAME, null);
             XMLStoreProtocolClassName = true;
         }
 
         String transportProtocolValue = mailSession.getTransportProtocol();
-        if (transportProtocolValue != null)
-        {
+        if (transportProtocolValue != null) {
             transportProtocol = mergeXMLValue(transportProtocol, transportProtocolValue, "transport-protocol", KEY_TRANSPORT_PROTOCOL, null);
             XMLTransportProtocol = true;
         }
 
         String transportProtocolClassNameValue = mailSession.getTransportProtocolClassName();
-        if (transportProtocolClassNameValue != null)
-        {
+        if (transportProtocolClassNameValue != null) {
             transportProtocolClassName = mergeXMLValue(transportProtocolClassName, transportProtocolClassNameValue, "transport-protocol-class-name",
                                                        KEY_TRANSPORT_PROTOCOL_CLASS_NAME, null);
             XMLTransportProtocolClassName = true;
@@ -246,9 +233,7 @@ public class MailSessionDefinitionInjectionBinding extends InjectionBinding<Mail
     }
 
     @Override
-    public void mergeSaved(InjectionBinding<MailSessionDefinition> injectionBinding)
-                    throws InjectionException
-    {
+    public void mergeSaved(InjectionBinding<MailSessionDefinition> injectionBinding) throws InjectionException {
         MailSessionDefinitionInjectionBinding mailSessionBinding = (MailSessionDefinitionInjectionBinding) injectionBinding;
 
         mergeSavedValue(description, mailSessionBinding.description, "description");
@@ -265,8 +250,7 @@ public class MailSessionDefinitionInjectionBinding extends InjectionBinding<Mail
     }
 
     @Override
-    public Class<?> getAnnotationType()
-    {
+    public Class<?> getAnnotationType() {
         return MailSessionDefinition.class;
     }
 

--- a/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionDefinitionInjectionProcessor.java
+++ b/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionDefinitionInjectionProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015,2017,2021
+ * Copyright (c) 2015,2021
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionDefinitionInjectionProcessor.java
+++ b/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionDefinitionInjectionProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015,2017
+ * Copyright (c) 2015,2017,2021
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,13 +26,10 @@ import com.ibm.wsspi.injectionengine.InjectionBinding;
 import com.ibm.wsspi.injectionengine.InjectionException;
 import com.ibm.wsspi.injectionengine.InjectionProcessor;
 
-public class MailSessionDefinitionInjectionProcessor extends InjectionProcessor<MailSessionDefinition, MailSessionDefinitions>
-{
-    static final TraceComponent tc = Tr.register
-                    (MailSessionDefinitionInjectionProcessor.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
+public class MailSessionDefinitionInjectionProcessor extends InjectionProcessor<MailSessionDefinition, MailSessionDefinitions> {
+    static final TraceComponent tc = Tr.register(MailSessionDefinitionInjectionProcessor.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
 
-    public MailSessionDefinitionInjectionProcessor()
-    {
+    public MailSessionDefinitionInjectionProcessor() {
         super(MailSessionDefinition.class, MailSessionDefinitions.class);
     }
 
@@ -47,35 +44,28 @@ public class MailSessionDefinitionInjectionProcessor extends InjectionProcessor<
 
     /**
      * Processes {@link ComponentNameSpaceConfiguration#getJNDIEnvironmnetRefs} for MailSessions.
-     * 
+     *
      * </ul>
-     * 
+     *
      * @throws InjectionException if an error is found processing the XML.
      **/
     @Override
-    public void processXML()
-                    throws InjectionException
-    {
+    public void processXML() throws InjectionException {
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
         if (isTraceOn && tc.isEntryEnabled())
             Tr.entry(tc, "processXML : " + this);
 
         List<? extends MailSession> mailSessionDefinitions = ivNameSpaceConfig.getJNDIEnvironmentRefs(MailSession.class);
 
-        if (mailSessionDefinitions != null)
-        {
-            for (MailSession mailSession : mailSessionDefinitions)
-            {
+        if (mailSessionDefinitions != null) {
+            for (MailSession mailSession : mailSessionDefinitions) {
                 String jndiName = mailSession.getName();
                 InjectionBinding<MailSessionDefinition> injectionBinding = ivAllAnnotationsCollection.get(jndiName);
                 MailSessionDefinitionInjectionBinding binding;
 
-                if (injectionBinding != null)
-                {
+                if (injectionBinding != null) {
                     binding = (MailSessionDefinitionInjectionBinding) injectionBinding;
-                }
-                else
-                {
+                } else {
                     binding = new MailSessionDefinitionInjectionBinding(jndiName, ivNameSpaceConfig);
                     addInjectionBinding(binding);
                 }
@@ -91,21 +81,21 @@ public class MailSessionDefinitionInjectionProcessor extends InjectionProcessor<
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.wsspi.injectionengine.InjectionProcessor#createInjectionBinding(java.lang.annotation.Annotation, java.lang.Class, java.lang.reflect.Member, java.lang.String)
      */
     @Sensitive
     @Override
-    public InjectionBinding<MailSessionDefinition> createInjectionBinding(@Sensitive MailSessionDefinition annotation, Class<?> instanceClass, Member member, String jndiName) throws InjectionException {
-        InjectionBinding<MailSessionDefinition> injectionBinding =
-                        new MailSessionDefinitionInjectionBinding(jndiName, ivNameSpaceConfig);
+    public InjectionBinding<MailSessionDefinition> createInjectionBinding(@Sensitive MailSessionDefinition annotation, Class<?> instanceClass, Member member,
+                                                                          String jndiName) throws InjectionException {
+        InjectionBinding<MailSessionDefinition> injectionBinding = new MailSessionDefinitionInjectionBinding(jndiName, ivNameSpaceConfig);
         injectionBinding.merge(annotation, instanceClass, null);
         return injectionBinding;
     }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.wsspi.injectionengine.InjectionProcessor#resolve(com.ibm.wsspi.injectionengine.InjectionBinding)
      */
     @Override
@@ -117,7 +107,7 @@ public class MailSessionDefinitionInjectionProcessor extends InjectionProcessor<
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.wsspi.injectionengine.InjectionProcessor#getJndiName(java.lang.annotation.Annotation)
      */
     @Override
@@ -128,7 +118,7 @@ public class MailSessionDefinitionInjectionProcessor extends InjectionProcessor<
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.wsspi.injectionengine.InjectionProcessor#getAnnotations(java.lang.annotation.Annotation)
      */
     @Sensitive

--- a/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionDefinitionInjectionProcessor.java
+++ b/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionDefinitionInjectionProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015,2017
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionDefinitionInjectionProcessorProvider.java
+++ b/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionDefinitionInjectionProcessorProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015,2017 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionDefinitionInjectionProcessorProvider.java
+++ b/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionDefinitionInjectionProcessorProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015,2017 IBM Corporation and others.
+ * Copyright (c) 2015,2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,14 +27,12 @@ import com.ibm.wsspi.injectionengine.InjectionProcessorProvider;
  *
  */
 @Component(service = { InjectionProcessorProvider.class })
-public class MailSessionDefinitionInjectionProcessorProvider
-                extends InjectionProcessorProvider<MailSessionDefinition, MailSessionDefinitions> {
-    List<Class<? extends JNDIEnvironmentRef>> REF_CLASSES =
-                    Collections.<Class<? extends JNDIEnvironmentRef>> singletonList(MailSession.class);
+public class MailSessionDefinitionInjectionProcessorProvider extends InjectionProcessorProvider<MailSessionDefinition, MailSessionDefinitions> {
+    List<Class<? extends JNDIEnvironmentRef>> REF_CLASSES = Collections.<Class<? extends JNDIEnvironmentRef>> singletonList(MailSession.class);
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.wsspi.injectionengine.InjectionProcessorProvider#getAnnotationClass()
      */
     @Override
@@ -45,7 +43,7 @@ public class MailSessionDefinitionInjectionProcessorProvider
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.wsspi.injectionengine.InjectionProcessorProvider#getAnnotationsClass()
      */
     @Override
@@ -56,7 +54,7 @@ public class MailSessionDefinitionInjectionProcessorProvider
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.wsspi.injectionengine.InjectionProcessorProvider#getJNDIEnvironmentRefClasses()
      */
     @Override
@@ -67,7 +65,7 @@ public class MailSessionDefinitionInjectionProcessorProvider
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.wsspi.injectionengine.InjectionProcessorProvider#createInjectionProcessor()
      */
     @Override

--- a/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionDefinitionInjectionProcessorProvider.java
+++ b/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionDefinitionInjectionProcessorProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015,2017,2021 IBM Corporation and others.
+ * Copyright (c) 2015,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionResourceFactory.java
+++ b/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionResourceFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015,2017 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionResourceFactory.java
+++ b/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionResourceFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015,2017 IBM Corporation and others.
+ * Copyright (c) 2015,2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,11 +29,12 @@ public class MailSessionResourceFactory extends MailSessionService implements co
     }
 
     /**
-     * 
+     *
      * @throws Exception if an error occurs.
      */
     @Override
-    public void destroy() throws Exception {}
+    public void destroy() throws Exception {
+    }
 
     @Override
     public void modify(Map<String, Object> props) throws Exception {

--- a/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionResourceFactory.java
+++ b/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionResourceFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015,2017,2021 IBM Corporation and others.
+ * Copyright (c) 2015,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionResourceFactoryBuilder.java
+++ b/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionResourceFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015,2017,2021
+ * Copyright (c) 2015,2021
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionResourceFactoryBuilder.java
+++ b/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionResourceFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015,2017
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@ package com.ibm.ws.javamail.internal.injection;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
+import java.util.Set;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.ComponentContext;
@@ -29,12 +30,9 @@ import com.ibm.wsspi.kernel.service.utils.FilterUtils;
 /**
  *
  */
-@Component(service = { ResourceFactoryBuilder.class },
-                configurationPolicy = ConfigurationPolicy.IGNORE,
-                immediate = true,
-                property = { "service.vendor=IBM",
-                            "creates.objectClass=javax.mail.Session"
-                })
+@Component(service = { ResourceFactoryBuilder.class }, configurationPolicy = ConfigurationPolicy.IGNORE, immediate = true, property = { "service.vendor=IBM",
+                                                                                                                                        "creates.objectClass=javax.mail.Session"
+})
 public class MailSessionResourceFactoryBuilder implements ResourceFactoryBuilder {
 
     private static final TraceComponent tc = Tr.register(MailSessionResourceFactoryBuilder.class);
@@ -49,7 +47,7 @@ public class MailSessionResourceFactoryBuilder implements ResourceFactoryBuilder
     /**
      * Declarative Services method to activate this component.
      * Best practice: this should be a protected method, not public or private
-     * 
+     *
      * @param context context for this component
      */
     protected void activate(ComponentContext context) {
@@ -71,21 +69,10 @@ public class MailSessionResourceFactoryBuilder implements ResourceFactoryBuilder
             Object value = prop.getValue();
             annotationProps.put(prop.getKey(), value);
         }
-
         String application = (String) annotationProps.remove("application");
         String module = (String) annotationProps.remove("module");
         String component = (String) annotationProps.remove("component");
         String jndiName = (String) annotationProps.remove(MailSessionService.JNDI_NAME);
-        String description = (String) annotationProps.remove(MailSessionService.DESCRIPTION);
-        String storeProtocol = (String) annotationProps.remove(MailSessionService.STOREPROTOCOL);
-        String transportProtocol = (String) annotationProps.remove(MailSessionService.TRANSPORTPROTOCOL);
-        String host = (String) annotationProps.remove(MailSessionService.HOST);
-        String user = (String) annotationProps.remove(MailSessionService.USER);
-        String password = (String) annotationProps.remove(MailSessionService.PASSWORD);
-        String from = (String) annotationProps.remove(MailSessionService.FROM);
-        String storeProtocolClass = (String) annotationProps.remove(MailSessionService.STOREPROTOCOLCLASSNAME);
-        String transportProtocolClass = (String) annotationProps.remove(MailSessionService.TRANSPORTPROTOCOLCLASSNAME);
-        String property = (String) annotationProps.remove(MailSessionService.PROPERTY);
         String mailSessionID = getMailSessionID(application, module, component, jndiName);
 
         StringBuilder filter = new StringBuilder(FilterUtils.createPropertyFilter(ID, mailSessionID));
@@ -95,33 +82,20 @@ public class MailSessionResourceFactoryBuilder implements ResourceFactoryBuilder
             throw new IllegalArgumentException(mailSessionID); // internal error, shouldn't ever have been permitted in server.xml
 
         mailSessionSvcProps.put(MailSessionService.JNDI_NAME, jndiName);
-        if (description != null)
-            mailSessionSvcProps.put(MailSessionService.DESCRIPTION, description);
-        if (storeProtocol != null)
-            mailSessionSvcProps.put(MailSessionService.STOREPROTOCOL, storeProtocol);
-        if (transportProtocol != null)
-            mailSessionSvcProps.put(MailSessionService.TRANSPORTPROTOCOL, transportProtocol);
-        if (host != null)
-            mailSessionSvcProps.put(MailSessionService.HOST, host);
-        if (user != null)
-            mailSessionSvcProps.put(MailSessionService.USER, user);
-        if (password != null)
-            mailSessionSvcProps.put(MailSessionService.PASSWORD, password);
-        if (from != null)
-            mailSessionSvcProps.put(MailSessionService.FROM, from);
-        if (storeProtocolClass != null)
-            mailSessionSvcProps.put(MailSessionService.STOREPROTOCOLCLASSNAME, storeProtocolClass);
-        if (transportProtocolClass != null)
-            mailSessionSvcProps.put(MailSessionService.TRANSPORTPROTOCOLCLASSNAME, transportProtocolClass);
-        if (property != null)
-            mailSessionSvcProps.put(MailSessionService.PROPERTY, property);
-
+        mailSessionSvcProps.put(MailSessionService.MAILSESSIONID, mailSessionID);
         if (application != null) {
             mailSessionSvcProps.put("application", application);
             if (module != null) {
                 mailSessionSvcProps.put("module", module);
                 if (component != null)
                     mailSessionSvcProps.put("component", component);
+            }
+        }
+
+        if (!annotationProps.isEmpty()) {
+            Set<String> annotationKeys = annotationProps.keySet();
+            for (String key : annotationKeys) {
+                mailSessionSvcProps.put(key, annotationProps.get(key));
             }
         }
 
@@ -137,7 +111,7 @@ public class MailSessionResourceFactoryBuilder implements ResourceFactoryBuilder
     /**
      * Declarative Services method to deactivate this component.
      * Best practice: this should be a protected method, not public or private
-     * 
+     *
      * @param context context for this component
      */
     protected void deactivate(ComponentContext context) {
@@ -149,7 +123,7 @@ public class MailSessionResourceFactoryBuilder implements ResourceFactoryBuilder
      * Utility method that creates a unique identifier for an application defined data source.
      * For example,
      * application[MyApp]/module[MyModule]/connectionFactory[java:module/env/jdbc/cf1]
-     * 
+     *
      * @param application application name if data source is in java:app, java:module, or java:comp. Otherwise null.
      * @param module module name if data source is in java:module or java:comp. Otherwise null.
      * @param component component name if data source is in java:comp and isn't in web container. Otherwise null.

--- a/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionResourceFactoryBuilder.java
+++ b/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionResourceFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015,2017
+ * Copyright (c) 2015,2017,2021
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -125,9 +125,9 @@ public class MailSessionResourceFactoryBuilder implements ResourceFactoryBuilder
      * application[MyApp]/module[MyModule]/connectionFactory[java:module/env/jdbc/cf1]
      *
      * @param application application name if data source is in java:app, java:module, or java:comp. Otherwise null.
-     * @param module module name if data source is in java:module or java:comp. Otherwise null.
-     * @param component component name if data source is in java:comp and isn't in web container. Otherwise null.
-     * @param jndiName configured JNDI name for the data source. For example, java:module/env/jca/cf1
+     * @param module      module name if data source is in java:module or java:comp. Otherwise null.
+     * @param component   component name if data source is in java:comp and isn't in web container. Otherwise null.
+     * @param jndiName    configured JNDI name for the data source. For example, java:module/env/jca/cf1
      * @return the unique identifier
      */
     private static final String getMailSessionID(String application, String module, String component, String jndiName) {


### PR DESCRIPTION
This PR does two things:

One uses the existing `com.ibm.ws.javamai.1.6_fat` to repeat the same tests with the javaMail-1.5, as well as includes a fix for javaMail-1.6 that should have been backported to javaMail-1.5.