### PR TITLE
Remove test folder from eclipse classpath

### DIFF
--- a/dev/io.openliberty.accesslists.internal/.classpath
+++ b/dev/io.openliberty.accesslists.internal/.classpath
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" output="bin" path="src"/>
-	<classpathentry kind="src" output="bin_test" path="test"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>


### PR DESCRIPTION
Project does not build properly in eclipse because the test folder can not be found.
No point running a PB because that doesn't use the eclipse classpath.