### PR TITLE
Exclude useJandex attribute from springappcfg metatype

### DIFF
--- a/dev/com.ibm.ws.app.manager.springboot/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.app.manager.springboot/resources/OSGI-INF/metatype/metatype.xml
@@ -15,7 +15,7 @@
     <OCD description="%springapp.desc" name="%springapp.name" id="com.ibm.ws.app.manager.springappcfg"
                  ibm:alias="springBootApplication"
                  ibm:extends="com.ibm.ws.app.manager"
-                 ibm:excludeChildren="context-root,
+                 ibm:excludeChildren="context-root, useJandex,
                          com.ibm.ws.appconfig.appProperties,
                          com.ibm.ws.javaee.dd.appbnd.ApplicationBnd,
                          com.ibm.ws.javaee.dd.clientbnd.ApplicationClientBnd,


### PR DESCRIPTION
Fixes #18928 

Exclude the useJandex attribute from the SpringBoot application configuration.
