### PR TITLE
Don't transform bundles that don't need it.

### DIFF
--- a/dev/com.ibm.websphere.appserver.api.persistence/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.persistence/bnd.bnd
@@ -15,8 +15,6 @@ Bundle-Name: WebSphere Persistence Service API
 Bundle-Description: WebSphere Persistence Service API, version ${bVersion}
 Bundle-SymbolicName: com.ibm.websphere.appserver.api.persistence
 
-jakartaeeMe: true
-
 Import-Package: com.ibm.websphere.persistence.mbean
 
 Export-Package: com.ibm.websphere.persistence.mbean

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.persistenceService-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.persistenceService-2.0.feature
@@ -9,9 +9,9 @@ IBM-API-Package: com.ibm.websphere.persistence.mbean; type="ibm-api"
   com.ibm.websphere.appserver.jndi-1.0, \
   com.ibm.websphere.appserver.transaction-2.0
 -bundles=com.ibm.ws.persistence.jakarta, \
- com.ibm.ws.persistence.mbean.jakarta, \
- com.ibm.websphere.appserver.api.persistence.jakarta; location:="dev/api/ibm/", \
- com.ibm.ws.persistence.utility.jakarta
+ com.ibm.ws.persistence.mbean, \
+ com.ibm.websphere.appserver.api.persistence; location:="dev/api/ibm/", \
+ com.ibm.ws.persistence.utility
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.persistence_1.0-javadoc.zip, \
  bin/tools/ws-generateddlutil.jar, \
  bin/ddlGen.bat, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wsSecurity1.1.internal.jaxws-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wsSecurity1.1.internal.jaxws-3.0.feature
@@ -15,7 +15,7 @@ singleton=true
  com.ibm.ws.org.jasypt.jasypt.1.9.3, \
  com.ibm.ws.org.apache.cxf.rt.ws.mex.3.4.1.jakarta, \
  com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1.jakarta, \
- com.ibm.ws.org.apache.cxf.rt.security.3.4.1.jakarta, \
+ com.ibm.ws.org.apache.cxf.rt.security.3.4.1, \
  com.ibm.ws.org.apache.cxf.rt.security.saml.3.4.1.jakarta, \
  com.ibm.ws.wssecurity.3.4.1.jakarta
 kind=beta

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wss4j-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wss4j-2.3.feature
@@ -5,10 +5,10 @@ singleton=true
 -bundles=com.ibm.ws.org.apache.santuario.xmlsec.2.2.0.jakarta, \
  com.ibm.ws.com.google.guava, \
  com.ibm.ws.org.apache.wss4j.bindings.2.3.0.jakarta, \
- com.ibm.ws.org.apache.wss4j.policy.2.3.0.jakarta, \
+ com.ibm.ws.org.apache.wss4j.policy.2.3.0, \
  com.ibm.ws.org.apache.wss4j.ws.security.common.2.3.0.jakarta, \
  com.ibm.ws.org.apache.wss4j.ws.security.dom.2.3.0.jakarta, \
- com.ibm.ws.org.apache.wss4j.ws.security.policy.stax.2.3.0.jakarta, \
+ com.ibm.ws.org.apache.wss4j.ws.security.policy.stax.2.3.0, \
  com.ibm.ws.org.apache.wss4j.ws.security.stax.2.3.0.jakarta, \
  com.ibm.ws.org.apache.wss4j.ws.security.web.2.3.0.jakarta, \
  com.ibm.ws.org.cryptacular.cryptacular.1.2.4, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlws.common-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlws.common-3.0.feature
@@ -34,12 +34,12 @@ IBM-API-Package:\
  com.ibm.ws.org.apache.cxf.cxf.rt.bindings.xml.3.2.jakarta, \
  com.ibm.ws.org.apache.cxf.cxf.core.3.2.jakarta, \
  com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.3.2.jakarta, \
