### PR TITLE
Add the boilerplate to enable trace for CXF classes in jaxrs-2.0 and jaxrs-2.1

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
@@ -154,6 +154,7 @@ Include-Resource: \
 
 -dependson: com.ibm.ws.org.codehaus.jackson
 
+instrument.ffdc: false
 instrument.classesExcludes: com/ibm/ws/jaxrs20/internal/resources/*.class, \
 	org/apache/cxf/common/util/UrlUtils.class
 

--- a/dev/com.ibm.ws.jaxrs.2.0.common/build.gradle
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/build.gradle
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+configurations {
+  cxf
+}
+
+dependencies {
+  cxf 'org.apache.cxf:cxf-core:3.1.18',
+      'org.apache.cxf:cxf-rt-frontend-jaxrs:3.1.18',
+      'org.apache.cxf:cxf-rt-rs-client:3.1.18',
+      'org.apache.cxf:cxf-rt-transports-http:3.1.18'
+}
+
+// Copy each class from each CXF jar into the build directory
+// so the build can inject entry/exit trace into the bytecode
+task extractInjectedClasses(type: Copy) {
+  from zipTree(configurations.cxf[0])
+  include "**/*.class"
+  into compileJava.destinationDir
+
+  from zipTree(configurations.cxf[1])
+  include "**/*.class"
+  into compileJava.destinationDir
+
+  from zipTree(configurations.cxf[2])
+  include "**/*.class"
+  into compileJava.destinationDir
+
+  from zipTree(configurations.cxf[3])
+  include "**/*.class"
+  into compileJava.destinationDir
+}
+
+// uncomment this line to enable entry/exit trace for CXF
+//compileJava.dependsOn extractInjectedClasses

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.bnd
@@ -15,7 +15,8 @@
    @${repo;org.apache.cxf:cxf-core;3.4.3;EXACT}!/!*-INF/*,\
    org/apache/cxf=${bin}/org/apache/cxf,\
    META-INF=resources/META-INF
-   
+
+instrument.ffdc: false
 instrument.classesExcludes: org/apache/cxf/common/jaxb/*.class, \
   org/apache/cxf/service/invoker/*.class
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/build.gradle
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/build.gradle
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+configurations {
+  cxf
+}
+
+dependencies {
+  cxf 'org.apache.cxf:cxf-core:3.4.3'
+}
+
+// Copy each class from the CXF jar into the build directory
+// so the build can inject entry/exit trace into the bytecode
+task extractInjectedClasses(type: Copy) {
+  from zipTree(configurations.cxf[0])
+  into compileJava.destinationDir
+}
+
+// Copy each class from the CXF jar into the build directory
+// so the build can inject entry/exit trace into the bytecode
+//compileJava.dependsOn extractInjectedClasses


### PR DESCRIPTION
We don't want to start tracing all CXF classes due to performance and privacy concerns, but we'd like to be able to turn on the ability to trace all CXF classes in a development environment. 

To enable tracing CXF classes, simply enable the `extractInjectedClasses` task in the bundles' `build.gradle` file.