### PR TITLE
getContextService and withContextCapture for nested config

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/ManagedExecutorExtension.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/ManagedExecutorExtension.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
+import javax.enterprise.concurrent.ContextService;
 import javax.enterprise.concurrent.ManagedExecutorService;
 
 import org.eclipse.microprofile.context.ManagedExecutor;
@@ -35,7 +36,6 @@ import com.ibm.ws.threading.CompletionStageExecutor;
 import com.ibm.ws.threading.PolicyExecutor;
 import com.ibm.wsspi.resource.ResourceInfo;
 import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
-import com.ibm.wsspi.threadcontext.WSContextService;
 
 /**
  * Extend this interface to intercept and replace resource reference lookups for
@@ -99,8 +99,7 @@ public class ManagedExecutorExtension implements CompletionStageExecutor, Manage
         return ((ManagedExecutor) executor).failedStage(x);
     }
 
-    @Deprecated // being replaced with captureThreadContext so that this method signature can change to spec
-    public final WSContextService getContextService() {
+    public final ContextService getContextService() {
         return ((ManagedExecutorServiceImpl) executor).getContextService();
     }
 

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
@@ -654,6 +654,7 @@ public class ContextServiceImpl implements ContextService, //
             lock.readLock().unlock();
         }
 
+        // TODO still need to implement for multiple managed executors sharing the same context service
         throw new UnsupportedOperationException("need to implement for " + this);
     }
 

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
@@ -18,11 +18,13 @@ import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +35,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -41,10 +44,12 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import javax.enterprise.concurrent.ContextService;
+import javax.enterprise.concurrent.ManagedExecutorService;
 
-import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;
+import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
+import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -71,6 +76,7 @@ import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 import com.ibm.wsspi.application.lifecycle.ApplicationRecycleComponent;
 import com.ibm.wsspi.application.lifecycle.ApplicationRecycleContext;
+import com.ibm.wsspi.kernel.service.utils.FilterUtils;
 import com.ibm.wsspi.kernel.service.utils.OnErrorUtil;
 import com.ibm.wsspi.kernel.service.utils.OnErrorUtil.OnError;
 import com.ibm.wsspi.resource.ResourceFactory;
@@ -142,10 +148,12 @@ public class ContextServiceImpl implements ContextService, //
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
     /**
-     * MicroProfile ManagedExecutor that uses this ThreadContext. Otherwise null.
-     * TODO this will be used for Jakarta EE 10 as well
+     * Reference to the
+     * managed executor service under which this context service is nested,
+     * or a MicroProfile ManagedExecutor that uses this ThreadContext.
+     * Otherwise null.
      */
