### PR TITLE
replace getContextService with captureThreadContext (part 1)

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/WSManagedExecutorService.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/WSManagedExecutorService.java
@@ -10,19 +10,24 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent;
 
+import java.util.Map;
+
 import com.ibm.ws.threading.PolicyExecutor;
-import com.ibm.wsspi.threadcontext.WSContextService;
+import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 
 /**
  * Interface that exposes various details about a managed executor service internally to other bundles.
  */
 public interface WSManagedExecutorService {
     /**
-     * Returns the context service instance backing the managed executor.
+     * <p>Captures context from the thread that invokes this method,
+     * or creates new thread context as determined by the execution properties.
+     * Do not expect the captured context to be serializable.</p>
      *
-     * @return the context service instance backing the managed executor.
+     * @param props execution properties. Custom property keys must not begin with "javax.enterprise.concurrent."
+     * @return captured thread context.
      */
-    WSContextService getContextService();
+    ThreadContextDescriptor captureThreadContext(Map<String, String> props);
 
     /**
      * When the longRunningPolicy is configured, returns the policy executor for running tasks against the long running concurrency policy.

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/ManagedExecutorExtension.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/ManagedExecutorExtension.java
@@ -12,6 +12,7 @@ package com.ibm.ws.concurrent.ext;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -29,9 +30,11 @@ import org.eclipse.microprofile.context.ThreadContext;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrent.WSManagedExecutorService;
+import com.ibm.ws.concurrent.internal.ManagedExecutorServiceImpl;
 import com.ibm.ws.threading.CompletionStageExecutor;
 import com.ibm.ws.threading.PolicyExecutor;
 import com.ibm.wsspi.resource.ResourceInfo;
+import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 import com.ibm.wsspi.threadcontext.WSContextService;
 
 /**
@@ -54,6 +57,11 @@ public class ManagedExecutorExtension implements CompletionStageExecutor, Manage
     @Override
     public final boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
         return ((ExecutorService) executor).awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public final ThreadContextDescriptor captureThreadContext(Map<String, String> props) {
+        return executor.captureThreadContext(props);
     }
 
     @Override
@@ -91,9 +99,9 @@ public class ManagedExecutorExtension implements CompletionStageExecutor, Manage
         return ((ManagedExecutor) executor).failedStage(x);
     }
 
-    @Override
+    @Deprecated // being replaced with captureThreadContext so that this method signature can change to spec
     public final WSContextService getContextService() {
-        return executor.getContextService();
+        return ((ManagedExecutorServiceImpl) executor).getContextService();
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextualDefaultExecutor.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextualDefaultExecutor.java
@@ -13,6 +13,7 @@ package com.ibm.ws.concurrent.internal;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collection;
+import java.util.Map;
 import java.util.concurrent.Executor;
 
 import org.eclipse.microprofile.context.ManagedExecutor;
@@ -24,6 +25,7 @@ import org.osgi.framework.ServiceReference;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrent.WSManagedExecutorService;
 import com.ibm.ws.threading.PolicyExecutor;
+import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 import com.ibm.wsspi.threadcontext.WSContextService;
 
 /**
@@ -60,14 +62,14 @@ class ContextualDefaultExecutor implements Executor, WSManagedExecutorService {
     }
 
     @Override
-    public void execute(Runnable command) {
-        defaultManagedExecutor.getNormalPolicyExecutor().execute(command);
+    @SuppressWarnings("unchecked")
+    public ThreadContextDescriptor captureThreadContext(Map<String, String> props) {
+        return contextService.captureThreadContext(props);
     }
 
     @Override
-    @Trivial
-    public WSContextService getContextService() {
-        return contextService;
+    public void execute(Runnable command) {
+        defaultManagedExecutor.getNormalPolicyExecutor().execute(command);
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedCompletableFuture.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedCompletableFuture.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -48,7 +48,6 @@ import com.ibm.ws.concurrent.WSManagedExecutorService;
 import com.ibm.ws.kernel.service.util.JavaInfo;
 import com.ibm.ws.threading.PolicyExecutor;
 import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
-import com.ibm.wsspi.threadcontext.WSContextService;
 
 /**
  * Extension to CompletableFuture for managed executors.
@@ -464,8 +463,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
             contextDescriptor = r.getContextDescriptor();
             action = r.getAction();
         } else if (executor instanceof WSManagedExecutorService) {
-            WSContextService contextSvc = ((WSManagedExecutorService) executor).getContextService();
-            contextDescriptor = contextSvc.captureThreadContext(XPROPS_SUSPEND_TRAN);
+            contextDescriptor = ((WSManagedExecutorService) executor).captureThreadContext(XPROPS_SUSPEND_TRAN);
         } else {
             contextDescriptor = null;
         }
@@ -514,8 +512,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
             contextDescriptor = s.getContextDescriptor();
             action = s.getAction();
         } else if (executor instanceof WSManagedExecutorService) {
-            WSContextService contextSvc = ((WSManagedExecutorService) executor).getContextService();
-            contextDescriptor = contextSvc.captureThreadContext(XPROPS_SUSPEND_TRAN);
+            contextDescriptor = ((WSManagedExecutorService) executor).captureThreadContext(XPROPS_SUSPEND_TRAN);
         } else {
             contextDescriptor = null;
         }
@@ -697,9 +694,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (managedExecutor == null)
             return null;
 
-        @SuppressWarnings("unchecked")
-        ThreadContextDescriptor contextDescriptor = managedExecutor.getContextService().captureThreadContext(XPROPS_SUSPEND_TRAN);
-        return contextDescriptor;
+        return managedExecutor.captureThreadContext(XPROPS_SUSPEND_TRAN);
     }
 
     /**
@@ -1080,11 +1075,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
     /**
      * @see java.util.concurrent.CompletableFuture#newIncompleteFuture()
      */
-    public CompletableFuture<T> newIncompleteFuture() {
+    public <R> CompletableFuture<R> newIncompleteFuture() {
         if (JAVA8)
-            return new ManagedCompletableFuture<T>(new CompletableFuture<T>(), defaultExecutor, null);
+            return new ManagedCompletableFuture<R>(new CompletableFuture<R>(), defaultExecutor, null);
         else
-            return new ManagedCompletableFuture<T>(defaultExecutor, futureRefLocal.get());
+            return new ManagedCompletableFuture<R>(defaultExecutor, futureRefLocal.get());
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ScheduledTask.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ScheduledTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2019 IBM Corporation and others.
+ * Copyright (c) 2013, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -41,7 +41,6 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.wsspi.kernel.service.utils.FrameworkState;
 import com.ibm.wsspi.threadcontext.ThreadContext;
 import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
-import com.ibm.wsspi.threadcontext.WSContextService;
 
 /**
  * This class represents a scheduled task and its future.
@@ -232,10 +231,9 @@ public class ScheduledTask<T> implements Callable<T> {
             this.threadContextDescriptor = a.getContextDescriptor();
         } else {
             this.task = task;
-            WSContextService contextSvc = managedExecSvc.getContextService();
             Map<String, String> execProps = managedExecSvc.getExecutionProperties(task);
             try {
-                this.threadContextDescriptor = contextSvc.captureThreadContext(execProps);
+                this.threadContextDescriptor = managedExecSvc.captureThreadContext(execProps);
             } catch (NullPointerException x) {
                 throw x;
             } catch (Throwable x) {
@@ -299,10 +297,9 @@ public class ScheduledTask<T> implements Callable<T> {
             this.threadContextDescriptor = a.getContextDescriptor();
         } else {
             this.task = task;
-            WSContextService contextSvc = managedExecSvc.getContextService();
             Map<String, String> execProps = managedExecSvc.getExecutionProperties(task);
             try {
-                this.threadContextDescriptor = contextSvc.captureThreadContext(execProps);
+                this.threadContextDescriptor = managedExecSvc.captureThreadContext(execProps);
             } catch (Throwable x) {
                 throw new RejectedExecutionException(x);
             }

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/UnusableExecutor.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/UnusableExecutor.java
@@ -10,11 +10,13 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent.internal;
 
+import java.util.Map;
 import java.util.concurrent.Executor;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrent.WSManagedExecutorService;
 import com.ibm.ws.threading.PolicyExecutor;
+import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 import com.ibm.wsspi.threadcontext.WSContextService;
 
 /**
@@ -32,13 +34,14 @@ class UnusableExecutor implements Executor, WSManagedExecutorService {
     }
 
     @Override
-    public void execute(Runnable command) {
-        throw new UnsupportedOperationException();
+    @SuppressWarnings("unchecked")
+    public ThreadContextDescriptor captureThreadContext(Map<String, String> props) {
+        return contextService.captureThreadContext(props);
     }
 
     @Override
-    public WSContextService getContextService() {
-        return contextService;
+    public void execute(Runnable command) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/DependentScopedBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/DependentScopedBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2020 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,7 +33,7 @@ public class DependentScopedBean {
      */
     @Async
     public CompletionStage<String> lookupAndConvertToString(String jndiName) {
-        CompletableFuture<String> future = Async.Result.getFuture(String.class);
+        CompletableFuture<String> future = Async.Result.getFuture();
         try {
             future.complete(InitialContext.doLookup(jndiName).toString());
         } catch (NamingException x) {

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/RequestScopedBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/RequestScopedBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2020 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -44,7 +44,7 @@ public class RequestScopedBean {
      */
     @Async(executor = "java:app/env/concurrent/sampleExecutorRef")
     public CompletableFuture<Executor> getExecutorOfAsyncMethods() throws Exception {
-        CompletableFuture<Executor> future = Async.Result.getFuture(Executor.class);
+        CompletableFuture<Executor> future = Async.Result.getFuture();
         // CompletatbleFuture.defaultExecutor() is unavailable on Java 8 CompletableFuture
         Method CompletableFuture_defaultExecutor;
         try {

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/TaskBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/TaskBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2020 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -71,7 +71,7 @@ public class TaskBean implements Callable<String> {
      */
     @Async
     public CompletionStage<List<String>> lookupAll(String jndiName1, String jndiName2, String jndiName3) {
-        if (Async.Result.getFuture(List.class).isDone())
+        if (Async.Result.getFuture().isDone())
             throw new AssertionError("Result CompletableFuture should not be done already!");
         try {
             return dependentScopedBean.lookupAndConvertToString(jndiName1)

--- a/dev/com.ibm.ws.jaxrs.2.x.concurrent/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.x.concurrent/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018,2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -23,6 +23,7 @@ WS-TraceGroup: JAXRS
 Import-Package: \
   org.apache.cxf.*;version="[3.0.2,4)", \
   com.ibm.websphere.ras.*, \
+  com.ibm.ws.context.service.serializable.*, \
   com.ibm.ws.jaxrs20.client, \
   com.ibm.ws.ffdc, \
   com.ibm.ws.concurrent, \

--- a/dev/io.openliberty.concurrent.cdi/src/prototype/enterprise/concurrent/Async.java
+++ b/dev/io.openliberty.concurrent.cdi/src/prototype/enterprise/concurrent/Async.java
@@ -255,13 +255,12 @@ public @interface Async {
          * <p>
          * This method must only be invoked by the asynchronous method implementation.
          *
-         * @param <T>  type of result returned by the asynchronous method's <code>CompletableFuture</code>.
-         * @param type type of result returned by the asynchronous method's <code>CompletableFuture</code>.
+         * @param <T> type of result returned by the asynchronous method's <code>CompletableFuture</code>.
          * @return the same <code>CompletableFuture</code> that the container returns to the caller.
          * @throws IllegalStateException if the <code>CompletableFuture</code> for an asynchronous
          *                                   method is not present on the thread.
          */
-        public static <T> CompletableFuture<T> getFuture(Class<T> type) {
+        public static <T> CompletableFuture<T> getFuture() {
             @SuppressWarnings("unchecked")
             CompletableFuture<T> future = (CompletableFuture<T>) futures.get();
             if (future == null)
@@ -281,9 +280,10 @@ public @interface Async {
          * <p>
          * This method must only be invoked by the Jakarta EE Product Provider.
          *
+         * @param <T>    type of result returned by the asynchronous method's <code>CompletableFuture</code>.
          * @param future
          */
-        public static void setFuture(CompletableFuture<?> future) {
+        public static <T> void setFuture(CompletableFuture<T> future) {
             if (future == null)
                 futures.remove();
             else


### PR DESCRIPTION
Part of the removal of WSManagedExecutorService.getContextService, so that we can replace this method signature with the new method signature with the same name that is being added in Concurrency 3.0.  This is a 3 step process, which involves providing an alternative way to capture thread context and mostly removing getContextService under part 1, then updating the ManagedExecutorExtensions to switch over to the new interface under part 2, then complete removal under part 3.
Also, update the mock Async signature to match the spec proposal.