### PR TITLE
Fix missing database skip in JPA FAT

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.beanvalidation/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation/bnd.bnd
@@ -11,15 +11,15 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
+test.project: true
+publish.wlp.jar.disabled: true
+instrument.disabled: true
+
 src: \
     fat/src,\
     test-applications/beanvalidation/src,\
     test-applications/beanvalidation20/src,\
     test-applications/helpers/DatabaseManagement/src
-
-test.project: false
-publish.wlp.jar.disabled: true
-instrument.disabled: true
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)
@@ -36,6 +36,6 @@ instrument.disabled: true
     com.ibm.websphere.javaee.transaction.1.2;version=latest,\
     com.ibm.websphere.javaee.validation.2.0;version=latest,\
     io.openliberty.org.testcontainers;version=latest,\
-    org.jboss.shrinkwrap:shrinkwrap-api;version=1.2.3,\
-    org.jboss.shrinkwrap:shrinkwrap-impl-base;version=1.2.3,\
-    org.jboss.shrinkwrap:shrinkwrap-spi;version=1.2.3
+    org.jboss.shrinkwrap:shrinkwrap-api;version=latest,\
+    org.jboss.shrinkwrap:shrinkwrap-impl-base;version=latest,\
+    org.jboss.shrinkwrap:shrinkwrap-spi;version=latest

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation20_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation20_EJB.java
@@ -32,6 +32,7 @@ import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.ws.jpa.beanvalidation20.ejb.TestBeanValidation20_EJB_SFEx_Servlet;
 import com.ibm.ws.jpa.beanvalidation20.ejb.TestBeanValidation20_EJB_SF_Servlet;
 import com.ibm.ws.jpa.beanvalidation20.ejb.TestBeanValidation20_EJB_SL_Servlet;
+import com.ibm.ws.testtooling.database.DatabaseVendor;
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
 import componenttest.annotation.Server;
