### PR TITLE
Upgrade to RC5 and put mpRestClient-3.0 in beta and umbrella feature

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2099,7 +2099,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.rest.client</groupId>
       <artifactId>microprofile-rest-client-api</artifactId>
-      <version>3.0-RC3</version>
+      <version>3.0-RC5</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.persistence</groupId>

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.rest.client-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.rest.client-3.0.feature
@@ -8,6 +8,6 @@ singleton=true
   io.openliberty.jakarta.restfulWS-3.0, \
   io.openliberty.org.eclipse.microprofile.config-3.0
 -bundles=io.openliberty.org.eclipse.microprofile.rest.client.3.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.rest.client:microprofile-rest-client-api:3.0"
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-5.0/io.openliberty.microProfile-5.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-5.0/io.openliberty.microProfile-5.0.feature
@@ -18,9 +18,9 @@ Subsystem-Name: MicroProfile 5.0
   io.openliberty.mpFaultTolerance-4.0, \
   io.openliberty.mpHealth-4.0, \
   io.openliberty.mpJwt-2.0,\
-  io.openliberty.mpOpenAPI-3.0
-  #io.openliberty.mpMetrics-4.0, \
-  #io.openliberty.mpOpenTracing-3.0, \
-  #io.openliberty.mpRestClient-3.0
+  io.openliberty.mpOpenAPI-3.0, \
+  io.openliberty.mpMetrics-4.0, \
+  io.openliberty.mpRestClient-3.0
+  #io.openliberty.mpOpenTracing-3.0
 kind=noship
 edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpRestClient-3.0/io.openliberty.mpRestClient-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpRestClient-3.0/io.openliberty.mpRestClient-3.0.feature
@@ -24,10 +24,10 @@ Subsystem-Name: MicroProfile Rest Client 3.0
   io.openliberty.mpCompatible-5.0, \
   io.openliberty.org.eclipse.microprofile.rest.client-3.0, \
   com.ibm.websphere.appserver.org.reactivestreams.reactive-streams-1.0
-  
+
 -bundles=\
   io.openliberty.org.jboss.resteasy.cdi.jakarta; apiJar=false; location:="lib/", \
   io.openliberty.org.jboss.resteasy.mprestclient.jakarta; apiJar=false; location:="lib/"
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
@@ -206,9 +206,9 @@ public class MicroProfileActions {
                                                           "mpHealth-4.0",
                                                           "mpJwt-2.0",
                                                           "mpOpenAPI-3.0",
-                                                          "mpMetrics-4.0" };
+                                                          "mpMetrics-4.0",
 //                                                          "mpOpenTracing-3.0",
-//                                                          "mpRestClient-3.0" };
+                                                          "mpRestClient-3.0" };
 
     private static final Set<String> MP10_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MP10_FEATURES_ARRAY)));
     private static final Set<String> MP12_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MP12_FEATURES_ARRAY)));

--- a/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -17,7 +17,7 @@
     <name>MicroProfile RestClient 3.0 TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.rest.client.version>3.0-RC1</microprofile.rest.client.version>
+        <microprofile.rest.client.version>3.0-RC5</microprofile.rest.client.version>
         <arquillian.version>1.7.0.Alpha10</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->


### PR DESCRIPTION
Upgrading MP Rest Client to use API/TCK at 3.0-RC5. Also adding mpRestClient-3.0 beta and to microprofile-5.0 feature (along with MP Metrics 4.0). Lastly - adding mpRestClient-3.0 to MicroProfileActions.