### PR TITLE
Avoid getting name every request

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.1/src/com/ibm/ws/microprofile/config/sources/EnvConfigSource.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1/src/com/ibm/ws/microprofile/config/sources/EnvConfigSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,6 +29,12 @@ import io.openliberty.microprofile.config.internal.common.InternalConfigSource;
 public class EnvConfigSource extends InternalConfigSource implements StaticConfigSource {
 
     private static final TraceComponent tc = Tr.register(EnvConfigSource.class);
+    private final String name;
+
+    @Trivial
+    public EnvConfigSource() {
+        name = Tr.formatMessage(tc, "environment.variables.config.source");
+    }
 
     /** {@inheritDoc} */
     @Override
@@ -49,7 +55,7 @@ public class EnvConfigSource extends InternalConfigSource implements StaticConfi
     @Override
     @Trivial
     public String getName() {
-        return Tr.formatMessage(tc, "environment.variables.config.source");
+        return name;
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.ws.microprofile.config.1.1/src/com/ibm/ws/microprofile/config/sources/SystemConfigSource.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1/src/com/ibm/ws/microprofile/config/sources/SystemConfigSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,12 +30,18 @@ import io.openliberty.microprofile.config.internal.common.InternalConfigSource;
 public class SystemConfigSource extends InternalConfigSource implements StaticConfigSource {
 
     private static final TraceComponent tc = Tr.register(SystemConfigSource.class);
+    private final String name;
+
+    @Trivial
+    public SystemConfigSource() {
+        name = Tr.formatMessage(tc, "system.properties.config.source");
+    }
 
     /** {@inheritDoc} */
     @Override
     @Trivial
     public String getName() {
-        return Tr.formatMessage(tc, "system.properties.config.source");
+        return name;
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/sources/EnvConfig14Source.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/sources/EnvConfig14Source.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,6 +31,8 @@ public class EnvConfig14Source extends InternalConfigSource {
 
     private static Pattern p = null;
 
+    private final String name;
+
     /**
      * The environment. This is unmodifiable and can be returned to the user.
      */
@@ -48,10 +50,15 @@ public class EnvConfig14Source extends InternalConfigSource {
         p = Pattern.compile(ConfigConstants.CONFIG13_ALLOWABLE_CHARS_IN_ENV_VAR_SOURCE);
     }
 
+    @Trivial
+    public EnvConfig14Source() {
+        name = Tr.formatMessage(tc, "environment.variables.config.source");
+    }
+
     @Override
     @Trivial
     public String getName() {
-        return Tr.formatMessage(tc, "environment.variables.config.source");
+        return name;
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/sources/SystemConfig14Source.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/sources/SystemConfig14Source.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,10 +32,17 @@ public class SystemConfig14Source extends InternalConfigSource implements Extend
     private static final TraceComponent tc = Tr.register(SystemConfig14Source.class);
     static final SecureAction priv = AccessController.doPrivileged(SecureAction.get());
 
+    private final String name;
+
+    @Trivial
+    public SystemConfig14Source() {
+        name = Tr.formatMessage(tc, "system.properties.config.source");
+    }
+
     @Override
     @Trivial
     public String getName() {
-        return Tr.formatMessage(tc, "system.properties.config.source");
+        return name;
     }
 
     /** {@inheritDoc} */

--- a/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/AppPropertyConfigSource.java
+++ b/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/AppPropertyConfigSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -55,14 +55,20 @@ public class AppPropertyConfigSource extends InternalConfigSource {
     private final PrivilegedAction<String> getApplicationPidAction = new GetApplicationPidAction();
 
     private BundleContext bundleContext;
+    private String name;
     private String applicationName;
     private String applicationPID;
+
+    @Trivial
+    public AppPropertyConfigSource() {
+        name = Tr.formatMessage(tc, "server.xml.appproperties.config.source");
+    }
 
     /** {@inheritDoc} */
     @Override
     @Trivial
     public String getName() {
-        return Tr.formatMessage(tc, "server.xml.appproperties.config.source");
+        return name;
     }
 
     /** {@inheritDoc} */

--- a/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/AppPropertyConfigSource.java
+++ b/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/AppPropertyConfigSource.java
@@ -53,9 +53,9 @@ public class AppPropertyConfigSource extends InternalConfigSource {
     private static final TraceComponent tc = Tr.register(AppPropertyConfigSource.class);
 
     private final PrivilegedAction<String> getApplicationPidAction = new GetApplicationPidAction();
-
+    private final String name;
+    
     private BundleContext bundleContext;
-    private String name;
     private String applicationName;
     private String applicationPID;
 

--- a/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/ServerXMLDefaultVariableConfigSource.java
+++ b/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/ServerXMLDefaultVariableConfigSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,6 +29,12 @@ import com.ibm.ws.config.xml.LibertyVariable;
 public class ServerXMLDefaultVariableConfigSource extends ServerXMLVariableConfigSource {
 
     private static final TraceComponent tc = Tr.register(ServerXMLDefaultVariableConfigSource.class);
+    private String name;
+
+    @Trivial
+    public ServerXMLDefaultVariableConfigSource() {
+        name = Tr.formatMessage(tc, "server.xml.default.variables.config.source");
+    }
 
     /** {@inheritDoc} */
     @Override
@@ -41,7 +47,7 @@ public class ServerXMLDefaultVariableConfigSource extends ServerXMLVariableConfi
     @Override
     @Trivial
     public String getName() {
-        return Tr.formatMessage(tc, "server.xml.default.variables.config.source");
+        return name;
     }
 
     @Override

--- a/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/ServerXMLDefaultVariableConfigSource.java
+++ b/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/ServerXMLDefaultVariableConfigSource.java
@@ -29,7 +29,7 @@ import com.ibm.ws.config.xml.LibertyVariable;
 public class ServerXMLDefaultVariableConfigSource extends ServerXMLVariableConfigSource {
 
     private static final TraceComponent tc = Tr.register(ServerXMLDefaultVariableConfigSource.class);
-    private String name;
+    private final String name;
 
     @Trivial
     public ServerXMLDefaultVariableConfigSource() {

--- a/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/ServerXMLVariableConfigSource.java
+++ b/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/ServerXMLVariableConfigSource.java
@@ -36,7 +36,7 @@ public class ServerXMLVariableConfigSource extends InternalConfigSource implemen
 
     private static final TraceComponent tc = Tr.register(ServerXMLVariableConfigSource.class);
     private final GetServerXMLVariablesAction getServerXMLVariablesAction = new GetServerXMLVariablesAction();
-    private String name;
+    private final String name;
     private BundleContext bundleContext;
     private ConfigVariables configVariables;
 

--- a/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/ServerXMLVariableConfigSource.java
+++ b/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/ServerXMLVariableConfigSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,14 +36,20 @@ public class ServerXMLVariableConfigSource extends InternalConfigSource implemen
 
     private static final TraceComponent tc = Tr.register(ServerXMLVariableConfigSource.class);
     private final GetServerXMLVariablesAction getServerXMLVariablesAction = new GetServerXMLVariablesAction();
+    private String name;
     private BundleContext bundleContext;
     private ConfigVariables configVariables;
+
+    @Trivial
+    public ServerXMLVariableConfigSource() {
+        name = Tr.formatMessage(tc, "server.xml.variables.config.source");
+    }
 
     /** {@inheritDoc} */
     @Override
     @Trivial
     public String getName() {
-        return Tr.formatMessage(tc, "server.xml.variables.config.source");
+        return name;
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
While testing something else, I noticed the below in a profile. Changing to get the name formatted in the constructor instead of on every request takes away this extra time spent here.

  ```
  Parent      0   0.00  11.24           0         770    J:io/smallrye/config/ConfigValueConfigSourceWrapper.getName()Ljava/lang/String;
 
    Self      0   0.00  11.24           0         770    J:io/openliberty/microprofile/config/internal/serverxml/ServerXMLVariableConfigSource.getName()Ljava/lang/String;
 
   Child      0   0.00  11.24           0         770    J:com/ibm/websphere/ras/Tr.formatMessage(Lcom/ibm/websphere/ras/TraceComponent;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
 
 ```

