### PR TITLE
update sshd-core version

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1554,7 +1554,7 @@
     <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-core</artifactId>
-      <version>2.5.1</version>
+      <version>2.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.sshd</groupId>


### PR DESCRIPTION
update the sshd-core version from 2.5.1 to 2.7.0 per dependabot's recommendation: https://github.com/OpenLiberty/open-liberty/pull/18782

PB's do not run on dependabot PR's so created this PR to run a PB against spnego FAT tests that use the ssh utility

