### PR TITLE
add kerberos trace to spnegofat1

### DIFF
--- a/dev/com.ibm.ws.security.spnego_fat.1/publish/servers/S4U2ProxyTest/bootstrap.properties
+++ b/dev/com.ibm.ws.security.spnego_fat.1/publish/servers/S4U2ProxyTest/bootstrap.properties
@@ -12,6 +12,7 @@
 bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
+com.ibm.ws.security.kerberos*=all=enabled:\
 com.ibm.ws.security.spnego*=all=enabled:\
 com.ibm.wsspi.security.*=all=enabled:\
 com.ibm.websphere.security.*=all=enabled:\

--- a/dev/com.ibm.ws.security.spnego_fat.1/publish/servers/S4U2SelfTest/bootstrap.properties
+++ b/dev/com.ibm.ws.security.spnego_fat.1/publish/servers/S4U2SelfTest/bootstrap.properties
@@ -12,6 +12,7 @@
 bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
+com.ibm.ws.security.kerberos*=all=enabled:\
 com.ibm.ws.security.spnego*=all=enabled:\
 com.ibm.wsspi.security.*=all=enabled:\
 com.ibm.websphere.security.*=all=enabled:\


### PR DESCRIPTION
add `com.ibm.ws.security.kerberos*=all=enabled` trace for better debugging in s4u2 tests