### PR TITLE
[18794] LibertyAuthFilter for checking RoleMethodAuthUtil

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.restfulWS3.0-appSecurity4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.restfulWS3.0-appSecurity4.0.feature
@@ -6,7 +6,8 @@ IBM-App-ForceRestart: install, \
 Subsystem-Version: 1.1.0
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.restfulWS-3.0))", \
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.appSecurity-4.0))"
--bundles=io.openliberty.restfulWS30.appSecurity
+-bundles=io.openliberty.restfulWS30.appSecurity, \
+ com.ibm.ws.security.authorization.util.jakarta
 IBM-Install-Policy: when-satisfied
 kind=beta
 edition=core

--- a/dev/io.openliberty.org.jboss.resteasy.common/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.common/bnd.bnd
@@ -47,7 +47,7 @@ Service-Component: \
     properties:="resources=${app-resources}"
 
 Export-Package: \
-  com.ibm.websphere.jaxrs20.multipart;thread-local=true, \
+  com.ibm.websphere.jaxrs20.multipart;thread-context=true, \
   com.ibm.ws.jaxrs20.client, \
   com.ibm.ws.jaxrs20.providers.api, \
   com.ibm.ws.resteasy.cdi.component;version=${resteasy-version};thread-context=true, \

--- a/dev/io.openliberty.org.jboss.resteasy.server/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.server/bnd.bnd
@@ -32,7 +32,7 @@ Service-Component: \
      properties:="service.vendor=IBM"
 
 Export-Package: \
-  com.ibm.websphere.jaxrs.server;version=3.0.0;thread-local=true, \
+  com.ibm.websphere.jaxrs.server;version=3.0.0;thread-context=true, \
   io.openliberty.org.jboss.resteasy.common.cdi;thread-context=true, \
   org.jboss.resteasy.cdi;version=${resteasy-version};thread-context=true, \
   org.jboss.resteasy.cdi.i18n;version=${resteasy-version}, \

--- a/dev/io.openliberty.restfulWS30.appSecurity/.classpath
+++ b/dev/io.openliberty.restfulWS30.appSecurity/.classpath
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/io.openliberty.restfulWS30.appSecurity/bnd.bnd
+++ b/dev/io.openliberty.restfulWS30.appSecurity/bnd.bnd
@@ -27,6 +27,9 @@ Include-Resource:\
   META-INF=resources/META-INF
 #  io/openliberty=${bin}/io/openliberty, \
 
+Export-Package: \
+ io.openliberty.restfulWS30.appSecurity;thread-context=true
+
 Import-Package: \
  com.ibm.wsspi.classloading, \
  jakarta.annotation, \
@@ -38,13 +41,17 @@ Import-Package: \
  org.jboss.resteasy.annotations.cache, \
  org.jboss.resteasy.plugins.interceptors, \
  org.jboss.resteasy.spi, \
- org.jboss.resteasy.util
+ org.jboss.resteasy.util, \
+ *
  
 
 -buildpath: \
-  com.ibm.websphere.javaee.jaxrs.2.1, \
+  io.openliberty.jakarta.annotation.2.0, \
+  io.openliberty.jakarta.restfulWS.3.0, \
+  io.openliberty.jakarta.servlet.5.0, \
   com.ibm.websphere.org.osgi.core;version=latest, \
   com.ibm.websphere.org.osgi.service.component;version=latest, \
   com.ibm.ws.logging.core, \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
+  com.ibm.ws.security.authorization.util;version=latest, \
   io.openliberty.org.jboss.resteasy.common;version=latest

--- a/dev/io.openliberty.restfulWS30.appSecurity/resources/META-INF/services/jakarta.ws.rs.ext.Providers
+++ b/dev/io.openliberty.restfulWS30.appSecurity/resources/META-INF/services/jakarta.ws.rs.ext.Providers
@@ -1,1 +1,1 @@
-org.jboss.resteasy.plugins.interceptors.RoleBasedSecurityFeature
+io.openliberty.restfulWS30.appSecurity.LibertyAuthFilter

--- a/dev/io.openliberty.restfulWS30.appSecurity/src/io/openliberty/restfulWS30/appSecurity/LibertyAuthFilter.java
+++ b/dev/io.openliberty.restfulWS30.appSecurity/src/io/openliberty/restfulWS30/appSecurity/LibertyAuthFilter.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.appSecurity;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import jakarta.annotation.Priority;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
+import jakarta.ws.rs.ext.Provider;
+
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.security.authorization.util.RoleMethodAuthUtil;
+import com.ibm.ws.security.authorization.util.UnauthenticatedException;
+
+// This code is practically an EE9 version of the LibertyAuthFilter in the com.ibm.ws.jaxrs.2.1.common project.
+// Changes here may need to be reflected there also - and vice versa.
+
+// Set the Priority to Priorities.AUTHORIZATION + 1 so that user filters take precedence.
+@Priority(Priorities.AUTHORIZATION + 1)
+@Provider
+public class LibertyAuthFilter implements ContainerRequestFilter {
+
+    @Context
+    HttpServletRequest req;
+
+    @Context
+    HttpServletResponse resp;
+
+    @Context
+    SecurityContext securityContext;
+
+    @Context
+    ResourceInfo resourceInfo;
+
+    @Override
+    @FFDCIgnore({ UnauthenticatedException.class, UnauthenticatedException.class })
+    public void filter(ContainerRequestContext context) {
+        try {
+            handleMessage();
+        } catch (UnauthenticatedException ex) {
+            try { 
+                if (authenticate()) {
+                    // try again with authenticated user
+                    handleMessage();
+                    return;
+                }
+            } catch (UnauthenticatedException ex2) {
+                // ignore - still abort with 401
+            }
+            // could not authenticate - return 401
+            // TODO: check response code on servlet response and use the same status?
+            context.abortWith(Response.status(Response.Status.UNAUTHORIZED).build());
+        }
+    }
+
+    private boolean authenticate() {
+        try {
+            return req.authenticate(resp);
+        } catch (IOException | ServletException e) {
+            // AutoFFDC
+        }
+        return false;
+    }
+
+    private void handleMessage() throws UnauthenticatedException, ForbiddenException {
+        Method method = resourceInfo.getResourceMethod();
+        if (method == null) {
+            throw new ForbiddenException("Method is not available : Unauthorized");
+        }
+        if (securityContext != null && RoleMethodAuthUtil.parseMethodSecurity(method,
+                                                       securityContext.getUserPrincipal(),
+                                                       s -> securityContext.isUserInRole(s))) {
+            return;
+        } else if (RoleMethodAuthUtil.parseMethodSecurity(method,
+                                                       req.getUserPrincipal(),
+                                                       s -> req.isUserInRole(s))) {
+            return;
+        }
+
+        throw new ForbiddenException("Unauthorized");
+    }
+}

--- a/dev/io.openliberty.restfulWS30.appSecurity/src/io/openliberty/restfulWS30/appSecurity/package-info.java
+++ b/dev/io.openliberty.restfulWS30.appSecurity/src/io/openliberty/restfulWS30/appSecurity/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+@org.osgi.annotation.versioning.Version("1.0")
+@TraceOptions(traceGroup = "RESTfulWS")
+package io.openliberty.restfulWS30.appSecurity;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;


### PR DESCRIPTION
Fixes #18794 by adding a new filter (enabled by auto feature when the `restfulWS-3.0` and `appSecurity-4.0` features are enabled) that will check JAX-RS resource classes and methods for `@RolesAllowed`, `@PermitAll`, `@DenyAll` annotations and react accordingly.