### PR TITLE
Cloudant NLS messages are not used

### DIFF
--- a/dev/com.ibm.ws.cloudant/bnd.bnd
+++ b/dev/com.ibm.ws.cloudant/bnd.bnd
@@ -18,7 +18,8 @@ DynamicImport-Package: \
     com.ibm.wsspi.ssl
 
 Private-Package:\
-     com.ibm.ws.cloudant.internal
+     com.ibm.ws.cloudant.internal,\
+     com.ibm.ws.cloudant.internal.resources
      
 Export-Package: \
     com.ibm.ws.cloudant


### PR DESCRIPTION
fixes #18925

Message keys were being displayed instead of the translated messages because the message files (in the resource package) weren't being included in the bundle.