### PR TITLE
Enable Last Two EE9 Grpc Tests

### DIFF
--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/GrpcMetricsTest.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/GrpcMetricsTest.java
@@ -36,7 +36,6 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldCDITests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldCDITests.java
@@ -29,7 +29,6 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldTest.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldTest.java
@@ -26,7 +26,6 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 

--- a/dev/com.ibm.ws.grpc_fat/test-applications/StoreConsumerApp.war/src/com/ibm/testapp/g3store/restConsumer/client/ConsumerEndpointFATServlet.java
+++ b/dev/com.ibm.ws.grpc_fat/test-applications/StoreConsumerApp.war/src/com/ibm/testapp/g3store/restConsumer/client/ConsumerEndpointFATServlet.java
@@ -43,7 +43,6 @@ import com.ibm.testapp.g3store.restProducer.model.Price;
 import com.ibm.testapp.g3store.restProducer.model.Price.PurchaseType;
 import com.ibm.testapp.g3store.utilsConsumer.ConsumerUtils;
 
-import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 /**
@@ -123,7 +122,6 @@ public class ConsumerEndpointFATServlet extends FATServlet {
      * @throws Exception
      */
     @Test
-    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     public void testGetAppInfo_Bad_BasicAuth(HttpServletRequest req, HttpServletResponse resp) throws Exception {
         this.getAppInfo_BadBasicAuth(req, resp);
     }

--- a/dev/com.ibm.ws.grpc_fat/test-applications/StoreConsumerApp.war/src/com/ibm/testapp/g3store/restConsumer/client/ConsumerEndpointJWTCookieFATServlet.java
+++ b/dev/com.ibm.ws.grpc_fat/test-applications/StoreConsumerApp.war/src/com/ibm/testapp/g3store/restConsumer/client/ConsumerEndpointJWTCookieFATServlet.java
@@ -42,7 +42,6 @@ import com.ibm.testapp.g3store.restProducer.model.Price;
 import com.ibm.testapp.g3store.restProducer.model.Price.PurchaseType;
 import com.ibm.testapp.g3store.utilsConsumer.ConsumerUtils;
 
-import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 /**
@@ -126,7 +125,6 @@ public class ConsumerEndpointJWTCookieFATServlet extends FATServlet {
      * @throws Exception
      */
     @Test
-    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     public void testGetApp_BadRole_JWTCookie_GrpcClient(HttpServletRequest req, HttpServletResponse resp) throws Exception {
         this.getAppName_BadRole_CookieAuth_GrpcClient(req, resp);
     }

--- a/dev/io.openliberty.grpc.1.0.internal/src/io/openliberty/grpc/internal/servlet/GrpcServerComponent.java
+++ b/dev/io.openliberty.grpc.1.0.internal/src/io/openliberty/grpc/internal/servlet/GrpcServerComponent.java
@@ -280,7 +280,7 @@ public class GrpcServerComponent implements ServletContainerInitializer, Applica
     private void setSecurityEnabled() {
         Set<String> currentFeatureSet = _featureProvisioner.getService().getInstalledFeatures();
         if (currentFeatureSet.contains("appSecurity-2.0") || currentFeatureSet.contains("appSecurity-1.0")
-                || currentFeatureSet.contains("appSecurity-3.0")) {
+                || currentFeatureSet.contains("appSecurity-3.0") || currentFeatureSet.contains("appSecurity-4.0")) {
             useSecurity = true;
             return;
         }


### PR DESCRIPTION
fixes #19592

Turns out GrpcServerComponent#setSecurityEnabled was missing a check for the new appSecurity-4.0 feature. 