### PR TITLE
mpOpenAPI: Don't scan if scanning is disabled

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/ApplicationProcessor.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/ApplicationProcessor.java
@@ -294,7 +294,9 @@ public class ApplicationProcessor {
             
             openAPIModel = OpenApiProcessor.modelFromReader(config, tccl);
             openAPIModel = MergeUtil.merge(openAPIModel, OpenApiProcessor.modelFromStaticFile(staticFile));
-            openAPIModel = MergeUtil.merge(openAPIModel, OpenApiProcessor.modelFromAnnotations(config, IndexUtils.getIndexView(moduleInfo, moduleClassesContainerInfo, config)));
+            if (!config.scanDisable()) {
+                openAPIModel = MergeUtil.merge(openAPIModel, OpenApiProcessor.modelFromAnnotations(config, IndexUtils.getIndexView(moduleInfo, moduleClassesContainerInfo, config)));
+            }
             
             OASFilter filter = OpenApiProcessor.getFilter(config, appClassloader);
             if (filter != null) {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/publish/servers/ApplicationProcessorServer/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/publish/servers/ApplicationProcessorServer/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -9,4 +9,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
+
+# Note: testScanDisabled needs mpOpenApi trace enabled
 com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=info=enabled:mpOpenAPI=all=enabled


### PR DESCRIPTION
Previously, if scanning was disabled we would scan but then discard the result.

Fixes #19585