### PR TITLE
Check default config settings to drive reprocessing config

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/variables/ConfigVariable.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/variables/ConfigVariable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,7 +25,7 @@ public class ConfigVariable extends AbstractLibertyVariable {
     private final String location;
     private final boolean sensitive;
 
-    public ConfigVariable(String name, @Sensitive String value, String variableDefault, MergeBehavior mb, String l, boolean isSensitive) {
+    public ConfigVariable(String name, @Sensitive String value, @Sensitive String variableDefault, MergeBehavior mb, String l, boolean isSensitive) {
         this.name = name;
         this.value = value;
         this.defaultValue = variableDefault;

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/variables/ConfigVariableRegistry.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/variables/ConfigVariableRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -385,6 +385,10 @@ public class ConfigVariableRegistry implements VariableRegistry, ConfigVariables
 
             if (newVariableValue == null) {
                 newVariableValue = lookupVariableFromAdditionalSources(variableName);
+            }
+
+            if (newVariableValue == null) {
+                newVariableValue = lookupVariableDefaultValue(variableName);
             }
 
             if (!isEqual(oldVariableValue, newVariableValue)) {


### PR DESCRIPTION
The variablesChanged check did not correctly check the defined variable
default values when calculating if any variable values had changed.

Also make the defaultValue @Sensitive for the ConfigVariable
constructor.
