### PR TITLE
asynchronous methods can run inline on join and untimed get

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/WSManagedExecutorService.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/WSManagedExecutorService.java
@@ -11,6 +11,8 @@
 package com.ibm.ws.concurrent;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
 
 import com.ibm.ws.threading.PolicyExecutor;
 import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
@@ -43,4 +45,20 @@ public interface WSManagedExecutorService {
      * @return the policy executor for running tasks against the normal concurrency policy.
      */
     PolicyExecutor getNormalPolicyExecutor();
+
+    /**
+     * Construct a CompletableFuture that represents the execution of an asynchronous method,
+     * to be performed asynchronously to the caller, either on the specified executor
+     * or on a thread that attempts join or untimed get.
+     *
+     * @param <I>        jakarta.interceptor.InvocationContext.
+     * @param <T>        type of result.
+     * @param invoker    completion stage action that invokes the asynchronous method.
+     *                       The first parameter to the BiFunction is the interceptor's InvocationContext.
+     *                       The second parameter is the BiFunction is the CompletableFuture that will be returned to the caller.
+     *                       The result parameter of the BiFunction is the same CompletableFuture.
+     * @param invocation the interceptor's InvocationContext that will be supplied to the BiFunction.
+     * @return CompletableFuture that represents the invocation of the asynchronous method.
+     */
+    <I, T> CompletableFuture<T> newAsyncMethod(BiFunction<I, CompletableFuture<T>, T> invoker, I invocation);
 }

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/ManagedExecutorExtension.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/ManagedExecutorExtension.java
@@ -17,10 +17,12 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import javax.enterprise.concurrent.ContextService;
@@ -146,6 +148,11 @@ public class ManagedExecutorExtension implements CompletionStageExecutor, Manage
     @Override
     public final boolean isTerminated() {
         return ((ExecutorService) executor).isTerminated();
+    }
+
+    @Override
+    public <I, T> CompletableFuture<T> newAsyncMethod(BiFunction<I, CompletableFuture<T>, T> invoker, I invocation) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/AsyncMethod.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/AsyncMethod.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.internal;
+
+import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+
+import com.ibm.ws.concurrent.WSManagedExecutorService;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.wsspi.threadcontext.ThreadContext;
+import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
+
+/**
+ * Represents an asynchronous method (@Asynchronous).
+ * This extension to ManagedCompletableFuture allows join and untimed get
+ * to execute inline if it hasn't already started running.
+ *
+ * @param <T> type of result
+ */
+public class AsyncMethod<I, T> extends ManagedCompletableFuture<T> {
+    /**
+     * Completion stage action that runs the asynchronous method.
+     */
+    private final BiFunction<I, CompletableFuture<T>, T> action;
+
+    /**
+     * Thread context that is captured when the asynchronous method is requested,
+     * and gets applied to the thread upon which the asynchronous method executes.
+     */
+    private final ThreadContextDescriptor contextDescriptor;
+
+    /**
+     * CDI interceptor's jakarta.interceptor.InvocationContext for the asynchronous method.
+     */
+    private final I invocation;
+
+    /**
+     * Remains false until a thread claims the right to run the asynchronous method.
+     */
+    private final AtomicBoolean started = new AtomicBoolean(false);
+
+    /**
+     * Construct a CompletableFuture that represents the execution of the specified action,
+     * to be performed asynchronously to the caller, either on the specified executor
+     * or on a thread that attempts join or untimed get.
+     *
+     * @param <I>        jakarta.interceptor.InvocationContext.
+     * @param <T>        type of result.
+     * @param invoker    completion stage action that invokes the asynchronous method.
+     *                       The first parameter to the BiFunction is the interceptor's InvocationContext.
+     *                       The second parameter is the BiFunction is the CompletableFuture that will be returned to the caller.
+     *                       The result parameter of the BiFunction is the same CompletableFuture.
+     *                       that the Asynchronous method implementation returns to indicate its completion.
+     * @param invocation the interceptor's InvocationContext that will be supplied to the BiFunction.
+     * @param executor   WSManagedExecutorService to submit the asynchronous method to.
+     */
+    public AsyncMethod(BiFunction<I, CompletableFuture<T>, T> invoker, I invocation, Executor executor) {
+        super(executor, supportsAsync(executor));
+
+        if (JAVA8)
+            throw new UnsupportedOperationException();
+
+        rejectManagedTask(invoker);
+
+        this.action = invoker;
+        this.contextDescriptor = ((WSManagedExecutorService) executor).captureThreadContext(XPROPS_SUSPEND_TRAN);
+        this.invocation = invocation;
+
+        ((Executor) futureRef).execute(this::runIfNotStarted);
+    }
+
+    @Override
+    public T get() throws ExecutionException, InterruptedException {
+        runIfNotStarted();
+        return super.get();
+    }
+
+    @Override
+    public T join() {
+        runIfNotStarted();
+        return super.join();
+    }
+
+    /**
+     * Run the method inline if it hasn't started yet,
+     * and complete this CompletableFuture with its result.
+     */
+    @FFDCIgnore({ Error.class, RuntimeException.class })
+    private void runIfNotStarted() {
+        if (!isDone() && started.compareAndSet(false, true)) {
+            T result = null;
+            Throwable failure = null;
+            ArrayList<ThreadContext> contextApplied = null;
+            try {
+                if (contextDescriptor != null)
+                    contextApplied = contextDescriptor.taskStarting();
+                result = action.apply(invocation, this);
+            } catch (RuntimeException x) {
+                failure = x;
+            } catch (Error x) {
+                failure = x;
+            } finally {
+                try {
+                    if (contextApplied != null)
+                        contextDescriptor.taskStopping(contextApplied);
+                } catch (RuntimeException x) {
+                    failure = x;
+                } finally {
+                    if (failure == null)
+                        super_complete(result);
+                    else
+                        super_completeExceptionally(failure);
+                }
+            }
+        }
+    }
+}

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextualDefaultExecutor.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextualDefaultExecutor.java
@@ -14,7 +14,9 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collection;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.function.BiFunction;
 
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.osgi.framework.BundleContext;
@@ -88,5 +90,10 @@ class ContextualDefaultExecutor implements Executor, WSManagedExecutorService {
     @Trivial
     public int hashCode() {
         return contextService.hashCode(); // for easy correlation in trace with the context service that created it
+    }
+
+    @Override
+    public <I, T> CompletableFuture<T> newAsyncMethod(BiFunction<I, CompletableFuture<T>, T> invoker, I invocation) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedCompletableFuture.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedCompletableFuture.java
@@ -121,7 +121,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
     /**
      * Execution property that indicates a task should run with any previous transaction suspended.
      */
-    private static final Map<String, String> XPROPS_SUSPEND_TRAN = new TreeMap<String, String>();
+    static final Map<String, String> XPROPS_SUSPEND_TRAN = new TreeMap<String, String>();
     static {
         XPROPS_SUSPEND_TRAN.put("jakarta.enterprise.concurrent.TRANSACTION", "SUSPEND");
         XPROPS_SUSPEND_TRAN.put("javax.enterprise.concurrent.TRANSACTION", "SUSPEND");
@@ -161,7 +161,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
      * Reference is null when the action cannot be async.
      * Value is null when an async action has not yet been submitted.
      */
-    private final AtomicReference<Future<?>> futureRef;
+    final AtomicReference<Future<?>> futureRef;
 
     /**
      * Stores a futureRef value to use during construction of a ManagedCompletableFuture.
@@ -1241,7 +1241,8 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
     /**
      * Reject ManagedTask so that we have the flexibility to decide later how to handle ManagedTaskListener and execution properties
      */
-    private static final void rejectManagedTask(Object action) {
+    @Trivial
+    static final void rejectManagedTask(Object action) {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
     }
@@ -1419,7 +1420,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
      * @throws UnsupportedOperation if the executor is incapable of running tasks.
      */
     @Trivial
-    private final static FutureRefExecutor supportsAsync(Executor executor) {
+    final static FutureRefExecutor supportsAsync(Executor executor) {
         if (executor instanceof ExecutorService)
             return new FutureRefExecutor((ExecutorService) executor); // valid
         if (executor instanceof UnusableExecutor)

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
@@ -36,6 +36,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import javax.enterprise.concurrent.ContextService;
@@ -609,6 +610,11 @@ public class ManagedExecutorServiceImpl implements ExecutorService, //
             return getNormalPolicyExecutor().isTerminated();
         else // Section 3.1.6.1 of the Concurrency Utilities spec requires IllegalStateException
             throw new IllegalStateException(new UnsupportedOperationException("isTerminated"));
+    }
+
+    @Override
+    public <I, T> CompletableFuture<T> newAsyncMethod(BiFunction<I, CompletableFuture<T>, T> invoker, I invocation) {
+        return new AsyncMethod<>(invoker, invocation, this);
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/UnusableExecutor.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/UnusableExecutor.java
@@ -11,7 +11,9 @@
 package com.ibm.ws.concurrent.internal;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.function.BiFunction;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrent.WSManagedExecutorService;
@@ -57,5 +59,10 @@ class UnusableExecutor implements Executor, WSManagedExecutorService {
     @Override
     public int hashCode() {
         return contextService.hashCode(); // for easy correlation in trace with the context service that created it
+    }
+
+    @Override
+    public <I, T> CompletableFuture<T> newAsyncMethod(BiFunction<I, CompletableFuture<T>, T> invoker, I invocation) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/dev/io.openliberty.concurrent.cdi/bnd.bnd
+++ b/dev/io.openliberty.concurrent.cdi/bnd.bnd
@@ -44,11 +44,14 @@ instrument.classesExcludes: io/openliberty/concurrent/cdi/resources/*.class
   com.ibm.websphere.javaee.interceptor.1.2,\
   com.ibm.websphere.javaee.transaction.1.2,\
   com.ibm.ws.cdi.interfaces,\
+  com.ibm.ws.concurrent,\
+  com.ibm.ws.threading,\
   io.openliberty.jakarta.annotation.2.0,\
   io.openliberty.jakarta.cdi.3.0,\
   io.openliberty.jakarta.concurrency.3.0,\
   io.openliberty.jakarta.interceptor.2.0,\
-  io.openliberty.jakarta.transaction.2.0
+  io.openliberty.jakarta.transaction.2.0,\
+  jakarta.enterprise.concurrent-api
 #  ../com.ibm.ws.cdi.interfaces/build/libs/com.ibm.ws.cdi.interfaces.jakarta.jar;version=file
 
 # last line above is in place of com.ibm.ws.cdi.interfaces.jakarta;version=latest

--- a/dev/io.openliberty.concurrent.cdi/src/io/openliberty/concurrent/cdi/interceptor/AsyncInterceptor.java
+++ b/dev/io.openliberty.concurrent.cdi/src/io/openliberty/concurrent/cdi/interceptor/AsyncInterceptor.java
@@ -12,12 +12,9 @@ package io.openliberty.concurrent.cdi.interceptor;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
-import java.util.Collections;
-import java.util.Map;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 
 import javax.annotation.Priority;
@@ -29,13 +26,10 @@ import javax.naming.NamingException;
 import javax.transaction.Transactional;
 
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.concurrent.WSManagedExecutorService;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
-import jakarta.enterprise.concurrent.AbortedException;
 import jakarta.enterprise.concurrent.Asynchronous;
-import jakarta.enterprise.concurrent.ManagedExecutorService;
-import jakarta.enterprise.concurrent.ManagedTask;
-import jakarta.enterprise.concurrent.ManagedTaskListener;
 
 @Asynchronous
 @Interceptor
@@ -45,8 +39,8 @@ public class AsyncInterceptor implements Serializable {
 
     @AroundInvoke
     @FFDCIgnore({ ClassCastException.class, NamingException.class }) // application errors raised directly to the app
-    public Object intercept(InvocationContext context) throws Exception {
-        Method method = context.getMethod();
+    public Object intercept(InvocationContext invocation) throws Exception {
+        Method method = invocation.getMethod();
         validateTransactional(method);
         if (method.getDeclaringClass().getAnnotation(Asynchronous.class) != null)
             throw new UnsupportedOperationException("@Asynchronous " + method.getDeclaringClass()); // TODO NLS?
@@ -60,7 +54,7 @@ public class AsyncInterceptor implements Serializable {
             && !returnType.equals(Void.TYPE)) // void
             throw new UnsupportedOperationException("@Asynchronous " + returnType.getName() + " " + method.getName()); // TODO NLS?
 
-        ManagedExecutorService executor;
+        WSManagedExecutorService executor;
         try {
             executor = InitialContext.doLookup(anno.executor());
         } catch (ClassCastException x) {
@@ -69,17 +63,44 @@ public class AsyncInterceptor implements Serializable {
             throw new RejectedExecutionException(x);
         }
 
-        // TODO allow join and untimed get to run the method inline if not already started?
-        AsyncMethod asyncMethod = new AsyncMethod(executor, context);
-        Future<?> policyTaskFuture = executor.submit(asyncMethod, asyncMethod);
-        // If caller cancels the future, cancel the policy executor task that will run it
-        // TODO - should this action be taken whenever completed prematurely?
-        asyncMethod.future.exceptionally(failure -> { // TODO this doesn't need thread context overhead
-            if (failure instanceof CancellationException)
-                policyTaskFuture.cancel(true);
-            return null;
-        });
-        return asyncMethod.future;
+        return executor.newAsyncMethod(this::invoke, invocation);
+    }
+
+    /**
+     * Invokes the asynchronous method either on a thread from the managed executor, or possibly
+     * inline in response to a join or untimed get.
+     *
+     * @param <T>        type of result.
+     * @param invocation interceptor's invocation context.
+     * @param future     CompletableFuture that will be returned to the caller of the asynchronous method.
+     * @return the same future that will be returned to the caller of the asynchronous method.
+     */
+    @FFDCIgnore(Throwable.class) // errors raised by an @Asynchronous method implementation
+    public <T> CompletableFuture<T> invoke(InvocationContext invocation, CompletableFuture<T> future) {
+        Asynchronous.Result.setFuture(future);
+        try {
+            Object returnVal = invocation.proceed();
+            if (returnVal != future)
+                if (returnVal == null) {
+                    future.complete(null);
+                } else { // returnVal must be CompletionStage or CompletableFuture per prior validation
+                    @SuppressWarnings("unchecked")
+                    CompletionStage<T> stage = (CompletionStage<T>) returnVal;
+                    stage.whenComplete((result, failure) -> { // TODO inefficient if a ManagedCompletableFuture
+                        if (failure == null)
+                            future.complete(result);
+                        else
+                            future.completeExceptionally(failure);
+                    });
+                }
+        } catch (Throwable x) {
+            if (x instanceof CompletionException && x.getCause() != null)
+                x = x.getCause();
+            future.completeExceptionally(x);
+        } finally {
+            Asynchronous.Result.setFuture(null);
+        }
+        return future;
     }
 
     /**
@@ -88,6 +109,7 @@ public class AsyncInterceptor implements Serializable {
      * @param method annotated method.
      * @throws UnsupportedOperationException for unsupported combinations.
      */
+    @Trivial
     private static void validateTransactional(Method method) throws UnsupportedOperationException {
         Transactional tx = method.getAnnotation(Transactional.class);
         if (tx == null)
@@ -100,87 +122,5 @@ public class AsyncInterceptor implements Serializable {
                 default:
                     throw new UnsupportedOperationException("@Asynchronous @Transactional(" + tx.value().name() + ")");
             }
-    }
-
-    private static class AsyncMethod implements Runnable, ManagedTask, ManagedTaskListener {
-        private final Map<String, String> execProps;
-        private final CompletableFuture<Object> future;
-        private final InvocationContext invocation;
-
-        @Trivial
-        private AsyncMethod(ManagedExecutorService executor, InvocationContext invocation) throws Exception {
-            execProps = Collections.singletonMap(ManagedTask.IDENTITY_NAME, "@Asynchronous " + invocation.getMethod().getName());
-            future = executor.newIncompleteFuture();
-            this.invocation = invocation;
-        }
-
-        @Override
-        @Trivial
-        public Map<String, String> getExecutionProperties() {
-            return execProps;
-        }
-
-        @Override
-        @Trivial
-        public ManagedTaskListener getManagedTaskListener() {
-            return this;
-        }
-
-        /**
-         * Runs the asynchronous method.
-         */
-        @FFDCIgnore(Throwable.class) // application errors are raised directly to the application
-        @Override
-        public void run() {
-            Asynchronous.Result.setFuture(future);
-            try {
-                Object returnVal = invocation.proceed();
-                if (returnVal != future)
-                    if (returnVal instanceof CompletionStage) { // which includes CompletableFuture
-                        @SuppressWarnings("unchecked")
-                        CompletionStage<Object> stage = (CompletionStage<Object>) returnVal;
-                        stage.whenComplete((result, failure) -> {
-                            if (failure == null)
-                                future.complete(result);
-                            else
-                                future.completeExceptionally(failure);
-                        });
-                    } else if (returnVal == null) {
-                        future.complete(null);
-                    } else { // returned object is not a CompletionStage or CompletableFuture
-                        throw new UnsupportedOperationException("@Asynchronous with result type " + returnVal.getClass().getName());
-                    }
-            } catch (Throwable x) {
-                future.completeExceptionally(x);
-                // TODO when is setRollbackOnly appropriate?
-            } finally {
-                Asynchronous.Result.setFuture(null);
-            }
-        }
-
-        /**
-         * Complete the future exceptionally if the task is aborted.
-         */
-        @Override
-        public void taskAborted(Future<?> policyTaskFuture, ManagedExecutorService executor, Object task, Throwable exception) {
-            if (exception instanceof AbortedException && exception.getCause() != null)
-                exception = new CancellationException(exception.getMessage()).initCause(exception.getCause());
-            future.completeExceptionally(exception);
-        }
-
-        @Override
-        @Trivial
-        public void taskDone(Future<?> policyTaskFuture, ManagedExecutorService executor, Object task, Throwable exception) {
-        }
-
-        @Override
-        @Trivial
-        public void taskStarting(Future<?> policyTaskFuture, ManagedExecutorService executor, Object task) {
-        }
-
-        @Override
-        @Trivial
-        public void taskSubmitted(Future<?> policyTaskFuture, ManagedExecutorService executor, Object task) {
-        }
     }
 }


### PR DESCRIPTION
When join or untimed get is invoked on the CompletableFuture for an Asynchronous method, the method can run inline on the join/get thread if it hasn't already started.