### PR TITLE
Fix jwtSso-1.0 EE9 enablement in the OIDC server fat

### DIFF
--- a/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/oidc_featuresWithJwtSso.xml
+++ b/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/oidc_featuresWithJwtSso.xml
@@ -15,6 +15,7 @@
 		<feature>securitylibertyinternals-1.0</feature>
 		<feature>openidConnectServer-1.0</feature>
 		<feature>jwtSso-1.0</feature>
+		<feature>servlet-3.1</feature> <!-- required for EE9 repeat -->
 	</featureManager>
 	<jwtSso id="defaultJwtSso" cookieName="JWT"></jwtSso>
 


### PR DESCRIPTION
The tests that use jwtSso-1.0 in the oidc server fat project are not properly triggering the including of EE9 features.  The apps are being "transformed", but the jars they need after the transform and not available because the proper features are not available.
Updating the one config file with a feature that will be converted instead of adding .alwaysAddFeature(“servlet-5.0”) to the repeat in the FATSuite.  That would add some overhead to every config file.