### PR TITLE
Issue 18828: Remove Oracle Ldap refs from FATs

### DIFF
--- a/dev/com.ibm.ws.com.unboundid/resources/SunOne.ldif
+++ b/dev/com.ibm.ws.com.unboundid/resources/SunOne.ldif
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020,2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -26,8 +26,7 @@ objectClass: organizationalPerson
 objectClass: person
 objectClass: inetOrgPerson
 objectClass: top
-userPassword:: e1NTSEF9ekdZQjZJZ1BWVzE4WjJ5d3RrNGlkMTVRRm5DWTJKOGtGQVlKaEE9PQ=
- =
+userPassword: password
 uid: noNSUID
 
 dn: uid=persona1,ou=users,dc=rtp,dc=raleigh,dc=ibm,dc=com
@@ -109,7 +108,7 @@ objectClass: inetOrgPerson
 objectClass: person
 objectClass: top
 title: FVT user
-userPassword:: e1NIQX1DOFlVWjhlcGY5UlRjK0wzV29RK1U2VHdLb2s9
+userPassword: vmmtestuserpwd
 uid: vmmtestuser
 
 dn: uid=vmmuser1,ou=users,dc=rtp,dc=raleigh,dc=ibm,dc=com

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/CommonLocalLDAPServerSuite.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/CommonLocalLDAPServerSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,17 +35,11 @@ public class CommonLocalLDAPServerSuite {
         LocalLDAPServerSuite.addTestServer(LDAPUtils.LDAP_SERVER_1_NAME, LDAPUtils.LDAP_SERVER_1_PORT,
                                            LDAPUtils.LDAP_SERVER_5_NAME, LDAPUtils.LDAP_SERVER_5_PORT, testServers);
 
-        // TODO REMOTE LDAP_SERVER_6 is dead.
         LocalLDAPServerSuite.addTestServer(LDAPUtils.LDAP_SERVER_2_NAME, LDAPUtils.LDAP_SERVER_2_PORT,
                                            LDAPUtils.LDAP_SERVER_6_NAME, LDAPUtils.LDAP_SERVER_6_PORT, testServers);
         LocalLDAPServerSuite.addTestServer(LDAPUtils.LDAP_SERVER_2_NAME, LDAPUtils.LDAP_SERVER_2_SSL_PORT, true, LDAPUtils.LDAP_SERVER_2_BINDDN, LDAPUtils.LDAP_SERVER_2_BINDPWD,
                                            LDAPUtils.LDAP_SERVER_6_NAME, LDAPUtils.LDAP_SERVER_6_SSL_PORT, false, null, null, testServers);
 
-        LocalLDAPServerSuite.addTestServer(LDAPUtils.LDAP_SERVER_13_NAME, LDAPUtils.LDAP_SERVER_13_PORT, LDAPUtils.LDAP_SERVER_3_NAME, LDAPUtils.LDAP_SERVER_3_PORT, testServers);
-        LocalLDAPServerSuite.addTestServer(LDAPUtils.LDAP_SERVER_13_NAME, LDAPUtils.LDAP_SERVER_13_SSL_PORT, true, LDAPUtils.LDAP_SERVER_13_BINDDN,
-                                           LDAPUtils.LDAP_SERVER_13_BINDPWD,
-                                           LDAPUtils.LDAP_SERVER_3_NAME, LDAPUtils.LDAP_SERVER_3_SSL_PORT, true, LDAPUtils.LDAP_SERVER_3_BINDDN, LDAPUtils.LDAP_SERVER_3_BINDPWD,
-                                           testServers);
         LocalLDAPServerSuite.addTestServer(LDAPUtils.LDAP_SERVER_4_NAME, LDAPUtils.LDAP_SERVER_4_PORT,
                                            LDAPUtils.LDAP_SERVER_1_NAME, LDAPUtils.LDAP_SERVER_1_PORT, testServers);
         LocalLDAPServerSuite.addTestServer(LDAPUtils.LDAP_SERVER_4_NAME, LDAPUtils.LDAP_SERVER_4_PORT,

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.multipleldaps/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.multipleldaps/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017,2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -28,7 +28,7 @@
         </failoverServers>
     </ldapRegistry>    
 		
-	<ldapRegistry id="LDAP" realm="SampleLdapSUNRealm" host="${ldap.server.13.name}" port="${ldap.server.13.port}" ignoreCase="true"
+	<ldapRegistry id="LDAP" realm="SampleLdapSUNRealm" host="${ldap.server.13.name}" port="0" ignoreCase="true"
 		baseDN="dc=rtp,dc=raleigh,dc=ibm,dc=com"
 		ldapType="Sun Java System Directory Server"
 		searchTimeout="8m">

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.sun.attrMappingVar4/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.sun.attrMappingVar4/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017,2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@
 		<feature>ldapRegistry-3.0</feature>
     </featureManager>
 
-	<ldapRegistry id="LDAP" realm="SampleLdapSUNRealm" host="${ldap.server.13.name}" port="${ldap.server.13.port}" ignoreCase="true"
+	<ldapRegistry id="LDAP" realm="SampleLdapSUNRealm" host="${ldap.server.13.name}" port="0" ignoreCase="true"
 		baseDN="dc=rtp,dc=raleigh,dc=ibm,dc=com"
 		ldapType="Sun Java System Directory Server"
 		searchTimeout="8m">

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.sun.default/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.sun.default/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017,2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@
 		<feature>ldapRegistry-3.0</feature>
     </featureManager>
 
-	<ldapRegistry id="LDAP" realm="SampleLdapSUNRealm" host="${ldap.server.13.name}" port="${ldap.server.13.port}" ignoreCase="true"
+	<ldapRegistry id="LDAP" realm="SampleLdapSUNRealm" host="${ldap.server.13.name}" port="0" ignoreCase="true"
 		baseDN="dc=rtp,dc=raleigh,dc=ibm,dc=com"
 		ldapType="Sun Java System Directory Server"
 		searchTimeout="8m">

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.sun/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.sun/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017,2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@
 		<feature>ldapRegistry-3.0</feature>
     </featureManager>
 
-	<ldapRegistry id="LDAP" realm="SampleLdapSUNRealm" host="${ldap.server.13.name}" port="${ldap.server.13.port}" ignoreCase="true"
+	<ldapRegistry id="LDAP" realm="SampleLdapSUNRealm" host="${ldap.server.13.name}" port="0" ignoreCase="true"
 		baseDN="dc=rtp,dc=raleigh,dc=ibm,dc=com"
 		ldapType="Sun Java System Directory Server"
 		searchTimeout="8m">

--- a/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/CommonLocalLDAPServerSuite.java
+++ b/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/CommonLocalLDAPServerSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,8 +27,7 @@ public class CommonLocalLDAPServerSuite {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        HashMap<String, ArrayList<String>> testServers = LocalLDAPServerSuite.addTestServer(LDAPUtils.LDAP_SERVER_3_NAME, LDAPUtils.LDAP_SERVER_3_PORT, null, null, null);
-        LocalLDAPServerSuite.addTestServer(LDAPUtils.LDAP_SERVER_2_NAME, LDAPUtils.LDAP_SERVER_2_PORT, null, null, testServers);
+        HashMap<String, ArrayList<String>> testServers = LocalLDAPServerSuite.addTestServer(LDAPUtils.LDAP_SERVER_2_NAME, LDAPUtils.LDAP_SERVER_2_PORT, null, null, null);
 
         Log.info(c, "setUp", "Calling LocalLDAPServerSuite.setUpUsingServers()");
         LocalLDAPServerSuite.setUpUsingServers(testServers);

--- a/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/DefaultWIMRealmMultipleReposTest.java
+++ b/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/DefaultWIMRealmMultipleReposTest.java
@@ -74,12 +74,14 @@ public class DefaultWIMRealmMultipleReposTest {
          */
         ServerConfiguration serverConfig = server.getServerConfiguration();
         for (LdapRegistry ldap : serverConfig.getLdapRegistries()) {
-            if (ldap.getRealm().equals("SUN_LDAP")) {
+            Log.info(c, "setUp", ldap.getRealm());
+            if (ldap.getId().equals("SUN_LDAP")) {
                 ldap.setHost("localhost");
                 ldap.setPort(String.valueOf(sunLdapServer.getLdapPort()));
                 ldap.setBindDN(InMemorySunLDAPServer.getBindDN());
                 ldap.setBindPassword(InMemorySunLDAPServer.getBindPassword());
                 server.updateServerConfiguration(serverConfig);
+                Log.info(c, "setUp", "Updated the SUN_LDAP to unboundID");
                 break;
             }
         }

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/LDAPFatUtils.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/LDAPFatUtils.java
@@ -204,26 +204,31 @@ public class LDAPFatUtils {
     }
 
     /**
-     * Convenience method to create an LdapRegistry configuration object for Oracle / Sun LDAP server
+     * Convenience method to create an LdapRegistry configuration object for InMemorySunLDAPServer
      * and if provided a {@link ServerConfiguration} instance add it to the list of LDAP registries.
      *
      * @param  serverConfiguration The {@link ServerConfiguration} instance. Can be null.
      * @param  id                  The registry ID. Can be null.
      * @param  realm               The realm name. Can be null.
+     * @param  name                The name of the Ldap registry
+     * @param  ldapPort            The port of the ldap server
+     * @param  bindDN              The bindDN of the ldap server
+     * @param  bindPwd             The password of the ldap server
      * @return                     The LdapRegistry instance.
      */
-    public static LdapRegistry createSunLdapRegistry(ServerConfiguration serverConfiguration, String id, String realm, String name) {
+    public static LdapRegistry createSunLdapRegistry(ServerConfiguration serverConfiguration, String id, String realm, String name, String ldapPort, String bindDN,
+                                                     String bindPwd) {
         LdapRegistry ldap = new LdapRegistry();
         ldap.setId(id);
         ldap.setRealm(realm);
         ldap.setName(name);
         ldap.setLdapType("Sun Java System Directory Server");
         ldap.setBaseDN("dc=rtp,dc=raleigh,dc=ibm,dc=com");
-        ldap.setHost("${ldap.server.13.name}");
-        ldap.setPort("${ldap.server.13.port}");
+        ldap.setHost("localhost");
+        ldap.setPort(ldapPort);
+        ldap.setBindDN(bindDN);
+        ldap.setBindPassword(bindPwd);
         ldap.setSearchTimeout("8m");
-
-        ldap.setFailoverServer(new FailoverServers("failoverLdapServers", new String[][] { { "${ldap.server.3.name}", "${ldap.server.3.port}" } }));
 
         if (serverConfiguration != null) {
             serverConfiguration.getLdapRegistries().add(ldap);

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/LDAPUtils.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/LDAPUtils.java
@@ -46,7 +46,7 @@ public class LDAPUtils {
 
     public static String LDAP_SERVER_1_NAME;
     public static String LDAP_SERVER_2_NAME;
-    public static String LDAP_SERVER_3_NAME;
+    // public static String LDAP_SERVER_3_NAME;
     public static String LDAP_SERVER_4_NAME;
     public static String LDAP_SERVER_5_NAME;
     public static String LDAP_SERVER_6_NAME;
@@ -56,12 +56,12 @@ public class LDAPUtils {
     public static String LDAP_SERVER_10_NAME;
 //    public static String LDAP_SERVER_11_NAME;
     public static String LDAP_SERVER_12_NAME;
-    public static String LDAP_SERVER_13_NAME;
+    // public static String LDAP_SERVER_13_NAME;
     public static String LDAP_SERVER_1_PORT;
     public static String LDAP_SERVER_2_PORT;
     public static String LDAP_SERVER_2_SSL_PORT;
-    public static String LDAP_SERVER_3_PORT;
-    public static String LDAP_SERVER_3_SSL_PORT;
+    //public static String LDAP_SERVER_3_PORT;
+    //public static String LDAP_SERVER_3_SSL_PORT;
     public static String LDAP_SERVER_4_PORT;
     public static String LDAP_SERVER_4_SSL_PORT;
     public static String LDAP_SERVER_5_PORT;
@@ -75,13 +75,13 @@ public class LDAPUtils {
     public static String LDAP_SERVER_10_PORT;
 //    public static String LDAP_SERVER_11_PORT;
     public static String LDAP_SERVER_12_PORT;
-    public static String LDAP_SERVER_13_PORT;
-    public static String LDAP_SERVER_13_SSL_PORT;
+    //public static String LDAP_SERVER_13_PORT;
+    //public static String LDAP_SERVER_13_SSL_PORT;
 
     public static String LDAP_SERVER_2_BINDDN;
     public static String LDAP_SERVER_2_BINDPWD;
-    public static String LDAP_SERVER_3_BINDDN;
-    public static String LDAP_SERVER_3_BINDPWD;
+    //public static String LDAP_SERVER_3_BINDDN;
+    //public static String LDAP_SERVER_3_BINDPWD;
 
     public static String LDAP_SERVER_4_BINDDN;
     public static String LDAP_SERVER_4_BINDPWD;
@@ -98,8 +98,8 @@ public class LDAPUtils {
     public static String LDAP_SERVER_12_BINDDN;
     public static String LDAP_SERVER_12_BINDPWD;
 
-    public static String LDAP_SERVER_13_BINDDN;
-    public static String LDAP_SERVER_13_BINDPWD;
+    //public static String LDAP_SERVER_13_BINDDN;
+    //public static String LDAP_SERVER_13_BINDPWD;
 
     /** Service name for SVT's Active Directory servers. */
     private static final String CONSUL_LDAP_AD_SVT_SERVICE = "ldap-ad-svt";
@@ -113,8 +113,8 @@ public class LDAPUtils {
     /** Service name for Security's IBM / Tivoli servers. */
     private static final String CONSUL_LDAP_IBM_SECURITY_SERVICE = "ldap-ibm-security";
 
-    /** Service name for SVT's Oracle servers. */
-    private static final String CONSUL_LDAP_ORACLE_SVT_SERVICE = "ldap-oracle-svt";
+    /** Service name for SVT's Oracle servers. Servers 3 and 13 */
+    // private static final String CONSUL_LDAP_ORACLE_SVT_SERVICE = "ldap-oracle-svt";
 
     /** Key to retrieve LDAP port from Consul LDAP service. */
     private static final String CONSUL_LDAP_PORT_KEY = "ldapPort";
@@ -284,27 +284,6 @@ public class LDAPUtils {
             releaseServices(services);
         }
 
-        services = null;
-        try {
-            services = getLdapServices(1, CONSUL_LDAP_ORACLE_SVT_SERVICE);
-
-            remoteServers[3] = new LdapServer();
-            remoteServers[3].serverName = services.get(0).getAddress();
-            remoteServers[3].ldapPort = services.get(0).getProperties().get(CONSUL_LDAP_PORT_KEY);
-            remoteServers[3].ldapsPort = services.get(0).getProperties().get(CONSUL_LDAPS_PORT_KEY);
-            remoteServers[3].bindDn = services.get(0).getProperties().get(CONSUL_BIND_DN_KEY);
-            remoteServers[3].bindPwd = services.get(0).getProperties().get(CONSUL_BIND_PASSWORD_KEY);
-
-            /* Server 13 is dead. Reuse server 3. */
-            remoteServers[13] = new LdapServer();
-            remoteServers[13].serverName = remoteServers[3].serverName;
-            remoteServers[13].ldapPort = remoteServers[3].ldapPort;
-            remoteServers[13].ldapsPort = remoteServers[3].ldapsPort;
-            remoteServers[13].bindDn = remoteServers[3].bindDn;
-            remoteServers[13].bindPwd = remoteServers[3].bindPwd;
-        } finally {
-            releaseServices(services);
-        }
     }
 
     private static void initializeLocalLdapServers() {
@@ -472,16 +451,6 @@ public class LDAPUtils {
         LDAP_SERVER_12_BINDDN = (USE_LOCAL_LDAP_SERVER ? localServers[12] : remoteServers[12]).bindDn;
         LDAP_SERVER_12_BINDPWD = (USE_LOCAL_LDAP_SERVER ? localServers[12] : remoteServers[12]).bindPwd;
 
-        LDAP_SERVER_3_NAME = (USE_LOCAL_LDAP_SERVER ? localServers[3] : remoteServers[3]).serverName;
-        LDAP_SERVER_3_PORT = (USE_LOCAL_LDAP_SERVER ? localServers[3] : remoteServers[3]).ldapPort;
-        LDAP_SERVER_3_SSL_PORT = (USE_LOCAL_LDAP_SERVER ? localServers[3] : remoteServers[3]).ldapsPort;
-        LDAP_SERVER_3_BINDDN = (USE_LOCAL_LDAP_SERVER ? localServers[3] : remoteServers[3]).bindDn;
-        LDAP_SERVER_3_BINDPWD = (USE_LOCAL_LDAP_SERVER ? localServers[3] : remoteServers[3]).bindPwd;
-        LDAP_SERVER_13_NAME = (USE_LOCAL_LDAP_SERVER ? localServers[13] : remoteServers[13]).serverName;
-        LDAP_SERVER_13_PORT = (USE_LOCAL_LDAP_SERVER ? localServers[13] : remoteServers[13]).ldapPort;
-        LDAP_SERVER_13_SSL_PORT = (USE_LOCAL_LDAP_SERVER ? localServers[13] : remoteServers[13]).ldapsPort;
-        LDAP_SERVER_13_BINDDN = (USE_LOCAL_LDAP_SERVER ? localServers[13] : remoteServers[13]).bindDn;
-        LDAP_SERVER_13_BINDPWD = (USE_LOCAL_LDAP_SERVER ? localServers[13] : remoteServers[13]).bindPwd;
     }
 
     /*
@@ -523,13 +492,8 @@ public class LDAPUtils {
         Log.info(c, METHOD_NAME, "           LDAP_SERVER_12_NAME=" + LDAP_SERVER_12_NAME);
         Log.info(c, METHOD_NAME, "           LDAP_SERVER_12_PORT=" + LDAP_SERVER_12_PORT + '\n');
 
-        Log.info(c, METHOD_NAME, "Oracle WAS SVT LDAP Servers");
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_3_NAME=" + LDAP_SERVER_3_NAME);
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_3_PORT=" + LDAP_SERVER_3_PORT);
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_3_SSL_PORT=" + LDAP_SERVER_3_SSL_PORT + '\n');
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_13_NAME=" + LDAP_SERVER_13_NAME);
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_13_PORT=" + LDAP_SERVER_13_PORT);
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_13_SSL_PORT=" + LDAP_SERVER_13_SSL_PORT + '\n');
+        Log.info(c, METHOD_NAME, "Oracle WAS SVT LDAP Servers -- removed");
+
     }
 
     /**


### PR DESCRIPTION
Fixes #18828

Removed the oracle ldap call to Consul.

Updated the port variable in the server.xml files or we get a `AttributeValidationException`. In those tests, we dynamic update the config to the UnboundId server. We could update the tests to create the Ldap server from scratch and remove it from the server.xml, but this was the least churn.

Updated `LDAPRegistryDynamicUpdateTest` to use the `InMemorySunLDAPServer`

Had to update the vmmtestuser password (which we also did in AD.ldif) Also had to fix noNSUID.

Fixed a bug in `DefaultWIMRealmMultipleReposTest` where we weren't replacing the server.xml variables for UnboundID as expected.