### PR TITLE
Ensure JAX-RS 3.0 Client can run in Java SE env without needing OSGi

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/publish/servers/jaxrs21.client.JAXRS21ProxyAuthTest/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/publish/servers/jaxrs21.client.JAXRS21ProxyAuthTest/bootstrap.properties
@@ -1,5 +1,6 @@
 bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=*=info:\
+org.apache.cxf.transport.http.*=all:\
 RESTfulWS=all:\
 org.jboss.resteasy.*=all

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/HTTPConduit.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/HTTPConduit.java
@@ -1429,6 +1429,10 @@ public abstract class HTTPConduit
                 if (origMessage != null && origMessage.contains(url.toString())) {
                     throw e;
                 }
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    // tracing here because this exception can get lost in async scenarios
+                    Tr.debug(tc, "Caught IOException while closing HTTPConduit", e);
+                }
                 throw mapException(e.getClass().getSimpleName()
                                    + " invoking " + url + ": "
                                    + e.getMessage(), e,

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/client/OsgiFacade.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/client/OsgiFacade.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.org.jboss.resteasy.common.client;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+
+class OsgiFacade {
+    private static final boolean isSecurityManagerPresent = null != System.getSecurityManager();
+    private static final Map<Integer, Tuple<?>> tupleMap = new HashMap<>();
+    private static final AtomicInteger counter = new AtomicInteger(0);
+
+    static Optional<OsgiFacade> instance() {
+        try {
+            Class.forName("org.osgi.framework.Bundle");
+            return Optional.of(new OsgiFacade());
+        } catch (Throwable t) {
+            //expected in non-OSGI, Java SE env
+            return Optional.empty();
+        }
+    }
+
+    <T> Integer invoke(Class<T> service, Consumer<T> consumer) {
+        BundleContext ctx = getBundleContext();
+        Tuple<T> tuple = new Tuple<>(ctx, getServiceRefs(service, ctx).orElse(Collections.emptyList()));
+        tuple.serviceRefs.stream().map(sr -> getService(tuple.bundleCtx, sr)).forEach(consumer);
+        Integer key = counter.incrementAndGet();
+        tupleMap.put(key, tuple);
+        return key;
+    }
+
+    @SuppressWarnings("unchecked")
+    <T> void invoke(Integer key, Class<T> clz, Consumer<T> consumer) {
+        Tuple<T> tuple = (Tuple<T>) tupleMap.remove(key);
+        tuple.serviceRefs.stream().map(sr -> getService(tuple.bundleCtx, sr)).forEach(consumer);
+    }
+
+    private BundleContext getBundleContext() {
+        if (isSecurityManagerPresent) {
+            return AccessController.doPrivileged((PrivilegedAction<BundleContext>) () -> {
+                Bundle b = FrameworkUtil.getBundle(getClass());
+                return b == null ? null : b.getBundleContext(); 
+            });
+        }
+        Bundle b = FrameworkUtil.getBundle(getClass());
+        return b == null ? null : b.getBundleContext();
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> Optional<List<ServiceReference<T>>> getServiceRefs(Class<T> serviceClass, BundleContext ctx) {
+        if (ctx == null) {
+            return Optional.empty();
+        }
+        try {
+            ServiceReference<?>[] serviceRefs;
+            if (isSecurityManagerPresent) {
+                serviceRefs = AccessController.doPrivileged((PrivilegedExceptionAction<ServiceReference<?>[]>) () -> 
+                    ctx.getServiceReferences(serviceClass.getName(), null));
+            } else {
+                serviceRefs = ctx.getServiceReferences(serviceClass.getName(), null);
+            }
+            return Optional.ofNullable(serviceRefs == null ? null : Arrays.asList((ServiceReference<T>[]) serviceRefs));
+        } catch (PrivilegedActionException pae) {
+            throw new RuntimeException(pae.getCause());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private <T> T getService(BundleContext ctx, ServiceReference<T> ref) {
+        if (isSecurityManagerPresent) {
+            return AccessController.doPrivileged((PrivilegedAction<T>) () -> ctx.getService(ref));
+        }
+        return ctx.getService(ref);
+    }
+
+    class Tuple<T> {
+        final BundleContext bundleCtx;
+        final List<ServiceReference<T>> serviceRefs;
+
+        Tuple(BundleContext bundleCtx, List<ServiceReference<T>> serviceRefs) {
+            this.bundleCtx = bundleCtx;
+            this.serviceRefs = serviceRefs;
+        }
+    }
+}


### PR DESCRIPTION
Verified manually - still need following dependencies:
- Jakarta RESTful WS 3.0
- Jakarta Activation 2.0
- Jakarta Annotations 2.0
- Liberty logging (com.ibm.ws.logging)
- JBoss logging (com.ibm.ws.org.jboss.logging)
- Reactive Streams (com.ibm.websphere.org.reactivestreams.reactive-streams.1.0)
