### PR TITLE
Add missing Jakarta versions of API and SPI bundles

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.csiv2-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.csiv2-1.0.feature
@@ -4,8 +4,6 @@ IBM-Provision-Capability:\
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.ejbRemote-3.2))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.appSecurity-2.0)(osgi.identity=com.ibm.websphere.appserver.appSecurity-3.0)))"
 IBM-Install-Policy: when-satisfied
--features=com.ibm.websphere.appserver.transaction-1.2, \
-  com.ibm.websphere.appserver.security-1.0
 -bundles=\
   com.ibm.ws.security.csiv2.common, \
   com.ibm.ws.security.csiv2

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.webAppSecurity-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.webAppSecurity-2.0.feature
@@ -14,7 +14,7 @@ IBM-Install-Policy: when-satisfied
  com.ibm.ws.security.appbnd, \
  io.openliberty.security.authentication.internal.filter, \
  io.openliberty.security.sso.internal
--jars=com.ibm.websphere.appserver.api.webcontainer.security.app; location:=dev/api/ibm/
--files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.webcontainer.security.app_1.4-javadoc.zip
+-jars=io.openliberty.webcontainer.security.app; location:=dev/api/ibm/
+-files=dev/api/ibm/javadoc/io.openliberty.webcontainer.security.app_1.4-javadoc.zip
 kind=beta
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.security-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.security-1.0.feature
@@ -12,13 +12,13 @@ IBM-API-Package: com.ibm.wsspi.security.tai; type="ibm-api", \
   com.ibm.websphere.appserver.ssl-1.0, \
   com.ibm.websphere.appserver.securityInfrastructure-1.0, \
   com.ibm.websphere.appserver.ltpa-1.0, \
-  com.ibm.websphere.appserver.builtinAuthentication-1.0; ibm.tolerates:="2.0"
+  io.openliberty.security.internal.ee-6.0; ibm.tolerates:="9.0"
 -bundles=com.ibm.websphere.security.impl, \
  com.ibm.ws.management.security, \
  com.ibm.ws.security.quickstart
--jars=com.ibm.websphere.appserver.api.security; location:=dev/api/ibm/, \
+-jars= \
  com.ibm.websphere.appserver.api.security.spnego; location:=dev/api/ibm/
--files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.security_1.3-javadoc.zip, \
+-files= \
  dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.security.spnego_1.1-javadoc.zip
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.appSecurityClient1.0.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.appSecurityClient1.0.internal.ee-9.0.feature
@@ -6,5 +6,7 @@ visibility = private
   io.openliberty.servlet.api-5.0
 -bundles=\
   io.openliberty.security.jaas.internal.common
+-jars=io.openliberty.securityClient; location:=dev/api/ibm/
+-files=dev/api/ibm/javadoc/io.openliberty.securityClient_1.1-javadoc.zip
 kind=beta
 edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.restHandler1.0.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.restHandler1.0.internal.ee-9.0.feature
@@ -5,7 +5,8 @@ singleton=true
 visibility = private
 
 -features=\
-  com.ibm.websphere.appserver.servlet-5.0
+  com.ibm.websphere.appserver.servlet-5.0, \
+  io.openliberty.securityAPI.jakarta-1.0
 
 -bundles= com.ibm.ws.rest.handler.jakarta
 

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.security.internal.ee-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.security.internal.ee-6.0.feature
@@ -1,0 +1,11 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.security.internal.ee-6.0
+WLP-DisableAllFeatures-OnConflict: false
+visibility=private
+singleton=true
+-features= \
+  io.openliberty.servlet.api-3.0; apiJar=false; ibm.tolerates:="3.1,4.0", \
+  com.ibm.websphere.appserver.builtinAuthentication-1.0, \
+  io.openliberty.securityAPI.javaee-1.0
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.security.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.security.internal.ee-9.0.feature
@@ -1,0 +1,10 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.security.internal.ee-9.0
+visibility=private
+singleton=true
+-features= \
+  io.openliberty.servlet.api-5.0; apiJar=false, \
+  com.ibm.websphere.appserver.builtinAuthentication-2.0, \
+  io.openliberty.securityAPI.jakarta-1.0
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.securityAPI.jakarta-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.securityAPI.jakarta-1.0.feature
@@ -1,0 +1,8 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.securityAPI.jakarta-1.0
+visibility=private
+-jars=io.openliberty.security; location:=dev/api/ibm/
+-files=dev/api/ibm/javadoc/io.openliberty.security_1.3-javadoc.zip
+kind=beta
+edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.securityAPI.javaee-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.securityAPI.javaee-1.0.feature
@@ -1,0 +1,9 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.securityAPI.javaee-1.0
+WLP-DisableAllFeatures-OnConflict: false
+visibility=private
+-jars=com.ibm.websphere.appserver.api.security; location:=dev/api/ibm/
+-files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.security_1.3-javadoc.zip
+kind=ga
+edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.servlet-servletSpi2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.servlet-servletSpi2.0.feature
@@ -1,0 +1,8 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.servlet-servletSpi2.0
+visibility=private
+-jars=io.openliberty.servlet.spi; location:=dev/spi/ibm/
+-files=dev/spi/ibm/javadoc/io.openliberty.servlet.spi_2.9-javadoc.zip
+kind=beta
+edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webBundleSecurity1.0.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webBundleSecurity1.0.internal.ee-9.0.feature
@@ -5,7 +5,8 @@ singleton=true
 visibility = private
 
 -features=\
