### PR TITLE
disable tests with deps on external maven on z/os

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
@@ -54,7 +54,8 @@ public abstract class FeatureUtilityToolTest {
     private static String originalWlpInstallType;
     static boolean isClosedLiberty = false;
     private static String pathToAutoFVTTestFiles = "lib/LibertyFATTestFiles/";
-
+    public static boolean isZos = System.getProperty("os.name").toLowerCase().contains("z/os") || System.getProperty("os.name").toLowerCase().contains("os/390");
+    
     protected static void setupEnv() throws Exception {
         final String methodName = "setup";
         server = LibertyServerFactory.getLibertyServer("com.ibm.ws.install.featureUtility_fat");

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -35,6 +36,8 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	@BeforeClass
 	public static void beforeClassSetup() throws Exception {
 		final String methodName = "beforeClassSetup";
+        /* Enable tests only if running on a zOS machine, otherwise skip class */
+        Assume.assumeTrue(!isZos);
 		Log.entering(c, methodName);
 		setupEnv();
 		Log.exiting(c, methodName);

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallServerTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallServerTest.java
@@ -17,6 +17,7 @@ import java.io.File;
 
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -32,6 +33,8 @@ public class InstallServerTest extends FeatureUtilityToolTest {
     public static void beforeClassSetup() throws Exception {
         final String methodName = "setup";
         Log.entering(c, methodName);
+        /* Enable tests only if running on a zOS machine, otherwise skip class */
+        Assume.assumeTrue(!isZos);
         setupEnv();
         copyFileToMinifiedRoot("usr/temp", "../../publish/tmp/serverX.zip");
         replaceWlpProperties(getPreviousWlpVersion());


### PR DESCRIPTION
Some of our tests are connecting to maven central when running on z/OS.
This PR will disable these from running on z/OS.

