### PR TITLE
Clarify FATServlet failure messages

### DIFF
--- a/dev/com.ibm.ws.componenttest.2.0/bnd.bnd
+++ b/dev/com.ibm.ws.componenttest.2.0/bnd.bnd
@@ -73,5 +73,6 @@ test.project: true
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
     com.ibm.ws.kernel.feature.core;version=latest,\
     com.ibm.ws.kernel.service;version=latest,\
-    org.glassfish:javax.json;version=1.1.4
+    com.ibm.websphere.javaee.jsonp.1.1;version=latest,\
+    com.ibm.ws.org.glassfish.json.1.1
     

--- a/dev/com.ibm.ws.componenttest.2.0/bnd.bnd
+++ b/dev/com.ibm.ws.componenttest.2.0/bnd.bnd
@@ -28,7 +28,9 @@ Export-Package: \
   org.hamcrest.*;version=1.0.16
   
 Private-Package: \
-  componenttest.serverinfo.impl
+  componenttest.serverinfo.impl,\
+  javax.json.*,\
+  org.glassfish.json.*
 
 # componenttest.app depends on jakarta.servlet, but we don't want to include it in
 # the componenttest-2.0 feature since we want tests to fail if a product feature
@@ -70,5 +72,6 @@ test.project: true
     com.ibm.websphere.org.osgi.service.component;version=latest,\
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
     com.ibm.ws.kernel.feature.core;version=latest,\
-    com.ibm.ws.kernel.service;version=latest
+    com.ibm.ws.kernel.service;version=latest,\
+    org.glassfish:javax.json;version=1.1.4
     

