### PR TITLE
Fix NPE in URAPIs_ADWildCardTest

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_ADWildCardTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_ADWildCardTest.java
@@ -102,8 +102,11 @@ public class URAPIs_ADWildCardTest {
         String user = "vmmtestuser";
         String password = "vmmtestuserpwd";
         Log.info(c, "checkPassword", "Checking good credentials");
+
+        String userReturned = servlet.checkPassword(user, password);
+        assertNotNull("Authentication should succeed.", userReturned);
         assertEquals("Authentication should succeed.",
-                     "cn=vmmtestuser,cn=users,dc=secfvt2,dc=austin,dc=ibm,dc=com", servlet.checkPassword(user, password).toLowerCase());
+                     "cn=vmmtestuser,cn=users,dc=secfvt2,dc=austin,dc=ibm,dc=com", userReturned.toLowerCase());
         passwordChecker.checkForPasswordInAnyFormat(password);
     }
 


### PR DESCRIPTION
Hit an NPE when password authentication failed. The underlaying cause (for auth failure) was an issue that I resolved on the LDAP server.

RTC 286844