### PR TITLE
[19501] - add the multi release jar flag to microprofile rest client

### DIFF
--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/bnd.bnd
@@ -13,6 +13,8 @@ bVersion=1.0
 
 Bundle-SymbolicName: io.openliberty.org.jboss.resteasy.mprestclient
 
+Multi-Release: true
+
 # Only publish the Jakarta one
 publish.wlp.jar.include: io.openliberty.org.jboss.resteasy.mprestclient.jakarta.jar
 


### PR DESCRIPTION
added the `Multi-Release: true` flag to `io.openliberty.org.jboss.resteasy.mprestclient` for Java 17 support.

