### PR TITLE
Add new name of AdoptOpenJDK to isWin Acme check

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
@@ -903,7 +903,13 @@ public class AcmeFatUtils {
 				skipOnWin = true;
 			} else if (javaVendor.contains("temurin") && javaVersion.equals("1.8.0_302")) {
 				/*
-				 * Delete issue popped on temurin as well. The "if" check was getting complicated to read so breaking these vendor/version checks into
+				 * Delete issue popped on new AdoptOpenJDK name, temurin, as well. The "if" check was getting complicated to read so breaking these vendor/version checks into
+				 * more if/else branches to making it easier to follow.
+				 */
+				skipOnWin = true;
+			} else if (javaVendor.contains("eclipse adoptium") && javaVersion.equals("11.0.13")) {
+				/*
+				 * Delete issue popped on new AdoptOpenJDK name, eclipse adoptium, as well. The "if" check was getting complicated to read so breaking these vendor/version checks into
 				 * more if/else branches to making it easier to follow.
 				 */
 				skipOnWin = true;


### PR DESCRIPTION
AdoptOpenJDK vendor name is changing, adding new vendor name check for ACME FAT `isWindowsWithOpenJDK` checking.

RTC 287990