### PR TITLE
PR for Issue 18880: Update OIDC client JWE handling

### DIFF
--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JweHelper.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JweHelper.java
@@ -73,6 +73,14 @@ public class JweHelper {
     }
 
     /**
+     * Returns whether the given configuration must only accept JWS tokens. If the keyManagementKeyAlias config attribute is NOT
+     * set, then we must only accept JWS tokens; tokens in JWE format should be rejected.
+     */
+    public static boolean isJwsRequired(JwtConsumerConfig config) {
+        return !isJweRequired(config);
+    }
+
+    /**
      * Returns whether the current request must only accept JWS tokens, per the MP JWT 1.2 specification. Per the spec, if the
      * {@value MpConfigProperties.DECRYPT_KEY_LOCATION} MP Config property (or, in our case, the keyManagementKeyAlias config
      * attribute) is NOT set, then we must only accept JWS tokens; tokens in JWE format should be rejected.
@@ -82,6 +90,15 @@ public class JweHelper {
      */
     public static boolean isJwsRequired(JwtConsumerConfig config, MpConfigProperties mpConfigProps) {
         return !isJweRequired(config, mpConfigProps);
+    }
+
+    /**
+     * Returns whether the given configuration must only accept JWE tokens. If the keyManagementKeyAlias config attribute is set,
+     * then we must only accept JWE tokens; tokens in JWS format should be rejected.
+     */
+    public static boolean isJweRequired(JwtConsumerConfig config) {
+        String keyAlias = config.getKeyManagementKeyAlias();
+        return (keyAlias != null);
     }
 
     /**

--- a/dev/com.ibm.ws.security.openidconnect.client/resources/com/ibm/ws/security/openidconnect/client/internal/resources/OidcClientMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/com/ibm/ws/security/openidconnect/client/internal/resources/OidcClientMessages.nlsprops
@@ -293,6 +293,6 @@ OIDC_CLIENT_ERROR_EXTRACTING_JWT_CLAIMS_FROM_WEB_RESPONSE=CWWKS1533E: The {0} Op
 OIDC_CLIENT_ERROR_EXTRACTING_JWT_CLAIMS_FROM_WEB_RESPONSE.explanation=The web response must be a JWT in either JSON Web Encryption (JWE) or JSON Web Signature (JWS) format. The response might be malformed, or the OpenID Connect client encountered another error processing the response.
 OIDC_CLIENT_ERROR_EXTRACTING_JWT_CLAIMS_FROM_WEB_RESPONSE.useraction=See the error in the message for more information. Verify that the response is in JWT format.
 
-#1534, 1535 used in clients.common bundle, do not use here.
+#1534, 1535, 1536, 1537 used in clients.common bundle, do not use here.
 
 # STOP HERE, OIDC SERVER HAS RESERVED 1600 - 1649

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
@@ -218,4 +218,15 @@ OIDC_CLIENT_NULL_TOKEN_ENDPOINT=CWWKS1535E: The OpenID Connect client [{0}] requ
 OIDC_CLIENT_NULL_TOKEN_ENDPOINT.explanation=A token endpoint URL must be set to obtain the required tokens.
 OIDC_CLIENT_NULL_TOKEN_ENDPOINT.useraction=Set the tokenEndpointUrl attribute in the OpenID Connect client configuration to the token endpoint URL of the OpenID Connect provider. Alternatively, set the discoveryEndpointUrl attribute in the OpenID Connect client configuration to the discovery endpoint URL of the OpenID Connect provider.
 
+# Do not translate "keyManagementKeyAlias"
+# 0=OIDC client config ID
+OIDC_CLIENT_JWS_REQUIRED_BUT_TOKEN_NOT_JWS=CWWKS1536E: The token is not in JSON Web Signature (JWS) format, but the [{0}] OpenID Connect client only accepts tokens that are in JWS format.
+OIDC_CLIENT_JWS_REQUIRED_BUT_TOKEN_NOT_JWS.explanation=The token might be malformed or might be in JSON Web Encryption (JWE) format. Tokens must be in JWS format if the keyManagementKeyAlias attribute is not configured.
+OIDC_CLIENT_JWS_REQUIRED_BUT_TOKEN_NOT_JWS.useraction=To accept JWE tokens, configure the keyManagementKeyAlias attribute in the OpenID Connect client configuration. Otherwise, ensure that only JWS tokens are sent to this resource.
+
+# 0=OIDC client config ID
+OIDC_CLIENT_JWE_REQUIRED_BUT_TOKEN_NOT_JWE=CWWKS1537E: The token is not in JSON Web Encryption (JWE) format, but the [{0}] OpenID Connect client only accepts tokens that are in JWE format.
+OIDC_CLIENT_JWE_REQUIRED_BUT_TOKEN_NOT_JWE.explanation=The token might be malformed or might be in JSON Web Signature (JWS) format. Tokens must be in JWE format if the keyManagementKeyAlias attribute is configured.
+OIDC_CLIENT_JWE_REQUIRED_BUT_TOKEN_NOT_JWE.useraction=To accept JWS tokens instead of JWE tokens, remove the keyManagementKeyAlias attribute in the OpenID Connect client configuration. Otherwise, ensure that only JWE tokens are sent to this resource.
+
 # STOP HERE, OIDC SERVER HAS RESERVED 1600 - 1649

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
@@ -220,12 +220,12 @@ OIDC_CLIENT_NULL_TOKEN_ENDPOINT.useraction=Set the tokenEndpointUrl attribute in
 
 # Do not translate "keyManagementKeyAlias"
 # 0=OIDC client config ID
-OIDC_CLIENT_JWS_REQUIRED_BUT_TOKEN_NOT_JWS=CWWKS1536E: The token is not in JSON Web Signature (JWS) format, but the [{0}] OpenID Connect client only accepts tokens that are in JWS format.
+OIDC_CLIENT_JWS_REQUIRED_BUT_TOKEN_NOT_JWS=CWWKS1536E: The token is not in JSON Web Signature (JWS) format because it does not contain three parts, but the [{0}] OpenID Connect client only accepts tokens that are in JWS format.
 OIDC_CLIENT_JWS_REQUIRED_BUT_TOKEN_NOT_JWS.explanation=The token might be malformed or might be in JSON Web Encryption (JWE) format. Tokens must be in JWS format if the keyManagementKeyAlias attribute is not configured.
 OIDC_CLIENT_JWS_REQUIRED_BUT_TOKEN_NOT_JWS.useraction=To accept JWE tokens, configure the keyManagementKeyAlias attribute in the OpenID Connect client configuration. Otherwise, ensure that only JWS tokens are sent to this resource.
 
 # 0=OIDC client config ID
-OIDC_CLIENT_JWE_REQUIRED_BUT_TOKEN_NOT_JWE=CWWKS1537E: The token is not in JSON Web Encryption (JWE) format, but the [{0}] OpenID Connect client only accepts tokens that are in JWE format.
+OIDC_CLIENT_JWE_REQUIRED_BUT_TOKEN_NOT_JWE=CWWKS1537E: The token is not in JSON Web Encryption (JWE) format because it does not contain five parts, but the [{0}] OpenID Connect client only accepts tokens that are in JWE format.
 OIDC_CLIENT_JWE_REQUIRED_BUT_TOKEN_NOT_JWE.explanation=The token might be malformed or might be in JSON Web Signature (JWS) format. Tokens must be in JWE format if the keyManagementKeyAlias attribute is configured.
 OIDC_CLIENT_JWE_REQUIRED_BUT_TOKEN_NOT_JWE.useraction=To accept JWS tokens instead of JWE tokens, remove the keyManagementKeyAlias attribute in the OpenID Connect client configuration. Otherwise, ensure that only JWE tokens are sent to this resource.
 

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtilTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtilTest.java
@@ -12,9 +12,9 @@ package com.ibm.ws.security.openidconnect.client.jose4j.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.security.PublicKey;
 import java.util.HashMap;
@@ -30,6 +30,7 @@ import org.junit.Test;
 import com.ibm.ws.security.common.jwk.impl.JwKRetriever;
 import com.ibm.ws.security.openidconnect.clients.common.ConvergedClientConfig;
 import com.ibm.ws.security.openidconnect.common.Constants;
+import com.ibm.ws.security.openidconnect.token.JWTTokenValidationFailedException;
 import com.ibm.ws.security.test.common.CommonTestClass;
 import com.ibm.wsspi.ssl.SSLSupport;
 
@@ -205,6 +206,154 @@ public class Jose4jUtilTest extends CommonTestClass {
     public void test_useAccessTokenAsIdToken_true() {
         mockUseAccessTokenAsIdTokenValue(true);
         assertTrue("Result did not match the expected value.", util.useAccessTokenAsIdToken(clientConfig));
+    }
+
+    /************************************** checkJwtFormatAgainstConfigRequirements **************************************/
+
+    @Test
+    public void test_checkJwtFormatAgainstConfigRequirements_nullJwt_nullKeyAlias() {
+        String jwtString = null;
+        mockery.checking(new Expectations() {
+            {
+                one(clientConfig).getKeyManagementKeyAlias();
+                will(returnValue(null));
+                one(clientConfig).getId();
+                will(returnValue("configId"));
+            }
+        });
+        try {
+            util.checkJwtFormatAgainstConfigRequirements(jwtString, clientConfig);
+            fail("Should have thrown a JWTTokenValidationFailedException exception but did not.");
+        } catch (JWTTokenValidationFailedException e) {
+            verifyException(e, "CWWKS1536E");
+        }
+    }
+
+    @Test
+    public void test_checkJwtFormatAgainstConfigRequirements_nullJwt_withKeyAlias() {
+        String jwtString = null;
+        mockery.checking(new Expectations() {
+            {
+                allowing(clientConfig).getKeyManagementKeyAlias();
+                will(returnValue("someAlias"));
+                one(clientConfig).getId();
+                will(returnValue("configId"));
+            }
+        });
+        try {
+            util.checkJwtFormatAgainstConfigRequirements(jwtString, clientConfig);
+            fail("Should have thrown a JWTTokenValidationFailedException exception but did not.");
+        } catch (JWTTokenValidationFailedException e) {
+            verifyException(e, "CWWKS1537E");
+        }
+    }
+
+    @Test
+    public void test_checkJwtFormatAgainstConfigRequirements_emptyJwt_nullKeyAlias() {
+        String jwtString = "";
+        mockery.checking(new Expectations() {
+            {
+                one(clientConfig).getKeyManagementKeyAlias();
+                will(returnValue(null));
+                one(clientConfig).getId();
+                will(returnValue("configId"));
+            }
+        });
+        try {
+            util.checkJwtFormatAgainstConfigRequirements(jwtString, clientConfig);
+            fail("Should have thrown a JWTTokenValidationFailedException exception but did not.");
+        } catch (JWTTokenValidationFailedException e) {
+            verifyException(e, "CWWKS1536E");
+        }
+    }
+
+    @Test
+    public void test_checkJwtFormatAgainstConfigRequirements_emptyJwt_withKeyAlias() {
+        String jwtString = "";
+        mockery.checking(new Expectations() {
+            {
+                allowing(clientConfig).getKeyManagementKeyAlias();
+                will(returnValue("someAlias"));
+                one(clientConfig).getId();
+                will(returnValue("configId"));
+            }
+        });
+        try {
+            util.checkJwtFormatAgainstConfigRequirements(jwtString, clientConfig);
+            fail("Should have thrown a JWTTokenValidationFailedException exception but did not.");
+        } catch (JWTTokenValidationFailedException e) {
+            verifyException(e, "CWWKS1537E");
+        }
+    }
+
+    @Test
+    public void test_checkJwtFormatAgainstConfigRequirements_jws_nullKeyAlias() {
+        String jwtString = "xxx.yyy.zzz";
+        mockery.checking(new Expectations() {
+            {
+                allowing(clientConfig).getKeyManagementKeyAlias();
+                will(returnValue(null));
+            }
+        });
+        try {
+            util.checkJwtFormatAgainstConfigRequirements(jwtString, clientConfig);
+        } catch (JWTTokenValidationFailedException e) {
+            fail("Should not have thrown a JWTTokenValidationFailedException exception but did: " + e);
+        }
+    }
+
+    @Test
+    public void test_checkJwtFormatAgainstConfigRequirements_jws_withKeyAlias() {
+        String jwtString = "xxx.yyy.zzz";
+        mockery.checking(new Expectations() {
+            {
+                allowing(clientConfig).getKeyManagementKeyAlias();
+                will(returnValue("someAlias"));
+                one(clientConfig).getId();
+                will(returnValue("configId"));
+            }
+        });
+        try {
+            util.checkJwtFormatAgainstConfigRequirements(jwtString, clientConfig);
+            fail("Should have thrown a JWTTokenValidationFailedException exception but did not.");
+        } catch (JWTTokenValidationFailedException e) {
+            verifyException(e, "CWWKS1537E");
+        }
+    }
+
+    @Test
+    public void test_checkJwtFormatAgainstConfigRequirements_jwe_nullKeyAlias() {
+        String jwtString = "xxx.yyy.zzz.aaa.bbb";
+        mockery.checking(new Expectations() {
+            {
+                one(clientConfig).getKeyManagementKeyAlias();
+                will(returnValue(null));
+                one(clientConfig).getId();
+                will(returnValue("configId"));
+            }
+        });
+        try {
+            util.checkJwtFormatAgainstConfigRequirements(jwtString, clientConfig);
+            fail("Should have thrown a JWTTokenValidationFailedException exception but did not.");
+        } catch (JWTTokenValidationFailedException e) {
+            verifyException(e, "CWWKS1536E");
+        }
+    }
+
+    @Test
+    public void test_checkJwtFormatAgainstConfigRequirements_jwe_withKeyAlias() {
+        String jwtString = "xxx.yyy.zzz.aaa.bbb";
+        mockery.checking(new Expectations() {
+            {
+                allowing(clientConfig).getKeyManagementKeyAlias();
+                will(returnValue("someAlias"));
+            }
+        });
+        try {
+            util.checkJwtFormatAgainstConfigRequirements(jwtString, clientConfig);
+        } catch (JWTTokenValidationFailedException e) {
+            fail("Should not have thrown a JWTTokenValidationFailedException exception but did: " + e);
+        }
     }
 
     /************************************** getVerifyKey **************************************/


### PR DESCRIPTION
Resolves #18880

Updates the runtime to require JWE-formatted ID tokens if the `keyManagementKeyAlias` config attribute is set, and require JWS-formatted ID tokens if that attribute is not set.