-  com.ibm.websphere.appserver.servlet-5.0
+  com.ibm.websphere.appserver.servlet-5.0, \
+  io.openliberty.securityAPI.jakarta-1.0
 
 -bundles= io.openliberty.webcontainer.security.internal; start-phase:=SERVICE_EARLY, \
           io.openliberty.security.authentication.internal.filter, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webCache1.0.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webCache1.0.internal.ee-9.0.feature
@@ -7,5 +7,7 @@ visibility=private
   io.openliberty.pages-3.0
 -bundles=com.ibm.ws.dynacache.web.jakarta, \
   com.ibm.ws.dynacache.web.servlet31.jakarta
+-jars=io.openliberty.webCache; location:=dev/api/ibm/
+-files=dev/api/ibm/javadoc/io.openliberty.webCache_1.1-javadoc.zip
 kind=beta
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wimcore.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wimcore.internal.ee-9.0.feature
@@ -8,5 +8,7 @@ visibility = private
   com.ibm.websphere.appserver.eeCompatible-9.0
 -bundles=\
   io.openliberty.security.wim.internal.base
+-jars=io.openliberty.federatedRepository.spi; location:=dev/spi/ibm/
+-files=dev/spi/ibm/javadoc/io.openliberty.federatedRepository.spi_1.2-javadoc.zip
 kind=beta
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wsAtomicTransaction1.2.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wsAtomicTransaction1.2.internal.ee-9.0.feature
@@ -10,5 +10,7 @@ visibility = private
   com.ibm.ws.wsat.cxf.utils.3.2.jakarta, \
   com.ibm.ws.wsat.webclient.3.2.jakarta, \
   com.ibm.ws.wsat.webservice.3.2.jakarta
+-jars=io.openliberty.wsat.spi; location:=dev/spi/ibm/
+-files=dev/spi/ibm/javadoc/io.openliberty.wsat.spi_1.0-javadoc.zip
 kind=beta
 edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.restHandler-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.restHandler-1.0.feature
@@ -12,6 +12,7 @@ IBM-SPI-Package: com.ibm.wsspi.rest.handler; type="ibm-spi", \
   com.ibm.websphere.appserver.ssl-1.0, \
   com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0", \
   com.ibm.websphere.appserver.adminSecurity-1.0; ibm.tolerates:="2.0", \
+  io.openliberty.securityAPI.javaee-1.0, \
   io.openliberty.restHandler1.0.internal.ee-6.0; ibm.tolerates:="9.0", \
   com.ibm.websphere.appserver.httptransport-1.0
 -bundles=com.ibm.ws.org.joda.time.1.6.2, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.wsspi.appserver.webBundleSecurity-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.wsspi.appserver.webBundleSecurity-1.0.feature
@@ -7,6 +7,7 @@ visibility=protected
   com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0", \
   com.ibm.websphere.appserver.distributedMap-1.0, \
   com.ibm.websphere.appserver.security-1.0, \
+  io.openliberty.securityAPI.javaee-1.0, \
   com.ibm.websphere.appserver.authFilter-1.0, \
   io.openliberty.webBundleSecurity1.0.internal.ee-6.0; ibm.tolerates:="9.0"
 -bundles=com.ibm.websphere.security, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-2.0/com.ibm.websphere.appserver.appSecurity-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-2.0/com.ibm.websphere.appserver.appSecurity-2.0.feature
@@ -5,7 +5,8 @@ visibility=public
 IBM-ShortName: appSecurity-2.0
 Subsystem-Name: Application Security 2.0
 -features=com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0,8.0", \
-  com.ibm.websphere.appserver.security-1.0
+  com.ibm.websphere.appserver.security-1.0, \
+  io.openliberty.securityAPI.javaee-1.0
 -bundles=com.ibm.ws.security.authentication.tai
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-3.0/com.ibm.websphere.appserver.appSecurity-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-3.0/com.ibm.websphere.appserver.appSecurity-3.0.feature
@@ -17,7 +17,8 @@ Subsystem-Name: Application Security 3.0
   com.ibm.websphere.appserver.eeCompatible-8.0, \
   com.ibm.websphere.appserver.el-3.0, \
   com.ibm.websphere.appserver.cdi-2.0, \
-  com.ibm.websphere.appserver.security-1.0
+  com.ibm.websphere.appserver.security-1.0, \
+  io.openliberty.securityAPI.javaee-1.0
 -bundles=com.ibm.websphere.javaee.security.1.0; location:=dev/api/spec/; mavenCoordinates="javax.security.enterprise:javax.security.enterprise-api:1.0", \
  com.ibm.ws.security.javaeesec.1.0, \
  com.ibm.ws.security.javaeesec.cdi, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-4.0/io.openliberty.appSecurity-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-4.0/io.openliberty.appSecurity-4.0.feature
