### PR TITLE
Further aid in debugging

### DIFF
--- a/dev/com.ibm.ws.junit.extensions/src/com/ibm/websphere/ras/CapturedOutputHolder.java
+++ b/dev/com.ibm.ws.junit.extensions/src/com/ibm/websphere/ras/CapturedOutputHolder.java
@@ -21,6 +21,7 @@ import com.ibm.websphere.logging.WsLevel;
 import com.ibm.ws.logging.internal.impl.BaseTraceService;
 import com.ibm.ws.logging.internal.impl.LogProviderConfigImpl;
 import com.ibm.ws.logging.internal.impl.RoutedMessageImpl;
+import com.ibm.wsspi.logprovider.LogProviderConfig;
 
 /**
  *
@@ -62,6 +63,19 @@ public class CapturedOutputHolder extends BaseTraceService {
         earlyMessageTraceKiller_Timer = null;
     }
 
+    @Override
+    public void init(LogProviderConfig config) {
+        systemOut.getOriginalStream().println("init: Did BaseTraceService.captureSystemStreams() already get excuted? : " + isCaptureSystemStreamsExecuted);
+        super.init(config);
+    }
+
+    @Override
+    protected void registerLoggerHandlerSingleton() {
+        systemOut.getOriginalStream().println("registerLoggerHandlerSingleton: Did BaseTraceService.captureSystemStreams() already get excuted? : "
+                                              + isCaptureSystemStreamsExecuted);
+        super.registerLoggerHandlerSingleton();
+    }
+
     /**
      * This is not to be used by the SharedOutputManager! This is an override
      * of the BaseTraceService method that captures system streams.
@@ -78,7 +92,8 @@ public class CapturedOutputHolder extends BaseTraceService {
 
         if (sysOut != trSysOut) {
             throw new ConcurrentModificationException("Someone else has reset or cached System.out. Current System.out value: " + System.out + " and current original stream: "
-                                                      + systemOut.getOriginalStream());
+                                                      + systemOut.getOriginalStream() + ". Did someone already execute BaseTraceService.captureSystemStreams : "
+                                                      + isCaptureSystemStreamsExecuted);
         }
         if (sysErr != trSysErr) {
             throw new ConcurrentModificationException("Someone else has reset or cached System.err");

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
@@ -129,6 +129,8 @@ import com.ibm.wsspi.logprovider.TrService;
  */
 public class BaseTraceService implements TrService {
 
+    protected boolean isCaptureSystemStreamsExecuted = false;
+
     static final PrintStream rawSystemOut = System.out;
     static final PrintStream rawSystemErr = System.err;
 
@@ -1649,6 +1651,8 @@ public class BaseTraceService implements TrService {
      * when the special trace components are created.
      */
     protected void captureSystemStreams() {
+        isCaptureSystemStreamsExecuted = true;
+
         teeOut = new TeePrintStream(new TrOutputStream(systemOut, this), true);
         System.setOut(teeOut);
 


### PR DESCRIPTION
#build

Extra trace to identify at _which point_ BaseTraceService.captureSystemStreams() was executed in the initialization process.
This is to see if it has executed before CapturedLogHoler.captureSystemStreams() (the child class of BTS)