### PR TITLE
Split jwtsso fat - with FATSuite

### DIFF
--- a/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/FATSuite.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.jwtsso.fat;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.ws.security.fat.common.AlwaysRunAndPassTest;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+                AlwaysRunAndPassTest.class
+})
+public class FATSuite {
+
+}


### PR DESCRIPTION
Split the jwtsso fat.
This fat runs the same tests multiple times - each run specifies a different setup of mpJwt.
It runs without mpJwt (and that runs with and without EE9)
It runs with mpJwt 1.1, mpJwt 1.2 and mpJwt 2.0. This just got too large and time consuming.
com.ibm.ws.security.jwtsso_fat
has now become:
com.ibm.ws.security.jwtsso_fat.commonTest - contains the tests (run the always AlwaysRunAndPassTest class - to prevent automated build failures)
com.ibm.ws.security.jwtsso_fat.mpJwt-1.1 - runs with mpJwt 1.1
com.ibm.ws.security.jwtsso_fat.mpJwt-1.2 - runs with mpJwt 1.2
com.ibm.ws.security.jwtsso_fat.mpJwt-2.0 - runs with mpJwt 2.0 (which include EE9)
com.ibm.ws.security.jwtsso_fat.noMpJwt - has no mpJwt in the config and runs with/without EE9