### PR TITLE
Clean up some more unnecessary transformations

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpJwtPropagation-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpJwtPropagation-2.0.feature
@@ -5,7 +5,7 @@ IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.mpJwt-2.0)))"
 IBM-Install-Policy: when-satisfied
 -bundles=io.openliberty.org.eclipse.microprofile.jwt.2.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:2.0-RC2",\
- io.openliberty.security.mp.jwt.propagation.internal, \
+ com.ibm.ws.security.mp.jwt.propagation, \
  io.openliberty.org.jboss.resteasy.common.jakarta, \
  io.openliberty.restfulWS.internal.globalhandler.jakarta
 kind=beta

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-4.0/io.openliberty.mpMetrics-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-4.0/io.openliberty.mpMetrics-4.0.feature
@@ -15,7 +15,7 @@ Subsystem-Name: MicroProfile Metrics 4.0
   io.openliberty.org.eclipse.microprofile.metrics-4.0, \
   com.ibm.websphere.appserver.anno-2.0, \
   com.ibm.websphere.appserver.monitor-1.0
--bundles=com.ibm.ws.microprofile.metrics.common.jakarta, \
+-bundles=com.ibm.ws.microprofile.metrics.common, \
  io.openliberty.microprofile.metrics.internal.3.0.jakarta, \
  io.openliberty.microprofile.metrics.internal.cdi.3.0.jakarta, \
  io.openliberty.microprofile.metrics.internal.private, \

--- a/dev/com.ibm.ws.microprofile.metrics.common/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics.common/bnd.bnd
@@ -17,13 +17,10 @@ Bundle-SymbolicName: com.ibm.ws.microprofile.metrics.common
 
 Bundle-Description: MicroProfile Metrics Common, version ${bVersion}
 
-jakartaeeMe: true
-
 IBM-Authorization-Roles: com.ibm.ws.management
 IBM-Web-Extension-Processing-Disabled: true
 
 Import-Package: \
-	javax.enterprise.inject; version="[1.1,3)",\
 	*
 
 Private-Package: \

--- a/dev/com.ibm.ws.security.mp.jwt.propagation/bnd.bnd
+++ b/dev/com.ibm.ws.security.mp.jwt.propagation/bnd.bnd
@@ -16,15 +16,6 @@ Bundle-SymbolicName: com.ibm.ws.security.mp.jwt.propagation
 Bundle-Description: Security MicroProfile JWT Propagation service, version=${bVersion}
 Bundle-ActivationPolicy: lazy
 
-#
-# Generate a Jakarta EE compliant JAR for the bundle.
-#
-jakartaeeMe: true
-jakartaFinalJarName: io.openliberty.security.mp.jwt.propagation.internal.jar
-jakartaFinalBundleName: Liberty Security MP JWT Propagation
-jakartaFinalBundleId: io.openliberty.security.mp.jwt.propagation.internal
-jakartaFinalBundleDescription: Liberty Security MP JWT Propagation; Jakarta Enabled
-
 WS-TraceGroup: \
   Security
 

--- a/dev/com.ibm.ws.transaction.fat.util/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.fat.util/bnd.bnd
@@ -32,5 +32,3 @@ Export-Package: com.ibm.ws.transaction.fat.util
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.ws.componenttest:public.api;version=1.0.0,\
 	fattest.simplicity;version=latest
-
-jakartaeeMe: true


### PR DESCRIPTION
- Do not transform com.ibm.ws.micrprofile.metrics.common, com.ibm.ws.security.mp.jwt.propagation or com.ibm.ws.transaction.fat.util
