### PR TITLE
Register the Phase as a service

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
@@ -41,6 +41,7 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.FrameworkEvent;
+import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.launch.Framework;
@@ -568,7 +569,9 @@ public class FrameworkManager {
                 String phaseProp = config.get(BootstrapConstants.CHECKPOINT_PROPERTY_NAME);
                 if (phaseProp != null) {
                     // register the checkpoint phase as early as possible
-                    fwk.getBundleContext().registerService(Phase.class, Phase.getPhase(phaseProp), null);
+                    Phase phase = Phase.getPhase(phaseProp);
+                    fwk.getBundleContext().registerService(Phase.class, phase,
+                                                           FrameworkUtil.asDictionary(Collections.singletonMap(BootstrapConstants.CHECKPOINT_PROPERTY_NAME, phase)));
                 }
             }
             return fwk;

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -1358,7 +1358,7 @@ restoreServer()
   # - SHLVL the shell level could be different
   # - HOSTNAME the host name likely is always different for containers
   # - _ holds the currently running process, here we do no need to have it set to `env`
-  env | grep -Ev "JAVA_OPTIONS=|SHLVL=|HOSTNAME=|_=" > ${SERVER_OUTPUT_DIR}/workarea/checkpoint/.env.properties
+  env | grep -Ev "JAVA_OPTIONS=|SHLVL=|HOSTNAME=|_=|X_LOG_FILE=|X_LOG_DIR=" > ${SERVER_OUTPUT_DIR}/workarea/checkpoint/.env.properties
 
   criuRestore $BACKGROUND_RESTORE
   rc=$?

--- a/dev/io.openliberty.checkpoint/bnd.bnd
+++ b/dev/io.openliberty.checkpoint/bnd.bnd
@@ -41,5 +41,6 @@ Import-Package: org.apache.felix.service.command; resolution:=optional, org.ecli
 -dsannotations: \
     io.openliberty.checkpoint.internal.CheckpointImpl, \
     io.openliberty.checkpoint.internal.CheckpointApplications, \
-    io.openliberty.checkpoint.internal.CheckpointFeatures
+    io.openliberty.checkpoint.internal.CheckpointFeatures, \
+    io.openliberty.checkpoint.internal.CheckpointOSGiConsole
 

--- a/dev/io.openliberty.checkpoint/src/io/openliberty/checkpoint/internal/CheckpointImpl.java
+++ b/dev/io.openliberty.checkpoint/src/io/openliberty/checkpoint/internal/CheckpointImpl.java
@@ -187,6 +187,7 @@ public class CheckpointImpl implements RuntimeUpdateListener, ServerReadyStatus 
         Object[] factories = cc.locateServices("hookFactories");
         List<CheckpointHook> checkpointHooks = getHooks(factories);
         prepare(checkpointHooks);
