### PR TITLE
concurrent-2.0 should not tolerate mpContextPropagation 1.0

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-2.0/io.openliberty.concurrent-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-2.0/io.openliberty.concurrent-2.0.feature
@@ -15,7 +15,7 @@ Subsystem-Name: Jakarta Concurrency 2.0
   com.ibm.websphere.appserver.contextService-1.0, \
   io.openliberty.jakarta.concurrency-2.0, \
   com.ibm.websphere.appserver.concurrencyPolicy-1.0, \
-  com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.0; ibm.tolerates:="1.2,1.3"
+  io.openliberty.org.eclipse.microprofile.contextpropagation-1.3
 -bundles=\
   com.ibm.ws.concurrent.jakarta, \
   com.ibm.ws.javaee.platform.defaultresource, \


### PR DESCRIPTION
concurrent-2.0 is from Jakarta EE 9, which shouldn't interoperate with mpContextPropagation-1.0