### PR TITLE
featureUtility installServerFeatures user feature bug

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
+++ b/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
@@ -622,14 +622,21 @@ public class FeatureUtility {
     }
 
     /**
-     * Extracts the feature name and version from an ESA filepath. Example:
-     * extractFeature(appSecurity-3.0-19.0.0.8.esa) returns appSecurity-3.0
-     * 
-     * @param filename
-     * @return
-     */
+	 * Extracts the feature name from an ESA filepath. Example:
+	 * extractFeature(appSecurity-3.0-19.0.0.8.esa) returns appSecurity-3.0 filename
+	 * extractFeature(userFeature1-1.0.esa) returns userFeature1 filename filename
+	 * cannot be null
+	 * 
+	 * @param filename
+	 * @return returns the feature name from the esa file path
+	 */
     private String extractFeature(String filename) {
-        return filename.replaceFirst("(-\\d\\d\\.\\d\\.\\d\\.\\d\\.esa)", "");
+		String[] split = filename.split("-");
+		if (split.length > 2) {
+			return split[0] + "-" + split[1];
+		}
+
+		return split[0];
     }
 
     public List<File> getJsonFiles(File fromDir, Set<String> jsonsRequired) throws InstallException {

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/AbstractDirector.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/AbstractDirector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -51,9 +51,9 @@ public abstract class AbstractDirector {
     /**
      * Creates a Progress event message.
      *
-     * @param state the state integer
+     * @param state    the state integer
      * @param progress the progress integer
-     * @param message the message to be displayed
+     * @param message  the message to be displayed
      */
     void fireProgressEvent(int state, int progress, String message) {
         try {
@@ -65,9 +65,9 @@ public abstract class AbstractDirector {
     /**
      * Creates a Progress event message that can handle cancel exceptions.
      *
-     * @param state the state integer
-     * @param progress the progress integer
-     * @param message the message to be displayed
+     * @param state       the state integer
+     * @param progress    the progress integer
+     * @param message     the message to be displayed
      * @param allowCancel if cancel exceptions should be handled
      * @throws InstallException
      */
@@ -91,7 +91,7 @@ public abstract class AbstractDirector {
      * Logs a message.
      *
      * @param level the level of the message
-     * @param msg the message
+     * @param msg   the message
      */
     void log(Level level, String msg) {
         if (msg != null && !msg.isEmpty())
@@ -102,8 +102,8 @@ public abstract class AbstractDirector {
      * Logs a message with an exception.
      *
      * @param level the level of the message
-     * @param msg the message
-     * @param e the exception causing the message
+     * @param msg   the message
+     * @param e     the exception causing the message
      */
     void log(Level level, String msg, Exception e) {
         if (e != null)
@@ -148,13 +148,19 @@ public abstract class AbstractDirector {
      * Checks if the feature is in installedFeatures
      *
      * @param installedFeatures the map of installed features
-     * @param feature the feature to look for
+     * @param feature           the feature to look for
      * @return true if feature is in installedFeatures
      */
     boolean containFeature(Map<String, ProvisioningFeatureDefinition> installedFeatures, String feature) {
+        if (feature.split(":").length == 2)
+            feature = feature.split(":")[1];
+
         if (installedFeatures.containsKey(feature))
             return true;
         for (ProvisioningFeatureDefinition pfd : installedFeatures.values()) {
+            if (pfd.getSymbolicName().equals(feature)) {
+                return true;
+            }
             String shortName = InstallUtils.getShortName(pfd);
             if (shortName != null && shortName.equalsIgnoreCase(feature))
                 return true;
@@ -166,7 +172,7 @@ public abstract class AbstractDirector {
      * Creates a collection of features that still need to be installed
      *
      * @param requiredFeatures Collection of all features that should be installed
-     * @param download if all features (including already installed) should be downloaded
+     * @param download         if all features (including already installed) should be downloaded
      * @return The subset of requiredFeatures containing features that still need to be installed
      */
     Collection<String> getFeaturesToInstall(Collection<String> requiredFeatures, boolean download) {


### PR DESCRIPTION
fixes #19631

- extractFeature(String filename) does not extract feature name correctly from the filename. 
    - user features doesn't necessarily have the same version as the Liberty version. i.e) userfeature-1.0 instead of userfeature-21.0.0.9

- containFeature(Map<String, ProvisioningFeatureDefinition> installedFeatures, String feature):
    - user features that are listed in server.xml can have [product extensions](https://www.ibm.com/docs/en/was-liberty/base?topic=overview-product-extension) as `[extension:featureName]`. e.g) `<feature>myExt:userfeature-1.0</feature>`
    - need to pass in the feature name without the extension
    - Liberty feature manifest doesn't require `IBM-ShortName` [(reference)](https://www.ibm.com/docs/en/was-liberty/base?topic=manually-liberty-feature-manifest-files) . User feature might not have this header. Checking the required header `Subsystem-SymbolicName` first to see if the features are already installed. 