### PR TITLE
Update user login sample number for UserEnum Test

### DIFF
--- a/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/UserEnumerationTest.java
+++ b/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/UserEnumerationTest.java
@@ -257,7 +257,7 @@ public class UserEnumerationTest {
         int allowedRatioMin = 70;
         int allowedRatioMax = 130;
 
-        int validityCheckRounds = 10;
+        int validityCheckRounds = 15;
 
         for (int j = 0; j < validityCheckRounds; j++) {
             /*


### PR DESCRIPTION
Occasional build break not getting a mix of "valid" and "invalid" comparisons -- although the login padding is varied.

RTC 286735