### PR TITLE
Add DS component LoadConfig to bean validation.

### DIFF
--- a/dev/com.ibm.ws.beanvalidation/bnd.bnd
+++ b/dev/com.ibm.ws.beanvalidation/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2020 IBM Corporation and others.
+# Copyright (c) 2017,2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -40,13 +40,16 @@ Private-Package: \
 Include-Resource: \
   OSGI-INF=resources/OSGI-INF
 
+IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml
+
 -dsannotations-inherit: true
 -dsannotations: \
   com.ibm.ws.beanvalidation.OSGiBeanValidationImpl, \
   com.ibm.ws.beanvalidation.BeanValidationJavaColonHelper, \
   com.ibm.ws.beanvalidation.ValidatorFactoryObjectFactoryInfo, \
   com.ibm.ws.beanvalidation.ValidatorObjectFactoryInfo, \
-  com.ibm.ws.beanvalidation.config.internal.ValidationConfigurationFactoryImpl
+  com.ibm.ws.beanvalidation.config.internal.ValidationConfigurationFactoryImpl, \
+  com.ibm.ws.beanvalidation.LoadConfigImpl
 
 instrument.classesExcludes: com/ibm/ws/beanvalidation/resources/nls/*.class
 

--- a/dev/com.ibm.ws.beanvalidation/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.beanvalidation/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017,2020 IBM Corporation and others.
+    Copyright (c) 2017,2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -46,6 +46,14 @@
         <Object ocdref="com.ibm.ws.beanvalidation.service.ConstrainedHelper"/>
     </Designate>
     
+    <OCD description="internal use only" name="internal" 
+         id="com.ibm.ws.beanvalidation.service.LoadConfig">
+    </OCD>
+    
+    <Designate factoryPid="com.ibm.ws.beanvalidation.service.LoadConfig">
+        <Object ocdref="com.ibm.ws.beanvalidation.service.LoadConfig"/>
+    </Designate>
+    
     <OCD name="internal" description="internal use only"
          id="com.ibm.ws.beanvalidation.OSGiBeanValidationImpl">
 
@@ -62,6 +70,15 @@
 
         <AD id="ConstrainedHelper.cardinality.minimum" name="internal"  description="internal use only" 
             type="String" required="true" default="${count(ConstrainedHelper)}"/>
+            
+        <AD name="internal" description="internal use only"
+            id="LoadConfig" required="true" type="String" cardinality="1"
+            ibm:type="pid" ibm:reference="com.ibm.ws.beanvalidation.service.LoadConfig" default="loadConfigDefault" ibm:final="true"/>
+            
+        <AD id="LoadConfig.target" type="String" default="(service.pid=${LoadConfig})" ibm:final="true" name="internal" description="internal use only"/>
+          
+        <AD id="LoadConfig.cardinality.minimum" name="internal" description="internal use only" 
+            type="String" required="true" default="${count(LoadConfig)}"/>
     </OCD>
     
     <Designate pid="com.ibm.ws.beanvalidation.OSGiBeanValidationImpl">

--- a/dev/com.ibm.ws.beanvalidation/resources/OSGI-INF/wlp/defaultInstances.xml
+++ b/dev/com.ibm.ws.beanvalidation/resources/OSGI-INF/wlp/defaultInstances.xml
@@ -1,0 +1,15 @@
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+  <com.ibm.ws.beanvalidation.service.LoadConfig id="loadConfigDefault" />
+
+</server>

--- a/dev/com.ibm.ws.beanvalidation/src/com/ibm/ws/beanvalidation/LoadConfigImpl.java
+++ b/dev/com.ibm.ws.beanvalidation/src/com/ibm/ws/beanvalidation/LoadConfigImpl.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.beanvalidation;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+
+import com.ibm.ws.beanvalidation.service.LoadConfig;
+
+/**
+ * Dummy component for ensuring all config has been loaded before OSGiBeanValidationImpl can become active.
+ */
+@Component(configurationPid = "com.ibm.ws.beanvalidation.service.LoadConfig",
+           configurationPolicy = ConfigurationPolicy.REQUIRE)
+public class LoadConfigImpl implements LoadConfig {
+
+}

