### PR TITLE
put grpc_fat protobuf compilation behind prop

### DIFF
--- a/dev/com.ibm.ws.grpc_fat/README.md
+++ b/dev/com.ibm.ws.grpc_fat/README.md
@@ -1,0 +1,18 @@
+## Summary
+A functional automated test (FAT) bucket for the `grpc-1.0` and `grpcClient-1.0` features. 
+
+## Building
+
+The default build targets will not cause the gRPC stubs to be recompiled (via the [protobuf plugin](https://github.com/google/protobuf-gradle-plugin)). Any time changes are made to protobuf files, for example `./test-applications/HelloWorldService.war/resources/proto/helloworld.proto`, be sure enable the protobuf plugin via `-PcompileProtobufs`: 
+
+    ./gradlew com.ibm.ws.grpc_fat:build -PcompileProtobufs
+
+If changes have been made to the protobufs, this execution should cause changes in `./generated-src`. Check those changes in along with any protobuf changes.
+
+## Running the tests
+### Run in default LITE mode
+    ./gradlew com.ibm.ws.grpc_fat:buildandrun
+
+### Run in FULL mode
+    ./gradlew com.ibm.ws.grpc_fat:buildandrun -Dfat.test.mode=full
+

--- a/dev/com.ibm.ws.grpc_fat/build.gradle
+++ b/dev/com.ibm.ws.grpc_fat/build.gradle
@@ -201,7 +201,6 @@ addRequiredLibraries {
     dependsOn copyToConsumerAppWarLibs
 }
 
-// Inform IDE Eclipse about the generated code.
 sourceSets {
     main {
         if (project.hasProperty('compileProtobufs')) {

--- a/dev/com.ibm.ws.grpc_fat/build.gradle
+++ b/dev/com.ibm.ws.grpc_fat/build.gradle
@@ -9,6 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
+
 // configure protobuf-gradle-plugin and liberty-gradle-plugin
 buildscript {
     repositories.clear()
@@ -25,16 +26,55 @@ buildscript {
             mavenCentral()
         }
     }
-  dependencies {
-    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.12'
-    classpath 'io.openliberty.tools:liberty-gradle-plugin:3.0'
-  }
+    dependencies {
+        if (project.hasProperty('compileProtobufs')) {
+            classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.12'
+        }
+        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.0'
+    }
 }
+
 plugins {	
     id 'war'
     id "eclipse-wtp"
 }
-apply plugin: 'com.google.protobuf'
+
+def grpcVersion = '1.38.1'
+def protocVersion = '3.13.0'
+
+// only run the protobuf compilation plugin if the build is run with "-PcompileProtobufs"
+// this will allow us to avoid recompiling the protobuf stubs on every build, and additionally
+// it will allow this test bucket to run on platforms not supported by the protoc tooling. 
+// See https://github.com/OpenLiberty/open-liberty/issues/17913
+if (project.hasProperty('compileProtobufs')) {
+
+    apply plugin: 'com.google.protobuf'
+
+    protobuf {
+        protoc { artifact = "com.google.protobuf:protoc:" + protocVersion }
+        plugins {
+            grpc { artifact = "io.grpc:protoc-gen-grpc-java:" + grpcVersion }
+        }
+        generateProtoTasks {
+            all()*.plugins { 
+                grpc {} 
+            }
+        }
+    }
+
+    assemble.doLast {
+        // update the generated-src dir with the new stubs that have been generated
+        copy {
+        from "build/libs/generated/source/proto/main/java"
+            into "generated-src"
+        }
+        copy {
+        from "build/libs/generated/source/proto/main/grpc"
+            into "generated-src"
+        }
+    }
+}
+
 repositories.clear()
 repositories {
     if (isUsingArtifactory) {
@@ -78,30 +118,28 @@ repositories {
 }
 
 configurations {
-  storeAppWarLibs
+    storeAppWarLibs
 }
 
-def grpcVersion = '1.38.1'
-
 dependencies {
- 
- 	// Adding libraries the application to run in FAT
-	storeAppWarLibs 'com.google.protobuf:protobuf-java-util:3.13.0',
-	'com.google.code.gson:gson:2.8.6',
-	'com.google.guava:guava:30.1-android',
-	'com.google.errorprone:error_prone_annotations:2.4.0',
-	'com.google.guava:failureaccess:1.0.1',
-	'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava',
-	'org.codehaus.mojo:animal-sniffer-annotations:1.18',
-	'org.checkerframework:checker-compat-qual:2.5.5',
-	'com.google.j2objc:j2objc-annotations:1.3',
-	'com.google.code.findbugs:jsr305:3.0.2',
-	'net.sourceforge.htmlunit:htmlunit:2.20'
+
+    // Adding libraries the application to run in FAT
+    storeAppWarLibs 'com.google.protobuf:protobuf-java-util:3.13.0',
+    'com.google.code.gson:gson:2.8.6',
+    'com.google.guava:guava:30.1-android',
+    'com.google.errorprone:error_prone_annotations:2.4.0',
+    'com.google.guava:failureaccess:1.0.1',
+    'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava',
+    'org.codehaus.mojo:animal-sniffer-annotations:1.18',
+    'org.checkerframework:checker-compat-qual:2.5.5',
+    'com.google.j2objc:j2objc-annotations:1.3',
+    'com.google.code.findbugs:jsr305:3.0.2',
+    'net.sourceforge.htmlunit:htmlunit:2.20'
  
     // test
     testImplementation 'commons-httpclient:commons-httpclient:3.1'
     testImplementation 'junit:junit:4.12'
-	
+
     //
     implementation 'com.google.protobuf:protobuf-java-util:3.13.0'
     // @jar is needed since some of the dependencies of java-util were overwritten
@@ -111,13 +149,13 @@ dependencies {
     providedCompile 'io.grpc:grpc-netty:' + grpcVersion + '@jar'
     //dynamic caching map
     implementation 'com.ibm.websphere.appserver.api:com.ibm.websphere.appserver.api.distributedMap:2.0.37'
-	
+
     // provided
     providedCompile 'com.google.protobuf:protobuf-java:3.13.0'
     providedCompile 'javax.annotation:javax.annotation-api:1.2'
     providedCompile 'jakarta.platform:jakarta.jakartaee-api:8.0.0'
     providedCompile 'org.eclipse.microprofile:microprofile:3.2'
-    
+
     // test runtime 
     requiredLibs 'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
       'net.sourceforge.htmlunit:htmlunit:2.44.0',
@@ -144,89 +182,52 @@ dependencies {
       'com.google.protobuf:protobuf-java-util:3.13.0'
 }
 
-protobuf {
-    protoc { artifact = "com.google.protobuf:protoc:3.13.0" }
-    plugins {
-        grpc { artifact = "io.grpc:protoc-gen-grpc-java:" + grpcVersion }
-    }
-    generateProtoTasks {
-        all()*.plugins { 
-        			grpc {} 
-        		}
-    }
-}
 
 // copy into application lib at build time
 task copyToConsumerAppWarLibs(type: Copy) {
-  from configurations.storeAppWarLibs
-  	into new File(autoFvtDir, 'test-applications/StoreConsumerApp.war/resources/WEB-INF/lib')
+    from configurations.storeAppWarLibs
+     into new File(autoFvtDir, 'test-applications/StoreConsumerApp.war/resources/WEB-INF/lib')
 }
 
 // copy into application lib at build time
 task copyToStoreAppWarLibs(type: Copy) {
-  from configurations.storeAppWarLibs
-  	into new File(autoFvtDir, 'test-applications/StoreApp.war/resources/WEB-INF/lib')
+    from configurations.storeAppWarLibs
+        into new File(autoFvtDir, 'test-applications/StoreApp.war/resources/WEB-INF/lib')
 }
 
 //runs task at FAT build time
 addRequiredLibraries {
-  dependsOn copyToStoreAppWarLibs
-  dependsOn copyToConsumerAppWarLibs
+    dependsOn copyToStoreAppWarLibs
+    dependsOn copyToConsumerAppWarLibs
 }
 
 // Inform IDE Eclipse about the generated code.
 sourceSets {
-	main {
-    	proto {
-    		srcDirs 'test-applications/HelloWorldService.war/resources/proto'
-    	}
+    main {
+        if (project.hasProperty('compileProtobufs')) {
+            proto {
+                srcDirs 'test-applications/HelloWorldService.war/resources/proto'
+                srcDirs 'test-applications/FavoriteBeerService.war/resources/proto'
+                srcDirs 'test-applications/StoreProducerApp.war/resources/proto'
+                srcDirs 'test-applications/StoreConsumerApp.war/resources/proto'
+                srcDirs 'test-applications/StoreApp.war/resources/proto'
+                srcDirs 'test-applications/StreamingService.war/resources/proto'
+            }
+        } else {
+            java {
+                // if we're not regenerating protoc stubs, reuse the stubs in generated-src
+                srcDirs 'generated-src'
+            }
+        }
         java {
             srcDirs 'test-applications/HelloWorldClient.war/src/java'
             srcDirs 'test-applications/HelloWorldService.war/src/java'
-       }
-	}
-    main {
-        proto {
-            srcDirs 'test-applications/FavoriteBeerService.war/resources/proto'
-        }
-        java {
             srcDirs 'test-applications/FavoriteBeerService.war/src/java'
-        }
-    }
-    // StoreProducerApp
-    // StoreConsumerApp
-    // StoreApp
-    main {
-        proto {
-            srcDirs 'test-applications/StoreProducerApp.war/resources/proto'
-            srcDirs 'test-applications/StoreConsumerApp.war/resources/proto'
-            srcDirs 'test-applications/StoreApp.war/resources/proto'
-        }
-        java {
             srcDirs 'test-applications/StoreProducerApp.war/src/java'
             srcDirs 'test-applications/StoreConsumerApp.war/src/java'
             srcDirs 'test-applications/StoreApp.war/src/java'
-        }
-    }
-
-    main {
-        proto {
-            srcDirs 'test-applications/StreamingService.war/resources/proto'
-        }
-        java {
             srcDirs 'test-applications/StreamingService.war/src/java'
-        }
-    }
-}
-
-assemble.doLast {
-    copy {
-       from "build/libs/generated/source/proto/main/java"
-          into "generated-src"
-    }
-    copy {
-       from "build/libs/generated/source/proto/main/grpc"
-          into "generated-src"
+       }
     }
 }
 


### PR DESCRIPTION
- The grpc_fat build has been updated so that the protobuf compilation step will only occur if a new a new property `compileProtobufs` is present. This will allow us to reuse the generated source we already check in, and so avoid regenerating the stubs for each build.
- Future updates to the grpc_fat protos will require the extra step of adding the new prop to the build command, eg. `./gradlew com.ibm.ws.grpc_fat -PcompileProtobufs`. The updated files under `generated-src` will need to be checked in, as before. A new README has been added to the grpc_fat project to document this.

Fixes #17913