### PR TITLE
use PrintStream to avoid risk of out of memory errors

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertNotNull;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
+import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -25,6 +26,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.io.PrintStream;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -1056,23 +1058,17 @@ public class LibertyServer implements LogMonitorClient {
         if (prefix != null && ! prefix.isEmpty()) {
             fileName = prefix + "-" + fileName;
         }
-        PrintWriter writer = null;
         Props properties = Props.getInstance();
 
         Log.info(c, m, "Printing processes to file: " + fileName);
 
-        try {
-            String filePath = properties.getFileProperty(Props.DIR_LOG).getAbsolutePath() + File.separator + fileName;
+        String filePath = properties.getFileProperty(Props.DIR_LOG).getAbsolutePath() + File.separator + fileName;
+        try (PrintStream stream = new PrintStream(new BufferedOutputStream(new FileOutputStream(filePath)), true, "UTF-8")) {
             PortDetectionUtil detector = PortDetectionUtil.getPortDetector(host);
-            writer = new PrintWriter(filePath, "UTF-8");
-            writer.println(detector.listProcesses());
+            stream.print(detector.listProcesses());
         } catch (Exception ex) {
             Log.error(c, m, ex, "Caught exception while trying to list processes");
-        } finally {
-            if (writer != null) {
-                writer.close();
-            }
-        }
+        } 
     }
 
     public void printProcessHoldingPort(int port) {


### PR DESCRIPTION
An OOM was seen from from calling Log on detector.listProcesses() so lets use a print stream set to flush after every new line. 