### PR TITLE
Fix a couple of test bugs in JAX-WS Tests

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/PureCXFTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/PureCXFTest.java
@@ -30,6 +30,8 @@ import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
@@ -37,7 +39,8 @@ import componenttest.topology.utils.HttpUtils;
 // Capping this test to JDK 8, because the CXF libs checked in only work with the JDK's copy of JAX-B (which was removed in JDK 9)
 @MaximumJavaLevel(javaLevel = 8)
 @RunWith(FATRunner.class)
-@SkipForRepeat({ "jaxws-2.3", JakartaEE9Action.ID })
+@SkipForRepeat({ SkipForRepeat.NO_MODIFICATION, JakartaEE9Action.ID })
+@Mode(TestMode.FULL)
 public class PureCXFTest {
 
     @Server("PureCXFTestServer")

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/test-applications/testMTOM/src/com/ibm/jaxws/MTOM/MTOMService.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/test-applications/testMTOM/src/com/ibm/jaxws/MTOM/MTOMService.java
@@ -16,9 +16,11 @@ import java.util.Random;
 
 import javax.annotation.Resource;
 import javax.jws.WebService;
+import javax.xml.soap.SOAPMessage;
 import javax.xml.ws.BindingType;
 import javax.xml.ws.WebServiceContext;
 import javax.xml.ws.handler.MessageContext;
+import javax.xml.ws.handler.soap.SOAPMessageContext;
 import javax.xml.ws.soap.SOAPBinding;
 
 @WebService(serviceName = "MTOMService", endpointInterface = "com.ibm.jaxws.MTOM.MTOMInter", targetNamespace = "http://MTOMService/")
@@ -30,6 +32,12 @@ public class MTOMService implements MTOMInter {
 
     @Override
     public byte[] getAttachment() {
+
+        // Use existing test to verify that we can properly cast a the MessageContext to the SOAPMessageContext
+        SOAPMessageContext smc = (SOAPMessageContext) wsc.getMessageContext();
+        SOAPMessage message = smc.getMessage();
+        System.out.println(message.getContentDescription());
+
         byte[] barr = new byte[10000];
         Random r = new Random();
         r.nextBytes(barr);

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/HandlerChainTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/HandlerChainTest.java
@@ -26,7 +26,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.ibm.websphere.simplicity.RemoteFile;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
@@ -274,30 +273,14 @@ public class HandlerChainTest {
     }
 
     private void uninstallApplications(LibertyServer server) throws Exception {
-        RemoteFile warFile;
-//        try {
-//            warFile = server.getFileFromLibertyServerRoot(PROVIDER_APP_LOCATION_DROPINS);
-//            warFile.delete();
-//            assertNotNull("Application testHandlerProvider does not appear to have removed.", server.waitForStringInLog(" CWWKT0017I:.*testHandlerProvider"));
-//        } catch (FileNotFoundException e) {
-//            Log.warning(this.getClass(), e.getMessage());
-//        }
-
         try {
-            //warFile = server.getFileFromLibertyServerRoot(CLIENT_APP_LOCATION_DROPINS);
-            //warFile.delete();
-
             server.removeDropinsApplications("testHandlerClient.war");
-            //assertNotNull("Application testHandlerClient does not appear to have removed.", server.waitForStringInLog(" CWWKT0017I:.*testHandlerClient"));
         } catch (FileNotFoundException e) {
             Log.warning(this.getClass(), e.getMessage());
         }
 
         try {
-            //warFile = server.getFileFromLibertyServerRoot(CLIENT_APP_WITHOUTXML_LOCATION_DROPINS);
-            //warFile.delete();
             server.removeDropinsApplications("testHandlerClientWithoutXML.war");
-            //assertNotNull("Application testHandlerClientWithoutXML does not appear to have removed.", server.waitForStringInLog(" CWWKT0017I:.*testHandlerClientWithoutXML"));
         } catch (FileNotFoundException e) {
             Log.warning(this.getClass(), e.getMessage());
         }

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/HandlerChainTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/HandlerChainTest.java
@@ -284,17 +284,20 @@ public class HandlerChainTest {
 //        }
 
         try {
-            warFile = server.getFileFromLibertyServerRoot(CLIENT_APP_LOCATION_DROPINS);
-            warFile.delete();
-            assertNotNull("Application testHandlerClient does not appear to have removed.", server.waitForStringInLog(" CWWKT0017I:.*testHandlerClient"));
+            //warFile = server.getFileFromLibertyServerRoot(CLIENT_APP_LOCATION_DROPINS);
+            //warFile.delete();
+
+            server.removeDropinsApplications("testHandlerClient.war");
+            //assertNotNull("Application testHandlerClient does not appear to have removed.", server.waitForStringInLog(" CWWKT0017I:.*testHandlerClient"));
         } catch (FileNotFoundException e) {
             Log.warning(this.getClass(), e.getMessage());
         }
 
         try {
-            warFile = server.getFileFromLibertyServerRoot(CLIENT_APP_WITHOUTXML_LOCATION_DROPINS);
-            warFile.delete();
-            assertNotNull("Application testHandlerClientWithoutXML does not appear to have removed.", server.waitForStringInLog(" CWWKT0017I:.*testHandlerClientWithoutXML"));
+            //warFile = server.getFileFromLibertyServerRoot(CLIENT_APP_WITHOUTXML_LOCATION_DROPINS);
+            //warFile.delete();
+            server.removeDropinsApplications("testHandlerClientWithoutXML.war");
+            //assertNotNull("Application testHandlerClientWithoutXML does not appear to have removed.", server.waitForStringInLog(" CWWKT0017I:.*testHandlerClientWithoutXML"));
         } catch (FileNotFoundException e) {
             Log.warning(this.getClass(), e.getMessage());
         }

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/injection/WebServiceContextWrapper.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/injection/WebServiceContextWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,9 @@ import javax.xml.ws.WebServiceContext;
 import javax.xml.ws.handler.MessageContext;
 
 import org.apache.cxf.jaxws.context.WebServiceContextImpl;
+import org.apache.cxf.jaxws.context.WrappedMessageContext;
+import org.apache.cxf.jaxws.handler.soap.SOAPMessageContextImpl;
+import org.apache.cxf.message.Message;
 import org.w3c.dom.Element;
 
 public class WebServiceContextWrapper implements WebServiceContext {
@@ -40,10 +43,19 @@ public class WebServiceContextWrapper implements WebServiceContext {
         return context.getEndpointReference(clazz, referenceParameters);
     }
 
-    /** {@inheritDoc} */
     @Override
     public MessageContext getMessageContext() {
-        return context.getMessageContext();
+
+        WrappedMessageContext wmc = (WrappedMessageContext) context.getMessageContext();
+
+        if (wmc != null) {
+            Message msg = wmc.getWrappedMessage();
+            SOAPMessageContextImpl smci = new SOAPMessageContextImpl(msg);
+            return smci;
+        } else {
+            return wmc;
+        }
+
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.ws.jaxws.common/src/com/ibm/ws/jaxws/client/injection/ServiceRefObjectFactory.java
+++ b/dev/com.ibm.ws.jaxws.common/src/com/ibm/ws/jaxws/client/injection/ServiceRefObjectFactory.java
@@ -84,7 +84,8 @@ public class ServiceRefObjectFactory implements javax.naming.spi.ObjectFactory {
 
     private static final TraceComponent tc = Tr.register(ServiceRefObjectFactory.class);
 
-    private final AtomicServiceReference<JaxWsSecurityConfigurationService> securityConfigSR = new AtomicServiceReference<JaxWsSecurityConfigurationService>("securityConfigurationService");
+    private final AtomicServiceReference<JaxWsSecurityConfigurationService> securityConfigSR =
+                    new AtomicServiceReference<JaxWsSecurityConfigurationService>("securityConfigurationService");
 
     /**
      * For getting the https host+port
@@ -109,40 +110,9 @@ public class ServiceRefObjectFactory implements javax.naming.spi.ObjectFactory {
                                                       cardinality = ReferenceCardinality.OPTIONAL,
                                                       policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
     protected void setSecurityConfigurationService(ServiceReference<JaxWsSecurityConfigurationService> serviceRef) {
-
-        ClassLoader cl = null;
-        try {
-            //Liberty code change start
-            //TODO: look into why we are not finding this provider
-            ClassLoader libertyProviderCL = null;
-            try {
-                libertyProviderCL = LibertyProviderImpl.class.getClassLoader();
-            } catch (Throwable t) {
-            }
-            if (libertyProviderCL != null) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "setting LibertyProviderImpl classloader!");
-
-                }
-                cl = Thread.currentThread().getContextClassLoader();
-                Thread.currentThread().setContextClassLoader(libertyProviderCL);
-            }
-            securityConfigSR.setReference(serviceRef);
-            LibertyProviderImpl.setSecurityConfigService(securityConfigSR);
-            LibertyHTTPTransportFactory.setSecurityConfigService(securityConfigSR);
-
-        } catch (Throwable t) {
-            throw new RuntimeException(t.getMessage(), t);
-        } finally { //Liberty code change start
-            if (cl != null) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "setting LibertyProviderImpl classloader!");
-
-                }
-                Thread.currentThread().setContextClassLoader(cl);
-            }
-        }
-
+        securityConfigSR.setReference(serviceRef);
+        LibertyProviderImpl.setSecurityConfigService(securityConfigSR);
+        LibertyHTTPTransportFactory.setSecurityConfigService(securityConfigSR);
     }
 
     protected void unsetSecurityConfigurationService(ServiceReference<JaxWsSecurityConfigurationService> serviceRef) {
@@ -244,8 +214,7 @@ public class ServiceRefObjectFactory implements javax.naming.spi.ObjectFactory {
         }
     }
 
-    public ServiceRefObjectFactory() {
-    }
+    public ServiceRefObjectFactory() {}
 
     /**
      * This method will create an instance of either a javax.xml.ws.Service subclass, or it will create an SEI type.
@@ -330,7 +299,8 @@ public class ServiceRefObjectFactory implements javax.naming.spi.ObjectFactory {
         try {
             //Check @MTOM @RespectBinding @Addressing 
             //set web service features to ThreadLocal
-            final List<WebServiceFeature> wsFeatureList = wsrInfo.getWSFeatureForSEIClass(wsrInfo.getServiceRefTypeClassName());
+            final List<WebServiceFeature> wsFeatureList =
+                            wsrInfo.getWSFeatureForSEIClass(wsrInfo.getServiceRefTypeClassName());
 
             LibertyProviderImpl.setWebServiceRefInfo(wsrInfo);
             LibertyProviderImpl.setWebServiceFeatures(wsFeatureList);
@@ -426,7 +396,8 @@ public class ServiceRefObjectFactory implements javax.naming.spi.ObjectFactory {
 //        need to consider in the ear level
 //        need to consider virtual host
 
-        if (url == null) {
+        if (url == null)
+        {
             JaxWsModuleMetaData jaxwsModuleMetaData = tInfo.getClientMetaData().getModuleMetaData();
             String applicationName = jaxwsModuleMetaData.getJ2EEName().getApplication();
             String contextRoot = jaxwsModuleMetaData.getContextRoot();
@@ -440,7 +411,8 @@ public class ServiceRefObjectFactory implements javax.naming.spi.ObjectFactory {
                     for (EndpointInfo endpointInfo : jaxWsModuleInfo.getEndpointInfos()) {
                         String address = endpointInfo.getAddress(0).substring(1);
                         String serviceName = wsrInfo.getServiceQName().getLocalPart();
-                        if (serviceName.equals(address)) {
+                        if (serviceName.equals(address))
+                        {
                             String wsdlLocation = null;
                             if ((appNameURLMap != null) && (!appNameURLMap.isEmpty())) {
                                 String applicationURL = appNameURLMap.get(applicationName);
@@ -479,7 +451,8 @@ public class ServiceRefObjectFactory implements javax.naming.spi.ObjectFactory {
 
             }
         }
-        if (instance != null) {
+        if (instance != null)
+        {
             return instance;
         }
 

--- a/dev/com.ibm.ws.jaxws.common/src/com/ibm/ws/jaxws/injection/WebServiceContextWrapper.java
+++ b/dev/com.ibm.ws.jaxws.common/src/com/ibm/ws/jaxws/injection/WebServiceContextWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,11 +17,11 @@ import javax.xml.ws.WebServiceContext;
 import javax.xml.ws.handler.MessageContext;
 
 import org.apache.cxf.jaxws.context.WebServiceContextImpl;
+import org.apache.cxf.jaxws.context.WrappedMessageContext;
+import org.apache.cxf.jaxws.handler.soap.SOAPMessageContextImpl;
+import org.apache.cxf.message.Message;
 import org.w3c.dom.Element;
 
-/**
- *
- */
 public class WebServiceContextWrapper implements WebServiceContext {
 
     private WebServiceContext context = null;
@@ -43,10 +43,19 @@ public class WebServiceContextWrapper implements WebServiceContext {
         return context.getEndpointReference(clazz, referenceParameters);
     }
 
-    /** {@inheritDoc} */
     @Override
     public MessageContext getMessageContext() {
-        return context.getMessageContext();
+
+        WrappedMessageContext wmc = (WrappedMessageContext) context.getMessageContext();
+
+        if (wmc != null) {
+            Message msg = wmc.getWrappedMessage();
+            SOAPMessageContextImpl smci = new SOAPMessageContextImpl(msg);
+            return smci;
+        } else {
+            return wmc;
+        }
+
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
This pull requests fixes two seperate test bugs in the JAX-WS webcontainer bucket. 

One is to limit the the Pure CXF test to just a normal unmodified run, and the other is to use the Test Framework's method to remove apps from the drop-ins directory. 