### PR TITLE
fix installUtility bug 

### DIFF
--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/Director.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/Director.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -852,6 +852,7 @@ public class Director extends AbstractDirector {
                         ESAAsset esaa = ((ESAAsset) installAsset);
                         if (esaa.isPublic()) {
                             log(Level.FINE, installAsset.installedLogMsg());
+                            log(Level.FINE, "ESA file is installed from : " + esaa.getAsset().getAbsolutePath());
                         }
                     } else {
                         log(Level.FINE, installAsset.installedLogMsg());

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ResolveDirector.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ResolveDirector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -866,11 +866,18 @@ class ResolveDirector extends AbstractDirector {
         ESAAsset esaAsset;
         String esaPath = esaFile.getAbsolutePath();
         String debugHeader = "createESAAsset(" + esaFile.getAbsolutePath() + ", \"" + toExtension + "\"): ";
+
         try {
             if (esaAssetCach.containsKey(esaPath)) {
                 return esaAssetCach.get(esaPath);
             }
             esaAsset = new ESAAsset(esaFile, toExtension, false);
+            ProvisioningFeatureDefinition fd = esaAsset.getProvisioningFeatureDefinition();
+            if (esaAssetCach.containsKey(fd.getSymbolicName())) {
+                //if the feature already exists in cache, return
+                return esaAssetCach.get(fd.getSymbolicName());
+            }
+
         } catch (Exception e) {
             esaAssetCach.put(esaPath, null);
             log(Level.SEVERE, debugHeader + Messages.PROVISIONER_MESSAGES.getLogMessage("tool.install.bad.zip", esaFile.getAbsolutePath(), e.getMessage()), e);


### PR DESCRIPTION

When checking for auto features, if the same feature exists in the same directory as one specified in the command, the esa cache that stores the esa file path was getting overwritten (possibly to older version)

Added a debug log that shows the esa file being installed 