### PR TITLE
GrpcMetricsTest is not correct for sequential runs 

### DIFF
--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/GrpcMetricsTest.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/GrpcMetricsTest.java
@@ -56,7 +56,7 @@ public class GrpcMetricsTest extends FATServletClient {
     String clientContextRoot = "HelloWorldClient";
 
     // keep track of the number of client calls made, at the class level since the client server and app are never restarted
-    private static int clientCallCount = 0;
+    private static int clientCallCount;
 
     @Rule
     public TestName name = new TestName();
@@ -88,6 +88,7 @@ public class GrpcMetricsTest extends FATServletClient {
         GrpcClientOnly.useSecondaryHTTPPort();
         GrpcClientOnly.startServer(GrpcMetricsTest.class.getSimpleName() + ".client.log");
         GrpcServerOnly.startServer(GrpcMetricsTest.class.getSimpleName() + ".server.log");
+        clientCallCount = 0;
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/GrpcTestUtils.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/GrpcTestUtils.java
@@ -91,6 +91,7 @@ public class GrpcTestUtils {
                                                 Logger logger,
                                                 boolean skipValidation) throws Exception {
         logger.info("Entered set server config with xml " + serverXML);
+        server.setConfigUpdateTimeout(180 * 1000);
         if (originalServerXML == null || !originalServerXML.equals(serverXML)) {
             server.setMarkToEndOfLog();
             // Update server.xml


### PR DESCRIPTION
* reset `GrpcMetricsTest` counter between class invocations
* increase the app update timeout length for `grpc_fat` - I get occasional server update timeouts on my 2017 MBP. The default _local run_ timeout is 12s; I'll set it to the default value for _non-local runs_