### PR TITLE
Code is incorrectly expecting Void.class to identify void return type

### DIFF
--- a/dev/io.openliberty.concurrent.cdi/src/io/openliberty/concurrent/cdi/interceptor/AsyncInterceptor.java
+++ b/dev/io.openliberty.concurrent.cdi/src/io/openliberty/concurrent/cdi/interceptor/AsyncInterceptor.java
@@ -57,7 +57,7 @@ public class AsyncInterceptor implements Serializable {
         Class<?> returnType = method.getReturnType();
         if (!returnType.equals(CompletableFuture.class)
             && !returnType.equals(CompletionStage.class)
-            && !returnType.equals(Void.class))
+            && !returnType.equals(Void.TYPE)) // void
             throw new UnsupportedOperationException("@Asynchronous " + returnType.getName() + " " + method.getName()); // TODO NLS?
 
         ManagedExecutorService executor;


### PR DESCRIPTION
Code has a bug where it is expecting Void.class to identify void return type on a method.  The way to refer to void.class in Java is with the Void.TYPE constant, which ought to be used instead.