### PR TITLE
Enable EE9 Repeat Tests for Remaining gRPC FAT Tests (MicroProfile)

### DIFF
--- a/dev/com.ibm.ws.grpc_fat/bnd.bnd
+++ b/dev/com.ibm.ws.grpc_fat/bnd.bnd
@@ -29,12 +29,19 @@ fat.minimum.java.level: 1.8
 
 # Define additional tested features that are NOT present in any XML files in this bucket.
 tested.features:\
-    servlet-4.0,\
+	servlet-4.0,\
 	jaxrs-2.1,\
 	servlet-5.0,\
 	appsecurity-4.0,\
 	expressionlanguage-4.0,\
-	cdi-3.0
+	cdi-3.0,\
+	mpOpenAPI-3.0,\
+	mpRestClient-3.0,\
+	mpMetrics-4.0,\
+	mpJwt-2.0,\
+	mpConfig-3.0,\
+	pages-3.0,\
+	jsonb-2.0
 
 -buildpath: \
     com.ibm.websphere.javaee.servlet.4.0;version=latest,\

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/FATSuite.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/FATSuite.java
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package com.ibm.ws.fat.grpc;
 
+import java.util.Arrays;
+import java.util.HashSet;
+
 import org.junit.ClassRule;
 
 import org.junit.runner.RunWith;
