### PR TITLE
Fix spnego_fat.1 on jdk8 build break 

### DIFF
--- a/dev/com.ibm.ws.security.spnego.fat.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.spnego.fat.common/bnd.bnd
@@ -22,8 +22,6 @@ test.project: true
     fattest.simplicity;version=latest,\
     io.openliberty.org.apache.commons.codec;version=latest,\
     io.openliberty.org.apache.commons.logging;version=latest,\
-    org.apache.directory.server:apacheds-all;version=latest, \
-    org.apache.directory.server:kerberos-client;version=latest, \
     org.slf4j:slf4j-jdk14;version=latest, \
     com.ibm.websphere.javaee.servlet.3.1;version=latest,\
     com.ibm.websphere.security;version=latest,\
@@ -36,7 +34,6 @@ test.project: true
     com.ibm.ws.security.kerberos.java8;version=latest,\
     com.ibm.ws.security.token;version=latest,\
     com.ibm.ws.security.token.s4u2;version=latest,\
-    com.ibm.ws.security.wim.adapter.ldap_fat.krb5;version=latest, \
     com.ibm.ws.webcontainer.security;version=latest,\
     com.ibm.ws.webcontainer.security_test.servlets;version=latest,\
     org.apache.httpcomponents:httpcore;version=4.1.2,\

--- a/dev/com.ibm.ws.security.spnego.fat.common/build.gradle
+++ b/dev/com.ibm.ws.security.spnego.fat.common/build.gradle
@@ -8,16 +8,6 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-apply from: '../wlp-gradle/subprojects/fat.gradle'
-
-dependencies { 
-    requiredLibs 'org.apache.directory.server:apacheds-all:2.0.0-M24',
-	'org.apache.directory.server:kerberos-client:2.0.0-M24',
-    project(':fattest.simplicity'),
-    project(':com.ibm.ws.security.registry_test.servlet'),
-    project(':com.ibm.ws.security.wim.adapter.ldap_fat.krb5'),
-    'org.slf4j:slf4j-jdk14:1.7.7'
-}
 
 apply plugin: 'war'
 

--- a/dev/com.ibm.ws.security.spnego_fat.1/bnd.bnd
+++ b/dev/com.ibm.ws.security.spnego_fat.1/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@ src: \
 
 fat.project: true
 
-tested.features: pages-3.0, appsecurity-4.0, cdi-3.0
+tested.features: pages-3.0, appsecurity-4.0, cdi-3.0, constraineddelegation-1.0
 
 -buildpath: \
     fattest.simplicity;version=latest,\

--- a/dev/com.ibm.ws.security.spnego_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.spnego_fat/bnd.bnd
@@ -16,12 +16,14 @@ src: \
 
 fat.project: true
 
-tested.features: pages-3.0, appsecurity-4.0, cdi-3.0
+tested.features: pages-3.0, appsecurity-4.0, cdi-3.0, spnego-1.0
 
 -buildpath: \
     fattest.simplicity;version=latest,\
     io.openliberty.org.apache.commons.codec;version=latest,\
     io.openliberty.org.apache.commons.logging;version=latest,\
+    org.apache.directory.server:apacheds-all;version=latest, \
+    org.apache.directory.server:kerberos-client;version=latest, \
     com.ibm.websphere.javaee.servlet.3.1;version=latest,\
     com.ibm.websphere.security;version=latest,\
     com.ibm.ws.kernel.service;version=latest,\

--- a/dev/com.ibm.ws.security.spnego_fat/build.gradle
+++ b/dev/com.ibm.ws.security.spnego_fat/build.gradle
@@ -13,6 +13,7 @@ dependencies {
   requiredLibs 'org.apache.httpcomponents:httpclient:4.1.2',
                'org.apache.httpcomponents:httpcore:4.1.2',
                'org.slf4j:slf4j-jdk14:1.7.7',
+               project(':com.ibm.ws.security.wim.adapter.ldap_fat.krb5'),
                project(':com.ibm.ws.security.spnego.fat.common'),
                project(':io.openliberty.org.apache.commons.codec'),
                project(':io.openliberty.org.apache.commons.logging')          

--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/ApacheKDCCommonTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/ApacheKDCCommonTest.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.security.spnego.fat.config;
+package com.ibm.ws.security.spnego.fat;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -38,6 +38,14 @@ import org.junit.rules.TestName;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.config.Spnego;
 import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.security.spnego.fat.config.CommonTestHelper;
+import com.ibm.ws.security.spnego.fat.config.InitClass;
+import com.ibm.ws.security.spnego.fat.config.JDK11Expectations;
+import com.ibm.ws.security.spnego.fat.config.JDK8Expectations;
+import com.ibm.ws.security.spnego.fat.config.JDKExpectationTestClass;
+import com.ibm.ws.security.spnego.fat.config.KdcHelper;
+import com.ibm.ws.security.spnego.fat.config.Krb5Helper;
+import com.ibm.ws.security.spnego.fat.config.SPNEGOConstants;
 import com.ibm.ws.webcontainer.security.test.servlets.BasicAuthClient;
 import com.ibm.ws.webcontainer.security.test.servlets.SSLBasicAuthClient;
 

--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/ApacheKDCforSPNEGO.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/ApacheKDCforSPNEGO.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.security.spnego.fat.config;
+package com.ibm.ws.security.spnego.fat;
 
 import java.io.File;
 import java.util.List;
@@ -23,6 +23,7 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.security.spnego.fat.config.InitClass;
 import com.ibm.ws.security.wim.adapter.ldap.fat.krb5.ApacheDSandKDC;
 
 import componenttest.custom.junit.runner.FATRunner;

--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/BasicAuthTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/BasicAuthTest.java
@@ -30,8 +30,6 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.config.Spnego;
 import com.ibm.websphere.simplicity.log.Log;
-import com.ibm.ws.security.spnego.fat.config.ApacheKDCCommonTest;
-import com.ibm.ws.security.spnego.fat.config.ApacheKDCforSPNEGO;
 import com.ibm.ws.security.spnego.fat.config.CommonTest;
 import com.ibm.ws.security.spnego.fat.config.InitClass;
 import com.ibm.ws.security.spnego.fat.config.Krb5Helper;

--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/FATSuite.java
@@ -23,8 +23,6 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.websphere.simplicity.log.Log;
-import com.ibm.ws.security.spnego.fat.config.ApacheKDCCommonTest;
-import com.ibm.ws.security.spnego.fat.config.ApacheKDCforSPNEGO;
 import com.ibm.ws.security.spnego.fat.config.InitClass;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;


### PR DESCRIPTION
Fixes build break 285663

Problem: Jar used for the apacheKDCforSpnego class for the spnego_fat causes the spnego_fat.1 to fail on java8 because of an unsigned entries exception.

Solution: Move the jar and the classes that use it from the spnego.fat.common project to the spnego_fat project.