### PR TITLE
Reactive Messaging: allow slow container startup

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/PlaintextTests.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/PlaintextTests.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.reactive.messaging.fat.suite;
 
+import java.time.Duration;
+
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -64,5 +66,8 @@ public class PlaintextTests {
     public static Network network = Network.newNetwork();
 
     @ClassRule
-    public static KafkaContainer kafkaContainer = new KafkaContainer().withNetwork(network);
+    public static KafkaContainer kafkaContainer = new KafkaContainer()
+                    .withNetwork(network)
+                    .withStartupTimeout(Duration.ofMinutes(2))
+                    .withStartupAttempts(3);
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/SaslPlainTests.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/SaslPlainTests.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.reactive.messaging.fat.suite;
 
+import java.time.Duration;
+
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -46,6 +48,8 @@ public class SaslPlainTests {
     }
 
     @ClassRule
-    public static KafkaSaslPlainContainer kafkaContainer = new KafkaSaslPlainContainer();
+    public static KafkaSaslPlainContainer kafkaContainer = new KafkaSaslPlainContainer()
+                    .withStartupTimeout(Duration.ofMinutes(2))
+                    .withStartupAttempts(3);
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/TlsTests.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/TlsTests.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.reactive.messaging.fat.suite;
 
+import java.time.Duration;
+
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -35,6 +37,8 @@ public class TlsTests {
     }
 
     @ClassRule
-    public static KafkaTlsContainer kafkaContainer = new KafkaTlsContainer();
+    public static KafkaTlsContainer kafkaContainer = new KafkaTlsContainer()
+                    .withStartupTimeout(Duration.ofMinutes(2))
+                    .withStartupAttempts(3);
 
 }


### PR DESCRIPTION
Increase the startup timeout and number of attempts to make when
starting a Kafka broker container.

This is trying to work around an issue we're seeing regularly but
infrequently in the build where the test fails because the container
does not start and open ports within the timeout.

For RTC 280258