### PR TITLE
Update entity for isPartitioned field

### DIFF
--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/TopLevelStepInstanceEntity.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/TopLevelStepInstanceEntity.java
@@ -49,7 +49,7 @@ public class TopLevelStepInstanceEntity extends StepThreadInstanceEntity {
 	// This is meant to signify whether the step is partitioned or not.
 	// It is not meant, in contract, to say whether for a partitioned step, 
 	// this object represents the top-level or partition-level thread of the partitioned step.
-	@Column(name="PARTITIONED", nullable=false)
+	@Column(name="PARTITIONED")
 	private boolean isPartitionedStep;
 	
 	// Not a useful constructor from the "real" flow of creating a step execution for the first time,


### PR DESCRIPTION
Builds running all the test buckets:
https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.build.viewResult&id=_o75msCwhEeyF1bm_xnmrjA

https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.build.viewResult&id=_mCEYUCqsEeyF1bm_xnmrjA&tab=com.ibm.team.build.web.ui.internal.editors.result.overview.OverviewPage

Ignore the errors on this 2nd one, the normal and full fats ran fine. The errors are from an SOE DB2 run since the tooling is pointing to a non-existing system.

I ran the REST FATs from eclipse pointing to the new DB2 location and they passed.

Fixes #18662
