### PR TITLE
NullPointerException when max or priority are unspecified

### DIFF
--- a/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedExecutorResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedExecutorResourceFactoryBuilder.java
@@ -171,7 +171,7 @@ public class ManagedExecutorResourceFactoryBuilder implements ResourceFactoryBui
         concurrencyPolicyProps.put(ID, concurrencyPolicyId);
         concurrencyPolicyProps.put(CONFIG_DISPLAY_ID, concurrencyPolicyId);
         concurrencyPolicyProps.put("expedite", 0);
-        if (maxAsync > 0)
+        if (maxAsync != null && maxAsync > 0)
             concurrencyPolicyProps.put("max", maxAsync);
         concurrencyPolicyProps.put("maxPolicy", "loose");
         concurrencyPolicyProps.put("maxWaitForEnqueue", 0L);

--- a/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedScheduledExecutorResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedScheduledExecutorResourceFactoryBuilder.java
@@ -174,7 +174,7 @@ public class ManagedScheduledExecutorResourceFactoryBuilder implements ResourceF
         concurrencyPolicyProps.put(ID, concurrencyPolicyId);
         concurrencyPolicyProps.put(CONFIG_DISPLAY_ID, concurrencyPolicyId);
         concurrencyPolicyProps.put("expedite", 0);
-        if (maxAsync > 0)
+        if (maxAsync != null && maxAsync > 0)
             concurrencyPolicyProps.put("max", maxAsync);
         concurrencyPolicyProps.put("maxPolicy", "loose");
         concurrencyPolicyProps.put("maxWaitForEnqueue", 0L);

--- a/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedThreadFactoryResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedThreadFactoryResourceFactoryBuilder.java
@@ -129,6 +129,7 @@ public class ManagedThreadFactoryResourceFactoryBuilder implements ResourceFacto
         String component = (String) threadFactoryProps.get("component");
         String jndiName = (String) threadFactoryProps.get(ResourceFactory.JNDI_NAME);
         String contextSvcJndiName = (String) threadFactoryProps.remove("context");
+        Integer priority = (Integer) threadFactoryProps.remove("priority");
 
         String managedThreadFactoryID = getManagedThreadFactoryID(application, module, component, jndiName);
         String contextServiceId = contextSvcJndiName == null || "java:comp/DefaultContextService".equals(contextSvcJndiName) //
@@ -150,7 +151,7 @@ public class ManagedThreadFactoryResourceFactoryBuilder implements ResourceFacto
         threadFactoryProps.put("contextService.cardinality.minimum", 1);
 
         threadFactoryProps.put("createDaemonThreads", false);
-        threadFactoryProps.put("defaultPriority", threadFactoryProps.remove("priority"));
+        threadFactoryProps.put("defaultPriority", priority == null ? Thread.NORM_PRIORITY : priority);
 
         // TODO process these?
         String[] properties = (String[]) threadFactoryProps.remove("properties");


### PR DESCRIPTION
This fixes the NullPointerException that can arise from a couple of different places if one of the int type attributes (max or priority) is unspecified.