### PR TITLE
adding block so windows doesn't run retrieveUninstallFileList twice

### DIFF
--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/UninstallDirector.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/UninstallDirector.java
@@ -14,6 +14,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -100,7 +102,7 @@ class UninstallDirector extends AbstractDirector {
     void uninstall(boolean checkDependency, String[] productIds, Collection<File> toBeDeleted) throws InstallException {
         if (uninstallAssets.isEmpty())
             return;
-
+        Instant start = Instant.now();
         if (InstallUtils.isWindows) {
             // check any file is locked
             fireProgressEvent(InstallProgressEvent.CHECK, 10, Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("STATE_CHECKING"));
@@ -119,7 +121,8 @@ class UninstallDirector extends AbstractDirector {
                 }
             }
         }
-
+        log(Level.ALL, "Lock check took <" + Duration.between(start, Instant.now()).toMillis() + "> milliseconds");
+        start = Instant.now();
         // proceed to uninstall
         int progress = 20;
         int interval = 70 / uninstallAssets.size();
@@ -149,6 +152,8 @@ class UninstallDirector extends AbstractDirector {
                     InstallUtils.deleteDirectory(f);
             }
         }
+        log(Level.ALL, "Uninstall took <" + Duration.between(start, Instant.now()).toMillis() + "> milliseconds");
+
     }
 
     /**

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/UninstallDirector.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/UninstallDirector.java
@@ -152,9 +152,11 @@ class UninstallDirector extends AbstractDirector {
     }
 
     /**
-     * @param baseDirs
-     * @param uninstallAsset
-     * @throws InstallException
+     *
+     * @param uninstallAsset the uninstall asset to derive a base directory from
+     * @param baseDir        the base directory of the uninstallAsset
+     * @return the uninstallAsset's base directory derived from the asset and appended to baseDir. For example, if the uninstallAsset location is dev/spi/ibm and baseDir is
+     *         /opt/IBM/WebSphere/AppServer, this will return 'Set[/opt/IBM/WebSphere/AppServer/dev]' iff the path exists, an empty Set otherwise.
      */
     private Set<File> getAssetBaseDirectories(UninstallAsset uninstallAsset, File baseDir) {
 
@@ -174,9 +176,9 @@ class UninstallDirector extends AbstractDirector {
     }
 
     /**
-     * @param uninstallAsset
-     * @param resourceFilter
-     * @return
+     * @param uninstallAsset the asset to process for relevant location data
+     * @return a set of strings that are the location data derived from uninstallAsset. This set my be empty if the asset is not BUNDLE_TYPE, JAR_TYPE, BOOT_JAR_TYPE or FILE_TYPE.
+     *         It could also be empty if the getLocation() call returns null or an empty string.
      */
     private Set<String> getAssetLocations(UninstallAsset uninstallAsset) {
         final List<SubsystemContentType> resourceFilter = Arrays.asList(SubsystemContentType.BUNDLE_TYPE, SubsystemContentType.JAR_TYPE, SubsystemContentType.BOOT_JAR_TYPE,
@@ -186,9 +188,10 @@ class UninstallDirector extends AbstractDirector {
     }
 
     /**
-     * @param baseDir
-     * @param location
-     * @return
+     *
+     * @param locString the location string to parse, may be null.
+     * @return the first child directory specified in the locString. For example, if the locString is bin/tools/tools.zip, this method will return 'bin'.
+     *
      */
     private List<String> getFirstChildSubdirectoryFromLocations(String locString) {
         List<String> subdirectories = new ArrayList<>();
@@ -197,6 +200,10 @@ class UninstallDirector extends AbstractDirector {
             for (String loc : locs) {
                 File fle = new File(loc);
                 String fileStr = fle.toString();
+                // skip a leading separator
+                if (fileStr.charAt(0) == File.separatorChar) {
+                    fileStr = fileStr.substring(1);
+                }
                 int index = fileStr.indexOf(File.separator);
                 if (index > 0) {
                     fileStr = fileStr.substring(0, fileStr.indexOf(File.separator));

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/UninstallDirector.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/UninstallDirector.java
@@ -62,8 +62,8 @@ class UninstallDirector extends AbstractDirector {
      * Creates array and calls method below
      *
      * @param checkDependency if uninstall should check for dependencies
-     * @param productId product id to uninstall
-     * @param toBeDeleted Collection of files to uninstall
+     * @param productId       product id to uninstall
+     * @param toBeDeleted     Collection of files to uninstall
      * @throws InstallException
      */
     void uninstall(boolean checkDependency, String productId, Collection<File> toBeDeleted) throws InstallException {
@@ -88,8 +88,8 @@ class UninstallDirector extends AbstractDirector {
      * Uninstalls product depending on dependencies
      *
      * @param checkDependency if uninstall should check for dependencies
-     * @param productIds product ids to uninstall
-     * @param toBeDeleted Collection of files to uninstall
+     * @param productIds      product ids to uninstall
+     * @param toBeDeleted     Collection of files to uninstall
      * @throws InstallException
      */
     void uninstall(boolean checkDependency, String[] productIds, Collection<File> toBeDeleted) throws InstallException {
@@ -121,7 +121,10 @@ class UninstallDirector extends AbstractDirector {
             fireProgressEvent(InstallProgressEvent.UNINSTALL, progress, Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("STATE_UNINSTALLING", uninstallAsset.getName()));
             progress += interval;
             try {
-                retrieveUninstallFileList(uninstallAsset, checkDependency);
+                if (!InstallUtils.isWindows) {
+
+                    retrieveUninstallFileList(uninstallAsset, checkDependency);
+                }
                 engine.uninstall(uninstallAsset, checkDependency, filesRestored);
                 log(Level.FINE, uninstallAsset.uninstalledLogMsg());
             } catch (IOException e) {
@@ -172,7 +175,7 @@ class UninstallDirector extends AbstractDirector {
      *
      * @param featureNames a list of the feature names and feature symbolic names to uninstall
      * @throws InstallException if there is a feature not installed or
-     *             there is another feature still requires the uninstalling features.
+     *                              there is another feature still requires the uninstalling features.
      */
     void uninstallFeatures(Collection<String> featureNames, Collection<String> uninstallInstallFeatures, boolean force) {
         product.refresh();
@@ -209,7 +212,7 @@ class UninstallDirector extends AbstractDirector {
     /**
      * Creates array and calls method below
      *
-     * @param productId product id to uninstall
+     * @param productId              product id to uninstall
      * @param exceptPlatfromFeatuers If platform features should be ignored
      * @throws InstallException
      */
@@ -222,7 +225,7 @@ class UninstallDirector extends AbstractDirector {
     /**
      * Uninstalls features by product id
      *
-     * @param productIds product ids to uninstall
+     * @param productIds             product ids to uninstall
      * @param exceptPlatfromFeatuers If platform features should be ignored
      * @throws InstallException
      */


### PR DESCRIPTION
Check all asset's subdirectories for locked files before uninstalling. 