### PR TITLE
Use osgiresourcelocator to load xmlBinding impl

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2202,6 +2202,11 @@
       <version>1.0.1</version>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.hk2</groupId>
+      <artifactId>osgi-resource-locator</artifactId>
+      <version>1.0.3</version>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>codemodel</artifactId>
       <version>3.0.1</version>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -436,6 +436,7 @@ org.glassfish.hk2:hk2-locator:2.5.0-b42
 org.glassfish.hk2:hk2-utils:2.3.0-b10
 org.glassfish.hk2:hk2-utils:2.5.0-b42
 org.glassfish.hk2:osgi-resource-locator:1.0.1
+org.glassfish.hk2:osgi-resource-locator:1.0.3
 org.glassfish.jaxb:codemodel:3.0.1
 org.glassfish.jaxb:jaxb-core:3.0.1
 org.glassfish.jaxb:jaxb-jxc:3.0.1

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.xmlBinding-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.xmlBinding-3.0.feature
@@ -11,7 +11,8 @@ Subsystem-Name: Jakarta XML Bindings 3.0
   com.ibm.websphere.appserver.classloading-1.0, \
   io.openliberty.jakarta.activation-2.0
 -bundles=\
-  io.openliberty.jakarta.xmlBinding.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.xml.bind:jakarta.xml.bind-api:3.0.1"
+  io.openliberty.jakarta.xmlBinding.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.xml.bind:jakarta.xml.bind-api:3.0.1", \
+  io.openliberty.org.glassfish.hk2.osgi-resource-locator
 kind=beta
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/io.openliberty.jakarta.xmlBinding.3.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.xmlBinding.3.0/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -15,20 +15,15 @@ Bundle-SymbolicName: io.openliberty.jakarta.xmlBinding.3.0; singleton:=true
 
 Export-Package: jakarta.xml.bind.*;version="3.0"
 
-#Private-Package: org.apache.geronimo.osgi.locator
-
 Import-Package: \
   jakarta.activation, \
   javax.xml.namespace, \
   javax.xml.stream, \
-  org.apache.geronimo.osgi.registry.api;resolution:=optional,\
-  !org.glassfish.hk2.osgiresourcelocator,\
+  org.glassfish.hk2.osgiresourcelocator, \
   *
 
 DynamicImport-Package: \
   org.glassfish.jaxb.*
-
-#Bundle-Activator: org.apache.geronimo.osgi.locator.Activator
 
 Include-Resource:\
   @${repo;jakarta.xml.bind:jakarta.xml.bind-api;3.0.1;EXACT}!/!(META-INF/maven/*|module-info.class)
@@ -40,4 +35,5 @@ instrument.disabled: true
 publish.wlp.jar.suffix: dev/api/spec
 
 -buildpath: \
-	jakarta.xml.bind:jakarta.xml.bind-api;strategy=exact;version=3.0.1
+	jakarta.xml.bind:jakarta.xml.bind-api;strategy=exact;version=3.0.1,\
+	io.openliberty.org.glassfish.hk2.osgi-resource-locator

--- a/dev/io.openliberty.org.glassfish.hk2.osgi-resource-locator/.classpath
+++ b/dev/io.openliberty.org.glassfish.hk2.osgi-resource-locator/.classpath
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="src" output="bin" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.org.glassfish.hk2.osgi-resource-locator/.project
+++ b/dev/io.openliberty.org.glassfish.hk2.osgi-resource-locator/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.org.glassfish.hk2.osgi-resource-locator</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.org.glassfish.hk2.osgi-resource-locator/.settings/bndtools.core.prefs
+++ b/dev/io.openliberty.org.glassfish.hk2.osgi-resource-locator/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.org.glassfish.hk2.osgi-resource-locator/.settings/org.eclipse.core.resources.prefs
+++ b/dev/io.openliberty.org.glassfish.hk2.osgi-resource-locator/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/bnd.bnd=UTF-8

--- a/dev/io.openliberty.org.glassfish.hk2.osgi-resource-locator/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/io.openliberty.org.glassfish.hk2.osgi-resource-locator/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,12 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/io.openliberty.org.glassfish.hk2.osgi-resource-locator/bnd.bnd
+++ b/dev/io.openliberty.org.glassfish.hk2.osgi-resource-locator/bnd.bnd
@@ -1,0 +1,27 @@
+#*******************************************************************************
+# Copyright (c) 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+Bundle-SymbolicName: io.openliberty.org.glassfish.hk2.osgi-resource-locator; singleton:=true
+
+Export-Package:\
+    org.glassfish.hk2.osgiresourcelocator;version=1.0.3
+
+Bundle-Activator: org.glassfish.hk2.osgiresourcelocator.Activator
+
+Include-Resource:\
+  @${repo;org.glassfish.hk2:osgi-resource-locator;1.0.3;EXACT}!/!(META-INF/*|module-info.class)
+
+instrument.disabled: true
+
+-buildpath: \
+    org.glassfish.hk2:osgi-resource-locator;stragety=exact;version=1.0.3

--- a/dev/io.openliberty.xmlBinding.3.0.internal.tools/bnd.bnd
+++ b/dev/io.openliberty.xmlBinding.3.0.internal.tools/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -30,7 +30,12 @@ Service-Component: \
     implementation:=com.ibm.wsspi.classloading.ResourceProvider; \
     provide:=com.ibm.wsspi.classloading.ResourceProvider; \
     configuration-policy:=ignore; \
-    properties:= "resources=${app-resources}"
+    properties:= "resources=${app-resources}",\
+  org.glassfish.jaxb.runtime.v2.JAXBContextFactory; \
+    implementation:=org.glassfish.jaxb.runtime.v2.JAXBContextFactory; \
+    provide:=jakarta.xml.bind.JAXBContextFactory; \
+    configuration-policy:=ignore
+
 
 Import-Package: \
   jakarta.activation,\


### PR DESCRIPTION
Get the XML Binding implementation by using the glassfish OSGi resource
locator to get it if we couldn't service load it using the TCCL.

This ensures we can get the XML Binding implementation outside of the
context of an application (e.g. when batch uses it to deserialize
messages received over JMS).