### PR TITLE
Add 'zip.reaper.assume.valid' with its default set to true.

### DIFF
--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/ZipCachingProperties.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/ZipCachingProperties.java
@@ -51,6 +51,11 @@ import com.ibm.ws.artifact.zip.internal.SystemUtils;
  * zip.reaper.slow.pend.min    (>0)     [ 100,000,000 ns ] [ 0.1s ]
  * zip.reaper.slow.pend.max    (>0)     [ 200,000,000 ns ] [ 0.2s ]
  *
+ * One property disables the time stamp and size checking when re-acquiring
+ * zip files:
+ * 
+ * zip.reaper.assume.valid    true | false   [ false ]
+ *
  * Property Details:
  *
  * zip.cache.debug.state      true | false   [ false ]
@@ -73,7 +78,7 @@ import com.ibm.ws.artifact.zip.internal.SystemUtils;
  * The zip cache service has three cache layers: A cache of zip file handles,
  * a cache of data for small classes (per zip file handle), and a cache of zip
  * files.
- *
+ * 
  * zip.cache.handle.max       -1 | (>0)      [ 255 ]
  *
  * This property sets the maximum number of zip file handles which are
@@ -144,6 +149,22 @@ import com.ibm.ws.artifact.zip.internal.SystemUtils;
  *
  * The short and long interval values are specified in nano-seconds (ns):
  * 1,000,000,000 ns is 1 s, 100,000,000 ns is 0.1 s.
+ * 
+ * zip.reaper.assume.valid    true | false   [ false ]
+ * 
+ * A zip file which has a pending close will have that close discarded if an
+ * open request is made before the pending close was processed.  Before
+ * re-acquiring the zip file, the zip file size and last modified time are
+ * checked against the zip file size and last modified time when the zip file
+ * was initially opened.  If either value has changed, instead of continuing
+ * use of the same, already opened zip file, the zip file is closed and
+ * re-opened.
+ * 
+ * Setting 'zip.reaper.assume.valid' disables the checks against the zip file
+ * size and last modified times.
+ * 
+ * This property is provided for experimental use, only, and is not approved
+ * for use in production environments.
  */
 public class ZipCachingProperties {
     private static final TraceComponent tc = Tr.register(ZipFileHandleImpl.class);
@@ -288,8 +309,11 @@ public class ZipCachingProperties {
      * closed, and displaying lifetime statistics for all.</li>
      * </ul>
      */
-    public static final String ZIP_REAPDER_DEBUG_STATE_PROPERTY_NAME =
+    public static final String ZIP_REAPER_DEBUG_STATE_PROPERTY_NAME =
         "zip.reaper.debug.state";
+    @Deprecated
+    public static final String ZIP_REAPDER_DEBUG_STATE_PROPERTY_NAME =
+        ZIP_REAPER_DEBUG_STATE_PROPERTY_NAME;
     public static final boolean ZIP_REAPER_DEBUG_STATE_DEFAULT_VALUE = false;
     public static final boolean ZIP_REAPER_DEBUG_STATE;
 
@@ -306,7 +330,7 @@ public class ZipCachingProperties {
             ZIP_REAPER_COLLECT_TIMINGS_DEFAULT_VALUE);
 
         ZIP_REAPER_DEBUG_STATE = getProperty(methodName,
-            ZIP_REAPDER_DEBUG_STATE_PROPERTY_NAME,
+            ZIP_REAPER_DEBUG_STATE_PROPERTY_NAME,
             ZIP_REAPER_DEBUG_STATE_DEFAULT_VALUE);
     }
 
@@ -358,6 +382,13 @@ public class ZipCachingProperties {
         ZipCachingProperties.NANO_IN_ONE / 5; // 0.2s
     public static final long ZIP_CACHE_REAPER_SLOW_PEND_MAX;
 
+    /** Don't let re-acquire do file size and last modified checks. */
+    public static final String ZIP_CACHE_REAPER_ASSUME_VALID_PROPERTY_NAME =
+        "zip.reaper.assume.valid";
+    /** Temporarily set this to true, to simplify testing. */
+    public static final boolean ZIP_CACHE_REAPER_ASSUME_VALID_DEFAULT_VALUE = true;
+    public static final boolean ZIP_CACHE_REAPER_ASSUME_VALID;
+    
     static {
         String methodName = "<static init>";
 
@@ -380,6 +411,10 @@ public class ZipCachingProperties {
         ZIP_CACHE_REAPER_SLOW_PEND_MAX = getProperty(methodName,
             ZIP_CACHE_REAPER_SLOW_PEND_MAX_PROPERTY_NAME,
             ZIP_CACHE_REAPER_SLOW_PEND_MAX_DEFAULT_VALUE);
+        
+        ZIP_CACHE_REAPER_ASSUME_VALID = getProperty(methodName,
+           ZIP_CACHE_REAPER_ASSUME_VALID_PROPERTY_NAME,
+           ZIP_CACHE_REAPER_ASSUME_VALID_DEFAULT_VALUE);
     }
 
     //

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipCachingServiceImpl.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipCachingServiceImpl.java
@@ -290,8 +290,15 @@ public class ZipCachingServiceImpl implements ZipCachingService {
             "ns");
 
         introspectProperty(output,
+            "Assume valid",
+            ZipCachingProperties.ZIP_CACHE_REAPER_ASSUME_VALID_PROPERTY_NAME,
+            Boolean.valueOf(ZipCachingProperties.ZIP_CACHE_REAPER_ASSUME_VALID),
+            Boolean.valueOf(ZipCachingProperties.ZIP_CACHE_REAPER_ASSUME_VALID_DEFAULT_VALUE),
+            "true/false");        
+        
+        introspectProperty(output,
             "State debugging",
-            ZipCachingProperties.ZIP_REAPDER_DEBUG_STATE_PROPERTY_NAME,
+            ZipCachingProperties.ZIP_REAPER_DEBUG_STATE_PROPERTY_NAME,
             (ZipCachingProperties.ZIP_REAPER_DEBUG_STATE ? "enabled" : "disabled"),
             (ZipCachingProperties.ZIP_REAPER_DEBUG_STATE_DEFAULT_VALUE ? "enabled" : "disabled"),
             "enabled/disabled");


### PR DESCRIPTION
Experimental change:

The zip caching subsystem checks the zip file size and last modified times when a new open is performed on a zip file.

(See: com.ibm.ws.artifact.zip.cache.internal.ZipFileData.reacquireZipFile().)

This change adds a property 'zip.reaper.assume.valid', which when true disables calls to obtain the size and last modified times.

For this PR only, the default value of the new is set to 'true', with the intent to simplify testing the setting.

The motivation for this change is a customer issue where the reacquire size and last modified checks were using about 0.3s each.  This is highly unusual and indicates a problem in the customer's file system.  However, a question lingered: How much time do these checks cost us?

The new property has been added to answer this question.  The goal is to run standard performance tests with this PR and compare those results against a usual performance test (against 'integration', or any other suitable build) to tell if there is any appreciable difference.