@@ -17,6 +17,7 @@ Subsystem-Name: Application Security 4.0 (Jakarta Security 2.0)
   com.ibm.websphere.appserver.servlet-5.0, \
   com.ibm.websphere.appserver.eeCompatible-9.0, \
   com.ibm.websphere.appserver.security-1.0, \
+  io.openliberty.securityAPI.jakarta-1.0, \
   io.openliberty.jakarta.security.enterprise-2.0, \
   io.openliberty.expressionLanguage-4.0
 -bundles=\

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/connectorsInboundSecurity-2.0/io.openliberty.connectorsInboundSecurity-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/connectorsInboundSecurity-2.0/io.openliberty.connectorsInboundSecurity-2.0.feature
@@ -9,6 +9,7 @@ Subsystem-Name: Jakarta Connectors 2.0 Inbound Security
   com.ibm.websphere.appserver.eeCompatible-9.0, \
   io.openliberty.connectors-2.0, \
   com.ibm.websphere.appserver.security-1.0, \
+  io.openliberty.securityAPI.jakarta-1.0, \
   com.ibm.websphere.appserver.transaction-2.0
 -bundles=\
    io.openliberty.connectors.security.internal.inbound

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jcaInboundSecurity-1.0/com.ibm.websphere.appserver.jcaInboundSecurity-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jcaInboundSecurity-1.0/com.ibm.websphere.appserver.jcaInboundSecurity-1.0.feature
@@ -8,6 +8,7 @@ Subsystem-Name: Java Connector Architecture Security Inflow 1.0
 -features=com.ibm.websphere.appserver.jca-1.6; ibm.tolerates:="1.7", \
   com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0,8.0", \
   com.ibm.websphere.appserver.security-1.0, \
+  io.openliberty.securityAPI.javaee-1.0, \
   com.ibm.websphere.appserver.transaction-1.1; ibm.tolerates:="1.2"
 -bundles=\
    com.ibm.ws.jca.inbound.security, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/messagingSecurity-3.0/io.openliberty.messagingSecurity-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/messagingSecurity-3.0/io.openliberty.messagingSecurity-3.0.feature
@@ -7,6 +7,7 @@ Subsystem-Name: Messaging Server 3.0 Security
 -features=com.ibm.websphere.appserver.eeCompatible-9.0, \
   io.openliberty.messagingServer-3.0, \
   com.ibm.websphere.appserver.security-1.0, \
+  io.openliberty.securityAPI.jakarta-1.0, \
   com.ibm.websphere.appserver.transaction-2.0
 -bundles=com.ibm.ws.messaging.utils, \
  com.ibm.ws.messaging.security, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-4.0/io.openliberty.mpMetrics-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-4.0/io.openliberty.mpMetrics-4.0.feature
@@ -8,7 +8,6 @@ IBM-ShortName: mpMetrics-4.0
 Subsystem-Name: MicroProfile Metrics 4.0
 -features=com.ibm.websphere.appserver.restHandler-1.0, \
   io.openliberty.mpConfig-3.0, \
-  com.ibm.websphere.appserver.adminSecurity-2.0, \
   io.openliberty.jakarta.annotation-2.0, \
   com.ibm.websphere.appserver.servlet-5.0, \
   io.openliberty.mpCompatible-5.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/openapi-3.1/com.ibm.websphere.appserver.openapi-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/openapi-3.1/com.ibm.websphere.appserver.openapi-3.1.feature
@@ -12,6 +12,7 @@ Subsystem-Name: OpenAPI 3.1
 -features=com.ibm.wsspi.appserver.webBundle-1.0, \
   com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
   com.ibm.websphere.appserver.adminSecurity-1.0, \
+  io.openliberty.securityAPI.javaee-1.0, \
   com.ibm.websphere.appserver.mpOpenAPI-1.0, \
   com.ibm.websphere.appserver.jaxrs-2.0; ibm.tolerates:="2.1"
 

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/servlet-5.0/com.ibm.websphere.appserver.servlet-5.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/servlet-5.0/com.ibm.websphere.appserver.servlet-5.0.feature
@@ -39,7 +39,7 @@ Subsystem-Category: JakartaEE9Application
   com.ibm.websphere.appserver.containerServices-1.0, \
   com.ibm.websphere.appserver.classloading-1.0, \
   com.ibm.websphere.appserver.injection-2.0, \
-  com.ibm.websphere.appserver.servlet-servletSpi1.0, \
+  io.openliberty.servlet-servletSpi2.0, \
   com.ibm.websphere.appserver.httptransport-1.0, \
   com.ibm.websphere.appserver.javaeedd-1.0, \
   com.ibm.websphere.appserver.appmanager-1.0, \
