### PR TITLE
Update OpenTracing to RC4

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2054,7 +2054,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.opentracing</groupId>
       <artifactId>microprofile-opentracing-api</artifactId>
-      <version>3.0-RC3</version>
+      <version>3.0-RC4</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -406,7 +406,7 @@ org.eclipse.microprofile.opentracing:microprofile-opentracing-api:1.1
 org.eclipse.microprofile.opentracing:microprofile-opentracing-api:1.2
 org.eclipse.microprofile.opentracing:microprofile-opentracing-api:1.3
 org.eclipse.microprofile.opentracing:microprofile-opentracing-api:2.0
-org.eclipse.microprofile.opentracing:microprofile-opentracing-api:3.0-RC3
+org.eclipse.microprofile.opentracing:microprofile-opentracing-api:3.0-RC4
 org.eclipse.microprofile.reactive-streams-operators:microprofile-reactive-streams-operators-api:1.0.1
 org.eclipse.microprofile.reactive-streams-operators:microprofile-reactive-streams-operators-core:1.0.1
 org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-api:1.0

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
@@ -207,7 +207,7 @@ public class MicroProfileActions {
                                                           "mpJwt-2.0",
                                                           "mpOpenAPI-3.0",
                                                           "mpMetrics-4.0",
-//                                                          "mpOpenTracing-3.0",
+                                                          "mpOpenTracing-3.0",
                                                           "mpRestClient-3.0" };
 
     private static final Set<String> MP10_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MP10_FEATURES_ARRAY)));

--- a/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -13,9 +13,9 @@
     <name>MicroProfile Opentracing TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.opentracing.version>3.0-RC3</microprofile.opentracing.version>
+        <microprofile.opentracing.version>3.0-RC4</microprofile.opentracing.version>
         <microprofile.config.version>3.0-RC5</microprofile.config.version>
-        <microprofile.rest.client.version>3.0-RC3</microprofile.rest.client.version>
+        <microprofile.rest.client.version>3.0-RC5</microprofile.rest.client.version>
         <arquillian.version>1.7.0.Alpha10</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->

--- a/dev/io.openliberty.org.eclipse.microprofile/opentracing.3.0.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile/opentracing.3.0.bnd
@@ -20,6 +20,6 @@ Export-Package: \
   org.eclipse.microprofile.opentracing;version=3.0
 
 Include-Resource: \
-  @${repo;org.eclipse.microprofile.opentracing:microprofile-opentracing-api;3.0.0.RC3;EXACT}
+  @${repo;org.eclipse.microprofile.opentracing:microprofile-opentracing-api;3.0.0.RC4;EXACT}
 
 WS-TraceGroup: OPENTRACING


### PR DESCRIPTION
Upgrading OpenTracing to use the 3.0-RC4 API, updating Rest-Client API to RC5 in the OT TCK and adding OpenTracing to MicroProfileActions.