### PR TITLE
Update mpOT API from RC4 to final release

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2054,7 +2054,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.opentracing</groupId>
       <artifactId>microprofile-opentracing-api</artifactId>
-      <version>3.0-RC4</version>
+      <version>3.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -406,7 +406,7 @@ org.eclipse.microprofile.opentracing:microprofile-opentracing-api:1.1
 org.eclipse.microprofile.opentracing:microprofile-opentracing-api:1.2
 org.eclipse.microprofile.opentracing:microprofile-opentracing-api:1.3
 org.eclipse.microprofile.opentracing:microprofile-opentracing-api:2.0
-org.eclipse.microprofile.opentracing:microprofile-opentracing-api:3.0-RC4
+org.eclipse.microprofile.opentracing:microprofile-opentracing-api:3.0
 org.eclipse.microprofile.reactive-streams-operators:microprofile-reactive-streams-operators-api:1.0.1
 org.eclipse.microprofile.reactive-streams-operators:microprofile-reactive-streams-operators-core:1.0.1
 org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-api:1.0

--- a/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -13,9 +13,9 @@
     <name>MicroProfile Opentracing TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.opentracing.version>3.0-RC4</microprofile.opentracing.version>
+        <microprofile.opentracing.version>3.0</microprofile.opentracing.version>
         <microprofile.config.version>3.0.1</microprofile.config.version>
-        <microprofile.rest.client.version>3.0-RC5</microprofile.rest.client.version>
+        <microprofile.rest.client.version>3.0</microprofile.rest.client.version>
         <arquillian.version>1.7.0.Alpha10</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->

--- a/dev/io.openliberty.org.eclipse.microprofile/opentracing.3.0.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile/opentracing.3.0.bnd
@@ -20,6 +20,6 @@ Export-Package: \
   org.eclipse.microprofile.opentracing;version=3.0
 
 Include-Resource: \
-  @${repo;org.eclipse.microprofile.opentracing:microprofile-opentracing-api;3.0.0.RC4;EXACT}
+  @${repo;org.eclipse.microprofile.opentracing:microprofile-opentracing-api;3.0.0;EXACT}
 
 WS-TraceGroup: OPENTRACING


### PR DESCRIPTION
Updating OpenTracing to use the 3.0 final API release and changing the Rest-Client API to 3.0 in the OT TCK.

#build