### PR TITLE
Make reentrantlock transient in EJSHome

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/EJSHome.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/EJSHome.java
@@ -3302,7 +3302,7 @@ public abstract class EJSHome implements PoolDiscardStrategy, HomeInternal, Sess
         return homeRecord;
     }
 
-    private final ReentrantLock createSingletonLock = new ReentrantLock();
+    private transient final ReentrantLock createSingletonLock = new ReentrantLock();
 
     /**
      * Create the Singleton bean instance if it doesn't

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/RemoteTests.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/RemoteTests.java
@@ -155,7 +155,7 @@ public class RemoteTests extends AbstractTest {
 
         ShrinkHelper.exportDropinAppToServer(server, CrossAppRemoteEJB, DeployOptions.SERVER_ONLY);
 
-        //#################### CrossApp2xEJB.war
+        //#################### CrossApp2xTest.ear
         JavaArchive CrossApp2xEJB = ShrinkHelper.buildJavaArchive("CrossApp2xEJB.jar", "com.ibm.ws.ejbcontainer.remote.fat.crossapp.home2x.ejb.");
         CrossApp2xEJB = (JavaArchive) ShrinkHelper.addDirectory(CrossApp2xEJB, "test-applications/CrossApp2xEJB.jar/resources");
 


### PR DESCRIPTION
change a recently added private variable to transient to not affect serialization.