### PR TITLE
Refine the MP Config Stress Test

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.1_fat/fat/src/com/ibm/ws/microprofile/config/fat/suite/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat/fat/src/com/ibm/ws/microprofile/config/fat/suite/FATSuite.java
@@ -31,7 +31,7 @@ import com.ibm.ws.microprofile.config.fat.tests.StressTest;
 /**
  * Tests specific to appConfig
  *
- * BasicConfigTests repeats across all MP Config versions (EE8)
+ * BasicConfigTests repeats across all MP Config versions
  * the rest repeat against the lastest version of MP Config (where appropriate) and then one other combination of MP Config and EE version
  * the aim is that each combination is used to test at least once, across all of the MP Config FAT buckets
  * some classes do not repeat against the latest due to functional changes between MP Config 1.4 -> 2.0


### PR DESCRIPTION
Previously `testRegistrationDeregistration` used a single ConfigBuilder throughout. This actually meant that number of sources added to each Config was cumulative. When SmallRye Config reached around 2500 sources, a StackOverFlowError was seen. However, since that is not the aim of the test, it has been changed to use a fresh builder for each config.

See https://github.com/smallrye/smallrye-config/issues/661

#build