@@ -63,11 +63,11 @@ Subsystem-Category: JakartaEE9Application
  com.ibm.ws.webserver.plugin.runtime.jakarta, \
  com.ibm.ws.webserver.plugin.runtime.interfaces
 -jars=com.ibm.ws.webserver.plugin.utility, \
- com.ibm.websphere.appserver.api.servlet; location:=dev/api/ibm/
+ io.openliberty.servlet; location:=dev/api/ibm/
 -files=bin/tools/ws-webserverPluginutil.jar, \
  bin/pluginUtility; ibm.executable:=true; ibm.file.encoding:=ebcdic, \
  bin/pluginUtility.bat, \
- dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.servlet_1.1-javadoc.zip
+ dev/api/ibm/javadoc/io.openliberty.servlet_1.1-javadoc.zip
 Subsystem-Name: Jakarta Servlet 5.0
 kind=beta
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/wasJmsSecurity-1.0/com.ibm.websphere.appserver.wasJmsSecurity-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/wasJmsSecurity-1.0/com.ibm.websphere.appserver.wasJmsSecurity-1.0.feature
@@ -8,6 +8,7 @@ Subsystem-Name: Message Server Security 1.0
   com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0, 8.0", \
   com.ibm.websphere.appserver.wasJmsServer-1.0, \
   com.ibm.websphere.appserver.security-1.0, \
+  io.openliberty.securityAPI.javaee-1.0, \
   com.ibm.websphere.appserver.transaction-1.1; ibm.tolerates:="1.2"
 -bundles=\
   com.ibm.ws.messaging.utils, \

--- a/dev/io.openliberty.federatedRepository.spi/.classpath
+++ b/dev/io.openliberty.federatedRepository.spi/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.federatedRepository.spi/.gitignore
+++ b/dev/io.openliberty.federatedRepository.spi/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+/build/
+/generated/

--- a/dev/io.openliberty.federatedRepository.spi/.project
+++ b/dev/io.openliberty.federatedRepository.spi/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.federatedRepository.spi</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.federatedRepository.spi/.settings/bndtools.core.prefs
+++ b/dev/io.openliberty.federatedRepository.spi/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.federatedRepository.spi/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/io.openliberty.federatedRepository.spi/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/io.openliberty.federatedRepository.spi/bnd.bnd
+++ b/dev/io.openliberty.federatedRepository.spi/bnd.bnd
@@ -1,0 +1,36 @@
+#*******************************************************************************
+# Copyright (c) 2017, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion: 1.2
+
+Bundle-Name: Federated Repository Interface SPI
+Bundle-Description: Federated Repository Interface SPI, version ${bVersion}; Jakarta enabled
+Bundle-SymbolicName: io.openliberty.federatedRepository.spi.javaee
+
+-pom: artifactid=io.openliberty.federatedRepository.spi
+
+jakartaeeMe: true
+jakartaFinalJarName: io.openliberty.federatedRepository.spi.jakarta.jar
+jakartaFinalBundleId: io.openliberty.federatedRepository.spi
+
+# Only publish the Jakarta one
+publish.wlp.jar.include: io.openliberty.federatedRepository.spi.jakarta.jar
+
+Import-Package: com.ibm.wsspi.security.wim,com.ibm.wsspi.security.wim.exception,com.ibm.wsspi.security.wim.model
+
+Export-Package: com.ibm.wsspi.security.wim,com.ibm.wsspi.security.wim.exception,com.ibm.wsspi.security.wim.model
+
+-includeresource: {META-INF/maven/io.openliberty.spi/io.openliberty.federatedRepository.spi/pom.xml=io.openliberty.federatedRepository.spi.pom}
+
+publish.wlp.jar.suffix: dev/spi/ibm
+
+-buildpath: \
+	com.ibm.websphere.security.wim.base

--- a/dev/io.openliberty.federatedRepository.spi/io.openliberty.federatedRepository.spi.pom
+++ b/dev/io.openliberty.federatedRepository.spi/io.openliberty.federatedRepository.spi.pom
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <licenses>
+    <license>
+      <name>Eclipse Public License</name>
+      <url>https://www.eclipse.org/legal/epl-v10.html</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.openliberty.spi</groupId>
+  <artifactId>io.openliberty.federatedRepository.spi</artifactId>
+  <version>${bFullVersion}</version>
+  <name>Federated Repository Interface SPI</name>
+  <description>Federated Repository Interface SPI, version 1.2; Jakarta enabled</description>
+</project>

--- a/dev/io.openliberty.security/.classpath
+++ b/dev/io.openliberty.security/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.security/.gitignore
+++ b/dev/io.openliberty.security/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+/build/
+/generated/

