### PR TITLE
Jakarta Concurrency 3.0.0.20211022 snapshot build

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -68,7 +68,7 @@ com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.jpa:2.6.8.WAS-ce829af
 com.ibm.ws.org.objenesis:objenesis:1.0
 com.ibm.ws:geronimo-validation:1.1
 com.ibm.ws:nekohtml:1.9.18
-io.openliberty.jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:3.0.0.20211013
+io.openliberty.jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:3.0.0.20211022
 net.sf.jtidy:jtidy:9.3.8
 org.apache.aries.blueprint:org.apache.aries.blueprint:1.3.0-ibm-s20170710-0926
 org.apache.cxf:cxf-rt-ws-mex:2.6.2-ibm-s20180529-1900

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.concurrency-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.concurrency-3.0.feature
@@ -4,7 +4,7 @@ visibility=private
 singleton=true
 #TODO update to eeCompatible-10.0 once other features are ready to use it
 -features=com.ibm.websphere.appserver.eeCompatible-9.0
--bundles=io.openliberty.jakarta.concurrency.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="io.openliberty.jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:3.0.0.20211013"
+-bundles=io.openliberty.jakarta.concurrency.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="io.openliberty.jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:3.0.0.20211022"
 kind=noship
 edition=full
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-3.0/io.openliberty.concurrent-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-3.0/io.openliberty.concurrent-3.0.feature
@@ -3,7 +3,8 @@ symbolicName=io.openliberty.concurrent-3.0
 visibility=public
 singleton=true
 IBM-ShortName: concurrent-3.0
-IBM-API-Package: jakarta.enterprise.concurrent; type="spec"
+IBM-API-Package: jakarta.enterprise.concurrent; type="spec",\
+  jakarta.enterprise.concurrent.spi; type="spec"
 IBM-API-Service: jakarta.enterprise.concurrent.ContextService; id="DefaultContextService", \
   jakarta.enterprise.concurrent.ManagedExecutorService; id="DefaultManagedExecutorService", \
   jakarta.enterprise.concurrent.ManagedScheduledExecutorService; id="DefaultManagedScheduledExecutorService"

--- a/dev/io.openliberty.jakarta.concurrency.3.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.concurrency.3.0/bnd.bnd
@@ -14,15 +14,25 @@ bVersion=1.0
 Bundle-SymbolicName: io.openliberty.jakarta.concurrency.3.0; singleton:=true
 
 Export-Package: \
-  jakarta.enterprise.concurrent;version="3.0.0"
+  jakarta.enterprise.concurrent;version="3.0.0",\
+  jakarta.enterprise.concurrent.spi;version="3.0.0"
+
+DynamicImport-Package: \
+  jakarta.enterprise.util,\
+  jakarta.interceptor
+
+Import-Package:
+  !jakarta.enterprise.util,\
+  !jakarta.interceptor,\
+  *
 
 Include-Resource: \
-  @${repo;io.openliberty.jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api;3.0.0.20211013;EXACT}!/META-INF/NOTICE
+  @${repo;io.openliberty.jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api;3.0.0.20211022;EXACT}!/META-INF/NOTICE
 
 instrument.disabled: true
 
 publish.wlp.jar.suffix: dev/api/spec
 
 -buildpath: \
-  io.openliberty.jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api;version=3.0.0.20211013
+  io.openliberty.jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api;version=3.0.0.20211022
   


### PR DESCRIPTION
Snapshot build from 2021-10-22 includes the third-party context provider API and the Asynchronous methods annotation.