### PR TITLE
Enable user-provided interceptors to work with MP Rest Client 3.0

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client.FT_fat/test-applications/retryApp/src/mpRestClientFT/retry/Driver.java
+++ b/dev/com.ibm.ws.microprofile.rest.client.FT_fat/test-applications/retryApp/src/mpRestClientFT/retry/Driver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -37,5 +37,10 @@ public class Driver {
 
     String failThenSucceed_RestClient() {
         return client.failThenSucceed();
+    }
+
+    @Loggable
+    String alwaysSucceed() {
+        return client.alwaysSucceed();
     }
 }

--- a/dev/com.ibm.ws.microprofile.rest.client.FT_fat/test-applications/retryApp/src/mpRestClientFT/retry/LoggableInterceptor.java
+++ b/dev/com.ibm.ws.microprofile.rest.client.FT_fat/test-applications/retryApp/src/mpRestClientFT/retry/LoggableInterceptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,11 +14,12 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.Priority;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 
-@Loggable @Interceptor
+@Loggable @Interceptor @Priority(10)
 public class LoggableInterceptor {
 
     static Map<String, Integer> invocations = new HashMap<>();

--- a/dev/com.ibm.ws.microprofile.rest.client.FT_fat/test-applications/retryApp/src/mpRestClientFT/retry/RetryTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client.FT_fat/test-applications/retryApp/src/mpRestClientFT/retry/RetryTestServlet.java
@@ -59,12 +59,21 @@ public class RetryTestServlet extends FATServlet {
     }
 
     @Test
-    @SkipForRepeat(JakartaEE9Action.ID) // CDI not resolving app-supplied interceptor here TODO: investigate and resolve
     public void testCustomLoggingInterceptorInvoked(HttpServletRequest req, HttpServletResponse resp) throws Exception {
         LoggableInterceptor.invocations.clear();
         client.alwaysSucceed();
         assertEquals(1, LoggableInterceptor.invocations.size());
         Integer invocationCount = LoggableInterceptor.invocations.get(RetryClient.class.getName()+"."+"alwaysSucceed");
+        assertNotNull(invocationCount);
+        assertEquals(1, (int) invocationCount);
+    }
+
+    @Test
+    public void testCustomLoggingInterceptorInvoked_separateMethod(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        LoggableInterceptor.invocations.clear();
+        driver.alwaysSucceed();
+        //assertEquals(2, LoggableInterceptor.invocations.size()); // should have 2 entries - 1 for driver bean, and 1 for rest client bean
+        Integer invocationCount = LoggableInterceptor.invocations.get(Driver.class.getName()+"."+"alwaysSucceed");
         assertNotNull(invocationCount);
         assertEquals(1, (int) invocationCount);
     }

--- a/dev/com.ibm.ws.microprofile.rest.client.FT_fat/test-applications/timeoutApp/src/mpRestClientFT/timeout/TimeoutTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client.FT_fat/test-applications/timeoutApp/src/mpRestClientFT/timeout/TimeoutTestServlet.java
@@ -52,7 +52,9 @@ public class TimeoutTestServlet extends FATServlet {
     }
 
     @Test
-    @SkipForRepeat(JakartaEE9Action.ID) // not timing out as expected.. TODO: investigate and resolve
+    @SkipForRepeat(JakartaEE9Action.ID) // this is proper behavior - @Timeout not expected to stop blocking I/O operations
+                                        // note that this works with previous MP Rest Client versions because we set the http
+                                        // connect and read timeouts based on the value of the @Timeout annotation.
     public void testTimeoutOnSyncMethod(HttpServletRequest req, HttpServletResponse resp) throws Exception {
         testTimeout(() -> {return client.sync(WAIT_TIME);}, WAIT_TIME);
     }


### PR DESCRIPTION
This PR partially resolves an issue in MP Rest Client 3.0 wrt to CDI interceptors.  Prior to this change user-provided CDI interceptors (i.e. interceptors in the user application)  enabled via the `@Priority` annotation and bound to MP Rest Client interface methods would be executed twice.  This change resolves this issue so that they are only executed once.

Note that interceptors bound to rest client interface methods that are enabled via the `beans.xml` file are not invoked at all like they were with previous versions of the MP Rest Client. 

While Liberty's CDI implementation does invoke user-provided interceptors when they are enabled via `@Priority`, CDI does not invoke MP Fault Tolerance interceptors (perhaps because those aren't annotated with `@Priority`??).  So this fix (somewhat hackishly) explicitly invokes MP FT interceptors via the Rest Client implementation. This means that potentially other Liberty-provided interceptors would not be invoked. This should be investigated to see if a better solution is possible.