### PR TITLE
OpenAPI: Cancel listener synchronously

### DIFF
--- a/dev/com.ibm.ws.openapi.3.1/src/com/ibm/ws/openapi31/OpenAPIModuleListener.java
+++ b/dev/com.ibm.ws.openapi.3.1/src/com/ibm/ws/openapi31/OpenAPIModuleListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -337,16 +337,10 @@ public class OpenAPIModuleListener implements ModuleMetaDataListener, VirtualHos
             }
         }
 
-        //We have processed all WABs, so we can now cancel our scheduler
-        getExecutorService().execute(new Runnable() {
-            @Override
-            public void run() {
-                if (OpenAPIUtils.isEventEnabled(tc)) {
-                    Tr.event(tc, "Finished processing WABs, so cleaning up scheduler");
-                }
-                cancelScheduler();
-            }
-        });
+        if (OpenAPIUtils.isEventEnabled(tc)) {
+            Tr.event(tc, "Finished processing WABs, so cleaning up scheduler");
+        }
+        cancelScheduler();
     }
 
     private void cancelScheduler() {


### PR DESCRIPTION
OpenAPI runs a scheduled task which processes already deployed modules.
If required services are not ready it repeats. When it succeeds, it
cancels itself.

The cancellation is done asynchronously which can cause problems if the
server is shutting down as the executor serivce will no longer be
available.

I think the easiest way to avoid the problem is to do the cancellation
synchronously instead, which doesn't require the executor service.

For RTC 281148 and RTC 280848