### PR TITLE
Don't put processed file paths into errors

### DIFF
--- a/dev/com.ibm.ws.jmx.connector.server.rest/src/com/ibm/ws/jmx/connector/server/rest/helpers/FileTransferHelper.java
+++ b/dev/com.ibm.ws.jmx.connector.server.rest/src/com/ibm/ws/jmx/connector/server/rest/helpers/FileTransferHelper.java
@@ -639,8 +639,8 @@ public class FileTransferHelper {
             IOException ioe = new IOException(TraceNLS.getFormattedMessage(this.getClass(),
                                                                            APIConstants.TRACE_BUNDLE_FILE_TRANSFER,
                                                                            "DELETE_REQUEST_ERROR",
-                                                                           null,
-                                                                           "CWWKX0126E: Delete request for file " + processedPath + " could not be completed."));
+                                                                           new Object[] { filePath },
+                                                                           "CWWKX0126E: Delete request for file " + filePath + " could not be completed."));
             throw ErrorHelper.createRESTHandlerJsonException(ioe, null, APIConstants.STATUS_BAD_REQUEST);
         }
 
@@ -667,7 +667,7 @@ public class FileTransferHelper {
                 IOException ioe = new IOException(TraceNLS.getFormattedMessage(this.getClass(),
                                                                                APIConstants.TRACE_BUNDLE_FILE_TRANSFER,
                                                                                "UPLOAD_EXPANSION_ERROR",
-                                                                               new Object[] { processedPath },
+                                                                               new Object[] { filePath },
                                                                                "CWWKX0129E: Uploaded archive could not be expanded."));
                 throw ErrorHelper.createRESTHandlerJsonException(ioe, null, APIConstants.STATUS_INTERNAL_SERVER_ERROR);
             }


### PR DESCRIPTION
As this leaks internal server information, which is against
good security practices
fixes #19410 
