### PR TITLE
Avoid test failures when using TestContainers

### DIFF
--- a/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/ContainersTest.java
+++ b/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/ContainersTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package com.ibm.ws.testcontainers.example;
 
-import static componenttest.custom.junit.runner.Mode.TestMode.FULL;
-
 import java.time.Duration;
 
 import org.junit.AfterClass;
@@ -27,7 +25,6 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.custom.junit.runner.Mode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import web.generic.ContainersTestServlet;
@@ -37,7 +34,6 @@ import web.generic.ContainersTestServlet;
  * TestContainer for use to test against.
  */
 @RunWith(FATRunner.class)
-@Mode(FULL)
 public class ContainersTest extends FATServletClient {
 
     public static final String APP_NAME = "containerApp";

--- a/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/DockerfileTest.java
+++ b/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/DockerfileTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.testcontainers.example;
 
+import static componenttest.custom.junit.runner.Mode.TestMode.FULL;
+
 import java.time.Duration;
 
 import org.junit.AfterClass;
@@ -25,12 +27,14 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
 import componenttest.topology.impl.LibertyServer;
 import web.generic.ContainersTestServlet;
 
 /**
  * Example test class showing how to setup a testcontainer that uses a custom dockerfile.
  */
+@Mode(FULL)
 @RunWith(FATRunner.class)
 public class DockerfileTest {
 

--- a/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/FATSuite.java
+++ b/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/FATSuite.java
@@ -24,9 +24,10 @@ import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                ContainersTest.class,
-                DatabaseRotationTest.class,
-                DockerfileTest.class
+                ContainersTest.class,       //LITE
+                DatabaseRotationTest.class, //LITE
+                DockerfileTest.class,       //FULL
+                ProgrammaticImageTest.class, //FULL
 })
 /**
  * Example FATSuite class to show how to setup suite level testcontainers and properties
@@ -41,35 +42,36 @@ public class FATSuite {
          * - OTHER: ERROR
          *
          * You can overwrite these default configurations programmatically here.
-         * This can help in debugging build errors related to testcontaienrs and docker-java.
+         * This can help in debugging build errors related to testcontainers and docker-java.
          * However, this is not required for successful use of testcontainers.
          */
         Logger root = (Logger) LoggerFactory.getLogger("org.testcontainers");
         root.setLevel(Level.ALL);
 
         /*
-         * Testcontainers uses a properties file located at ~/.testcontainers.properties
-         * This method call clears and set's the values in this property file.
-         *
-         * Unless otherwise specified testcontaienrs will attempt to run against a local
-         * docker instance, and pull from DockerHub.
-         *
-         * If you set the property: -Dfat.test.use.remote.docker=true
-         * This only works if you are on the IBM network.
-         *
-         * We will change the properties below.
-         * 1. docker.client.strategy:
-         * Default: [Depends on local OS]
-         * Custom : componenttest.containers.ExternalTestServiceDockerClientStrategy
-         * Purpose: This is the strategy testcontaienrs uses to locate and run against a docker instance.
-         *
-         * 2. image.substitutor:
-         * Default: [none]
-         * Custom : componenttest.containers.ArtifactoryImageNameSubstitutor
-         * Purpose: This defines a strategy for substituting image names.
-         * This is so that we can use a private docker repository to cache docker images
-         * to avoid the docker pull limits.
-         * Example: foo/bar:1.0 it will get changed to wasliberty-docker-remote.artifactory.swg-devops.com/foo/bar:1.0
+        * THIS METHOD CALL IS REQUIRED TO USE TESTCONTAINERS PLEASE READ:
+        *
+        * Testcontainers caches data in a properties file located at $HOME/.testcontainers.properties
+        * The ExternalTestServiceDockerClientStrategy.setup* methods will clear and reset the values in this property file.
+        *
+        * By default, testcontainers will attempt to run against a local docker instance and pull from DockerHub.
+        * If you want testcontainers to run against a remote docker host to mirror the behavior of an RTC build
+        * Then, set property: -Dfat.test.use.remote.docker=true
+        * This will only work if you are on the IBM network.
+        *
+        * We will set the following properties:
+        * 1. docker.client.strategy:
+        * Default: [Depends on local OS]
+        * Custom : componenttest.containers.ExternalTestServiceDockerClientStrategy
+        * Purpose: This is the strategy testcontainers uses to locate and run against a remote docker instance.
+        *
+        * 2. image.substitutor:
+        * Default: [none]
+        * Custom : componenttest.containers.ArtifactoryImageNameSubstitutor
+        * Purpose: This defines a strategy for substituting image names.
+        * This is so that we can use a private docker repository to cache docker images
+        * to avoid the docker pull limits.
+        * Example: foo/bar:1.0 it will get changed to wasliberty-docker-remote.artifactory.swg-devops.com/foo/bar:1.0
          */
         ExternalTestServiceDockerClientStrategy.setupTestcontainers();
     }

