### PR TITLE
PR for Issue 17448: OIDC client update for allowing and/or requiring JWT access token remote validation

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
@@ -168,6 +168,13 @@ validationMethod.introspect=Validate inbound tokens using token introspection
 validationMethod.userinfo=Validate inbound tokens using the userinfo endpoint
 validationMethod.local=Validate inbound tokens locally using JWT validation
 
+jwtAccessTokenRemoteValidation=JWT access token remote validation
+jwtAccessTokenRemoteValidation.desc=Specifies whether a JWT access token that is received for inbound propagation is validated locally by the OpenID Connect client or by using the validation method that is configured by the OpenID Connect client.
+
+jwtAccessTokenRemoteValidation.none=A JWT access token that is received for inbound propagation is parsed and validated locally by the OpenID Connect client. If validation fails, the access token is not validated by using the validation method that is configured by the OpenID Connect client.
+jwtAccessTokenRemoteValidation.allow=A JWT access token that is received for inbound propagation is parsed and validated locally by the OpenID Connect client. If validation fails, the access token is validated by using the validation method that is configured by the OpenID Connect client.
+jwtAccessTokenRemoteValidation.require=A JWT access token that is received for inbound propagation is validated by using the validation method that is configured by the OpenID Connect client. The access token is not parsed or validated locally by the OpenID Connect client.
+
 headerName=Name of the header containing the inbound token
 headerName.desc=The name of the header which carries the inbound token in the request.
 

--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
@@ -111,7 +111,12 @@
          </AD>
          <AD id="validationMethod" name="%validationMethod" description="%validationMethod.desc" required="false" type="String" default="introspect">
                 <Option label="%validationMethod.introspect" value="introspect" />
-            	<Option label="%validationMethod.userinfo" value="userinfo" />
+                <Option label="%validationMethod.userinfo" value="userinfo" />
+         </AD>
+         <AD id="jwtAccessTokenRemoteValidation" name="%jwtAccessTokenRemoteValidation" description="%jwtAccessTokenRemoteValidation.desc" required="false" type="String" default="none" ibm:beta="true">
+                <Option label="%jwtAccessTokenRemoteValidation.none" value="none" />
+                <Option label="%jwtAccessTokenRemoteValidation.allow" value="allow" />
+                <Option label="%jwtAccessTokenRemoteValidation.require" value="require" />
          </AD>
          <AD id="authzParameter" name="%authzParameter" description="%authzParameter.desc" required="false" type="String" ibm:type="pid" ibm:reference="com.ibm.ws.security.openidconnect.client.param" cardinality="20" />
          <AD id="tokenParameter" name="%tokenParameter" description="%tokenParameter.desc" required="false" type="String" ibm:type="pid" ibm:reference="com.ibm.ws.security.openidconnect.client.param" cardinality="20" />

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
@@ -146,6 +146,7 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     public static final String CFG_KEY_CREATE_SESSION = "createSession";
     public static final String CFG_KEY_INBOUND_PROPAGATION = "inboundPropagation";
     public static final String CFG_KEY_VALIDATION_METHOD = "validationMethod";
+    public static final String CFG_KEY_JWT_ACCESS_TOKEN_REMOTE_VALIDATION = "jwtAccessTokenRemoteValidation";
     public static final String CFG_KEY_HEADER_NAME = "headerName";
     public static final String CFG_KEY_propagation_authnSessionDisabled = "authnSessionDisabled";
     public static final String CFG_KEY_reAuthnOnAccessTokenExpire = "reAuthnOnAccessTokenExpire";
@@ -253,6 +254,7 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     private boolean createSession;
     private String inboundPropagation;
     private String validationMethod;
+    private String jwtAccessTokenRemoteValidation;
     private String headerName;
     private boolean disableIssChecking;
     private String[] audiences;
