### PR TITLE
update java2sec permission

### DIFF
--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/test-applications/samlwsstemplatesclient/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/test-applications/samlwsstemplatesclient/resources/META-INF/permissions.xml
@@ -43,4 +43,8 @@
    	   <name>suppressAccessChecks</name>
     </permission>
 	
+	<permission>
+       <class-name>javax.security.auth.AuthPermission</class-name>
+       <name>getSubject</name>
+    </permission>
 </permissions>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/test-applications/samlwsstemplatesclientwithep/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/test-applications/samlwsstemplatesclientwithep/resources/META-INF/permissions.xml
@@ -43,4 +43,8 @@
    	   <name>suppressAccessChecks</name>
     </permission>
  
+    <permission>
+       <class-name>javax.security.auth.AuthPermission</class-name>
+       <name>getSubject</name>
+    </permission>
 </permissions>


### PR DESCRIPTION
wsstemplates tests (CxfWssTemplatesTests*)already have this permision specified - 
javaPermission className="javax.security.auth.AuthPermission" name="getSubject" 

However, we are missing this in the similar tests that use saml (CxfSAMLWSSTemplatesWithExternalPolicy2ServerTests and CxfSAMLWSSTemplates*Tests)