### PR TITLE
testTLD assertion fix

### DIFF
--- a/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSPTests.java
+++ b/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSPTests.java
@@ -785,11 +785,11 @@ public class JSPTests {
         server.copyFileToLibertyServerRoot(relEdrPath, orgEdrFile);
         String url = JSPUtils.createHttpUrlString(server, TestEDR_APP_NAME, "index.jsp");
         LOG.info("url: " + url);
-        server.setMarkToEndOfLog();
         WebConversation wc1 = new WebConversation();
         WebRequest request1 = new GetMethodWebRequest(url);
         wc1.getResponse(request1);
 
+        server.setMarkToEndOfLog(); // mark after 1st call to index.jsp since it might have compiled and caused a SRVE0253I
         Thread.sleep(5000L); // sleep necessary to insure sufficient time delta for epoch timestamp comparisons
         WebConversation wc2 = new WebConversation();
         WebRequest request2 = new GetMethodWebRequest(url);


### PR DESCRIPTION
Fixes #19123 
The issue is that an assertion trips as false because an SRVE0253I is within the log mark window.  This was caused by the first log mark being set too early.