--- a/dev/com.ibm.ws.beanvalidation/src/com/ibm/ws/beanvalidation/OSGiBeanValidationImpl.java
+++ b/dev/com.ibm.ws.beanvalidation/src/com/ibm/ws/beanvalidation/OSGiBeanValidationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,6 +47,7 @@ import com.ibm.ws.beanvalidation.service.BeanValidationExtensionHelper;
 import com.ibm.ws.beanvalidation.service.BeanValidationRuntimeVersion;
 import com.ibm.ws.beanvalidation.service.BeanValidationUsingClassLoader;
 import com.ibm.ws.beanvalidation.service.ConstrainedHelper;
+import com.ibm.ws.beanvalidation.service.LoadConfig;
 import com.ibm.ws.beanvalidation.service.ValidatorFactoryBuilder;
 import com.ibm.ws.container.service.app.deploy.ModuleInfo;
 import com.ibm.ws.container.service.app.deploy.extended.ExtendedModuleInfo;
@@ -83,6 +84,7 @@ public class OSGiBeanValidationImpl extends AbstractBeanValidation implements Mo
     private static final String REFERENCE_CLASSLOADING_SERVICE = "classLoadingService";
     private static final String REFERENCE_VALIDATOR_FACTORY_BUILDER = "ValidatorFactoryBuilder";
     private static final String REFERENCE_CONSTRAINED_HELPER = "ConstrainedHelper";
+    private static final String REFERENCE_LOAD_CONFIG = "LoadConfig";
 
     private MetaDataSlot ivModuleMetaDataSlot;
 
@@ -93,6 +95,8 @@ public class OSGiBeanValidationImpl extends AbstractBeanValidation implements Mo
     private final AtomicServiceReference<ValidatorFactoryBuilder> validatorFactoryBuilderSR = new AtomicServiceReference<ValidatorFactoryBuilder>(REFERENCE_VALIDATOR_FACTORY_BUILDER);
 
     private final AtomicServiceReference<ConstrainedHelper> constrainedHelperSR = new AtomicServiceReference<ConstrainedHelper>(REFERENCE_CONSTRAINED_HELPER);
+
+    private final AtomicServiceReference<LoadConfig> loadConfigSR = new AtomicServiceReference<LoadConfig>(REFERENCE_LOAD_CONFIG);
 
     private static final Version DEFAULT_VERSION = BeanValidationRuntimeVersion.VERSION_1_0;
     private Version runtimeVersion = DEFAULT_VERSION;
@@ -523,6 +527,16 @@ public class OSGiBeanValidationImpl extends AbstractBeanValidation implements Mo
 
     protected void unsetValidationConfigFactory(ServiceReference<ValidationConfigurationFactory> factoryRef) {
         validationConfigFactorySR.unsetReference(factoryRef);
+    }
+
+    @Reference(cardinality = ReferenceCardinality.AT_LEAST_ONE,
+               target = "(id=unbound)")
+    protected void setLoadConfig(ServiceReference<LoadConfig> ref) {
+        loadConfigSR.setReference(ref);
+    }
+
+    protected void unsetLoadConfig(ServiceReference<LoadConfig> ref) {
+        loadConfigSR.unsetReference(ref);
     }
 
     private boolean isBeanValidationVersion11OrGreater() {

--- a/dev/com.ibm.ws.beanvalidation/src/com/ibm/ws/beanvalidation/service/LoadConfig.java
+++ b/dev/com.ibm.ws.beanvalidation/src/com/ibm/ws/beanvalidation/service/LoadConfig.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.beanvalidation.service;
+
+/**
+ *
+ */
+public interface LoadConfig {
+
+}


### PR DESCRIPTION
Add DS component LoadConfig to prevent the OSGiBeanValidationImpl service from starting before reading the config.
Fixes #18896


