### PR TITLE
Jakarta-ize MP JWT propagation project

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpJwtPropagation-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpJwtPropagation-2.0.feature
@@ -2,7 +2,7 @@
 symbolicName=io.openliberty.mpJwtPropagation-2.0
 visibility=private
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.restfulWSClient-3.0)))", \
- osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpJwt-2.0)))"
+ osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.mpJwt-2.0)))"
 IBM-Install-Policy: when-satisfied
 -bundles=io.openliberty.org.eclipse.microprofile.jwt.2.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:2.0-RC2",\
  io.openliberty.security.mp.jwt.propagation.internal, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpJwtPropagation-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpJwtPropagation-2.0.feature
@@ -1,0 +1,12 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.mpJwtPropagation-2.0
+visibility=private
+IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.restfulWSClient-3.0)))", \
+ osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpJwt-2.0)))"
+IBM-Install-Policy: when-satisfied
+-bundles=io.openliberty.org.eclipse.microprofile.jwt.2.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:2.0-RC2",\
+ io.openliberty.security.mp.jwt.propagation.internal, \
+ io.openliberty.org.jboss.resteasy.common.jakarta, \
+ io.openliberty.restfulWS.internal.globalhandler.jakarta
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpJwt-2.0/io.openliberty.mpJwt-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpJwt-2.0/io.openliberty.mpJwt-2.0.feature
@@ -19,6 +19,7 @@ Subsystem-Name: MicroProfile JSON Web Token 2.0
   com.ibm.websphere.appserver.authFilter-1.0
 -bundles=io.openliberty.security.mp.jwt.internal,\
   io.openliberty.security.mp.jwt.cdi.internal,\
+  io.openliberty.security.mp.jwt.propagation.internal,\
   io.openliberty.security.mp.jwt.1.2.config,\
   com.ibm.ws.security.mp.jwt.1.1.config
 kind=noship

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpJwt-2.0/io.openliberty.mpJwt-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpJwt-2.0/io.openliberty.mpJwt-2.0.feature
@@ -19,7 +19,6 @@ Subsystem-Name: MicroProfile JSON Web Token 2.0
   com.ibm.websphere.appserver.authFilter-1.0
 -bundles=io.openliberty.security.mp.jwt.internal,\
   io.openliberty.security.mp.jwt.cdi.internal,\
-  io.openliberty.security.mp.jwt.propagation.internal,\
   io.openliberty.security.mp.jwt.1.2.config,\
   com.ibm.ws.security.mp.jwt.1.1.config
 kind=noship

--- a/dev/com.ibm.ws.security.mp.jwt.propagation/bnd.bnd
+++ b/dev/com.ibm.ws.security.mp.jwt.propagation/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,15 @@ Bundle-SymbolicName: com.ibm.ws.security.mp.jwt.propagation
 Bundle-Description: Security MicroProfile JWT Propagation service, version=${bVersion}
 Bundle-ActivationPolicy: lazy
 
+#
+# Generate a Jakarta EE compliant JAR for the bundle.
+#
+jakartaeeMe: true
+jakartaFinalJarName: io.openliberty.security.mp.jwt.propagation.internal.jar
+jakartaFinalBundleName: Liberty Security MP JWT Propagation
+jakartaFinalBundleId: io.openliberty.security.mp.jwt.propagation.internal
+jakartaFinalBundleDescription: Liberty Security MP JWT Propagation; Jakarta Enabled
+
 WS-TraceGroup: \
   Security
 
@@ -24,6 +33,7 @@ Export-Package: \
 
 Import-Package: \
   !com.ibm.ws.security.mp.jwt.propagation, \
+  org.eclipse.microprofile.jwt; version="[1.0,3)", \
   !*.internal.*, *
    
 -dsannotations: \


### PR DESCRIPTION
The `com.ibm.ws.security.mp.jwt.propagation` project needs to have a Jakarta-compatible jar generated for it in order for MP JWT JAX-RS propagation scenarios to work with the `mpJwt-2.0` feature.