### PR TITLE
Use getURI instead of getPath because it behaves the same in Javaee8 …

### DIFF
--- a/dev/com.ibm.ws.ui/resources/WEB-CONTENT/js/toolbox/toolbox.js
+++ b/dev/com.ibm.ws.ui/resources/WEB-CONTENT/js/toolbox/toolbox.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -177,7 +177,7 @@ define(["dojo/_base/declare", "dojo/request/xhr", "dojo/Deferred", "dojo/json", 
       });
 
       xhrDef.then(function handleAppState(tool) {
-        deferred.resolve(bookmarkProps, true);
+        deferred.resolve(tool, true);
       }, function(err) {
         deferred.reject(err, true);
       }, function(evt) {

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/AdminCenterRouter.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/AdminCenterRouter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2019 IBM Corporation and others.
+ * Copyright (c) 2013, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,13 +38,14 @@ import com.ibm.ws.ui.internal.v1.ICatalogService;
 import com.ibm.ws.ui.internal.v1.IFeatureToolService;
 import com.ibm.ws.ui.internal.v1.IToolDataService;
 import com.ibm.ws.ui.internal.v1.IToolboxService;
+import com.ibm.ws.ui.internal.v1.utils.Utils;
 import com.ibm.wsspi.rest.handler.RESTHandler;
 import com.ibm.wsspi.rest.handler.RESTRequest;
 import com.ibm.wsspi.rest.handler.RESTResponse;
 
 /**
  * <p>Defines the URL router for adminCenter REST API.</p>
- * 
+ *
  * <p>Maps to host:port/ibm/api/adminCenter</p>
  */
 @Component(service = { RESTHandler.class },
@@ -107,7 +108,7 @@ public class AdminCenterRouter implements RESTHandler, HTTPConstants {
 
     /**
      * The injection point for the IFeatureToolService that allows us to get feature tools.
-     * 
+     *
      * @param variableRegistryService - The variableRegistry service
      */
     @Reference(service = IFeatureToolService.class)
@@ -123,7 +124,7 @@ public class AdminCenterRouter implements RESTHandler, HTTPConstants {
 
     /**
      * Add the specified handler to the set of default handlers.
-     * 
+     *
      * @param defaultHandlers
      * @param handler
      */
@@ -161,7 +162,7 @@ public class AdminCenterRouter implements RESTHandler, HTTPConstants {
 
     /**
      * For unit testing.
-     * 
+     *
      * @param handlers
      */
     AdminCenterRouter(Map<String, AdminCenterRestHandler> handlers) {
@@ -171,7 +172,7 @@ public class AdminCenterRouter implements RESTHandler, HTTPConstants {
     /**
      * Try to find the appropriate rest handler for the given URL.
      * Return null if no match found.
-     * 
+     *
      * @param requestURL The URL from the HTTP request. This is the URL that needs to be matched.
      * @return The RESTHandler for the given URL.
      */
@@ -242,10 +243,10 @@ public class AdminCenterRouter implements RESTHandler, HTTPConstants {
     @Override
     public void handleRequest(final RESTRequest request, final RESTResponse response) throws IOException {
         if (tc.isEventEnabled()) {
-            Tr.event(tc, "REST request received from " + request.getRemoteHost() + ":" + request.getRemotePort() + " - path: " + request.getPath());
+            Tr.event(tc, "REST request received from " + request.getRemoteHost() + ":" + request.getRemotePort() + " - path: " + request.getPath() + " - URI: " + request.getURI());
         }
 
-        final RESTHandler handler = getHandler(request.getPath());
+        final RESTHandler handler = getHandler(Utils.getPath(request));
         if (handler != null) {
             try {
                 RequestNLS.setRESTRequest(request);
@@ -261,7 +262,7 @@ public class AdminCenterRouter implements RESTHandler, HTTPConstants {
     /**
      * Returns a read-only view of the handlers map.
      * Primarily used for unit testing.
-     * 
+     *
      * @return a read-only view of the handlers map.
      */
     Map<String, AdminCenterRestHandler> getHandlers() {

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/CommonRESTHandler.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/CommonRESTHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,6 +34,7 @@ import com.ibm.ws.ui.internal.rest.exceptions.MethodNotSupportedException;
 import com.ibm.ws.ui.internal.rest.exceptions.NoSuchResourceException;
 import com.ibm.ws.ui.internal.rest.exceptions.RESTException;
 import com.ibm.ws.ui.internal.v1.pojo.Message;
+import com.ibm.ws.ui.internal.v1.utils.Utils;
 import com.ibm.wsspi.rest.handler.RESTRequest;
 import com.ibm.wsspi.rest.handler.RESTResponse;
 
@@ -79,17 +80,17 @@ public class CommonRESTHandler implements AdminCenterRestHandler, APIConstants, 
     /**
      * Constructor which should be called by all extenders.
      *
-     * @param handlerURL                The URL for which this handler is registered.
-     *                                      Should not end with a trailing slash. Must not be {@code null}.
-     * @param handlesChildResource      Indicate whether or not child resources are
-     *                                      expected to be handled by this handler. Note only immediate
-     *                                      children are handled when this is set to true. Deeply nested
-     *                                      children are not considered to match.
+     * @param handlerURL The URL for which this handler is registered.
+     *            Should not end with a trailing slash. Must not be {@code null}.
+     * @param handlesChildResource Indicate whether or not child resources are
+     *            expected to be handled by this handler. Note only immediate
+     *            children are handled when this is set to true. Deeply nested
+     *            children are not considered to match.
      * @param handlesGrandchildResource Indicate whether or not grandchild
-     *                                      resources are expected to be handled by this handler. Note
-     *                                      only immediate grandchildren are handled when this is set
-     *                                      to true. Deeply nested grandchildren are not considered to
-     *                                      match.
+     *            resources are expected to be handled by this handler. Note
+     *            only immediate grandchildren are handled when this is set
+     *            to true. Deeply nested grandchildren are not considered to
+     *            match.
      */
     protected CommonRESTHandler(final String handlerURL, final boolean handlesChildResource, final boolean handlesGrandchildResource) {
         this(handlerURL, handlesChildResource, handlesGrandchildResource, new Filter(), null);
@@ -98,19 +99,19 @@ public class CommonRESTHandler implements AdminCenterRestHandler, APIConstants, 
     /**
      * Unit test constructor.
      *
-     * @param handlerURL                The URL for which this handler is registered.
-     *                                      Should not end with a trailing slash. Must not be {@code null}.
-     * @param handlesChildResource      Indicate whether or not child resources are
-     *                                      expected to be handled by this handler. Note only immediate
-     *                                      children are handled when this is set to true. Deeply nested
-     *                                      children are not considered to match.
+     * @param handlerURL The URL for which this handler is registered.
+     *            Should not end with a trailing slash. Must not be {@code null}.
+     * @param handlesChildResource Indicate whether or not child resources are
+     *            expected to be handled by this handler. Note only immediate
+     *            children are handled when this is set to true. Deeply nested
+     *            children are not considered to match.
      * @param handlesGrandchildResource Indicate whether or not grandchild
-     *                                      resources are expected to be handled by this handler. Note
-     *                                      only immediate grandchildren are handled when this is set
-     *                                      to true. Deeply nested grandchildren are not considered to
-     *                                      match.
-     * @param filter                    Injection point for the Filter
-     * @param mapper                    Injection point for the ObjectMapper
+     *            resources are expected to be handled by this handler. Note
+     *            only immediate grandchildren are handled when this is set
+     *            to true. Deeply nested grandchildren are not considered to
+     *            match.
+     * @param filter Injection point for the Filter
+     * @param mapper Injection point for the ObjectMapper
      */
     protected CommonRESTHandler(final String handlerURL, final boolean handlesChildResource, final boolean handlesGrandchildResource, final Filter filter,
                                 final JSON json) {
@@ -350,7 +351,7 @@ public class CommonRESTHandler implements AdminCenterRestHandler, APIConstants, 
      * <p>By default, the method is not supported. Implementors should override
      * this implementation to provide supported behaviour.</p>
      *
-     * @param request  The RESTRequest from handleRequest
+     * @param request The RESTRequest from handleRequest
      * @param response The RESTResponse from handleRequest
      */
     @Override
@@ -364,7 +365,7 @@ public class CommonRESTHandler implements AdminCenterRestHandler, APIConstants, 
      * <p>By default, the method is not supported. Implementors should override
      * this implementation to provide supported behaviour.</p>
      *
-     * @param request  The RESTRequest from handleRequest
+     * @param request The RESTRequest from handleRequest
      * @param response The RESTResponse from handleRequest
      */
     @Override
@@ -382,7 +383,7 @@ public class CommonRESTHandler implements AdminCenterRestHandler, APIConstants, 
      * <p>By default, the method is not supported. Implementors should override
      * this implementation to provide supported behaviour.</p>
      *
-     * @param request  The RESTRequest from handleRequest
+     * @param request The RESTRequest from handleRequest
      * @param response The RESTResponse from handleRequest
      */
     @Override
@@ -400,11 +401,11 @@ public class CommonRESTHandler implements AdminCenterRestHandler, APIConstants, 
      * <p>By default, the method is not supported. Implementors should override
      * this implementation to provide supported behaviour.</p>
      *
-     * @param request  The RESTRequest from handleRequest
+     * @param request The RESTRequest from handleRequest
      * @param response The RESTResponse from handleRequest
      */
     protected final Object doGET(final RESTRequest request, final RESTResponse response) throws RESTException {
-        final String requestPath = request.getPath();
+        final String requestPath = Utils.getPath(request);
         if (isBaseResource(requestPath)) {
             return getBase(request, response);
         } else if (isChildResource(requestPath)) {
@@ -436,7 +437,7 @@ public class CommonRESTHandler implements AdminCenterRestHandler, APIConstants, 
      * <p>By default, the method is not supported. Implementors should override
      * this implementation to provide supported behaviour.</p>
      *
-     * @param request  The RESTRequest from handleRequest
+     * @param request The RESTRequest from handleRequest
      * @param response The RESTResponse from handleRequest
      */
     @Override
@@ -454,11 +455,11 @@ public class CommonRESTHandler implements AdminCenterRestHandler, APIConstants, 
      * <p>By default, the method is not supported. Implementors should override
      * this implementation to provide supported behaviour.</p>
      *
-     * @param request  The RESTRequest from handleRequest
+     * @param request The RESTRequest from handleRequest
      * @param response The RESTResponse from handleRequest
      */
     protected final POSTResponse doPOST(final RESTRequest request, final RESTResponse response) throws RESTException {
-        final String requestPath = request.getPath();
+        final String requestPath = Utils.getPath(request);
         if (isBaseResource(requestPath)) {
             return postBase(request, response);
         } else if (isChildResource(requestPath)) {
@@ -490,7 +491,7 @@ public class CommonRESTHandler implements AdminCenterRestHandler, APIConstants, 
      * <p>By default, the method is not supported. Implementors should override
      * this implementation to provide supported behaviour.</p>
      *
-     * @param request  The RESTRequest from handleRequest
+     * @param request The RESTRequest from handleRequest
      * @param response The RESTResponse from handleRequest
      */
     @Override
@@ -508,11 +509,11 @@ public class CommonRESTHandler implements AdminCenterRestHandler, APIConstants, 
      * <p>By default, the method is not supported. Implementors should override
      * this implementation to provide supported behaviour.</p>
      *
-     * @param request  The RESTRequest from handleRequest
+     * @param request The RESTRequest from handleRequest
      * @param response The RESTResponse from handleRequest
      */
     protected final Object doPUT(final RESTRequest request, final RESTResponse response) throws RESTException {
-        final String requestPath = request.getPath();
+        final String requestPath = Utils.getPath(request);
         if (isBaseResource(requestPath)) {
             return putBase(request, response);
         } else if (isChildResource(requestPath)) {
@@ -544,7 +545,7 @@ public class CommonRESTHandler implements AdminCenterRestHandler, APIConstants, 
      * <p>By default, the method is not supported. Implementors should override
      * this implementation to provide supported behaviour.</p>
      *
-     * @param request  The RESTRequest from handleRequest
+     * @param request The RESTRequest from handleRequest
      * @param response The RESTResponse from handleRequest
      */
     @Override
@@ -562,11 +563,11 @@ public class CommonRESTHandler implements AdminCenterRestHandler, APIConstants, 
      * <p>By default, the method is not supported. Implementors should override
      * this implementation to provide supported behaviour.</p>
      *
-     * @param request  The RESTRequest from handleRequest
+     * @param request The RESTRequest from handleRequest
      * @param response The RESTResponse from handleRequest
      */
     protected final Object doDELETE(final RESTRequest request, final RESTResponse response) throws RESTException {
-        final String requestPath = request.getPath();
+        final String requestPath = Utils.getPath(request);
         if (isBaseResource(requestPath)) {
             return deleteBase(request, response);
         } else if (isChildResource(requestPath)) {
@@ -600,7 +601,7 @@ public class CommonRESTHandler implements AdminCenterRestHandler, APIConstants, 
      * Delegates to the appropriate HTTP method handler, or sets the RESTResponse
      * to 405 if the method is not supported.
      *
-     * @param request  The RESTRequest from handleRequest
+     * @param request The RESTRequest from handleRequest
      * @param response The RESTResponse from handleRequest
      * @throws RESTException Re-throws any exceptions thrown by the delegates
      */
@@ -639,8 +640,8 @@ public class CommonRESTHandler implements AdminCenterRestHandler, APIConstants, 
      * but we shouldn't need to do that since we should always POJO'able.</p>
      *
      * @param response The RESTResponse from handleRequest
-     * @param pojo     The POJO to convert to a JSON object and set in the response payload
-     * @param status   The desired HTTPS status to set
+     * @param pojo The POJO to convert to a JSON object and set in the response payload
+     * @param status The desired HTTPS status to set
      */
     protected final void setPlainTextResponse(final RESTResponse response, final Object obj, final int status) {
         response.setResponseHeader(HTTP_HEADER_CONTENT_TYPE, MEDIA_TYPE_TEXT_PLAIN);
@@ -666,8 +667,8 @@ public class CommonRESTHandler implements AdminCenterRestHandler, APIConstants, 
      * but we shouldn't need to do that since we should always POJO'able.</p>
      *
      * @param response The RESTResponse from handleRequest
-     * @param pojo     The POJO to convert to a JSON object and set in the response payload
-     * @param status   The desired HTTPS status to set
+     * @param pojo The POJO to convert to a JSON object and set in the response payload
+     * @param status The desired HTTPS status to set
      */
     protected final void setJSONResponse(final RESTResponse response, final Object pojo, final int status) {
         response.setResponseHeader(HTTP_HEADER_CONTENT_TYPE, MEDIA_TYPE_APPLICATION_JSON);
@@ -742,7 +743,7 @@ public class CommonRESTHandler implements AdminCenterRestHandler, APIConstants, 
      * Processes the RESTException thrown by delegateMethod().
      *
      * @param response The RESTResponse from handleRequest
-     * @param e        The RESTException thrown by the delegate doX method
+     * @param e The RESTException thrown by the delegate doX method
      * @throws IOException
      */
     protected void handleRESTException(final RESTResponse response, RESTException e) throws IOException {
@@ -778,7 +779,7 @@ public class CommonRESTHandler implements AdminCenterRestHandler, APIConstants, 
     @FFDCIgnore(RESTException.class)
     public final void handleRequest(final RESTRequest request, final RESTResponse response) throws IOException {
         try {
-            if (matchesExpectedResource(request.getPath())) {
+            if (matchesExpectedResource(Utils.getPath(request))) {
                 try {
                     delegateMethod(request, response);
                 } catch (RESTException e) {

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/v1/CatalogAPI.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/v1/CatalogAPI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,7 +31,6 @@ import com.ibm.ws.ui.internal.v1.ITool;
 import com.ibm.ws.ui.internal.v1.pojo.Bookmark;
 import com.ibm.ws.ui.internal.v1.pojo.DuplicateException;
 import com.ibm.ws.ui.internal.v1.pojo.Message;
-import com.ibm.ws.ui.internal.v1.utils.Utils;
 import com.ibm.ws.ui.internal.validation.InvalidToolException;
 import com.ibm.wsspi.rest.handler.RESTRequest;
 import com.ibm.wsspi.rest.handler.RESTResponse;
@@ -94,7 +93,7 @@ public class CatalogAPI extends CommonJSONRESTHandler implements V1Constants {
     /** {@inheritDoc} */
     @Override
     public boolean isKnownGrandchildResource(String child, String grandchild, RESTRequest request) {
-        final String toolId = Utils.urlEncode(grandchild);
+        final String toolId = grandchild;
         if (CHILD_RESOURCE_BOOKMARKS.equals(child)) {
             return getCatalog().getBookmark(toolId) != null;
         } else if (CHILD_RESOURCE_FEATURE_TOOLS.equals(child)) {
@@ -174,8 +173,8 @@ public class CatalogAPI extends CommonJSONRESTHandler implements V1Constants {
         if (!isAuthorizedDefault(request, response)) {
             throw new UserNotAuthorizedException();
         }
-        // The inbound grandchild resource name is not URL encoded, need to encode it
-        final String toolId = Utils.urlEncode(grandchild);
+
+        final String toolId = grandchild;
         if (CHILD_RESOURCE_BOOKMARKS.equals(child)) {
             return handleToolResponse(request, toolId, getCatalog().getBookmark(toolId));
         } else if (CHILD_RESOURCE_FEATURE_TOOLS.equals(child)) {
@@ -252,8 +251,8 @@ public class CatalogAPI extends CommonJSONRESTHandler implements V1Constants {
         if (!isAuthorizedDefault(request, response)) {
             throw new UserNotAuthorizedException();
         }
-        // The inbound child resource name is not URL encoded, need to encode it
-        String toolId = Utils.urlEncode(grandchild);
+
+        String toolId = grandchild;
         if (CHILD_RESOURCE_BOOKMARKS.equals(child)) {
             ITool deletedTool = getCatalog().deleteBookmark(toolId);
             return handleToolResponse(request, toolId, deletedTool);

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/v1/ToolboxAPI.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/v1/ToolboxAPI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,7 +38,6 @@ import com.ibm.ws.ui.internal.v1.pojo.DuplicateException;
 import com.ibm.ws.ui.internal.v1.pojo.Message;
 import com.ibm.ws.ui.internal.v1.pojo.NoSuchToolException;
 import com.ibm.ws.ui.internal.v1.pojo.ToolEntry;
-import com.ibm.ws.ui.internal.v1.utils.Utils;
 import com.ibm.ws.ui.internal.validation.InvalidToolException;
 import com.ibm.wsspi.rest.handler.RESTRequest;
 import com.ibm.wsspi.rest.handler.RESTResponse;
@@ -112,7 +111,7 @@ public class ToolboxAPI extends CommonJSONRESTHandler implements V1Constants {
     /** {@inheritDoc} */
     @Override
     public boolean isKnownGrandchildResource(String child, String grandchild, RESTRequest request) {
-        final String toolId = Utils.urlEncode(grandchild);
+        final String toolId = grandchild;
         if (CHILD_RESOURCE_BOOKMARKS.equals(child)) {
             return getToolbox(request).getBookmark(toolId) != null;
         } else if (CHILD_RESOURCE_TOOL_ENTRIES.equals(child)) {
@@ -195,8 +194,8 @@ public class ToolboxAPI extends CommonJSONRESTHandler implements V1Constants {
         if (!isAuthorizedAdminOrReader(request, response)) {
             throw new UserNotAuthorizedException();
         }
-        // The inbound child resource name is not URL encoded, need to encode it
-        final String toolId = Utils.urlEncode(grandchild);
+
+        final String toolId = grandchild;
         if (CHILD_RESOURCE_TOOL_ENTRIES.equals(child)) {
             return handleToolResponse(request, toolId, getToolbox(request).getToolEntry(toolId));
         } else if (CHILD_RESOURCE_BOOKMARKS.equals(child)) {
@@ -328,8 +327,8 @@ public class ToolboxAPI extends CommonJSONRESTHandler implements V1Constants {
         if (!isAuthorizedAdminOrReader(request, response)) {
             throw new UserNotAuthorizedException();
         }
-        // The inbound child resource name is not URL encoded, need to encode it
-        String toolId = Utils.urlEncode(grandchild);
+
+        String toolId = grandchild;
         if (CHILD_RESOURCE_BOOKMARKS.equals(child)) {
             return handleToolResponse(request, toolId, getToolbox(request).deleteBookmark(toolId));
         } else if (CHILD_RESOURCE_TOOL_ENTRIES.equals(child)) {

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/utils/Utils.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/utils/Utils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.wsspi.rest.handler.RESTRequest;
 
 /**
  * This class is designed to hold utility methods that different parts of the server side UI will need to use.
@@ -43,7 +44,7 @@ public class Utils {
 
     /**
      * Encodes the specified String using URL encoding.
-     * 
+     *
      * @param toEncode The String to URL encode
      * @return The URL encoded String
      */
@@ -64,8 +65,31 @@ public class Utils {
     }
 
     /**
+     * Returns a deterministic already encoded path since Jakarta EE9 switch the default value of decodeUrlPlusSign we can no longer tell if getPath() is
+     * returning a string that is encoded or decoded.
+     *
+     * @param request The request to get the path from
+     * @return The URL encoded String
+     */
+    public static String getPath(final RESTRequest request) {
+        String path = request.getURI();
+
+        try {
+            //take off context path
+            String contextPath = request.getContextPath();
+            path = path.substring(path.indexOf(contextPath) + contextPath.length());
+        } catch (Exception e) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Caught exception while trying to get urlencoded path from request.", e);
+            }
+            return request.getPath();
+        }
+        return path;
+    }
+
+    /**
      * This method returns a URL object for the supplied url name.
-     * 
+     *
      * @param url The String urlName that we should turn into a URL Object.
      * @return The URL object.
      * @throws MalformedURLException
@@ -90,7 +114,7 @@ public class Utils {
 
     /**
      * Generates the md5 checksum of the given string
-     * 
+     *
      * @param str The input string
      * @return The MD5 checksum of the given string.
      * @throws UnsupportedEncodingException


### PR DESCRIPTION
This is caused by a Servlet 5.0 change to the default behavior of the property decodeUrlPlusSign. See #12290. Admin center needs to be able to handle requests that no longer have the plus sign decoded.

RESTRequest.getPath() prior to servlet 5 used to return a path that was plus sign decoded. IE the path would be returned as:
/adminCenter/v1/toolbox/toolEntries/Test Bookmark1

After servlet 5, that same request would be this:
/adminCenter/v1/toolbox/toolEntries/Test+Bookmark1

Also, note that the user can change these settings with the decodeUrlPlusSign.  We cannot guess if its decoded or not and there isn't a way for us to get the value of that property.  So instead of using getPath, I am going to use getURI and stip off the contextpath.  getURI always returns the same path regardless if using servlet 5.0 or not.

