### PR TITLE
Move Manifest processing to container instead of entry

### DIFF
--- a/dev/com.ibm.ws.classloading_test/build.gradle
+++ b/dev/com.ibm.ws.classloading_test/build.gradle
@@ -15,7 +15,7 @@ test {
 
     doFirst {
         ant.jar(destfile: new File(compileTestJava.destinationDir, 'test.jar'), manifest: project.file('test-resources/PackageDefineTestResources/MANIFEST.MF')) {
-            fileset(dir: compileTestJava.destinationDir, includes: 'test/')
+            fileset(dir: compileTestJava.destinationDir, includes: "test/,test2/")
         }
     }
 

--- a/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/LibertyClassLoaderTest.java
+++ b/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/LibertyClassLoaderTest.java
@@ -15,15 +15,20 @@ import static com.ibm.ws.classloading.internal.TestUtil.createAppClassloader;
 import static com.ibm.ws.classloading.internal.TestUtil.getClassLoadingService;
 import static com.ibm.ws.classloading.internal.TestUtil.getOtherClassesURL;
 import static com.ibm.ws.classloading.internal.TestUtil.getServletJarURL;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.jar.Manifest;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -76,6 +81,33 @@ public class LibertyClassLoaderTest {
         } catch (ClassFormatError e) {
             assertTrue("Should have traced an error", outputManager.checkForStandardErr("CWWKL0002E"));
         }
+    }
+
+    /**
+     * Validates that we only load the Manifest one time for a particular jar.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testManifestLoadedOnce() throws Exception {
+        Container c = buildMockContainer("testJar", TestUtil.getTestJarURL());
+
+        List<Manifest> manifests = new ArrayList<>();
+        loader = new AppClassLoader(null, loader.config, Arrays.asList(c), (DeclaredApiAccess) (loader.getParent()), null, null, new GlobalClassloadingConfiguration()) {
+            @Override
+            public Package definePackage(String name, Manifest manifest, URL sealBase) throws IllegalArgumentException {
+                manifests.add(manifest);
+                return super.definePackage(name, manifest, sealBase);
+            }
+        };
+
+        loader.loadClass("test.StringReturner");
+
+        loader.loadClass("test2.Package2Class");
+
+        assertEquals(2, manifests.size());
+
+        assertSame(manifests.get(0), manifests.get(1));
     }
 
     @Test

--- a/dev/com.ibm.ws.classloading_test/test/test2/Package2Class.java
+++ b/dev/com.ibm.ws.classloading_test/test/test2/Package2Class.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test2;
+
+/**
+ *
+ */
+public class Package2Class {
+
+}


### PR DESCRIPTION
- Update to move the MANIFEST.MF file processing and caching from the class level of the container level.
- This change reduces the amount of times we read the same MANIFEST file for the same container in the application classloader.