### PR TITLE
Increase timeout for testConfigChangeWithActiveConnections

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/ConfigTest.java
+++ b/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/ConfigTest.java
@@ -112,6 +112,11 @@ public class ConfigTest extends FATServletClient {
     private static ServerConfiguration originalServerConfig;
     private static ServerConfiguration originalServerConfigUpdatedForJDBC;
 
+    static final long FIVE_MINUTE_MS_TIMEOUT = 300000; // Five minutes in milliseconds
+
+    // Interval (in milliseconds) that tests should use for polling
+    static final long POLLING_INTERVAL_MS = 500; // 500 milliseconds
+
     @BeforeClass
     public static void setUp() throws Exception {
         // Delete the Derby database that might be left over from last run
@@ -1149,10 +1154,13 @@ public class ConfigTest extends FATServletClient {
     public void testConfigChangeWithActiveConnections() throws Throwable {
         String method = "testConfigChangeWithActiveConnections";
         Log.info(c, method, "Executing " + method);
+        final long start = System.currentTimeMillis();
+        Object result;
+        boolean success = false;
 
         // On a separate thread, run a servlet that keeps a connection open for a few seconds
-        // and checks the default queryTimeout value every 100 milliseconds.
-        // this will fail if the timeout does not increase or goes above a certain hardcoded value.
+        // and frequently checks the default queryTimeout value.
+        // this will fail if the timeout does not increase during the test interval.
         final BlockingQueue<Object> results = new LinkedBlockingQueue<Object>();
         new Thread() {
             @Override
@@ -1169,9 +1177,10 @@ public class ConfigTest extends FATServletClient {
         ServerConfiguration config = server.getServerConfiguration();
         DataSource dsfat5 = config.getDataSources().getBy("id", "dsfat5derby");
         try {
-            // Increase the queryTimeout several times
-            for (int qt = 31; qt <= 34; qt++) {
-                dsfat5.setQueryTimeout("" + qt);
+            final long testTimeout = FIVE_MINUTE_MS_TIMEOUT - (System.currentTimeMillis() - start); // Roughly calculate a 5 minute total timeout
+            // Continually increase the queryTimeout every interval
+            for (int qt = 30; !success && System.currentTimeMillis() - start < testTimeout; Thread.sleep(POLLING_INTERVAL_MS)) {
+                dsfat5.setQueryTimeout("" + ++qt);
                 /*
                  * each time we change the file we toggle beginTranForResultSetScrollingAPIs from true to false to change the file size
                  * otherwise defect 58455 may occur as when the file is changed but remains the same size and has the same timestamp the
@@ -1183,18 +1192,21 @@ public class ConfigTest extends FATServletClient {
                     dsfat5.setBeginTranForResultSetScrollingAPIs("false");
                 }
                 updateServerConfig(config, EMPTY_EXPR_LIST);
-                Thread.sleep(100);
+                result = results.poll(POLLING_INTERVAL_MS, TimeUnit.MILLISECONDS);
+                if (result != null && "successful".equals(result)) {
+                    success = true;
+                } else if (result instanceof Throwable) {
+                    throw (Throwable) result;
+                }
+            }
+
+            if (!success) {
+                throw new Exception("Test testConfigChangeWithActiveConnections did not complete within the allotted time of " + FIVE_MINUTE_MS_TIMEOUT + " ms.");
             }
         } catch (Throwable x) {
-            System.out.println("Failure during " + method + " with the following config:");
-            System.out.println(config);
+            Log.warning(c, "Failure during " + method + " with the following config:");
+            Log.warning(c, config.toString());
             throw x;
-        } finally {
-            Object result = results.poll(10, TimeUnit.SECONDS);
-            if (result == null)
-                throw new Exception("Test did not complete within allotted time");
-            else if (result instanceof Throwable)
-                throw (Throwable) result;
         }
 
         cleanUpExprs = EMPTY_EXPR_LIST;

--- a/dev/com.ibm.ws.jdbc_fat/test-applications/basicfat/src/basicfat/DataSourceTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat/test-applications/basicfat/src/basicfat/DataSourceTestServlet.java
@@ -40,7 +40,6 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Set;
-import java.util.Stack;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -215,6 +214,12 @@ public class DataSourceTestServlet extends FATServlet {
 
     @Resource
     private ExecutorService executor;
+
+    static final long TWO_MINUTE_MS_TIMEOUT = 120000; // Two minutes in milliseconds
+    static final long FIVE_MINUTE_MS_TIMEOUT = 300000; // Five minutes in milliseconds
+
+    // Atypical uneven interval (in milliseconds) for special polling
+    static final long ODD_POLLING_INTERVAL_MS = 867; // 867 milliseconds
 
     /**
      * Standard isolation level values.
@@ -872,26 +877,23 @@ public class DataSourceTestServlet extends FATServlet {
      * Keep a connection open for a few seconds while ConfigTest increases the queryTimeout.
      */
     public void testConfigChangeWithActiveConnections() throws Exception {
-
-        Stack<Integer> results = new Stack<Integer>();
-        Connection con = ds5.getConnection();
-        try {
-            for (int i = 0; i < 40; i++) {
-                Thread.sleep(100);
-                Statement s = con.createStatement();
-                int queryTimeout = s.getQueryTimeout();
-                int previous = results.isEmpty() ? 30 : results.peek();
-                results.push(queryTimeout);
-                if (queryTimeout < previous || queryTimeout > 34)
-                    throw new Exception("Unexpected queryTimeout in " + results);
+        boolean isFound = false;
+        try (Connection con = ds5.getConnection()) {
+            Statement s = con.createStatement();
+            int queryTimeout = s.getQueryTimeout(); // Initial value should be 30 from the "dsfat5derby" dataSource defined in server.xml
+            int initialTimeout = queryTimeout;
+            s.close();
+            for (long start = System.currentTimeMillis(); !isFound && System.currentTimeMillis() - start < FIVE_MINUTE_MS_TIMEOUT; Thread.sleep(ODD_POLLING_INTERVAL_MS)) {
+                s = con.createStatement();
+                queryTimeout = s.getQueryTimeout();
+                isFound = queryTimeout > initialTimeout ? true : false;
                 s.close();
             }
         } finally {
-            con.close();
+            if (!isFound) {
+                throw new Exception("Test testConfigChangeWithActiveConnections did not complete within the allotted time of " + FIVE_MINUTE_MS_TIMEOUT + " ms.");
+            }
         }
-
-        if (results.peek() == 30) // no updates were made
-            throw new Exception("Did not observe any updates to the queryTimeout: " + results);
     }
 
     /**


### PR DESCRIPTION
In the `com.ibm.ws.jdbc_fat` FAT, the client side test `testConfigChangeWithActiveConnections` calls a servlet that runs over the course of 40 time intervals.  At every interval, it creates an SQL Statement from a connection (defined as dataSource "dsfat5derby" in the `server.xml`) and checks the `queryTimeout` value of it.  In parallel, the client side attempts to manipulate that same dataSource definition and slowly increase the default `queryTimeout` value by 1 second every 100ms.  At the end of the test, the client checks to see if the default `queryTimeout` ever goes above 30s.

In this particular build break, we saw a `J2CA8040E` in messages.log likely because the server side was trying to use the dataSource information from the server.xml file at the same time the client side was trying to manipulate it and got caught.  For what little information about J2CA8040E I could find, [look here](https://www.ibm.com/docs/pt-br/was-zos/9.0.5?topic=SS7K4U_9.0.5/com.ibm.websphere.wlp.zseries.doc/ae/rwlp_restrict.html).

In trying to reproduce this problem locally (Windows 10), I found that the servlet piece ran so fast, it completely finished before the client side could even update the default `queryTimeout` once.  The number of servlet checking intervals was reduced from 40 to 20 and the interval duration was changed from 100ms to 867ms to be an uneven interval of the sleep delay on the client side (100ms).  This will hopefully reduce the likelihood that the servlet will be trying to access the dataSource at the same time the client is updating it.
