### PR TITLE
configurable transaction context on ContextServiceDefinition

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ApplicationScopedBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ApplicationScopedBean.java
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package concurrent.cdi.web;
 
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.ALL_REMAINING;
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.TRANSACTION;
+
 import java.io.Serializable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -17,6 +20,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.enterprise.concurrent.Asynchronous;
+import jakarta.enterprise.concurrent.ContextServiceDefinition;
 import jakarta.enterprise.concurrent.ManagedExecutorService;
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -24,6 +28,9 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
 @ApplicationScoped
+@ContextServiceDefinition(name = "java:app/concurrent/txcontext",
+                          propagated = TRANSACTION,
+                          cleared = ALL_REMAINING)
 public class ApplicationScopedBean implements Serializable {
     private static final long serialVersionUID = -2075274815197982538L;
 

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/RequestScopedBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/RequestScopedBean.java
@@ -10,6 +10,10 @@
  *******************************************************************************/
 package concurrent.cdi.web;
 
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.ALL_REMAINING;
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.APPLICATION;
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.TRANSACTION;
+
 import java.lang.reflect.Method;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -19,8 +23,13 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.enterprise.concurrent.Asynchronous;
+import jakarta.enterprise.concurrent.ContextServiceDefinition;
 import jakarta.enterprise.context.RequestScoped;
 
+@ContextServiceDefinition(name = "java:comp/concurrent/txcontextunchanged",
+                          propagated = APPLICATION,
+                          unchanged = TRANSACTION,
+                          cleared = ALL_REMAINING)
 @RequestScoped
 public class RequestScopedBean {
     private int number;

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/SingletonScopedBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/SingletonScopedBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2020 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,11 +10,18 @@
  *******************************************************************************/
 package concurrent.cdi.web;
 
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.ALL_REMAINING;
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.TRANSACTION;
+
 import java.util.HashMap;
 import java.util.Map;
 
+import jakarta.enterprise.concurrent.ContextServiceDefinition;
 import jakarta.inject.Singleton;
 
+@ContextServiceDefinition(name = "java:module/concurrent/txcontextcleared",
+                          cleared = TRANSACTION,
+                          propagated = ALL_REMAINING)
 @Singleton
 public class SingletonScopedBean {
     private final Map<Object, Object> map = new HashMap<Object, Object>();

--- a/dev/com.ibm.ws.context/src/com/ibm/ws/context/service/serializable/ThreadContextManager.java
+++ b/dev/com.ibm.ws.context/src/com/ibm/ws/context/service/serializable/ThreadContextManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013,2020 IBM Corporation and others.
+ * Copyright (c) 2013,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -174,8 +174,10 @@ public class ThreadContextManager implements WSContextService {
             // context that is always captured per the alwaysCaptureThreadContext service property
             for (int i = 0; i < alwaysEnabledProviders.size(); i++) {
                 ThreadContextProvider provider = alwaysEnabledProviders.get(i);
-                ThreadContext context = provider.captureThreadContext(execProps, null);
-                capturedThreadContext.add(alwaysEnabledProviderNames.get(i), context);
+                if (!configuredProviders.contains(provider)) {
+                    ThreadContext context = provider.captureThreadContext(execProps, null);
+                    capturedThreadContext.add(alwaysEnabledProviderNames.get(i), context);
+                }
             }
         }
 

--- a/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/TransactionContextProviderImpl.java
+++ b/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/TransactionContextProviderImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -82,6 +82,16 @@ public class TransactionContextProviderImpl implements JCAContextProvider, Threa
             value = execProps.get(key = ManagedTask.TRANSACTION);
             if (value == null)
                 value = execProps.get(key = OTHER_SPEC_TRANSACTION_CONSTANT);
+        }
+        if (value == null && threadContextConfig != null) {
+            // Concurrency 3.0+ application-defined context service configuration
+            value = (String) threadContextConfig.get("transaction");
+            if ("cleared".equals(value))
+                value = ManagedTask.SUSPEND;
+            else if ("propagated".equals(value))
+                value = "PROPAGATE";
+            else if ("unchanged".equals(value))
+                value = ManagedTask.USE_TRANSACTION_OF_EXECUTION_THREAD;
         }
         if (value == null || ManagedTask.SUSPEND.equals(value))
             return new TransactionContextImpl(true);


### PR DESCRIPTION
Honor the propagation setting for Transaction context on ContextServiceDefinition,
including getting the precedence correct with the similar execution property, which should override.