### PR TITLE
mpOpenApi-2.0: avoid processing apps on shutdown

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/ApplicationRegistry.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/ApplicationRegistry.java
@@ -35,6 +35,7 @@ import com.ibm.ws.container.service.app.deploy.ContainerInfo.Type;
 import com.ibm.ws.container.service.app.deploy.WebModuleInfo;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.feature.ServerStartedPhase2;
+import com.ibm.wsspi.kernel.service.utils.FrameworkState;
 
 import io.openliberty.microprofile.openapi20.merge.MergeProcessor;
 import io.openliberty.microprofile.openapi20.utils.Constants;
@@ -136,12 +137,13 @@ public class ApplicationRegistry {
                 // If the removed application had any providers, invalidate the provider cache
                 cachedProvider = null;
                 
-                if (moduleSelectionConfig.useFirstModuleOnly()) {
+                if (moduleSelectionConfig.useFirstModuleOnly() && !FrameworkState.isStopping()) {
                     if (LoggingUtils.isEventEnabled(tc)) {
                         Tr.event(this, tc, "Application Processor: Current OpenAPI application removed, looking for another application to document.");
                     }
 
-                    // We just removed the module used for the OpenAPI document, we need to find a new module to use if there is one
+                    // We just removed the module used for the OpenAPI document and the server is not shutting down.
+                    // We need to find a new module to use if there is one
                     for (ApplicationRecord app : applications.values()) {
                         Collection<OpenAPIProvider> providers = applicationProcessor.processApplication(app.info, moduleSelectionConfig);
                         if (!providers.isEmpty()) {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/FATSuite.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/FATSuite.java
@@ -18,6 +18,7 @@ import io.openliberty.microprofile.openapi20.fat.cache.CacheTest;
 import io.openliberty.microprofile.openapi20.fat.deployments.DeploymentTest;
 import io.openliberty.microprofile.openapi20.fat.deployments.MergeConfigTest;
 import io.openliberty.microprofile.openapi20.fat.deployments.MergeTest;
+import io.openliberty.microprofile.openapi20.fat.shutdown.ShutdownTest;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -25,7 +26,8 @@ import io.openliberty.microprofile.openapi20.fat.deployments.MergeTest;
     CacheTest.class,
     DeploymentTest.class,
     MergeConfigTest.class,
-    MergeTest.class
+    MergeTest.class,
+    ShutdownTest.class
 })
 public class FATSuite {
 }

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/shutdown/ShutdownTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/shutdown/ShutdownTest.java
@@ -1,0 +1,63 @@
+package io.openliberty.microprofile.openapi20.fat.shutdown;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+import io.openliberty.microprofile.openapi20.fat.deployments.test1.DeploymentTestApp;
+
+@Mode(TestMode.FULL)
+@RunWith(FATRunner.class)
+public class ShutdownTest {
+
+    @Server("OpenAPITestServer")
+    public static LibertyServer server;
+    
+    @After
+    public void cleanup() throws Exception {
+        if (server.isStarted()) {
+            server.stopServer();
+        }
+    }
+    
+    /**
+     * Check that we don't process any apps on shutdown when multiple apps are deployed
+     */
+    @Test
+    public void multiAppShutdownTest() throws Exception {
+        for (int i = 0; i < 10; i++) {
+            WebArchive war = ShrinkWrap.create(WebArchive.class, "test-app-" + i + ".war")
+                            .addPackage(DeploymentTestApp.class.getPackage());
+            ShrinkHelper.exportDropinAppToServer(server, war, DeployOptions.SERVER_ONLY);
+        }
+        
+        server.startServer();
+        
+        List<String> appProcessedMessages = server.findStringsInLogs("CWWKO1660I");
+        assertThat("Exactly one app should be processed on startup", appProcessedMessages, hasSize(1));
+
+        server.stopServer(false); // stop server without archiving, since we want to check logs
+        
+        try {
+            appProcessedMessages = server.findStringsInLogs("CWWKO1660I");
+            assertThat("No further apps should be processed on shutdown", appProcessedMessages, hasSize(1));
+        } finally {
+            server.postStopServerArchive();
+        }
+    }
+}


### PR DESCRIPTION
In the default configuration, where only one app is processed to create
OpenAPI documentation, when that app is removed we then processed the
next app so that while any app is deployed we will have OpenAPI
documentation for one of them.

During shutdown all apps are removed in turn so we can end up creating
OpenAPI documentation for some apps while the server is shutting down,
which is a waste of time.

Fixes #19375 