### PR TITLE
286891 Fix io.openliberty.java.internal_fat to pass at least 1 test

### DIFF
--- a/dev/io.openliberty.java.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.java.internal_fat/bnd.bnd
@@ -18,7 +18,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-fat.minimum.java.level: 17
+#fat.minimum.java.level: 17
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/io.openliberty.java.internal_fat/fat/src/io/openliberty/java/internal/fat/FATSuite.java
+++ b/dev/io.openliberty.java.internal_fat/fat/src/io/openliberty/java/internal/fat/FATSuite.java
@@ -14,9 +14,12 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import componenttest.custom.junit.runner.AlwaysPassesTest;
+
 @RunWith(Suite.class)
 @SuiteClasses({
-                Java17Test.class
+                Java17Test.class,
+                AlwaysPassesTest.class
 })
 public class FATSuite {
 }


### PR DESCRIPTION
This fixes RTC defect 286891.  FAT tests need to pass at least one test.  The main test can only run at Java 17, so when this test is run at Java 11, it fails to run any tests and shows up as a failing test.  Added the `AlwaysPassesTest.class` to fix.