### PR TITLE
fix NPE for tld file not found

### DIFF
--- a/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestEDR.war/resources/index.jsp
+++ b/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestEDR.war/resources/index.jsp
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@
         <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
         <title>TestEDR</title>
         <%@ taglib prefix="test" uri="/WEB-INF/tags/sampleTag.tld" %>
+        <!-- The following taglib is purposely a tld that does not exist.  For issue 18941 that fixes NPE. -->
+        <%@ taglib prefix="nf" uri="/WEB-INF/pluto/notplanet.tld" %>
     </head>
     <body>
         <p>This tests a JSP in the Extended Document Root.</p>

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/webcontainerext/JspDependent.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/webcontainerext/JspDependent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2004 IBM Corporation and others.
+ * Copyright (c) 1997, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -80,7 +80,7 @@ public class JspDependent {
                 }
                 // end 213703: add logging for isoutdated checks
             
-        } else {
+        } else if (dependentFilePath != null) {
             File dependentFile = new File(context.getRealPath(dependentFilePath));
             long ts = dependentFile.lastModified();
             if (ts == 0) {ts = getTimestamp();}
@@ -93,7 +93,12 @@ public class JspDependent {
     			}
     			// end 213703: add logging for isoutdated checks
             }
-        }                
+        } else {
+            // handle null dependentFilePath (means a referenced file doesn't exist)
+            if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINE)) {
+                logger.logp(Level.FINE, CLASS_NAME, "isOutdated", "dependentFilePath is null (check for earlier file not found message)"); 
+            }
+        }
         return outdated;                
     }
         


### PR DESCRIPTION
fixes #18941 
A taglib referencing a tld file that doesn't exist could cause a NullPointerException.