### PR TITLE
Do not capture standard in when doing a checkpoint

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -922,7 +922,7 @@ javaCmd()
     # trap on the signals here to ensure the background tail process ends.
     trap "exit" INT TERM
     trap "killIfRunning $TAIL_PID" EXIT
-    "${JAVA_CMD}" "$@" >> "${CHECKPOINT_CONSOLE_LOG}" 2>&1
+    "${JAVA_CMD}" "$@" >> "${CHECKPOINT_CONSOLE_LOG}" 2>&1 < /dev/null
     rc=$?
     kill $TAIL_PID
     # Above JAVA_CMD should terminate after a criu dump and SIGKILL. 


### PR DESCRIPTION
There is no need to capture standard in when doing a
checkpoint.  This also helps for restore if we can
avoiding having to connect standard in to a TTY
for some restore scenarios
