### PR TITLE
[18849] - skip test for jaxrs-2.1

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientSSLProxyAuthTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientSSLProxyAuthTest.java
@@ -146,7 +146,7 @@ public class JAXRS21ClientSSLProxyAuthTest extends JAXRS21AbstractTest {
         // amF4cnNVc2VyOm15UGEkJHdvcmQ=").withSecure(false)); //jaxrsUser:myPa$$word
     }
 
-    @Test
+    //@Test TODO: https://github.com/OpenLiberty/open-liberty/issues/18849
     public void testTunnelThroughProxyToHTTPSEndpoint_ClientBuilder() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         p.put("param", "helloRochester");


### PR DESCRIPTION
#18849

#18850 failed unexpectedly, spinning a new personal build and created this PR for redundancy. If that PR fails again, I'll merge this one instead.

UPDATE: There is a bug in the test harness where this test gets ran even though it has been skipped. I suspect that this is because we have tests in both the Test class and the Test Servlet. Disabling the test completely until we can sort this out.