### PR TITLE
demo timers test gets CWWKZ0002E due to transaction timeout on slow infrastructure

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/publish/servers/com.ibm.ws.concurrent.persistent.fat.demo.timers/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/publish/servers/com.ibm.ws.concurrent.persistent.fat.demo.timers/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020,2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -43,6 +43,9 @@
   <javaPermission className="java.util.PropertyPermission" name="user.dir" actions="read"/>
   <javaPermission className="java.io.FilePermission" name="files/timertestoutput.txt" actions="read,write"/>
   <javaPermission className="java.io.FilePermission" name="files" actions="write"/>
-  
+
+  <!-- Work around infrastructure slowness where it takes over 2 minutes for Derby to access the file system  -->
+  <transaction totalTranLifetimeTimeout="5m"/>
+
   <variable name="onError" value="FAIL"/>
 </server>


### PR DESCRIPTION
fixes #19411