--- a/dev/com.ibm.ws.componenttest.2.0/src/componenttest/app/AssertionErrorSerializer.java
+++ b/dev/com.ibm.ws.componenttest.2.0/src/componenttest/app/AssertionErrorSerializer.java
@@ -1,0 +1,216 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package componenttest.app;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonReader;
+import javax.json.JsonWriter;
+
+/**
+ * Serializes and Deserializes an AssertionError to JSON
+ */
+public class AssertionErrorSerializer {
+
+    //eye-catcher tags to denote the start and end of JSON content
+    public static final String START_TAG = "###AssertionError Json Start###";
+    public static final String END_TAG = "###AssertionError Json End###";
+    //JSON property names
+    private static final String CLASS_NAME_KEY = "className";
+    private static final String METHOD_NAME_KEY = "methodName";
+    private static final String EXCEPTION_TYPE_KEY = "exceptionType";
+    private static final String MESSAGE_KEY = "message";
+    private static final String STACK_KEY = "stack";
+    private static final String FILE_NAME_KEY = "fileName";
+    private static final String LINE_NUMBER_KEY = "lineNumber";
+    //The FATServlet.doGet method name
+    private static final String DO_GET = "doGet";
+
+    /**
+     * Simplify an AssertionError that has been thrown from a test in a subclass of FATServlet.
+     * This will change the error message to include the FAT classname and test method name.
+     * It will also shorten the stacktrace to stop at FATServlet.doGet because everything after that
+     * will always be the same and is not of any interest.
+     *
+     * @param fatClass      The FAT class which originally threw the AssertionError
+     * @param fatMethodName The FAT method which originally threw the AssertionError
+     * @param e             The original AssertionError
+     * @return A simplified AssertionError
+     */
+    public static <T extends FATServlet> AssertionError simplify(Class<T> fatClass, String fatMethodName, AssertionError e) {
+        AssertionError assertionError = new AssertionError(fatClass.getSimpleName() + "." + fatMethodName + ": " + e.getMessage());
+        StackTraceElement[] originalStack = e.getStackTrace();
+        ArrayList<StackTraceElement> shortenedStack = new ArrayList<>();
+
+        for (StackTraceElement element : originalStack) {
+            String declaringClass = element.getClassName();
+            String methodName = element.getMethodName();
+            String fileName = element.getFileName();
+            int lineNumber = element.getLineNumber();
+            StackTraceElement newElement = new StackTraceElement(declaringClass, methodName, fileName, lineNumber);
+
+            shortenedStack.add(newElement);
+
+            //the stack beyond doGet is always the same so don't output any more
+            if ((FATServlet.class.getSimpleName() + ".java").equals(fileName) && DO_GET.equals(methodName)) {
+                break;
+            }
+        }
+
+        assertionError.setStackTrace(shortenedStack.toArray(new StackTraceElement[shortenedStack.size()]));
+        return assertionError;
+    }
+
+    /**
+     * Serialize out an AssertionError as a JSON String
+     *
+     * @param e The AssertionError
+     * @return A JSON String
+     */
+    public static String serialize(AssertionError e) {
+        JsonObject json = serializeAssertionError(e);
+        StringWriter writer = new StringWriter();
+        JsonWriter jsonWriter = Json.createWriter(writer);
+        jsonWriter.writeObject(json);
+        jsonWriter.close();
+        return writer.toString();
+    }
+
+    /**
+     * @param json A json string containing the serialized form of an AssertionError
+     * @return An instance of AssertionError
+     */
+    public static AssertionError deserialize(String json) {
+        StringReader reader = new StringReader(json);
+        JsonReader jsonReader = Json.createReader(reader);
+        JsonObject jsonObject = jsonReader.readObject();
+        jsonReader.close();
+
+        AssertionError e = deserializeAssertionError(jsonObject);
+        return e;
+    }
+
+    /**
+     * Serialize out an AssertionError as a JsonObject
+     *
+     * @param e The AssertionError
+     * @return A JsonObject
+     */
+    private static JsonObject serializeAssertionError(AssertionError e) {
+        JsonObjectBuilder builder = Json.createObjectBuilder();
+        builder.add(EXCEPTION_TYPE_KEY, "AssertionError");
+        builder.add(MESSAGE_KEY, e.getMessage());
+
+        StackTraceElement[] stack = e.getStackTrace();
+        JsonArray stackJson = serializeStack(stack);
+        builder.add(STACK_KEY, stackJson);
+
+        return builder.build();
+    }
+
+    /**
+     * Deserialize an AssertionError from a JsonObject
+     *
+     * @param jsonObject The JsonObject which represents the AssertionError
+     * @return An instance of AssertionError
+     * @throws IllegalStateException if the exception type specified was not AssertionError
+     */
+    private static AssertionError deserializeAssertionError(JsonObject jsonObject) {
+
+        String exceptionType = jsonObject.getString(EXCEPTION_TYPE_KEY);
+        if (!"AssertionError".equals(exceptionType)) {
+            throw new IllegalStateException("Unknown exception type: " + exceptionType);
+        }
+
+        String message = jsonObject.getString(MESSAGE_KEY);
+
+        JsonArray stackJson = jsonObject.getJsonArray(STACK_KEY);
+        StackTraceElement[] stack = deserializeStack(stackJson);
+
+        AssertionError assertionError = new AssertionError(message);
+        assertionError.setStackTrace(stack);
+
+        return assertionError;
+    }
+
+    /**
+     * Serialize an exception stacktrace as a JsonArray
+     *
+     * @param stack an array of stack trace elements
+     * @return A JsonArray
+     */
+    private static JsonArray serializeStack(StackTraceElement[] stack) {
+        JsonArrayBuilder stackBuilder = Json.createArrayBuilder();
+
+        for (StackTraceElement element : stack) {
+            JsonObject elementJson = serializeStackTraceElement(element);
+            stackBuilder.add(elementJson);
+        }
+
+        return stackBuilder.build();
+    }
+
+    /**
+     * Deserialize an exception stacktrace from a JsonArray
+     *
+     * @param jsonArray A JsonArray that represents the stacktrace
+     * @return An array of StackTraceElements
+     */
+    private static StackTraceElement[] deserializeStack(JsonArray jsonArray) {
+        int size = jsonArray.size();
+        StackTraceElement[] stack = new StackTraceElement[size];
+        for (int i = 0; i < size; i++) {
+            JsonObject elementJson = jsonArray.getJsonObject(i);
+            StackTraceElement element = deserializeStackTraceElement(elementJson);
+            stack[i] = element;
+        }
+
+        return stack;
+    }
+
+    /**
+     * Serialize a StackTraceElement out as a JsonObject
+     *
+     * @param stackTraceElement A stack trace element
+     * @return A JsonObject
+     */
+    private static JsonObject serializeStackTraceElement(StackTraceElement stackTraceElement) {
+        JsonObjectBuilder builder = Json.createObjectBuilder();
+        builder.add(CLASS_NAME_KEY, stackTraceElement.getClassName());
+        builder.add(METHOD_NAME_KEY, stackTraceElement.getMethodName());
+        builder.add(FILE_NAME_KEY, stackTraceElement.getFileName());
+        builder.add(LINE_NUMBER_KEY, stackTraceElement.getLineNumber());
+        return builder.build();
+    }
+
+    /**
+     * Deserialize a StackTraceElement from a JsonObject
+     *
+     * @param jsonObject A JsonObject that represents a stack trace element
+     * @return A StackTraceElement instance
+     */
+    private static StackTraceElement deserializeStackTraceElement(JsonObject jsonObject) {
+        String declaringClass = jsonObject.getString(CLASS_NAME_KEY);
+        String methodName = jsonObject.getString(METHOD_NAME_KEY);
+        String fileName = jsonObject.getString(FILE_NAME_KEY);
+        int lineNumber = jsonObject.getInt(LINE_NUMBER_KEY);
+        StackTraceElement element = new StackTraceElement(declaringClass, methodName, fileName, lineNumber);
+        return element;
+    }
+
+}

