### PR TITLE
enable Resteasy entry/exit trace for restfulWs-3.0

### DIFF
--- a/dev/io.openliberty.org.jboss.resteasy.common/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.common/bnd.bnd
@@ -152,8 +152,19 @@ Private-Package: \
   org.apache.james.*
   
 instrument.ffdc: false
-instrument.disabled: false
-
+instrument.classesExcludes: \
+  org/jboss/resteasy/client/jaxrs/internal/ClientConfiguration.class, \
+  org/jboss/resteasy/client/jaxrs/internal/ClientInvocationBuilder.class, \
+  org/jboss/resteasy/client/jaxrs/internal/ClientWebTarget.class, \
+  org/jboss/resteasy/client/jaxrs/internal/ResteasyClientBuilderImpl.class, \
+  org/jboss/resteasy/client/jaxrs/internal/ResteasyClientImpl.class, \
+  org/jboss/resteasy/core/interception/jaxrs/ContainerResponseContextImpl.class, \
+  org/jboss/resteasy/core/providerfactory/ResteasyProviderFactoryImpl.class, \
+  org/jboss/resteasy/core/ResteasyContext.class, \
+  org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegate.class, \
+  org/jboss/resteasy/specimpl/MultivaluedTreeMap.class, \
+  org/jboss/resteasy/util/snapshot/SnapshotMap.class, \
+  org/jboss/resteasy/util/ThreadLocalStack.class
 
 Include-Resource:\
   @${repo;org.jboss.resteasy:resteasy-client;${resteasy-version};EXACT}, \

--- a/dev/io.openliberty.org.jboss.resteasy.common/build.gradle
+++ b/dev/io.openliberty.org.jboss.resteasy.common/build.gradle
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+configurations {
+  resteasy
+}
+  
+dependencies {
+  resteasy 'org.jboss.resteasy:resteasy-client:4.7.0.Final',
+           'org.jboss.resteasy:resteasy-client-api:4.7.0.Final',
+           'org.jboss.resteasy:resteasy-core:4.7.0.Final',
+           'org.jboss.resteasy:resteasy-core-spi:4.7.0.Final'
+}
+
+task extractInjectedClasses(type: Copy) {
+  from zipTree(configurations.resteasy[0])
+  include '**/*.class'
+  into compileJava.destinationDir
+  
+  from zipTree(configurations.resteasy[1])
+  include '**/*.class'
+  into compileJava.destinationDir
+
+  from zipTree(configurations.resteasy[2])
+  include '**/*.class'
+  into compileJava.destinationDir
+
+  from zipTree(configurations.resteasy[3])
+  include '**/*.class'
+  into compileJava.destinationDir
+}
+
+compileJava.dependsOn extractInjectedClasses
+


### PR DESCRIPTION
Enabling entry/exit tracing for Resteasy classes that we don't overlay in Liberty.