--- a/dev/io.openliberty.security/.project
+++ b/dev/io.openliberty.security/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.security</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.security/.settings/bndtools.core.prefs
+++ b/dev/io.openliberty.security/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.security/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/io.openliberty.security/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/io.openliberty.security/bnd.bnd
+++ b/dev/io.openliberty.security/bnd.bnd
@@ -1,0 +1,40 @@
+#*******************************************************************************
+# Copyright (c) 2017, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion: 1.3
+
+Bundle-Name: Liberty Security API
+Bundle-Description: Liberty Security API, version ${bVersion}; Jakarta enabled
+Bundle-SymbolicName: io.openliberty.security.javaee
+
+-pom: artifactid=io.openliberty.security
+
+jakartaeeMe: true
+jakartaFinalJarName: io.openliberty.security.jar
+jakartaFinalBundleId: io.openliberty.security
+
+# Only publish the Jakarta one
+publish.wlp.jar.include: io.openliberty.security.jar
+
+Import-Package: com.ibm.websphere.security.auth.callback,com.ibm.wsspi.security.auth.callback,com.ibm.wsspi.security.common.auth.module,com.ibm.wsspi.security.tai,com.ibm.wsspi.security.token
+
+Export-Package: com.ibm.websphere.security.auth.callback,com.ibm.wsspi.security.auth.callback,com.ibm.wsspi.security.common.auth.module,com.ibm.wsspi.security.tai,com.ibm.wsspi.security.token
+
+-includeresource: {META-INF/maven/io.openliberty.api/io.openliberty.security/pom.xml=io.openliberty.security.pom}
+
+publish.wlp.jar.suffix: dev/api/ibm
+
+-buildpath: \
+	com.ibm.ws.security;version=latest, \
+	com.ibm.ws.security.authentication.builtin;version=latest, \
+	com.ibm.ws.security.jaas.common;version=latest, \
+	com.ibm.ws.security.authentication.tai;version=latest, \
+	com.ibm.ws.security.token;version=latest

--- a/dev/io.openliberty.security/io.openliberty.security.pom
+++ b/dev/io.openliberty.security/io.openliberty.security.pom
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <licenses>
+    <license>
+      <name>Eclipse Public License</name>
+      <url>https://www.eclipse.org/legal/epl-v10.html</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.openliberty.api</groupId>
+  <artifactId>io.openliberty.security</artifactId>
+  <version>${bFullVersion}</version>
+  <name>Liberty Security API</name>
+  <description>Liberty Security API, version 1.3; Jakarta enabled</description>
+</project>

--- a/dev/io.openliberty.securityClient/.classpath
+++ b/dev/io.openliberty.securityClient/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.securityClient/.gitignore
+++ b/dev/io.openliberty.securityClient/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+/build/
+/generated/

--- a/dev/io.openliberty.securityClient/.project
+++ b/dev/io.openliberty.securityClient/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.securityClient</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.securityClient/.settings/bndtools.core.prefs
+++ b/dev/io.openliberty.securityClient/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.securityClient/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/io.openliberty.securityClient/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/io.openliberty.securityClient/bnd.bnd
+++ b/dev/io.openliberty.securityClient/bnd.bnd
@@ -1,0 +1,37 @@
+#*******************************************************************************
+# Copyright (c) 2017, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion: 1.1
+
+Bundle-Name: Liberty Security Client API
+Bundle-Description: Liberty Security Client API, version ${bVersion}; Jakarta enabled
+Bundle-SymbolicName: io.openliberty.securityClient.javaee
+
+-pom: artifactid=io.openliberty.securityClient
+
+jakartaeeMe: true
+jakartaFinalJarName: io.openliberty.securityClient.jakarta.jar
+jakartaFinalBundleId: io.openliberty.securityClient
+
+# Only publish the Jakarta one
+publish.wlp.jar.include: io.openliberty.securityClient.jakarta.jar
+
+Import-Package: com.ibm.websphere.security,com.ibm.websphere.security.auth.callback,com.ibm.wsspi.security.auth.callback
+
+Export-Package: com.ibm.websphere.security,com.ibm.websphere.security.auth.callback,com.ibm.wsspi.security.auth.callback
+
+-includeresource: {META-INF/maven/io.openliberty.api/io.openliberty.securityClient/pom.xml=io.openliberty.securityClient.pom}
+
+publish.wlp.jar.suffix: dev/api/ibm
+
+-buildpath: \
+	com.ibm.websphere.security, \
+	com.ibm.ws.security.jaas.common

--- a/dev/io.openliberty.securityClient/io.openliberty.securityClient.pom
+++ b/dev/io.openliberty.securityClient/io.openliberty.securityClient.pom
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <licenses>
+    <license>
+      <name>Eclipse Public License</name>
+      <url>https://www.eclipse.org/legal/epl-v10.html</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.openliberty.api</groupId>
+  <artifactId>io.openliberty.securityClient</artifactId>
+  <version>${bFullVersion}</version>
+  <name>Liberty Security Client API</name>
+  <description>Liberty Security Client API, version 1.1; Jakarta enabled</description>
+</project>

--- a/dev/io.openliberty.servlet.spi/.classpath
+++ b/dev/io.openliberty.servlet.spi/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.servlet.spi/.gitignore
+++ b/dev/io.openliberty.servlet.spi/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+/build/
+/generated/

