### PR TITLE
Remove unneeded restfulWSCleint feature from microProfile-5.0 feature file

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-5.0/io.openliberty.microProfile-5.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-5.0/io.openliberty.microProfile-5.0.feature
@@ -11,7 +11,6 @@ Subsystem-Name: MicroProfile 5.0
   io.openliberty.jsonb-2.0, \
   io.openliberty.jsonp-2.0, \
   io.openliberty.restfulWS-3.0, \
-  io.openliberty.restfulWSClient-3.0, \
   com.ibm.websphere.appserver.servlet-5.0, \
   io.openliberty.mpCompatible-5.0, \
   io.openliberty.mpConfig-3.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/restfulWS-3.0/io.openliberty.restfulWS-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/restfulWS-3.0/io.openliberty.restfulWS-3.0.feature
@@ -8,7 +8,8 @@ IBM-App-ForceRestart: uninstall, \
 IBM-ShortName: restfulWS-3.0
 WLP-AlsoKnownAs: jaxrs-3.0
 Subsystem-Name: Jakarta RESTful Web Services 3.0
--features=io.openliberty.restfulWSClient-3.0, \
+-features=\
+  io.openliberty.restfulWSClient-3.0, \
   com.ibm.websphere.appserver.eeCompatible-9.0
 -bundles=\
  io.openliberty.org.jboss.resteasy.cdi.jakarta, \


### PR DESCRIPTION
 The microProfile-5.0 feature brings in the restfulWS-3.0 feature, which in turn brings in the restfulWSClient-3.0 feature. So it is not necessary for microProfile-5.0 to also bring in the restfulWSClient-3.0 feature.  

