### PR TITLE
Remove "doPriv" wrappers from calls made within SystemUtils.

### DIFF
--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/ZipCachingProperties.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/ZipCachingProperties.java
@@ -42,6 +42,10 @@ import com.ibm.ws.artifact.zip.internal.SystemUtils;
  * zip.cache.entry.limit       0 | (>0)      [ 8192 ]
  * zip.cache.entry.max         0 | (>0)      [ 16 ]
  *
+ * One property is used to disable cache invalidation:
+ * 
+ * zip.reaper.assume.value     false | true  [ false ]
+ *
  * Three properties are used to configure the zip file cache layer:
  *
  * zip.reaper.max.pending     -1 | 0 | (>0)  [ 255 ]
@@ -94,6 +98,12 @@ import com.ibm.ws.artifact.zip.internal.SystemUtils;
  * entry maximum property sets the number of entries for which data is held.
  * Setting 0 disables the entry cache.
  *
+ * zip.reaper.assume.valid     false | true  [ false ]
+ * 
+ * By default, when re-acquiring a zip file, size and last-modified
+ * checks are done.  This is expensive when many resources are accessed.
+ * Setting "true" turns off the checks.
+ * 
  * zip.reaper.max.pending     -1 | 0 | (>0)  [ 255 ]
  *
  * The zip file cache layer delays closes of zip files according to the
