### PR TITLE
eclipse cleanup for MDB JMS FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.mdb.jms_fat/.classpath
+++ b/dev/com.ibm.ws.ejbcontainer.mdb.jms_fat/.classpath
@@ -9,15 +9,15 @@
 	<classpathentry kind="src" path="test-applications/MDBAnnWeb.war/src"/>
 	<classpathentry kind="src" path="test-applications/MDBIntAnnEJB.jar/src"/>
 	<classpathentry kind="src" path="test-applications/MDBIntAnnWeb.war/src"/>
-	<classpathentry kind="src" path="test-applications/MDBMixEJB.jar/src"/>
-	<classpathentry kind="src" path="test-applications/MDBMixWeb.war/src"/>
 	<classpathentry kind="src" path="test-applications/MDBIntMixEJB.jar/src"/>
 	<classpathentry kind="src" path="test-applications/MDBIntMixWeb.war/src"/>
-	<classpathentry kind="src" path="test-applications/MDBXMLEJB.jar/src"/>
-	<classpathentry kind="src" path="test-applications/MDBXMLWeb.war/src"/>
 	<classpathentry kind="src" path="test-applications/MDBIntXMLEJB.jar/src"/>
-	<classpathentry kind="src" path="test-applications/MDBIntXMLEJB2.jar/src"/>
 	<classpathentry kind="src" path="test-applications/MDBIntXMLWeb.war/src"/>
+	<classpathentry kind="src" path="test-applications/MDBMixEJB.jar/src"/>
+	<classpathentry kind="src" path="test-applications/MDBMixWeb.war/src"/>
+	<classpathentry kind="src" path="test-applications/MDBXMLEJB.jar/src"/>
+	<classpathentry kind="src" path="test-applications/MDBXMLEJB2.jar/src"/>
+	<classpathentry kind="src" path="test-applications/MDBXMLWeb.war/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.ejbcontainer.mdb.jms_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.mdb.jms_fat/bnd.bnd
@@ -21,15 +21,15 @@ src: \
 	test-applications/MDBAnnWeb.war/src, \
 	test-applications/MDBIntAnnEJB.jar/src, \
 	test-applications/MDBIntAnnWeb.war/src, \
-	test-applications/MDBMixEJB.jar/src, \
-	test-applications/MDBMixWeb.war/src, \
 	test-applications/MDBIntMixEJB.jar/src, \
 	test-applications/MDBIntMixWeb.war/src, \
+	test-applications/MDBIntXMLEJB.jar/src, \
+	test-applications/MDBIntXMLWeb.war/src, \
+	test-applications/MDBMixEJB.jar/src, \
+	test-applications/MDBMixWeb.war/src, \
 	test-applications/MDBXMLEJB.jar/src, \
 	test-applications/MDBXMLEJB2.jar/src, \
-	test-applications/MDBXMLWeb.war/src, \
-	test-applications/MDBIntXMLEJB.jar/src, \
-	test-applications/MDBIntXMLWeb.war/src
+	test-applications/MDBXMLWeb.war/src
 
 fat.project: true
 


### PR DESCRIPTION
- correct an invalid classpath entry in .classpath
- alphabetize the test applications in .classpath/bnd.bnd
