### PR TITLE
GA the identifyException subelement of dataSource

### DIFF
--- a/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/metatype/metatype.xml
@@ -81,7 +81,7 @@
   <AD id="enableBeginEndRequest"                  name="internal"      description="internal use only"  ibmui:group="Advanced" required="false" type="Boolean"/>
   <AD id="enableConnectionCasting"                name="%enblConCast"  description="%enblConCast.desc"  ibmui:group="Advanced" type="Boolean" default="false"/>
   <AD id="heritage"                               name="internal"      description="internal use only"  ibmui:group="Advanced" required="false" type="String"  cardinality="1" ibm:type="pid" ibm:reference="com.ibm.ws.jdbc.dataSource.heritage" ibm:flat="true"/>
-  <AD id="identifyException"                                                                            ibmui:group="Advanced" required="false" type="String"  cardinality="1000" ibm:type="pid" ibm:reference="com.ibm.ws.jdbc.dataSource.identifyException" ibm:flat="true"/>
+  <AD id="identifyException"                      name="%identifyException" description="%identifyException.desc" ibmui:group="Advanced" required="false" type="String"  cardinality="1000" ibm:type="pid" ibm:reference="com.ibm.ws.jdbc.dataSource.identifyException" ibm:flat="true"/>
   <AD id="onConnect"                              name="%onConnect"    description="%onConnect.desc"    ibmui:group="Advanced" required="false" type="String"  cardinality="1000"/>
   <AD id="queryTimeout"                           name="%qryTimeout"   description="%qryTimeout.desc"   ibmui:group="Advanced" required="false" type="String"  ibm:type="duration(s)"/>
   <AD id="recoveryAuthDataRef"                    name="%recoveryAuth" description="%recoveryAuth.desc" ibmui:group="Advanced" required="false" type="String"  cardinality="1" ibm:type="pid" ibm:reference="com.ibm.ws.security.jca.internal.authdata.config"/>

--- a/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/metatype/metatype.xml
@@ -81,7 +81,7 @@
   <AD id="enableBeginEndRequest"                  name="internal"      description="internal use only"  ibmui:group="Advanced" required="false" type="Boolean"/>
   <AD id="enableConnectionCasting"                name="%enblConCast"  description="%enblConCast.desc"  ibmui:group="Advanced" type="Boolean" default="false"/>
   <AD id="heritage"                               name="internal"      description="internal use only"  ibmui:group="Advanced" required="false" type="String"  cardinality="1" ibm:type="pid" ibm:reference="com.ibm.ws.jdbc.dataSource.heritage" ibm:flat="true"/>
-  <AD id="identifyException"                      ibm:beta="true"                                       ibmui:group="Advanced" required="false" type="String"  cardinality="1000" ibm:type="pid" ibm:reference="com.ibm.ws.jdbc.dataSource.identifyException" ibm:flat="true"/>
+  <AD id="identifyException"                                                                            ibmui:group="Advanced" required="false" type="String"  cardinality="1000" ibm:type="pid" ibm:reference="com.ibm.ws.jdbc.dataSource.identifyException" ibm:flat="true"/>
   <AD id="onConnect"                              name="%onConnect"    description="%onConnect.desc"    ibmui:group="Advanced" required="false" type="String"  cardinality="1000"/>
   <AD id="queryTimeout"                           name="%qryTimeout"   description="%qryTimeout.desc"   ibmui:group="Advanced" required="false" type="String"  ibm:type="duration(s)"/>
   <AD id="recoveryAuthDataRef"                    name="%recoveryAuth" description="%recoveryAuth.desc" ibmui:group="Advanced" required="false" type="String"  cardinality="1" ibm:type="pid" ibm:reference="com.ibm.ws.security.jca.internal.authdata.config"/>
@@ -106,7 +106,7 @@
   <Object ocdref="com.ibm.ws.jdbc.dataSource.identifyException"/>
  </Designate>
 
- <OCD id="com.ibm.ws.jdbc.dataSource.identifyException" name="internal" description="internal use only" ibmui:localization="OSGI-INF/l10n/metatype">
+ <OCD id="com.ibm.ws.jdbc.dataSource.identifyException" name="%identifyException" description="%identifyException.desc" ibmui:localization="OSGI-INF/l10n/metatype">
   <AD id="sqlState"  required="false" type="String"  name="%identifyException.sqlState"  description="%identifyException.sqlState.desc"/>
   <AD id="errorCode" required="false" type="Integer" name="%identifyException.errorCode" description="%identifyException.errorCode.desc"/>
   <AD id="as"        required="true"  type="String"  name="%identifyException.as"        description="%identifyException.as.desc"/>


### PR DESCRIPTION
GA the identifyException element under dataSource.

After making this update, I ran the schema generator and checked that the identifyException element is showing under dataSource and not as a top level element,

```
    <xsd:complexType name="com.ibm.ws.jdbc.dataSource.identifyException">
        <xsd:annotation>
            <xsd:documentation>Identify a specific SQL error code or SQL state on a SQLException. This enables the server to take appropriate action based on the error condition. For example, closing a stale connection instead of returning it to the connection pool.</xsd:documentation>
            <xsd:appinfo>
                <ext:label>Identify Exception</ext:label>
            </xsd:appinfo>
        ...
```

```
    <xsd:complexType name="com.ibm.ws.jdbc.dataSource.identifyException-factory">
        <xsd:complexContent>
            <xsd:extension base="com.ibm.ws.jdbc.dataSource.identifyException">
        ...
```

```
    <xsd:complexType name="com.ibm.ws.jdbc.dataSource">
        <xsd:annotation>
            <xsd:documentation>Defines a data source configuration.</xsd:documentation>
            <xsd:appinfo>
                <ext:label>Data Source</ext:label>
                <ext:groupDecl id="Advanced" label="Advanced Properties">Additional properties for more advanced usage.</ext:groupDecl>
            </xsd:appinfo>
        </xsd:annotation>
        <xsd:choice minOccurs="0" maxOccurs="unbounded">
            ...
            <xsd:element name="identifyException" type="com.ibm.ws.jdbc.dataSource.identifyException-factory">
                <xsd:annotation>
                    <xsd:appinfo>
                        <ext:group id="Advanced"/>
                    </xsd:appinfo>
                </xsd:annotation>
            </xsd:element>
            ...
```