### PR TITLE
beta of Concurrency 3.0

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.cdi-concurrent3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.cdi-concurrent3.0.feature
@@ -8,5 +8,5 @@ IBM-Provision-Capability: \
 -bundles=\
   io.openliberty.concurrent.cdi.jakarta
 IBM-Install-Policy: when-satisfied
-kind=noship
-edition=full
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.eeCompatible-10.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.eeCompatible-10.0.feature
@@ -5,6 +5,6 @@ singleton=true
 Subsystem-Version: 10.0.0
 -bundles=com.ibm.ws.javaee.version, \
   io.openliberty.java11.internal
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.concurrency-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.concurrency-3.0.feature
@@ -5,6 +5,6 @@ singleton=true
 #TODO remove toleration of eeCompatible-9.0 once other EE 10 features are usable in beta form
 -features=com.ibm.websphere.appserver.eeCompatible-10.0; ibm.tolerates:="9.0"
 -bundles=io.openliberty.jakarta.concurrency.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="io.openliberty.jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:3.0.0.20220120"
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakartaeePlatform-10.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakartaeePlatform-10.0.feature
@@ -4,6 +4,6 @@ IBM-Process-Types: client, server
 -features=io.openliberty.jakartaeePlatform-9.0
 -bundles=io.openliberty.jakartaee.platform.v10, \
  com.ibm.ws.javaee.version
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-3.0/io.openliberty.concurrent-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-3.0/io.openliberty.concurrent-3.0.feature
@@ -28,6 +28,6 @@ Subsystem-Name: Jakarta Concurrency 3.0
   com.ibm.ws.javaee.platform.defaultresource, \
   com.ibm.ws.resource, \
   io.openliberty.concurrent
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/io.openliberty.concurrent.cdi/bnd.bnd
+++ b/dev/io.openliberty.concurrent.cdi/bnd.bnd
@@ -22,10 +22,6 @@ Bundle-Description: Provides interceptors for Jakarta Concurrency; version=${bVe
 
 WS-TraceGroup: concurrent
 
-# temporary package for simulating possible additions to Jakarta Concurrency
-Export-Package: \
-  prototype.enterprise.concurrent
-
 Import-Package: !jakarta.interceptor,*
 
 Private-Package: \


### PR DESCRIPTION
Pull to use for beta of Concurrency 3.0.  This pull was prepared in advance of being ready to save us some time on figuring out what changes are needed to get us through builds when this is eventually ready for beta.