### PR TITLE
NullPointerException from transactions while computing message for different error

### DIFF
--- a/dev/com.ibm.ws.tx.embeddable/src/com/ibm/tx/jta/embeddable/impl/EmbeddableTranManagerImpl.java
+++ b/dev/com.ibm.ws.tx.embeddable/src/com/ibm/tx/jta/embeddable/impl/EmbeddableTranManagerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2020 IBM Corporation and others.
+ * Copyright (c) 2009, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -119,8 +119,9 @@ public class EmbeddableTranManagerImpl extends TranManagerImpl {
 
             if (!t.isResumable()) {
                 final IllegalStateException ise;
-                if (t.getThread() != null) {
-                    ise = new IllegalStateException("Transaction already active on thread " + String.format("%08X", t.getThread().getId()));
+                Thread thread = t.getThread(); // avoid race condition where value becomes null after first check
+                if (thread != null) {
+                    ise = new IllegalStateException("Transaction already active on thread " + String.format("%08X", thread.getId()));
                 } else {
                     ise = new IllegalStateException("Transaction cannot be resumed on this thread");
                 }


### PR DESCRIPTION
fixes #18813

The NullPointerException is due to a bug in transactions code where it falsely assumes that if getThread() returned a value once then it will return the same non-null value again shortly after.  There is a small timing window where that won't be the case which leads to this NullPointerException.