### PR TITLE
Additional reties and debug when deleting files

### DIFF
--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/RemoteFile.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/RemoteFile.java
@@ -24,10 +24,11 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
-import com.ibm.websphere.simplicity.RemoteFile.Operation;
 import com.ibm.websphere.simplicity.log.Log;
+
 //open-liberty uses 'LocalProvider', where-as WS-CD-Open uses 'RXAProvider'.
 import componenttest.common.apiservices.cmdline.LocalProvider;
+import componenttest.topology.impl.LibertyServer;
 
 /**
  * Represents a file or directory on a {@link Machine}. This file or directory
@@ -49,12 +50,12 @@ public class RemoteFile {
      * Thread.sleep() is repeated until System.nanoTime() shows that the thread
      * has waited at least the specified time in milliseconds.
      *
-     * @param requestedNs The requested sleep time, in nano-seconds.
+     * @param  requestedNs          The requested sleep time, in nano-seconds.
      *
-     * @return The time slept, in nano-seconds.
+     * @return                      The time slept, in nano-seconds.
      *
      * @throws InterruptedException Thrown if if the sleep is
-     *     interrupted.
+     *                                  interrupted.
      */
     public static long sleep(long requestedNs) throws InterruptedException {
         long startNs = System.nanoTime();
@@ -62,12 +63,12 @@ public class RemoteFile {
         long elapsedNs = 0L;
         long remainingNs = requestedNs;
 
-        while ( remainingNs > 0 ) {
+        while (remainingNs > 0) {
             TimeUnit.NANOSECONDS.sleep(remainingNs); // throws InterruptedException
 
             elapsedNs = System.nanoTime() - startNs;
             remainingNs = requestedNs - elapsedNs;
-       }
+        }
 
         return elapsedNs;
     }
@@ -78,62 +79,60 @@ public class RemoteFile {
      * This is based on the artifact file system minimum
      * retry interval of 200 milliseconds, per
      * <code>
-     *   open-liberty/dev/com.ibm.ws.artifact.zip/src/
-     *   com/ibm/ws/artifact/zip/cache/
-     *   ZipCachingProperties.java
+     * open-liberty/dev/com.ibm.ws.artifact.zip/src/
+     * com/ibm/ws/artifact/zip/cache/
+     * ZipCachingProperties.java
      * </code>
      *
      * The default largest pending close time is specified
      * by property <code>zip.reaper.slow.pend.max</code>.
-     * 
-     * The current largest pend time is 200 milliseconds.  For
+     *
+     * The current largest pend time is 200 milliseconds. For
      * extra safety, the retry interval is set to twice this value.
-     * 
+     *
      * Note: This does not handle when the server is prevented
-     * from running.  In a typical case, where application files
+     * from running. In a typical case, where application files
      * are updated after accessing the server files, if the server
      * is prevented from running while an application file has a
      * pending close, the usual pend time may be exceeded without
      * the file being closed.
      */
-    public static final long STANDARD_RETRY_INTERVAL_NS =
-        TimeUnit.MILLISECONDS.toNanos(200 * 2);
+    public static final long STANDARD_RETRY_INTERVAL_NS = TimeUnit.MILLISECONDS.toNanos(200 * 2);
 
     // Increase this to 0.1s instead of 0.05s.  The sleep granularity
-    // on windows is too small to reliably handle 0.05s. 
+    // on windows is too small to reliably handle 0.05s.
 
-    public static final long STANDARD_RETRY_PARTIAL_INTERVAL_NS =
-        TimeUnit.MILLISECONDS.toNanos(100); // 0.1s
+    public static final long STANDARD_RETRY_PARTIAL_INTERVAL_NS = TimeUnit.MILLISECONDS.toNanos(100); // 0.1s
 
     public interface Operation {
         public boolean act() throws Exception;
     }
 
     /**
-     * Attempt an operation.  Retry the operation, possibly several times,
+     * Attempt an operation. Retry the operation, possibly several times,
      * across a specified retry interval.
      *
-     * @param op The operation which is being performed.
-     * @param fullRetryNs The full retry duration.
+     * @param  op          The operation which is being performed.
+     * @param  fullRetryNs The full retry duration.
      *
-     * @return True or false telling if the operation was successful.
+     * @return             True or false telling if the operation was successful.
      *
      * @throws Exception
      */
     private boolean retry(Operation op, long fullRetryNs) throws Exception {
-        // First try is immediate. 
-        if ( op.act() ) {
+        // First try is immediate.
+        if (op.act()) {
             return true;
         }
 
         // Don't retry unless a retry interval was specified.
-        if ( fullRetryNs == 0 ) {
+        if (fullRetryNs == 0) {
             return false;
         }
 
         // Make sure the retry interval is usable.
-        if ( fullRetryNs < 0 ) {
-            throw new IllegalArgumentException("Full retry interval [ " + fullRetryNs + " ] for [ " + getAbsolutePath() + " ] is less then 0"); 
+        if (fullRetryNs < 0) {
+            throw new IllegalArgumentException("Full retry interval [ " + fullRetryNs + " ] for [ " + getAbsolutePath() + " ] is less then 0");
         }
 
         // Delay and retry, in increments of the partial retry interval, until
@@ -148,10 +147,10 @@ public class RemoteFile {
         long finalNs = System.nanoTime() + fullRetryNs;
         do {
             sleep(STANDARD_RETRY_PARTIAL_INTERVAL_NS); // throws InterruptedException
-            if ( op.act() ) {
+            if (op.act()) {
                 return true;
             }
-        } while ( System.nanoTime() < finalNs );
+        } while (System.nanoTime() < finalNs);
 
         return false;
     }
@@ -168,11 +167,11 @@ public class RemoteFile {
     /**
      * Construct an instance based on the fully qualified path of the remote
      * file.
-     * 
+     *
      * @param host
-     *            The {@link Machine} where this file is physically located
+     *                     The {@link Machine} where this file is physically located
      * @param filePath
-     *            The fully qualified (absolute) path of the file
+     *                     The fully qualified (absolute) path of the file
      */
     public RemoteFile(Machine host, String filePath) {
         this(host, filePath, Charset.defaultCharset());
@@ -181,13 +180,13 @@ public class RemoteFile {
     /**
      * Construct an instance based on the fully qualified path of the remote
      * file.
-     * 
+     *
      * @param host
-     *            The {@link Machine} where this file is physically located
+     *                     The {@link Machine} where this file is physically located
      * @param filePath
-     *            The fully qualified (absolute) path of the file
+     *                     The fully qualified (absolute) path of the file
      * @param encoding
-     *            The character set the file is encoded in
+     *                     The character set the file is encoded in
      */
     public RemoteFile(Machine host, String filePath, Charset encoding) {
         this.host = host;
@@ -199,13 +198,13 @@ public class RemoteFile {
 
     /**
      * Construct an instance based on the parent of the remote file.
-     * 
+     *
      * @param host
-     *            The {@link Machine} where this file is physically located
+     *                   The {@link Machine} where this file is physically located
      * @param parent
-     *            The remote file's parent directory
+     *                   The remote file's parent directory
      * @param name
-     *            The name of the file
+     *                   The name of the file
      */
     public RemoteFile(Machine host, RemoteFile parent, String name) {
         this(host, parent, name, Charset.defaultCharset());
@@ -213,15 +212,15 @@ public class RemoteFile {
 
     /**
      * Construct an instance based on the parent of the remote file.
-     * 
+     *
      * @param host
-     *            The {@link Machine} where this file is physically located
+     *                     The {@link Machine} where this file is physically located
      * @param parent
-     *            The remote file's parent directory
+     *                     The remote file's parent directory
      * @param name
-     *            The name of the file
+     *                     The name of the file
      * @param encoding
-     *            The character set the file is encoded in
+     *                     The character set the file is encoded in
      */
     public RemoteFile(Machine host, RemoteFile parent, String name, Charset encoding) {
         if (parent.getAbsolutePath().endsWith("/")
@@ -239,11 +238,11 @@ public class RemoteFile {
 
     /**
      * Construct an instance based on the parent of the remote file. Assumes that the new instance resides on the same machine as the parent file.
-     * 
+     *
      * @param parent
-     *            The remote file's parent directory
+     *                   The remote file's parent directory
      * @param name
-     *            The name of the file
+     *                   The name of the file
      */
     public RemoteFile(RemoteFile parent, String name) {
         this(parent.getMachine(), parent, name, Charset.defaultCharset());
@@ -251,13 +250,13 @@ public class RemoteFile {
 
     /**
      * Construct an instance based on the parent of the remote file. Assumes that the new instance resides on the same machine as the parent file.
-     * 
+     *
      * @param parent
-     *            The remote file's parent directory
+     *                     The remote file's parent directory
      * @param name
-     *            The name of the file
+     *                     The name of the file
      * @param encoding
-     *            The character set the file is encoded in
+     *                     The character set the file is encoded in
      */
     public RemoteFile(RemoteFile parent, String name, Charset encoding) {
         this(parent.getMachine(), parent, name, encoding);
@@ -265,7 +264,7 @@ public class RemoteFile {
 
     /**
      * Get the {@link Machine} of this RemoteFile
-     * 
+     *
      * @return The {@link Machine}
      */
     public Machine getMachine() {
@@ -275,7 +274,7 @@ public class RemoteFile {
     /**
      * Returns a String representation the parent directory of this file, or
      * null if this pathname does not name a parent directory.
-     * 
+     *
      * @return A String representation of this remote file's parent directory
      */
     public String getParent() throws Exception {
@@ -290,8 +289,8 @@ public class RemoteFile {
     /**
      * Returns a RemoteFile representation of the parent directory of this file
      * or null if this pathname does not name a parent directory.
-     * 
-     * @return A RemoteFile representation of the parent directory.
+     *
+     * @return           A RemoteFile representation of the parent directory.
      * @throws Exception
      */
     public RemoteFile getParentFile() throws Exception {
@@ -305,7 +304,7 @@ public class RemoteFile {
     /**
      * Returns the absolute pathname string of this RemoteFile in the form
      * /dir1/dir2/file
-     * 
+     *
      * @return The absolute pathname of this RemoteFile
      */
     public String getAbsolutePath() {
@@ -324,20 +323,20 @@ public class RemoteFile {
      * <p>
      * This method is not thread-safe.
      * </p>
-     * 
-     * @param prefix
-     *            an optional String that proceeds ordering information. All
-     *            characters must match: [a-zA-Z_0-9\\.]
-     * @param digits
-     *            the number of digits to use for generated identifiers
-     * @param suffix
-     *            the optional name of the desired file, without any numeric identifier.
-     *            All characters must match: [a-zA-Z_0-9\\.]
-     * @return a new RemoteFile representing a unique child of the parent. The file must be created before use.
+     *
+     * @param  prefix
+     *                                      an optional String that proceeds ordering information. All
+     *                                      characters must match: [a-zA-Z_0-9\\.]
+     * @param  digits
+     *                                      the number of digits to use for generated identifiers
+     * @param  suffix
+     *                                      the optional name of the desired file, without any numeric identifier.
+     *                                      All characters must match: [a-zA-Z_0-9\\.]
+     * @return                          a new RemoteFile representing a unique child of the parent. The file must be created before use.
      * @throws IllegalArgumentException
-     *             if this instance does not denote a directory,
-     *             if input arguments are invalid,
-     *             or if the file cannot be created
+     *                                      if this instance does not denote a directory,
+     *                                      if input arguments are invalid,
+     *                                      or if the file cannot be created
      */
     public RemoteFile getOrderedChild(String prefix, int digits, String suffix) throws Exception {
         RemoteFile[] children = list(false);
@@ -397,16 +396,16 @@ public class RemoteFile {
      * Prepends zeros to the left of the input number to ensure that the input
      * number is a total of <code>width</code> digits. Truncates the input
      * number if it has more than <code>width</code> digits.
-     * 
-     * @param number
-     *            a positive integer (negative integers cause problems with odd
-     *            widths)
-     * @param width
-     *            the number of characters that you want in a String
-     *            representation of <code>number</code>; must be a positive
-     *            integer smaller than 18 (larger numbers cause an overflow
-     *            issue)
-     * @return a zero-padded String representation of the input number
+     *
+     * @param  number
+     *                    a positive integer (negative integers cause problems with odd
+     *                    widths)
+     * @param  width
+     *                    the number of characters that you want in a String
+     *                    representation of <code>number</code>; must be a positive
+     *                    integer smaller than 18 (larger numbers cause an overflow
+     *                    issue)
+     * @return        a zero-padded String representation of the input number
      */
     private String zeroPad(long number, int width) {
         long n = Math.abs(number);
@@ -423,19 +422,19 @@ public class RemoteFile {
     /**
      * Copies the file or directory represented by this instance to a remote
      * machine.
-     * 
-     * @param destFile
-     *            The location on the remote device where you want to place this
-     *            file
-     * @param recursive
-     *            If this instance represents a directory, whether or not to
-     *            recursively transfer all files and directories within this
-     *            directory
-     * @param overwrite
-     *            true if files should be overwritten durin the copy. If this is
-     *            false and a file is encountered in the destination of the
-     *            copy, an Exception is thrown.
-     * @return true if the copy was successful
+     *
+     * @param  destFile
+     *                       The location on the remote device where you want to place this
+     *                       file
+     * @param  recursive
+     *                       If this instance represents a directory, whether or not to
+     *                       recursively transfer all files and directories within this
+     *                       directory
+     * @param  overwrite
+     *                       true if files should be overwritten durin the copy. If this is
+     *                       false and a file is encountered in the destination of the
+     *                       copy, an Exception is thrown.
+     * @return           true if the copy was successful
      */
     public boolean copyToDest(RemoteFile destFile, boolean recursive,
                               boolean overwrite) throws Exception {
@@ -445,19 +444,19 @@ public class RemoteFile {
     /**
      * Copies the file or directory represented by this instance to a remote
      * machine.
-     * 
-     * @param destFile
-     *            The location on the remote device where you want to place this
-     *            file
-     * @param recursive
-     *            If this instance represents a directory, whether or not to
-     *            recursively transfer all files and directories within this
-     *            directory
-     * @param overwrite
-     *            true if files should be overwritten durin the copy. If this is
-     *            false and a file is encountered in the destination of the
-     *            copy, an Exception is thrown.
-     * @return true if the copy was successful
+     *
+     * @param  destFile
+     *                       The location on the remote device where you want to place this
+     *                       file
+     * @param  recursive
+     *                       If this instance represents a directory, whether or not to
+     *                       recursively transfer all files and directories within this
+     *                       directory
+     * @param  overwrite
+     *                       true if files should be overwritten durin the copy. If this is
+     *                       false and a file is encountered in the destination of the
+     *                       copy, an Exception is thrown.
+     * @return           true if the copy was successful
      */
     public boolean copyToDestText(RemoteFile destFile, boolean recursive,
                                   boolean overwrite) throws Exception {
@@ -468,11 +467,11 @@ public class RemoteFile {
      * Copies the file or directory represented by this instance to a remote
      * machine. If this is a directory the copy is not done recursively. Files
      * are overwritten during the copy.
-     * 
-     * @param destFile
-     *            The location on the remote device where you want to place this
-     *            file
-     * @return true if the copy was successful
+     *
+     * @param  destFile
+     *                       The location on the remote device where you want to place this
+     *                       file
+     * @return           true if the copy was successful
      * @throws Exception
      */
     public boolean copyToDest(RemoteFile destFile) throws Exception {
@@ -483,11 +482,11 @@ public class RemoteFile {
      * Copies the file or directory represented by this instance to a remote
      * machine. If this is a directory the copy is not done recursively. Files
      * are overwritten during the copy.
-     * 
-     * @param destFile
-     *            The location on the remote device where you want to place this
-     *            file
-     * @return true if the copy was successful
+     *
+     * @param  destFile
+     *                       The location on the remote device where you want to place this
+     *                       file
+     * @return           true if the copy was successful
      * @throws Exception
      */
     public boolean copyToDestText(RemoteFile destFile) throws Exception {
@@ -497,19 +496,19 @@ public class RemoteFile {
     /**
      * Copies the file or directory from a RemoteMachine to the path specified
      * by this instance
-     * 
-     * @param srcFile
-     *            The location on the remote device where you want to get this
-     *            file
-     * @param recursive
-     *            If this srcFile represents a directory, whether or not to
-     *            recursively transfer all files and directories within the
-     *            source directory
-     * @param overwrite
-     *            true if files should be overwritten durin the copy. If this is
-     *            false and a file is encountered in the destination of the
-     *            copy, an Exception is thrown.
-     * @return true if the copy was successful
+     *
+     * @param  srcFile
+     *                       The location on the remote device where you want to get this
+     *                       file
+     * @param  recursive
+     *                       If this srcFile represents a directory, whether or not to
+     *                       recursively transfer all files and directories within the
+     *                       source directory
+     * @param  overwrite
+     *                       true if files should be overwritten durin the copy. If this is
+     *                       false and a file is encountered in the destination of the
+     *                       copy, an Exception is thrown.
+     * @return           true if the copy was successful
      */
     public boolean copyFromSource(RemoteFile srcFile, boolean recursive,
                                   boolean overwrite) throws Exception {
@@ -519,19 +518,19 @@ public class RemoteFile {
     /**
      * Copies the file or directory from a RemoteMachine to the path specified
      * by this instance
-     * 
-     * @param srcFile
-     *            The location on the remote device where you want to get this
-     *            file
-     * @param recursive
-     *            If this srcFile represents a directory, whether or not to
-     *            recursively transfer all files and directories within the
-     *            source directory
-     * @param overwrite
-     *            true if files should be overwritten durin the copy. If this is
-     *            false and a file is encountered in the destination of the
-     *            copy, an Exception is thrown.
-     * @return true if the copy was successful
+     *
+     * @param  srcFile
+     *                       The location on the remote device where you want to get this
+     *                       file
+     * @param  recursive
+     *                       If this srcFile represents a directory, whether or not to
+     *                       recursively transfer all files and directories within the
+     *                       source directory
+     * @param  overwrite
+     *                       true if files should be overwritten durin the copy. If this is
+     *                       false and a file is encountered in the destination of the
+     *                       copy, an Exception is thrown.
+     * @return           true if the copy was successful
      */
     public boolean copyFromSourceText(RemoteFile srcFile, boolean recursive,
                                       boolean overwrite) throws Exception {
@@ -542,11 +541,11 @@ public class RemoteFile {
      * Copies the file or directory from a RemoteMachine to the path specified
      * by this instance. If the source is a directory the copy is not done
      * recursively. Files are overwritten during the copy.
-     * 
-     * @param srcFile
-     *            The location on the remote device where you want to get this
-     *            file
-     * @return true if the copy was successful
+     *
+     * @param  srcFile
+     *                       The location on the remote device where you want to get this
+     *                       file
+     * @return           true if the copy was successful
      * @throws Exception
      */
     public boolean copyFromSource(RemoteFile srcFile) throws Exception {
@@ -557,17 +556,16 @@ public class RemoteFile {
      * Copies the file or directory from a RemoteMachine to the path specified
      * by this instance. If the source is a directory the copy is not done
      * recursively. Files are overwritten during the copy.
-     * 
-     * @param srcFile
-     *            The location on the remote device where you want to get this
-     *            file
-     * @param binary
-     *            true if you want the file transfered in binary, ascii if false
-     * @return true if the copy was successful
+     *
+     * @param  srcFile
+     *                       The location on the remote device where you want to get this
+     *                       file
+     * @param  binary
+     *                       true if you want the file transfered in binary, ascii if false
+     * @return           true if the copy was successful
      * @throws Exception
      */
-    public boolean copyFromSource(RemoteFile srcFile, boolean binary)
-                    throws Exception {
+    public boolean copyFromSource(RemoteFile srcFile, boolean binary) throws Exception {
         return RemoteFile.copy(srcFile, this, false, true, binary);
     }
 
@@ -583,11 +581,16 @@ public class RemoteFile {
 
     public boolean delete(long retryNs) throws Exception {
         Operation deleteOp = new Operation() {
+            @Override
             public boolean act() throws Exception {
                 return basicDelete();
             }
         };
-        return retry(deleteOp, retryNs);
+        boolean deleted = retry(deleteOp, retryNs);
+        if (!deleted) {
+            LibertyServer.printProcesses(host);
+        }
+        return deleted;
         // return retry( () -> basicDelete(), retryNs );
     }
 
@@ -601,6 +604,7 @@ public class RemoteFile {
 
     public boolean deleteLocalDirectory(final File localDir, long retryNs) throws Exception {
         Operation deleteOp = new Operation() {
+            @Override
             public boolean act() {
                 return basicDeleteLocalDirectory(localDir);
             }
@@ -610,8 +614,8 @@ public class RemoteFile {
     }
 
     private boolean basicDelete() throws Exception {
-        if ( host.isLocal() ) { // This is 'localFile != null' in open-liberty.
-            if ( localFile.isDirectory() ) {
+        if (host.isLocal()) { // This is 'localFile != null' in open-liberty.
+            if (localFile.isDirectory()) {
                 return basicDeleteLocalDirectory(localFile);
             } else {
                 return basicDeleteLocalFile(localFile);
@@ -622,24 +626,24 @@ public class RemoteFile {
     }
 
     private boolean basicDeleteLocalDirectory(File localDir) {
-        if ( !localDir.exists() ) {
+        if (!localDir.exists()) {
             return true;
         }
 
         File[] files = localDir.listFiles();
-        for ( File file : files ) {
-            if ( file.isDirectory() ) {
-                if ( !basicDeleteLocalDirectory(file) ) {
+        for (File file : files) {
+            if (file.isDirectory()) {
+                if (!basicDeleteLocalDirectory(file)) {
                     return false;
                 }
             } else {
-                if ( !basicDeleteLocalFile(file) ) {
+                if (!basicDeleteLocalFile(file)) {
                     return false;
                 }
             }
         }
 
-        return ( basicDeleteLocalFile(localDir) );
+        return (basicDeleteLocalFile(localDir));
     }
 
     private boolean basicDeleteLocalFile(File useLocalFile) {
@@ -648,7 +652,7 @@ public class RemoteFile {
         Path localPath = useLocalFile.toPath();
         try {
             return Files.deleteIfExists(localPath);
-        } catch ( IOException e ) {
+        } catch (IOException e) {
             Log.info(c, methodName, "Failed to delete '" + localPath + "': " + e.getMessage());
             return false;
         }
@@ -662,7 +666,7 @@ public class RemoteFile {
 
     /**
      * Tests whether the file represented by this RemoteFile is a directory.
-     * 
+     *
      * @return true if and only if the file denoted by this abstract pathname
      *         exists and is a directory; false otherwise
      */
@@ -681,7 +685,7 @@ public class RemoteFile {
      * file is normal if it is not a directory and, in addition, satisfies other
      * system-dependent criteria. Any non-directory file created by a Java
      * application is guaranteed to be a normal file.
-     * 
+     *
      * @return true if and only if the file denoted by this abstract pathname
      *         exists and is a normal file; false otherwise
      */
@@ -697,7 +701,7 @@ public class RemoteFile {
 
     /**
      * Tests whether the file or directory denoted by this Remotefile exists
-     * 
+     *
      * @return if and only if the file or directory denoted by this abstract
      *         pathname exists; false otherwise
      */
@@ -711,15 +715,15 @@ public class RemoteFile {
     /**
      * Returns an array of RemoteFiles denoting the files in the directory
      * denoted by this RemoteFile.
-     * 
-     * @param recursive
-     *            If this instance represents a directory, whether or not to
-     *            recursively list all files and directories
-     * 
-     * @return An array of RemoteFiles denoting the files and directories in the
-     *         directory denoted by this RemoteFile. The array will be empty if
-     *         the directory is empty. Returns null if this abstract pathname
-     *         does not denote a directory
+     *
+     * @param  recursive
+     *                       If this instance represents a directory, whether or not to
+     *                       recursively list all files and directories
+     *
+     * @return           An array of RemoteFiles denoting the files and directories in the
+     *                   directory denoted by this RemoteFile. The array will be empty if
+     *                   the directory is empty. Returns null if this abstract pathname
+     *                   does not denote a directory
      */
     public RemoteFile[] list(boolean recursive) throws Exception {
         final String method = "list";
@@ -761,7 +765,7 @@ public class RemoteFile {
 
     /**
      * Creates the directory named by this RemoteFile
-     * 
+     *
      * @return true if and only if the directory was created; false otherwise
      */
     public boolean mkdir() throws Exception {
@@ -775,7 +779,7 @@ public class RemoteFile {
      * Creates the directory named by this RemoteFile, including any necessary
      * but nonexistent parent directories. Note that if this operation fails it
      * may have succeeded in creating some of the necessary parent directories.
-     * 
+     *
      * @return true if and only if the directory was created, along with all
      *         necessary parent directories; false otherwise
      */
@@ -798,6 +802,7 @@ public class RemoteFile {
 
     public boolean rename(final RemoteFile newFile, long retryNs) throws Exception {
         Operation renameOp = new Operation() {
+            @Override
             public boolean act() throws Exception {
                 return basicRename(newFile);
             }
@@ -807,7 +812,7 @@ public class RemoteFile {
     }
 
     private boolean basicRename(RemoteFile newFile) throws Exception {
-        if ( host.isLocal() ) {
+        if (host.isLocal()) {
             return localFile.renameTo(new File(newFile.getAbsolutePath()));
         } else {
             return providerRename(newFile);
@@ -818,8 +823,8 @@ public class RemoteFile {
 
     /**
      * Returns the name of the file or directory denoted by this RemoteFile
-     * 
-     * @return The name of the file
+     *
+     * @return           The name of the file
      * @throws Exception
      */
     public String getName() throws Exception {
@@ -857,21 +862,20 @@ public class RemoteFile {
 
     /**
      * Copy a RemoteFile
-     * 
-     * @param srcFile
-     *            The source RemoteFile
-     * @param destFile
-     *            The destination RemoteFile
-     * @param recursive
-     *            true if this a recursive copy
-     * @param overwrite
-     *            true if files should be overwritten during the copy
-     * @return true if the copy was successful
+     *
+     * @param  srcFile
+     *                       The source RemoteFile
+     * @param  destFile
+     *                       The destination RemoteFile
+     * @param  recursive
+     *                       true if this a recursive copy
+     * @param  overwrite
+     *                       true if files should be overwritten during the copy
+     * @return           true if the copy was successful
      * @throws Exception
      */
     private static boolean copy(RemoteFile srcFile, RemoteFile destFile,
-                                boolean recursive, boolean overwrite, boolean binary)
-                    throws Exception {
+                                boolean recursive, boolean overwrite, boolean binary) throws Exception {
         final String method = "copy";
         Log.entering(c, method, new Object[] { srcFile, destFile, recursive, overwrite });
 
@@ -922,7 +926,7 @@ public class RemoteFile {
 
         } else {
             Log.finer(c, method, "The source file is a file. Copying the file.");
-            if ( !destFile.getParentFile().equals(null) ) {
+            if (!destFile.getParentFile().equals(null)) {
                 RemoteFile parentFolder = new RemoteFile(destFile.getMachine(), destFile.getParent());
                 Log.finer(c, method, destFile.getParent());
                 parentFolder.mkdirs();
@@ -936,10 +940,10 @@ public class RemoteFile {
 
     /**
      * Get the parent path of a file
-     * 
-     * @param path
-     *            The path of the file
-     * @return The parent path of the file
+     *
+     * @param  path
+     *                  The path of the file
+     * @return      The parent path of the file
      */
     private String getParentPath(String path) {
         if (path.equals("/")) { // root
@@ -974,7 +978,7 @@ public class RemoteFile {
 
     /**
      * Get the size of the file
-     * 
+     *
      * @return the size of the file
      */
     public long length() {
@@ -987,7 +991,7 @@ public class RemoteFile {
     /**
      * Get the last modified timestamp of the file. If directory
      * returns 0L
-     * 
+     *
      * @return the last modified timestamp
      */
     public long lastModified() {
@@ -996,7 +1000,7 @@ public class RemoteFile {
 
     /**
      * Returns the encoding of the file
-     * 
+     *
      * @return the character set the file is encoded in
      */
     public Charset getEncoding() {
@@ -1008,10 +1012,10 @@ public class RemoteFile {
     // Isolate these changes to keep the open-liberty and WS-CD-Open
     // copies of this source as close as possible.
 
-    private boolean providerDelete() throws Exception{
+    private boolean providerDelete() throws Exception {
         return LocalProvider.delete(this);
     }
-    
+
     private boolean providerIsDirectory() throws Exception {
         return LocalProvider.isDirectory(this);
     }
@@ -1023,7 +1027,7 @@ public class RemoteFile {
     private boolean providerExists() throws Exception {
         return LocalProvider.exists(this);
     }
-    
+
     private String[] providerList(boolean recursive) throws Exception {
         return LocalProvider.list(this, recursive);
     }


### PR DESCRIPTION
Despite the auto-reformatting, the only change to RemoteFile is in `delete(long retryNs)`, to dump the processes if the delete fails.

A retry is also added to `LibertyServer.postStopServerArchive`

#build