### PR TITLE
Serviceability: Print Http header contents 

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/genericbnf/PasswordNullifier.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/genericbnf/PasswordNullifier.java
@@ -19,6 +19,7 @@ public class PasswordNullifier {
     /** Search patterns to use for passwords */
     private static final String PASSWORD_PATTERN = "password=";
     private static final String CLIENT_SECRET_PATTERN = "client_secret=";
+    private static final String BASICAUTH_PATTERN = "basic ";
 
     /**
      * Scan the input value for the "password=" and "client_secret=" key markers
@@ -30,6 +31,18 @@ public class PasswordNullifier {
      */
     public static String nullifyParams(String value) {
         return nullify(value, (byte) '&');
+    }
+
+    /**
+     * Scan the input value for the "password=" and "client_secret=" key markers
+     * and convert the password value to a series of *s. The delimiter value '&'
+     * is used for the expected input format of "key=value&key2=value2".
+     *
+     * @param header, value
+     * @return String
+     */
+    public static String nullifyParams(String header, String value) {
+        return nullify(header, value, (byte) '&');
     }
 
     /**
@@ -52,6 +65,36 @@ public class PasswordNullifier {
         StringBuilder b = new StringBuilder(value);
         boolean modified = optionallyMaskChars(b, source, delimiter, PASSWORD_PATTERN);
         modified = optionallyMaskChars(b, source, delimiter, CLIENT_SECRET_PATTERN) || modified;
+
+        if (modified) {
+            return b.toString();
+        }
+        return value;
+    }
+
+    /**
+     * Scan the input value for the "password=" and "client_secret=" key markers
+     * and convert the password value to a series of *s. The delimiter value
+     * can be used if the search string is a sequence like
+     * "key=value<delim>key2=value2".
+     *
+     * @param value
+     * @param delimiter
+     * @return String
+     */
+    public static String nullify(String header, String value, byte delimiter) {
+        // check to see if we need to null out passwords
+        if (null == value) {
+            return null;
+        }
+
+        String source = value.toLowerCase();
+        StringBuilder b = new StringBuilder(value);
+        boolean modified = optionallyMaskChars(b, source, delimiter, PASSWORD_PATTERN);
+        modified = optionallyMaskChars(b, source, delimiter, CLIENT_SECRET_PATTERN) || modified;
+        if (header.equalsIgnoreCase(com.ibm.wsspi.http.channel.values.HttpHeaderKeys.HDR_AUTHORIZATION.getName())) {
+            modified = optionallyMaskChars(b, source, delimiter, BASICAUTH_PATTERN) || modified;
+        }
 
         if (modified) {
             return b.toString();

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/ServletRequestInfoDebug.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/ServletRequestInfoDebug.java
@@ -17,6 +17,7 @@ import javax.servlet.http.HttpServletRequestWrapper;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.webcontainer.srt.SRTServletRequest;
 
 /**
@@ -35,6 +36,7 @@ public class ServletRequestInfoDebug {
     static final String DEBUG_REMOTE_ADDRESS = ", Remote Address=";
     static final String DEBUG_REMOTE_PORT = ", Remote Port=";
 
+    @Trivial
     static void logServerRequestInfo(HttpServletRequest req) {
         if (tc.isDebugEnabled() && req != null) {
             Tr.debug(tc, servletRequestInfo(req));
@@ -48,6 +50,7 @@ public class ServletRequestInfoDebug {
      * @return Returns a string that contains each parameter and it value(s)
      *         in the HttpServletRequest object.
      */
+    @Trivial
     static String servletRequestInfo(HttpServletRequest req) {
 
         StringBuffer sb = new StringBuffer(DEBUG_REQ_INFO_BUFSIZE);
@@ -91,6 +94,7 @@ public class ServletRequestInfoDebug {
      * @return Returns a string value for the given header in the HttpServletRequest object.
      *
      **/
+    @Trivial
     static String getHeader(HttpServletRequest req, String key) {
         HttpServletRequest sr = req;
         String header = null;

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/ServletRequestInfoDebug.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/ServletRequestInfoDebug.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.webcontainer.security;
+
+import java.util.Enumeration;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.webcontainer.srt.SRTServletRequest;
+
+/**
+ *
+ */
+public class ServletRequestInfoDebug {
+
+    private static final TraceComponent tc = Tr.register(ServletRequestInfoDebug.class);
+    static final String AUTHORIZATION_HEADER = "Authorization";
+    static final String MASKED_BASIC_AUTH = "Basic xxxxx";
+    static final String DEBUG_HEADER_EYECATCHER = "Http Header names and values:";
+    static final int DEBUG_REQ_INFO_BUFSIZE = 512;
+    static final String DEBUG_CONTEXT_PATH = "Request Context Path=";
+    static final String DEBUG_SERVLET_PATH = ", Servlet Path=";
+    static final String DEBUG_PATH_INFO = ", Path Info=";
+    static final String DEBUG_REMOTE_ADDRESS = ", Remote Address=";
+    static final String DEBUG_REMOTE_PORT = ", Remote Port=";
+
+    static void logServerRequestInfo(HttpServletRequest req) {
+        if (tc.isDebugEnabled() && req != null) {
+            Tr.debug(tc, servletRequestInfo(req));
+        }
+    }
+
+    /**
+     * Collect all the Http header names and values.
+     *
+     * @param req HttpServletRequest
+     * @return Returns a string that contains each parameter and it value(s)
+     *         in the HttpServletRequest object.
+     */
+    static String servletRequestInfo(HttpServletRequest req) {
+
+        StringBuffer sb = new StringBuffer(DEBUG_REQ_INFO_BUFSIZE);
+        sb.append(DEBUG_HEADER_EYECATCHER).append("\n");
+
+        try {
+            Enumeration<String> headerNames = req.getHeaderNames();
+            while (headerNames.hasMoreElements()) {
+                String headerName = headerNames.nextElement();
+                sb.append(headerName).append("=");
+                sb.append("[").append(getHeader(req, headerName)).append("]\n");
+            }
+        } catch (Throwable t) {
+            // do nothing because it probably means the parser was trying to parse
+            // non form data or serialized object data.  This is a trace issue and
+            // has nothing to do with the spec.
+        }
+
+        if (req.getContextPath() != null)
+            sb.append(DEBUG_CONTEXT_PATH).append(req.getContextPath());
+        if (req.getServletPath() != null)
+            sb.append(DEBUG_SERVLET_PATH).append(req.getServletPath());
+        if (req.getPathInfo() != null)
+            sb.append(DEBUG_PATH_INFO).append(req.getPathInfo());
+        String remoteAddress = req.getHeader("X-FORWARDED-FOR");
+        if (remoteAddress == null) {
+            remoteAddress = req.getRemoteAddr();
+        }
+        sb.append(DEBUG_REMOTE_ADDRESS).append(remoteAddress);
+        sb.append(DEBUG_REMOTE_PORT).append(req.getRemotePort());
+
+        return sb.toString();
+    }
+
+    /**
+     *
+     * This method returns header information of the incoming HttpServletRequest
+     *
+     * @param req HttpServletRequest
+     * @param key String (header name)
+     * @return Returns a string value for the given header in the HttpServletRequest object.
+     *
+     **/
+    static String getHeader(HttpServletRequest req, String key) {
+        HttpServletRequest sr = req;
+        String header = null;
+
+        if (sr instanceof HttpServletRequestWrapper) {
+            HttpServletRequestWrapper w = (HttpServletRequestWrapper) sr;
+            // make sure we drill all the way down to an SRTServletRequest...there
+            // may be multiple proxied objects
+            sr = (HttpServletRequest) w.getRequest();
+            while (sr != null && sr instanceof HttpServletRequestWrapper)
+                sr = (HttpServletRequest) ((HttpServletRequestWrapper) sr).getRequest();
+        }
+
+        if (sr != null && sr instanceof SRTServletRequest) {
+            // Cast and return result
+            header = ((SRTServletRequest) sr).getHeaderDirect(key);
+        } else {
+            header = req.getHeader(key);
+        }
+
+        if (key != null && key.equalsIgnoreCase(AUTHORIZATION_HEADER) && header != null && header.startsWith("Basic")) {
+            header = MASKED_BASIC_AUTH;
+        }
+
+        return ((header == null) ? "" : header);
+    }
+
+}

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
@@ -15,7 +15,6 @@ import java.security.AccessController;
 import java.security.Principal;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,7 +25,6 @@ import javax.security.auth.login.CredentialExpiredException;
 import javax.servlet.DispatcherType;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.framework.ServiceReference;
@@ -36,7 +34,6 @@ import com.ibm.ejs.ras.TraceNLS;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
-import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.websphere.security.audit.AuditConstants;
 import com.ibm.websphere.security.audit.AuditEvent;
 import com.ibm.websphere.security.audit.context.AuditManager;
@@ -86,7 +83,6 @@ import com.ibm.ws.webcontainer.security.metadata.SecurityMetadata;
 import com.ibm.ws.webcontainer.security.metadata.WebResourceCollection;
 import com.ibm.ws.webcontainer.security.util.SSOAuthFilter;
 import com.ibm.ws.webcontainer.security.util.WebConfigUtils;
-import com.ibm.ws.webcontainer.srt.SRTServletRequest;
 import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 import com.ibm.wsspi.kernel.service.utils.ConcurrentServiceReferenceMap;
@@ -118,15 +114,6 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
     public static final String KEY_WEB_AUTHENTICATOR = "webAuthenticator";
     public static final String KEY_UNPROTECTED_RESOURCE_SERVICE = "unprotectedResourceService";
     static final String KEY_CONFIG_CHANGE_LISTENER = "webAppSecurityConfigChangeListener";
-    static final String AUTHORIZATION_HEADER = "Authorization";
-    static final String MASKED_BASIC_AUTH = "Basic xxxxx";
-    static final String DEBUG_HEADER_EYECATCHER = "Http Header names and values:";
-    static final int DEBUG_REQ_INFO_BUFSIZE = 512;
-    static final String DEBUG_CONTEXT_PATH = "Request Context Path=";
-    static final String DEBUG_SERVLET_PATH = ", Servlet Path=";
-    static final String DEBUG_PATH_INFO = ", Path Info=";
-    static final String DEBUG_REMOTE_ADDRESS = ", Remote Address=";
-    static final String DEBUG_REMOTE_PORT = ", Remote Port=";
 
     static final String DELEGATION_USERS_LIST = "DELEGATION_USERS_LIST";
     protected final ConcurrentServiceReferenceMap<String, WebAuthenticator> webAuthenticatorRef = new ConcurrentServiceReferenceMap<String, WebAuthenticator>(KEY_WEB_AUTHENTICATOR);
@@ -591,10 +578,7 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
     @Override
     public Object preInvoke(HttpServletRequest req, HttpServletResponse resp, String servletName, boolean enforceSecurity) throws SecurityViolationException, IOException {
 
-        if (tc.isDebugEnabled() && req != null) {
-
-            Tr.debug(tc, servletRequestInfo(req));
-        }
+        ServletRequestInfoDebug.logServerRequestInfo(req);
 
         Subject invokedSubject = subjectManager.getInvocationSubject();
         Subject receivedSubject = subjectManager.getCallerSubject();
@@ -625,85 +609,6 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
         }
 
         return webSecurityContext;
-    }
-
-    /**
-     * Collect all the Http header names and values.
-     *
-     * @param req HttpServletRequest
-     * @return Returns a string that contains each parameter and it value(s)
-     *         in the HttpServletRequest object.
-     */
-    @Trivial
-    private String servletRequestInfo(HttpServletRequest req) {
-
-        StringBuffer sb = new StringBuffer(DEBUG_REQ_INFO_BUFSIZE);
-        sb.append(DEBUG_HEADER_EYECATCHER).append("\n");
-
-        try {
-            Enumeration<String> headerNames = req.getHeaderNames();
-            while (headerNames.hasMoreElements()) {
-                String headerName = headerNames.nextElement();
-                sb.append(headerName).append("=");
-                sb.append("[").append(getHeader(req, headerName)).append("]\n");
-            }
-        } catch (Throwable t) {
-            // do nothing because it probably means the parser was trying to parse
-            // non form data or serialized object data.  This is a trace issue and
-            // has nothing to do with the spec.
-        }
-
-        if (req.getContextPath() != null)
-            sb.append(DEBUG_CONTEXT_PATH).append(req.getContextPath());
-        if (req.getServletPath() != null)
-            sb.append(DEBUG_SERVLET_PATH).append(req.getServletPath());
-        if (req.getPathInfo() != null)
-            sb.append(DEBUG_PATH_INFO).append(req.getPathInfo());
-	String remoteAddress = req.getHeader("X-FORWARDED-FOR"); 
-	if (remoteAddress == null) {  
-	    remoteAddress = req.getRemoteAddr();
-	}
-	sb.append(DEBUG_REMOTE_ADDRESS).append(remoteAddress);
-	sb.append(DEBUG_REMOTE_PORT).append(req.getRemotePort()); 
-
-        return sb.toString();
-    }
-
-    /**
-     *
-     * This method returns header information of the incoming HttpServletRequest
-     *
-     * @param req HttpServletRequest
-     * @param key String (header name)
-     * @return Returns a string value for the given header in the HttpServletRequest object.
-     *
-     **/
-    @Trivial
-    private String getHeader(HttpServletRequest req, String key) {
-        HttpServletRequest sr = req;
-        String header = null;
-
-        if (sr instanceof HttpServletRequestWrapper) {
-            HttpServletRequestWrapper w = (HttpServletRequestWrapper) sr;
-            // make sure we drill all the way down to an SRTServletRequest...there
-            // may be multiple proxied objects
-            sr = (HttpServletRequest) w.getRequest();
-            while (sr != null && sr instanceof HttpServletRequestWrapper)
-                sr = (HttpServletRequest) ((HttpServletRequestWrapper) sr).getRequest();
-        }
-
-        if (sr != null && sr instanceof SRTServletRequest) {
-            // Cast and return result
-            header = ((SRTServletRequest) sr).getHeaderDirect(key);
-        } else {
-            header = req.getHeader(key);
-        }
-
-        if (key != null && key.equalsIgnoreCase(AUTHORIZATION_HEADER) && header != null && header.startsWith("Basic")) {
-            header = MASKED_BASIC_AUTH;
-        }
-
-        return ((header == null) ? "" : header);
     }
 
     /**

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
@@ -15,6 +15,7 @@ import java.security.AccessController;
 import java.security.Principal;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +26,7 @@ import javax.security.auth.login.CredentialExpiredException;
 import javax.servlet.DispatcherType;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.framework.ServiceReference;
@@ -34,6 +36,7 @@ import com.ibm.ejs.ras.TraceNLS;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.websphere.security.audit.AuditConstants;
 import com.ibm.websphere.security.audit.AuditEvent;
 import com.ibm.websphere.security.audit.context.AuditManager;
@@ -83,6 +86,7 @@ import com.ibm.ws.webcontainer.security.metadata.SecurityMetadata;
 import com.ibm.ws.webcontainer.security.metadata.WebResourceCollection;
 import com.ibm.ws.webcontainer.security.util.SSOAuthFilter;
 import com.ibm.ws.webcontainer.security.util.WebConfigUtils;
+import com.ibm.ws.webcontainer.srt.SRTServletRequest;
 import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 import com.ibm.wsspi.kernel.service.utils.ConcurrentServiceReferenceMap;
@@ -114,6 +118,15 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
     public static final String KEY_WEB_AUTHENTICATOR = "webAuthenticator";
     public static final String KEY_UNPROTECTED_RESOURCE_SERVICE = "unprotectedResourceService";
     static final String KEY_CONFIG_CHANGE_LISTENER = "webAppSecurityConfigChangeListener";
+    static final String AUTHORIZATION_HEADER = "Authorization";
+    static final String MASKED_BASIC_AUTH = "Basic xxxxx";
+    static final String DEBUG_HEADER_EYECATCHER = "Http Header names and values:";
+    static final int DEBUG_REQ_INFO_BUFSIZE = 512;
+    static final String DEBUG_CONTEXT_PATH = "Request Context Path=";
+    static final String DEBUG_SERVLET_PATH = ", Servlet Path=";
+    static final String DEBUG_PATH_INFO = ", Path Info=";
+    static final String DEBUG_REMOTE_ADDRESS = ", Remote Address=";
+    static final String DEBUG_REMOTE_PORT = ", Remote Port=";
 
     static final String DELEGATION_USERS_LIST = "DELEGATION_USERS_LIST";
     protected final ConcurrentServiceReferenceMap<String, WebAuthenticator> webAuthenticatorRef = new ConcurrentServiceReferenceMap<String, WebAuthenticator>(KEY_WEB_AUTHENTICATOR);
@@ -578,6 +591,11 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
     @Override
     public Object preInvoke(HttpServletRequest req, HttpServletResponse resp, String servletName, boolean enforceSecurity) throws SecurityViolationException, IOException {
 
+        if (tc.isDebugEnabled() && req != null) {
+
+            Tr.debug(tc, servletRequestInfo(req));
+        }
+
         Subject invokedSubject = subjectManager.getInvocationSubject();
         Subject receivedSubject = subjectManager.getCallerSubject();
 
@@ -607,6 +625,85 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
         }
 
         return webSecurityContext;
+    }
+
+    /**
+     * Collect all the Http header names and values.
+     *
+     * @param req HttpServletRequest
+     * @return Returns a string that contains each parameter and it value(s)
+     *         in the HttpServletRequest object.
+     */
+    @Trivial
+    private String servletRequestInfo(HttpServletRequest req) {
+
+        StringBuffer sb = new StringBuffer(DEBUG_REQ_INFO_BUFSIZE);
+        sb.append(DEBUG_HEADER_EYECATCHER).append("\n");
+
+        try {
+            Enumeration<String> headerNames = req.getHeaderNames();
+            while (headerNames.hasMoreElements()) {
+                String headerName = headerNames.nextElement();
+                sb.append(headerName).append("=");
+                sb.append("[").append(getHeader(req, headerName)).append("]\n");
+            }
+        } catch (Throwable t) {
+            // do nothing because it probably means the parser was trying to parse
+            // non form data or serialized object data.  This is a trace issue and
+            // has nothing to do with the spec.
+        }
+
+        if (req.getContextPath() != null)
+            sb.append(DEBUG_CONTEXT_PATH).append(req.getContextPath());
+        if (req.getServletPath() != null)
+            sb.append(DEBUG_SERVLET_PATH).append(req.getServletPath());
+        if (req.getPathInfo() != null)
+            sb.append(DEBUG_PATH_INFO).append(req.getPathInfo());
+	String remoteAddress = req.getHeader("X-FORWARDED-FOR"); 
+	if (remoteAddress == null) {  
+	    remoteAddress = req.getRemoteAddr();
+	}
+	sb.append(DEBUG_REMOTE_ADDRESS).append(remoteAddress);
+	sb.append(DEBUG_REMOTE_PORT).append(req.getRemotePort()); 
+
+        return sb.toString();
+    }
+
+    /**
+     *
+     * This method returns header information of the incoming HttpServletRequest
+     *
+     * @param req HttpServletRequest
+     * @param key String (header name)
+     * @return Returns a string value for the given header in the HttpServletRequest object.
+     *
+     **/
+    @Trivial
+    private String getHeader(HttpServletRequest req, String key) {
+        HttpServletRequest sr = req;
+        String header = null;
+
+        if (sr instanceof HttpServletRequestWrapper) {
+            HttpServletRequestWrapper w = (HttpServletRequestWrapper) sr;
+            // make sure we drill all the way down to an SRTServletRequest...there
+            // may be multiple proxied objects
+            sr = (HttpServletRequest) w.getRequest();
+            while (sr != null && sr instanceof HttpServletRequestWrapper)
+                sr = (HttpServletRequest) ((HttpServletRequestWrapper) sr).getRequest();
+        }
+
+        if (sr != null && sr instanceof SRTServletRequest) {
+            // Cast and return result
+            header = ((SRTServletRequest) sr).getHeaderDirect(key);
+        } else {
+            header = req.getHeader(key);
+        }
+
+        if (key != null && key.equalsIgnoreCase(AUTHORIZATION_HEADER) && header != null && header.startsWith("Basic")) {
+            header = MASKED_BASIC_AUTH;
+        }
+
+        return ((header == null) ? "" : header);
     }
 
     /**

--- a/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImplTest.java
+++ b/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImplTest.java
@@ -729,6 +729,10 @@ public class WebAppSecurityCollaboratorImplTest {
                 allowing(request).getAttribute("com.ibm.ws.webcontainer.security.webmodulemetadata");
                 will(returnValue(null));
                 allowing(request).setAttribute("com.ibm.ws.webcontainer.security.webmodulemetadata", wmmd);
+                allowing(request).getHeaderNames();
+                will(returnValue("anyHeaderString"));
+                allowing(request).getContextPath();
+                will(returnValue("contextPath"));
             }
         });
     }

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletRequest.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletRequest.java
@@ -544,7 +544,7 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
                 header = _request.getHeader(name);
         }// PK80362 End
         if (TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) {  //306998.15
-            logger.logp(Level.FINE, CLASS_NAME,"getHeader", "this->"+this+": "+" name --> " + name + " header --> " + PasswordNullifier.nullifyParams(header));
+            logger.logp(Level.FINE, CLASS_NAME,"getHeader", "this->"+this+": "+" name --> " + name + " header --> " + PasswordNullifier.nullifyParams(name, header));
         }
         return header;
     }
@@ -571,7 +571,7 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
             header = _request.getHeader(name);
         }// PK80362 End
         if (TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) {  //306998.15
-            logger.logp(Level.FINE, CLASS_NAME,"getHeaderDirect", "this->"+this+": "+" name --> " + name + " header --> " + header);
+            logger.logp(Level.FINE, CLASS_NAME,"getHeaderDirect", "this->"+this+": "+" name --> " + name + " header --> " + PasswordNullifier.nullifyParams(name, header));
         }
         return header;
     }


### PR DESCRIPTION
Trying to address following issue.  This is also one of the top serviceability items to add our familiar "Http Header names and values" trace in Liberty (from tWAS) 

Issues to address:  
https://github.com/OpenLiberty/open-liberty/issues/5082
https://github.com/OpenLiberty/open-liberty/issues/9061

Previously tried PR: 
https://github.com/OpenLiberty/open-liberty/pull/9402

Initial test with the PR code 
```
wlp-1.0.59.202111022013
trace.specification = *=info:SSL=all:com.ibm.ws.security.*=all:com.ibm.ws.webcontainer.security.*=all

[11/3/21, 14:11:39:281 EDT] 00000038 WebAppSecurit 3   Http Header names and values:
Host=[localhost:9443]
Connection=[keep-alive]
Cache-Control=[max-age=0]
sec-ch-ua=["Google Chrome";v="95", "Chromium";v="95", ";Not A Brand";v="99"]
sec-ch-ua-mobile=[?0]
sec-ch-ua-platform=["Windows"]
Upgrade-Insecure-Requests=[1]
User-Agent=[Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Safari/537.36]
Accept=[text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9]
Sec-Fetch-Site=[none]
Sec-Fetch-Mode=[navigate]
Sec-Fetch-User=[?1]
Sec-Fetch-Dest=[document]
Accept-Encoding=[gzip, deflate, br]
Accept-Language=[en-US,en;q=0.9,ja;q=0.8]
Cookie=[JSESSIONID=0000QghAeZRk7aaJAroYabnjr0s:b0ca18ac-036d-49a6-95c3-357b217219b6]
Request Context Path=/adminCenter, Servlet Path=/login.jsp, Remote Address=127.0.0.1, Remote Port=49741
```

