### PR TITLE
Fix EJB Container API Type in features

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.ejbRemoteClient-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.ejbRemoteClient-1.0.feature
@@ -2,7 +2,7 @@
 symbolicName=com.ibm.websphere.appserver.ejbRemoteClient-1.0
 WLP-DisableAllFeatures-OnConflict: false
 visibility=private
-IBM-API-Package: com.ibm.websphere.ejbcontainer; type="internal"
+IBM-API-Package: com.ibm.websphere.ejbcontainer; type="ibm-api"
 -features=com.ibm.websphere.appserver.transaction-1.2, \
   com.ibm.websphere.appserver.ejbCore-1.0, \
   com.ibm.websphere.appserver.iiopclient-1.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.enterpriseBeansRemoteClient-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.enterpriseBeansRemoteClient-2.0.feature
@@ -1,7 +1,7 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.enterpriseBeansRemoteClient-2.0
 visibility=private
-IBM-API-Package: com.ibm.websphere.ejbcontainer; type="internal", \
+IBM-API-Package: com.ibm.websphere.ejbcontainer; type="ibm-api", \
  com.ibm.ws.ejb.portable; type="internal"
 -features=io.openliberty.jakartaeePlatform-9.0, \
   com.ibm.websphere.appserver.iiopclient-1.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/ejbLite-3.2/com.ibm.websphere.appserver.ejbLite-3.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/ejbLite-3.2/com.ibm.websphere.appserver.ejbLite-3.2.feature
@@ -7,7 +7,7 @@ IBM-App-ForceRestart: install, \
  uninstall
 IBM-ShortName: ejbLite-3.2
 IBM-API-Package: com.ibm.websphere.ejbcontainer.mbean; type="ibm-api", \
- com.ibm.websphere.ejbcontainer; type="internal"
+ com.ibm.websphere.ejbcontainer; type="ibm-api"
 Subsystem-Category: JavaEE7Application
 -features=com.ibm.websphere.appserver.transaction-1.2, \
   com.ibm.websphere.appserver.ejbLiteCore-1.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/enterpriseBeansLite-4.0/io.openliberty.enterpriseBeansLite-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/enterpriseBeansLite-4.0/io.openliberty.enterpriseBeansLite-4.0.feature
@@ -7,7 +7,7 @@ IBM-App-ForceRestart: install, \
 IBM-ShortName: enterpriseBeansLite-4.0
 WLP-AlsoKnownAs: ejbLite-4.0
 IBM-API-Package: com.ibm.websphere.ejbcontainer.mbean; type="ibm-api", \
- com.ibm.websphere.ejbcontainer; type="internal"
+ com.ibm.websphere.ejbcontainer; type="ibm-api"
 Subsystem-Category: JakartaEE9Application
 -features=io.openliberty.jakartaeePlatform-9.0, \
   com.ibm.websphere.appserver.eeCompatible-9.0, \


### PR DESCRIPTION
The EJB Container API package com.ibm.websphere.ejbcontainer is incorrectly
set to a type of "internal" rather than "ibm-api" and needs to be corrected.
The API jar is already present in wlp/dev/api/ibm and FAT tested.