### PR TITLE
Pass the class name instead of the resource name to transformers

### DIFF
--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/AppClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/AppClassLoader.java
@@ -309,7 +309,7 @@ public class AppClassLoader extends ContainerClassLoader implements SpringLoader
             return findClassCommonLibraryClassLoaders(name);
         }
 
-        byte[] bytes = transformClassBytes(resourceName, byteResourceInformation);
+        byte[] bytes = transformClassBytes(name, byteResourceInformation);
 
         return definePackageAndClass(name, resourceName, byteResourceInformation, bytes);
     }


### PR DESCRIPTION
The refactoring of the transformer code broke by passing the resource name to the transformers.