@@ -124,6 +125,8 @@ public class BeanValidation20_EJB extends JPAFATServletClient {
         executeDDL(server, ddlSet, false);
 
         setupTestApplication();
+
+        skipDBRule.setDatabase(getDbVendor().name());
     }
 
     private static void setupTestApplication() throws Exception {
@@ -138,6 +141,15 @@ public class BeanValidation20_EJB extends JPAFATServletClient {
         ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + appFolder + "/" + appName + ".war");
 
         final JavaArchive testApiJar = buildTestAPIJar();
+
+        /*
+         * Hibernate 5.2 (JPA 2.1) contains a bug that requires a dialect property to be set
+         * for Oracle platform detection: https://hibernate.atlassian.net/browse/HHH-13184
+         */
+        if (AbstractFATSuite.repeatPhase != null && AbstractFATSuite.repeatPhase.contains("21")
+            && DatabaseVendor.ORACLE.equals(getDbVendor())) {
+            ejbApp.move("/META-INF/persistence-oracle-21.xml", "/META-INF/persistence.xml");
+        }
 
         final EnterpriseArchive app = ShrinkWrap.create(EnterpriseArchive.class, appNameEar);
         app.addAsModule(ejbApp);

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation20_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation20_Web.java
@@ -30,6 +30,7 @@ import com.ibm.websphere.simplicity.config.ClassloaderElement;
 import com.ibm.websphere.simplicity.config.ConfigElementList;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.ws.jpa.beanvalidation20.web.TestBeanValidation20Servlet;
+import com.ibm.ws.testtooling.database.DatabaseVendor;
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
 import componenttest.annotation.Server;
@@ -120,6 +121,8 @@ public class BeanValidation20_Web extends JPAFATServletClient {
         executeDDL(server, ddlSet, false);
 
         setupTestApplication();
+
+        skipDBRule.setDatabase(getDbVendor().name());
     }
 
     private static void setupTestApplication() throws Exception {
@@ -130,6 +133,15 @@ public class BeanValidation20_Web extends JPAFATServletClient {
         ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + appFolder + "/" + appName + ".war");
 
         final JavaArchive testApiJar = buildTestAPIJar();
+
+        /*
+         * Hibernate 5.2 (JPA 2.1) contains a bug that requires a dialect property to be set
+         * for Oracle platform detection: https://hibernate.atlassian.net/browse/HHH-13184
+         */
+        if (AbstractFATSuite.repeatPhase != null && AbstractFATSuite.repeatPhase.contains("21")
+            && DatabaseVendor.ORACLE.equals(getDbVendor())) {
+            webApp.move("/WEB-INF/classes/META-INF/persistence-oracle-21.xml", "/WEB-INF/classes/META-INF/persistence.xml");
+        }
 
         final EnterpriseArchive app = ShrinkWrap.create(EnterpriseArchive.class, appNameEar);
         app.addAsModule(webApp);

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation_EJB.java
@@ -32,6 +32,7 @@ import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.ws.jpa.beanvalidation.ejb.TestBeanValidation_EJB_SFEx_Servlet;
 import com.ibm.ws.jpa.beanvalidation.ejb.TestBeanValidation_EJB_SF_Servlet;
 import com.ibm.ws.jpa.beanvalidation.ejb.TestBeanValidation_EJB_SL_Servlet;
+import com.ibm.ws.testtooling.database.DatabaseVendor;
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
 import componenttest.annotation.Server;
@@ -124,6 +125,8 @@ public class BeanValidation_EJB extends JPAFATServletClient {
         executeDDL(server, ddlSet, false);
 
         setupTestApplication();
+
+        skipDBRule.setDatabase(getDbVendor().name());
     }
 
     private static void setupTestApplication() throws Exception {
@@ -138,6 +141,15 @@ public class BeanValidation_EJB extends JPAFATServletClient {
         ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + appFolder + "/" + appName + ".war");
 
         final JavaArchive testApiJar = buildTestAPIJar();
+
+        /*
+         * Hibernate 5.2 (JPA 2.1) contains a bug that requires a dialect property to be set
+         * for Oracle platform detection: https://hibernate.atlassian.net/browse/HHH-13184
+         */
+        if (AbstractFATSuite.repeatPhase != null && AbstractFATSuite.repeatPhase.contains("21")
+            && DatabaseVendor.ORACLE.equals(getDbVendor())) {
+            ejbApp.move("/META-INF/persistence-oracle-21.xml", "/META-INF/persistence.xml");
+        }
 
         final EnterpriseArchive app = ShrinkWrap.create(EnterpriseArchive.class, appNameEar);
         app.addAsModule(ejbApp);

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation/test-applications/beanvalidation/ejb/beanvalidationEjb.jar/META-INF/persistence-oracle-21.xml
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation/test-applications/beanvalidation/ejb/beanvalidationEjb.jar/META-INF/persistence-oracle-21.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+    version="2.0">
+
+    <persistence-unit name="BEANVALIDATION_JTA">
+        <jta-data-source>jdbc/JPA_JTA_DS</jta-data-source>
+        <non-jta-data-source>jdbc/JPA_NJTA_DS</non-jta-data-source>
+        <mapping-file>META-INF/orm.xml</mapping-file>
+        <validation-mode>AUTO</validation-mode>
+        <properties>
+            <property name="eclipselink.logging.parameters" value="true"/>
+            <property name="eclipselink.cache.shared.default" value="false"/>
+
+            <!-- Hibernate 5.2 (JPA 2.1) contains a bug that requires this property to be set
+            for Oracle platform detection: https://hibernate.atlassian.net/browse/HHH-13184 -->
+            <property name="hibernate.dialect" value="org.hibernate.dialect.Oracle12cDialect"/>
+        </properties>
+    </persistence-unit>
+
+    <persistence-unit name="BEANVALIDATION_RL" transaction-type="RESOURCE_LOCAL">
+        <non-jta-data-source>jdbc/JPA_NJTA_DS</non-jta-data-source>
+        <mapping-file>META-INF/orm.xml</mapping-file>
+        <validation-mode>AUTO</validation-mode>
+        <properties>
+            <property name="eclipselink.logging.parameters" value="true"/>
+            <property name="eclipselink.cache.shared.default" value="false"/>
+
+            <!-- Hibernate 5.2 (JPA 2.1) contains a bug that requires this property to be set
+            for Oracle platform detection: https://hibernate.atlassian.net/browse/HHH-13184 -->
+            <property name="hibernate.dialect" value="org.hibernate.dialect.Oracle12cDialect"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation/test-applications/beanvalidation/web/beanvalidationWeb.war/WEB-INF/classes/META-INF/persistence-oracle-21.xml
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation/test-applications/beanvalidation/web/beanvalidationWeb.war/WEB-INF/classes/META-INF/persistence-oracle-21.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+    version="2.0">
+
+    <persistence-unit name="BEANVALIDATION_JTA">
+        <jta-data-source>jdbc/JPA_JTA_DS</jta-data-source>
+        <non-jta-data-source>jdbc/JPA_NJTA_DS</non-jta-data-source>
+        <mapping-file>META-INF/orm.xml</mapping-file>
+        <validation-mode>AUTO</validation-mode>
+        <properties>
+            <property name="eclipselink.logging.parameters" value="true"/>
+            <property name="eclipselink.cache.shared.default" value="false"/>
+
+            <!-- Hibernate 5.2 (JPA 2.1) contains a bug that requires this property to be set
+            for Oracle platform detection: https://hibernate.atlassian.net/browse/HHH-13184 -->
+            <property name="hibernate.dialect" value="org.hibernate.dialect.Oracle12cDialect"/>
+        </properties>
+    </persistence-unit>
+
+    <persistence-unit name="BEANVALIDATION_RL" transaction-type="RESOURCE_LOCAL">
+        <non-jta-data-source>jdbc/JPA_NJTA_DS</non-jta-data-source>
+        <mapping-file>META-INF/orm.xml</mapping-file>
+        <validation-mode>AUTO</validation-mode>
+        <properties>
+            <property name="eclipselink.logging.parameters" value="true"/>
+            <property name="eclipselink.cache.shared.default" value="false"/>
+
+            <!-- Hibernate 5.2 (JPA 2.1) contains a bug that requires this property to be set
+            for Oracle platform detection: https://hibernate.atlassian.net/browse/HHH-13184 -->
+            <property name="hibernate.dialect" value="org.hibernate.dialect.Oracle12cDialect"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation/test-applications/beanvalidation20/ejb/beanvalidation20Ejb.jar/META-INF/persistence-oracle-21.xml
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation/test-applications/beanvalidation20/ejb/beanvalidation20Ejb.jar/META-INF/persistence-oracle-21.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+    version="2.0">
+
+    <persistence-unit name="BEANVALIDATION_JTA">
+        <jta-data-source>jdbc/JPA_JTA_DS</jta-data-source>
+        <non-jta-data-source>jdbc/JPA_NJTA_DS</non-jta-data-source>
+        <mapping-file>META-INF/orm.xml</mapping-file>
+        <validation-mode>AUTO</validation-mode>
+        <properties>
+            <property name="eclipselink.logging.parameters" value="true"/>
+            <property name="eclipselink.cache.shared.default" value="false"/>
+
+            <!-- Hibernate 5.2 (JPA 2.1) contains a bug that requires this property to be set
+            for Oracle platform detection: https://hibernate.atlassian.net/browse/HHH-13184 -->
+            <property name="hibernate.dialect" value="org.hibernate.dialect.Oracle12cDialect"/>
+        </properties>
+    </persistence-unit>
+
+    <persistence-unit name="BEANVALIDATION_RL" transaction-type="RESOURCE_LOCAL">
+        <non-jta-data-source>jdbc/JPA_NJTA_DS</non-jta-data-source>
+        <mapping-file>META-INF/orm.xml</mapping-file>
+        <validation-mode>AUTO</validation-mode>
+        <properties>
+            <property name="eclipselink.logging.parameters" value="true"/>
+            <property name="eclipselink.cache.shared.default" value="false"/>
+
+            <!-- Hibernate 5.2 (JPA 2.1) contains a bug that requires this property to be set
+            for Oracle platform detection: https://hibernate.atlassian.net/browse/HHH-13184 -->
+            <property name="hibernate.dialect" value="org.hibernate.dialect.Oracle12cDialect"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation/test-applications/beanvalidation20/web/beanvalidation20Web.war/WEB-INF/classes/META-INF/persistence-oracle-21.xml
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation/test-applications/beanvalidation20/web/beanvalidation20Web.war/WEB-INF/classes/META-INF/persistence-oracle-21.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+    version="2.0">
+
+    <persistence-unit name="BEANVALIDATION_JTA">
+        <jta-data-source>jdbc/JPA_JTA_DS</jta-data-source>
+        <non-jta-data-source>jdbc/JPA_NJTA_DS</non-jta-data-source>
+        <mapping-file>META-INF/orm.xml</mapping-file>
+        <validation-mode>AUTO</validation-mode>
+        <properties>
+            <property name="eclipselink.logging.parameters" value="true"/>
+            <property name="eclipselink.cache.shared.default" value="false"/>
+
+            <!-- Hibernate 5.2 (JPA 2.1) contains a bug that requires this property to be set
+            for Oracle platform detection: https://hibernate.atlassian.net/browse/HHH-13184 -->
+            <property name="hibernate.dialect" value="org.hibernate.dialect.Oracle12cDialect"/>
+        </properties>
+    </persistence-unit>
+
+    <persistence-unit name="BEANVALIDATION_RL" transaction-type="RESOURCE_LOCAL">
+        <non-jta-data-source>jdbc/JPA_NJTA_DS</non-jta-data-source>
+        <mapping-file>META-INF/orm.xml</mapping-file>
+        <validation-mode>AUTO</validation-mode>
+        <properties>
+            <property name="eclipselink.logging.parameters" value="true"/>
+            <property name="eclipselink.cache.shared.default" value="false"/>
+
+            <!-- Hibernate 5.2 (JPA 2.1) contains a bug that requires this property to be set
+            for Oracle platform detection: https://hibernate.atlassian.net/browse/HHH-13184 -->
+            <property name="hibernate.dialect" value="org.hibernate.dialect.Oracle12cDialect"/>
+        </properties>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
The BeanValidation FAT was not meant to execute against non-Derby databases, however #18444 didnt completely enable the skip database Rule.

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>