### PR TITLE
http2_fat updates

### DIFF
--- a/dev/com.ibm.ws.transport.http2_fat/publish/servers/com.ibm.ws.transport.http2.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.transport.http2_fat/publish/servers/com.ibm.ws.transport.http2.fat/bootstrap.properties
@@ -1,12 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=info=enabled:\
-HttpTransport=all:\
-HttpDispatcher=all:\
-TCPChannel=all:\
-channelframework=all:\
-HTTPChannel=all:\
-GenericBNF=all:\
-com.ibm.ws.app.manager=all:\
-com.ibm.ws.kernel.*=all
+com.ibm.ws.logging.trace.specification=*=info=enabled
 com.ibm.ws.logging.max.file.size=0
 
 ds.loglevel=debug

--- a/dev/com.ibm.ws.transport.http2_fat/publish/servers/http2ClientRuntime/bootstrap.properties
+++ b/dev/com.ibm.ws.transport.http2_fat/publish/servers/http2ClientRuntime/bootstrap.properties
@@ -1,12 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=info=enabled:\
-HttpTransport=all:\
-HttpDispatcher=all:\
-TCPChannel=all:\
-channelframework=all:\
-HTTPChannel=all:\
-GenericBNF=all:\
-com.ibm.ws.app.manager=all:\
-com.ibm.ws.kernel.*=all
+com.ibm.ws.logging.trace.specification=*=info=enabled
 com.ibm.ws.logging.max.file.size=0
 
 ds.loglevel=debug


### PR DESCRIPTION
* slim down http2_fat default trace spec - currently the trace file is unbounded and can get very large
* correct the exception processing in `MultiSessionTests` 