### PR TITLE
Update openapi.2.0.bnd to not pick up the 3.0 APIs.

### DIFF
--- a/dev/io.openliberty.org.eclipse.microprofile/openapi.2.0.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile/openapi.2.0.bnd
@@ -18,6 +18,6 @@ Export-Package: \
   org.eclipse.microprofile.openapi.*
 
 Include-Resource: \
-  @${repo;org.eclipse.microprofile.openapi:microprofile-openapi-api;2.0}
+  @${repo;org.eclipse.microprofile.openapi:microprofile-openapi-api;2.0;EXACT}
 
 WS-TraceGroup: MPOPENAPI


### PR DESCRIPTION
- Change to add the EXACT directive so that the io.openliberty.org.eclipse.microprofile.openapi.2.0.jar file does not include the 3.0 APIs.