### PR TITLE
Add allowed warning to stopserver list for OutboundSSLLDAPTest

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/OutboundSSLLDAPTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/OutboundSSLLDAPTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -88,7 +88,7 @@ public class OutboundSSLLDAPTest {
     @After
     public void tearDown() throws Exception {
         Log.info(c, "tearDown", "Stopping the server...");
-        myServer.stopServer("CWPKI0022E:", "CWPKI0823E:");
+        myServer.stopServer("CWPKI0022E:", "CWPKI0823E:", "CWPKI0815W");
     }
 
     /**


### PR DESCRIPTION
Add `CWPKI0815W` as an allowed message in the stopServer checks. `CWPKI0815W: More than one OutboundConnection element specifies the [was-ldap21.fyre.ibm.com] host and [636] port as a filter. The OutboundConnection element configured on the [AlternateSSLSettings] SSL element will be used.` We are intentionally testing multiple SSL configs -- `* Test to make sure the correct SSL outbound filter configuration is used.`

RTC 287495