### PR TITLE
PR for Issue 16320: Close database connection in OAuth getDBType call

### DIFF
--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/db/OAuthJDBCImpl.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/db/OAuthJDBCImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2014 IBM Corporation and others.
+ * Copyright (c) 1997, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -133,7 +133,7 @@ public abstract class OAuthJDBCImpl {
 
     @Trivial
     private void getDBClogAndSleep(int msec) {
-        String methodName = "getDBConnection";
+        String methodName = "getDBClogAndSleep";
         if (_log.isLoggable(Level.FINEST)) {
             _log.logp(Level.FINEST, CLASS, methodName,
                     "caught exception getting db connection, will retry in " + msec + " msec");
@@ -204,10 +204,16 @@ public abstract class OAuthJDBCImpl {
 
     protected DBType getDBType() {
         if (databaseType == null) {
+            Connection conn = null;
             try {
-                databaseType = DetectDatabaseType.DetectionUtils.detectDbType(getDBConnection());
+                conn = getDBConnection();
+                databaseType = DetectDatabaseType.DetectionUtils.detectDbType(conn);
             } catch (OAuthDataException e) {
                 Tr.error(tc, "Internal error getting DB connection: " + e.getMessage(), e);
+            } finally {
+                if (conn != null) {
+                    closeConnection(conn, false);
+                }
             }
         }
         return databaseType;


### PR DESCRIPTION
Fixes an issue where database connections could be cached and remain open when determining the database type using `OAuthJDBCImpl.getDBType()`. This ensures the connection is closed once the database type is successfully found.

Resolves #16320