### PR TITLE
mpOpenApi-2.0 merge improvements

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/merge/MergeProcessor.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/merge/MergeProcessor.java
@@ -374,6 +374,14 @@ public class MergeProcessor {
         if (contextRoot == null) {
             return;
         }
+        
+        if (contextRoot.endsWith("/")) {
+            contextRoot = contextRoot.substring(0, contextRoot.length()-1);
+        }
+        
+        if (contextRoot.isEmpty()) {
+            return;
+        }
 
         Paths paths = model.getPaths();
         if (paths == null) {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/merge/MergeProcessor.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/merge/MergeProcessor.java
@@ -448,7 +448,46 @@ public class MergeProcessor {
                 newPathItems.put(newPath, pathItem);
             }
             paths.setPathItems(newPathItems);
+            
+            // In some cases, removing the context root can leave all servers with no information at all.
+            // In these cases they can be removed.
+            boolean allServersEmpty = notNull(servers).stream()
+                            .allMatch(s -> isServerEmpty(s));
+            
+            if (allServersEmpty) {
+                model.setServers(null);
+            }
         }
+    }
+
+    /**
+     * Check whether a server element contains no useful data
+     * 
+     * @param server the server element to check
+     * @return true if the server element has no extensions, no description, no variables and a URL which is empty or {@code "/"}
+     */
+    private static boolean isServerEmpty(Server server) {
+        Map<String, Object> extensions = server.getExtensions();
+        if (extensions != null && !extensions.isEmpty()) {
+            return false;
+        }
+        
+        String description = server.getDescription();
+        if (description != null && !description.isEmpty()) {
+            return false;
+        }
+        
+        Map<String, ?> variables = server.getVariables();
+        if (variables != null && !variables.isEmpty()) {
+            return false;
+        }
+        
+        String url = server.getUrl();
+        if (url != null && !url.isEmpty() && !url.equals("/")) {
+            return false;
+        }
+        
+        return true;
     }
 
     /**

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/AssertModel.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/AssertModel.java
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.openapi20.test.merge;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.microprofile.openapi.models.Constructible;
+import org.junit.Assert;
+
+import io.openliberty.microprofile.openapi20.merge.ModelType;
+import io.openliberty.microprofile.openapi20.merge.ModelType.ModelParameter;
+
+public class AssertModel {
+
+    /**
+     * Recursively traverse two OpenAPI models and assert that they are equal
+     * 
+     * @param expected the expected result
+     * @param actual the model to test for equality to {@code expected}
+     */
+    public static void assertModelsEqual(Constructible expected, Constructible actual) {
+        assertModelsEqual(expected, actual, new ArrayDeque<>());
+    }
+    
+    /**
+     * Recursively traverse two maps containing OpenAPI model objects and assert that they are equal
+     * 
+     * @param expected the expected result
+     * @param actual the map to test for equality to {@code expected}
+     */
+    public static void assertModelMaps(Map<?, ?> expected, Map<?, ?> actual) {
+        assertEqualMap(expected, actual, new ArrayDeque<>());
+    }
+
+    private static void assertModelsEqual(Object expected, Object actual, Deque<String> context) {
+    
+        if (expected == null) {
+            // When smallrye merges model parts, if a map is null it sometimes gets initialized to an empty map
+            // so treat an empty map as being equal to null
+            assertNullOrEmptyMap(context, actual);
+            return;
+        } else {
+            assertNotNull(context, actual);
+        }
+    
+        Optional<ModelType> mtExpected = ModelType.getModelObject(expected.getClass());
+        Optional<ModelType> mtActual = ModelType.getModelObject(actual.getClass());
+        assertEquals("Model types not equal", context, mtExpected, mtActual);
+    
+        if (mtExpected.isPresent()) {
+            assertEqualModelObject(expected, actual, mtExpected.get(), context);
+        } else if (expected instanceof Map) {
+            assertEqualMap(expected, actual, context);
+        } else if (expected instanceof List) {
+            assertEqualList(expected, actual, context);
+        } else {
+            // assert that non-model, non-collection objects are not copied
+            assertEquals("Values not equal", context, expected, actual);
+        }
+    }
+
+    private static void assertEqualModelObject(Object expected, Object actual, ModelType mt, Deque<String> context) {
+        for (ModelParameter desc : mt.getParameters()) {
+            context.push(desc.toString());
+            assertModelsEqual(desc.get(expected), desc.get(actual), context);
+            context.pop();
+        }
+    }
+
+    private static void assertEqualMap(Object expected, Object actual, Deque<String> context) {
+        Map<?, ?> expectedMap = (Map<?, ?>) expected;
+        assertThat(actual, instanceOf(Map.class));
+        Map<?, ?> actualMap = (Map<?, ?>) actual;
+    
+        assertEquals("Different key set", context, expectedMap.keySet(), actualMap.keySet());
+        for (Object key : expectedMap.keySet()) {
+            context.push(key.toString());
+            assertModelsEqual(expectedMap.get(key), actualMap.get(key), context);
+            context.pop();
+        }
+    }
+
+    private static void assertEqualList(Object expected, Object actual, Deque<String> context) {
+        List<?> expectedList = (List<?>) expected;
+        assertThat(actual, instanceOf(List.class));
+        List<?> actualList = (List<?>) actual;
+    
+        assertThat("List has wrong size at " + contextString(context), actualList, hasSize(expectedList.size()));
+    
+        Iterator<?> expectedIterator = expectedList.iterator();
+        Iterator<?> actualIterator = actualList.iterator();
+        int i = 0;
+        while (expectedIterator.hasNext()) {
+            context.push("[" + i + "]");
+            assertModelsEqual(expectedIterator.next(), actualIterator.next(), context);
+            context.pop();
+            i++;
+        }
+    }
+
+    private static void assertEquals(String message, Deque<String> context, Object expected, Object actual) {
+        if (!Objects.equals(expected, actual)) {
+            Assert.assertEquals(message + " at " + contextString(context), expected, actual);
+        }
+    }
+
+    private static void assertNullOrEmptyMap(Deque<String> context, Object actual) {
+        if (actual != null) {
+            // When smallrye merges models, if a map is null, it sometimes gets initialized to an empty map
+            Optional<ModelType> mt = ModelType.getModelObject(actual.getClass());
+            if (!mt.isPresent() && actual instanceof Map) {
+                if (!((Map<?, ?>) actual).isEmpty()) {
+                    throw new AssertionError("Value is neither null nor empty map at " + contextString(context) + ". Was: " + actual);
+                }
+            } else {
+                throw new AssertionError("Value not null at " + contextString(context) + ". Was: " + actual);
+            }
+        }
+    }
+
+    private static void assertNotNull(Deque<String> context, Object actual) {
+        if (actual == null) {
+            throw new AssertionError("Value null at " + contextString(context));
+        }
+    }
+
+    private static String contextString(Deque<String> context) {
+        // Most recent context is pushed onto the front of the queue
+        // Reverse it to get a hierarchical path
+        List<String> contextCopy = new ArrayList<>(context);
+        Collections.reverse(contextCopy);
+        return String.join("/", contextCopy);
+    }
+
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/MergeProcessorTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/MergeProcessorTest.java
@@ -10,13 +10,12 @@
  *******************************************************************************/
 package io.openliberty.microprofile.openapi20.test.merge;
 