-    ManagedExecutor managedExecutor;
+    final AtomicReference<Executor> managedExecutorRef = new AtomicReference<Executor>();
 
     /**
      * These listeners (other contextService instances which are using this instance as the base instance)
@@ -570,6 +578,85 @@ public class ContextServiceImpl implements ContextService, //
         }
     }
 
+    /**
+     * Determines the backing executor to use for completion stages that are created by the
+     * withContextCapture methods.
+     *
+     * @return executor to use for completion stages.
+     */
+    private final Executor executorForCompletionStages() {
+        Executor executor;
+        if (MPContextPropagationVersion.atLeast(MPContextPropagationVersion.V1_1)) {
+            if ((executor = managedExecutorRef.get()) == null) {
+                lock.readLock().lock();
+                try { // look for a parent config element of managedExecutorService or managedScheduledExecutorService
+                    if (properties == null)
+                        throw new IllegalStateException(name);
+                    String parentPid = (String) properties.get("config.parentPID");
+                    if (parentPid != null) {
+                        String filter = FilterUtils.createPropertyFilter("service.pid", parentPid);
+                        BundleContext bc = priv.getBundleContext(componentContext);
+                        Collection<ServiceReference<ManagedExecutorService>> refs = //
+                                        priv.getServiceReferences(bc, ManagedExecutorService.class, filter);
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                            Tr.debug(this, tc, filter + " found:", refs);
+                        Iterator<ServiceReference<ManagedExecutorService>> it = refs.iterator();
+                        if (it.hasNext()) {
+                            ServiceReference<ManagedExecutorService> ref = refs.iterator().next();
+                            executor = priv.getService(bc, ref);
+                            if (executor == null)
+                                throw new IllegalStateException(filter);
+                            else
+                                managedExecutorRef.set(executor);
+                        } // else parent pid might be something other than a managed executor service
+                    }
+                } catch (InvalidSyntaxException x) {
+                    throw new RuntimeException(x); // internal error - this should never happen
+                } finally {
+                    lock.readLock().unlock();
+                }
+                if (executor == null)
+                    executor = new ContextualDefaultExecutor(this);
+            }
+        } else {
+            executor = new UnusableExecutor(this);
+        }
+        return executor;
+    }
+
+    /**
+     * A ContextService (preferably this same instance) that is backed by the managed executor.
+     *
+     * This same ContextService instance can be used if it has a one-to-one relationship with the
+     * managed executor due to the contextService config being a nested element of the managed
+     * executor service config, or due to it being created by a MicroProfile ManagedExecutor builder.
+     *
+     * If this same instance cannot be used, then a new instance must be created for this purpose.
+     *
+     * @param executor           managed executor.
+     * @param executorServicePid service.pid of the managed executor.
+     * @return a ContextService that is backed by this managed executor.
+     */
+    ContextService forManagedExecutor(ManagedExecutorService executor, String executorServicePid) {
+        if (executor == managedExecutorRef.get())
+            return this;
+
+        lock.readLock().lock();
+        try { // look for a parent config element of managedExecutorService or managedScheduledExecutorService
+            if (properties == null)
+                throw new IllegalStateException(name);
+            String parentPid = (String) properties.get("config.parentPID");
+            if (parentPid != null && parentPid.equals(executorServicePid)) {
+                managedExecutorRef.set(executor);
+                return this;
+            }
+        } finally {
+            lock.readLock().unlock();
+        }
+
+        throw new UnsupportedOperationException("need to implement for " + this);
+    }
+
     @Override
     public ApplicationRecycleContext getContext() {
         return null;
@@ -892,9 +979,7 @@ public class ContextServiceImpl implements ContextService, //
     public <T> CompletableFuture<T> withContextCapture(CompletableFuture<T> stage) {
         CompletableFuture<T> newCompletableFuture;
 
-        Executor executor = MPContextPropagationVersion.atLeast(MPContextPropagationVersion.V1_1) //
-                        ? (managedExecutor == null ? new ContextualDefaultExecutor(this) : managedExecutor) //
-                        : new UnusableExecutor(this);
+        Executor executor = executorForCompletionStages();
 
         if (ManagedCompletableFuture.JAVA8)
             newCompletableFuture = new ManagedCompletableFuture<T>(new CompletableFuture<T>(), executor, null);
@@ -917,9 +1002,7 @@ public class ContextServiceImpl implements ContextService, //
     public <T> CompletionStage<T> withContextCapture(CompletionStage<T> stage) {
         ManagedCompletionStage<T> newStage;
 
-        Executor executor = MPContextPropagationVersion.atLeast(MPContextPropagationVersion.V1_1) //
-                        ? (managedExecutor == null ? new ContextualDefaultExecutor(this) : managedExecutor) //
-                        : new UnusableExecutor(this);
+        Executor executor = executorForCompletionStages();
 
         if (ManagedCompletableFuture.JAVA8)
             newStage = new ManagedCompletionStage<T>(new CompletableFuture<T>(), executor, null);

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/publish/servers/com.ibm.ws.concurrent.fat.jakarta/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/publish/servers/com.ibm.ws.concurrent.fat.jakarta/server.xml
@@ -19,6 +19,35 @@
     
   <include location="../fatTestPorts.xml"/>
 
+  <contextService id="AppContext" jndiName="concurrent/appContext">
+    <classloaderContext/>
+    <jeeMetadataContext/>
+  </contextService>
+
+  <managedExecutorService id="executor1" jndiName="concurrent/executor1">
+    <concurrencyPolicy max="1" maxQueueSize="1"/>
+    <contextService>
+      <jeeMetadataContext/>
+    </contextService>
+  </managedExecutorService>
+
+  <!-- Do not use directly. Tests must only use this through its nested contextService. -->
+  <managedScheduledExecutorService id="executor2" jndiName="concurrent/executor2">
+    <concurrencyPolicy max="2" maxQueueSize="2"/>
+    <contextService jndiName="concurrent/context2">
+      <classloaderContext/>
+      <jeeMetadataContext/>
+    </contextService>
+  </managedScheduledExecutorService>
+
+  <managedScheduledExecutorService id="executor3" jndiName="concurrent/executor3" contextServiceRef="AppContext">
+    <concurrencyPolicy max="3" maxQueueSize="3"/>
+  </managedScheduledExecutorService>
+
+  <managedScheduledExecutorService id="executor4" jndiName="concurrent/executor4" contextServiceRef="AppContext">
+    <concurrencyPolicy max="4" maxQueueSize="4"/>
+  </managedScheduledExecutorService>
+
   <!-- needed by ForkJoinPool, which the test application uses -->
   <javaPermission codebase="${server.config.dir}/dropins/ConcurrencyTestApp.war" className="java.lang.RuntimePermission" name="modifyThread"/>
 

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestApp/src/test/jakarta/concurrency/web/ConcurrencyTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestApp/src/test/jakarta/concurrency/web/ConcurrencyTestServlet.java
@@ -12,15 +12,24 @@ package test.jakarta.concurrency.web;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinPool.ForkJoinWorkerThreadFactory;
 import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.annotation.Resource;
+import jakarta.enterprise.concurrent.ContextService;
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
 import jakarta.enterprise.concurrent.ManagedThreadFactory;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
@@ -39,8 +48,20 @@ public class ConcurrencyTestServlet extends FATServlet {
     // Maximum number of nanoseconds to wait for a task to finish.
     private static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
 
+    @Resource(lookup = "concurrent/context2")
+    ContextService contextSvc2;
+
     @Resource(name = "java:module/env/concurrent/threadFactoryRef")
     ManagedThreadFactory defaultThreadFactory;
+
+    @Resource(lookup = "concurrent/executor1")
+    ManagedExecutorService executor1;
+
+    @Resource(name = "java:comp/env/concurrent/executor3Ref", lookup = "concurrent/executor3")
+    ManagedExecutorService executor3;
+
+    @Resource(name = "java:global/env/concurrent/executor4Ref", lookup = "concurrent/executor4")
+    ManagedScheduledExecutorService executor4;
 
     // TODO @Resource(lookup = "java:comp/DefaultManagedThreadFactory")
     ForkJoinWorkerThreadFactory forkJoinThreadFactory;
@@ -62,6 +83,168 @@ public class ConcurrencyTestServlet extends FATServlet {
                 }
             }
         };
+    }
+
+    /**
+     * Verify that it is possible to obtain the nested ContextService of a ManagedExecutorService
+     * that is configured in server.xml, and that when withContextCapture is invoked on this ContextService,
+     * the resulting CompletableFuture is backed by the ManagedExecutorService, subject to its concurrency
+     * constraints, and runs tasks under the context propagation settings of its nested ContextService.
+     */
+    @Test
+    public void testGetContextService1WithContextCapture() throws Exception {
+        // TODO ContextService contextSvc = executor1.getContextService();
+        ContextService contextSvc = (ContextService) executor1.getClass().getMethod("getContextService").invoke(executor1);
+
+        CompletableFuture<String> stage1 = new CompletableFuture<String>();
+
+        // TODO CompletableFuture<String> stage1copy = contextSvc.withContextCapture(stage1);
+        CompletableFuture<String> stage1copy = (CompletableFuture<String>)
+                        contextSvc.getClass().getMethod("withContextCapture", CompletableFuture.class)
+                                             .invoke(contextSvc, stage1);
+
+        // block the managed executor's only thread
+        CountDownLatch blocker = new CountDownLatch(1);
+        CountDownLatch blocking = new CountDownLatch(1);
+        try {
+            CompletableFuture<Object> stage2a = stage1copy.thenApplyAsync(jndiName -> {
+                try {
+                    blocking.countDown();
+                    if (blocker.await(TIMEOUT_NS, TimeUnit.NANOSECONDS))
+                        return InitialContext.doLookup(jndiName);
+                    else
+                        return "timed out";
+                } catch (InterruptedException | NamingException x) {
+                    throw new CompletionException(x);
+                }
+            });
+            stage1.complete("java:comp/env/concurrent/executor3Ref");
+            assertTrue(blocking.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+            // fill the managed executor's only queue slot
+            CompletableFuture<Object> stage2b = stage1copy.thenApplyAsync(jndiName -> {
+                try {
+                    return InitialContext.doLookup(jndiName);
+                } catch (NamingException x) {
+                    throw new CompletionException(x);
+                }
+            });
+
+            // attempt to exceed the managed executor's maximum queue size
+            CompletableFuture<String> stage2c = stage1copy.thenApplyAsync(s -> s);
+            try {
+                String result = stage2c.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+                fail("Should not be able to queue another completion stage " + stage2c + ", with result: " + result);
+            } catch (ExecutionException x) {
+                if (x.getCause() instanceof RejectedExecutionException)
+                    ; // expected
+                else
+                    throw x;
+            }
+
+            blocker.countDown();
+
+            Object result;
+            assertNotNull(result = stage2a.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+            assertTrue(result.toString(), result instanceof ManagedScheduledExecutorService);
+
+            assertNotNull(result = stage2b.join());
+            assertTrue(result.toString(), result instanceof ManagedScheduledExecutorService);
+        } finally {
+            blocker.countDown();
+        }
+    }
+
+    /**
+     * Verify that it is possible to use nested ContextService without ever having obtained the
+     * managed executor that it is nested under, and that is possible to use the withContextCapture
+     * methods which create completion stages that are backed by that managed executor.
+     * Verify that the completion stages run on the managed executor, subject to its concurrency
+     * constraints, and runs tasks under the context propagation settings of its nested ContextService.
+     */
+    @Test
+    public void testNestedContextService2WithContextCapture() throws Exception {
+        CompletableFuture<String> stage1 = new CompletableFuture<String>();
+
+        // TODO CompletableFuture<String> stage1copy = contextSvc2.withContextCapture(stage1);
+        CompletableFuture<String> stage1copy = (CompletableFuture<String>)
+                        contextSvc2.getClass().getMethod("withContextCapture", CompletableFuture.class)
+                                              .invoke(contextSvc2, stage1);
+
+        // block the managed executor's 2 threads
+        CountDownLatch blocker = new CountDownLatch(1);
+        CountDownLatch blocking = new CountDownLatch(2);
+        try {
+            CompletableFuture<Object> stage2a = stage1copy.thenApplyAsync(jndiName -> {
+                try {
+                    blocking.countDown();
+                    if (blocker.await(TIMEOUT_NS, TimeUnit.NANOSECONDS))
+                        return InitialContext.doLookup(jndiName);
+                    else
+                        return "timed out";
+                } catch (InterruptedException | NamingException x) {
+                    throw new CompletionException(x);
+                }
+            });
+            CompletableFuture<Object> stage2b = stage1copy.thenApplyAsync(jndiName -> {
+                try {
+                    blocking.countDown();
+                    if (blocker.await(TIMEOUT_NS, TimeUnit.NANOSECONDS))
+                        return InitialContext.doLookup(jndiName);
+                    else
+                        return "timed out";
+                } catch (InterruptedException | NamingException x) {
+                    throw new CompletionException(x);
+                }
+            });
+            stage1.complete("java:comp/env/concurrent/executor3Ref");
+            assertTrue(blocking.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+            // fill the managed executor's 2 queue slots
+            CompletableFuture<Object> stage2c = stage1copy.thenApplyAsync(jndiName -> {
+                try {
+                    return InitialContext.doLookup(jndiName);
+                } catch (NamingException x) {
+                    throw new CompletionException(x);
+                }
+            });
+            CompletableFuture<Object> stage2d = stage1copy.thenApplyAsync(jndiName -> {
+                try {
+                    return InitialContext.doLookup(jndiName);
+                } catch (NamingException x) {
+                    throw new CompletionException(x);
+                }
+            });
+
+            // attempt to exceed the managed executor's maximum queue size
+            CompletableFuture<String> stage2e = stage1copy.thenApplyAsync(s -> s);
+            try {
+                String result = stage2e.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+                fail("Should not be able to queue another completion stage " + stage2e + ", with result: " + result);
+            } catch (ExecutionException x) {
+                if (x.getCause() instanceof RejectedExecutionException)
+                    ; // expected
+                else
+                    throw x;
+            }
+
+            blocker.countDown();
+
+            Object result;
+            assertNotNull(result = stage2a.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+            assertTrue(result.toString(), result instanceof ManagedScheduledExecutorService);
+
+            assertNotNull(result = stage2b.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+            assertTrue(result.toString(), result instanceof ManagedScheduledExecutorService);
+
+            assertNotNull(result = stage2c.join());
+            assertTrue(result.toString(), result instanceof ManagedScheduledExecutorService);
+
+            assertNotNull(result = stage2d.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+            assertTrue(result.toString(), result instanceof ManagedScheduledExecutorService);
+        } finally {
+            blocker.countDown();
+        }
     }
 
     /**


### PR DESCRIPTION
Concurrency 3.0 spec method getContextService and the corresponding withContextCapture behavior that it permits can be implemented based on the association between a managed executor and its nested context service for server config such as the following:

```
<managedExecutorService jndiName="concurrent/executor">
  <contextService ...
</managedExecutorService>
```

and similarly for managedScheduledExecutorService.

This pull implements for this sort of configuration, while leaving the solution for top-level contextService and resource definition annotations to other pulls.