- com.ibm.ws.org.apache.cxf.cxf.rt.features.logging.3.2.jakarta, \
+ com.ibm.ws.org.apache.cxf.cxf.rt.features.logging.3.2, \
  com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.3.2.jakarta, \
  com.ibm.ws.org.apache.cxf.cxf.rt.frontend.simple.3.2.jakarta, \
  com.ibm.ws.org.apache.cxf.cxf.rt.management.3.2.jakarta, \
  com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2.jakarta, \
- com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2.jakarta, \
+ com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2, \
  com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2.jakarta, \
  com.ibm.ws.org.apache.cxf.cxf.rt.ws.addr.3.2.jakarta, \
  com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2.jakarta, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/connectors-2.0/io.openliberty.connectors-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/connectors-2.0/io.openliberty.connectors-2.0.feature
@@ -11,7 +11,7 @@ Subsystem-Category: JakartaEE9Application
   io.openliberty.connectors-2.0.internal, \
   com.ibm.websphere.appserver.eeCompatible-9.0, \
   com.ibm.websphere.appserver.transaction-2.0
--bundles=com.ibm.ws.app.manager.rar.jakarta, \
+-bundles=com.ibm.ws.app.manager.rar, \
  com.ibm.ws.jca.1.7.jakarta
 kind=beta
 edition=base

--- a/dev/com.ibm.ws.app.manager.rar/bnd.bnd
+++ b/dev/com.ibm.ws.app.manager.rar/bnd.bnd
@@ -16,8 +16,6 @@ Bundle-Name: WebSphere Connector Support
 Bundle-SymbolicName: com.ibm.ws.app.manager.rar
 Bundle-Description: WebSphere Connector Support, version ${bVersion}
 
-jakartaeeMe: true
-
 Import-Package: \
   !com.ibm.ws.container.service.metadata, \
   !com.ibm.ws.container.service.state, \

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.features.logging.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.features.logging.3.2/bnd.bnd
@@ -23,5 +23,3 @@ CXFVersion=3.4.3
   com.ibm.ws.logging.core;version=latest, \
   com.ibm.ws.org.slf4j.api.1.7.7;version=latest, \
   com.ibm.websphere.org.osgi.service.cm;version=latest
-
-jakartaeeMe: true

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2/bnd.bnd
@@ -21,5 +21,3 @@
  com.ibm.ws.cxf.client,\
  com.ibm.ws.org.apache.httpcomponents;version=latest,\
  com.ibm.ws.logging.core;version=latest
- 
-jakartaeeMe: true

--- a/dev/com.ibm.ws.org.apache.cxf.rt.security.3.4.1/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.rt.security.3.4.1/bnd.overrides
@@ -29,5 +29,3 @@ Import-Package:  \
   com.ibm.websphere.ras.annotation, \
   com.ibm.ws.ffdc, \
   *
-
-jakartaeeMe: true

--- a/dev/com.ibm.ws.org.apache.neethi.3.1.1/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.neethi.3.1.1/bnd.overrides
@@ -12,5 +12,3 @@
 bVersion=1.0
 
 Bundle-SymbolicName: com.ibm.ws.org.apache.neethi.3.1.1
-
-jakartaeeMe: true

--- a/dev/com.ibm.ws.org.apache.wss4j.policy.2.3.0/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.wss4j.policy.2.3.0/bnd.overrides
@@ -20,5 +20,3 @@ WS-TraceGroup: WSS4J
 
 Export-Package: \
  org.apache.wss4j.policy.*
- 
-jakartaeeMe: true

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.policy.stax.2.3.0/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.policy.stax.2.3.0/bnd.overrides
@@ -26,5 +26,3 @@ Import-Package: \
  !com.sun.security.jgss, \
  !org.bouncycastle.asn1.*, \
  * 
-
-jakartaeeMe: true

--- a/dev/com.ibm.ws.org.opensaml.opensaml/bnd.overrides
+++ b/dev/com.ibm.ws.org.opensaml.opensaml/bnd.overrides
@@ -15,16 +15,6 @@ Bundle-Name: org.opensaml.opensaml
 Bundle-Description: org.opensaml opensaml; version=2.6.6
 Bundle-SymbolicName: com.ibm.ws.org.opensaml.opensaml.2.6.1
 
