### PR TITLE
JAX-WS, JAX-B, JavaMail: Limit tracing in FAT buckets

### DIFF
--- a/dev/com.ibm.ws.javamail.1.6_fat/publish/servers/com.ibm.ws.javamail.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.javamail.1.6_fat/publish/servers/com.ibm.ws.javamail.fat/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=event=enabled:com.ibm.ws.javamail.*=all=enabled:com.ibm.ws.jndi.*=all:com.ibm.ws.webcontainer.osgi.*=all=enabled:Injection=all=enabled
+com.ibm.ws.logging.trace.specification=com.ibm.ws.javamail.*=all=enabled
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 

--- a/dev/com.ibm.ws.javamail.1.6_fat/publish/servers/com.ibm.ws.javamail.management.j2ee.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.javamail.1.6_fat/publish/servers/com.ibm.ws.javamail.management.j2ee.fat/bootstrap.properties
@@ -1,10 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=event=enabled:\
-Injection=all=enabled:\
-com.ibm.ws.javamail.*=all=enabled:\
-com.ibm.ws.kernel.boot.jmx.internal.*=all:\
-com.ibm.ws.jmx.connector.client.rest.internal.*=all=enabled:\
-com.ibm.ws.kernel.filemonitor.internal.*=all=enabled:\
-logService=all
+com.ibm.ws.logging.trace.specification=com.ibm.ws.javamail.*=all=enabled
 
 ds.loglevel=debug
 

--- a/dev/com.ibm.ws.javamail.1.6_fat/publish/servers/mailSessionTestServer/bootstrap.properties
+++ b/dev/com.ibm.ws.javamail.1.6_fat/publish/servers/mailSessionTestServer/bootstrap.properties
@@ -1,5 +1,4 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=event=enabled:com.ibm.ws.javamail.*=all=enabled:com.ibm.ws.jndi.*=all:com.ibm.ws.webcontainer.osgi.*=all=enabled:Injection=all=enabled
-
+com.ibm.ws.logging.trace.specification=com.ibm.ws.javamail.*=all=enabled
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug

--- a/dev/com.ibm.ws.jaxb_fat/publish/servers/com.ibm.ws.jaxb.tools.TestServer/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxb_fat/publish/servers/com.ibm.ws.jaxb.tools.TestServer/bootstrap.properties
@@ -1,2 +1,1 @@
-com.ibm.ws.logging.trace.specification=ddmodel=all=enabled:*=info=enabled
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxb_fat/publish/servers/jaxb_fat.no-jaxb-feature/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxb_fat/publish/servers/jaxb_fat.no-jaxb-feature/bootstrap.properties
@@ -9,7 +9,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info
 # This server is exempt from j2sec because it only tests third-party/JDK usage of JAX-B
 # The only Liberty code involved is trivial server start and servlet GET logic
 websphere.java.security.exempt=true

--- a/dev/com.ibm.ws.jaxb_fat/publish/servers/jaxb_fat/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxb_fat/publish/servers/jaxb_fat/bootstrap.properties
@@ -9,7 +9,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info
 # This server is exempt from j2sec because it only tests third-party/JDK usage of JAX-B
 # The only Liberty code involved is trivial server start and servlet GET logic
 websphere.java.security.exempt=true

--- a/dev/com.ibm.ws.jaxb_fat/publish/servers/jaxb_internal_optional_feature_toleration_fat/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxb_fat/publish/servers/jaxb_internal_optional_feature_toleration_fat/bootstrap.properties
@@ -9,4 +9,3 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.jaxb_fat/publish/servers/jaxb_optional_feature_toleration_fat/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxb_fat/publish/servers/jaxb_optional_feature_toleration_fat/bootstrap.properties
@@ -9,4 +9,3 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/publish/servers/com.ibm.ws.jaxws.virtualhost/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/publish/servers/com.ibm.ws.jaxws.virtualhost/bootstrap.properties
@@ -1,5 +1,2 @@
-com.ibm.ws.logging.trace.specification=*=info=enabled:\
-com.ibm.ws.jaxws.*=all=enabled
-com.ibm.ws.logging.max.file.size=0
 websphere.java.security.exempt=true
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxws.clientcontainer_fat/publish/servers/JaxWsTransportSecurityServer/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxws.clientcontainer_fat/publish/servers/JaxWsTransportSecurityServer/bootstrap.properties
@@ -1,2 +1,1 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all=enabled:JaxWsSecurity=debug=enabled:SSL=all=enabled:ChannelFramework=all=enabled:HttpTransport=all=enabled:com.ibm.ws.bytebuffer.internal.WsByteBufferImpl=debug=enabled:com.ibm.ws.jaxws.*=all=enabled

--- a/dev/io.openliberty.mail.2.0.internal_fat/publish/servers/com.ibm.ws.javamail.fat/bootstrap.properties
+++ b/dev/io.openliberty.mail.2.0.internal_fat/publish/servers/com.ibm.ws.javamail.fat/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=event=enabled:com.ibm.ws.javamail.*=all=enabled:com.ibm.ws.jndi.*=all:com.ibm.ws.webcontainer.osgi.*=all=enabled:Injection=all=enabled
+com.ibm.ws.logging.trace.specification=com.ibm.ws.javamail.*=all=enabled
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 

--- a/dev/io.openliberty.mail.2.0.internal_fat/publish/servers/mailSessionTestServer/bootstrap.properties
+++ b/dev/io.openliberty.mail.2.0.internal_fat/publish/servers/mailSessionTestServer/bootstrap.properties
@@ -1,5 +1,5 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=event=enabled:com.ibm.ws.javamail.*=all=enabled:com.ibm.ws.jndi.*=all:com.ibm.ws.webcontainer.osgi.*=all=enabled:Injection=all=enabled
+com.ibm.ws.logging.trace.specification=com.ibm.ws.javamail.*=all=enabled
 
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug


### PR DESCRIPTION
This PR is to limit the amount of trace an assortment of servers use in our FAT projects by removing or cleaning up entries in the `bootstrap.properties` files. 