### PR TITLE
Revert "grpc microprofile enablement for EE9 FAT"

### DIFF
--- a/dev/com.ibm.ws.grpc_fat/bnd.bnd
+++ b/dev/com.ibm.ws.grpc_fat/bnd.bnd
@@ -34,14 +34,7 @@ tested.features:\
 	servlet-5.0,\
 	appsecurity-4.0,\
 	expressionlanguage-4.0,\
-	cdi-3.0,\
-    mpOpenAPI-3.0,\
-    mpRestClient-3.0,\
-    mpMetrics-4.0,\
-    mpJwt-2.0,\
-    mpConfig-3.0,\
-    pages-3.0,\
-    jsonb-2.0
+	cdi-3.0
 
 -buildpath: \
     com.ibm.websphere.javaee.servlet.4.0;version=latest,\

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/FATSuite.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/FATSuite.java
@@ -10,9 +10,6 @@
  *******************************************************************************/
 package com.ibm.ws.fat.grpc;
 
-import java.util.Arrays;
-import java.util.HashSet;
-
 import org.junit.ClassRule;
 
 import org.junit.runner.RunWith;
@@ -49,16 +46,8 @@ public class FATSuite {
 
     private static final Class<?> c = FATSuite.class;
 
-    static String[] removedFeatures = {"mpOpenAPI-1.1", "mpMetrics-2.3", "mpJwt-1.1", "mpConfig-1.3", "mpRestClient-1.3", "appSecurity-2.0"};
-
-    static String[] addedFeatures = {"mpOpenAPI-3.0", "mpMetrics-4.0", "mpJwt-2.0", "mpConfig-3.0", "mpRestClient-3.0", "appSecurity-4.0"};
-
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly())
-                             .andWith(FeatureReplacementAction.EE9_FEATURES()
-                             .removeFeatures(new HashSet<>(Arrays.asList(removedFeatures)))
-                             .addFeatures(new HashSet<>(Arrays.asList(addedFeatures)))
-                             .alwaysAddFeature("servlet-5.0")
-                             .alwaysAddFeature("jsonb-2.0"));
+    public static RepeatTests r = RepeatTests.withoutModification()
+                    .andWith(FeatureReplacementAction.EE9_FEATURES().removeFeature("servlet-4.0").alwaysAddFeature("servlet-5.0"));
 
 }

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/GrpcMetricsTest.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/GrpcMetricsTest.java
@@ -41,6 +41,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
+@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 public class GrpcMetricsTest extends FATServletClient {
 

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldCDITests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldCDITests.java
@@ -33,6 +33,7 @@ import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
+@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 public class HelloWorldCDITests extends HelloWorldBasicTest {
 

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldTest.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldTest.java
@@ -30,6 +30,7 @@ import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
+@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 public class HelloWorldTest extends HelloWorldBasicTest {
 

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreConsumerServletClientTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreConsumerServletClientTests.java
@@ -29,6 +29,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -39,6 +40,7 @@ import componenttest.topology.utils.FATServletClient;
  * @author anupag
  *
  */
+@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class StoreConsumerServletClientTests extends FATServletClient {

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreProducerServletClientTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreProducerServletClientTests.java
@@ -26,6 +26,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -36,6 +37,7 @@ import componenttest.topology.utils.FATServletClient;
  * @author anupag
  *
  */
+@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class StoreProducerServletClientTests extends FATServletClient {

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesRESTClientTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesRESTClientTests.java
@@ -27,6 +27,7 @@ import com.ibm.testapp.g3store.restProducer.client.ProducerEndpointFATServlet;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -36,6 +37,7 @@ import componenttest.topology.utils.FATServletClient;
  * @author anupag
  *
  */
+@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 public class StoreServicesRESTClientTests extends FATServletClient {
 

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesSecurityTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesSecurityTests.java
@@ -26,6 +26,7 @@ import com.ibm.testapp.g3store.restConsumer.client.ConsumerEndpointJWTCookieFATS
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -34,6 +35,8 @@ import componenttest.topology.utils.FATServletClient;
 /**
  *
  */
+
+@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 public class StoreServicesSecurityTests extends FATServletClient {
 

--- a/dev/com.ibm.ws.grpc_fat/test-applications/StoreConsumerApp.war/src/com/ibm/testapp/g3store/restConsumer/client/ConsumerEndpointFATServlet.java
+++ b/dev/com.ibm.ws.grpc_fat/test-applications/StoreConsumerApp.war/src/com/ibm/testapp/g3store/restConsumer/client/ConsumerEndpointFATServlet.java
@@ -43,7 +43,6 @@ import com.ibm.testapp.g3store.restProducer.model.Price;
 import com.ibm.testapp.g3store.restProducer.model.Price.PurchaseType;
 import com.ibm.testapp.g3store.utilsConsumer.ConsumerUtils;
 
-import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 /**
@@ -123,7 +122,6 @@ public class ConsumerEndpointFATServlet extends FATServlet {
      * @throws Exception
      */
     @Test
-    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     public void testGetAppInfo_Bad_BasicAuth(HttpServletRequest req, HttpServletResponse resp) throws Exception {
         this.getAppInfo_BadBasicAuth(req, resp);
     }

--- a/dev/com.ibm.ws.grpc_fat/test-applications/StoreConsumerApp.war/src/com/ibm/testapp/g3store/restConsumer/client/ConsumerEndpointJWTCookieFATServlet.java
+++ b/dev/com.ibm.ws.grpc_fat/test-applications/StoreConsumerApp.war/src/com/ibm/testapp/g3store/restConsumer/client/ConsumerEndpointJWTCookieFATServlet.java
@@ -42,7 +42,6 @@ import com.ibm.testapp.g3store.restProducer.model.Price;
 import com.ibm.testapp.g3store.restProducer.model.Price.PurchaseType;
 import com.ibm.testapp.g3store.utilsConsumer.ConsumerUtils;
 
-import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 /**
@@ -126,7 +125,6 @@ public class ConsumerEndpointJWTCookieFATServlet extends FATServlet {
      * @throws Exception
      */
     @Test
-    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     public void testGetApp_BadRole_JWTCookie_GrpcClient(HttpServletRequest req, HttpServletResponse resp) throws Exception {
         this.getAppName_BadRole_CookieAuth_GrpcClient(req, resp);
     }

--- a/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/MappingTable.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/MappingTable.java
@@ -40,9 +40,6 @@ public class MappingTable {
 	public static final String SESSION_TAG_NAME = "appname";
 	public static final String JAXWS_SERVER_TAG_NAME = "endpoint";
 	public static final String JAXWS_CLIENT_TAG_NAME = "endpoint";
-
-	public static final String GRPC_SERVER_TAG_NAME = "grpc";
-	public static final String GRPC_CLIENT_TAG_NAME = "grpc";
 	
 	public static final String COUNTER = MetricType.COUNTER.toString().toUpperCase();
 	public static final String GAUGE = MetricType.GAUGE.toString().toUpperCase();
@@ -129,25 +126,6 @@ public class MappingTable {
         	{ "vendor", "jaxws.client.responseTime.total", "Total Response Time", "jaxws.responseTime.total.description", GAUGE, MetricUnits.MILLISECONDS, "TotalHandlingTime", null, JAXWS_CLIENT_TAG_NAME }
 		};
 		mappingTable.put("WebSphere:feature=jaxws,*,type=Performance.Counter.Client", jaxwsClientTable);
-
-		String[][] grpcServerTable = new String[][]{
-	    	{ "vendor", "grpc.server.rpcStarted.total", "Total Server RPCs Started Count", "grpc.server.rpcStarted.total.description", COUNTER, MetricUnits.NONE, "RpcStartedCount", null, GRPC_SERVER_TAG_NAME },
-	    	{ "vendor", "grpc.server.rpcCompleted.total", "Total Server RPCs Completed Count", "grpc.server.rpcCompleted	.total.description", COUNTER, MetricUnits.NONE, "RpcCompletedCount", null, GRPC_SERVER_TAG_NAME },
-        	{ "vendor", "grpc.server.sentMessages.total", "Total Sent Stream Messages", "grpc.server.sentMessages.total.description", COUNTER, MetricUnits.NONE, "SentMessagesCount", null, GRPC_SERVER_TAG_NAME },
-        	{ "vendor", "grpc.server.receivedMessages.total", "Total Received Stream Messages", "grpc.server.receivedMessages.total.description", COUNTER, MetricUnits.NONE, "ReceivedMessagesCount", null, GRPC_SERVER_TAG_NAME },
-        	{ "vendor", "grpc.server.responseTime.total", "Total Response Time", "grpc.server.responseTime.total.description", GAUGE, MetricUnits.MILLISECONDS, "ResponseTimeDetails", "total", GRPC_SERVER_TAG_NAME }
-		};
-		mappingTable.put("WebSphere:type=GrpcServerStats,name=*", grpcServerTable);
-
-		String[][] grpcClientTable = new String[][]{
-	    	{ "vendor", "grpc.client.rpcStarted.total", "Total Client RPCs Started Count", "grpc.client.rpcStarted.total.description", COUNTER, MetricUnits.NONE, "RpcStartedCount", null, GRPC_CLIENT_TAG_NAME },
-	    	{ "vendor", "grpc.client.rpcCompleted.total", "Total Client RPCs Completed Count", "grpc.client.rpcCompleted.total.description", COUNTER, MetricUnits.NONE, "RpcCompletedCount", null, GRPC_CLIENT_TAG_NAME },
-        	{ "vendor", "grpc.client.sentMessages.total", "Total Sent Stream Messages", "grpc.client.sentMessages.total.description", COUNTER, MetricUnits.NONE, "SentMessagesCount", null, GRPC_CLIENT_TAG_NAME },
-        	{ "vendor", "grpc.client.receivedMessages.total", "Total Received Stream Messages", "grpc.client.receivedMessages.total.description", COUNTER, MetricUnits.NONE, "ReceivedMessagesCount", null, GRPC_CLIENT_TAG_NAME },
-        	{ "vendor", "grpc.client.responseTime.total", "Total Response Time", "grpc.client.responseTime.total.description", GAUGE, MetricUnits.MILLISECONDS, "ResponseTimeDetails", "total", GRPC_CLIENT_TAG_NAME }
-		};
-		mappingTable.put("WebSphere:type=GrpcClientStats,name=*", grpcClientTable);
-		
 	}
 	
 	


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#19146

Hard break in OL;
```
[11/25/21, 10:52:12:221 UTC] 0000001a gService-187-io.openliberty.grpc.1.0.internal.client.monitor E CWWKE0702E: Could not resolve module: io.openliberty.grpc.1.0.internal.client.monitor [187]
  Unresolved requirement: Import-Package: io.grpc; version="[1.38.0,2.0.0)"

[11/25/21, 10:52:12:226 UTC] 0000001a LogService-191-io.openliberty.grpc.1.0.internal.monitor      E CWWKE0702E: Could not resolve module: io.openliberty.grpc.1.0.internal.monitor [191]
  Unresolved requirement: Import-Package: io.grpc; version="[1.38.0,2.0.0)"
```

We think that these new tests on EE9 are exposing an existing bug.