### PR TITLE
Allow SSL failures possibly resolved by retries

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/MessageConstants.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/MessageConstants.java
@@ -26,6 +26,7 @@ public class MessageConstants {
     public static final String CWWKG0014E_XML_PARSER_ERROR = "CWWKG0014E";
     public static final String CWWKO0221E_PORT_IN_USE = "CWWKO0221E";
     public static final String CWWKO0227E_EXECUTOR_SERVICE_MISSING = "CWWKO0227E";
+    public static final String CWWKO0801E_UNABLE_TO_INIT_SSL = "CWWKO0801E";
 
     public static final String SSL_NOT_RESTARTED_PROPERLY = "SSL may not have started properly";
 

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/TestServer.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/TestServer.java
@@ -714,6 +714,9 @@ public class TestServer extends ExternalResource {
             addIgnoredServerExceptions(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING);
             // ignore ssl restart warnings - if they caused problems, tests would also be failing
             addIgnoredServerExceptions(MessageConstants.SSL_NOT_RESTARTED_PROPERLY);
+            // ignore ssl message - runtime retries and can proceed (sometimes) when it can't tests will fail when they don't get the correct response
+            server.addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0801E_UNABLE_TO_INIT_SSL));
+
             server.stopServer(ignoredServerExceptions);
         }
         unInstallCallbackHandler(callback, callbackFeature);

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/ServerTracker.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/ServerTracker.java
@@ -63,6 +63,8 @@ public class ServerTracker {
         server.addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
         // ignore potential timing issue with SSL port restart - if the port was ready when tests need it, that's good enough
         server.addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
+        // ignore ssl message - runtime retries and can proceed (sometimes) when it can't tests will fail when they don't get the correct response
+        server.addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0801E_UNABLE_TO_INIT_SSL));
 
     }
 

--- a/dev/com.ibm.ws.security.fat.common/test/com/ibm/ws/security/fat/common/servers/ServerTrackerTest.java
+++ b/dev/com.ibm.ws.security.fat.common/test/com/ibm/ws/security/fat/common/servers/ServerTrackerTest.java
@@ -109,6 +109,7 @@ public class ServerTrackerTest extends CommonTestClass {
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0801E_UNABLE_TO_INIT_SSL));
                 }
             });
 
@@ -139,6 +140,7 @@ public class ServerTrackerTest extends CommonTestClass {
                     exactly(2).of(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     exactly(2).of(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     exactly(2).of(server1).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
+                    exactly(2).of(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0801E_UNABLE_TO_INIT_SSL));
                 }
             });
 
@@ -170,18 +172,21 @@ public class ServerTrackerTest extends CommonTestClass {
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0801E_UNABLE_TO_INIT_SSL));
                     one(server2).addInstalledAppForValidation(Constants.APP_TESTMARKER);
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKE1102W_QUIESCE_WARNING, MessageConstants.CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE, MessageConstants.CWWKE1107W_QUIESCE_WAITING_ON_THREAD));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0221E_PORT_IN_USE));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
+                    one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0801E_UNABLE_TO_INIT_SSL));
                     one(server3).addInstalledAppForValidation(Constants.APP_TESTMARKER);
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKE1102W_QUIESCE_WARNING, MessageConstants.CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE, MessageConstants.CWWKE1107W_QUIESCE_WAITING_ON_THREAD));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0221E_PORT_IN_USE));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
+                    one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0801E_UNABLE_TO_INIT_SSL));
                 }
             });
 
@@ -250,6 +255,7 @@ public class ServerTrackerTest extends CommonTestClass {
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0801E_UNABLE_TO_INIT_SSL));
                 }
             });
 
@@ -285,6 +291,7 @@ public class ServerTrackerTest extends CommonTestClass {
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0801E_UNABLE_TO_INIT_SSL));
                 }
             });
 
@@ -325,18 +332,21 @@ public class ServerTrackerTest extends CommonTestClass {
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0801E_UNABLE_TO_INIT_SSL));
                     one(server2).addInstalledAppForValidation(Constants.APP_TESTMARKER);
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKE1102W_QUIESCE_WARNING, MessageConstants.CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE, MessageConstants.CWWKE1107W_QUIESCE_WAITING_ON_THREAD));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0221E_PORT_IN_USE));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
+                    one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0801E_UNABLE_TO_INIT_SSL));
                     one(server3).addInstalledAppForValidation(Constants.APP_TESTMARKER);
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKE1102W_QUIESCE_WARNING, MessageConstants.CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE, MessageConstants.CWWKE1107W_QUIESCE_WAITING_ON_THREAD));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0221E_PORT_IN_USE));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
+                    one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0801E_UNABLE_TO_INIT_SSL));
                 }
             });
 
@@ -376,18 +386,21 @@ public class ServerTrackerTest extends CommonTestClass {
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0801E_UNABLE_TO_INIT_SSL));
                     one(server2).addInstalledAppForValidation(Constants.APP_TESTMARKER);
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKE1102W_QUIESCE_WARNING, MessageConstants.CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE, MessageConstants.CWWKE1107W_QUIESCE_WAITING_ON_THREAD));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0221E_PORT_IN_USE));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
+                    one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0801E_UNABLE_TO_INIT_SSL));
                     one(server3).addInstalledAppForValidation(Constants.APP_TESTMARKER);
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKE1102W_QUIESCE_WARNING, MessageConstants.CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE, MessageConstants.CWWKE1107W_QUIESCE_WAITING_ON_THREAD));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0221E_PORT_IN_USE));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
+                    one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0801E_UNABLE_TO_INIT_SSL));
                 }
             });
 


### PR DESCRIPTION
The server records error message CWWKO0801E, but does sometimes retry and the connection will work.  The FAT framework searches for extra error or warning messages on server shutdown.  It finds this message and fails the test even though everything worked just fine.
I'm adding this error message to the allowed errors for all servers.  If there is truly a connection failure, the test case will NOT get the response that it expects and the test will fail.
This should not mask any real issues.