### PR TITLE
Update the ValidatorFactoryBuilder reference

### DIFF
--- a/dev/com.ibm.ws.beanvalidation.v20/resources/OSGI-INF/wlp/defaultInstances.xml
+++ b/dev/com.ibm.ws.beanvalidation.v20/resources/OSGI-INF/wlp/defaultInstances.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017,2020 IBM Corporation and others.
+    Copyright (c) 2017,2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  -->
 <server>
 
-  <com.ibm.ws.beanvalidation.service.ValidatorFactoryBuilder type="ValidatorFactoryBuilderV20"/>
+  <com.ibm.ws.beanvalidation.service.ValidatorFactoryBuilder id="ValidatorFactoryBuilder" type="ValidatorFactoryBuilderV20"/>
   <com.ibm.ws.beanvalidation.service.ConstrainedHelper type="ConstrainedHelperV20"/>
   <com.ibm.ws.beanvalidation.OSGiBeanValidationImpl />
 

--- a/dev/com.ibm.ws.beanvalidation/bnd.bnd
+++ b/dev/com.ibm.ws.beanvalidation/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2020 IBM Corporation and others.
+# Copyright (c) 2017,2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -39,6 +39,8 @@ Private-Package: \
 
 Include-Resource: \
   OSGI-INF=resources/OSGI-INF
+
+IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml; addIfMissing=true
 
 -dsannotations-inherit: true
 -dsannotations: \

--- a/dev/com.ibm.ws.beanvalidation/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.beanvalidation/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017,2020 IBM Corporation and others.
+    Copyright (c) 2017,2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -53,6 +53,9 @@
             id="ValidatorFactoryBuilder" required="true" type="String" cardinality="100"
             ibm:type="pid" ibm:reference="com.ibm.ws.beanvalidation.service.ValidatorFactoryBuilder" default="*" ibm:final="true"/> 
 
+        <AD id="ValidatorFactoryBuilder.target" type="String" ibm:final="true" 
+            default="(service.pid=${ValidatorFactoryBuilder})" name="internal" description="internal use only"/>
+            
         <AD id="ValidatorFactoryBuilder.cardinality.minimum" name="internal"  description="internal use only" 
             type="String" required="true" default="${count(ValidatorFactoryBuilder)}"/>
             

--- a/dev/com.ibm.ws.beanvalidation/resources/OSGI-INF/wlp/defaultInstances.xml
+++ b/dev/com.ibm.ws.beanvalidation/resources/OSGI-INF/wlp/defaultInstances.xml
@@ -1,0 +1,13 @@
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+  <com.ibm.ws.beanvalidation.service.ValidatorFactoryBuilder id="ValidatorFactoryBuilder" type="ValidatorFactoryBuilderDummy"/>
+</server>

--- a/dev/com.ibm.ws.beanvalidation/src/com/ibm/ws/beanvalidation/OSGiBeanValidationImpl.java
+++ b/dev/com.ibm.ws.beanvalidation/src/com/ibm/ws/beanvalidation/OSGiBeanValidationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -502,9 +502,10 @@ public class OSGiBeanValidationImpl extends AbstractBeanValidation implements Mo
 
     @Reference(name = REFERENCE_VALIDATOR_FACTORY_BUILDER,
                service = ValidatorFactoryBuilder.class,
-               cardinality = ReferenceCardinality.MULTIPLE,
+               cardinality = ReferenceCardinality.AT_LEAST_ONE,
                policy = ReferencePolicy.STATIC,
-               policyOption = ReferencePolicyOption.GREEDY)
+               policyOption = ReferencePolicyOption.GREEDY,
+               target = "(id=unbound)")
     protected void setValidatorFactoryBuilder(ServiceReference<ValidatorFactoryBuilder> ref) {
         validatorFactoryBuilderSR.setReference(ref);
     }


### PR DESCRIPTION
Update the ValidatorFactoryBuilder reference to use ReferenceCardinality.AT_LEAST_ONE to prevent startup of the bean validation service before all config has been accounted for.

OpenLiberty Pull Requester,

ATTENTION, READ THIS: Updated 4/11/2018 - Read and understand this completely,
then delete this entire template. If a reviewer or merger sees this template,
they should fail the review or merge.

If this code change is fixing a user-visible bug in previously released code, it MUST
have an associated issue mentioned in the PR text or description. That Issue also
MUST be labelled “release bug”

This directs automation to scrape this fix for inclusion in the next release's
list of bugs fixed.

If this code is NOT for fixing a released bug, for example new function, fixing
a bug in unreleased function, or other improvements that do not affect the
user-space, no label is needed. An issue could or could not be used based
on the developer’s discretion, but do still delete this text block.

For full details, please see this wiki page:

https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions

