### PR TITLE
No longer need to check the provider

### DIFF
--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/JSSEProviderFactory.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/JSSEProviderFactory.java
@@ -132,15 +132,15 @@ public class JSSEProviderFactory {
                 Tr.debug(tc, "Provider name [" + i + "]: " + providerList[i].getName());
 
             if (providerList[i].getName().equalsIgnoreCase(contextProvider)) {
-                if (contextProvider.equalsIgnoreCase(Constants.IBMJSSE2_NAME) && validateProvider(Constants.IBMJSSE2_NAME)) {
+                if (contextProvider.equalsIgnoreCase(Constants.IBMJSSE2_NAME)) {
                     cachedProvider = new IBMJSSEProvider();
                     providerCache.put(Constants.IBMJSSE2_NAME, cachedProvider);
                     providerCache.put(contextProvider, cachedProvider);
-                } else if (contextProvider.equalsIgnoreCase(Constants.IBMJSSE_NAME) && validateProvider(Constants.IBMJSSE_NAME)) {
+                } else if (contextProvider.equalsIgnoreCase(Constants.IBMJSSE_NAME)) {
                     cachedProvider = new IBMJSSEProvider();
                     providerCache.put(Constants.IBMJSSE_NAME, cachedProvider);
                     providerCache.put(contextProvider, cachedProvider);
-                } else if (contextProvider.equalsIgnoreCase(Constants.SUNJSSE_NAME) && validateProvider(Constants.SUNJSSE_NAME)) {
+                } else if (contextProvider.equalsIgnoreCase(Constants.SUNJSSE_NAME)) {
                     cachedProvider = new SunJSSEProvider();
                     providerCache.put(Constants.SUNJSSE_NAME, cachedProvider);
                     providerCache.put(contextProvider, cachedProvider);


### PR DESCRIPTION
We are needlessly checking to see if the provider is valid.  The check is causing errors.