### PR TITLE
Remove extra trace on Ldap krb5 FATs

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/publish/servers/com.ibm.ws.security.registry.ldap.fat.krb5.base/bootstrap.properties
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/publish/servers/com.ibm.ws.security.registry.ldap.fat.krb5.base/bootstrap.properties
@@ -9,5 +9,5 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.security.*=all:ChannelFramework=all:com.ibm.ws.app.manager=all:com.ibm.ws.kernel.*=all
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.security.*=all
 com.ibm.ws.logging.max.file.size=0


### PR DESCRIPTION
Remove trace we no longer need from the LDAP Kerberos FATs. Was added for debugging the issue eventually resolved by #16092 