--- a/dev/com.ibm.ws.componenttest.2.0/src/componenttest/app/FATServlet.java
+++ b/dev/com.ibm.ws.componenttest.2.0/src/componenttest/app/FATServlet.java
@@ -82,13 +82,22 @@ public abstract class FATServlet extends HttpServlet {
                     t = t.getCause();
                 }
 
-                System.out.println("ERROR: " + t);
                 StringWriter sw = new StringWriter();
                 t.printStackTrace(new PrintWriter(sw));
                 System.err.print(sw);
-
-                writer.println("ERROR: Caught exception attempting to call test method " + method + " on servlet " + getClass().getName());
-                t.printStackTrace(writer);
+                if (t instanceof AssertionError) {
+                    AssertionError e = (AssertionError) t;
+                    System.out.println("ASSERTION ERROR: " + e);
+                    writer.write(AssertionErrorSerializer.START_TAG);
+                    AssertionError simple = AssertionErrorSerializer.simplify(getClass(), method, e);
+                    String json = AssertionErrorSerializer.serialize(simple);
+                    writer.write(json);
+                    writer.write(AssertionErrorSerializer.END_TAG);
+                } else {
+                    System.out.println("ERROR: " + t);
+                    writer.println("ERROR: Caught exception attempting to call test method " + method + " on servlet " + getClass().getName());
+                    t.printStackTrace(writer);
+                }
             }
         } else {
             System.out.println("ERROR: expected testMethod parameter");

--- a/dev/com.ibm.ws.componenttest.2.0/src/componenttest/app/FATServlet.java
+++ b/dev/com.ibm.ws.componenttest.2.0/src/componenttest/app/FATServlet.java
@@ -85,13 +85,12 @@ public abstract class FATServlet extends HttpServlet {
                 StringWriter sw = new StringWriter();
                 t.printStackTrace(new PrintWriter(sw));
                 System.err.print(sw);
-                if (t instanceof AssertionError) {
+                if (t instanceof AssertionError && t.getCause() == null) {
                     AssertionError e = (AssertionError) t;
                     System.out.println("ASSERTION ERROR: " + e);
                     writer.write(AssertionErrorSerializer.START_TAG);
                     AssertionError simple = AssertionErrorSerializer.simplify(getClass(), method, e);
-                    String json = AssertionErrorSerializer.serialize(simple);
-                    writer.write(json);
+                    AssertionErrorSerializer.serialize(simple, writer);
                     writer.write(AssertionErrorSerializer.END_TAG);
                 } else {
                     System.out.println("ERROR: " + t);

--- a/dev/com.ibm.ws.componenttest/bnd.bnd
+++ b/dev/com.ibm.ws.componenttest/bnd.bnd
@@ -73,5 +73,6 @@ test.project: true
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
     com.ibm.ws.kernel.feature.core;version=latest,\
     com.ibm.ws.kernel.service;version=latest,\
-    org.glassfish:javax.json;version=1.1.4
+    com.ibm.websphere.javaee.jsonp.1.1;version=latest,\
+    com.ibm.ws.org.glassfish.json.1.1
     

--- a/dev/com.ibm.ws.componenttest/bnd.bnd
+++ b/dev/com.ibm.ws.componenttest/bnd.bnd
@@ -28,7 +28,9 @@ Export-Package: \
   org.hamcrest.*;version=1.0.16
   
 Private-Package: \
-  componenttest.serverinfo.impl
+  componenttest.serverinfo.impl,\
+  javax.json.*,\
+  org.glassfish.json.*
 
 # componenttest.app depends on javax.servlet, but we don't want to include it in
 # the componenttest-1.0 feature since we want tests to fail if a product feature
@@ -70,5 +72,6 @@ test.project: true
     com.ibm.websphere.org.osgi.service.component;version=latest,\
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
     com.ibm.ws.kernel.feature.core;version=latest,\
-    com.ibm.ws.kernel.service;version=latest
+    com.ibm.ws.kernel.service;version=latest,\
+    org.glassfish:javax.json;version=1.1.4
     

--- a/dev/com.ibm.ws.componenttest/src/componenttest/app/AssertionErrorSerializer.java
+++ b/dev/com.ibm.ws.componenttest/src/componenttest/app/AssertionErrorSerializer.java
@@ -1,0 +1,216 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package componenttest.app;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonReader;
+import javax.json.JsonWriter;
+
+/**
+ * Serializes and Deserializes an AssertionError to JSON
+ */
+public class AssertionErrorSerializer {
+
+    //eye-catcher tags to denote the start and end of JSON content
+    public static final String START_TAG = "###AssertionError Json Start###";
+    public static final String END_TAG = "###AssertionError Json End###";
+    //JSON property names
+    private static final String CLASS_NAME_KEY = "className";
+    private static final String METHOD_NAME_KEY = "methodName";
+    private static final String EXCEPTION_TYPE_KEY = "exceptionType";
+    private static final String MESSAGE_KEY = "message";
+    private static final String STACK_KEY = "stack";
+    private static final String FILE_NAME_KEY = "fileName";
+    private static final String LINE_NUMBER_KEY = "lineNumber";
+    //The FATServlet.doGet method name
+    private static final String DO_GET = "doGet";
+
+    /**
+     * Simplify an AssertionError that has been thrown from a test in a subclass of FATServlet.
+     * This will change the error message to include the FAT classname and test method name.
+     * It will also shorten the stacktrace to stop at FATServlet.doGet because everything after that
+     * will always be the same and is not of any interest.
+     *
+     * @param fatClass      The FAT class which originally threw the AssertionError
+     * @param fatMethodName The FAT method which originally threw the AssertionError
+     * @param e             The original AssertionError
+     * @return A simplified AssertionError
+     */
+    public static <T extends FATServlet> AssertionError simplify(Class<T> fatClass, String fatMethodName, AssertionError e) {
+        AssertionError assertionError = new AssertionError(fatClass.getSimpleName() + "." + fatMethodName + ": " + e.getMessage());
+        StackTraceElement[] originalStack = e.getStackTrace();
+        ArrayList<StackTraceElement> shortenedStack = new ArrayList<>();
+
+        for (StackTraceElement element : originalStack) {
+            String declaringClass = element.getClassName();
+            String methodName = element.getMethodName();
+            String fileName = element.getFileName();
+            int lineNumber = element.getLineNumber();
+            StackTraceElement newElement = new StackTraceElement(declaringClass, methodName, fileName, lineNumber);
+
+            shortenedStack.add(newElement);
+
+            //the stack beyond doGet is always the same so don't output any more
+            if ((FATServlet.class.getSimpleName() + ".java").equals(fileName) && DO_GET.equals(methodName)) {
+                break;
+            }
+        }
+
+        assertionError.setStackTrace(shortenedStack.toArray(new StackTraceElement[shortenedStack.size()]));
+        return assertionError;
+    }
+
+    /**
+     * Serialize out an AssertionError as a JSON String
+     *
+     * @param e The AssertionError
+     * @return A JSON String
+     */
+    public static String serialize(AssertionError e) {
+        JsonObject json = serializeAssertionError(e);
+        StringWriter writer = new StringWriter();
+        JsonWriter jsonWriter = Json.createWriter(writer);
+        jsonWriter.writeObject(json);
+        jsonWriter.close();
+        return writer.toString();
+    }
+
+    /**
+     * @param json A json string containing the serialized form of an AssertionError
+     * @return An instance of AssertionError
+     */
+    public static AssertionError deserialize(String json) {
+        StringReader reader = new StringReader(json);
+        JsonReader jsonReader = Json.createReader(reader);
+        JsonObject jsonObject = jsonReader.readObject();
+        jsonReader.close();
+
+        AssertionError e = deserializeAssertionError(jsonObject);
+        return e;
+    }
+
+    /**
+     * Serialize out an AssertionError as a JsonObject
+     *
+     * @param e The AssertionError
+     * @return A JsonObject
+     */
+    private static JsonObject serializeAssertionError(AssertionError e) {
+        JsonObjectBuilder builder = Json.createObjectBuilder();
+        builder.add(EXCEPTION_TYPE_KEY, "AssertionError");
+        builder.add(MESSAGE_KEY, e.getMessage());
+
+        StackTraceElement[] stack = e.getStackTrace();
+        JsonArray stackJson = serializeStack(stack);
+        builder.add(STACK_KEY, stackJson);
+
+        return builder.build();
+    }
+
+    /**
+     * Deserialize an AssertionError from a JsonObject
+     *
+     * @param jsonObject The JsonObject which represents the AssertionError
+     * @return An instance of AssertionError
+     * @throws IllegalStateException if the exception type specified was not AssertionError
+     */
+    private static AssertionError deserializeAssertionError(JsonObject jsonObject) {
+
+        String exceptionType = jsonObject.getString(EXCEPTION_TYPE_KEY);
+        if (!"AssertionError".equals(exceptionType)) {
+            throw new IllegalStateException("Unknown exception type: " + exceptionType);
+        }
+
+        String message = jsonObject.getString(MESSAGE_KEY);
+
+        JsonArray stackJson = jsonObject.getJsonArray(STACK_KEY);
+        StackTraceElement[] stack = deserializeStack(stackJson);
+
+        AssertionError assertionError = new AssertionError(message);
+        assertionError.setStackTrace(stack);
+
+        return assertionError;
+    }
+
+    /**
+     * Serialize an exception stacktrace as a JsonArray
+     *
+     * @param stack an array of stack trace elements
+     * @return A JsonArray
+     */
+    private static JsonArray serializeStack(StackTraceElement[] stack) {
+        JsonArrayBuilder stackBuilder = Json.createArrayBuilder();
+
+        for (StackTraceElement element : stack) {
+            JsonObject elementJson = serializeStackTraceElement(element);
+            stackBuilder.add(elementJson);
+        }
+
+        return stackBuilder.build();
+    }
+
+    /**
+     * Deserialize an exception stacktrace from a JsonArray
+     *
+     * @param jsonArray A JsonArray that represents the stacktrace
+     * @return An array of StackTraceElements
+     */
+    private static StackTraceElement[] deserializeStack(JsonArray jsonArray) {
+        int size = jsonArray.size();
+        StackTraceElement[] stack = new StackTraceElement[size];
+        for (int i = 0; i < size; i++) {
+            JsonObject elementJson = jsonArray.getJsonObject(i);
+            StackTraceElement element = deserializeStackTraceElement(elementJson);
+            stack[i] = element;
+        }
+
+        return stack;
+    }
+
+    /**
+     * Serialize a StackTraceElement out as a JsonObject
+     *
+     * @param stackTraceElement A stack trace element
+     * @return A JsonObject
+     */
+    private static JsonObject serializeStackTraceElement(StackTraceElement stackTraceElement) {
+        JsonObjectBuilder builder = Json.createObjectBuilder();
+        builder.add(CLASS_NAME_KEY, stackTraceElement.getClassName());
+        builder.add(METHOD_NAME_KEY, stackTraceElement.getMethodName());
+        builder.add(FILE_NAME_KEY, stackTraceElement.getFileName());
+        builder.add(LINE_NUMBER_KEY, stackTraceElement.getLineNumber());
+        return builder.build();
+    }
+
+    /**
+     * Deserialize a StackTraceElement from a JsonObject
+     *
+     * @param jsonObject A JsonObject that represents a stack trace element
+     * @return A StackTraceElement instance
+     */
+    private static StackTraceElement deserializeStackTraceElement(JsonObject jsonObject) {
+        String declaringClass = jsonObject.getString(CLASS_NAME_KEY);
+        String methodName = jsonObject.getString(METHOD_NAME_KEY);
+        String fileName = jsonObject.getString(FILE_NAME_KEY);
+        int lineNumber = jsonObject.getInt(LINE_NUMBER_KEY);
+        StackTraceElement element = new StackTraceElement(declaringClass, methodName, fileName, lineNumber);
+        return element;
+    }
+
+}

--- a/dev/com.ibm.ws.componenttest/src/componenttest/app/FATServlet.java
+++ b/dev/com.ibm.ws.componenttest/src/componenttest/app/FATServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 IBM Corporation and others.
+ * Copyright (c) 2013, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -82,13 +82,22 @@ public abstract class FATServlet extends HttpServlet {
                     t = t.getCause();
                 }
 
-                System.out.println("ERROR: " + t);
                 StringWriter sw = new StringWriter();
                 t.printStackTrace(new PrintWriter(sw));
                 System.err.print(sw);
-
-                writer.println("ERROR: Caught exception attempting to call test method " + method + " on servlet " + getClass().getName());
-                t.printStackTrace(writer);
+                if (t instanceof AssertionError) {
+                    AssertionError e = (AssertionError) t;
+                    System.out.println("ASSERTION ERROR: " + e);
+                    writer.write(AssertionErrorSerializer.START_TAG);
+                    AssertionError simple = AssertionErrorSerializer.simplify(getClass(), method, e);
+                    String json = AssertionErrorSerializer.serialize(simple);
+                    writer.write(json);
+                    writer.write(AssertionErrorSerializer.END_TAG);
+                } else {
+                    System.out.println("ERROR: " + t);
+                    writer.println("ERROR: Caught exception attempting to call test method " + method + " on servlet " + getClass().getName());
+                    t.printStackTrace(writer);
+                }
             }
         } else {
             System.out.println("ERROR: expected testMethod parameter");
@@ -104,12 +113,14 @@ public abstract class FATServlet extends HttpServlet {
     /**
      * Override to mimic JUnit's {@code @Before} annotation.
      */
-    protected void before() throws Exception {}
+    protected void before() throws Exception {
+    }
 
     /**
      * Override to mimic JUnit's {@code @After} annotation.
      */
-    protected void after() throws Exception {}
+    protected void after() throws Exception {
+    }
 
     /**
      * Implement this method for custom test invocation, such as specific test method signatures

--- a/dev/com.ibm.ws.componenttest/src/componenttest/app/FATServlet.java
+++ b/dev/com.ibm.ws.componenttest/src/componenttest/app/FATServlet.java
@@ -85,13 +85,12 @@ public abstract class FATServlet extends HttpServlet {
                 StringWriter sw = new StringWriter();
                 t.printStackTrace(new PrintWriter(sw));
                 System.err.print(sw);
-                if (t instanceof AssertionError) {
+                if (t instanceof AssertionError && t.getCause() == null) {
                     AssertionError e = (AssertionError) t;
                     System.out.println("ASSERTION ERROR: " + e);
                     writer.write(AssertionErrorSerializer.START_TAG);
                     AssertionError simple = AssertionErrorSerializer.simplify(getClass(), method, e);
-                    String json = AssertionErrorSerializer.serialize(simple);
-                    writer.write(json);
+                    AssertionErrorSerializer.serialize(simple, writer);
                     writer.write(AssertionErrorSerializer.END_TAG);
                 } else {
                     System.out.println("ERROR: " + t);

--- a/dev/fattest.simplicity/bnd.bnd
+++ b/dev/fattest.simplicity/bnd.bnd
@@ -61,7 +61,7 @@ test.project: true
 	../build.sharedResources/lib/junit/old/junit.jar;version=file,\
 	com.ibm.ws.junit.extensions;version=latest,\
 	commons-httpclient:commons-httpclient;version=3.1,\
-	com.ibm.websphere.javaee.jsonp.1.0;version=latest,\
+	com.ibm.websphere.javaee.jsonp.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
 	io.openliberty.jakarta.servlet.5.0;version=latest,\
 	org.eclipse.transformer:org.eclipse.transformer.cli;version=0.3.0.20211005,\

--- a/dev/fattest.simplicity/src/componenttest/annotation/processor/TestServletProcessor.java
+++ b/dev/fattest.simplicity/src/componenttest/annotation/processor/TestServletProcessor.java
@@ -64,7 +64,7 @@ public class TestServletProcessor {
                 int initialSize = testMethods.size();
                 for (Method method : getTestServletMethods(anno)) {
                     if (method.isAnnotationPresent(Test.class)) {
-                        testMethods.add(new SyntheticServletTest(serverField, getQueryPath(anno), method));
+                        testMethods.add(new SyntheticServletTest(anno.servlet(), serverField, getQueryPath(anno), method));
                     }
                 }
                 Log.info(c, m, "Added " + (testMethods.size() - initialSize) + " test methods from " + anno.servlet());

--- a/dev/fattest.simplicity/src/componenttest/custom/junit/runner/SyntheticServletTest.java
+++ b/dev/fattest.simplicity/src/componenttest/custom/junit/runner/SyntheticServletTest.java
@@ -25,12 +25,14 @@ public class SyntheticServletTest extends FrameworkMethod {
     private final Field server;
     private final String queryPath;
     private final String testName;
+    private final String syntheticName;
 
-    public SyntheticServletTest(Field server, String queryPath, Method method) {
+    public SyntheticServletTest(Class<?> servletClass, Field server, String queryPath, Method method) {
         super(method);
         this.server = server;
         this.queryPath = queryPath;
         this.testName = method.getName();
+        this.syntheticName = servletClass.getSimpleName() + "." + this.testName;
     }
 
     @Override
@@ -39,5 +41,10 @@ public class SyntheticServletTest extends FrameworkMethod {
         LibertyServer s = (LibertyServer) server.get(null);
         FATServletClient.runTest(s, queryPath, testName);
         return null;
+    }
+
+    @Override
+    public String getName() {
+        return this.syntheticName;
     }
 }


### PR DESCRIPTION
- Don't print out excessive stack traces for AssertionErrors (these are still in the logs if needed)
- Include the name of the servlet in the test name ... this helps when multiple servlets have the same test method names

eg
```
2021-12-07-14:27:48:649 SPIExtensionServlet.testUnregisteredBean: Intentional FAIL 1

junit.framework.AssertionFailedError: 2021-12-07-14:27:48:649 SPIExtensionServlet.testUnregisteredBean: Intentional FAIL 1
at <unknown class>.fail(Assert.java:93)
at com.ibm.ws.cdi.extension.apps.spi.SPIExtensionServlet.testUnregisteredBean(SPIExtensionServlet.java:52)
at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at componenttest.app.FATServlet.doGet(FATServlet.java:71) 
```