### PR TITLE
Avoid EJB timer cancel while timer running

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/MissedTimerActionEJB.jar/src/com/ibm/ws/ejbcontainer/timer/persistent/missed/ejb/MissedTimerActionBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/MissedTimerActionEJB.jar/src/com/ibm/ws/ejbcontainer/timer/persistent/missed/ejb/MissedTimerActionBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -132,6 +132,10 @@ public class MissedTimerActionBean implements MissedTimerAction {
                 nextTimeouts.add(timer.getNextTimeout());
                 timeRemains.add(timer.getTimeRemaining());
                 logger.info("MissedTimerActionBean.timeout : " + timer.getNextTimeout() + ", " + timer.getTimeRemaining());
+                if (latch.getCount() == 1) {
+                    logger.info("MissedTimerActionBean.timeout : countdown reached, canceling timer : " + timer);
+                    timer.cancel();
+                }
                 timerLatch.countDown();
             }
         }


### PR DESCRIPTION
For EJB timer missed timer action tests, have the timer
self cancel to avoid rollbacks if timer concurrently
canceled while the timer is running.