-#
-# Generate an Jakarta EE compliant JAR for the bundle.
-#
-jakartaeeMe: true
-jakartaFinalJarName=io.openliberty.org.opensaml.opensaml.2.6.1.jar
-jakartaFinalBundleName: org.opensaml.opensaml
-jakartaFinalBundleId: io.openliberty.org.opensaml.opensaml.2.6.1
-jakartaFinalBundleDescription: org.opensaml.opensaml; Jakarta Enabled
-
-
 WS-TraceGroup: SAML20
 
 Export-Package: \

--- a/dev/com.ibm.ws.org.opensaml.openws/bnd.overrides
+++ b/dev/com.ibm.ws.org.opensaml.openws/bnd.overrides
@@ -15,15 +15,6 @@ Bundle-Name: org.opensaml.openws
 Bundle-Description: org.opensaml openws; version=1.5.6
 Bundle-SymbolicName: com.ibm.ws.org.opensaml.openws.1.5.6
 
-#
-# Generate an Jakarta EE compliant JAR for the bundle.
-#
-jakartaeeMe: true
-jakartaFinalJarName=io.openliberty.org.opensaml.openws.1.5.6.jar
-jakartaFinalBundleName: org.opensaml.openws
-jakartaFinalBundleId: io.openliberty.org.opensaml.openws.1.5.6
-jakartaFinalBundleDescription: org.opensaml.openws; Jakarta Enabled
-
 WS-TraceGroup: SAML20
 
 Export-Package: \

--- a/dev/com.ibm.ws.persistence.mbean/bnd.bnd
+++ b/dev/com.ibm.ws.persistence.mbean/bnd.bnd
@@ -15,8 +15,6 @@ Bundle-Name: PersistenceService MBeans
 Bundle-SymbolicName: com.ibm.ws.persistence.mbean
 Bundle-Description: MBeans for the WebSphere Persistence Service; version=${bVersion}
 
-jakartaeeMe: true
-
 WS-TraceGroup: persistenceservice
 
 Export-Package: com.ibm.websphere.persistence.mbean

--- a/dev/com.ibm.ws.persistence.utility/bnd.bnd
+++ b/dev/com.ibm.ws.persistence.utility/bnd.bnd
@@ -15,8 +15,6 @@ Bundle-Name: PersistenceService Utility
 Bundle-SymbolicName: com.ibm.ws.persistence.utility
 Bundle-Description: WebSphere Persistence Service Utility; version=${bVersion}
 
-jakartaeeMe: true
-
 Main-Class: com.ibm.ws.persistence.utility.DDLGenerationUtility
 
 WS-TraceGroup: persistenceservice

--- a/dev/com.ibm.ws.security.saml.sso/bnd.bnd
+++ b/dev/com.ibm.ws.security.saml.sso/bnd.bnd
@@ -15,15 +15,6 @@ Bundle-Name: WAS Security SAML Web SSO 2.0
 Bundle-SymbolicName: com.ibm.ws.security.saml.sso.2.0
 Bundle-Description: WAS Security SAML WebSso 2.0, version=${bVersion}
 
-#
-# Generate an Jakarta EE compliant JAR for the bundle.
-#
-jakartaeeMe: true
-jakartaFinalJarName: io.openliberty.security.saml.internal.sso.2.0.jar
-jakartaFinalBundleName: Liberty Security SAML Web SSO 2.0
-jakartaFinalBundleId: io.openliberty.security.saml.internal.sso.2.0
-jakartaFinalBundleDescription: Liberty Security SAML Web SSO 2.0; Jakarta Enabled
-
 WS-TraceGroup: SAML20
 
 # For each exported package, create (in that package) a package-info.java...


### PR DESCRIPTION
- Update to make ddlGen work with Jakarta EE 9.  The bundle was transformed, but it wasn't needed and with a minified image it wasn't working.
- Update other bundles that are identical to their non Jakarta EE 9 version so that we don't have extra bundles for no reason.