### PR TITLE
Don't exposed processed file paths

### DIFF
--- a/dev/com.ibm.ws.jmx.connector.server.rest/src/com/ibm/ws/jmx/connector/server/rest/helpers/FileTransferHelper.java
+++ b/dev/com.ibm.ws.jmx.connector.server.rest/src/com/ibm/ws/jmx/connector/server/rest/helpers/FileTransferHelper.java
@@ -238,12 +238,12 @@ public class FileTransferHelper {
 
         if (!checkAccess(processedPath, readOnly)) {
             //Return an exception
-            Object[] params = new String[] { processedPath };
+            Object[] params = new String[] { filePath };
             IOException ioe = new IOException(TraceNLS.getFormattedMessage(this.getClass(),
                                                                            APIConstants.TRACE_BUNDLE_FILE_TRANSFER,
                                                                            "SERVER_ACCESS_DENIED_ERROR",
                                                                            params,
-                                                                           "CWWKX0121E: Access denied to the " + processedPath + " path."));
+                                                                           "CWWKX0121E: Access denied to the " + filePath + " path."));
             throw ErrorHelper.createRESTHandlerJsonException(ioe, null, APIConstants.STATUS_BAD_REQUEST);
         }
 


### PR DESCRIPTION
If a file is not accessible from the FileTransfer rest handler,
then the error message returned should not contain the processed
path, it should only contain the originally requested path.
Otherwise, internal file path information could be leaked back
to the requester

fixes #19366

