### PR TITLE
Stop allowing creation of H2 streams if server is closing

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpRequestMessageImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpRequestMessageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2020 IBM Corporation and others.
+ * Copyright (c) 2004, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -2100,8 +2100,14 @@ public class HttpRequestMessageImpl extends HttpBaseMessageImpl implements HttpR
         H2StreamProcessor promisedSP = ((H2HttpInboundLinkWrap) link).muxLink.createNewInboundLink(promisedStreamId);
         if (promisedSP == null) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
-                Tr.exit(tc, "pushNewRequest exit; cannot create new push stream -"
-                            + " the max number of concurrent streams has already been reached on link: " + link);
+                if(((H2HttpInboundLinkWrap) link).muxLink.isClosing()){
+                    Tr.exit(tc, "pushNewRequest exit; cannot create new push stream - "
+                            + "server is shutting down, closing link: " + link);
+                }
+                else{
+                    Tr.exit(tc, "pushNewRequest exit; cannot create new push stream -"
+                            + " the max number of concurrent streams has already been reached on link: " + link); 
+                }                
             }
             return;
         }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
@@ -5654,8 +5654,15 @@ public abstract class HttpServiceContextImpl implements HttpServiceContext, FFDC
         H2StreamProcessor promisedSP = ((H2HttpInboundLinkWrap) link).muxLink.createNewInboundLink(promisedStreamId);
         if (promisedSP == null) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
-                Tr.exit(tc, "handleH2LinkPreload exit; cannot create new push stream - "
-                            + "the max number of concurrent streams has already been reached on link: " + link);
+                if(((H2HttpInboundLinkWrap) link).muxLink.isClosing()){
+                    Tr.exit(tc, "handleH2LinkPreload exit; cannot create new push stream - "
+                            + "server is shutting down, closing link: " + link);
+                }
+                else{
+                    Tr.exit(tc, "handleH2LinkPreload exit; cannot create new push stream - "
+                            + "the max number of concurrent streams has already been reached on link: " + link);  
+                }
+                
             }
             return;
         }


### PR DESCRIPTION
Fixes #19193
Quiesce is meant to allow chains to gracefully finish active request/responses during the configured time threshold. During quiesce, the accept selectors should no longer allow for new connections to be made. However, since HTTP/2 uses existing connections, it is possible for new HTTP/2 streams to be created during the quiesce period. 

Thus, this aims to disallow creation of new streams when the kernel signals that the framework is closing down, which should help diminish the cases where quiesce fails to finish due to HTTP/2 connections. 