### PR TITLE
Ejb bindings fat java2sec update

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/publish/servers/com.ibm.ws.ejbcontainer.bindings.fat.server.err/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/publish/servers/com.ibm.ws.ejbcontainer.bindings.fat.server.err/server.xml
@@ -10,7 +10,6 @@
 
     <iiopEndpoint id="defaultIiopEndpoint" iiopPort="${bvt.prop.IIOP}" iiopsPort="${bvt.prop.IIOP.secure}"/>
 	
-    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
-    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="line.separator" actions="read"/>
     <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission className="java.util.PropertyPermission" name="*" actions="read,write"/>
 </server>

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/publish/servers/com.ibm.ws.ejbcontainer.bindings.fat.server/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/publish/servers/com.ibm.ws.ejbcontainer.bindings.fat.server/server.xml
@@ -10,7 +10,6 @@
 
     <iiopEndpoint id="defaultIiopEndpoint" iiopPort="${bvt.prop.IIOP}" iiopsPort="${bvt.prop.IIOP.secure}"/>
 	
-    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
-    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="line.separator" actions="read"/>
     <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission className="java.util.PropertyPermission" name="*" actions="read,write"/>
 </server>

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/publish/servers/com.ibm.ws.ejbcontainer.bindings.fat.serverxml.testserver/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/publish/servers/com.ibm.ws.ejbcontainer.bindings.fat.serverxml.testserver/server.xml
@@ -44,7 +44,6 @@
         
     </application>
 
-    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
-    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="line.separator" actions="read"/>
     <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission className="java.util.PropertyPermission" name="*" actions="read,write"/>
 </server>

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/publish/servers/com.ibm.ws.ejbcontainer.bindings.noInterface.fat.server/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/publish/servers/com.ibm.ws.ejbcontainer.bindings.noInterface.fat.server/server.xml
@@ -10,6 +10,5 @@
 
     <iiopEndpoint id="defaultIiopEndpoint" iiopPort="${bvt.prop.IIOP}" iiopsPort="${bvt.prop.IIOP.secure}"/>
 	
-    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
-    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="line.separator" actions="read"/>
+    <javaPermission className="java.util.PropertyPermission" name="*" actions="read,write"/>
 </server>

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/AmbiguousTestApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/AmbiguousTestApp.ear/resources/META-INF/permissions.xml
@@ -4,7 +4,11 @@
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
         http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
     version="7">
-
-
+    
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>*</name>
+      <actions>read,write</actions>
+   </permission>
 
 </permissions>

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/BindingNameTestApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/BindingNameTestApp.ear/resources/META-INF/permissions.xml
@@ -5,6 +5,10 @@
         http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
     version="7">
 
-
+   <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>*</name>
+      <actions>read,write</actions>
+   </permission>
 
 </permissions>

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/ComponentIDBndTestApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/ComponentIDBndTestApp.ear/resources/META-INF/permissions.xml
@@ -4,7 +4,11 @@
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
         http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
     version="7">
-
-
+    
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>*</name>
+      <actions>read,write</actions>
+   </permission>
 
 </permissions>

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/ConfigTestsOtherTestApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/ConfigTestsOtherTestApp.ear/resources/META-INF/permissions.xml
@@ -4,7 +4,12 @@
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
         http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
     version="7">
-
+    
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>*</name>
+      <actions>read,write</actions>
+   </permission>
 
 
 </permissions>

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/ConfigTestsTestApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/ConfigTestsTestApp.ear/resources/META-INF/permissions.xml
@@ -4,7 +4,12 @@
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
         http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
     version="7">
-
+    
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>*</name>
+      <actions>read,write</actions>
+   </permission>
 
 
 </permissions>

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/EJB3BndTestApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/EJB3BndTestApp.ear/resources/META-INF/permissions.xml
@@ -15,4 +15,10 @@
         <class-name>java.lang.RuntimePermission</class-name>
         <name>getClassLoader</name>
     </permission> 
+    
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>*</name>
+      <actions>read,write</actions>
+   </permission>
 </permissions>

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/EJB3DefBndTestApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/EJB3DefBndTestApp.ear/resources/META-INF/permissions.xml
@@ -15,4 +15,10 @@
         <class-name>java.lang.RuntimePermission</class-name>
         <name>getClassLoader</name>
     </permission> 
+    
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>*</name>
+      <actions>read,write</actions>
+   </permission>
 </permissions>

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/EJBinWARTestApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/EJBinWARTestApp.ear/resources/META-INF/permissions.xml
@@ -15,4 +15,10 @@
         <class-name>java.lang.RuntimePermission</class-name>
         <name>getClassLoader</name>
     </permission>
+    
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>*</name>
+      <actions>read,write</actions>
+   </permission>
 </permissions>

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/HomeBindingNameTestApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/HomeBindingNameTestApp.ear/resources/META-INF/permissions.xml
@@ -4,6 +4,12 @@
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
         http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
     version="7">