@@ -274,8 +284,6 @@ public class ZipCachingProperties {
 
     //
 
-    //
-
     /**
      * Property for zip reaper state logging.
      *
@@ -288,8 +296,11 @@ public class ZipCachingProperties {
      * closed, and displaying lifetime statistics for all.</li>
      * </ul>
      */
-    public static final String ZIP_REAPDER_DEBUG_STATE_PROPERTY_NAME =
+    public static final String ZIP_REAPER_DEBUG_STATE_PROPERTY_NAME =
         "zip.reaper.debug.state";
+    @Deprecated // Typo.  Constant retained for backwards compatibility.
+    public static final String ZIP_REAPDER_DEBUG_STATE_PROPERTY_NAME =
+        ZIP_REAPER_DEBUG_STATE_PROPERTY_NAME;
     public static final boolean ZIP_REAPER_DEBUG_STATE_DEFAULT_VALUE = false;
     public static final boolean ZIP_REAPER_DEBUG_STATE;
 
@@ -298,6 +309,12 @@ public class ZipCachingProperties {
     public static final boolean ZIP_REAPER_COLLECT_TIMINGS_DEFAULT_VALUE = false;
     public static final boolean ZIP_REAPER_COLLECT_TIMINGS;
 
+    /** Tell whether invalidation is done on reaper cached data. */
+    public static final String ZIP_REAPER_ASSUME_VALID_PROPERTY_NAME =
+        "zip.reaper.assume.valid";
+    public static final boolean ZIP_REAPER_ASSUME_VALID_DEFAULT_VALUE = false;
+    public static final boolean ZIP_REAPER_ASSUME_VALID;
+    
     static {
         String methodName = "<static init>";
 
@@ -306,8 +323,12 @@ public class ZipCachingProperties {
             ZIP_REAPER_COLLECT_TIMINGS_DEFAULT_VALUE);
 
         ZIP_REAPER_DEBUG_STATE = getProperty(methodName,
-            ZIP_REAPDER_DEBUG_STATE_PROPERTY_NAME,
+            ZIP_REAPER_DEBUG_STATE_PROPERTY_NAME,
             ZIP_REAPER_DEBUG_STATE_DEFAULT_VALUE);
+        
+        ZIP_REAPER_ASSUME_VALID = getProperty(methodName,
+            ZIP_REAPER_ASSUME_VALID_PROPERTY_NAME,
+            ZIP_REAPER_ASSUME_VALID_DEFAULT_VALUE);        
     }
 
     /**

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipCachingServiceImpl.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipCachingServiceImpl.java
@@ -290,8 +290,15 @@ public class ZipCachingServiceImpl implements ZipCachingService {
             "ns");
 
         introspectProperty(output,
+            "Assume valid",
+            ZipCachingProperties.ZIP_REAPER_ASSUME_VALID_PROPERTY_NAME,
+            (ZipCachingProperties.ZIP_REAPER_ASSUME_VALID ? "true" : "false"),
+            (ZipCachingProperties.ZIP_REAPER_DEBUG_STATE_DEFAULT_VALUE ? "true" : "false"),
+            "true/false");
+
+        introspectProperty(output,
             "State debugging",
-            ZipCachingProperties.ZIP_REAPDER_DEBUG_STATE_PROPERTY_NAME,
+            ZipCachingProperties.ZIP_REAPER_DEBUG_STATE_PROPERTY_NAME,
             (ZipCachingProperties.ZIP_REAPER_DEBUG_STATE ? "enabled" : "disabled"),
             (ZipCachingProperties.ZIP_REAPER_DEBUG_STATE_DEFAULT_VALUE ? "enabled" : "disabled"),
             "enabled/disabled");

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipFileData.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipFileData.java
@@ -610,6 +610,13 @@ ZipFile [Path]
     protected ZipFile reacquireZipFile() throws IOException, ZipException {
         String methodName = "reacquireZipFile";
 
+        if ( ZipCachingProperties.ZIP_REAPER_ASSUME_VALID ) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+                Tr.debug(tc, methodName + " Zip [ " + path + " ]: Assumed valid");
+            }
+            return zipFile;
+        }
+        
         File rawZipFile = new File(path);
         long newZipLength = FileUtils.fileLength(rawZipFile);
         long newZipLastModified = FileUtils.fileLastModified(rawZipFile);

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/SystemUtils.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/SystemUtils.java
@@ -10,9 +10,6 @@
  *******************************************************************************/
 package com.ibm.ws.artifact.zip.internal;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 import com.ibm.ws.kernel.security.thread.ThreadIdentityManager;
 
 /**
@@ -20,44 +17,23 @@ import com.ibm.ws.kernel.security.thread.ThreadIdentityManager;
  */
 public class SystemUtils {
     /**
-     * Run {@link System#getProperty(String)} as a privileged action.
+     * Run {@link System#getProperty(String)}.
      *
      * @param propertyName The name of the property which is to be retrieved.
 
      * @return The string property value.  Null if the property is not set.
      */
     public static String getProperty(final String propertyName) {
-        Object token = ThreadIdentityManager.runAsServer();
-        try {
-            return AccessController.doPrivileged( new PrivilegedAction<String>() {
-                @Override
-                public String run() {
-                    return System.getProperty(propertyName);
-                }
-
-            } );
-        } finally {
-            ThreadIdentityManager.reset(token);
-        }
+        return System.getProperty(propertyName);
     }
 
     /**
-     * Run {@link System#getNanoTime} as a privileged action.
+     * Get the system time in nano-seconds.
      *
      * @return The system time in nano-seconds.
      */
     public static long getNanoTime() {
-        Object token = ThreadIdentityManager.runAsServer();
-        try {
-            return AccessController.doPrivileged( new PrivilegedAction<Long>() {
-                @Override
-                public Long run() {
-                    return System.nanoTime();
-                }
-            } ).longValue();
-        } finally {
-            ThreadIdentityManager.reset(token);
-        }
+        return System.nanoTime();
     }
 
     /**
@@ -68,17 +44,6 @@ public class SystemUtils {
      * @param shutdownHook The thread to add as a shutdown hook.
      */
     public static void addShutdownHook(final Thread shutdownHook) {
-        Object token = ThreadIdentityManager.runAsServer();
-        try {
-            AccessController.doPrivileged( new PrivilegedAction<Void>() {
-                @Override
-                public Void run() {
-                    Runtime.getRuntime().addShutdownHook(shutdownHook);
-                    return null; // Nothing to return
-                }
-            } );
-        } finally {
-            ThreadIdentityManager.reset(token);
-        }
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
     }
 }


### PR DESCRIPTION
See: #19596

Performance only change.

Remove "doPriv" wrappering from artifact.zip "SystemUtils" methods.