### PR TITLE
Increase Start Server Wait time for build machine runs

### DIFF
--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/fat/src/com/ibm/ws/microprofile/health20/fat/ApplicationStateHealthCheckTest.java
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/fat/src/com/ibm/ws/microprofile/health20/fat/ApplicationStateHealthCheckTest.java
@@ -111,15 +111,14 @@ public class ApplicationStateHealthCheckTest {
 
     @After
     public void cleanUp() throws Exception {
-        server1.removeAllInstalledAppsForValidation();
-        server2.removeAllInstalledAppsForValidation();
         if (server1.isStarted()) {
             server1.stopServer(EXPECTED_FAILURES);
         }
         if (server2.isStarted()) {
             server2.stopServer(FAILS_TO_START_EXPECTED_FAILURES);
         }
-
+        server1.removeAllInstalledAppsForValidation();
+        server2.removeAllInstalledAppsForValidation();
     }
 
     /**
@@ -296,6 +295,11 @@ public class ApplicationStateHealthCheckTest {
             }
             //Don't validate that FAILS_TO_START_APP_NAME starts correctly.
             ShrinkHelper.exportAppToServer(server, app, DeployOptions.DISABLE_VALIDATION);
+        } else if (appName.equals(DELAYED_APP_NAME)) {
+            //Don't wait for app to start because it sleeps for 60 seconds
+            ShrinkHelper.exportDropinAppToServer(server, app, DeployOptions.DISABLE_VALIDATION);
+            //But wait for the servlet to be up
+            server.waitForStringInLog("CWWKT0016I:.*" + DELAYED_APP_NAME);
         } else {
             ShrinkHelper.exportDropinAppToServer(server, app);
         }

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -227,7 +227,7 @@ public class LibertyServer implements LogMonitorClient {
     protected static final boolean DO_COVERAGE = PrivHelper.getBoolean("test.coverage");
     protected static final String JAVA_AGENT_FOR_JACOCO = PrivHelper.getProperty("javaagent.for.jacoco");
 
-    protected static final int SERVER_START_TIMEOUT = (FAT_TEST_LOCALRUN ? 15 : 30) * 1000;
+    protected static final int SERVER_START_TIMEOUT = (FAT_TEST_LOCALRUN ? 15 : 120) * 1000;
     protected static final int SERVER_STOP_TIMEOUT = SERVER_START_TIMEOUT;
 
     // How long to wait for an app to start before failing out


### PR DESCRIPTION
I've seen a few build breaks where if it just waiting a little longer things might have ran fine, I don't think increasing it is too unreasonable.