--- a/dev/io.openliberty.servlet.spi/.project
+++ b/dev/io.openliberty.servlet.spi/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.servlet.spi</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.servlet.spi/.settings/bndtools.core.prefs
+++ b/dev/io.openliberty.servlet.spi/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.servlet.spi/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/io.openliberty.servlet.spi/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/io.openliberty.servlet.spi/bnd.bnd
+++ b/dev/io.openliberty.servlet.spi/bnd.bnd
@@ -1,0 +1,49 @@
+#*******************************************************************************
+# Copyright (c) 2017, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion: 2.9
+
+Bundle-Name: WebSphere WebContainer Servlet SPI
+Bundle-Description: WebSphere WebContainer Servlet SPI, version ${bVersion}
+Bundle-SymbolicName: io.openliberty.servlet.spi.javaee
+
+-pom: artifactid=io.openliberty.servlet.spi
+
+jakartaeeMe: true
+jakartaFinalJarName: io.openliberty.servlet.spi.jar
+jakartaFinalBundleId: io.openliberty.servlet.spi
+
+# Only publish the Jakarta one
+publish.wlp.jar.include: io.openliberty.servlet.spi.jar
+
+Import-Package: com.ibm.wsspi.webcontainer.extension,com.ibm.wsspi.webcontainer.webapp,com.ibm.wsspi.webcontainer.filter,com.ibm.wsspi.webcontainer.collaborator,com.ibm.wsspi.webcontainer.osgi.extension,com.ibm.wsspi.webcontainer.servlet,com.ibm.ws.webcontainer.extension,com.ibm.websphere.servlet.filter,com.ibm.wsspi.webcontainer,com.ibm.wsspi.webcontainer.metadata,com.ibm.websphere.servlet.response,com.ibm.ws.webcontainer.spiadapter.collaborator
+
+Export-Package: com.ibm.wsspi.webcontainer.extension, \
+ com.ibm.wsspi.webcontainer.webapp, \
+ com.ibm.wsspi.webcontainer.filter, \
+ com.ibm.wsspi.webcontainer.collaborator, \
+ com.ibm.wsspi.webcontainer.osgi.extension, \
+ com.ibm.wsspi.webcontainer.servlet, \
+ com.ibm.ws.webcontainer.extension;version=2.0, \
+ com.ibm.websphere.servlet.filter, \
+ com.ibm.wsspi.webcontainer, \
+ com.ibm.wsspi.webcontainer.metadata, \
+ com.ibm.websphere.servlet.response, \
+ com.ibm.ws.webcontainer.spiadapter.collaborator, \
+ com.ibm.websphere.servlet.request, \
+ com.ibm.websphere.webcontainer.async
+
+-includeresource: {META-INF/maven/io.openliberty.spi/io.openliberty.servlet.spi/pom.xml=io.openliberty.servlet.spi.pom}
+
+publish.wlp.jar.suffix: dev/spi/ibm
+
+-buildpath: \
+	com.ibm.ws.webcontainer

--- a/dev/io.openliberty.servlet.spi/io.openliberty.servlet.spi.pom
+++ b/dev/io.openliberty.servlet.spi/io.openliberty.servlet.spi.pom
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <licenses>
+    <license>
+      <name>Eclipse Public License</name>
+      <url>https://www.eclipse.org/legal/epl-v10.html</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.openliberty.spi</groupId>
+  <artifactId>io.openliberty.servlet.spi</artifactId>
+  <version>${bFullVersion}</version>
+  <name>Liberty WebContainer Servlet SPI</name>
+  <description>Liberty WebContainer Servlet SPI, version 2.9; Jakarta enabled</description>
+</project>

--- a/dev/io.openliberty.servlet/.classpath
+++ b/dev/io.openliberty.servlet/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.servlet/.gitignore
+++ b/dev/io.openliberty.servlet/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+/build/
+/generated/

--- a/dev/io.openliberty.servlet/.project
+++ b/dev/io.openliberty.servlet/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.servlet</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.servlet/.settings/bndtools.core.prefs
+++ b/dev/io.openliberty.servlet/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.servlet/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/io.openliberty.servlet/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/io.openliberty.servlet/bnd.bnd
+++ b/dev/io.openliberty.servlet/bnd.bnd
@@ -1,0 +1,37 @@
+#*******************************************************************************
+# Copyright (c) 2017, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion: 1.1
+
+Bundle-Name: Liberty WebContainer Servlet API
+Bundle-Description: Liberty WebContainer Servlet API, version ${bVersion}; Jakarta enabled
+Bundle-SymbolicName: io.openliberty.servlet.javaee
+
+-pom: artifactid=io.openliberty.servlet
+
+jakartaeeMe: true
+jakartaFinalJarName: io.openliberty.servlet.jar
+jakartaFinalBundleId: io.openliberty.servlet
+
+# Only publish the Jakarta one
+publish.wlp.jar.include: io.openliberty.servlet.jar
+
+Import-Package: com.ibm.websphere.servlet.container,com.ibm.websphere.servlet.context,com.ibm.websphere.servlet.error,com.ibm.websphere.servlet.event,com.ibm.websphere.servlet.session,com.ibm.websphere.webcontainer,com.ibm.wsspi.servlet.session
+
+Export-Package: com.ibm.websphere.servlet.container,com.ibm.websphere.servlet.context,com.ibm.websphere.servlet.error,com.ibm.websphere.servlet.event,com.ibm.websphere.servlet.session,com.ibm.websphere.webcontainer,com.ibm.wsspi.servlet.session
+
+-includeresource: {META-INF/maven/io.openliberty.api/io.openliberty.servlet/pom.xml=io.openliberty.servlet.pom}
+
+publish.wlp.jar.suffix: dev/api/ibm
+
+-buildpath: \
+	com.ibm.ws.webcontainer;version=latest, \
+	com.ibm.ws.session;version=latest

