### PR TITLE
fix excessive servlet destroyed msgs

### DIFF
--- a/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/jspServer/server.xml
+++ b/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/jspServer/server.xml
@@ -17,5 +17,5 @@
     </featureManager>
 
     <logging traceSpecification="*=info=enabled:com.ibm.ws.webcontainer*=all:com.ibm.wsspi.webcontainer*=all:HTTPChannel=all:TCPChannel=all:GenericBNF=all:com.ibm.ws.jsp*=all" maxFileSize="32" maxFiles="24" traceFormat="BASIC"/>
-
+    <applicationManager autoExpand="false"/> <!-- for TestTLD -->
 </server>

--- a/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestEDR.war/resources/WEB-INF/tags/sampleTag.tld
+++ b/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestEDR.war/resources/WEB-INF/tags/sampleTag.tld
@@ -1,0 +1,19 @@
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<taglib>
+  <tlib-version>1.0</tlib-version>
+  <jsp-version>2.0</jsp-version>
+  <short-name>tag1</short-name>
+  <tag>
+    <name>hitMe</name>
+    <tag-class>com.ibm.ws.jsp23.fat.testinjection.tagHandler.JspCdiHitMeTag</tag-class>
+  </tag>
+</taglib>

--- a/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestEDR.war/resources/index.jsp
+++ b/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestEDR.war/resources/index.jsp
@@ -15,6 +15,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
 <title>TestEDR</title>
+<%@ taglib prefix="test" uri="/WEB-INF/tags/sampleTag.tld" %>
 </head>
 <body>
 <p>This tests a JSP in the Extended Document Root.</p>

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/webcontainerext/JspDependent.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/webcontainerext/JspDependent.java
@@ -82,11 +82,13 @@ public class JspDependent {
             
         } else {
             File dependentFile = new File(context.getRealPath(dependentFilePath));
-            if (dependentFile.lastModified() != lastModified){
+            long ts = dependentFile.lastModified();
+            if (ts == 0) {ts = getTimestamp();}
+            if (ts != lastModified){  
     			outdated = true;
     			// begin 213703: add logging for isoutdated checks
     			if(com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINER)){
-    				logger.logp(Level.FINER, CLASS_NAME, "isOutdated", "dependentFile ts [" + dependentFile.lastModified() + "] differs from cached ts [" + this.lastModified +"]. Recompile JSP.");
+    				logger.logp(Level.FINER, CLASS_NAME, "isOutdated", "dependentFile ts [" + ts + "] differs from cached ts [" + this.lastModified +"]. Recompile JSP."); 
     				logger.logp(Level.FINER, CLASS_NAME, "isOutdated", "dependentFile [" + dependentFile + "]");
     			}
     			// end 213703: add logging for isoutdated checks


### PR DESCRIPTION
Each time a JSP is accessed, if included files have been updated since last compile it causes a new JSP compile.   This will cause the message: SRVE0253I: [ ... ] Destroy successful.  The issue being fixed is that a TLD file under /WEB-INF in the war isn't being checked correctly, causing it to appear to always be out of date, therefore causing the JSP to compile every time it is accessed and resulting in a SRVE0253I.   In a heavily used app, the SRVE0253I might cause excessive logging due to the frequency of its occurrence.   The issue happens when \<applicationManager autoExpand="false"/\>. 

Fixes #18411 