### PR TITLE
Add strong encapsulation exception for JMX FAT with Semeru

### DIFF
--- a/dev/com.ibm.ws.jmx_fat/override/autoFVT/src/ant/launch.xml
+++ b/dev/com.ibm.ws.jmx_fat/override/autoFVT/src/ant/launch.xml
@@ -14,7 +14,7 @@
 	     When this FAT runs, the junit JVM will have the additional strong encapsulation overrides it needs:
 		 "<dash><dash>add-opens java.base/java.lang=ALL-UNNAMED <dash><dash>add-exports jdk.attach/sun.tools.attach=ALL-UNNAMED" 
 		 The assumption is that at this point, we will only be building using LTS versions of Java or interium versions 15 or higher--> 
-	<condition property="illegal.access.permit.jmx.fat" value="--add-opens java.base/java.lang=ALL-UNNAMED --add-exports jdk.attach/sun.tools.attach=ALL-UNNAMED">
+	<condition property="illegal.access.permit.jmx.fat" value="--add-opens java.base/java.lang=ALL-UNNAMED --add-exports jdk.attach/sun.tools.attach=ALL-UNNAMED --add-exports jdk.attach/com.ibm.tools.attach.attacher=ALL-UNNAMED">
 		<not>
 			<or>
 				<equals arg1="11" arg2="${java.specification.version}"/>


### PR DESCRIPTION
This is the same issue as described in fix #18324, except this for the Semeru JVM.  It needs a slightly different strong encapsulation exception `--add-exports jdk.attach/com.ibm.tools.attach.attacher=ALL-UNNAMED`.