### PR TITLE
OLGH18653: Update Eclipselink 2.7 (JPA 2.2) and 3.0 (JPA 3.0) to use …

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2114,7 +2114,7 @@
     <dependency>
       <groupId>org.eclipse.persistence</groupId>
       <artifactId>org.eclipse.persistence.asm</artifactId>
-      <version>9.1.0</version>
+      <version>9.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.persistence</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -418,7 +418,7 @@ org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.4.0
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:2.0
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:3.0-RC3
 org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.9
-org.eclipse.persistence:org.eclipse.persistence.asm:9.1.0
+org.eclipse.persistence:org.eclipse.persistence.asm:9.2.0
 org.eclipse.persistence:org.eclipse.persistence.core:2.7.9
 org.eclipse.persistence:org.eclipse.persistence.core:3.0.2
 org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:2.7.9

--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink.2.7/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink.2.7/bnd.bnd
@@ -16,7 +16,7 @@ eclVersion=2.7.9
 eclHash=2c549e2
 eclFullVersion=${eclVersion}
 eclPackageVersion=2.0.16
-asmFullVersion=9.1.0
+asmFullVersion=9.2.0
 
 Bundle-SymbolicName: com.ibm.websphere.appserver.thirdparty.eclipselink.2.7
 Bundle-Description: EclipseLink JPA

--- a/dev/io.openliberty.persistence.3.0.thirdparty/bnd.bnd
+++ b/dev/io.openliberty.persistence.3.0.thirdparty/bnd.bnd
@@ -15,7 +15,7 @@ bVersion=1.0
 eclVersion=3.0.2
 eclFullVersion=${eclVersion}
 eclPackageVersion=3.0.2
-asmFullVersion=9.1.0
+asmFullVersion=9.2.0
 
 Bundle-SymbolicName: io.openliberty.persistence.3.0.thirdparty
 Bundle-Description: EclipseLink JPA


### PR DESCRIPTION
fixes #19329

Update Eclipselink 2.7 and 3.0 (JPA 2.2 and 3.0 respectively) to use ASM 9.2.