### PR TITLE
Fix xmlBinding's XJC script path settings

### DIFF
--- a/dev/io.openliberty.xmlBinding.3.0.internal.tools.schemagen/bnd.bnd
+++ b/dev/io.openliberty.xmlBinding.3.0.internal.tools.schemagen/bnd.bnd
@@ -28,6 +28,6 @@ Command-Class: io.openliberty.xmlbinding.tools.SchemaGen
 
 publish.tool.script.subdir=xmlBinding/
 publish.tool.script.relative=..
-publish.tool.script.dir.length=11
+publish.tool.script.dir.length=16
 publish.tool.jar=ws-schemagen.jar
 publish.tool.script=schemagen

--- a/dev/io.openliberty.xmlBinding.3.0.internal.tools.xjc/bnd.bnd
+++ b/dev/io.openliberty.xmlBinding.3.0.internal.tools.xjc/bnd.bnd
@@ -28,6 +28,6 @@ Command-Class: io.openliberty.xmlbinding.tools.XJC
 
 publish.tool.script.subdir=xmlBinding/
 publish.tool.script.relative=..
-publish.tool.script.dir.length=11
+publish.tool.script.dir.length=16
 publish.tool.jar=ws-xjc.jar
 publish.tool.script=xjc


### PR DESCRIPTION
This PR fixes the xjc script for execution on Windows. 