+import static io.openliberty.microprofile.openapi20.test.merge.AssertModel.assertModelsEqual;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.stringContainsInOrder;
@@ -24,18 +23,10 @@ import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Deque;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 
-import org.eclipse.microprofile.openapi.models.Constructible;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.junit.Assert;
 import org.junit.Test;
@@ -43,8 +34,6 @@ import org.junit.Test;
 import io.openliberty.microprofile.openapi20.OpenAPIProvider;
 import io.openliberty.microprofile.openapi20.merge.MergeProcessor;
 import io.openliberty.microprofile.openapi20.merge.ModelCopy;
-import io.openliberty.microprofile.openapi20.merge.ModelType;
-import io.openliberty.microprofile.openapi20.merge.ModelType.ModelParameter;
 import io.smallrye.openapi.runtime.io.Format;
 import io.smallrye.openapi.runtime.io.OpenApiParser;
 import io.smallrye.openapi.runtime.io.OpenApiSerializer;
@@ -340,115 +329,5 @@ public class MergeProcessorTest {
                 return "Test model[" + modelResource + "]";
             }
         };
-    }
-
-    /**
-     * Recursively traverse two OpenAPI models and assert that they are equal
-     * 
-     * @param expected the expected result
-     * @param actual the model to test for equality to {@code expected}
-     */
-    private void assertModelsEqual(Constructible expected, Constructible actual) {
-        assertModelsEqual(expected, actual, new ArrayDeque<>());
-    }
-
-    private void assertModelsEqual(Object expected, Object actual, Deque<String> context) {
-
-        if (expected == null) {
-            // When smallrye merges model parts, if a map is null it sometimes gets initialized to an empty map
-            // so treat an empty map as being equal to null
-            assertNullOrEmptyMap(context, actual);
-            return;
-        } else {
-            assertNotNull(context, actual);
-        }
-
-        Optional<ModelType> mtExpected = ModelType.getModelObject(expected.getClass());
-        Optional<ModelType> mtActual = ModelType.getModelObject(actual.getClass());
-        assertEquals("Model types not equal", context, mtExpected, mtActual);
-
-        if (mtExpected.isPresent()) {
-            assertEqualModelObject(expected, actual, mtExpected.get(), context);
-        } else if (expected instanceof Map) {
-            assertEqualMap(expected, actual, context);
-        } else if (expected instanceof List) {
-            assertEqualList(expected, actual, context);
-        } else {
-            // assert that non-model, non-collection objects are not copied
-            assertEquals("Values not equal", context, expected, actual);
-        }
-    }
-
-    private void assertEqualModelObject(Object expected, Object actual, ModelType mt, Deque<String> context) {
-        for (ModelParameter desc : mt.getParameters()) {
-            context.push(desc.toString());
-            assertModelsEqual(desc.get(expected), desc.get(actual), context);
-            context.pop();
-        }
-    }
-
-    private void assertEqualMap(Object expected, Object actual, Deque<String> context) {
-        Map<?, ?> expectedMap = (Map<?, ?>) expected;
-        assertThat(actual, instanceOf(Map.class));
-        Map<?, ?> actualMap = (Map<?, ?>) actual;
-
-        assertEquals("Different key set", context, expectedMap.keySet(), actualMap.keySet());
-        for (Object key : expectedMap.keySet()) {
-            context.push(key.toString());
-            assertModelsEqual(expectedMap.get(key), actualMap.get(key), context);
-            context.pop();
-        }
-    }
-
-    private void assertEqualList(Object expected, Object actual, Deque<String> context) {
-        List<?> expectedList = (List<?>) expected;
-        assertThat(actual, instanceOf(List.class));
-        List<?> actualList = (List<?>) actual;
-
-        assertThat("List has wrong size at " + contextString(context), actualList, hasSize(expectedList.size()));
-
-        Iterator<?> expectedIterator = expectedList.iterator();
-        Iterator<?> actualIterator = actualList.iterator();
-        int i = 0;
-        while (expectedIterator.hasNext()) {
-            context.push("[" + i + "]");
-            assertModelsEqual(expectedIterator.next(), actualIterator.next(), context);
-            context.pop();
-            i++;
-        }
-    }
-
-    private void assertEquals(String message, Deque<String> context, Object expected, Object actual) {
-        if (!Objects.equals(expected, actual)) {
-            Assert.assertEquals(message + " at " + contextString(context), expected, actual);
-        }
-    }
-
-    private void assertNullOrEmptyMap(Deque<String> context, Object actual) {
-        if (actual != null) {
-            // When smallrye merges models, if a map is null, it sometimes gets initialized to an empty map
-            Optional<ModelType> mt = ModelType.getModelObject(actual.getClass());
-            if (!mt.isPresent() && actual instanceof Map) {
-                if (!((Map<?, ?>) actual).isEmpty()) {
-                    throw new AssertionError("Value is neither null nor empty map at " + contextString(context) + ". Was: " + actual);
-                }
-            } else {
-                throw new AssertionError("Value not null at " + contextString(context) + ". Was: " + actual);
-            }
-        }
-    }
-
-    private void assertNotNull(Deque<String> context, Object actual) {
-        if (actual == null) {
-            throw new AssertionError("Value null at " + contextString(context));
-        }
-    }
-
-    private String contextString(Deque<String> context) {
-        // Most recent context is pushed onto the front of the queue
-        // Reverse it to get a hierarchical path
-        List<String> contextCopy = new ArrayList<>(context);
-        Collections.reverse(contextCopy);
-        return String.join("/", contextCopy);
     }
 }

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/parts/ComponentsMergeTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/parts/ComponentsMergeTest.java
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.openapi20.test.merge.parts;
+
+import static io.openliberty.microprofile.openapi20.test.merge.AssertModel.assertModelMaps;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.models.Components;
+import org.eclipse.microprofile.openapi.models.Constructible;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.callbacks.Callback;
+import org.eclipse.microprofile.openapi.models.examples.Example;
+import org.eclipse.microprofile.openapi.models.headers.Header;
+import org.eclipse.microprofile.openapi.models.links.Link;
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.eclipse.microprofile.openapi.models.parameters.Parameter;
+import org.eclipse.microprofile.openapi.models.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.models.responses.APIResponse;
+import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ComponentsMergeTest {
+
+    @Test
+    public void testComponentsMerge() {
+        try {
+            testComponentsItem(Example.class);
+            testComponentsItem(Callback.class);
+            testComponentsItem(Header.class);
+            testComponentsItem(Link.class);
+            testComponentsItem(RequestBody.class);
+            testComponentsItem(Parameter.class);
+            testComponentsItem(SecurityScheme.class);
+            testComponentsItem(Schema.class);
+            testComponentsItem(APIResponse.class);
+            testComponentsItem(Object.class);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail(e.getMessage() != null ? e.getMessage() : "Test failed: " + e);
+        }
+
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> void testComponentsItem(Class<T> clazz) throws Exception {
+        OpenAPI primaryOpenAPI;
+        Components components = OASFactory.createComponents();
+
+        Method setter = findSetter(clazz);
+
+        Map<String, T> map1 = getTestMap(clazz, "test", "test1", "test2");
+        setter.invoke(components, map1);
+
+        OpenAPI doc1 = OASFactory.createOpenAPI();
+        doc1.setComponents(components);
+
+        components = OASFactory.createComponents();
+
+        Map<String, T> map2 = getTestMap(clazz, "test", "test3", "test4");
+        setter.invoke(components, map2);
+
+        OpenAPI doc2 = OASFactory.createOpenAPI();
+        doc2.setComponents(components);
+
+        components = OASFactory.createComponents();
+        Map<String, T> map3 = getTestMap(clazz, "test", "test5", "test6");
+        setter.invoke(components, map3);
+
+        OpenAPI doc3 = OASFactory.createOpenAPI();
+        doc3.setComponents(components);
+
+        Method getter = findGetter(clazz);
+
+        Map<String, T> doc1Map = (Map<String, T>) getter.invoke(doc1.getComponents());
+        Map<String, T> doc2Map = (Map<String, T>) getter.invoke(doc2.getComponents());
+        Map<String, T> doc3Map = (Map<String, T>) getter.invoke(doc3.getComponents());
+
+        primaryOpenAPI = TestUtil.merge(doc1);
+
+        Assert.assertNotNull(primaryOpenAPI.getComponents());
+        Map<String, T> primaryOpenAPIMap = (Map<String, T>) getter.invoke(primaryOpenAPI.getComponents());
+        Assert.assertNotNull(primaryOpenAPIMap);
+
+        Assert.assertEquals(3, primaryOpenAPIMap.size());
+
+        validateMap(primaryOpenAPIMap, doc1Map);
+
+        primaryOpenAPI = TestUtil.merge(doc1, doc2);
+        primaryOpenAPIMap = (Map<String, T>) getter.invoke(primaryOpenAPI.getComponents());
+
+        Assert.assertNotNull(primaryOpenAPIMap);
+        Assert.assertEquals(5, primaryOpenAPIMap.size());
+        validateMap(primaryOpenAPIMap, doc1Map, doc2Map);
+
+        primaryOpenAPI = TestUtil.merge(doc1, doc2, doc3);
+        primaryOpenAPIMap = (Map<String, T>) getter.invoke(primaryOpenAPI.getComponents());
+
+        Assert.assertNotNull(primaryOpenAPIMap);
+        Assert.assertEquals(7, primaryOpenAPIMap.size());
+        validateMap(primaryOpenAPIMap, doc1Map, doc2Map, doc3Map);
+
+        primaryOpenAPI = TestUtil.merge(doc1, doc3);
+        primaryOpenAPIMap = (Map<String, T>) getter.invoke(primaryOpenAPI.getComponents());
+
+        Assert.assertNotNull(primaryOpenAPIMap);
+        Assert.assertEquals(5, primaryOpenAPIMap.size());
+        validateMap(primaryOpenAPIMap, doc1Map, doc3Map);
+
+        primaryOpenAPI = TestUtil.merge(doc3);
+        primaryOpenAPIMap = (Map<String, T>) getter.invoke(primaryOpenAPI.getComponents());
+
+        Assert.assertNotNull(primaryOpenAPIMap);
+        Assert.assertEquals(3, primaryOpenAPIMap.size());
+        validateMap(primaryOpenAPIMap, doc3Map);
+
+        primaryOpenAPI = TestUtil.merge();
+
+        //no data in components anymore should have been set to null
+        Assert.assertNull(primaryOpenAPI.getComponents());
+
+    }
+
+    private void validateMap(Map<String, ?> map, Map<?, ?>... maps) {
+        Map<Object, Object> expectedMap = new HashMap<>();
+        for (Map<?, ?> m : maps) {
+            expectedMap.putAll(m);
+        }
+        assertModelMaps(expectedMap, map);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> Map<String, T> getTestMap(Class<T> clazz, String... keys) {
+        Map<String, T> map = new HashMap<>();
+        try {
+            for (String key : keys) {
+                if (clazz.equals(Object.class)) {
+                    key = "x-" + key;
+                    map.put(key, (T) clazz);
+                } else {
+                    map.put(key, (T) OASFactory.createObject((Class<? extends Constructible>) clazz));
+                }
+            }
+        } catch (Exception e) {
+            Assert.fail("Failed to create test map");
+        }
+        return map;
+    }
+
+    private Method findSetter(Class<?> clazz) {
+        Method setter = Arrays.asList(Components.class.getMethods()).stream().filter(method -> method.getName().startsWith("set") &&
+                                                                                               method.getGenericParameterTypes()[0].toString().contains(clazz.getName())).findFirst().get();
+        return setter;
+    }
+
+    private Method findGetter(Class<?> clazz) {
+        Method setter = Arrays.asList(Components.class.getMethods()).stream().filter(method -> method.getName().startsWith("get") &&
+                                                                                               method.getGenericReturnType().toString().contains(clazz.getName())).findFirst().get();
+        return setter;
+    }
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/parts/ExtensionsMergeTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/parts/ExtensionsMergeTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.openapi20.test.merge.parts;
+
+import static io.openliberty.microprofile.openapi20.test.merge.AssertModel.assertModelMaps;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class ExtensionsMergeTest {
+    @Test
+    public void testExtensionsMerge() {
+        OpenAPI primaryOpenAPI;
+        OpenAPI doc1 = OASFactory.createOpenAPI();
+        OpenAPI doc2 = OASFactory.createOpenAPI();
+        OpenAPI doc3 = OASFactory.createOpenAPI();
+
+        doc1.addExtension("x-ibm", new HashMap<>());
+        doc1.addExtension("x-ibm-1", new HashMap<>());
+        doc1.addExtension("x-ibm-2", new HashMap<>());
+
+        doc2.addExtension("x-ibm", new HashMap<>());
+        doc2.addExtension("x-ibm-3", new HashMap<>());
+        doc2.addExtension("x-ibm-4", new HashMap<>());
+
+        doc3.addExtension("x-ibm", new HashMap<>());
+        doc3.addExtension("x-ibm-5", new HashMap<>());
+        doc3.addExtension("x-ibm-6", new HashMap<>());
+
+        primaryOpenAPI = TestUtil.merge(doc1);
+        validateMap(primaryOpenAPI.getExtensions(), doc1.getExtensions());
+        primaryOpenAPI = TestUtil.merge(doc1, doc2);
+        validateMap(primaryOpenAPI.getExtensions(), doc1.getExtensions(), doc2.getExtensions());
+        primaryOpenAPI = TestUtil.merge(doc1, doc2, doc3);
+        validateMap(primaryOpenAPI.getExtensions(), doc1.getExtensions(), doc2.getExtensions(), doc3.getExtensions());
+
+        primaryOpenAPI = TestUtil.merge(doc1, doc3);
+        validateMap(primaryOpenAPI.getExtensions(), doc1.getExtensions(), doc3.getExtensions());
+        primaryOpenAPI = TestUtil.merge(doc3);
+        validateMap(primaryOpenAPI.getExtensions(), doc3.getExtensions());
+        primaryOpenAPI = TestUtil.merge();
+        Assert.assertNull(primaryOpenAPI.getExtensions());
+    }
+
+    private void validateMap(Map<String, ?> map, Map<?, ?>... maps) {
+        Map<Object, Object> expectedMap = new HashMap<>();
+        for (Map<?, ?> m : maps) {
+            expectedMap.putAll(m);
+        }
+        assertModelMaps(expectedMap, map);
+    }
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/parts/OpenAPIProviderCustom.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/parts/OpenAPIProviderCustom.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.openapi20.test.merge.parts;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+
+import io.openliberty.microprofile.openapi20.OpenAPIProvider;
+
+/**
+ *
+ */
+public class OpenAPIProviderCustom implements OpenAPIProvider {
+
+    private final OpenAPI openAPI;
+    private final String applicationPath;
+
+    public OpenAPIProviderCustom(OpenAPI openapi, String applicationPath) {
+        this.openAPI = openapi;
+        this.applicationPath = applicationPath;
+    }
+
+    @Override
+    public String getApplicationPath() {
+        return applicationPath;
+    }
+
+    @Override
+    public OpenAPI getModel() {
+        return this.openAPI;
+    }
+
+    @Override
+    public List<String> getMergeProblems() {
+        return Collections.emptyList();
+    }
+
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/parts/OperationIDMergeTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/parts/OperationIDMergeTest.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.openapi20.test.merge.parts;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.Operation;
+import org.eclipse.microprofile.openapi.models.PathItem;
+import org.eclipse.microprofile.openapi.models.Paths;
+import org.junit.Test;
+
+public class OperationIDMergeTest {
+    @Test
+    public void testRenameConflictingOperationIDs() {
+        OpenAPI primaryOpenAPI;
+
+        OpenAPI doc1 = OASFactory.createOpenAPI();
+        OpenAPI doc2 = OASFactory.createOpenAPI();
+
+        //setup doc1
+        Paths paths = OASFactory.createPaths();
+        PathItem pathItem = OASFactory.createPathItem();
+        Operation operation = OASFactory.createOperation();
+        operation.setOperationId("operationGet");
+        pathItem.setGET(operation);
+        operation = OASFactory.createOperation();
+        operation.setOperationId("operationPost");
+        pathItem.setPOST(operation);
+        operation = OASFactory.createOperation();
+        operation.setOperationId("delete");
+        pathItem.setDELETE(operation);
+        paths.addPathItem("/users", pathItem);
+        doc1.paths(paths);
+
+        //setup doc2
+        paths = OASFactory.createPaths();
+        pathItem = OASFactory.createPathItem();
+        operation = OASFactory.createOperation();
+        operation.setOperationId("operationGet");
+        pathItem.setGET(operation);
+        operation = OASFactory.createOperation();
+        operation.setOperationId("operationPost");
+        pathItem.setPOST(operation);
+        operation = OASFactory.createOperation();
+        operation.setOperationId("delete_products");
+        pathItem.setDELETE(operation);
+        paths.addPathItem("/products", pathItem);
+        doc2.paths(paths);
+
+        primaryOpenAPI = TestUtil.merge(doc1, doc2);
+
+        String opId = primaryOpenAPI.getPaths().getPathItem("/users").getGET().getOperationId();
+        assertEquals("operationGet", opId);
+        opId = primaryOpenAPI.getPaths().getPathItem("/users").getPOST().getOperationId();
+        assertEquals("operationPost", opId);
+        opId = primaryOpenAPI.getPaths().getPathItem("/users").getDELETE().getOperationId();
+        assertEquals("delete", opId);
+        opId = primaryOpenAPI.getPaths().getPathItem("/products").getGET().getOperationId();
+        assertEquals("operationGet1", opId);
+        opId = primaryOpenAPI.getPaths().getPathItem("/products").getPOST().getOperationId();
+        assertEquals("operationPost1", opId);
+        opId = primaryOpenAPI.getPaths().getPathItem("/products").getDELETE().getOperationId();
+        assertEquals("delete_products", opId);
+
+    }
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/parts/PathsMergeTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/parts/PathsMergeTest.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.openapi20.test.merge.parts;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.Paths;
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.openliberty.microprofile.openapi20.OpenAPIProvider;
+import io.openliberty.microprofile.openapi20.merge.MergeProcessor;
+
+public class PathsMergeTest {
+
+    @Test
+    public void testPathsMerger() {
+        OpenAPI primaryOpenAPI;
+
+        OpenAPI doc1 = OASFactory.createOpenAPI();
+        Paths paths = OASFactory.createPaths();
+        paths.addPathItem("/common", OASFactory.createPathItem());
+        paths.addPathItem("/users", OASFactory.createPathItem());
+        paths.addPathItem("/events", OASFactory.createPathItem());
+        doc1.setPaths(paths);
+
+        OpenAPI doc2 = OASFactory.createOpenAPI();
+        paths = OASFactory.createPaths();
+        paths.addPathItem("/common", OASFactory.createPathItem());
+        paths.addPathItem("/feed", OASFactory.createPathItem());
+        paths.addPathItem("/followers", OASFactory.createPathItem());
+        doc2.setPaths(paths);
+
+        OpenAPI doc3 = OASFactory.createOpenAPI();
+        paths = OASFactory.createPaths();
+        paths.addPathItem("/stores", OASFactory.createPathItem());
+        paths.addPathItem("/orders", OASFactory.createPathItem());
+        doc3.setPaths(paths);
+
+        Paths doc1Paths = doc1.getPaths();
+        Paths doc2Paths = doc2.getPaths();
+        Paths doc3Paths = doc3.getPaths();
+
+        primaryOpenAPI = TestUtil.merge(doc1);
+        validatePaths(primaryOpenAPI.getPaths(), doc1Paths);
+
+        primaryOpenAPI = mergeAndAssertClashes(doc1, doc2);
+        validatePaths(primaryOpenAPI.getPaths(), doc1Paths);
+
+        primaryOpenAPI = mergeAndAssertClashes(doc1, doc2, doc3);
+        validatePaths(primaryOpenAPI.getPaths(), doc1Paths, doc3Paths);
+
+        primaryOpenAPI = TestUtil.merge(doc1, doc3);
+        validatePaths(primaryOpenAPI.getPaths(), doc1Paths, doc3Paths);
+
+        primaryOpenAPI = TestUtil.merge(doc3);
+        validatePaths(primaryOpenAPI.getPaths(), doc3Paths);
+        
+        primaryOpenAPI = TestUtil.merge(doc2, doc3);
+        validatePaths(primaryOpenAPI.getPaths(), doc2Paths, doc3Paths);
+
+        primaryOpenAPI = TestUtil.merge();
+        Assert.assertNull(primaryOpenAPI.getPaths());
+
+    }
+    
+    private OpenAPI mergeAndAssertClashes(OpenAPI... docs) {
+        List<OpenAPIProvider> providers = Arrays.stream(docs)
+                                                .map(TestUtil::createProvider)
+                                                .collect(Collectors.toList());
+        OpenAPIProvider result = MergeProcessor.mergeDocuments(providers);
+        
+        assertThat(result.getMergeProblems(), is(not(empty())));
+        
+        return result.getModel();
+    }
+
+    private void validatePaths(Paths primaryOpenAPIPaths, Paths... documentPaths) {
+        Assert.assertNotNull(primaryOpenAPIPaths);
+        Set<String> actualpathsKeys = primaryOpenAPIPaths.getPathItems().keySet();
+
+        List<Paths> docPaths = Arrays.asList(documentPaths);
+
+        Set<String> docsKeys = docPaths.stream().flatMap(paths -> {
+            return paths.getPathItems().keySet().stream();
+        }).collect(Collectors.toSet());
+
+        Assert.assertEquals(docsKeys, actualpathsKeys);
+    }
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/parts/SecurityMergeTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/parts/SecurityMergeTest.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.openapi20.test.merge.parts;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.Operation;
+import org.eclipse.microprofile.openapi.models.PathItem;
+import org.eclipse.microprofile.openapi.models.Paths;
+import org.eclipse.microprofile.openapi.models.security.SecurityRequirement;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SecurityMergeTest {
+
+    @Test
+    public void testMergingServers() {
+
+        OpenAPI primaryOpenAPI;
+
+        OpenAPI doc1 = OASFactory.createOpenAPI();
+        doc1.addSecurityRequirement(OASFactory.createSecurityRequirement().addScheme("api-key", new ArrayList<>()));
+        doc1.addSecurityRequirement(OASFactory.createSecurityRequirement().addScheme("oauth", new ArrayList<>()));
+
+        Paths docPaths = OASFactory.createPaths();
+        docPaths.addPathItem("/users", createPathItem());
+        docPaths.addPathItem("/status", createPathItem());
+        doc1.setPaths(docPaths);
+
+        OpenAPI doc2 = OASFactory.createOpenAPI();
+        doc2.addSecurityRequirement(OASFactory.createSecurityRequirement().addScheme("api-key", new ArrayList<>()));
+        doc2.addSecurityRequirement(OASFactory.createSecurityRequirement().addScheme("basic", new ArrayList<>()));
+
+        docPaths = OASFactory.createPaths();
+        docPaths.addPathItem("/events", createPathItem());
+        docPaths.addPathItem("/airlines", createPathItem());
+        doc2.setPaths(docPaths);
+        doc2.setPaths(docPaths);
+
+        List<SecurityRequirement> doc1Security = doc1.getSecurity();
+        List<SecurityRequirement> doc2Security = doc2.getSecurity();
+
+        primaryOpenAPI = TestUtil.merge(doc1);
+        Paths paths = primaryOpenAPI.getPaths();
+
+        validatePathServers(paths.getPathItem("/users"), null);
+        validatePathServers(paths.getPathItem("/status"), null);
+
+        primaryOpenAPI = TestUtil.merge(doc1, doc2);
+        paths = primaryOpenAPI.getPaths();
+
+        validatePathServers(paths.getPathItem("/users"), doc1Security);
+        validatePathServers(paths.getPathItem("/status"), doc1Security);
+        validatePathServers(paths.getPathItem("/events"), doc2Security);
+        validatePathServers(paths.getPathItem("/airlines"), doc2Security);
+
+        Assert.assertNull("Master server should be null", primaryOpenAPI.getServers());
+    }
+
+    private PathItem createPathItem() {
+        PathItem pathItem = OASFactory.createPathItem();
+        pathItem.setGET(OASFactory.createOperation());
+        pathItem.setPOST(OASFactory.createOperation().addSecurityRequirement(OASFactory.createSecurityRequirement().addScheme("my-token", new ArrayList<>())));
+        pathItem.setPUT(OASFactory.createOperation());
+        pathItem.setDELETE(OASFactory.createOperation());
+        pathItem.setHEAD(OASFactory.createOperation());
+        pathItem.setPATCH(OASFactory.createOperation());
+        pathItem.setTRACE(OASFactory.createOperation());
+        pathItem.setOPTIONS(OASFactory.createOperation());
+        return pathItem;
+    }
+
+    private void validatePathServers(PathItem pathItem, List<SecurityRequirement> expectedSecRequirements) {
+        Assert.assertNotNull(pathItem);
+        validateOperationRequirements(pathItem.getGET(), expectedSecRequirements);
+        validateOperationRequirements(pathItem.getPOST(), Arrays.asList(OASFactory.createSecurityRequirement().addScheme("my-token", new ArrayList<>())));
+        validateOperationRequirements(pathItem.getPUT(), expectedSecRequirements);
+        validateOperationRequirements(pathItem.getDELETE(), expectedSecRequirements);
+        validateOperationRequirements(pathItem.getPATCH(), expectedSecRequirements);
+        validateOperationRequirements(pathItem.getHEAD(), expectedSecRequirements);
+        validateOperationRequirements(pathItem.getTRACE(), expectedSecRequirements);
+        validateOperationRequirements(pathItem.getOPTIONS(), expectedSecRequirements);
+    }
+
+    private void validateOperationRequirements(Operation operation, List<SecurityRequirement> expectedSecRequirements) {
+        Assert.assertNotNull(operation);
+        List<SecurityRequirement> actualSecurity = operation.getSecurity();
+        if (expectedSecRequirements == null) {
+            Assert.assertNull(actualSecurity);
+        } else {
+            Assert.assertNotNull(actualSecurity);
+            Set<SecurityRequirement> actualSecReq = new HashSet<>(operation.getSecurity());
+            Set<SecurityRequirement> expectedSecReq = new HashSet<>(expectedSecRequirements);
+            Assert.assertEquals(expectedSecReq, actualSecReq);
+        }
+    }
+
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/parts/ServersMergeTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/parts/ServersMergeTest.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.openapi20.test.merge.parts;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.PathItem;
+import org.eclipse.microprofile.openapi.models.Paths;
+import org.eclipse.microprofile.openapi.models.servers.Server;
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.openliberty.microprofile.openapi20.OpenAPIProvider;
+
+public class ServersMergeTest {
+
+    @Test
+    public void testMergingServers() {
+
+        OpenAPI primaryOpenAPI;
+
+        OpenAPI doc1 = OASFactory.createOpenAPI();
+        doc1.addServer(OASFactory.createServer().url("http://common"));
+        doc1.addServer(OASFactory.createServer().url("http://abc"));
+        doc1.addServer(OASFactory.createServer().url("http://xyz"));
+
+        Paths docPaths = OASFactory.createPaths();
+        docPaths.addPathItem("/users", OASFactory.createPathItem().addServer(OASFactory.createServer().url("http://custom")));
+        docPaths.addPathItem("/events", OASFactory.createPathItem());
+        docPaths.addPathItem("/status", OASFactory.createPathItem());
+        doc1.setPaths(docPaths);
+        
+        OpenAPIProvider provider1 = TestUtil.createProvider(doc1);
+
+        OpenAPI doc2 = OASFactory.createOpenAPI();
+        doc2.addServer(OASFactory.createServer().url("http://common"));
+        doc2.addServer(OASFactory.createServer().url("http://abc2"));
+        doc2.addServer(OASFactory.createServer().url("http://xyz2"));
+
+        docPaths = OASFactory.createPaths();
+        docPaths.addPathItem("/billing", OASFactory.createPathItem());
+        docPaths.addPathItem("/inventory", OASFactory.createPathItem());
+        docPaths.addPathItem("/store", OASFactory.createPathItem().addServer(OASFactory.createServer().url("http://custom")));
+        doc2.setPaths(docPaths);
+        
+        OpenAPIProvider provider2 = TestUtil.createProvider(doc2);
+
+        OpenAPI doc3 = OASFactory.createOpenAPI();
+        doc3.addServer(OASFactory.createServer().url("/basepath"));
+
+        docPaths = OASFactory.createPaths();
+        docPaths.addPathItem("/feed", OASFactory.createPathItem());
+        docPaths.addPathItem("/timeline", OASFactory.createPathItem());
+        docPaths.addPathItem("/news", OASFactory.createPathItem().addServer(OASFactory.createServer().url("http://custom/basepath")));
+        doc3.setPaths(docPaths);
+        
+        OpenAPIProvider provider3 = TestUtil.createProvider(doc3, "/basepath");
+
+        List<Server> doc1Servers = doc1.getServers();
+        List<Server> doc2Servers = doc2.getServers();
+
+        primaryOpenAPI = TestUtil.merge(Arrays.asList(provider1));
+        Paths paths = primaryOpenAPI.getPaths();
+
+        validatePathServers(paths.getPathItem("/users"), Arrays.asList(OASFactory.createServer().url("http://custom")));
+        validatePathServers(paths.getPathItem("/events"), null);
+        validatePathServers(paths.getPathItem("/status"), null);
+
+        primaryOpenAPI = TestUtil.merge(Arrays.asList(provider1, provider2));
+        paths = primaryOpenAPI.getPaths();
+
+        validatePathServers(paths.getPathItem("/users"), Arrays.asList(OASFactory.createServer().url("http://custom")));
+        validatePathServers(paths.getPathItem("/events"), doc1Servers);
+        validatePathServers(paths.getPathItem("/status"), doc1Servers);
+        validatePathServers(paths.getPathItem("/store"), Arrays.asList(OASFactory.createServer().url("http://custom")));
+        validatePathServers(paths.getPathItem("/inventory"), doc2Servers);
+        validatePathServers(paths.getPathItem("/billing"), doc2Servers);
+        
+        Assert.assertNull("Master server should be null", primaryOpenAPI.getServers());
+
+        primaryOpenAPI = TestUtil.merge(Arrays.asList(provider1, provider2, provider3));
+        paths = primaryOpenAPI.getPaths();
+
+        validatePathServersEmpty(paths.getPathItem("/basepath/feed"));
+        validatePathServersEmpty(paths.getPathItem("/basepath/timeline"));
+        validatePathServers(paths.getPathItem("/basepath/news"), Arrays.asList(OASFactory.createServer().url("http://custom")));
+
+        Assert.assertNull("Master server should be null", primaryOpenAPI.getServers());
+    }
+
+    private void validatePathServers(PathItem pathItem, List<Server> expectedServers) {
+        Assert.assertNotNull(pathItem);
+        if (expectedServers == null) {
+            Assert.assertNull(pathItem.getServers());
+        } else {
+            Assert.assertNotNull(pathItem.getServers());
+            Set<String> actualServerUrls = pathItem.getServers().stream().map(server -> server.getUrl()).collect(Collectors.toSet());
+            Set<String> expectedServerUrls = expectedServers.stream().map(server -> server.getUrl()).collect(Collectors.toSet());
+            Assert.assertEquals(expectedServerUrls, actualServerUrls);
+        }
+    }
+
+    private void validatePathServersEmpty(PathItem pathItem) {
+        Assert.assertNotNull(pathItem);
+        Assert.assertNull(pathItem.getServers());
+    }
+
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/parts/TagsMergeTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/parts/TagsMergeTest.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.openapi20.test.merge.parts;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.tags.Tag;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TagsMergeTest {
+
+    @Test
+    public void testMergingTags() {
+
+        OpenAPI primaryOpenAPI;
+
+        OpenAPI doc1 = OASFactory.createOpenAPI();
+        doc1.addTag(OASFactory.createTag().name("common"));
+        doc1.addTag(OASFactory.createTag().name("dog"));
+        doc1.addTag(OASFactory.createTag().name("cat"));
+
+        primaryOpenAPI = TestUtil.merge(doc1);
+
+        Assert.assertNotNull("Tags is null", primaryOpenAPI.getTags());
+        Assert.assertEquals(3, primaryOpenAPI.getTags().size());
+        validateTags(primaryOpenAPI.getTags(), "common", "dog", "cat");
+
+        OpenAPI doc2 = OASFactory.createOpenAPI();
+        doc2.addTag(OASFactory.createTag().name("common"));
+        doc2.addTag(OASFactory.createTag().name("users"));
+        doc2.addTag(OASFactory.createTag().name("events"));
+
+        primaryOpenAPI = TestUtil.merge(doc1, doc2);
+
+        Assert.assertNotNull("Tags is null", primaryOpenAPI.getTags());
+        Assert.assertEquals(5, primaryOpenAPI.getTags().size());
+        validateTags(primaryOpenAPI.getTags(), "common", "dog", "cat", "users", "events");
+
+        OpenAPI doc3 = OASFactory.createOpenAPI();
+        doc3.addTag(OASFactory.createTag().name("common"));
+        doc3.addTag(OASFactory.createTag().name("feed"));
+        doc3.addTag(OASFactory.createTag().name("status"));
+
+        primaryOpenAPI = TestUtil.merge(doc1, doc2, doc3);
+
+        Assert.assertNotNull("Tags is null", primaryOpenAPI.getTags());
+        Assert.assertEquals(7, primaryOpenAPI.getTags().size());
+        validateTags(primaryOpenAPI.getTags(), "common", "dog", "cat", "users", "events", "feed", "status");
+
+        primaryOpenAPI = TestUtil.merge(doc1, doc3);
+        Assert.assertNotNull("Tags is null", primaryOpenAPI.getTags());
+        Assert.assertEquals(5, primaryOpenAPI.getTags().size());
+        validateTags(primaryOpenAPI.getTags(), "common", "dog", "cat", "feed", "status");
+
+        primaryOpenAPI = TestUtil.merge(doc3);
+        Assert.assertNotNull("Tags is null", primaryOpenAPI.getTags());
+        Assert.assertEquals(3, primaryOpenAPI.getTags().size());
+        validateTags(primaryOpenAPI.getTags(), "common", "feed", "status");
+
+        primaryOpenAPI = TestUtil.merge();
+        Assert.assertNull("Tags is not null", primaryOpenAPI.getTags());
+    }
+
+    private void validateTags(List<Tag> tags, String... expected) {
+        Set<String> expectedTagNames = new HashSet<>(Arrays.asList(expected));
+        Set<String> currentTagNames = tags.stream().map(tag -> tag.getName()).collect(Collectors.toSet());
+        Assert.assertEquals(expectedTagNames, currentTagNames);
+    }
+
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/parts/TestUtil.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/parts/TestUtil.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.openapi20.test.merge.parts;
+
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+
+import io.openliberty.microprofile.openapi20.OpenAPIProvider;
+import io.openliberty.microprofile.openapi20.merge.MergeProcessor;
+
+public class TestUtil {
+
+    /**
+     * Create an OpenAPIProvdier for the given model with an application path of {@code /}
+     * 
+     * @param openapi the openapi model
+     * @return the provider
+     */
+    public static OpenAPIProvider createProvider(OpenAPI openapi) {
+        return createProvider(openapi, "/");
+    }
+
+    /**
+     * Create an OpenAPIProvider for the given model
+     * 
+     * @param openapi the openapi model
+     * @param applicationPath the application path for the returned provider
+     * @return the provider
+     */
+    public static OpenAPIProvider createProvider(OpenAPI openapi, String applicationPath) {
+        return new OpenAPIProviderCustom(openapi, applicationPath);
+    }
+
+    /**
+     * Merge several OpenAPI models using {@link MergeProcessor}
+     * 
+     * @param docs the openapi models
+     * @return the merged model
+     */
+    public static OpenAPI merge(OpenAPI... docs) {
+        List<OpenAPIProvider> providers = new ArrayList<>();
+        for (OpenAPI doc : docs) {
+            providers.add(createProvider(doc));
+        }
+        return merge(providers);
+    }
+
+    /**
+     * Merge several OpenAPI providers using {@link MergeProcessor}
+     * 
+     * @param providers the providers
+     * @return the merged model
+     */
+    public static OpenAPI merge(List<OpenAPIProvider> providers) {
+        OpenAPIProvider merged = MergeProcessor.mergeDocuments(providers);
+        assertThat("Merge problems", merged.getMergeProblems(), empty());
+        return merged.getModel();
+    }
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/parts/package-info.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/test/merge/parts/package-info.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+/**
+ * Test the merging strategy for individual components
+ * <p>
+ * These tests were originally ported from the openapi-3.1
+ */
+package io.openliberty.microprofile.openapi20.test.merge.parts;


### PR DESCRIPTION
* detect and remove a trailing slash in the context root
* if the server information is completely absorbed into the path names, clean up the empty server definitions
* port merge unit tests from openapi-3.1

Fixes #19154 
Fixes #19153 