+        Collections.reverse(checkpointHooks);
         try {
             try {
                 criu.checkpointSupported();

--- a/dev/io.openliberty.checkpoint/src/io/openliberty/checkpoint/internal/CheckpointOSGiConsole.java
+++ b/dev/io.openliberty.checkpoint/src/io/openliberty/checkpoint/internal/CheckpointOSGiConsole.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.checkpoint.internal;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.Constants;
+import org.osgi.framework.namespace.PackageNamespace;
+import org.osgi.framework.wiring.BundleCapability;
+import org.osgi.framework.wiring.BundleRevision;
+import org.osgi.framework.wiring.FrameworkWiring;
+import org.osgi.resource.Namespace;
+import org.osgi.resource.Requirement;
+import org.osgi.resource.Resource;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import io.openliberty.checkpoint.spi.CheckpointHook;
+import io.openliberty.checkpoint.spi.CheckpointHookFactory;
+
+@Component
+public class CheckpointOSGiConsole implements CheckpointHookFactory {
+    private final Bundle console;
+    private final FrameworkWiring fwkWiring;
+
+    @Activate
+    public CheckpointOSGiConsole(@Reference Phase phase, BundleContext context) {
+        Requirement consolePkg = new Requirement() {
+
+            @Override
+            public Resource getResource() {
+                return null;
+            }
+
+            @Override
+            public String getNamespace() {
+                return PackageNamespace.PACKAGE_NAMESPACE;
+            }
+
+            @Override
+            public Map<String, String> getDirectives() {
+                return Collections.singletonMap(Namespace.REQUIREMENT_FILTER_DIRECTIVE, "(" + PackageNamespace.PACKAGE_NAMESPACE + "=org.eclipse.equinox.console.common)");
+            }
+
+            @Override
+            public Map<String, Object> getAttributes() {
+                return Collections.emptyMap();
+            }
+        };
+
+        this.fwkWiring = context.getBundle(Constants.SYSTEM_BUNDLE_LOCATION).adapt(FrameworkWiring.class);
+        this.console = this.fwkWiring.findProviders(consolePkg).stream() //
+                        .findFirst() //
+                        .map(BundleCapability::getRevision) //
+                        .map(BundleRevision::getBundle)//
+                        .orElse(null);
+    }
+
+    @Override
+    public CheckpointHook create(Phase phase) {
+        if (console == null) {
+            return null;
+        }
+        return new CheckpointHook() {
+            @Override
+            public void prepare() {
+                try {
+                    // stop the console so we can restore the telnet port on restart
+                    console.stop();
+                    // The console bundle has an issue some static vars that do not get
+                    // properly reset on stop.  Refresh the bundle to start fresh on restore
+                    CountDownLatch refreshDone = new CountDownLatch(1);
+                    fwkWiring.refreshBundles(Collections.singleton(console), (e) -> {
+                        refreshDone.countDown();
+                    });
+                    refreshDone.await(30, TimeUnit.SECONDS);
+                } catch (BundleException e) {
+                    // ignore
+                    // auto FFDC is fine
+                } catch (InterruptedException e1) {
+                    // auto FFDC is fine
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            @Override
+            public void abortPrepare(Exception cause) {
+                restore();
+            }
+
+            @Override
+            public void restore() {
+                try {
+                    console.start();
+                } catch (BundleException e) {
+                    // ignore
+                    // auto FFDC is fine
+                }
+            }
+        };
+    }
+
+}

--- a/dev/io.openliberty.checkpoint/test/io/openliberty/checkpoint/internal/CheckpointImplTest.java
+++ b/dev/io.openliberty.checkpoint/test/io/openliberty/checkpoint/internal/CheckpointImplTest.java
@@ -312,14 +312,14 @@ public class CheckpointImplTest {
             assertEquals("Prepare not called.", true, hook.prepareCalled);
             assertNull("Unexpected Prepare Exception.", hook.abortPrepareCause);
         }
-        assertEquals("Restore not called.", true, f1.hook.restoreCalled);
-        assertEquals("Wrong cause.", restoreException, f1.hook.abortRestoreCause);
+        assertEquals("Restore not called.", true, f3.hook.restoreCalled);
+        assertEquals("Wrong cause.", restoreException, f3.hook.abortRestoreCause);
 
         assertEquals("Restore not called.", true, f2.hook.restoreCalled);
         assertNull("Wrong cause.", f2.hook.abortRestoreCause);
 
-        assertEquals("Unexpected Restore called.", false, f3.hook.restoreCalled);
-        assertNull("Wrong cause.", f3.hook.abortRestoreCause);
+        assertEquals("Unexpected Restore called.", false, f1.hook.restoreCalled);
+        assertNull("Wrong cause.", f1.hook.abortRestoreCause);
 
         assertTrue("Expected to have called criu", criu.imageDir.getAbsolutePath().contains(locAdmin.getServerName()));
     }

--- a/dev/io.openliberty.checkpoint/test/io/openliberty/checkpoint/internal/CheckpointImplTest.java
+++ b/dev/io.openliberty.checkpoint/test/io/openliberty/checkpoint/internal/CheckpointImplTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.ComponentContext;
 
-import com.ibm.ws.kernel.boot.internal.BootstrapConstants;
 import com.ibm.ws.runtime.update.RuntimeUpdateNotification;
 import com.ibm.ws.threading.listeners.CompletionListener;
 import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
@@ -53,14 +52,10 @@ public class CheckpointImplTest {
 
     static class Factories implements InvocationHandler {
         final Object[] factories;
-        final boolean applications;
-        final boolean features;
 
-        public Factories(Object[] factories, boolean applications, boolean features) {
+        public Factories(Object[] factories) {
             super();
             this.factories = factories;
-            this.applications = applications;
-            this.features = features;
         }
 
         @Override
@@ -71,14 +66,6 @@ public class CheckpointImplTest {
             if ("getBundleContext".equals(method.getName())) {
                 return Proxy.newProxyInstance(getClass().getClassLoader(), new Class[] { BundleContext.class }, (p, m, a) -> {
                     if ("getProperty".equals(m.getName())) {
-                        if (BootstrapConstants.CHECKPOINT_PROPERTY_NAME.equals(a[0])) {
-                            if (features) {
-                                return "features";
-                            }
-                            if (applications) {
-                                return "applications";
-                            }
-                        }
                         return null;
                     }
                     throw new UnsupportedOperationException(m.getName());
@@ -171,15 +158,10 @@ public class CheckpointImplTest {
     }
 
     private ComponentContext createComponentContext(CheckpointHookFactory... factories) {
-        return createComponentContext1(false, false, factories);
-
-    }
-
-    private ComponentContext createComponentContext1(boolean applications, boolean features, CheckpointHookFactory... factories) {
         if (factories.length == 0) {
             factories = null;
         }
-        return (ComponentContext) Proxy.newProxyInstance(getClass().getClassLoader(), new Class[] { ComponentContext.class }, new Factories(factories, applications, features));
+        return (ComponentContext) Proxy.newProxyInstance(getClass().getClassLoader(), new Class[] { ComponentContext.class }, new Factories(factories));
     }
 
     private RuntimeUpdateNotification createRuntimeUpdateNotification() {
@@ -219,10 +201,10 @@ public class CheckpointImplTest {
     public void testNullFactories() throws CheckpointFailedException {
         TestCRIU criu = new TestCRIU();
         WsLocationAdmin locAdmin = (WsLocationAdmin) SharedLocationManager.createLocations(testbuildDir, "test1");
-        CheckpointImpl checkpoint = new CheckpointImpl(createComponentContext(), criu, locAdmin);
-        checkDirectory(Phase.FEATURES, checkpoint, criu, locAdmin);
+        CheckpointImpl checkpoint = new CheckpointImpl(createComponentContext(), criu, locAdmin, Phase.FEATURES);
+        checkDirectory(checkpoint, criu, locAdmin);
         checkpoint.resetCheckpointCalled();
-        checkFailDump(Phase.FEATURES, checkpoint, criu, locAdmin);
+        checkFailDump(checkpoint, criu, locAdmin);
     }
 
     @Test
@@ -230,7 +212,7 @@ public class CheckpointImplTest {
         TestCRIU criu = new TestCRIU();
         TestCheckpointHookFactory factory = new TestCheckpointHookFactory();
         WsLocationAdmin locAdmin = (WsLocationAdmin) SharedLocationManager.createLocations(testbuildDir, "test2");
-        CheckpointImpl checkpoint = new CheckpointImpl(createComponentContext(factory), criu, locAdmin);
+        CheckpointImpl checkpoint = new CheckpointImpl(createComponentContext(factory), criu, locAdmin, Phase.APPLICATIONS);
         checkPhase(factory, checkpoint, criu, locAdmin);
     }
 
@@ -241,9 +223,9 @@ public class CheckpointImplTest {
         TestCheckpointHookFactory f2 = new TestCheckpointHookFactory();
         TestCheckpointHookFactory f3 = new TestCheckpointHookFactory();
         WsLocationAdmin locAdmin = (WsLocationAdmin) SharedLocationManager.createLocations(testbuildDir, "test3");
-        CheckpointImpl checkpoint = new CheckpointImpl(createComponentContext(f1, f2, f3), criu, locAdmin);
+        CheckpointImpl checkpoint = new CheckpointImpl(createComponentContext(f1, f2, f3), criu, locAdmin, Phase.APPLICATIONS);
 
-        checkDirectory(Phase.APPLICATIONS, checkpoint, criu, locAdmin);
+        checkDirectory(checkpoint, criu, locAdmin);
         List<TestCheckpointHook> hooks = getHooks(f1, f2, f3);
         for (TestCheckpointHook hook : hooks) {
             assertEquals("Prepare not called.", true, hook.prepareCalled);
@@ -261,10 +243,10 @@ public class CheckpointImplTest {
         TestCheckpointHookFactory f2 = new TestCheckpointHookFactory(prepareException, null);
         TestCheckpointHookFactory f3 = new TestCheckpointHookFactory();
         WsLocationAdmin locAdmin = (WsLocationAdmin) SharedLocationManager.createLocations(testbuildDir, "test4");
-        CheckpointImpl checkpoint = new CheckpointImpl(createComponentContext(f1, f2, f3), criu, locAdmin);
+        CheckpointImpl checkpoint = new CheckpointImpl(createComponentContext(f1, f2, f3), criu, locAdmin, Phase.APPLICATIONS);
 
         try {
-            checkpoint.checkpoint(Phase.APPLICATIONS);
+            checkpoint.checkpoint();
             fail("Expected CheckpointFailed exception.");
         } catch (CheckpointFailedException e) {
             assertEquals("Wrong type.", Type.PREPARE_ABORT, e.getType());
@@ -295,9 +277,9 @@ public class CheckpointImplTest {
         TestCheckpointHookFactory f2 = new TestCheckpointHookFactory();
         TestCheckpointHookFactory f3 = new TestCheckpointHookFactory();
         WsLocationAdmin locAdmin = (WsLocationAdmin) SharedLocationManager.createLocations(testbuildDir, "test5");
-        CheckpointImpl checkpoint = new CheckpointImpl(createComponentContext(f1, f2, f3), criu, locAdmin);
+        CheckpointImpl checkpoint = new CheckpointImpl(createComponentContext(f1, f2, f3), criu, locAdmin, Phase.FEATURES);
 
-        checkFailDump(Phase.FEATURES, checkpoint, criu, locAdmin);
+        checkFailDump(checkpoint, criu, locAdmin);
 
         List<TestCheckpointHook> hooks = getHooks(f1, f2, f3);
         for (TestCheckpointHook hook : hooks) {
@@ -316,10 +298,10 @@ public class CheckpointImplTest {
         TestCheckpointHookFactory f2 = new TestCheckpointHookFactory(null, restoreException);
         TestCheckpointHookFactory f3 = new TestCheckpointHookFactory();
         WsLocationAdmin locAdmin = (WsLocationAdmin) SharedLocationManager.createLocations(testbuildDir, "test6");
-        CheckpointImpl checkpoint = new CheckpointImpl(createComponentContext(f1, f2, f3), criu, locAdmin);
+        CheckpointImpl checkpoint = new CheckpointImpl(createComponentContext(f1, f2, f3), criu, locAdmin, Phase.APPLICATIONS);
 
         try {
-            checkpoint.checkpoint(Phase.APPLICATIONS);
+            checkpoint.checkpoint();
             fail("Expected CheckpointFailed exception.");
         } catch (CheckpointFailedException e) {
             assertEquals("Wrong type.", Type.RESTORE_ABORT, e.getType());
@@ -347,7 +329,7 @@ public class CheckpointImplTest {
         TestCRIU criu = new TestCRIU();
         TestCheckpointHookFactory factory = new TestCheckpointHookFactory();
         WsLocationAdmin locAdmin = (WsLocationAdmin) SharedLocationManager.createLocations(testbuildDir, "test7");
-        CheckpointImpl checkpoint = new CheckpointImpl(createComponentContext1(true, false, factory), criu, locAdmin);
+        CheckpointImpl checkpoint = new CheckpointImpl(createComponentContext(factory), criu, locAdmin, Phase.APPLICATIONS);
         checkpoint.check();
         assertEquals("Wrong phase.", Phase.APPLICATIONS, factory.phase);
         assertTrue("Expected to have called criu", criu.imageDir.getAbsolutePath().contains(locAdmin.getServerName()));
@@ -358,7 +340,7 @@ public class CheckpointImplTest {
         TestCRIU criu = new TestCRIU();
         TestCheckpointHookFactory factory = new TestCheckpointHookFactory();
         WsLocationAdmin locAdmin = (WsLocationAdmin) SharedLocationManager.createLocations(testbuildDir, "test8");
-        CheckpointImpl checkpoint = new CheckpointImpl(createComponentContext1(false, true, factory), criu, locAdmin);
+        CheckpointImpl checkpoint = new CheckpointImpl(createComponentContext(factory), criu, locAdmin, Phase.FEATURES);
         RuntimeUpdateNotification trn = createRuntimeUpdateNotification();
         checkpoint.notificationCreated(null, trn);
         CompletionListener<Boolean> cl = getCompletionListener();
@@ -373,7 +355,7 @@ public class CheckpointImplTest {
         TestCRIU criu = new TestCRIU();
         TestCheckpointHookFactory factory = new TestCheckpointHookFactory();
         WsLocationAdmin locAdmin = (WsLocationAdmin) SharedLocationManager.createLocations(testbuildDir, "test9");
-        CheckpointImpl checkpoint = new CheckpointImpl(createComponentContext1(true, false, factory), criu, locAdmin);
+        CheckpointImpl checkpoint = new CheckpointImpl(createComponentContext(factory), criu, locAdmin, Phase.FEATURES);
         checkpoint.check();
         assertTrue("Expected to have called checkpoint", checkpoint.checkpointCalledAlready());
         checkpoint.check();
@@ -397,19 +379,19 @@ public class CheckpointImplTest {
     }
 
     private void checkPhase(TestCheckpointHookFactory factory, CheckpointImpl checkpoint, TestCRIU criu, WsLocationAdmin locAdmin) throws CheckpointFailedException {
-        checkDirectory(Phase.APPLICATIONS, checkpoint, criu, locAdmin);
+        checkDirectory(checkpoint, criu, locAdmin);
         assertEquals("Wrong phase.", Phase.APPLICATIONS, factory.phase);
     }
 
-    private void checkDirectory(Phase phase, CheckpointImpl checkpoint, TestCRIU criu, WsLocationAdmin locAdmin) throws CheckpointFailedException {
-        checkpoint.checkpoint(phase);
+    private void checkDirectory(CheckpointImpl checkpoint, TestCRIU criu, WsLocationAdmin locAdmin) throws CheckpointFailedException {
+        checkpoint.checkpoint();
         assertTrue("Wrong file.", criu.imageDir.getAbsolutePath().contains(locAdmin.getServerName()));
     }
 
-    private void checkFailDump(Phase phase, CheckpointImpl checkpoint, TestCRIU criu, WsLocationAdmin locAdmin) {
+    private void checkFailDump(CheckpointImpl checkpoint, TestCRIU criu, WsLocationAdmin locAdmin) {
         criu.throwIOException = true;
         try {
-            checkpoint.checkpoint(phase);
+            checkpoint.checkpoint();
             fail("Expected CheckpointFailed exception.");
         } catch (CheckpointFailedException e) {
             assertEquals("Wrong type.", Type.SYSTEM_CHECKPOINT_FAILED, e.getType());

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FATSuite.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FATSuite.java
@@ -16,11 +16,16 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.websphere.simplicity.RemoteFile;
 
+import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(Suite.class)
-@SuiteClasses({ TestWithFATServlet.class, TestWithFATServlet2.class })
+@SuiteClasses({
+                AlwaysPassesTest.class,
+                TestWithFATServlet.class,
+                TestWithFATServlet2.class
+})
 public class FATSuite {
     public static void copyAppsAppToDropins(LibertyServer server, String appName) throws Exception {
         RemoteFile appFile = server.getFileFromLibertyServerRoot("apps/" + appName + ".war");


### PR DESCRIPTION
This PR has a few fixes to clean up checkpoint

1. The Phase enum is registered by the kernel.boot as a service.  This allows service components reference the phase as a requirement to activate.  The phase service also has its type stored as a service property so particular phases can be targeted with a filter.  For example: `(io.openliberty.checkpoint=APPLICATIONS)`.
2. A couple more env keys are filtered out for restore to avoid changing the values of the X_LOG_DIR and X_LOG_FILE.
3. The restore method of the hooks is called in the reverse order of the prepare hooks.  This follows a similar pattern to things like interceptors that use a call order like A->B->C action C->B->A.
4. Adds a hook to handle prepare/restore for the OSGi console.