### PR TITLE
Set the starter xml file for DynamicUpdateTest

### DIFF
--- a/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/DynamicUpdateTest.java
+++ b/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/DynamicUpdateTest.java
@@ -97,6 +97,7 @@ public class DynamicUpdateTest {
             servlet.getRealm();
         }
 
+        serverConfigurationFile = MASTER_SERVER_XML;
     }
 
     @AfterClass
@@ -131,6 +132,8 @@ public class DynamicUpdateTest {
             server.waitForStringInLogUsingMark("CWWKG0017I"); //CWWKG0017I: The server configuration was successfully updated in 0.2 seconds.
 
             serverConfigurationFile = serverXML;
+        } else {
+            Log.info(c, "setServerConfiguration", "serverConfig already set to " + serverXML + ", no config update.");
         }
     }
 


### PR DESCRIPTION
In the FAT failure, we're not flagging that the server.xml should be updated when it should be. Set it in the `setup` method -- it seems to be failing on the EE9 repeat at the start of the test so maybe we're running with an old config reference.

RTC 286331