### PR TITLE
Make tests wait for Discovery to complete and tokenEndpoint app to load

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/Constants.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/Constants.java
@@ -180,6 +180,8 @@ public class Constants {
 
     public static final String OPENID_APP = "formlogin";
     public static final String DEFAULT_SERVLET = "SimpleServlet";
+    public static final String TOKENENDPT_APP = "TokenEndpointServlet";
+    public static final String USERINFOENDPT_APP = "UserinfoEndpointServlet";
 
     public static final String LTPA_TOKEN = "LtpaToken2";
     public static final String JWT_SSO_COOKIE_NAME = "JWT";

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryBasicTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryBasicTests.java
@@ -85,7 +85,7 @@ public class OidcClientDiscoveryBasicTests extends GenericOidcClientTests {
         // Start the OIDC OP server
         testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.op", "op_server_orig.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
 
-        DiscoveryUtils.waitForDiscoveryToBeReady(testSettings);
+        DiscoveryUtils.waitForOPDiscoveryToBeReady(testSettings);
 
         //Start the OIDC RP server and setup default values
         testRPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.rpd", "rp_server_orig.xml", Constants.OIDC_RP, apps, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
@@ -112,6 +112,10 @@ public class OidcClientDiscoveryBasicTests extends GenericOidcClientTests {
         test_GOOD_LOGIN_AGAIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_AGAIN_ACTIONS;
         test_FinalAction = Constants.LOGIN_USER;
         testSettings.setFlowType(Constants.RP_FLOW);
+
+        // try to wait for discovery to have populated the RP config
+        // Don't stop if this fails (there is a chance it could be ready by the time the tests actually run
+        DiscoveryUtils.waitForRPDiscoveryToBeReady(testSettings);
 
     }
 

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorTests.java
@@ -90,7 +90,7 @@ public class OidcClientDiscoveryErrorTests extends CommonTest {
         // Start the OIDC OP server
         testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.op", "op_server_orig.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
 
-        DiscoveryUtils.waitForDiscoveryToBeReady(testSettings);
+        DiscoveryUtils.waitForOPDiscoveryToBeReady(testSettings);
 
         //Start the OIDC RP server and setup default values
         testRPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.rpd", "rp_server_orig.xml", Constants.OIDC_RP, apps, Constants.DO_NOT_USE_DERBY,
@@ -122,9 +122,11 @@ public class OidcClientDiscoveryErrorTests extends CommonTest {
         // Force discovery to run to access login page so that the discovery service is active. Then, in the actual tests the reconfig will initiate discovery and cause the
         // error messages to be generated on discovery failures during the reconfig (rather than waiting until the first authorization request in the runtime).
         CommonTestHelpers helpers = new CommonTestHelpers();
-        WebConversation wc = new WebConversation();
-        List<validationData> expectations = vData.addSuccessStatusCodes(null);
-        helpers.rpLoginPage("Setup", wc, testSettings, expectations, Constants.GETMETHOD);
+
+        // try to wait for discovery to have populated the RP config
+        // Don't stop if this fails (there is a chance it could be ready by the time the tests actually run
+        DiscoveryUtils.waitForRPDiscoveryToBeReady(testSettings);
+
     }
 
     /**
@@ -335,7 +337,7 @@ public class OidcClientDiscoveryErrorTests extends CommonTest {
         expectations = vData.addResponseStatusExpectation(expectations, Constants.GET_LOGIN_PAGE, Constants.UNAUTHORIZED_STATUS);
 
         testRPServer.addIgnoredServerException("CWWKS1534E");
-        
+
         WebConversation wc = new WebConversation();
         genericRP(_testName, wc, updatedTestSettings, test_LOGIN_PAGE_ONLY, expectations);
     }
@@ -374,7 +376,7 @@ public class OidcClientDiscoveryErrorTests extends CommonTest {
         expectations = vData.addResponseStatusExpectation(expectations, Constants.GET_LOGIN_PAGE, Constants.UNAUTHORIZED_STATUS);
 
         testRPServer.addIgnoredServerException("CWWKS1534E");
-        
+
         WebConversation wc = new WebConversation();
         genericRP(_testName, wc, updatedTestSettings, test_LOGIN_PAGE_ONLY, expectations);
     }

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryJWTBasicTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryJWTBasicTests.java
@@ -25,7 +25,6 @@ import com.ibm.ws.security.oauth_oidc.fat.commonTest.DiscoveryUtils;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.TestSettings;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.ValidationData.validationData;
 import com.meterware.httpunit.WebConversation;
-import com.meterware.httpunit.WebResponse;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.custom.junit.runner.FATRunner;
@@ -83,7 +82,7 @@ public class OidcClientDiscoveryJWTBasicTests extends CommonTest {
         // Start the OIDC OP server
         testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.op", "op_server_orig.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
 
-        DiscoveryUtils.waitForDiscoveryToBeReady(testSettings);
+        DiscoveryUtils.waitForOPDiscoveryToBeReady(testSettings);
 
         //Start the OIDC RP server and setup default values
         testRPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.rpd", "rp_server_orig.xml", Constants.OIDC_RP, apps, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
@@ -111,9 +110,10 @@ public class OidcClientDiscoveryJWTBasicTests extends CommonTest {
         // Force discovery to run to access login page so that the discovery service is active. Then, in the actual tests the reconfig will initiate discovery and cause the
         // error messages to be generated on discovery failures during the reconfig (rather than waiting until the first authorization request in the runtime).
         CommonTestHelpers helpers = new CommonTestHelpers();
-        WebConversation wc = new WebConversation();
-        List<validationData> expectations = vData.addSuccessStatusCodes(null);
-        WebResponse response = helpers.rpLoginPage("Setup", wc, testSettings, expectations, Constants.GETMETHOD);
+
+        // try to wait for discovery to have populated the RP config
+        // Don't stop if this fails (there is a chance it could be ready by the time the tests actually run
+        DiscoveryUtils.waitForRPDiscoveryToBeReady(testSettings);
 
     }
 

--- a/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/fat/src/com/ibm/ws/security/openidconnect/client/fat/jaxrs/IBM/OidcJaxRSClientAPITests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/fat/src/com/ibm/ws/security/openidconnect/client/fat/jaxrs/IBM/OidcJaxRSClientAPITests.java
@@ -86,14 +86,14 @@ public class OidcJaxRSClientAPITests extends JaxRSClientAPITests {
 
         thisClass = OidcJaxRSClientAPITests.class;
 
-        List<String> apps = new ArrayList<String>() {
+        List<String> rs_apps = new ArrayList<String>() {
             {
                 add(Constants.HELLOWORLD_SERVLET);
             }
         };
-        List<String> rp_apps = new ArrayList<String>() {
+        List<String> op_apps = new ArrayList<String>() {
             {
-                add(Constants.OPENID_APP);
+                add(Constants.TOKENENDPT_APP);
             }
         };
 
@@ -160,12 +160,12 @@ public class OidcJaxRSClientAPITests extends JaxRSClientAPITests {
         setMiscBootstrapParms(validationSettings);
 
         // Start the Generic/App Server
-        genericTestServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.jaxrs.rs", "rs_server_api_orig.xml", Constants.GENERIC_SERVER, apps, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, Constants.X509_CERT);
+        genericTestServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.jaxrs.rs", "rs_server_api_orig.xml", Constants.GENERIC_SERVER, rs_apps, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, Constants.X509_CERT);
         genericTestServer.addIgnoredServerException(MessageConstants.CWWKG0032W_CONFIG_INVALID_VALUE);
         genericTestServer.addIgnoredServerException(MessageConstants.CWWKG0033W_CONFIG_REFERENCE_NOT_FOUND);
 
         // Start the OIDC OP server - tell it to generate JWT access tokens
-        testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.jaxrs.opWithStub", "op_server_encrypt.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, null, null, true, true, tokenType, Constants.X509_CERT);
+        testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.jaxrs.opWithStub", "op_server_encrypt.xml", Constants.OIDC_OP, op_apps, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, null, null, true, true, tokenType, Constants.X509_CERT);
         //Start the OIDC RP server and setup default values
         testRPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.jaxrs.rp", "rp_server_api_orig.xml", Constants.OIDC_RP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, Constants.X509_CERT);
         testRPServer.addIgnoredServerException(MessageConstants.CWWKG0033W_CONFIG_REFERENCE_NOT_FOUND);


### PR DESCRIPTION
We have tests that are failing because they try to access a protected app and the authoriation endpoint has not been discovered by the time we try to use it.  We have a single attempt in the class startup method and I'm adding a retry loop to that.  I've also changed that startup code to not result in a failure if those multiple attempts fail - if there is an issue with discovery, the tests will fail (there is time between the end of setup and the first test - that may give it more time to complete).
We also have a test that is failing because we're not waiting for the TokenEndpointServlet in the test class setup.  When the first test runs, it tries to create and save a token and we can not because the app isn't ready.  When the runtime tries to retrieve the token, it gets a null and the test case fails.  The app is finally up by the end of that test, so all remaining tests succeed.