### PR TITLE
fix ClassCastException in JSP

### DIFF
--- a/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSPTests.java
+++ b/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSPTests.java
@@ -58,6 +58,7 @@ public class JSPTests {
     private static final String PI44611_APP_NAME = "PI44611";
     private static final String PI59436_APP_NAME = "PI59436";
     private static final String TestEDR_APP_NAME = "TestEDR";
+    private static final String TestJDT_APP_NAME = "TestJDT";
 
     @Server("jspServer")
     public static LibertyServer server;
@@ -79,6 +80,8 @@ public class JSPTests {
         ShrinkHelper.defaultDropinApp(server, PI44611_APP_NAME + ".war");
 
         ShrinkHelper.defaultDropinApp(server, PI59436_APP_NAME + ".war");
+
+        ShrinkHelper.defaultDropinApp(server, TestJDT_APP_NAME + ".war");
 
         server.startServer(JSPTests.class.getSimpleName() + ".log");
     }
@@ -814,6 +817,18 @@ public class JSPTests {
         LOG.info("url: " + url);
 
         runEDR(url, false);
+    }
+
+    /**
+     * This test verifies compile works without ClassCastException,
+     * per issue 19197.
+     *
+     * @throws Exception
+     */
+    @Mode(TestMode.FULL)
+    @Test
+    public void TestJDT() throws Exception {
+        this.verifyStringInResponse(TestJDT_APP_NAME, "index.jsp", "Test passed.");
     }
 
     /**

--- a/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestJDT.war/resources/WEB-INF/ibm-web-ext.xml
+++ b/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestJDT.war/resources/WEB-INF/ibm-web-ext.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<web-ext
+	xmlns="http://websphere.ibm.com/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-ext_1_0.xsd"
+	version="1.0">
+	<jsp-attribute name="jdkSourceLevel" value="18" />
+</web-ext>

--- a/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestJDT.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestJDT.war/resources/WEB-INF/web.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<web-app
+    version="3.1"
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+
+  <display-name>TestJDT</display-name>
+    
+</web-app>

--- a/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestJDT.war/resources/index.jsp
+++ b/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestJDT.war/resources/index.jsp
@@ -1,0 +1,50 @@
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<%@ page language="java" contentType="text/html; charset=ISO-8859-1"
+    pageEncoding="ISO-8859-1" %>
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<%@ page import="java.util.List"%>
+<%@ page import="java.util.ArrayList"%>
+<title>TestJDT</title>
+</head>
+<body>
+<%
+class InnerClass {
+    public int counter = 0;
+	public int r1 () {
+    	return 1;	
+    }
+    
+    public int r2 () {
+    	return 2;
+    }
+    public void resetCounter() {
+    	counter = 0;
+    }
+}
+
+List<InnerClass> list = new ArrayList<>();
+
+InnerClass iC = new InnerClass();
+
+for(InnerClass elements : list) {
+    // do sth
+    iC.counter++;
+}
+%>
+<!-- After JDT update to 3.22, the above construct fails compile with a ClassCastException.
+If this compiles OK, then fix for issue 19197 works.  -->
+<p>Test passed.</p>
+</body> 
+</html> 

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/compiler/JDTCompiler.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/compiler/JDTCompiler.java
@@ -318,7 +318,8 @@ public class JDTCompiler implements JspCompiler {
             boolean retbool=false;
                         try {
                                 for (int i = 0; i < jspCompilationUnits.length; i++) {
-                            if (result.equals(jspCompilationUnits[i].getJspClassName())) {
+                            if (result.equals(jspCompilationUnits[i].getJspClassName()) || 
+                                result.startsWith(jspCompilationUnits[i].getJspClassName() + '$')) {
                                 return false;
                             }
                                 }


### PR DESCRIPTION
fixes #19197 
ClassCastException in JSP on JDT classes

Tomcat 9.x Fix:

`https://github.com/apache/tomcat/commit/85e93fbf55e22dcfb6bbc54b9413051ccbabe5c0`

```
The private isPackage(String) method needed to be updated to correctly
identify that "org.apache.jsp.test_jsp$1InnerClass" is a class and not a
package.
```