### PR TITLE
Add comments to remind future i-fix work must add OLGH numbers to bot…

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.x.monitor.component/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.x.monitor.component/bnd.bnd
@@ -55,3 +55,7 @@ Liberty-Monitoring-Components:
 	com.ibm.ws.jaxrs.2.0.common,\
 	com.ibm.ws.jaxrs.2.x.monitor
 	
+#*** IMPORTANT ****: Whenever OLGH numbers are added to this file 
+# they must also be added to the bnd.bnd in com.ibm.ws.jaxrs.2.x.monitor 
+# or the i-fix may not pick up the changes
+	

--- a/dev/com.ibm.ws.jaxrs.2.x.monitor/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.x.monitor/bnd.bnd
@@ -70,3 +70,7 @@ jakartaeeMe: true
 
 # Only publish the Jakarta one
 publish.wlp.jar.include: com.ibm.ws.jaxrs.2.x.monitor.jakarta.jar
+
+#*** IMPORTANT ****: Whenever OLGH numbers are added to this file 
+# they must also be added to the bnd.bnd in com.ibm.ws.jaxrs.2.x.monitor.component 
+# or the i-fix may not pick up the changes


### PR DESCRIPTION
This PR puts comments in the bnd.bnd files for com.ibm.ws.jaxrs.2.x.monitor.component and com.ibm.ws.jaxrs.2.x.monitor to flag that any future APAR number (OLGHxxxxx) must be added to both bnd files or the i-fix tool may not pick up the changes.
