### PR TITLE
remove instramentation from packages with no source because it can ca…

### DIFF
--- a/dev/com.ibm.ws.org.jboss.weld/bnd.bnd
+++ b/dev/com.ibm.ws.org.jboss.weld/bnd.bnd
@@ -10,6 +10,10 @@
 #*******************************************************************************
 -include= jar:${fileuri;${repo;org.jboss.weld:weld-osgi-bundle;[2.4.8.Final,3)}}!/META-INF/MANIFEST.MF,bnd.overrides
 
+# Exclude this bundle from instrumentation (RAS & FFDC trace injection)
+instrument.disabled: true
+instrument.ffdc: false
+
 -buildpath: \
 	org.jboss.weld:weld-osgi-bundle;version=2.4.8.Final, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest

--- a/dev/com.ibm.ws.org.jboss.weld3/bnd.bnd
+++ b/dev/com.ibm.ws.org.jboss.weld3/bnd.bnd
@@ -10,6 +10,9 @@
 #*******************************************************************************
 -include= jar:${fileuri;${repo;org.jboss.weld:weld-osgi-bundle;[3.1.8.Final,3.2)}}!/META-INF/MANIFEST.MF,bnd.overrides
 
+# Exclude this bundle from instrumentation (RAS & FFDC trace injection)
+instrument.disabled: true
+instrument.ffdc: false
 
 -buildpath: \
 	org.jboss.weld:weld-osgi-bundle;version=3.1.8.Final, \


### PR DESCRIPTION
…use problems when code is back ported for an IFIX
