### PR TITLE
Reverting Oracle Connection Builder path

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/DSConfig.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/DSConfig.java
@@ -56,7 +56,6 @@ public class DSConfig implements FFDCSelfIntrospectable {
                     QUERY_TIMEOUT = "queryTimeout",
                     RECOVERY_AUTH_DATA_REF = "recoveryAuthDataRef",
                     REPLACE_EXCEPTIONS = "heritage.0.replaceExceptions", // from flattened heritage config
-                    SEND_GSS_CREDENTIAL_ON_ORACLE_BUILDER = "sendGSSCredentialOnOracleBuilder",
                     STATEMENT_CACHE_SIZE = "statementCacheSize",
                     SUPPLEMENTAL_JDBC_TRACE = "supplementalJDBCTrace",
                     SYNC_QUERY_TIMEOUT_WITH_TRAN_TIMEOUT = "syncQueryTimeoutWithTransactionTimeout",
@@ -82,7 +81,6 @@ public class DSConfig implements FFDCSelfIntrospectable {
                                                                ON_CONNECT,
                                                                QUERY_TIMEOUT,
                                                                RECOVERY_AUTH_DATA_REF,
-                                                               SEND_GSS_CREDENTIAL_ON_ORACLE_BUILDER,                                                           
                                                                STATEMENT_CACHE_SIZE,
                                                                SUPPLEMENTAL_JDBC_TRACE,
                                                                SYNC_QUERY_TIMEOUT_WITH_TRAN_TIMEOUT,
@@ -233,12 +231,6 @@ public class DSConfig implements FFDCSelfIntrospectable {
      * enabled. Default value is null (no default query timeout).
      */
     public final Integer queryTimeout;
-    
-    /**
-     * Use the connection builder API during Kerberos connections for Oracle to avoid an issue
-     * between the IBM Java SDK and Oracle Driver.
-     */
-    public final boolean sendGSSCredentialOnOracleBuilder;
 
     /**
      * Maximum cached statements per connection.
@@ -323,7 +315,6 @@ public class DSConfig implements FFDCSelfIntrospectable {
         isolationLevel = remove(DataSourceDef.isolationLevel.name(), -1, -1, null, -1, 0, 1, 2, 4, 8, 16, 4096);
         onConnect = remove(ON_CONNECT, (String[]) null);
         queryTimeout = remove(QUERY_TIMEOUT, (Integer) null, 0, TimeUnit.SECONDS);
-        sendGSSCredentialOnOracleBuilder = remove(SEND_GSS_CREDENTIAL_ON_ORACLE_BUILDER, false);
         statementCacheSize = remove(STATEMENT_CACHE_SIZE, 10, 0, null);
         supplementalJDBCTrace = remove(SUPPLEMENTAL_JDBC_TRACE, (Boolean) null);
         syncQueryTimeoutWithTransactionTimeout = remove(SYNC_QUERY_TIMEOUT_WITH_TRAN_TIMEOUT, false);

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
@@ -46,11 +46,8 @@ import java.util.logging.XMLFormatter;
 import javax.resource.ResourceException;
 import javax.sql.CommonDataSource;
 import javax.sql.DataSource;
-import javax.sql.PooledConnection;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
-
-import org.ietf.jgss.GSSCredential;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -860,25 +857,6 @@ public class OracleHelper extends DatabaseHelper {
             } catch (ResourceException ex) {
                 throw AdapterUtil.toSQLException(ex);
             }
-            
-            //Workaround for Oracle Driver + IBM JDK issue with non-connection builder path
-            if (mcf.dsConfig.get().sendGSSCredentialOnOracleBuilder) {
-                try {
-                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                        Tr.debug(this, tc, "Using Connection Builder path for Kerberos");
-                        Connection conn = AccessController.doPrivilegedWithCombiner(new PrivilegedExceptionAction<Connection>() {
-                            public Connection run() throws SQLException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException {
-                                Object oracleConnectionBuilder = ds.getClass().getMethod("createConnectionBuilder").invoke(ds);
-                                Object oracleConnectionBuilder2 = oracleConnectionBuilder.getClass().getMethod("gssCredential", GSSCredential.class).invoke(oracleConnectionBuilder, gssCredential);
-                                Method m = oracleConnectionBuilder.getClass().getMethod("build");
-                                m.setAccessible(true);
-                                return (Connection) m.invoke(oracleConnectionBuilder2);
-                            }
-                        });
-                } catch (Throwable t) {
-                    throw AdapterUtil.toSQLException(t);
-                }
-            };
         }
         
         return super.getConnectionFromDatasource(ds, useKerb, gssCredential);
@@ -896,33 +874,6 @@ public class OracleHelper extends DatabaseHelper {
         if (useKerberos != KerbUsage.NONE) {
             assertIBMKerberosSupported();
             setKerberosDatasourceProperties(ds);
-            
-            //Workaround for Oracle Driver + IBM JDK issue with non-connection builder path
-            if (mcf.dsConfig.get().sendGSSCredentialOnOracleBuilder) {
-                try {
-                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                        Tr.debug(this, tc, "Using Connection Builder path for Kerberos");
-
-                    PooledConnection pConn = AccessController.doPrivilegedWithCombiner(new PrivilegedExceptionAction<PooledConnection>() {
-                        public PooledConnection run() throws SQLException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException {
-                            Object oracleConnectionBuilder;
-                            if (is2Phase) { //XAConnection
-                                oracleConnectionBuilder = ds.getClass().getMethod("createXAConnectionBuilder").invoke(ds);
-                            } else { //PooledConnection
-                                oracleConnectionBuilder = ds.getClass().getMethod("createPooledConnectionBuilder").invoke(ds);    
-                            }
-                            Object oracleConnectionBuilder2 = oracleConnectionBuilder.getClass().getMethod("gssCredential", GSSCredential.class).invoke(oracleConnectionBuilder, gssCredential);
-                            Method m = oracleConnectionBuilder.getClass().getMethod("build");
-                            m.setAccessible(true);
-                            return (PooledConnection) m.invoke(oracleConnectionBuilder2);                          
-                        }
-                    });
-                    return new ConnectionResults(pConn, null);
-                } catch (Throwable e) {
-                    throw new ResourceException(e);
-                }
-            };
-            
         }
         ConnectionResults results = super.getPooledConnection(ds, userName, password, is2Phase, cri, useKerberos, gssCredential);
 

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/OracleKerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/OracleKerberosTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package com.ibm.ws.jdbc.fat.krb5;
 
-import static org.junit.Assert.assertTrue;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -136,22 +134,6 @@ public class OracleKerberosTest extends FATServletClient {
             config.getKerberos().keytab = originalKeytab;
             updateConfigAndWait(config);
         }
-    }
-
-    /**
-     * Test the hidden <i>sendGSSCredentialOnOracleBuilder</i> Datasource property.
-     * <p>
-     * This confirms that when the property is set on a datasource we will use the path through the OracleHelper
-     * class which creates a connection using the OracleConnectionBuilder, and sends the GSS credential via
-     * the Connection Builder API.
-     */
-    @Test
-    @AllowedFFDC
-    public void testGSSCredentialOnOracleBuilder() throws Exception {
-        server.setMarkToEndOfLog(server.getMostRecentTraceFile());
-        FATServletClient.runTest(server, APP_NAME + "/OracleKerberosTestServlet", testName);
-        int log = server.waitForMultipleStringsInLogUsingMark(3, "Using Connection Builder path for Kerberos", server.getMostRecentTraceFile());
-        assertTrue("Expected 3 Connection Builder strings in trace. Found: " + log, log == 3);
     }
 
     private static class IBMJava8Rule implements TestRule {

--- a/dev/com.ibm.ws.jdbc_fat_krb5/publish/servers/com.ibm.ws.jdbc.fat.krb5.oracle/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/publish/servers/com.ibm.ws.jdbc.fat.krb5.oracle/server.xml
@@ -52,26 +52,7 @@
     <properties.oracle databaseName="${ORACLE_DBNAME}" serverName="${ORACLE_HOSTNAME}" portNumber="${ORACLE_PORT}" driverType="thin"/>
     <containerAuthData user="${ORACLE_USER}" password="${ORACLE_PASS}"/>
   </dataSource>
-  
-  <!-- Datasources for the Connection Builder path-->
-  <dataSource jndiName="jdbc/krbcb/pool" sendGSSCredentialOnOracleBuilder="true">
-    <jdbcDriver libraryRef="OracleLib"/>
-    <properties.oracle URL="${oracle.url}"/>
-    <containerAuthData krb5Principal="${KRB5_USER}"/>
-  </dataSource>
-  
-  <dataSource jndiName="jdbc/krbcb/xa" type="javax.sql.XADataSource" sendGSSCredentialOnOracleBuilder="true">
-    <jdbcDriver libraryRef="OracleLib" />
-    <properties.oracle URL="${oracle.url}"/>
-    <containerAuthData krb5Principal="${KRB5_USER}"/>
-  </dataSource>
-
-  <dataSource jndiName="jdbc/krbcb/ds" type="javax.sql.DataSource" sendGSSCredentialOnOracleBuilder="true">
-    <jdbcDriver libraryRef="OracleLib" />
-    <properties.oracle URL="${oracle.url}"/>
-    <containerAuthData krb5Principal="${KRB5_USER}"/>
-  </dataSource>
-  
+    
   <javaPermission className="javax.security.auth.kerberos.ServicePermission" name="*" actions="initiate"/>
   <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
 </server>

--- a/dev/com.ibm.ws.jdbc_fat_krb5/test-applications/krb5-oracle-app/src/jdbc/krb5/oracle/web/OracleKerberosTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/test-applications/krb5-oracle-app/src/jdbc/krb5/oracle/web/OracleKerberosTestServlet.java
@@ -55,15 +55,6 @@ public class OracleKerberosTestServlet extends FATServlet {
     @Resource(lookup = "jdbc/krb/DataSource")
     DataSource krb5RegularDs;
 
-    @Resource(lookup = "jdbc/krbcb/pool")
-    DataSource cbPoolDS;
-
-    @Resource(lookup = "jdbc/krbcb/xa")
-    DataSource cbXADS;
-
-    @Resource(lookup = "jdbc/krbcb/ds")
-    DataSource cbDS;
-
     /**
      * Getting a connection too soon after the initial ticket is obtained can cause intermittent
      * issues where we getConnection() fails with: Oracle Error ORA-12631
@@ -213,21 +204,6 @@ public class OracleKerberosTestServlet extends FATServlet {
 
         assertEquals("Expected two connections from the same datasource to share the same underlying managed connection",
                      managedConn1, managedConn2);
-    }
-
-    public void testGSSCredentialOnOracleBuilder() throws Exception {
-
-        try (Connection con = getConnectionWithRetry(cbDS)) {
-            con.createStatement().execute("SELECT 1 FROM DUAL");
-        }
-
-        try (Connection con = getConnectionWithRetry(cbPoolDS)) {
-            con.createStatement().execute("SELECT 1 FROM DUAL");
-        }
-
-        try (Connection con = getConnectionWithRetry(cbXADS)) {
-            con.createStatement().execute("SELECT 1 FROM DUAL");
-        }
     }
 
     /**


### PR DESCRIPTION
Reverts #18122
Removes changes for issue #18121

It was determined that the connection builder path does not provide the intended benefit, so it is being removed.