### PR TITLE
OpenAPI FAT: Set read timeout

### DIFF
--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/utils/OpenAPIConnection.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/utils/OpenAPIConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -100,11 +100,9 @@ public class OpenAPIConnection {
         try {
             HttpURLConnection conn = getConnection();
             return readConnection(conn);
-
         } catch (Exception e) {
-            Assert.fail(e.getMessage());
+            throw new AssertionError("Failed to download from " + constructUrl() + ": " + e.getMessage(), e);
         }
-        return null;
     }
 
     /**
@@ -121,7 +119,9 @@ public class OpenAPIConnection {
                     return parseResult.getOpenAPI();
                 }
             } catch (Exception e) {
-                Assert.fail(e.getMessage());
+                throw new AssertionError(
+                    "Failed to construct model from document downloaded from " + constructUrl() + ": " + e.getMessage(),
+                    e);
             }
             return null;
         }
@@ -136,6 +136,7 @@ public class OpenAPIConnection {
     public HttpURLConnection getConnection() throws IOException, ProtocolException {
         HttpURLConnection conn = HttpUtils.getHttpConnection(constructUrl(), expectedResponseCode, null, 30, method,
             headers, streamToWrite);
+        conn.setReadTimeout(30 * 1000);
         return conn;
     }
 

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/utils/OpenAPIConnection.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/utils/OpenAPIConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -94,11 +94,9 @@ public class OpenAPIConnection {
         try {
             HttpURLConnection conn = getConnection();
             return readConnection(conn);
-
         } catch (Exception e) {
-            Assert.fail(e.getMessage());
+            throw new AssertionError("Failed to download from " + constructUrl() + ": " + e.getMessage(), e);
         }
-        return null;
     }
 
     /**
@@ -109,6 +107,7 @@ public class OpenAPIConnection {
     public HttpURLConnection getConnection() throws IOException, ProtocolException {
         HttpURLConnection conn = HttpUtils.getHttpConnection(constructUrl(), expectedResponseCode, null, 30, method,
             headers, streamToWrite);
+        conn.setReadTimeout(30 * 1000);
         return conn;
     }
 


### PR DESCRIPTION
Set the read timeout on the connection when downloading the OpenAPI
document. Hopefully this will prevent test timeouts and allow us to
debug further why we occasionally see this fail.

Also stop swallowing the real exception :angry: 

For RTC283961