### PR TITLE
Clean up and add trace for acmeCA FATs

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeDisableTriggerSimpleTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeDisableTriggerSimpleTest.java
@@ -244,7 +244,7 @@ public class AcmeDisableTriggerSimpleTest {
 			 * Start the server. The domain2.com domain will fail to validate.
 			 * 
 			 **********************************************************************/
-			Log.info(AcmeSimpleTest.class, testName.getMethodName(), "Starting server.");
+			Log.info(AcmeDisableTriggerSimpleTest.class, testName.getMethodName(), "Starting server.");
 			server.startServer();
 			server.waitForStringInLog("CWPKI2001E.*authorization challenge failed for the domain2.com domain");
 			AcmeFatUtils.waitForSslEndpoint(server);

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeRevocationTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeRevocationTest.java
@@ -69,7 +69,7 @@ import componenttest.topology.impl.LibertyServer;
 @Mode(TestMode.FULL)
 @SkipForRepeat(SkipForRepeat.EE9_FEATURES) // No value added
 public class AcmeRevocationTest {
-
+	
 	@Server("com.ibm.ws.security.acme.fat.revocation")
 	public static LibertyServer server;
 
@@ -143,7 +143,7 @@ public class AcmeRevocationTest {
 			/*
 			 * Startup the server.
 			 */
-			Log.info(AcmeSimpleTest.class, methodName, "Starting server.");
+			Log.info(AcmeRevocationTest.class, methodName, "Starting server.");
 			server.startServer();
 			AcmeFatUtils.waitForSslToCreateKeystore(server);
 			AcmeFatUtils.waitForSslEndpoint(server);
@@ -167,7 +167,7 @@ public class AcmeRevocationTest {
 			// account for possible time from Boulder: welcome-to-the-purge, purge expected in: 153s
 			long sleepFor = (153 * 1000) - (System.currentTimeMillis() - markStop);
 			if (sleepFor > 0) {
-				Log.info(AcmeSimpleTest.class, methodName, "Before restarting server, sleep for " + sleepFor);
+				Log.info(AcmeRevocationTest.class, methodName, "Before restarting server, sleep for " + sleepFor);
 				Thread.sleep(sleepFor);
 			}
 			server.startServer();
@@ -211,7 +211,7 @@ public class AcmeRevocationTest {
 			/*
 			 * Startup the server.
 			 */
-			Log.info(AcmeSimpleTest.class, methodName, "Starting server.");
+			Log.info(AcmeRevocationTest.class, methodName, "Starting server.");
 			server.startServer();
 			AcmeFatUtils.waitForSslToCreateKeystore(server);
 			AcmeFatUtils.waitForSslEndpoint(server);
@@ -271,7 +271,7 @@ public class AcmeRevocationTest {
 			/*
 			 * Startup the server.
 			 */
-			Log.info(AcmeSimpleTest.class, methodName, "Starting server.");
+			Log.info(AcmeRevocationTest.class, methodName, "Starting server.");
 			server.startServer();
 			AcmeFatUtils.waitForSslToCreateKeystore(server);
 			AcmeFatUtils.waitForSslEndpoint(server);
@@ -618,7 +618,7 @@ public class AcmeRevocationTest {
 			configureAcmeRevocation(configuration, true);
 			AcmeFatUtils.configureAcmeCA(server, pebble, configuration, false, DOMAIN);
 
-			Log.info(AcmeSimpleTest.class, methodName, "Starting server with Pebble");
+			Log.info(AcmeRevocationTest.class, methodName, "Starting server with Pebble");
 			server.startServer();
 			AcmeFatUtils.waitForSslToCreateKeystore(server);
 			AcmeFatUtils.waitForSslEndpoint(server);
@@ -627,18 +627,18 @@ public class AcmeRevocationTest {
 
 			Certificate[] certificates1 = AcmeFatUtils.assertAndGetServerCertificate(server, pebble);
 
-			Log.info(AcmeSimpleTest.class, methodName, "Swap to Boulder");
+			Log.info(AcmeRevocationTest.class, methodName, "Swap to Boulder");
 			AcmeFatUtils.configureAcmeCA(server, boulder, configuration, false, DOMAIN);
 			AcmeFatUtils.waitForAcmeToCreateCertificate(server);
 			certificates1 = AcmeFatUtils.waitForNewCert(server, boulder, certificates1);
 			server.setMarkToEndOfLog(server.getDefaultLogFile());
 
-			Log.info(AcmeSimpleTest.class, methodName, "Swap back to Pebble");
+			Log.info(AcmeRevocationTest.class, methodName, "Swap back to Pebble");
 			AcmeFatUtils.configureAcmeCA(server, pebble, configuration, false, DOMAIN);
 			AcmeFatUtils.waitForAcmeToCreateCertificate(server);
 			certificates1 = AcmeFatUtils.waitForNewCert(server, pebble, certificates1);
 
-			Log.info(AcmeSimpleTest.class, methodName, "Swap back to Boulder");
+			Log.info(AcmeRevocationTest.class, methodName, "Swap back to Boulder");
 			AcmeFatUtils.configureAcmeCA(server, boulder, configuration, false, DOMAIN);
 			AcmeFatUtils.waitForAcmeToCreateCertificate(server);
 			certificates1 = AcmeFatUtils.waitForNewCert(server, boulder, certificates1);

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
@@ -773,9 +773,10 @@ public class AcmeFatUtils {
 	}
 
 	public static void checkPortOpen(int port, long timeoutMs) {
-
+		Log.info(AcmeFatUtils.class, "checkPortOpen", "Checking if port " + port + " is open, will check for " + timeoutMs +"ms.");
 		boolean open = false;
 		long stoptime = System.currentTimeMillis() + timeoutMs;
+		Exception lastException = null;
 
 		while (!open && (stoptime > System.currentTimeMillis())) {
 			ServerSocket socket = null;
@@ -787,6 +788,7 @@ public class AcmeFatUtils {
 				socket.bind(new InetSocketAddress(port));
 				open = true;
 			} catch (Exception e) {
+				lastException = e;
 				try {
 					Thread.sleep(1000);
 				} catch (InterruptedException ie) {
@@ -806,8 +808,10 @@ public class AcmeFatUtils {
 				}
 			}
 		}
-
-		assertTrue("Expected port " + port + " to be open.", open);
+		if (!open) {
+			Log.error(AcmeFatUtils.class, "checkPortOpen", lastException, "Port was not available in time.");
+		}
+		assertTrue("Expected port " + port + " to be open. Last exception while checking: " + lastException, open);
 	}
 
 	/**


### PR DESCRIPTION
Clean up and add some trace for acmeCA FATs. We hit a possible HTTP port not open issue in a build, but it seems like the test continued fine anyway. Added some more trace for better debug and timestamps if it continues to happen.

RTC 287937