### PR TITLE
Fixes for Eclipse github actions and gradle builds

### DIFF
--- a/.github/test-categories/QUARANTINE
+++ b/.github/test-categories/QUARANTINE
@@ -9,6 +9,7 @@ com.ibm.ws.security.oidc.server_fat.spnego
 
 # Not a fat bucket, but still has '_fat' in name
 com.ibm.ws.jpa.tests.beanvalidation_fat.common
+com.ibm.ws.jpa.tests.jpaconfig_fat.common
 com.ibm.ws.jpa.tests.spec10.callback_fat.common
 com.ibm.ws.jpa.tests.spec10.entitymanager_fat.common
 com.ibm.ws.jpa.tests.spec10.entity_fat.common

--- a/dev/com.ibm.websphere.appserver.features/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.features/bnd.bnd
@@ -14,6 +14,10 @@
 
 testsrc: test/src
 
+# Setting this to false since this project does not have a resources directory.
+# The copyPiiFiles tasks in this project's build.gradle will do the right copy then.
+copy.pii: false
+
 instrument.disabled: true
 
 feature.project: true

--- a/dev/com.ibm.ws.security.oidc.server_fat.spnego/.project
+++ b/dev/com.ibm.ws.security.oidc.server_fat.spnego/.project
@@ -10,8 +10,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
 	</natures>
 </projectDescription>

--- a/dev/io.openliberty.concurrent/.classpath
+++ b/dev/io.openliberty.concurrent/.classpath
@@ -3,6 +3,5 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="src" path="/com.ibm.ws.concurrent"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
- Remove project reference and just rely on bnd for classpath for io.openliberty.concurrent
- Update spnego fat .project file to reference bnd buildCommand 
- Update com.ibm.webspere.appserver.features bnd to say not to copy pii so that it will use the copyPiiFiles task that is in its build.gradle file
- Add fat tools project to the QUARANTINE bucket for github actions build