--- a/dev/io.openliberty.servlet/io.openliberty.servlet.pom
+++ b/dev/io.openliberty.servlet/io.openliberty.servlet.pom
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <licenses>
+    <license>
+      <name>Eclipse Public License</name>
+      <url>https://www.eclipse.org/legal/epl-v10.html</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.openliberty.api</groupId>
+  <artifactId>io.openliberty.servlet</artifactId>
+  <version>${bFullVersion}</version>
+  <name>Liberty WebContainer Servlet API</name>
+  <description>Liberty WebContainer Servlet API, version 1.1; Jakarta enabled</description>
+</project>

--- a/dev/io.openliberty.webCache/.classpath
+++ b/dev/io.openliberty.webCache/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.webCache/.gitignore
+++ b/dev/io.openliberty.webCache/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/generated/

--- a/dev/io.openliberty.webCache/.project
+++ b/dev/io.openliberty.webCache/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.webCache</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.webCache/.settings/bndtools.core.prefs
+++ b/dev/io.openliberty.webCache/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.webCache/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/io.openliberty.webCache/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/io.openliberty.webCache/bnd.bnd
+++ b/dev/io.openliberty.webCache/bnd.bnd
@@ -1,0 +1,36 @@
+#*******************************************************************************
+# Copyright (c) 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion: 1.1
+
+Bundle-Name: Liberty Web Cache API
+Bundle-Description: Liberty Web Cache API, version ${bVersion}; Jakarta enabled
+Bundle-SymbolicName: io.openliberty.webCache.javaee
+
+-pom: artifactid=io.openliberty.webCache
+
+jakartaeeMe: true
+jakartaFinalJarName: io.openliberty.webCache.jakarta.jar
+jakartaFinalBundleId: io.openliberty.webCache
+
+# Only publish the Jakarta one
+publish.wlp.jar.include: io.openliberty.webCache.jakarta.jar
+
+Import-Package: com.ibm.websphere.command,com.ibm.websphere.command.web,com.ibm.websphere.servlet.cache
+
+Export-Package: com.ibm.websphere.command,com.ibm.websphere.command.web,com.ibm.websphere.servlet.cache
+
+-includeresource: {META-INF/maven/io.openliberty.api/io.openliberty.webCache/pom.xml=io.openliberty.webCache.pom}
+
+publish.wlp.jar.suffix: dev/api/ibm
+
+-buildpath: \
+	com.ibm.ws.dynacache.web

--- a/dev/io.openliberty.webCache/io.openliberty.webCache.pom
+++ b/dev/io.openliberty.webCache/io.openliberty.webCache.pom
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <licenses>
+    <license>
+      <name>Eclipse Public License</name>
+      <url>https://www.eclipse.org/legal/epl-v10.html</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.openliberty.api</groupId>
+  <artifactId>io.openliberty.webCache</artifactId>
+  <version>${bFullVersion}</version>
+  <name>Liberty Web Cache API</name>
+  <description>Liberty Web Cache API, version 1.1; Jakarta enabled</description>
+</project>

--- a/dev/io.openliberty.webcontainer.security.app/.classpath
+++ b/dev/io.openliberty.webcontainer.security.app/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.webcontainer.security.app/.gitignore
+++ b/dev/io.openliberty.webcontainer.security.app/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+/build/
+/generated/

--- a/dev/io.openliberty.webcontainer.security.app/.project
+++ b/dev/io.openliberty.webcontainer.security.app/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.webcontainer.security.app</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.webcontainer.security.app/.settings/bndtools.core.prefs
+++ b/dev/io.openliberty.webcontainer.security.app/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.webcontainer.security.app/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/io.openliberty.webcontainer.security.app/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/io.openliberty.webcontainer.security.app/bnd.bnd
+++ b/dev/io.openliberty.webcontainer.security.app/bnd.bnd
@@ -1,0 +1,36 @@
+#*******************************************************************************
+# Copyright (c) 2017, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion: 1.4
+
+Bundle-Name: WebSphere WebContainer Application Security API
+Bundle-Description: WebSphere WebContainer Application Security API, version ${bVersion}
+Bundle-SymbolicName: io.openliberty.webcontainer.security.app.javaee
+
+-pom: artifactid=io.openliberty.webcontainer.security.app
+
+jakartaeeMe: true
+jakartaFinalJarName: io.openliberty.webcontainer.security.app.jar
+jakartaFinalBundleId: io.openliberty.webcontainer.security.app
+
+# Only publish the Jakarta one
+publish.wlp.jar.include: io.openliberty.webcontainer.security.app.jar
+
+Import-Package: com.ibm.websphere.security.web
+
+Export-Package: com.ibm.websphere.security.web
+
+-includeresource: {META-INF/maven/io.openliberty.api/io.openliberty.webcontainer.security.app/pom.xml=io.openliberty.webcontainer.security.app.pom}
+
+publish.wlp.jar.suffix: dev/api/ibm
+
+-buildpath: \
+	com.ibm.ws.webcontainer.security

