### PR TITLE
test case for asynchronous method join

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/publish/servers/concurrent_fat_cdi/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/publish/servers/concurrent_fat_cdi/server.xml
@@ -30,4 +30,7 @@
         <concurrencyPolicy max="1" maxQueueSize="1" maxWaitForEnqueue="1m" startTimeout="3s"/>
     </managedScheduledExecutorService>
 
+    <!-- needed to shut down pool of unmanaged threads that is used by the application -->
+    <javaPermission codebase="${server.config.dir}/dropins/concurrentCDIApp.war" className="java.lang.RuntimePermission" name="modifyThread"/>
+
 </server>

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ConcurrentCDIServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ConcurrentCDIServlet.java
@@ -650,7 +650,7 @@ public class ConcurrentCDIServlet extends HttpServlet {
 
             // Run inline on an unmanaged thread,
             Future<Entry<Integer, Object>> unmanagedThreadFuture = unmanagedThreads.submit(() -> futureB.join());
-            Entry<Integer, Object> resultsB = unmanagedThreadFuture.get(TIMEOUT_MS, TimeUnit.NANOSECONDS);
+            Entry<Integer, Object> resultsB = unmanagedThreadFuture.get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
             assertEquals(Integer.valueOf(Status.STATUS_NO_TRANSACTION), resultsB.getKey());
             assertTrue("looked up " + resultsB.getValue(), resultsB.getValue() instanceof ManagedExecutorService);

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ConcurrentCDIServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ConcurrentCDIServlet.java
@@ -25,6 +25,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -34,6 +35,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
@@ -46,6 +48,7 @@ import jakarta.annotation.Resource;
 import jakarta.enterprise.concurrent.ContextService;
 import jakarta.enterprise.concurrent.ManagedExecutorService;
 import jakarta.inject.Inject;
+import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
@@ -116,8 +119,20 @@ public class ConcurrentCDIServlet extends HttpServlet {
     @Resource(lookup = "java:comp/TransactionSynchronizationRegistry")
     private TransactionSynchronizationRegistry tranSyncRegistry;
 
+    private ExecutorService unmanagedThreads;
+
     @Inject
     private ManagedExecutorService injectedExec; // produced by ResourcesProducer.exec field
+
+    @Override
+    public void destroy() {
+        unmanagedThreads.shutdownNow();
+    }
+
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        unmanagedThreads = Executors.newFixedThreadPool(5);
+    }
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
@@ -592,6 +607,66 @@ public class ConcurrentCDIServlet extends HttpServlet {
             future.get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
         } finally {
             future.cancel(true);
+        }
+    }
+
+    /**
+     * Verify that an asynchronous method can run inline upon CompletableFuture.join
+     * when maxAsync prevents running on a thread from the Liberty global thread pool.
+     */
+    // TODO this isn't implemented yet @Test
+    public void testInlineAsyncMethod() throws Exception {
+        CountDownLatch started = new CountDownLatch(2);
+        CountDownLatch blocker = new CountDownLatch(1);
+
+        Callable<Boolean> wait = () -> {
+            started.countDown();
+            return blocker.await(TIMEOUT_MS * 2, TimeUnit.MILLISECONDS);
+        };
+
+        // Use up maxAsync of 2
+        try {
+            injectedExec.submit(wait);
+            injectedExec.submit(wait);
+            assertTrue(started.await(TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+            // Queue up 2 asynchronous methods that won't be able to run yet
+            CompletableFuture<Entry<Integer, Object>> futureA = //
+                            dependentScopedBean.lookUpAndGetTransactionStatus("java:app/env/concurrent/sampleExecutorRef");
+            CompletableFuture<Entry<Integer, Object>> futureB = //
+                            dependentScopedBean.lookUpAndGetTransactionStatus("java:app/env/concurrent/sampleExecutorRef");
+
+            // Run one of them inline,
+            Entry<Integer, Object> resultsA = futureA.join();
+
+            assertEquals(Integer.valueOf(Status.STATUS_NO_TRANSACTION), resultsA.getKey());
+            assertTrue("looked up " + resultsA.getValue(), resultsA.getValue() instanceof ManagedExecutorService);
+
+            tran.begin();
+
+            // Should be able to queue up another
+            CompletableFuture<Entry<Integer, Object>> futureC = //
+                            dependentScopedBean.lookUpAndGetTransactionStatus("java:app/env/concurrent/sampleExecutorRef");
+
+            // Run inline on an unmanaged thread,
+            Future<Entry<Integer, Object>> unmanagedThreadFuture = unmanagedThreads.submit(() -> futureB.join());
+            Entry<Integer, Object> resultsB = unmanagedThreadFuture.get(TIMEOUT_MS, TimeUnit.NANOSECONDS);
+
+            assertEquals(Integer.valueOf(Status.STATUS_NO_TRANSACTION), resultsB.getKey());
+            assertTrue("looked up " + resultsB.getValue(), resultsB.getValue() instanceof ManagedExecutorService);
+
+            // Run inline again,
+            Entry<Integer, Object> resultsC = futureC.join();
+
+            assertEquals(Integer.valueOf(Status.STATUS_NO_TRANSACTION), resultsC.getKey());
+            assertTrue("looked up " + resultsC.getValue(), resultsC.getValue() instanceof ManagedExecutorService);
+
+            // Transaction that was active on this thread should be restored,
+            assertEquals(Status.STATUS_ACTIVE, tran.getStatus());
+        } finally {
+            blocker.countDown();
+            if (tran.getStatus() != Status.STATUS_NO_TRANSACTION)
+                tran.rollback();
         }
     }
 

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/DependentScopedBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/DependentScopedBean.java
@@ -10,11 +10,16 @@
  *******************************************************************************/
 package concurrent.cdi.web;
 
+import java.util.AbstractMap;
+import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 
 import jakarta.enterprise.concurrent.Asynchronous;
 import jakarta.enterprise.context.Dependent;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.UserTransaction;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -39,6 +44,21 @@ public class DependentScopedBean {
             future.completeExceptionally(x);
         }
         return future;
+    }
+
+    /**
+     * Return an entry consisting of (transaction status, lookup result)
+     */
+    @Asynchronous(executor = "concurrent/sampleExecutor")
+    public CompletableFuture<Entry<Integer, Object>> lookUpAndGetTransactionStatus(String jndiName) {
+        try {
+            UserTransaction tx = InitialContext.doLookup("java:comp/UserTransaction");
+            Entry<Integer, Object> result = new AbstractMap.SimpleEntry<Integer, Object>( //
+                            tx.getStatus(), InitialContext.doLookup(jndiName));
+            return Asynchronous.Result.complete(result);
+        } catch (NamingException | SystemException x) {
+            throw new CompletionException(x);
+        }
     }
 
     public void setBoolean(boolean value) {


### PR DESCRIPTION
Test case (currently disabled because the product feature isn't implemented yet) for join on an asynchronous method to be able to run inline when the method hasn't already run async (possibly due to the maxAsync constraint).