### PR TITLE
Disable test for server.env expansion var enablement

### DIFF
--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerEnvTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerEnvTest.java
@@ -79,6 +79,8 @@ public class ServerEnvTest {
 
     /**
      * Test - Variable expansion in server.env does NOT work when it is NOT enabled.
+     * -- Note it is ALWAYS enabled for Windows --
+     * -- So this test not applicable to Windows --
      * server.env contents:
      * [
      * LOG_FILE=${CONSOLE_LOG_FILE_NAME}
@@ -91,7 +93,9 @@ public class ServerEnvTest {
     public void testVariableExpansionInServerEnvWhenExpansionNotEnabled() throws Exception {
         final String METHOD_NAME = "testVariableExpansionInServerEnvWhenExpansionNotEnabled";
         Log.entering(c, METHOD_NAME);
-
+        if (OS.contains("win")) {
+            return;
+        }
         varsExpandInServerEnv(false);
 
         Log.exiting(c, METHOD_NAME);


### PR DESCRIPTION
The test for expansion var enablement is not applicable to Windows.   Variable expansion is enabled by default on Windows.  It's always been available.