### PR TITLE
openapi: cancel module listener job on shutdown

### DIFF
--- a/dev/com.ibm.ws.openapi.3.1/src/com/ibm/ws/openapi31/OpenAPIModuleListener.java
+++ b/dev/com.ibm.ws.openapi.3.1/src/com/ibm/ws/openapi31/OpenAPIModuleListener.java
@@ -116,6 +116,7 @@ public class OpenAPIModuleListener implements ModuleMetaDataListener, VirtualHos
 
     @Deactivate
     protected void deactivate(ComponentContext context, int reason) {
+        cancelScheduler();
         executorServiceRef.deactivate(context);
         this.context = null;
     }


### PR DESCRIPTION
When the OpenAPIModuleListener component is deactivated, it should
cancel its scheduled task if it's still running.

For RTC 274019