### PR TITLE
Update OidcClientConfigImpl to make SSLSupport service mandatory

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorTests.java
@@ -23,6 +23,7 @@ import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonTest;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonTestHelpers;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.Constants;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.DiscoveryUtils;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.MessageConstants;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.TestSettings;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.ValidationData.validationData;
 import com.ibm.ws.security.openidconnect.client.fat.CommonTests.GenericOidcClientTests;
@@ -195,22 +196,15 @@ public class OidcClientDiscoveryErrorTests extends CommonTest {
         TestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setScope("openid profile");
 
-        List<validationData> expectations = validationTools.add401Responses(Constants.LOGIN_USER);
-
-        // Client get login page
-        expectations = vData.addResponseStatusExpectation(expectations, Constants.GET_LOGIN_PAGE, Constants.OK_STATUS);
-        expectations = vData.addExpectation(expectations, Constants.GET_LOGIN_PAGE, Constants.RESPONSE_FULL, Constants.STRING_CONTAINS, "Did Not get the OpenID Connect login page.", null, Constants.LOGIN_PROMPT);
-
-        // login will fail
-        expectations = vData.addNoTokensInResponseExpectations(expectations, Constants.LOGIN_USER);
-
-        expectations = validationTools.addMessageExpectation(testRPServer, expectations, Constants.LOGIN_USER, Constants.MESSAGES_LOG, Constants.STRING_CONTAINS, "RP Server messages.log should contain msg indicating that ssl failure", "CWWKS1708E:.*unable to contact the OpenID Connect provider.*");
-
-        expectations = validationTools.addMessageExpectation(testRPServer, expectations, Constants.LOGIN_USER, Constants.MESSAGES_LOG, Constants.STRING_CONTAINS, "RP Server messages.log should contain msg indicating an SSL handshake error occurred.", "CWPKI0823E: SSL HANDSHAKE FAILURE.*");
+        List<validationData> expectations = validationTools.add401Responses(Constants.GET_LOGIN_PAGE);
+        expectations = validationTools.addMessageExpectation(testRPServer, expectations, Constants.GET_LOGIN_PAGE, Constants.MESSAGES_LOG, Constants.STRING_CONTAINS, "RP Server messages.log should contain msg indicating an SSL handshake error occurred.", "CWPKI0823E: SSL HANDSHAKE FAILURE.*");
+        expectations = validationTools.addMessageExpectation(testRPServer, expectations, Constants.GET_LOGIN_PAGE, Constants.MESSAGES_LOG, Constants.STRING_CONTAINS, "RP Server messages.log did not contain CWWKS1525E message indicating a successful response was not returned from the discovery endpoint.", MessageConstants.CWWKS1525E_SUCCESSFUL_RESPONSE_NOT_RETURNED);
+        expectations = validationTools.addMessageExpectation(testRPServer, expectations, Constants.GET_LOGIN_PAGE, Constants.MESSAGES_LOG, Constants.STRING_CONTAINS, "RP Server messages.log did not contain CWWKS1524E message saying we failed to obtain info from the OP.", MessageConstants.CWWKS1524E_DISCOVERY_FAILED_TO_RETURN_ENDPOINT);
+        expectations = validationTools.addMessageExpectation(testRPServer, expectations, Constants.GET_LOGIN_PAGE, Constants.MESSAGES_LOG, Constants.STRING_CONTAINS, "RP Server messages.log did not contain CWWKS1534E message saying the authorization endpoint URL is missing.", MessageConstants.CWWKS1534E_MISSING_AUTH_ENDPOINT);
 
         WebConversation wc = new WebConversation();
 
-        genericRP(_testName, wc, updatedTestSettings, test_GOOD_LOGIN_ACTIONS, expectations);
+        genericRP(_testName, wc, updatedTestSettings, test_LOGIN_PAGE_ONLY, expectations);
 
     }
 

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
@@ -333,7 +333,7 @@ public class OidcClientConfigImpl implements OidcClientConfig {
         locationAdminRef.unsetReference(ref);
     }
 
-    @Reference(service = SSLSupport.class, name = KEY_SSL_SUPPORT, policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.OPTIONAL)
+    @Reference(service = SSLSupport.class, name = KEY_SSL_SUPPORT, policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MANDATORY)
     protected void setSslSupport(ServiceReference<SSLSupport> ref) {
         sslSupportRef.setReference(ref);
         if (tc.isDebugEnabled()) {


### PR DESCRIPTION
When using an OIDC client configuring to use discovery, the SSLSupport service might not be available before performing discovery if the server was just reconfigured. This change should ensure that the SSLSupport service is available before the OIDC client config is activated.