### PR TITLE
Update to GA binaries of MP context propagation 1.3

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1879,7 +1879,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.context-propagation</groupId>
       <artifactId>microprofile-context-propagation-api</artifactId>
-      <version>1.3-RC1</version>
+      <version>1.3</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.fault-tolerance</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -371,7 +371,7 @@ org.eclipse.microprofile.config:microprofile-config-api:2.0
 org.eclipse.microprofile.config:microprofile-config-api:3.0-RC5
 org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0
 org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.2
-org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.3-RC1
+org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.3
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:1.0
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:1.1
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:2.0.1

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.contextpropagation-1.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.contextpropagation-1.3.feature
@@ -3,7 +3,7 @@ symbolicName=io.openliberty.org.eclipse.microprofile.contextpropagation-1.3
 singleton=true
 -features=io.openliberty.mpCompatible-5.0
 -bundles=\
- io.openliberty.org.eclipse.microprofile.contextpropagation.1.3; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.3-RC1"
+ io.openliberty.org.eclipse.microprofile.contextpropagation.1.3; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.3"
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <!-- Use the following to test a release (1.3) or release candidate (1.3-RC1) -->
-        <microprofile.context.propagation.version>1.3-RC1</microprofile.context.propagation.version>
+        <microprofile.context.propagation.version>1.3</microprofile.context.propagation.version>
 
         <!-- Use the following to test a local snaphost (1.3-SNAPSHOT) -->
         <!-- The test case launch must be guarded with "if (FATRunner.FAT_TEST_LOCALRUN)" of this option is delivered. -->
@@ -37,6 +37,17 @@
         <suiteXmlFile>${defaultSuiteFiles}</suiteXmlFile>
         <targetDirectory>${project.basedir}/target</targetDirectory>
     </properties>
+
+    <!-- When running locally, can test with a staging repo before pushing the official release to maven -->
+    <!--
+    <repositories>
+        <repository>
+            <id>orgeclipsemicroprofile-1542</id>
+            <name>MP staging</name>
+            <url>https://oss.sonatype.org/content/repositories/orgeclipsemicroprofile-1542</url>
+        </repository>
+    </repositories>
+    -->
 
     <dependencyManagement>
         <dependencies>

--- a/dev/io.openliberty.org.eclipse.microprofile.contextpropagation.1.3/bnd.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile.contextpropagation.1.3/bnd.bnd
@@ -23,7 +23,7 @@ Export-Package: \
   org.eclipse.microprofile.context.spi;version=1.3
 
 Include-Resource: \
-   @${repo;org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api;1.3.0.RC1;EXACT}
+   @${repo;org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api;1.3;EXACT}
 
 WS-TraceGroup: concurrent
 

--- a/dev/io.openliberty.org.eclipse.microprofile/contextpropagation.1.3.bnd.disabled
+++ b/dev/io.openliberty.org.eclipse.microprofile/contextpropagation.1.3.bnd.disabled
@@ -23,6 +23,6 @@ Export-Package: \
   org.eclipse.microprofile.context.spi;version=1.3
 
 Include-Resource: \
-   @${repo;org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api;1.3.0.RC1;EXACT}
+   @${repo;org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api;1.3;EXACT}
 
 WS-TraceGroup: concurrent


### PR DESCRIPTION
This pull updates us to the GA spec binaries and TCK of MicroProfile Context Propagation 1.3.  To clarify, this is not the same as GA of the mpContextPropagation-1.3 Liberty feature, which will be done as a follow-on pull after this.