### PR TITLE
287840 remove policy file dir

### DIFF
--- a/dev/com.ibm.ws.security.saml.sso_fat.common/publish/files/envVars/jvm.options
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/publish/files/envVars/jvm.options
@@ -1,3 +1,2 @@
--Dcom.ibm.security.jurisdictionPolicyDir=policyFiles
 -Djava.security.debug=ibmjcefw
 -D-Xtrace:print=mt,methods={com/sun/jndi/ldap/Connection.<init>*},trigger=method{com/sun/jndi/ldap/Connection.<init>*,jstacktrace}

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/publish/files/envVars/jvm.options
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/publish/files/envVars/jvm.options
@@ -1,3 +1,2 @@
--Dcom.ibm.security.jurisdictionPolicyDir=policyFiles
 -Djava.security.debug=ibmjcefw
 -D-Xtrace:print=mt,methods={com/sun/jndi/ldap/Connection.<init>*},trigger=method{com/sun/jndi/ldap/Connection.<init>*,jstacktrace}

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/publish/files/envVars/jvm.options
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/publish/files/envVars/jvm.options
@@ -1,3 +1,2 @@
--Dcom.ibm.security.jurisdictionPolicyDir=policyFiles
 -Djava.security.debug=ibmjcefw
 -D-Xtrace:print=mt,methods={com/sun/jndi/ldap/Connection.<init>*},trigger=method{com/sun/jndi/ldap/Connection.<init>*,jstacktrace}

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/publish/files/envVars/jvm.options
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/publish/files/envVars/jvm.options
@@ -1,3 +1,2 @@
--Dcom.ibm.security.jurisdictionPolicyDir=policyFiles
 -Djava.security.debug=ibmjcefw
 -D-Xtrace:print=mt,methods={com/sun/jndi/ldap/Connection.<init>*},trigger=method{com/sun/jndi/ldap/Connection.<init>*,jstacktrace}


### PR DESCRIPTION
Updating the jvm.options file to remove the com.ibm.security.jurisdictionPolicyDir property that is pointing to a now empty directiry.  The policy jars were deleted some time ago, but the property was left behind.  In the past, the jdk still found its jars in the default location.  A recent version of the jdk no longer seems to go to the default location.