--- a/dev/io.openliberty.webcontainer.security.app/io.openliberty.webcontainer.security.app.pom
+++ b/dev/io.openliberty.webcontainer.security.app/io.openliberty.webcontainer.security.app.pom
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <licenses>
+    <license>
+      <name>Eclipse Public License</name>
+      <url>https://www.eclipse.org/legal/epl-v10.html</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.openliberty.api</groupId>
+  <artifactId>io.openliberty.webcontainer.security.app</artifactId>
+  <version>${bFullVersion}</version>
+  <name>WebSphere WebContainer Application Security API</name>
+  <description>WebSphere WebContainer Application Security API, version 1.1; Jakarta enabled</description>
+</project>

--- a/dev/io.openliberty.wsat.spi/.classpath
+++ b/dev/io.openliberty.wsat.spi/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.wsat.spi/.gitignore
+++ b/dev/io.openliberty.wsat.spi/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/generated/

--- a/dev/io.openliberty.wsat.spi/.project
+++ b/dev/io.openliberty.wsat.spi/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.wsat.spi</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.wsat.spi/.settings/bndtools.core.prefs
+++ b/dev/io.openliberty.wsat.spi/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.wsat.spi/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/io.openliberty.wsat.spi/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/io.openliberty.wsat.spi/bnd.bnd
+++ b/dev/io.openliberty.wsat.spi/bnd.bnd
@@ -1,0 +1,36 @@
+#*******************************************************************************
+# Copyright (c) 2017, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion: 1.0
+
+Bundle-Name: WebSphere WSAT SPI
+Bundle-Description: WebSphere WSAT SPI, version ${bVersion}
+Bundle-SymbolicName: io.openliberty.wsat.spi.javaee
+
+-pom: artifactid=io.openliberty.wsat.spi
+
+jakartaeeMe: true
+jakartaFinalJarName: io.openliberty.wsat.spi.jakarta.jar
+jakartaFinalBundleId: io.openliberty.wsat.spi
+
+# Only publish the Jakarta one
+publish.wlp.jar.include: io.openliberty.wsat.spi.jakarta.jar
+
+Import-Package: com.ibm.wsspi.webservices.wsat
+
+Export-Package: com.ibm.wsspi.webservices.wsat
+
+-includeresource: {META-INF/maven/io.openliberty.spi/io.openliberty.wsat.spi/pom.xml=io.openliberty.wsat.spi.pom}
+
+publish.wlp.jar.suffix: dev/spi/ibm
+
+-buildpath: \
+	com.ibm.ws.wsat.common

--- a/dev/io.openliberty.wsat.spi/io.openliberty.wsat.spi.pom
+++ b/dev/io.openliberty.wsat.spi/io.openliberty.wsat.spi.pom
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <licenses>
+    <license>
+      <name>IBM International License Agreement for Non-Warranted Programs</name>
+      <url>http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/maven/licenses/L-JTHS-8SZMHX/HTML/</url>
+      <distribution>repo</distribution>
+      <comments>Additional notices http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/maven/licenses/L-JTHS-8SZMHX/HTML/notices.html</comments>
+    </license>
+  </licenses>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.openliberty.spi</groupId>
+  <artifactId>io.openliberty.wsat.spi</artifactId>
+  <version>${bFullVersion}</version>
+  <name>WebSphere WSAT SPI</name>
+  <description>WebSphere WSAT SPI, version 1.0; Jakarta enabled</description>
+</project>

--- a/dev/wlp-gradle/subprojects/tasks.gradle
+++ b/dev/wlp-gradle/subprojects/tasks.gradle
@@ -448,6 +448,7 @@ if (bnd('publish.wlp.jar.suffix', 'lib').contains('api/ibm') || bnd('publish.wlp
 
         def transformerArgs = [
           initialJavadocZipName, finalJavadocZipName,
+          '-q', // quiet output
           '-tf', transformProject.getFile('rules/jakarta-javadoc.properties').path ]
 
         javaexec {


### PR DESCRIPTION
- Add missing jakarta versions of API and SPI bundles for APIs and SPIs that include Java EE classes in their signatures.
- Update feature files to include the new bundles.
- Change to quiet output for the Javadoc transformer invocation