### PR TITLE
Eclipse and github action fix ups

### DIFF
--- a/.github/test-categories/CONCURRENT_3
+++ b/.github/test-categories/CONCURRENT_3
@@ -7,6 +7,7 @@ com.ibm.ws.concurrent_fat_config
 com.ibm.ws.concurrent_fat_db
 com.ibm.ws.concurrent_fat_demo
 com.ibm.ws.concurrent_fat_ejb
+com.ibm.ws.concurrent_fat_jakarta
 com.ibm.ws.concurrent_fat_policy
 com.ibm.ws.concurrent_fat_quartz
 com.ibm.ws.concurrent_fat_work

--- a/.github/test-categories/EJB_2
+++ b/.github/test-categories/EJB_2
@@ -1,3 +1,4 @@
+com.ibm.ws.ejbcontainer.mdb.jms_fat
 com.ibm.ws.ejbcontainer.remote.client_fat
 com.ibm.ws.ejbcontainer.remote_fat
 com.ibm.ws.ejbcontainer.security.jacc_fat

--- a/.github/test-categories/JAXRS_3
+++ b/.github/test-categories/JAXRS_3
@@ -1,3 +1,4 @@
+com.ibm.ws.jaxrs.defaultexceptionmapper_fat
 com.ibm.ws.jaxrs.2.0.cdi.1.2_fat
 com.ibm.ws.jaxrs.2.0.client_fat
 com.ibm.ws.jaxrs.2.0_fat

--- a/.github/test-categories/MP_JWT_2
+++ b/.github/test-categories/MP_JWT_2
@@ -1,2 +1,3 @@
 com.ibm.ws.security.jwtsso_fat
 com.ibm.ws.security.mp.jwt_fat_tck
+io.openliberty.microprofile.jwt.2.0.internal_fat_tck

--- a/.github/test-categories/MP_METRICS_2
+++ b/.github/test-categories/MP_METRICS_2
@@ -8,3 +8,4 @@ com.ibm.ws.security.mp.jwt.1.2_fat
 io.openliberty.microprofile.jwt.1.2.internal_fat_tck
 io.openliberty.microprofile.metrics.internal.3.0_fat_tck
 io.openliberty.microprofile.metrics.internal.3.x.monitor_fat
+io.openliberty.microprofile.metrics.internal.4.0_fat_tck

--- a/.github/test-categories/MP_OPENAPI
+++ b/.github/test-categories/MP_OPENAPI
@@ -8,3 +8,4 @@ com.ibm.ws.microprofile.opentracing.jaeger_fat
 com.ibm.ws.microprofile.opentracing_fat_tck
 io.openliberty.microprofile.openapi.2.0.internal_fat
 io.openliberty.microprofile.openapi.2.0.internal_fat_tck
+io.openliberty.microprofile.openapi.3.0.internal_fat_tck

--- a/.github/test-categories/MP_REST_CLIENT_2
+++ b/.github/test-categories/MP_REST_CLIENT_2
@@ -1,3 +1,4 @@
 com.ibm.ws.microprofile.rest.client14_fat_tck
 com.ibm.ws.microprofile.rest.client_fat
 com.ibm.ws.microprofile.rest.client_fat_tck
+io.openliberty.microprofile.rest.client.3.0.internal_fat_tck

--- a/dev/com.ibm.ws.jaxrs.defaultexceptionmapper_fat/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.jaxrs.defaultexceptionmapper_fat/.settings/bndtools.core.prefs
@@ -1,2 +1,2 @@
-compileErrorAction=skip
+compileErrorAction=build
 eclipse.preferences.version=1

--- a/dev/com.ibm.ws.jaxws.2.3.wsat/.classpath
+++ b/dev/com.ibm.ws.jaxws.2.3.wsat/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="com.ibm.ws.jaxws.wsat-src"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="com.ibm.ws.jaxws.wsat-src" excluding="com/ibm/ws/jaxws/wsat/WSATFeatureBusListener.java"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.jarfile_fat/.classpath
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.jarfile_fat/.classpath
@@ -2,7 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/helpers/DatabaseManagement/src"/>
-	<classpathentry kind="src" path="test-applications/injection_ejbinwar/src"/>
 	<classpathentry kind="src" path="test-applications/jarfile/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>

--- a/dev/com.ibm.ws.transaction.fat.util/.classpath
+++ b/dev/com.ibm.ws.transaction.fat.util/.classpath
@@ -3,13 +3,5 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="lib" path="C:/Users/JonHawkes/.m2/repository/com/ibm/ws/componenttest/public.api/1.0.0/public.api-1.0.0.jar">
-		<attributes>
-			<attribute name="bsn" value="com.ibm.ws.componenttest:public.api"/>
-			<attribute name="type" value="REPO"/>
-			<attribute name="project" value="build.example.testcontainers_fat"/>
-			<attribute name="version" value="1.0.0"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/.classpath
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/.classpath
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="resources"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/bnd.bnd
@@ -15,7 +15,7 @@ Bundle-SymbolicName: io.openliberty.org.jboss.resteasy.mprestclient
 
 resteasy-version=4.7.0.Final
 
-src: src, resources
+src: src
 
 app-resources= \
  META-INF/services/javax.enterprise.inject.spi.Extension | \


### PR DESCRIPTION
- Update classpath files to remove non existent source dirs
- Update classpath file to remove reference to library and just rely on the bnd buildpath
- Handle the source file addition to jaxws.2.3.swat.
- Update bndtools prefs to build instead of skip
- Add new FATs to the github action test categories.