### PR TITLE
Swap WIM Reg FATs to use Inbound ID LDAP where possible

### DIFF
--- a/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/CommonLocalLDAPServerSuite.java
+++ b/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/CommonLocalLDAPServerSuite.java
@@ -27,10 +27,13 @@ public class CommonLocalLDAPServerSuite {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        /**
+         * Remote servers are required for some tests that cannot be tested with a local LDAP. If the remote LDAP is not available, the tests will not run.
+         */
         HashMap<String, ArrayList<String>> testServers = LocalLDAPServerSuite.addTestServer(LDAPUtils.LDAP_SERVER_2_NAME, LDAPUtils.LDAP_SERVER_2_PORT, null, null, null);
 
         Log.info(c, "setUp", "Calling LocalLDAPServerSuite.setUpUsingServers()");
-        LocalLDAPServerSuite.setUpUsingServers(testServers);
+        LocalLDAPServerSuite.setUpUsingServers(testServers, false);
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/DefaultWIMRealmMultipleReposTest.java
+++ b/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/DefaultWIMRealmMultipleReposTest.java
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.config.wim.LdapRegistry;
 import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.com.unboundid.InMemoryADLDAPServer;
 import com.ibm.ws.com.unboundid.InMemorySunLDAPServer;
 import com.ibm.ws.security.registry.EntryNotFoundException;
 import com.ibm.ws.security.registry.RegistryException;
@@ -52,6 +53,7 @@ public class DefaultWIMRealmMultipleReposTest {
     private static UserRegistryServletConnection servlet;
 
     private static InMemorySunLDAPServer sunLdapServer;
+    private static InMemoryADLDAPServer adLdapServer;
 
     /**
      * Configure the embedded LDAP server.
@@ -60,6 +62,7 @@ public class DefaultWIMRealmMultipleReposTest {
      */
     private static void setupLdapServer() throws Exception {
         sunLdapServer = new InMemorySunLDAPServer();
+        adLdapServer = new InMemoryADLDAPServer();
     }
 
     /**
@@ -70,7 +73,7 @@ public class DefaultWIMRealmMultipleReposTest {
     public static void setUp() throws Exception {
         setupLdapServer();
         /*
-         * Update LDAP configuration with In-Memory Server
+         * Update LDAP configuration with default ldap config In-Memory Server (UnboundID)
          */
         ServerConfiguration serverConfig = server.getServerConfiguration();
         for (LdapRegistry ldap : serverConfig.getLdapRegistries()) {
@@ -82,7 +85,13 @@ public class DefaultWIMRealmMultipleReposTest {
                 ldap.setBindPassword(InMemorySunLDAPServer.getBindPassword());
                 server.updateServerConfiguration(serverConfig);
                 Log.info(c, "setUp", "Updated the SUN_LDAP to unboundID");
-                break;
+            } else if (ldap.getId().equals("AD_LDAP")) {
+                ldap.setHost("localhost");
+                ldap.setPort(String.valueOf(adLdapServer.getLdapPort()));
+                ldap.setBindDN(InMemoryADLDAPServer.getBindDN());
+                ldap.setBindPassword(InMemoryADLDAPServer.getBindPassword());
+                server.updateServerConfiguration(serverConfig);
+                Log.info(c, "setUp", "Updated the AD_LDAP to unboundID");
             }
         }
 
@@ -123,6 +132,9 @@ public class DefaultWIMRealmMultipleReposTest {
             try {
                 if (sunLdapServer != null) {
                     sunLdapServer.shutDown(true);
+                }
+                if (adLdapServer != null) {
+                    adLdapServer.shutDown(true);
                 }
             } catch (Exception e) {
                 Log.error(c, "teardown", e, "LDAP server threw error while shutting down. " + e.getMessage());

--- a/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/UserEnumerationTest.java
+++ b/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/UserEnumerationTest.java
@@ -60,11 +60,16 @@ public class UserEnumerationTest {
      */
     @BeforeClass
     public static void setupClass() throws Exception {
+        if (LDAPUtils.USE_LOCAL_LDAP_SERVER) {
+            Log.info(c, "setupClass", "The UserEnumerationTest will not run -- using local Ldaps and this test requires a remote LDAP.");
+        }
+        Assume.assumeTrue(!LDAPUtils.USE_LOCAL_LDAP_SERVER);
+
         /*
          * Add LDAP variables to bootstrap properties file
          */
         LDAPUtils.addLDAPVariables(libertyServer);
-        Log.info(c, "setUpLibertyServer", "Starting the server... (will wait for userRegistry servlet to start)");
+        Log.info(c, "setupClass", "Starting the server... (will wait for userRegistry servlet to start)");
         libertyServer.copyFileToLibertyInstallRoot("lib/features", "internalfeatures/securitylibertyinternals-1.0.mf");
         libertyServer.addInstalledAppForValidation("userRegistry");
         libertyServer.startServer(c.getName() + ".log");
@@ -79,7 +84,7 @@ public class UserEnumerationTest {
         assertNotNull("Server did not came up",
                       libertyServer.waitForStringInLog("CWWKF0011I"));
 
-        Log.info(c, "setUp", "Creating servlet connection the server");
+        Log.info(c, "setupClass", "Creating servlet connection the server");
         servlet = new UserRegistryServletConnection(libertyServer.getHostname(), libertyServer.getHttpDefaultPort());
 
         if (servlet.getRealm() == null) {


### PR DESCRIPTION
Only two tests in the wim.registry FAT bucket were still using remote LDAP. `EnumerateUsersTest` requires remote LDAP (need a long enough time for the LDAP calls to show a difference in timing), but `DefaultWIMRealmMultipleReposTest` does not.

I updated DefaultWIMRealmMultipleReposTest to use all InboundID LDAP.

I set this test to only allow remote LDAPs and EnumerateUsersTest should only run if remote is available. We don't want to start local ApacheDS if no tests are going to use it.

RTC 286750