--- a/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/ProgrammaticImageTest.java
+++ b/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/ProgrammaticImageTest.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.testcontainers.example;
+
+import static componenttest.custom.junit.runner.Mode.TestMode.FULL;
+
+import java.io.File;
+import java.time.Duration;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.ImageNameSubstitutor;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.containers.SimpleLogConsumer;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.topology.impl.LibertyServer;
+import web.generic.ContainersTestServlet;
+
+/**
+ * Example test class showing how to setup a testcontainer that programmatically creates a docker image.
+ */
+@Mode(FULL)
+@RunWith(FATRunner.class)
+public class ProgrammaticImageTest {
+
+    public static final String APP_NAME = "containerApp";
+
+    @Server("build.example.testcontainers")
+    @TestServlet(servlet = ContainersTestServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    public static final String POSTGRES_DB = "test";
+    public static final String POSTGRES_USER = "test";
+    public static final String POSTGRES_PASSWORD = "test";
+    public static final int POSTGRE_PORT = 5432;
+
+    /**
+     * <pre>
+     * There are times where we might want to extend a base docker image for our
+     * own testing needs. For example, using a docker image that already uses a startup script.
+     * It is possible with testcontainers to programmatically build a docker image instead of using
+     * a prebuilt custom image or building from a dockerfile.
+     *
+     * NOTE: building from a Dockerfile should be avoided at all costs.
+     *
+     * Here we are pulling from a base image postgres:11.2-alpine
+     *
+     * However, we use special processing for the image name to ensure that when testing locally we pull
+     * from DockerHub, and when testing against a remote docker image we use a subsituted image name to pull
+     * from artifactory.
+     *
+     * Example:
+     * ImageNameSubstitutor.instance().apply(DockerImageName.parse("postgres:11.2-alpine")).asCanonicalNameString()
+     *
+     * When testing locally a DefaultImageNameSubstitutor will be used and postgres:11.2-alpine will be returned as normal.
+     * When testing on a remote docker host, our internal ArtifactoryImageNameSubstitutor will be used and
+     *   wasliberty-docker-remote.artifactory.swg-devops.com/postgres:11.2-alpine will be returned
+     *
+     * </pre>
+     *
+     * @see DockerfileTest
+     */
+
+    @ClassRule
+    public static GenericContainer<?> container = new GenericContainer<>(//
+                    new ImageFromDockerfile().withDockerfileFromBuilder(builder -> builder.from(//
+                                                                                                ImageNameSubstitutor.instance()
+                                                                                                                .apply(DockerImageName.parse("postgres:11.2-alpine"))
+                                                                                                                .asCanonicalNameString()) //
+                                    .copy("/docker-entrypoint-initdb.d/initDB.sql", "/docker-entrypoint-initdb.d/initDB.sql")
+                                    .build())
+                                    .withFileFromFile("/docker-entrypoint-initdb.d/initDB.sql", new File("lib/LibertyFATTestFiles/postgres/scripts/initDB.sql"), 644))
+                                                    .withExposedPorts(POSTGRE_PORT)
+                                                    .withEnv("POSTGRES_DB", POSTGRES_DB)
+                                                    .withEnv("POSTGRES_USER", POSTGRES_USER)
+                                                    .withEnv("POSTGRES_PASSWORD", POSTGRES_PASSWORD)
+                                                    .withLogConsumer(new SimpleLogConsumer(ContainersTest.class, "postgres"))
+                                                    .waitingFor(new LogMessageWaitStrategy()
+                                                                    .withRegEx(".*database system is ready to accept connections.*\\s")
+                                                                    .withTimes(2)
+                                                                    .withStartupTimeout(Duration.ofSeconds(60)));
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultApp(server, APP_NAME, "web.generic");
+
+        //Execute a command within container after it has started
+        container.execInContainer("echo \"This is executed after container has started\"");
+
+        server.addEnvVar("PS_URL", "jdbc:postgresql://" + container.getContainerIpAddress() //
+                                   + ":" + container.getMappedPort(POSTGRE_PORT)
+                                   + "/" + POSTGRES_DB);
+        server.addEnvVar("PS_USER", POSTGRES_USER);
+        server.addEnvVar("PS_PASSWORD", POSTGRES_PASSWORD);
+
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/docker/pebble/PebbleContainer.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/docker/pebble/PebbleContainer.java
@@ -30,6 +30,8 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.ImageNameSubstitutor;
 
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.ContainerNetwork;
@@ -100,10 +102,8 @@ public class PebbleContainer extends CAContainer {
 	 */
 	public PebbleContainer() {
 		super(new ImageFromDockerfile()
-				.withDockerfileFromBuilder(builder -> builder
-						.from((ExternalTestServiceDockerClientStrategy.USE_REMOTE_DOCKER_HOST
-								? ArtifactoryImageNameSubstitutor.getPrivateRegistry() + "/"
-								: "") + "letsencrypt/pebble")
+				.withDockerfileFromBuilder(builder -> builder.from(
+						ImageNameSubstitutor.instance().apply(DockerImageName.parse("letsencrypt/pebble")).asCanonicalNameString())
 						.copy("pebble-config.json", "/test/config/pebble-config.json").build())
 				.withFileFromFile("pebble-config.json", PEBBLE_CONFIG_JSON_FILE), 5002, 14000, 15000);
 		challtestsrv.withStartupAttempts(20);

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/FATSuite.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/FATSuite.java
@@ -24,6 +24,8 @@ import org.junit.runners.Suite.SuiteClasses;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.ImageNameSubstitutor;
 
 import com.ibm.websphere.simplicity.Machine;
 import com.ibm.websphere.simplicity.RemoteFile;
@@ -88,7 +90,8 @@ public class FATSuite {
      */
     @ClassRule
     public static GenericContainer<?> infinispan = new GenericContainer<>(new ImageFromDockerfile()
-                    .withDockerfileFromBuilder(builder -> builder.from("infinispan/server:10.0.1.Final")
+                    .withDockerfileFromBuilder(builder -> builder.from(
+                    		ImageNameSubstitutor.instance().apply(DockerImageName.parse("infinispan/server:10.0.1.Final")).asCanonicalNameString())
                                     .user("root")
                                     .copy("/opt/infinispan_config/config.xml", "/opt/infinispan_config/config.xml")
                                     .copy("/opt/infinispan/server/conf/users.properties", "/opt/infinispan/server/conf/users.properties")

--- a/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryImageNameSubstitutor.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryImageNameSubstitutor.java
@@ -26,6 +26,8 @@ public class ArtifactoryImageNameSubstitutor extends ImageNameSubstitutor {
 
     private static final Class<?> c = ArtifactoryImageNameSubstitutor.class;
 
+    private static final String artifactoryRegistryKey = "fat.test.artifactory.download.server";
+
     @Override
     public DockerImageName apply(DockerImageName original) {
         // If we are using local docker, or a programmatically built image, or a registry was explicitly set,
@@ -64,10 +66,10 @@ public class ArtifactoryImageNameSubstitutor extends ImageNameSubstitutor {
         return isSynthetic;
     }
 
-    public static String getPrivateRegistry() {
-        String artifactoryServer = System.getProperty("fat.test.artifactory.download.server");
+    static String getPrivateRegistry() {
+        String artifactoryServer = System.getProperty(artifactoryRegistryKey);
         if (artifactoryServer == null || artifactoryServer.isEmpty() || artifactoryServer.startsWith("${"))
-            throw new IllegalStateException("No private registry configured. System property 'fat.test.artifactory.download.server' was: " + artifactoryServer);
+            throw new IllegalStateException("No private registry configured. System property '" + artifactoryRegistryKey + "' was: " + artifactoryServer);
         if (artifactoryServer.startsWith("na.") || artifactoryServer.startsWith("eu."))
             artifactoryServer = artifactoryServer.substring(3);
         return "wasliberty-docker-remote." + artifactoryServer;

--- a/dev/fattest.simplicity/src/componenttest/containers/ExternalTestServiceDockerClientStrategy.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/ExternalTestServiceDockerClientStrategy.java
@@ -102,8 +102,6 @@ public class ExternalTestServiceDockerClientStrategy extends DockerClientProvide
         setupComplete = true;
         Log.exiting(c, m, setupComplete);
     }
-        Log.info(c, "setupTestcontainersForArtifactory", "Exit", setupComplete);
-    }
 
     private static void generateTestcontainersConfig() {
         File testcontainersConfigFile = new File(System.getProperty("user.home"), ".testcontainers.properties");

--- a/dev/fattest.simplicity/src/componenttest/containers/ExternalTestServiceDockerClientStrategy.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/ExternalTestServiceDockerClientStrategy.java
@@ -75,13 +75,13 @@ public class ExternalTestServiceDockerClientStrategy extends DockerClientProvide
 
     /**
      * <pre>
-     * By default, Testcontainrs will cache the DockerClient strategy in <code>~/.testcontainers.properties</code>.
+     * By default, Testcontainers will cache the DockerClient strategy in <code>~/.testcontainers.properties</code>.
      *
-     * Calling this method in the FATSuite class is REQUIRED for any fat project that uses testconatiners.
+     * Calling this method in the FATSuite class is REQUIRED for any fat project that uses Testcontainers.
      * This is a safety measure to ensure that we run with the correct docker.client.stategy property
      * for each FATSuite run.
      *
-     * Example Useage:
+     * Example Usage:
      *
      * &#64;RunWith(Suite.class)
      * &#64;SuiteClasses({ FailoverTest.class })
@@ -93,11 +93,16 @@ public class ExternalTestServiceDockerClientStrategy extends DockerClientProvide
      * </pre>
      */
     public static void setupTestcontainers() {
+        String m = "setupTestcontainers";
+        Log.entering(c, m, setupComplete);
         if (setupComplete)
             return;
         generateTestcontainersConfig();
-        generateDockerConfig();
+        generateArtifactorySubstitutorConfig();
         setupComplete = true;
+        Log.exiting(c, m, setupComplete);
+    }
+        Log.info(c, "setupTestcontainersForArtifactory", "Exit", setupComplete);
     }
 
     private static void generateTestcontainersConfig() {
@@ -126,17 +131,15 @@ public class ExternalTestServiceDockerClientStrategy extends DockerClientProvide
      * Or if a config.json already exists, make sure that the private registry is listed. If not, add
      * the private registry to the existing config
      */
-    private static void generateDockerConfig() {
+    private static void generateDockerConfig(String registry, String authToken) {
         final String m = "generateDockerConfig";
-        if (!USE_REMOTE_DOCKER_HOST)
-            return;
 
         File configDir = new File(System.getProperty("user.home"), ".docker");
         File configFile = new File(configDir, "config.json");
         String contents = "";
 
-        String privateAuth = "\t\t\"" + ArtifactoryImageNameSubstitutor.getPrivateRegistry() + "\": {\n" +
-                             "\t\t\t\"auth\": \"" + ArtifactoryImageNameSubstitutor.getPrivateRegistryAuthToken() + "\",\n"
+        String privateAuth = "\t\t\"" + registry + "\": {\n" +
+                             "\t\t\t\"auth\": \"" + authToken + "\",\n"
                              + "\t\t\t\"email\": null\n" + "\t\t}";
         if (configFile.exists()) {
             Log.info(c, m, "Config already exists at: " + configFile.getAbsolutePath());
@@ -147,7 +150,7 @@ public class ExternalTestServiceDockerClientStrategy extends DockerClientProvide
                 throw new RuntimeException(e);
             }
             Log.info(c, m, "Original contents:\n" + contents);
-            if (contents.contains(ArtifactoryImageNameSubstitutor.getPrivateRegistry())) {
+            if (contents.contains(registry)) {
                 Log.info(c, m, "Config already contains private registry");
                 return;
             }
@@ -175,6 +178,15 @@ public class ExternalTestServiceDockerClientStrategy extends DockerClientProvide
         Log.info(c, m, "New config.json contents are:\n" + contents);
         configFile.delete();
         writeFile(configFile, contents);
+
+    }
+
+    private static void generateArtifactorySubstitutorConfig() {
+        // If we are using local docker host then we won't substitute names so skip this step.
+        if (!USE_REMOTE_DOCKER_HOST)
+            return;
+
+        generateDockerConfig(ArtifactoryImageNameSubstitutor.getPrivateRegistry(), ArtifactoryImageNameSubstitutor.getPrivateRegistryAuthToken());
     }
 
     @Override
@@ -211,12 +223,24 @@ public class ExternalTestServiceDockerClientStrategy extends DockerClientProvide
                 return false;
             }
 
-            System.setProperty("DOCKER_HOST", dockerHostURL);
+            String ca = dockerService.getProperties().get("ca.pem");
+            String cert = dockerService.getProperties().get("cert.pem");
+            String key = dockerService.getProperties().get("key.pem");
+
+            if (ca == null || cert == null || key == null) {
+                Log.info(c, m, "Will not select " + dockerHostURL
+                               + " because dockerService did not contain one or more of the authentication properties:"
+                               + " [ca.pem, cert.pem, key.pem].");
+                return false;
+            }
+
             File certDir = new File("docker-certificates");
             certDir.mkdirs();
-            writeFile(new File(certDir, "ca.pem"), dockerService.getProperties().get("ca.pem"));
-            writeFile(new File(certDir, "cert.pem"), dockerService.getProperties().get("cert.pem"));
-            writeFile(new File(certDir, "key.pem"), dockerService.getProperties().get("key.pem"));
+            writeFile(new File(certDir, "ca.pem"), ca);
+            writeFile(new File(certDir, "cert.pem"), cert);
+            writeFile(new File(certDir, "key.pem"), key);
+
+            System.setProperty("DOCKER_HOST", dockerHostURL);
             System.setProperty("DOCKER_TLS_VERIFY", "1");
             System.setProperty("DOCKER_CERT_PATH", certDir.getAbsolutePath());
 


### PR DESCRIPTION
This PR will help avoid issue:

1. Docker pull rate limits
   When using `ImageFromDockerfile().withDockerfileFromBuilder` to programmatically create a custom docker image, special care needs to happen to ensure that we do not reach our docker pull rate limit when pulling the base image. 
  To resolve this we should use our custom `ImageNameSubstitutor` class to substitute the image name and point to our Artifactory image repo.

2. Do not fail if a new docker service is not yet configured properly. 
  It could be the case that as new docker service machines are being brought up that they do not yet have the proper authentication data available to relay back to our external test service. 
  Do not fail in this case, instead skip and try the next docker service.

3. Minor changes to help sync this repository with our internal repository for commercial feature testing.
