### PR TITLE
Update postgreSQL table query

### DIFF
--- a/dev/com.ibm.ws.session.db/src/com/ibm/ws/session/store/db/DatabaseHashMap.java
+++ b/dev/com.ibm.ws.session.db/src/com/ibm/ws/session/store/db/DatabaseHashMap.java
@@ -506,7 +506,7 @@ public class DatabaseHashMap extends BackedHashMap {
                     }
                 } // Oracle case to be handled later
             } //PM27191 END
-        } else if (usingPostgreSQL) {
+        } else if (usingPostgreSQL && _smc.isUsingCustomSchemaName()) {
             qualifierName = dmd.getUserName();
         }
         


### PR DESCRIPTION
Default schema name should not be used to narrow the search.

Schema name only use when property usingCustomSchemaName="true"



