### PR TITLE
When AuthStatus.SEND_SUCCESS is received, return without proceeding to service 

### DIFF
--- a/dev/com.ibm.ws.security.jaspic/src/com/ibm/ws/security/jaspi/JaspiServiceImpl.java
+++ b/dev/com.ibm.ws.security.jaspic/src/com/ibm/ws/security/jaspi/JaspiServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.jaspic/src/com/ibm/ws/security/jaspi/JaspiServiceImpl.java
+++ b/dev/com.ibm.ws.security.jaspic/src/com/ibm/ws/security/jaspi/JaspiServiceImpl.java
@@ -695,6 +695,7 @@ public class JaspiServiceImpl implements JaspiService, WebAuthenticator {
         AuthenticationResult authResult = null;
         String pretty = "FAILURE";
         if (AuthStatus.SEND_SUCCESS == status) {
+	    if (tc.isDebugEnabled()) Tr.debug(tc, "SEND_SUCCES received. Returning without going to the service."); 
             authResult = new AuthenticationResult(AuthResult.RETURN, clientSubject);
             pretty = "SEND_SUCCESS";
 	}

--- a/dev/com.ibm.ws.security.jaspic/src/com/ibm/ws/security/jaspi/JaspiServiceImpl.java
+++ b/dev/com.ibm.ws.security.jaspic/src/com/ibm/ws/security/jaspi/JaspiServiceImpl.java
@@ -414,7 +414,10 @@ public class JaspiServiceImpl implements JaspiService, WebAuthenticator {
     private AuthenticationResult processAuthStatus(Subject clientSubject, JaspiRequest jaspiRequest, AuthStatus status,
                                                    MessageInfo msgInfo, boolean isJSR375) throws WSLoginFailedException {
         AuthenticationResult authResult;
-        if (AuthStatus.SUCCESS == status || AuthStatus.SEND_SUCCESS == status) {
+        if (AuthStatus.SEND_SUCCESS == status) {
+	    AuthResult.RETURN;
+	}
+        if (AuthStatus.SUCCESS == status) {
             // if the provider asked that the subject be used on subsequent
             // invocations then indicate that in the request object. later we will
             // create an ltpa token cookie for the jaspi session
@@ -694,8 +697,10 @@ public class JaspiServiceImpl implements JaspiService, WebAuthenticator {
             Tr.entry(tc, "mapToAuthenticationResult", "AuthStatus=" + status);
         AuthenticationResult authResult = null;
         String pretty = "FAILURE";
+        if (AuthStatus.SEND_SUCCESS == status) {
+	    authResult = AuthResult.RETURN; 
+	}
         if (AuthStatus.SUCCESS == status || AuthStatus.SEND_SUCCESS == status) {
-
             authResult = new AuthenticationResult(AuthResult.SUCCESS, clientSubject);
             pretty = "SUCCESS";
 

--- a/dev/com.ibm.ws.security.jaspic/src/com/ibm/ws/security/jaspi/JaspiServiceImpl.java
+++ b/dev/com.ibm.ws.security.jaspic/src/com/ibm/ws/security/jaspi/JaspiServiceImpl.java
@@ -414,10 +414,7 @@ public class JaspiServiceImpl implements JaspiService, WebAuthenticator {
     private AuthenticationResult processAuthStatus(Subject clientSubject, JaspiRequest jaspiRequest, AuthStatus status,
                                                    MessageInfo msgInfo, boolean isJSR375) throws WSLoginFailedException {
         AuthenticationResult authResult;
-        if (AuthStatus.SEND_SUCCESS == status) {
-	    AuthResult.RETURN;
-	}
-        if (AuthStatus.SUCCESS == status) {
+        if (AuthStatus.SUCCESS == status || AuthStatus.SEND_SUCCESS == status) {
             // if the provider asked that the subject be used on subsequent
             // invocations then indicate that in the request object. later we will
             // create an ltpa token cookie for the jaspi session
@@ -698,9 +695,10 @@ public class JaspiServiceImpl implements JaspiService, WebAuthenticator {
         AuthenticationResult authResult = null;
         String pretty = "FAILURE";
         if (AuthStatus.SEND_SUCCESS == status) {
-	    authResult = AuthResult.RETURN; 
+            authResult = new AuthenticationResult(AuthResult.RETURN, clientSubject);
+            pretty = "SEND_SUCCESS";
 	}
-        if (AuthStatus.SUCCESS == status || AuthStatus.SEND_SUCCESS == status) {
+        if (AuthStatus.SUCCESS == status) {
             authResult = new AuthenticationResult(AuthResult.SUCCESS, clientSubject);
             pretty = "SUCCESS";
 

--- a/dev/com.ibm.ws.security.jaspic/src/com/ibm/ws/security/jaspi/JaspiServiceImpl.java
+++ b/dev/com.ibm.ws.security.jaspic/src/com/ibm/ws/security/jaspi/JaspiServiceImpl.java
@@ -414,7 +414,7 @@ public class JaspiServiceImpl implements JaspiService, WebAuthenticator {
     private AuthenticationResult processAuthStatus(Subject clientSubject, JaspiRequest jaspiRequest, AuthStatus status,
                                                    MessageInfo msgInfo, boolean isJSR375) throws WSLoginFailedException {
         AuthenticationResult authResult;
-        if (AuthStatus.SUCCESS == status || AuthStatus.SEND_SUCCESS == status) {
+        if (AuthStatus.SUCCESS == status) {
             // if the provider asked that the subject be used on subsequent
             // invocations then indicate that in the request object. later we will
             // create an ltpa token cookie for the jaspi session
@@ -456,7 +456,8 @@ public class JaspiServiceImpl implements JaspiService, WebAuthenticator {
             }
             authResult = mapToAuthenticationResult(status, jaspiRequest, callerSubject);
             setRequestAuthType(msgInfo, jaspiRequest);
-        } else {
+        } 
+	else {
             authResult = mapToAuthenticationResult(status, jaspiRequest, null);
         }
         return authResult;
@@ -696,8 +697,9 @@ public class JaspiServiceImpl implements JaspiService, WebAuthenticator {
         String pretty = "FAILURE";
         if (AuthStatus.SEND_SUCCESS == status) {
 	    if (tc.isDebugEnabled()) Tr.debug(tc, "SEND_SUCCES received. Returning without going to the service."); 
-            authResult = new AuthenticationResult(AuthResult.RETURN, clientSubject);
-            pretty = "SEND_SUCCESS";
+	    int responseStatus = getResponseStatus(jaspiRequest.getHttpServletResponse());
+	    authResult = new AuthenticationResult(AuthResult.RETURN, "Returning response from JASPIC Authenticated with status: " + responseStatus);
+	    pretty = "SEND_SUCCESS";
 	}
         if (AuthStatus.SUCCESS == status) {
             authResult = new AuthenticationResult(AuthResult.SUCCESS, clientSubject);


### PR DESCRIPTION
Differentiate the behavior of AuthStatus.SUCCESS from SEND_SUCCESS

This PR is to fix https://github.com/OpenLiberty/open-liberty/issues/18208