@@ -46,8 +49,16 @@ public class FATSuite {
 
     private static final Class<?> c = FATSuite.class;
 
+    static String[] removedFeatures = {"mpOpenAPI-1.1", "mpMetrics-2.3", "mpJwt-1.1", "mpConfig-1.3", "mpRestClient-1.3", "appSecurity-2.0"};
+
+    static String[] addedFeatures = {"mpOpenAPI-3.0", "mpMetrics-4.0", "mpJwt-2.0", "mpConfig-3.0", "mpRestClient-3.0", "appSecurity-4.0"};
+
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE9_FEATURES().removeFeature("servlet-4.0").alwaysAddFeature("servlet-5.0"));
+    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly())
+                             .andWith(FeatureReplacementAction.EE9_FEATURES()
+                             .removeFeatures(new HashSet<>(Arrays.asList(removedFeatures)))
+                             .addFeatures(new HashSet<>(Arrays.asList(addedFeatures)))
+                             .alwaysAddFeature("servlet-5.0")
+                             .alwaysAddFeature("jsonb-2.0"));
 
 }

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/GrpcMetricsTest.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/GrpcMetricsTest.java
@@ -41,7 +41,6 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
-@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 public class GrpcMetricsTest extends FATServletClient {
 

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldCDITests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldCDITests.java
@@ -33,7 +33,6 @@ import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
-@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 public class HelloWorldCDITests extends HelloWorldBasicTest {
 

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldTest.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldTest.java
@@ -30,7 +30,6 @@ import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
-@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 public class HelloWorldTest extends HelloWorldBasicTest {
 

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreConsumerServletClientTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreConsumerServletClientTests.java
@@ -29,7 +29,6 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -40,7 +39,6 @@ import componenttest.topology.utils.FATServletClient;
  * @author anupag
  *
  */
-@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class StoreConsumerServletClientTests extends FATServletClient {

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreProducerServletClientTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreProducerServletClientTests.java
@@ -26,7 +26,6 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -37,7 +36,6 @@ import componenttest.topology.utils.FATServletClient;
  * @author anupag
  *
  */
-@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class StoreProducerServletClientTests extends FATServletClient {

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesRESTClientTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesRESTClientTests.java
@@ -27,7 +27,6 @@ import com.ibm.testapp.g3store.restProducer.client.ProducerEndpointFATServlet;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -37,7 +36,6 @@ import componenttest.topology.utils.FATServletClient;
  * @author anupag
  *
  */
-@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 public class StoreServicesRESTClientTests extends FATServletClient {
 

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesSecurityTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesSecurityTests.java
@@ -26,7 +26,6 @@ import com.ibm.testapp.g3store.restConsumer.client.ConsumerEndpointJWTCookieFATS
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -35,8 +34,6 @@ import componenttest.topology.utils.FATServletClient;
 /**
  *
  */
-
-@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 public class StoreServicesSecurityTests extends FATServletClient {
 

--- a/dev/com.ibm.ws.grpc_fat/test-applications/StoreConsumerApp.war/src/com/ibm/testapp/g3store/restConsumer/client/ConsumerEndpointFATServlet.java
+++ b/dev/com.ibm.ws.grpc_fat/test-applications/StoreConsumerApp.war/src/com/ibm/testapp/g3store/restConsumer/client/ConsumerEndpointFATServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -43,6 +43,7 @@ import com.ibm.testapp.g3store.restProducer.model.Price;
 import com.ibm.testapp.g3store.restProducer.model.Price.PurchaseType;
 import com.ibm.testapp.g3store.utilsConsumer.ConsumerUtils;
 
+import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 /**
@@ -122,6 +123,7 @@ public class ConsumerEndpointFATServlet extends FATServlet {
      * @throws Exception
      */
     @Test
+    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     public void testGetAppInfo_Bad_BasicAuth(HttpServletRequest req, HttpServletResponse resp) throws Exception {
         this.getAppInfo_BadBasicAuth(req, resp);
     }

--- a/dev/com.ibm.ws.grpc_fat/test-applications/StoreConsumerApp.war/src/com/ibm/testapp/g3store/restConsumer/client/ConsumerEndpointJWTCookieFATServlet.java
+++ b/dev/com.ibm.ws.grpc_fat/test-applications/StoreConsumerApp.war/src/com/ibm/testapp/g3store/restConsumer/client/ConsumerEndpointJWTCookieFATServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -42,6 +42,7 @@ import com.ibm.testapp.g3store.restProducer.model.Price;
 import com.ibm.testapp.g3store.restProducer.model.Price.PurchaseType;
 import com.ibm.testapp.g3store.utilsConsumer.ConsumerUtils;
 
+import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 /**
@@ -125,6 +126,7 @@ public class ConsumerEndpointJWTCookieFATServlet extends FATServlet {
      * @throws Exception
      */
     @Test
+    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     public void testGetApp_BadRole_JWTCookie_GrpcClient(HttpServletRequest req, HttpServletResponse resp) throws Exception {
         this.getAppName_BadRole_CookieAuth_GrpcClient(req, resp);
     }

--- a/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/MappingTable.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/MappingTable.java
@@ -40,6 +40,9 @@ public class MappingTable {
 	public static final String SESSION_TAG_NAME = "appname";
 	public static final String JAXWS_SERVER_TAG_NAME = "endpoint";
 	public static final String JAXWS_CLIENT_TAG_NAME = "endpoint";
+
+	public static final String GRPC_SERVER_TAG_NAME = "grpc";
+	public static final String GRPC_CLIENT_TAG_NAME = "grpc";
 	
 	public static final String COUNTER = MetricType.COUNTER.toString().toUpperCase();
 	public static final String GAUGE = MetricType.GAUGE.toString().toUpperCase();
@@ -126,6 +129,25 @@ public class MappingTable {
         	{ "vendor", "jaxws.client.responseTime.total", "Total Response Time", "jaxws.responseTime.total.description", GAUGE, MetricUnits.MILLISECONDS, "TotalHandlingTime", null, JAXWS_CLIENT_TAG_NAME }
 		};
 		mappingTable.put("WebSphere:feature=jaxws,*,type=Performance.Counter.Client", jaxwsClientTable);
+
+		String[][] grpcServerTable = new String[][]{
+	    	{ "vendor", "grpc.server.rpcStarted.total", "Total Server RPCs Started Count", "grpc.server.rpcStarted.total.description", COUNTER, MetricUnits.NONE, "RpcStartedCount", null, GRPC_SERVER_TAG_NAME },
+	    	{ "vendor", "grpc.server.rpcCompleted.total", "Total Server RPCs Completed Count", "grpc.server.rpcCompleted	.total.description", COUNTER, MetricUnits.NONE, "RpcCompletedCount", null, GRPC_SERVER_TAG_NAME },
+        	{ "vendor", "grpc.server.sentMessages.total", "Total Sent Stream Messages", "grpc.server.sentMessages.total.description", COUNTER, MetricUnits.NONE, "SentMessagesCount", null, GRPC_SERVER_TAG_NAME },
+        	{ "vendor", "grpc.server.receivedMessages.total", "Total Received Stream Messages", "grpc.server.receivedMessages.total.description", COUNTER, MetricUnits.NONE, "ReceivedMessagesCount", null, GRPC_SERVER_TAG_NAME },
+        	{ "vendor", "grpc.server.responseTime.total", "Total Response Time", "grpc.server.responseTime.total.description", GAUGE, MetricUnits.MILLISECONDS, "ResponseTimeDetails", "total", GRPC_SERVER_TAG_NAME }
+		};
+		mappingTable.put("WebSphere:type=GrpcServerStats,name=*", grpcServerTable);
+
+		String[][] grpcClientTable = new String[][]{
+	    	{ "vendor", "grpc.client.rpcStarted.total", "Total Client RPCs Started Count", "grpc.client.rpcStarted.total.description", COUNTER, MetricUnits.NONE, "RpcStartedCount", null, GRPC_CLIENT_TAG_NAME },
+	    	{ "vendor", "grpc.client.rpcCompleted.total", "Total Client RPCs Completed Count", "grpc.client.rpcCompleted.total.description", COUNTER, MetricUnits.NONE, "RpcCompletedCount", null, GRPC_CLIENT_TAG_NAME },
+        	{ "vendor", "grpc.client.sentMessages.total", "Total Sent Stream Messages", "grpc.client.sentMessages.total.description", COUNTER, MetricUnits.NONE, "SentMessagesCount", null, GRPC_CLIENT_TAG_NAME },
+        	{ "vendor", "grpc.client.receivedMessages.total", "Total Received Stream Messages", "grpc.client.receivedMessages.total.description", COUNTER, MetricUnits.NONE, "ReceivedMessagesCount", null, GRPC_CLIENT_TAG_NAME },
+        	{ "vendor", "grpc.client.responseTime.total", "Total Response Time", "grpc.client.responseTime.total.description", GAUGE, MetricUnits.MILLISECONDS, "ResponseTimeDetails", "total", GRPC_CLIENT_TAG_NAME }
+		};
+		mappingTable.put("WebSphere:type=GrpcClientStats,name=*", grpcClientTable);
+		
 	}
 	
 	


### PR DESCRIPTION
Fixes #19484 after the original PR was reverted 

Mostly addresses #18137 (original issue)

**Note**: Two tests were skipped

- testGetApp_BadRole_JWTCookie_GrpcClient_EE9_FEATURES
- testGetAppInfo_Bad_BasicAuth_EE9_FEATURES

Both expect a `Expected auth failure` error but it doesn’t occur.

LITE mode now runs the EE9 tests while FULL runs with both the original features and with EE9.


