### PR TITLE
Update string to search for in WS-Security SAML CXF test

### DIFF
--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken/OneServerTests/CxfSAMLBasic1ServerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/fat/src/com/ibm/ws/wssecurity/fat/cxf/samltoken/OneServerTests/CxfSAMLBasic1ServerTests.java
@@ -203,12 +203,12 @@ public class CxfSAMLBasic1ServerTests extends CxfSAMLBasicTests {
         //issue 18363
         if ("EE7".equals(getFeatureVersion())) {
             List<validationData> expectations = helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, SAMLConstants.CXF_SAML_TOKEN_GENERAL_FAILURE_MSG);
-            expectations = helpers.addMessageExpectation(testSAMLServer, expectations, SAMLConstants.INVOKE_ACS_WITH_SAML_RESPONSE, SAMLConstants.SAML_TRACE_LOG, SAMLConstants.STRING_CONTAINS, "Did NOT fail because the assertion did NOT require a signature.", "verifySubjectConfirmationMethod A Bearer Assertion was not signed");
+            expectations = helpers.addMessageExpectation(testSAMLServer, expectations, SAMLConstants.INVOKE_ACS_WITH_SAML_RESPONSE, SAMLConstants.SAML_TRACE_LOG, SAMLConstants.STRING_CONTAINS, "Did NOT fail because the assertion did NOT require a signature.", "A Bearer Assertion was not signed");
             genericSAML(_testName, webClient, updatedTestSettings, standardFlow, expectations);
         } else if ("EE8".equals(getFeatureVersion())) {
         	String CXF_SAML_TOKEN_GENERAL_FAILURE_MSG = "SAML token security failure";
             List<validationData> expectations = helpers.setErrorSAMLCXFExpectations(null, flowType, updatedTestSettings, CXF_SAML_TOKEN_GENERAL_FAILURE_MSG);
-            expectations = helpers.addMessageExpectation(testSAMLServer, expectations, SAMLConstants.INVOKE_ACS_WITH_SAML_RESPONSE, SAMLConstants.SAML_TRACE_LOG, SAMLConstants.STRING_CONTAINS, "Did NOT fail because the assertion did NOT require a signature.", "verifySubjectConfirmationMethod A Bearer Assertion was not signed");
+            expectations = helpers.addMessageExpectation(testSAMLServer, expectations, SAMLConstants.INVOKE_ACS_WITH_SAML_RESPONSE, SAMLConstants.SAML_TRACE_LOG, SAMLConstants.STRING_CONTAINS, "Did NOT fail because the assertion did NOT require a signature.", "A Bearer Assertion was not signed");
             genericSAML(_testName, webClient, updatedTestSettings, standardFlow, expectations);
         } // End of 18363
         


### PR DESCRIPTION
For 287982. The code is looking for "verifySubjectConfirmationMethod A Bearer Assertion was not signed" in the trace, but a recent run shows that "fillCallerData A Bearer Assertion was not signed" is being emitted now. I believe this might be due to an open source project having been updated, but I'm not entirely sure yet. I can update the test to just look for "A Bearer Assertion was not signed" since that should suffice.