### PR TITLE
add code to wait for keystore readiness

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/ServerInstanceUtils.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/ServerInstanceUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import com.ibm.websphere.simplicity.config.ConfigElementList;
+import com.ibm.websphere.simplicity.config.KeyStore;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.config.Variable;
 import com.ibm.websphere.simplicity.log.Log;
@@ -189,5 +190,22 @@ public class ServerInstanceUtils {
         Map<String, String> vars = new HashMap<String, String>();
         vars.put(key, value);
         updateServerSettings(server, vars);
+    }
+
+    public static void waitForKeyStores(LibertyServer server) throws Exception {
+
+        Log.info(thisClass, "waitForKeyStores", "Waiting for keystore configurations to be loaded");
+
+        ConfigElementList<KeyStore> keyStores = server.getServerConfiguration().getKeyStores();
+        if (keyStores == null) {
+            Log.info(thisClass, "waitForKeyStores", "No keystores were found in the configuration");
+        }
+        for (KeyStore keyStore : keyStores) {
+            String name = keyStore.getId();
+            Log.info(thisClass, "waitForKeyStores", "Searching for add of keystore: " + name);
+            server.waitForStringInTrace("Adding keystore: " + name);
+
+        }
+        Log.info(thisClass, "waitForKeyStores", "Done waiting for keystore configuration to be loaded - the waits in the method will not guarentee that the keystore setup is truly ready...");
     }
 }

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerApiConfigTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerApiConfigTests.java
@@ -33,6 +33,7 @@ import com.ibm.ws.security.fat.common.jwt.JwtConstants;
 import com.ibm.ws.security.fat.common.jwt.PayloadConstants;
 import com.ibm.ws.security.fat.common.jwt.expectations.JwtApiExpectation;
 import com.ibm.ws.security.fat.common.jwt.utils.JwtKeyTools;
+import com.ibm.ws.security.fat.common.servers.ServerInstanceUtils;
 import com.ibm.ws.security.fat.common.utils.SecurityFatHttpUtils;
 import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
 import com.ibm.ws.security.jwt.fat.consumer.actions.JwtConsumerActions;
@@ -86,6 +87,10 @@ public class JwtConsumerApiConfigTests extends CommonSecurityFat {
 
         // set the default signing key for this test class (individual test cases can override if needed)
         consumerHelpers.setDefaultKeyFile(consumerServer, "rsa_privateKey.pem");
+
+        // for some reason some of the keystore configs were taking too long to be loaded
+        ServerInstanceUtils.waitForKeyStores(consumerServer);
+
     }
 
     @Override


### PR DESCRIPTION
The consumer tests are failing because the rsa_trust keystore was not loaded before the test was run.  I'm adding some code to the setup method that will hopefully make the test class wait for keystore config to be loaded before running any tests.  If this works, other test classes can use the "waitForKeyStores" method in ServerInstanceUtils.java
There is no real message that we can check for in the messages.log.
The new method will list the keystores that are in the config and search for a specific trace entry.
We'll have to see if this check is sufficient to prevent the issue we're seeing in automated testing.