@@ -450,6 +452,7 @@ public class OidcClientConfigImpl implements OidcClientConfig {
         clockSkewInSeconds = clockSkew / 1000; // Duration types are always in milliseconds, convert to seconds.
         authenticationTimeLimitInSeconds = (Long) props.get(CFG_KEY_AUTHENTICATION_TIME_LIMIT) / 1000;
         validationMethod = trimIt((String) props.get(CFG_KEY_VALIDATION_METHOD));
+        jwtAccessTokenRemoteValidation = configUtils.getConfigAttribute(props, CFG_KEY_JWT_ACCESS_TOKEN_REMOTE_VALIDATION);
         userInfoEndpointEnabled = (Boolean) props.get(CFG_KEY_USERINFO_ENDPOINT_ENABLED);
         discoveryEndpointUrl = trimIt((String) props.get(CFG_KEY_DISCOVERY_ENDPOINT_URL));
         discoveryPollingRate = (Long) props.get(CFG_KEY_DISCOVERY_POLLING_RATE);
@@ -604,6 +607,7 @@ public class OidcClientConfigImpl implements OidcClientConfig {
             Tr.debug(tc, "createSession: " + createSession);
             Tr.debug(tc, "inboundPropagation: " + inboundPropagation);
             Tr.debug(tc, "validationMethod: " + validationMethod);
+            Tr.debug(tc, "jwtAccessTokenRemoteValidation: " + jwtAccessTokenRemoteValidation);
             Tr.debug(tc, "headerName: " + headerName);
             Tr.debug(tc, "authnSessionDisabled:" + authnSessionDisabled);
             Tr.debug(tc, "disableIssChecking:" + disableIssChecking);
@@ -1587,6 +1591,11 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     @Override
     public String getValidationMethod() {
         return this.validationMethod;
+    }
+
+    @Override
+    public String getJwtAccessTokenRemoteValidation() {
+        return this.jwtAccessTokenRemoteValidation;
     }
 
     // This is either null or not_empty_string

--- a/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/AccessTokenAuthenticatorTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/AccessTokenAuthenticatorTest.java
@@ -329,7 +329,7 @@ public class AccessTokenAuthenticatorTest extends CommonTestClass {
                 will(returnValue(false));
                 allowing(clientConfig).getAccessTokenCacheEnabled();
                 will(returnValue(false));
-                one(clientConfig).getValidationMethod();
+                allowing(clientConfig).getValidationMethod();
                 will(returnValue(ClientConstants.VALIDATION_USERINFO));
                 one(clientConfig).isHostNameVerificationEnabled();
                 will(returnValue(true));
@@ -369,7 +369,7 @@ public class AccessTokenAuthenticatorTest extends CommonTestClass {
                 will(returnValue(false));
                 one(clientConfig).getAccessTokenCacheEnabled();
                 will(returnValue(false));
-                exactly(2).of(clientConfig).getValidationMethod();
+                allowing(clientConfig).getValidationMethod();
                 will(returnValue(ClientConstants.VALIDATION_USERINFO));
                 one(clientConfig).isHostNameVerificationEnabled();
                 will(returnValue(false));
@@ -407,7 +407,7 @@ public class AccessTokenAuthenticatorTest extends CommonTestClass {
                 will(returnValue(false));
                 allowing(clientConfig).getAccessTokenCacheEnabled();
                 will(returnValue(false));
-                one(clientConfig).getValidationMethod();
+                allowing(clientConfig).getValidationMethod();
                 will(returnValue(ClientConstants.VALIDATION_INTROSPECT));
                 allowing(clientConfig).getInboundPropagation();
                 will(returnValue("required"));
@@ -462,7 +462,7 @@ public class AccessTokenAuthenticatorTest extends CommonTestClass {
                 will(returnValue(false));
                 allowing(clientConfig).getAccessTokenCacheEnabled();
                 will(returnValue(false));
-                one(clientConfig).getValidationMethod();
+                allowing(clientConfig).getValidationMethod();
                 will(returnValue(ClientConstants.VALIDATION_INTROSPECT));
                 one(clientConfig).getClientSecret();
                 will(returnValue("client_secret"));
@@ -514,7 +514,7 @@ public class AccessTokenAuthenticatorTest extends CommonTestClass {
                 will(returnValue(true));
                 one(clientConfig).getTokenReuse();
                 will(returnValue(false));
-                one(clientConfig).getValidationMethod();
+                allowing(clientConfig).getValidationMethod();
                 will(returnValue(ClientConstants.VALIDATION_INTROSPECT));
                 one(clientConfig).getClientSecret();
                 will(returnValue("client_secret"));
@@ -573,7 +573,7 @@ public class AccessTokenAuthenticatorTest extends CommonTestClass {
                 will(returnValue(false));
                 allowing(clientConfig).getAccessTokenCacheEnabled();
                 will(returnValue(false));
-                exactly(3).of(clientConfig).getValidationMethod();
+                allowing(clientConfig).getValidationMethod();
                 will(returnValue(ClientConstants.VALIDATION_INTROSPECT));
                 one(clientConfig).getClientSecret();
                 will(returnValue(null));
@@ -612,11 +612,11 @@ public class AccessTokenAuthenticatorTest extends CommonTestClass {
 
                 one(clientConfig).getAccessTokenInLtpaCookie();
                 will(returnValue(false));
+                one(clientConfig).getTokenReuse();
+                will(returnValue(true));
                 one(clientConfig).getAccessTokenCacheEnabled();
                 will(returnValue(false));
-                one(clientConfig).getTokenReuse();
-                will(returnValue(false));
-                exactly(2).of(clientConfig).getValidationMethod();
+                allowing(clientConfig).getValidationMethod();
                 will(returnValue(ClientConstants.VALIDATION_INTROSPECT));
                 one(clientConfig).getClientSecret();
                 will(returnValue(null));
@@ -651,7 +651,7 @@ public class AccessTokenAuthenticatorTest extends CommonTestClass {
                 will(returnValue(false));
                 one(clientConfig).getAccessTokenCacheEnabled();
                 will(returnValue(false));
-                one(clientConfig).getValidationMethod();
+                allowing(clientConfig).getValidationMethod();
                 will(returnValue(INVALID_VALIDATION));
                 one(clientConfig).getTokenEndpointUrl();
                 will(returnValue(HTTPS_URL));

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/ClientConstants.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/ClientConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 IBM Corporation and others.
+ * Copyright (c) 2013, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -84,6 +84,10 @@ public class ClientConstants {
     public final static String VALIDATION_INTROSPECT = "introspect";
     public final static String VALIDATION_USERINFO = "userinfo";
     public final static String VALIDATION_LOCAL = "local";
+
+    public final static String JWT_ACCESS_TOKEN_REMOTE_VALIDATION_NONE = "none";
+    public final static String JWT_ACCESS_TOKEN_REMOTE_VALIDATION_ALLOW = "allow";
+    public final static String JWT_ACCESS_TOKEN_REMOTE_VALIDATION_REQUIRE = "require";
 
     public final static String ATTRIB_OIDC_CLIENT_REQUEST = "com.ibm.wsspi.security.oidc.client.request";
     public static final String WLP_USER_DIR = "${wlp.user.dir}";

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientConfig.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientConfig.java
@@ -34,6 +34,8 @@ public interface OidcClientConfig extends ConvergedClientConfig {
 
     public String getValidationMethod();
 
+    public String getJwtAccessTokenRemoteValidation();
+
     public String getHeaderName();
 
     public boolean isValidConfig(); // when the inboundPropagation is required


### PR DESCRIPTION
For https://github.com/OpenLiberty/open-liberty/issues/17448

Note: This is an alternate approach from https://github.com/OpenLiberty/open-liberty/pull/18545. The plan is to deliver only one of these PRs, depending on the preferred implementation.

Adds a `jwtAccessTokenRemoteValidation` OIDC client config attribute to allow falling back to, or requiring, using introspect or userinfo to validate a JWT access token during inbound propagation. The attribute is starting with three possible options:
- `none`: (Default) Same behavior as today - JWT access tokens are not validated remotely. The OIDC client validates the token locally and fails if validation fails.
- `allow`: Falls back to validating JWT access tokens remotely if local validation fails.
- `require`: Performs remote validation on JWT access tokens. Local validation is not done, regardless of whether remote validation passes or fails.