### PR TITLE
combination with Transactional interceptors and more experimentation

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -41,6 +41,8 @@ public class ConcurrentCDITest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer(
+                          "CWWKE1205E" // test case intentionally causes startTimeout to be exceeded
+        );
     }
 }

--- a/dev/com.ibm.ws.concurrent_fat_cdi/publish/servers/concurrent_fat_cdi/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/publish/servers/concurrent_fat_cdi/server.xml
@@ -27,7 +27,7 @@
     </managedExecutorService>
 
     <managedScheduledExecutorService jndiName="concurrent/timeoutExecutor">
-        <concurrencyPolicy max="1" startTimeout="3s"/>
+        <concurrencyPolicy max="1" maxQueueSize="1" maxWaitForEnqueue="1m" startTimeout="3s"/>
     </managedScheduledExecutorService>
 
 </server>

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ApplicationScopedBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ApplicationScopedBean.java
@@ -38,9 +38,7 @@ public class ApplicationScopedBean implements Serializable {
      * and its return type of CompletableFuture.
      */
     public CompletableFuture<String> appendThreadNameFuture(String part1) {
-        CompletableFuture<String> future = Async.Result.getFuture(String.class);
-        future.complete(part1 + getCharacter() + Thread.currentThread().getName());
-        return future;
+        return Async.Result.complete(part1 + getCharacter() + Thread.currentThread().getName());
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/DependentScopedBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/DependentScopedBean.java
@@ -10,7 +10,15 @@
  *******************************************************************************/
 package concurrent.cdi.web;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
 import jakarta.enterprise.context.Dependent;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import prototype.enterprise.concurrent.Async;
 
 @Dependent
 public class DependentScopedBean {
@@ -18,6 +26,20 @@ public class DependentScopedBean {
 
     public boolean getBoolean() {
         return value;
+    }
+
+    /**
+     * Asynchronously, look up a JNDI name and convert the result to a String value.
+     */
+    @Async
+    public CompletionStage<String> lookupAndConvertToString(String jndiName) {
+        CompletableFuture<String> future = Async.Result.getFuture(String.class);
+        try {
+            future.complete(InitialContext.doLookup(jndiName).toString());
+        } catch (NamingException x) {
+            future.completeExceptionally(x);
+        }
+        return future;
     }
 
     public void setBoolean(boolean value) {

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/MyManagedBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/MyManagedBean.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi.web;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import prototype.enterprise.concurrent.Async;
+
+public class MyManagedBean {
+
+    @Async
+    public CompletableFuture<Object> asyncLookup(String jndiName) {
+        try {
+            return Async.Result.complete(InitialContext.doLookup(jndiName));
+        } catch (NamingException x) {
+            throw new CompletionException(x);
+        }
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/RequestScopedBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/RequestScopedBean.java
@@ -10,11 +10,51 @@
  *******************************************************************************/
 package concurrent.cdi.web;
 
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
 import jakarta.enterprise.context.RequestScoped;
 
+import prototype.enterprise.concurrent.Async;
+
+@Async(executor = "java:module/env/concurrent/timeoutExecutorRef")
 @RequestScoped
 public class RequestScopedBean {
     private int number;
+
+    /**
+     * Async method that waits the specifiee latch for up to the timeout.
+     */
+    public CompletionStage<Boolean> await(CountDownLatch latch, long timeout, TimeUnit unit) {
+        try {
+            return CompletableFuture.completedFuture(latch.await(timeout, unit));
+        } catch (InterruptedException x) {
+            throw new CompletionException(x);
+        }
+    }
+
+    /**
+     * Specify conflicting Async annotations at both class and method level
+     * pointing at different managed executors. Return the one that is actually used.
+     */
+    @Async(executor = "java:app/env/concurrent/sampleExecutorRef")
+    public CompletableFuture<Executor> getExecutorOfAsyncMethods() throws Exception {
+        CompletableFuture<Executor> future = Async.Result.getFuture(Executor.class);
+        // CompletatbleFuture.defaultExecutor() is unavailable on Java 8 CompletableFuture
+        Method CompletableFuture_defaultExecutor;
+        try {
+            CompletableFuture_defaultExecutor = CompletableFuture.class.getMethod("defaultExecutor");
+            future.complete((Executor) CompletableFuture_defaultExecutor.invoke(future));
+        } catch (NoSuchMethodException x) {
+            future.completeExceptionally(x);
+        }
+        return future;
+    }
 
     public int getNumber() {
         return number;

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/TaskBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/TaskBean.java
@@ -10,7 +10,12 @@
  *******************************************************************************/
 package concurrent.cdi.web;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
 
 import jakarta.enterprise.context.ContextNotActiveException;
@@ -18,6 +23,9 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import prototype.enterprise.concurrent.Async;
 
 @Singleton
 public class TaskBean implements Callable<String> {
@@ -56,5 +64,28 @@ public class TaskBean implements Callable<String> {
         singletonScopedBean.put("Key_TaskBean", singletonScopedBean.get("Key_TaskBean") + " and more text");
 
         return (String) new InitialContext().lookup("java:comp/env/entry1");
+    }
+
+    /**
+     * Asynchronously, look up a JNDI name and convert the result to a String value.
+     */
+    @Async
+    public CompletionStage<List<String>> lookupAll(String jndiName1, String jndiName2, String jndiName3) {
+        if (Async.Result.getFuture(List.class).isDone())
+            throw new AssertionError("Result CompletableFuture should not be done already!");
+        try {
+            return dependentScopedBean.lookupAndConvertToString(jndiName1)
+                            .thenCombine(CompletableFuture.completedFuture(InitialContext.doLookup(jndiName2).toString()),
+                                         (s1, s2) -> {
+                                             // application component context must be available to dependent stage
+                                             try {
+                                                 return Arrays.asList(s1, s2, InitialContext.doLookup(jndiName3).toString());
+                                             } catch (NamingException x) {
+                                                 throw new CompletionException(x);
+                                             }
+                                         });
+        } catch (NamingException x) {
+            throw new CompletionException(x);
+        }
     }
 }

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/TransactionScopedBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/TransactionScopedBean.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi.web;
+
+import java.io.Serializable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.transaction.TransactionScoped;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import prototype.enterprise.concurrent.Async;
+
+@TransactionScoped
+public class TransactionScopedBean implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private AtomicInteger intRef = new AtomicInteger();
+
+    public int get() {
+        return intRef.get();
+    }
+
+    public int increment(int amount) {
+        return intRef.addAndGet(amount);
+    }
+
+    @Async
+    public CompletableFuture<Integer> incrementAsync(int amount) {
+        try {
+            // Requires application component's context:
+            ManagedExecutorService executor = InitialContext.doLookup("java:module/env/concurrent/timeoutExecutorRef");
+            if (executor == null)
+                throw new AssertionError("Null result of resource reference lookup.");
+
+            return Async.Result.complete(intRef.addAndGet(amount));
+        } catch (NamingException x) {
+            throw new CompletionException(x);
+        }
+    }
+
+    public void set(int amount) {
+        intRef.set(amount);
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/TransactionalBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/TransactionalBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2020 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,8 @@ import java.io.Serializable;
 
 import jakarta.inject.Singleton;
 import jakarta.transaction.TransactionSynchronizationRegistry;
+import jakarta.transaction.Transactional;
+import jakarta.transaction.Transactional.TxType;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -22,15 +24,37 @@ import javax.naming.NamingException;
 public class TransactionalBean implements Serializable {
     private static final long serialVersionUID = 8518443344930037109L;
 
-    private static Object getTransactionKey() throws NamingException {
+    static Object getTransactionKey() throws NamingException {
         TransactionSynchronizationRegistry tranSyncRegistry = (TransactionSynchronizationRegistry) new InitialContext().lookup("java:comp/TransactionSynchronizationRegistry");
         return tranSyncRegistry.getTransactionKey();
     }
 
+    @Transactional(TxType.MANDATORY)
+    public Object runAsMandatory() throws Exception {
+        return getTransactionKey();
+    }
+
+    @Transactional(TxType.NEVER)
     public Object runAsNever() throws Exception {
         return getTransactionKey();
     }
 
+    @Transactional(TxType.NOT_SUPPORTED)
+    public Object runAsNotSupported() throws Exception {
+        return getTransactionKey();
+    }
+
+    @Transactional(TxType.REQUIRED)
+    public Object runAsRequired() throws Exception {
+        return getTransactionKey();
+    }
+
+    @Transactional(TxType.REQUIRES_NEW)
+    public Object runAsRequiresNew() throws Exception {
+        return getTransactionKey();
+    }
+
+    @Transactional(TxType.SUPPORTS)
     public Object runAsSupports() throws Exception {
         return getTransactionKey();
     }

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/TransactionalBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/TransactionalBean.java
@@ -11,6 +11,8 @@
 package concurrent.cdi.web;
 
 import java.io.Serializable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 import jakarta.inject.Singleton;
 import jakarta.transaction.TransactionSynchronizationRegistry;
@@ -20,6 +22,8 @@ import jakarta.transaction.Transactional.TxType;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
+import prototype.enterprise.concurrent.Async;
+
 @Singleton
 public class TransactionalBean implements Serializable {
     private static final long serialVersionUID = 8518443344930037109L;
@@ -27,6 +31,66 @@ public class TransactionalBean implements Serializable {
     static Object getTransactionKey() throws NamingException {
         TransactionSynchronizationRegistry tranSyncRegistry = (TransactionSynchronizationRegistry) new InitialContext().lookup("java:comp/TransactionSynchronizationRegistry");
         return tranSyncRegistry.getTransactionKey();
+    }
+
+    @Async
+    @Transactional(TxType.MANDATORY)
+    public CompletableFuture<Object> runAsyncAsMandatory() {
+        try {
+            return Async.Result.complete(getTransactionKey());
+        } catch (NamingException x) {
+            throw new CompletionException(x);
+        }
+    }
+
+    @Async
+    @Transactional(TxType.NEVER)
+    public CompletableFuture<Object> runAsyncAsNever() throws Exception {
+        try {
+            return Async.Result.complete(getTransactionKey());
+        } catch (NamingException x) {
+            throw new CompletionException(x);
+        }
+    }
+
+    @Async
+    @Transactional(TxType.NOT_SUPPORTED)
+    public CompletableFuture<Object> runAsyncAsNotSupported() throws Exception {
+        try {
+            return Async.Result.complete(getTransactionKey());
+        } catch (NamingException x) {
+            throw new CompletionException(x);
+        }
+    }
+
+    @Async
+    @Transactional(TxType.REQUIRED)
+    public CompletableFuture<Object> runAsyncAsRequired() throws Exception {
+        try {
+            return Async.Result.complete(getTransactionKey());
+        } catch (NamingException x) {
+            throw new CompletionException(x);
+        }
+    }
+
+    @Async
+    @Transactional(TxType.REQUIRES_NEW)
+    public CompletableFuture<Object> runAsyncAsRequiresNew() throws Exception {
+        try {
+            return Async.Result.complete(getTransactionKey());
+        } catch (NamingException x) {
+            throw new CompletionException(x);
+        }
+    }
+
+    @Async
+    @Transactional(TxType.SUPPORTS)
+    public CompletableFuture<Object> runAsyncAsSupports() throws Exception {
+        try {
+            return Async.Result.complete(getTransactionKey());
+        } catch (NamingException x) {
+            throw new CompletionException(x);
+        }
     }
 
     @Transactional(TxType.MANDATORY)

--- a/dev/io.openliberty.concurrent.cdi/bnd.bnd
+++ b/dev/io.openliberty.concurrent.cdi/bnd.bnd
@@ -44,11 +44,13 @@ instrument.classesExcludes: io/openliberty/concurrent/cdi/resources/*.class
   com.ibm.websphere.javaee.cdi.2.0,\
   com.ibm.websphere.javaee.concurrent.1.0,\
   com.ibm.websphere.javaee.interceptor.1.2,\
+  com.ibm.websphere.javaee.transaction.1.2,\
   com.ibm.ws.cdi.interfaces,\
   io.openliberty.jakarta.annotation.2.0,\
   io.openliberty.jakarta.cdi.3.0,\
   io.openliberty.jakarta.concurrency.2.0,\
-  io.openliberty.jakarta.interceptor.2.0
+  io.openliberty.jakarta.interceptor.2.0,\
+  io.openliberty.jakarta.transaction.2.0
 #  ../com.ibm.ws.cdi.interfaces/build/libs/com.ibm.ws.cdi.interfaces.jakarta.jar;version=file
 
 # last line above is in place of com.ibm.ws.cdi.interfaces.jakarta;version=latest

--- a/dev/io.openliberty.concurrent.cdi/src/prototype/enterprise/concurrent/Async.java
+++ b/dev/io.openliberty.concurrent.cdi/src/prototype/enterprise/concurrent/Async.java
@@ -24,7 +24,8 @@ import jakarta.interceptor.InterceptorBinding;
 // For experimentation with a possible Async or Asynchronous annotation in Jakarta Concurrency.
 // TODO Delete this class if it goes into the spec. Delete this class if it doesn't.
 /**
- * Annotates a method (or class containing suitable methods) to run asynchronously.
+ * Annotates a CDI managed bean method (or CDI managed bean class containing suitable methods)
+ * to run asynchronously.
  * <p>
  * The Jakarta EE Product Provider runs the method on a {@link ManagedExecutorService}
  * and returns to the caller a {@link java.util.concurrent.CompletableFuture CompletableFuture}
@@ -130,7 +131,7 @@ import jakarta.interceptor.InterceptorBinding;
  * {@link java.util.concurrent.CompletableFuture#completeExceptionally completeExceptionally}
  * to supply the original exception as the cause.
  * <p>
- * The Jakarta EE Product Provider raises
+ * Except where otherwise stated, the Jakarta EE Product Provider raises
  * {@link java.util.concurrent.RejectedExecutionException RejectedExecutionException}
  * upon invocation of the asynchronous method if evident upfront that it cannot
  * be accepted, for example if the JNDI name is not valid or points to something
@@ -139,7 +140,19 @@ import jakarta.interceptor.InterceptorBinding;
  * then the Jakarta EE Product Provider completes the <code>CompletableFuture</code>
  * exceptionally with {@link java.util.concurrent.CancellationException CancellationException},
  * and chains a cause exception if there is any.
+ * <p>
+ * The Jakarta EE Product Provider must assign the interceptor for asynchronous methods
+ * to have priority of <code>Interceptor.Priority.PLATFORM_BEFORE + 5</code>,
+ * so as to enable most other platform interceptors, such as <code>Transactional</code>,
+ * to be applied to the thread upon which the asynchronous method executes.
+ * When an asynchronous method is annotated as <code>Transactional</code>,
+ * the transactional types <code>TxType.REQUIRES_NEW</code> and
+ * <code>TxType.NOT_SUPPORTED</code> can be used. All other transaction attributes must
+ * result in {@link java.lang.UnsupportedOperationException UnsupportedOperationException}
+ * upon invocation of the asynchronous method.
  */
+// TODO the above restrictions on Transactional interceptors could be eliminated
+// if transaction context propagation is later added to the spec.
 @Documented
 @Inherited
 @InterceptorBinding


### PR DESCRIPTION
Consider the validity of combining with each of the `@Transactional` interceptors.  Limit to REQUIRES_NEW and NOT_SUPPORTED in order to avoid transaction context propagation, which is a separate spec issue.