### PR TITLE
Fix checkpii error in UtilityOptions.nlsprops

### DIFF
--- a/dev/com.ibm.ws.security.utility/resources/com/ibm/ws/security/utility/resources/UtilityOptions.nlsprops
+++ b/dev/com.ibm.ws.security.utility/resources/com/ibm/ws/security/utility/resources/UtilityOptions.nlsprops
@@ -260,7 +260,7 @@ createLTPAKeys.option-desc.password.key=\
 #------------------------------\n at 72 chars Leading "\ \ \ \ "-------\n\#
 #------------------------------\n at 72 chars Leading "\t"-------------\n\#
 tlsProfiler.desc=\
-\tTest the target host and port's compatibility with available TLS protocols and cipher suites.
+\tTest the target host and port''s compatibility with available TLS protocols and cipher suites.
 tlsProfiler.usage.options=\
 \t{0} tlsProfiler [options]
 tlsProfiler.required-key.port=\


### PR DESCRIPTION
Fixes error found  by CheckPII:
CHKPII version：v23.05
1 errors are found.
918 Found 1 single quote in text handled by Java MessageFormat class. Double this quote. Line: 263