### PR TITLE
PR for Issue 17448: OIDC client update for allowing and/or requiring JWT access token remote validation

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
@@ -168,6 +168,12 @@ validationMethod.introspect=Validate inbound tokens using token introspection
 validationMethod.userinfo=Validate inbound tokens using the userinfo endpoint
 validationMethod.local=Validate inbound tokens locally using JWT validation
 
+requireJwtAccessTokenRemoteValidation=Require JWT access token remote validation
+requireJwtAccessTokenRemoteValidation.desc=When this property is set to true, a JWT access token that is received for inbound propagation is validated using the validation method that is configured by the OpenID Connect client. The JWT access token is not parsed or validated locally by the OpenID Connect client.
+
+allowJwtAccessTokenRemoteValidation=Allow JWT access token remote validation
+allowJwtAccessTokenRemoteValidation.desc=When this property is set to true, a JWT access token that is received for inbound propagation is parsed and validated locally by the OpenID Connect client. If validation fails, the JWT access token is validated using the validation method that is configured by the OpenID Connect client.
+
 headerName=Name of the header containing the inbound token
 headerName.desc=The name of the header which carries the inbound token in the request.
 

--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
@@ -113,6 +113,8 @@
                 <Option label="%validationMethod.introspect" value="introspect" />
             	<Option label="%validationMethod.userinfo" value="userinfo" />
          </AD>
+         <AD id="requireJwtAccessTokenRemoteValidation" name="%requireJwtAccessTokenRemoteValidation" description="%requireJwtAccessTokenRemoteValidation.desc" required="false" type="Boolean" default="false" ibm:beta="true" />
+         <AD id="allowJwtAccessTokenRemoteValidation" name="%allowJwtAccessTokenRemoteValidation" description="%allowJwtAccessTokenRemoteValidation.desc" required="false" type="Boolean" default="false" ibm:beta="true" />
          <AD id="authzParameter" name="%authzParameter" description="%authzParameter.desc" required="false" type="String" ibm:type="pid" ibm:reference="com.ibm.ws.security.openidconnect.client.param" cardinality="20" />
          <AD id="tokenParameter" name="%tokenParameter" description="%tokenParameter.desc" required="false" type="String" ibm:type="pid" ibm:reference="com.ibm.ws.security.openidconnect.client.param" cardinality="20" />
          <AD id="userinfoParameter" name="internal" description="internal use only" required="false" type="String" ibm:type="pid" ibm:reference="com.ibm.ws.security.openidconnect.client.param" cardinality="20" />

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
@@ -146,6 +146,8 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     public static final String CFG_KEY_CREATE_SESSION = "createSession";
     public static final String CFG_KEY_INBOUND_PROPAGATION = "inboundPropagation";
     public static final String CFG_KEY_VALIDATION_METHOD = "validationMethod";
+    public static final String CFG_KEY_ALLOW_JWT_ACCESS_TOKEN_REMOTE_VALIDATION = "allowJwtAccessTokenRemoteValidation";
+    public static final String CFG_KEY_REQUIRE_JWT_ACCESS_TOKEN_REMOTE_VALIDATION = "requireJwtAccessTokenRemoteValidation";
     public static final String CFG_KEY_HEADER_NAME = "headerName";
     public static final String CFG_KEY_propagation_authnSessionDisabled = "authnSessionDisabled";
     public static final String CFG_KEY_reAuthnOnAccessTokenExpire = "reAuthnOnAccessTokenExpire";
@@ -253,6 +255,8 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     private boolean createSession;
     private String inboundPropagation;
     private String validationMethod;
+    private boolean allowJwtAccessTokenRemoteValidation = false;
+    private boolean requireJwtAccessTokenRemoteValidation = false;
     private String headerName;
     private boolean disableIssChecking;
     private String[] audiences;