+    
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>*</name>
+      <actions>read,write</actions>
+   </permission>
 
 
 

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/JNDINameTestApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/JNDINameTestApp.ear/resources/META-INF/permissions.xml
@@ -4,6 +4,12 @@
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
         http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
     version="7">
+    
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>*</name>
+      <actions>read,write</actions>
+   </permission>
 
 
 

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/NoInterfaceBndTestApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/NoInterfaceBndTestApp.ear/resources/META-INF/permissions.xml
@@ -15,4 +15,10 @@
         <class-name>java.lang.RuntimePermission</class-name>
         <name>getClassLoader</name>
     </permission> 
+    
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>*</name>
+      <actions>read,write</actions>
+   </permission>
 </permissions>

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/ServerXMLTestApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/ServerXMLTestApp.ear/resources/META-INF/permissions.xml
@@ -4,6 +4,12 @@
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
         http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
     version="7">
+    
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>*</name>
+      <actions>read,write</actions>
+   </permission>
 
 
 

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/SimpleBindingNameTestApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/SimpleBindingNameTestApp.ear/resources/META-INF/permissions.xml
@@ -4,6 +4,12 @@
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
         http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
     version="7">
+    
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>*</name>
+      <actions>read,write</actions>
+   </permission>
 
 
 

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/RemoteFile.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/RemoteFile.java
@@ -74,21 +74,7 @@ public class RemoteFile {
     }
 
     /**
-     * The standard retry interval for delete and rename operations.
-     *
-     * This is based on the artifact file system minimum
-     * retry interval of 200 milliseconds, per
-     * <code>
-     * open-liberty/dev/com.ibm.ws.artifact.zip/src/
-     * com/ibm/ws/artifact/zip/cache/
-     * ZipCachingProperties.java
-     * </code>
-     *
-     * The default largest pending close time is specified
-     * by property <code>zip.reaper.slow.pend.max</code>.
-     *
-     * The current largest pend time is 200 milliseconds. For
-     * extra safety, the retry interval is set to twice this value.
+     * The maximum wait time to retry an operation
      *
      * Note: This does not handle when the server is prevented
      * from running. In a typical case, where application files
@@ -97,12 +83,15 @@ public class RemoteFile {
      * pending close, the usual pend time may be exceeded without
      * the file being closed.
      */
-    public static final long STANDARD_RETRY_INTERVAL_NS = TimeUnit.MILLISECONDS.toNanos(200 * 2);
+    public static final long STANDARD_RETRY_MAX_INTERVAL_NS = TimeUnit.SECONDS.toNanos(10);
 
     // Increase this to 0.1s instead of 0.05s.  The sleep granularity
     // on windows is too small to reliably handle 0.05s.
 
-    public static final long STANDARD_RETRY_PARTIAL_INTERVAL_NS = TimeUnit.MILLISECONDS.toNanos(100); // 0.1s
+    /**
+     * The amount of time to wait before retrying
+     */
+    public static final long STANDARD_RETRY_INTERVAL_NS = TimeUnit.MILLISECONDS.toNanos(100); // 0.1s
 
     public interface Operation {
         public boolean act() throws Exception;
@@ -146,7 +135,7 @@ public class RemoteFile {
 
         long finalNs = System.nanoTime() + fullRetryNs;
         do {
-            sleep(STANDARD_RETRY_PARTIAL_INTERVAL_NS); // throws InterruptedException
+            sleep(STANDARD_RETRY_INTERVAL_NS); // throws InterruptedException
             if (op.act()) {
                 return true;
             }
@@ -572,7 +561,7 @@ public class RemoteFile {
     // Delete ...
 
     public boolean delete() throws Exception {
-        return delete(STANDARD_RETRY_INTERVAL_NS);
+        return delete(STANDARD_RETRY_MAX_INTERVAL_NS);
     }
 
     public boolean deleteNoRetry() throws Exception {
@@ -599,7 +588,7 @@ public class RemoteFile {
     }
 
     public boolean deleteLocalDirectory(File localDir) throws Exception {
-        return deleteLocalDirectory(localDir, STANDARD_RETRY_INTERVAL_NS);
+        return deleteLocalDirectory(localDir, STANDARD_RETRY_MAX_INTERVAL_NS);
     }
 
     public boolean deleteLocalDirectoryNoRetry(File localDir) throws Exception {
@@ -800,7 +789,7 @@ public class RemoteFile {
     //
 
     public boolean rename(RemoteFile newFile) throws Exception {
-        return rename(newFile, STANDARD_RETRY_INTERVAL_NS);
+        return rename(newFile, STANDARD_RETRY_MAX_INTERVAL_NS);
     }
 
     public boolean renameNoRetry(RemoteFile newFile) throws Exception {


### PR DESCRIPTION
The `com.ibm.ws.ejbcontainer.fat_tools.jar` permissions are not needed anymore as a recent code change in this FAT made it not use the FATHelper lookup method in the remote lookups.