@@ -450,6 +454,8 @@ public class OidcClientConfigImpl implements OidcClientConfig {
         clockSkewInSeconds = clockSkew / 1000; // Duration types are always in milliseconds, convert to seconds.
         authenticationTimeLimitInSeconds = (Long) props.get(CFG_KEY_AUTHENTICATION_TIME_LIMIT) / 1000;
         validationMethod = trimIt((String) props.get(CFG_KEY_VALIDATION_METHOD));
+        allowJwtAccessTokenRemoteValidation = configUtils.getBooleanConfigAttribute(props, CFG_KEY_ALLOW_JWT_ACCESS_TOKEN_REMOTE_VALIDATION, allowJwtAccessTokenRemoteValidation);
+        requireJwtAccessTokenRemoteValidation = configUtils.getBooleanConfigAttribute(props, CFG_KEY_REQUIRE_JWT_ACCESS_TOKEN_REMOTE_VALIDATION, requireJwtAccessTokenRemoteValidation);
         userInfoEndpointEnabled = (Boolean) props.get(CFG_KEY_USERINFO_ENDPOINT_ENABLED);
         discoveryEndpointUrl = trimIt((String) props.get(CFG_KEY_DISCOVERY_ENDPOINT_URL));
         discoveryPollingRate = (Long) props.get(CFG_KEY_DISCOVERY_POLLING_RATE);
@@ -604,6 +610,8 @@ public class OidcClientConfigImpl implements OidcClientConfig {
             Tr.debug(tc, "createSession: " + createSession);
             Tr.debug(tc, "inboundPropagation: " + inboundPropagation);
             Tr.debug(tc, "validationMethod: " + validationMethod);
+            Tr.debug(tc, "allowJwtAccessTokenRemoteValidation: " + allowJwtAccessTokenRemoteValidation);
+            Tr.debug(tc, "requireJwtAccessTokenRemoteValidation: " + requireJwtAccessTokenRemoteValidation);
             Tr.debug(tc, "headerName: " + headerName);
             Tr.debug(tc, "authnSessionDisabled:" + authnSessionDisabled);
             Tr.debug(tc, "disableIssChecking:" + disableIssChecking);
@@ -1587,6 +1595,16 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     @Override
     public String getValidationMethod() {
         return this.validationMethod;
+    }
+
+    @Override
+    public boolean isAllowJwtAccessTokenRemoteValidation() {
+        return allowJwtAccessTokenRemoteValidation;
+    }
+
+    @Override
+    public boolean isRequireJwtAccessTokenRemoteValidation() {
+        return requireJwtAccessTokenRemoteValidation;
     }
 
     // This is either null or not_empty_string

--- a/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/AccessTokenAuthenticatorTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/AccessTokenAuthenticatorTest.java
@@ -612,6 +612,8 @@ public class AccessTokenAuthenticatorTest extends CommonTestClass {
 
                 one(clientConfig).getAccessTokenInLtpaCookie();
                 will(returnValue(false));
+                one(clientConfig).getTokenReuse();
+                will(returnValue(true));
                 one(clientConfig).getAccessTokenCacheEnabled();
                 will(returnValue(false));
                 allowing(clientConfig).getValidationMethod();

--- a/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/AccessTokenAuthenticatorTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/AccessTokenAuthenticatorTest.java
@@ -329,7 +329,7 @@ public class AccessTokenAuthenticatorTest extends CommonTestClass {
                 will(returnValue(false));
                 allowing(clientConfig).getAccessTokenCacheEnabled();
                 will(returnValue(false));
-                one(clientConfig).getValidationMethod();
+                allowing(clientConfig).getValidationMethod();
                 will(returnValue(ClientConstants.VALIDATION_USERINFO));
                 one(clientConfig).isHostNameVerificationEnabled();
                 will(returnValue(true));
@@ -369,7 +369,7 @@ public class AccessTokenAuthenticatorTest extends CommonTestClass {
                 will(returnValue(false));
                 one(clientConfig).getAccessTokenCacheEnabled();
                 will(returnValue(false));
-                exactly(2).of(clientConfig).getValidationMethod();
+                allowing(clientConfig).getValidationMethod();
                 will(returnValue(ClientConstants.VALIDATION_USERINFO));
                 one(clientConfig).isHostNameVerificationEnabled();
                 will(returnValue(false));
@@ -407,7 +407,7 @@ public class AccessTokenAuthenticatorTest extends CommonTestClass {
                 will(returnValue(false));
                 allowing(clientConfig).getAccessTokenCacheEnabled();
                 will(returnValue(false));
-                one(clientConfig).getValidationMethod();
+                allowing(clientConfig).getValidationMethod();
                 will(returnValue(ClientConstants.VALIDATION_INTROSPECT));
                 allowing(clientConfig).getInboundPropagation();
                 will(returnValue("required"));
@@ -462,7 +462,7 @@ public class AccessTokenAuthenticatorTest extends CommonTestClass {
                 will(returnValue(false));
                 allowing(clientConfig).getAccessTokenCacheEnabled();
                 will(returnValue(false));
-                one(clientConfig).getValidationMethod();
+                allowing(clientConfig).getValidationMethod();
                 will(returnValue(ClientConstants.VALIDATION_INTROSPECT));
                 one(clientConfig).getClientSecret();
                 will(returnValue("client_secret"));
@@ -514,7 +514,7 @@ public class AccessTokenAuthenticatorTest extends CommonTestClass {
                 will(returnValue(true));
                 one(clientConfig).getTokenReuse();
                 will(returnValue(false));
-                one(clientConfig).getValidationMethod();
+                allowing(clientConfig).getValidationMethod();
                 will(returnValue(ClientConstants.VALIDATION_INTROSPECT));
                 one(clientConfig).getClientSecret();
                 will(returnValue("client_secret"));
@@ -573,7 +573,7 @@ public class AccessTokenAuthenticatorTest extends CommonTestClass {
                 will(returnValue(false));
                 allowing(clientConfig).getAccessTokenCacheEnabled();
                 will(returnValue(false));
-                exactly(3).of(clientConfig).getValidationMethod();
+                allowing(clientConfig).getValidationMethod();
                 will(returnValue(ClientConstants.VALIDATION_INTROSPECT));
                 one(clientConfig).getClientSecret();
                 will(returnValue(null));
@@ -614,9 +614,7 @@ public class AccessTokenAuthenticatorTest extends CommonTestClass {
                 will(returnValue(false));
                 one(clientConfig).getAccessTokenCacheEnabled();
                 will(returnValue(false));
-                one(clientConfig).getTokenReuse();
-                will(returnValue(false));
-                exactly(2).of(clientConfig).getValidationMethod();
+                allowing(clientConfig).getValidationMethod();
                 will(returnValue(ClientConstants.VALIDATION_INTROSPECT));
                 one(clientConfig).getClientSecret();
                 will(returnValue(null));
@@ -651,7 +649,7 @@ public class AccessTokenAuthenticatorTest extends CommonTestClass {
                 will(returnValue(false));
                 one(clientConfig).getAccessTokenCacheEnabled();
                 will(returnValue(false));
-                one(clientConfig).getValidationMethod();
+                allowing(clientConfig).getValidationMethod();
                 will(returnValue(INVALID_VALIDATION));
                 one(clientConfig).getTokenEndpointUrl();
                 will(returnValue(HTTPS_URL));

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientConfig.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientConfig.java
@@ -34,6 +34,10 @@ public interface OidcClientConfig extends ConvergedClientConfig {
 
     public String getValidationMethod();
 
+    public boolean isAllowJwtAccessTokenRemoteValidation();
+
+    public boolean isRequireJwtAccessTokenRemoteValidation();
+
     public String getHeaderName();
 
     public boolean isValidConfig(); // when the inboundPropagation is required


### PR DESCRIPTION
For https://github.com/OpenLiberty/open-liberty/issues/17448

Adds `allowJwtAccessTokenRemoteValidation` and `requireJwtAccessTokenRemoteValidation` OIDC client config attributes to allow falling back to, or requiring, using introspect or userinfo to validate a JWT access token during inbound propagation.