### PR TITLE
featureUtility fat test clean up 

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
@@ -122,10 +122,11 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 		// Begin Test
 		String[] param1s = { "installFeature", "jsp-2.2", "jsp-2.3", "--verbose" };
 		ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
-		assertEquals("Exit code should be 0", 0, po.getReturnCode());
 		String output = po.getStdout();
+
 		assertTrue("Should contain jsp-2.2", output.contains("jsp-2.2"));
 		assertTrue("Should contain jsp-2.3", output.contains("jsp-2.3"));
+		assertEquals("Exit code should be 0", 0, po.getReturnCode());
 	}
 
 	/**
@@ -160,9 +161,10 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 		String[] param1s = { "installFeature", "json-1.0", "--verbose" };
 //		String[] fileLists = { "lib/features/com.ibm.websphere.appserver.json-1.0.mf" };
 		ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
-		assertEquals("Exit code should be 0", 0, po.getReturnCode());
 		String output = po.getStdout();
+
 		assertTrue("Should contain json-1.0", output.contains("json-1.0"));
+		assertEquals("Exit code should be 0", 0, po.getReturnCode());
 
 		Log.exiting(c, METHOD_NAME);
 	}
@@ -221,10 +223,11 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 //		String[] fileListB = { "lib/features/com.ibm.websphere.appserver.osgiConsole-1.0.mf" };
 
 		ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
-		assertEquals("Exit code should be 0", 0, po.getReturnCode());
 		String output = po.getStdout();
+
 		assertTrue("Output should contain eventLogging-1.0", output.indexOf("eventLogging-1.0") >= 0);
 		assertTrue("Output should contain osgiConsole-1.0", output.indexOf("osgiConsole-1.0") >= 0);
+		assertEquals("Exit code should be 0", 0, po.getReturnCode());
 
 		Log.exiting(c, METHOD_NAME);
 	}
@@ -367,11 +370,11 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 		String[] param1s = { "installFeature", "el-3.0", "--verbose" };
 
 		ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
-		assertEquals("Exit code should be 0", 0, po.getReturnCode());
 		String output = po.getStdout();
-		assertTrue("Should contain el-3.0", output.contains("el-3.0"));
 
 		deleteEtcFolder(METHOD_NAME);
+		assertTrue("Should contain el-3.0", output.contains("el-3.0"));
+		assertEquals("Exit code should be 0", 0, po.getReturnCode());
 
 		Log.exiting(c, METHOD_NAME);
 	}
@@ -398,10 +401,11 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 		String[] param1s = { "installFeature",
 				"veryClearlyMadeUpFeatureThatNoOneWillEverThinkToCreateThemselvesAbCxYz-1.0", "--verbose" };
 		ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
-		assertEquals("Exit code should be 21", 21, po.getReturnCode());
 		String output = po.getStdout();
+
 		assertTrue("Should contain CWWKF1299E or CWWKF1203E",
 				output.indexOf("CWWKF1402E") >= 0 || output.indexOf("CWWKF1203E") >= 0);
+		assertEquals("Exit code should be 21", 21, po.getReturnCode());
 
 		Log.exiting(c, METHOD_NAME);
 	}
@@ -446,9 +450,9 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 		assertTrue("Should contain ssl-1.0", output.contains("ssl-1.0"));
 
 		po = runFeatureUtility(METHOD_NAME, param1s);
-		assertEquals("Exit code should be 22 indicating already installed feature", 22, po.getReturnCode());
 		output = po.getStdout();
 		assertTrue("Should contain CWWKF1250I", output.contains("CWWKF1250I"));
+		assertEquals("Exit code should be 22 indicating already installed feature", 22, po.getReturnCode());
 
 		Log.exiting(c, METHOD_NAME);
 	}
@@ -476,9 +480,10 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 
 		String[] param1s = { "if", "io.openliberty.features:mpHealth", "--verbose" };
 		ProgramOutput po = runFeatureUtility(methodName, param1s);
-		assertEquals("Invalid feature shortname", 21, po.getReturnCode());
 		String output = po.getStdout();
+
 		assertTrue("Expected CWWKF1402E", output.indexOf("CWWKF1402E") >= 0);
+		assertEquals("Invalid feature shortname", 21, po.getReturnCode());
 
 	}
 
@@ -496,9 +501,10 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 		String oldVersion = "19.0.0.1";
 		String[] param1s = { "if", "io.openliberty.features:mpHealth-2.0:" + oldVersion, "--verbose" };
 		ProgramOutput po = runFeatureUtility(methodName, param1s);
-		assertEquals("Incompatible feature version", 21, po.getReturnCode());
 		String output = po.getStdout();
+
 		assertTrue("Expected CWWKF1395E msg", output.indexOf("CWWKF1395E") >= 0);
+		assertEquals("Incompatible feature version", 21, po.getReturnCode());
 
 	}
 
@@ -572,9 +578,10 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 
 		String[] param1s = { "if", " ", "--verbose" };
 		ProgramOutput po = runFeatureUtility(methodName, param1s);
-		assertEquals(20, po.getReturnCode()); // 20 refers to ReturnCode.BAD_ARGUMENT
 		String output = po.getStdout();
+
 		assertTrue("Should refer to ./featureUtility help", output.indexOf("Usage") >= 0);
+		assertEquals(20, po.getReturnCode()); // 20 refers to ReturnCode.BAD_ARGUMENT
 
 	}
 
@@ -591,12 +598,14 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 		copyFileToMinifiedRoot("etc", "../../publish/tmp/cleanPropertyFile/featureUtility.properties");
 		String[] param1s = { "viewSettings", "--viewvalidationmessages" };
 		ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
-		assertEquals(0, po.getReturnCode());
 		String output = po.getStdout();
-		assertTrue("Should pass validation",
-				output.contains("Validation Results: The properties file successfully passed the validation."));
 
 		deleteEtcFolder(METHOD_NAME);
+		assertTrue("Should pass validation",
+				output.contains("Validation Results: The properties file successfully passed the validation."));
+		assertEquals(0, po.getReturnCode());
+
+
 		Log.exiting(c, METHOD_NAME);
 	}
 
@@ -613,11 +622,11 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 		copyFileToMinifiedRoot("etc", "../../publish/tmp/invalidPropertyFile/featureUtility.properties");
 		String[] param1s = { "viewSettings", "--viewvalidationmessages" };
 		ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
-		assertEquals(20, po.getReturnCode());
 		String output = po.getStdout();
-		assertTrue("Shouldnt pass validation", output.contains("Number of errors"));
 
+		assertTrue("Shouldnt pass validation", output.contains("Number of errors"));
 		deleteEtcFolder(METHOD_NAME);
+		assertEquals(20, po.getReturnCode());
 		Log.exiting(c, METHOD_NAME);
 	}
 
@@ -644,7 +653,6 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 				"../../publish/repo/com/ibm/ws/userFeature/testesa1/19.0.0.8/testesa1-19.0.0.8.esa");
 
 		writeToProps(minifiedRoot + "/etc/featureUtility.properties", "featureLocalRepo", minifiedRoot + "/repo/");
-		writeToProps(minifiedRoot + "/etc/featureUtility.properties", "enable.options", "true");
 
 		String[] filesList = { "usr/extension/lib/features/testesa1.mf", "usr/extension/bin/testesa1.bat" };
 
@@ -655,10 +663,11 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 
 		assertTrue("Should contain testesa1", output.contains("testesa1"));
 		assertFilesExist(filesList);
-		assertEquals("Exit code should be 0", 0, po.getReturnCode());
 
 		deleteUsrExtFolder(METHOD_NAME);
 		deleteEtcFolder(METHOD_NAME);
+
+		assertEquals("Exit code should be 0", 0, po.getReturnCode());
 		Log.exiting(c, METHOD_NAME);
 	}
 
@@ -685,7 +694,6 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 				"../../publish/repo/com/ibm/ws/userFeature/testesa1/19.0.0.8/testesa1-19.0.0.8.esa");
 
 		writeToProps(minifiedRoot + "/etc/featureUtility.properties", "featureLocalRepo", minifiedRoot + "/repo/");
-		writeToProps(minifiedRoot + "/etc/featureUtility.properties", "enable.options", "true");
 
 		String[] param1s = { "installFeature", "testesa1", "--featuresBOM=com.ibm.ws.userFeature:features-bom:19.0.0.8",
 				"--to=ext.test", "--verbose" };
@@ -700,10 +708,12 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 
 		assertTrue("Should contain testesa1", output.contains("testesa1"));
 		assertFilesExist(filesList);
-		assertEquals("Exit code should be 0", 0, po.getReturnCode());
 
 		deleteUsrToExtFolder(METHOD_NAME);
 		deleteEtcFolder(METHOD_NAME);
+
+		assertEquals("Exit code should be 0", 0, po.getReturnCode());
+
 		Log.exiting(c, METHOD_NAME);
 	}
 
@@ -719,16 +729,16 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 		copyFileToMinifiedRoot("etc", "../../publish/propertyFiles/publishRepoOverrideProps/featureUtility.properties");
 
 		writeToProps(minifiedRoot + "/etc/featureUtility.properties", "featureLocalRepo", minifiedRoot + "/repo/");
-		writeToProps(minifiedRoot + "/etc/featureUtility.properties", "enable.options", "true");
 
 		String[] param1s = { "installFeature", "testesa1", "--featuresBOM=invalid:invalid:19.0.0.8", "--verbose" };
 
 		ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
-		assertEquals("Exit code should be 21", 21, po.getReturnCode());
 		String output = po.getStdout();
-		assertTrue("Should contain CWWKF1409E", output.contains("CWWKF1409E"));
 
 		deleteEtcFolder(METHOD_NAME);
+
+		assertTrue("Should contain CWWKF1409E", output.contains("CWWKF1409E"));
+		assertEquals("Exit code should be 21", 21, po.getReturnCode());
 		Log.exiting(c, METHOD_NAME);
 	}
 
@@ -744,7 +754,6 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 		copyFileToMinifiedRoot("etc", "../../publish/propertyFiles/publishRepoOverrideProps/featureUtility.properties");
 
 		writeToProps(minifiedRoot + "/etc/featureUtility.properties", "featureLocalRepo", minifiedRoot + "/repo/");
-		writeToProps(minifiedRoot + "/etc/featureUtility.properties", "enable.options", "true");
 
 		String[] param1s = { "installFeature", "testesa1", "--featuresBOM=com.ibm.ws.userFeature:invalid",
 				"--verbose" };
@@ -752,10 +761,11 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 		ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
 		String output = po.getStdout();
 
+		deleteEtcFolder(METHOD_NAME);
+
 		assertTrue("Should contain CWWKF1503E", output.contains("CWWKF1503E"));
 		assertEquals("Exit code should be 21", 21, po.getReturnCode());
 
-		deleteEtcFolder(METHOD_NAME);
 		Log.exiting(c, METHOD_NAME);
 	}
 
@@ -806,11 +816,11 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 		String[] param1s = { "installFeature", "json-1.0", "--verbose" };
 		ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
 
-		assertEquals("Exit code should be 0", 0, po.getReturnCode());
-
 		// delete manifest file so the tool doesn't pick up.
 		deleteFiles(METHOD_NAME, "testIfix-1.0",
 				new String[] { relativeMinifiedRoot + "/wlp/lib/platform/testIfix-1.0.mf" });
+
+		assertEquals("Exit code should be 0", 0, po.getReturnCode());
 
 		Log.exiting(c, METHOD_NAME);
 	}

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallServerTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallServerTest.java
@@ -77,68 +77,52 @@ public class InstallServerTest extends FeatureUtilityToolTest {
         copyFileToMinifiedRoot("usr/servers/serverY", "../../publish/tmp/noFeaturesServerXml/server.xml");
         String[] param2s = { "installServerFeatures", "serverY", "--verbose"};
 
-
-        ProgramOutput po = runFeatureUtility(METHOD_NAME, param2s);
-        assertEquals("Exit code should be 0",0, po.getReturnCode());
+		ProgramOutput po = runFeatureUtility(METHOD_NAME, param2s);
         String output = po.getStdout();
-
         String noFeaturesMessage = "The server does not require any additional features.";
+
         assertTrue("No features should be installed", output.indexOf(noFeaturesMessage) >= 0);
+        assertEquals("Exit code should be 0",0, po.getReturnCode());
 
         Log.exiting(c, METHOD_NAME);
     }
 
-//    /**
-//     * // TODO. this test case will be added once the disableUsrFeatures pull request is merged!!
-//     * @throws Exception
-//     */
-//    @Test
-//    public void testUsrFeatureServerXml() throws Exception {
-//        String METHOD_NAME = "testUsrFeatureServerXml";
-//        copyFileToMinifiedRoot("usr/servers/serverZ", "../../publish/tmp/usrFeaturesServerXml/server.xml");
-//        String[] param2s = { "installServerFeatures", "serverZ"};
-//        deleteFeaturesAndLafilesFolders(METHOD_NAME);
-//
-//
-//        ProgramOutput po = runFeatureUtility(METHOD_NAME, param2s);
-//        assertEquals("Exit code should be 0",0, po.getReturnCode());
-//        String output = po.getStdout();
-//        // server.xml contains jsp-2.3, so jsp-2.3 should be installed.
-//        assertTrue("Output should contain jsp-2.3", output.indexOf("jsp-2.3") >= 0);
-//
-//        String noFeaturesMessage = InstallLogUtils.Messages.INSTALL_KERNEL_MESSAGES.getMessage("MSG_SERVER_NEW_FEATURES_NOT_REQUIRED");
-//        assertTrue("No features should be installed", output.indexOf(noFeaturesMessage) >= 0);
-//    }
 
-//    /**
-//     * Install a server twice.
-//     */
-//    public void testAlreadyInstalledFeatures() throws Exception {
-//        final String METHOD_NAME = "testAlreadyInstalledFeatures";
-//        Log.entering(c, METHOD_NAME);
-//
-//        // replace the server.xml
-//        copyFileToMinifiedRoot("usr/servers/serverX", "../../publish/tmp/plainServerXml/server.xml");
-//
-//        // install the server
-//        String[] param1s = { "installServerFeatures", "serverX"};
-//        deleteFeaturesAndLafilesFolders(METHOD_NAME);
-//        ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
-//        assertEquals("Exit code should be 0",0, po.getReturnCode());
-//        String output = po.getStdout();
-//        assertTrue("Output should contain jsp-2.3", output.indexOf("jsf-2.2") >= 0);
-//
-//        // install server again
-//        deleteFeaturesAndLafilesFolders(METHOD_NAME);
-//        po = runFeatureUtility(METHOD_NAME, param1s);
-//        assertEquals("Exit code should be 22",22, po.getReturnCode());
-////        output = po.getStdout();
-////        assertTrue("Output should contain jsp-2.3", output.indexOf("jsf-2.2") >= 0);
-//
-//
-//
-//        Log.exiting(c, METHOD_NAME);
-//    }
+
+	/**
+	 * Install a server twice. If new features are added, it should install new
+	 * features. If all features all already installed, then exit with rc = 0.
+	 */
+	@Test
+	public void testAlreadyInstalledFeatures() throws Exception {
+		final String METHOD_NAME = "testAlreadyInstalledFeatures";
+		Log.entering(c, METHOD_NAME);
+
+		copyFileToMinifiedRoot("etc", "../../publish/propertyFiles/publishRepoOverrideProps/featureUtility.properties");
+
+		copyFileToMinifiedRoot("repo/com/ibm/websphere/appserver/features/features/21.0.0.4",
+				"../../publish/repo/com/ibm/websphere/appserver/features/features/21.0.0.4/features-21.0.0.4.json");
+
+		copyFileToMinifiedRoot("repo/io/openliberty/features/features/21.0.0.4",
+				"../../publish/repo/io/openliberty/features/features/21.0.0.4/features-21.0.0.4.json");
+
+		copyFileToMinifiedRoot("repo/io/openliberty/features/json-1.0/21.0.0.4",
+				"../../publish/repo/io/openliberty/features/json-1.0/21.0.0.4/json-1.0-21.0.0.4.esa");
+
+		// replace the server.xml
+		copyFileToMinifiedRoot("usr/servers/serverX", "../../publish/tmp/plainServerXml/server.xml");
+
+		// install the server
+		String[] param1s = { "installServerFeatures", "serverX" };
+		ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
+		assertEquals("Exit code should be 0", 0, po.getReturnCode());
+
+		// install server again
+		po = runFeatureUtility(METHOD_NAME, param1s);
+		assertEquals("Exit code should be 0", 0, po.getReturnCode());
+
+		Log.exiting(c, METHOD_NAME);
+	}
 
 
     /**
@@ -184,9 +168,9 @@ public class InstallServerTest extends FeatureUtilityToolTest {
         String [] param1s = {"installFeature", "osgiConsole-1.0", "--verbose"};
 
         ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
-        assertEquals("Exit code should be 0",0, po.getReturnCode());
         String output = po.getStdout();
         assertTrue("Output should contain osgiConsole-1.0", output.indexOf("osgiConsole-1.0") >= 0);
+		assertEquals("Exit code should be 0", 0, po.getReturnCode());
 
         // replace the server.xml and install from server.xml now
         copyFileToMinifiedRoot("usr/servers/serverX", "../../publish/tmp/autoFeatureServerXml/server.xml");
@@ -195,12 +179,11 @@ public class InstallServerTest extends FeatureUtilityToolTest {
 
 
         po = runFeatureUtility(METHOD_NAME, param2s);
-        assertEquals("Exit code should be 0",0, po.getReturnCode());
         output = po.getStdout();
         assertTrue("Output should contain osgiConsole-1.0", output.indexOf("osgiConsole-1.0") >= 0);
         assertTrue("Output should contain eventLogging-1.0", output.indexOf("eventLogging-1.0") >= 0);
         // assertTrue("The autofeature eventLogging-1.0-osgiConsole-1.0 should be installed" , new File(minifiedRoot + "/lib/features/com.ibm.websphere.appserver.eventLogging-1.0-osgiConsole-1.0.mf").exists());
-
+		assertEquals("Exit code should be 0", 0, po.getReturnCode());
         Log.exiting(c, METHOD_NAME);
     }
 
@@ -215,15 +198,31 @@ public class InstallServerTest extends FeatureUtilityToolTest {
         final String METHOD_NAME = "testInvalidMultiVersionFeatures";
         Log.entering(c, METHOD_NAME);
         
+		replaceWlpProperties("20.0.0.4");
+		copyFileToMinifiedRoot("repo/com/ibm/websphere/appserver/features/features/20.0.0.4",
+				"../../publish/repo/com/ibm/websphere/appserver/features/features/20.0.0.4/features-20.0.0.4.json");
 
+		copyFileToMinifiedRoot("repo/io/openliberty/features/features/20.0.0.4",
+				"../../publish/repo/io/openliberty/features/features/20.0.0.4/features-20.0.0.4.json");
+
+		copyFileToMinifiedRoot("repo/io/openliberty/features/jsp-2.3/20.0.0.4",
+				"../../publish/repo/io/openliberty/features/jsp-2.3/20.0.0.4/jsp-2.3-20.0.0.4.esa");
+
+		copyFileToMinifiedRoot("repo/io/openliberty/features/jsp-2.2/20.0.0.4",
+				"../../publish/repo/io/openliberty/features/jsp-2.2/20.0.0.4/jsp-2.2-20.0.0.4.esa");
+
+		copyFileToMinifiedRoot("etc", "../../publish/propertyFiles/publishRepoOverrideProps/featureUtility.properties");
         copyFileToMinifiedRoot("usr/servers/serverX", "../../publish/tmp/multiVersionServerXml/server.xml");
+		writeToProps(minifiedRoot + "/etc/featureUtility.properties", "featureLocalRepo", minifiedRoot + "/repo/");
+
         String[] param1s = { "installServerFeatures", "serverX", "--verbose"};
         ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
-        assertEquals("Exit code should be 21",21, po.getReturnCode());
         String output = po.getStdout();
+
         assertTrue("Should contain CWWKF1405E", output.contains("CWWKF1405E"));
 
 //        deleteFiles(METHOD_NAME, "com.ibm.websphere.appserver.jsp-2.3", fileLists);
+		assertEquals("Exit code should be 21", 21, po.getReturnCode());
         Log.exiting(c, METHOD_NAME);
     }
 
@@ -251,7 +250,6 @@ public class InstallServerTest extends FeatureUtilityToolTest {
                 "../../publish/repo/com/ibm/ws/userFeature/testesa1/19.0.0.8/testesa1-19.0.0.8.esa");
         
         writeToProps(minifiedRoot+ "/etc/featureUtility.properties", "featureLocalRepo", minifiedRoot + "/repo/");
-        writeToProps(minifiedRoot+ "/etc/featureUtility.properties", "enable.options", "true");
         
         String[] filesList = { "usr/extension/lib/features/testesa1.mf",
 								"usr/extension/bin/testesa1.bat" };
@@ -262,10 +260,12 @@ public class InstallServerTest extends FeatureUtilityToolTest {
         
         assertFilesExist(filesList);
         assertTrue("Should contain testesa1", output.contains("testesa1"));
+
+		deleteUsrExtFolder(METHOD_NAME);
+		deleteEtcFolder(METHOD_NAME);
+
         assertEquals("Exit code should be 0",0, po.getReturnCode());
 
-        deleteUsrExtFolder(METHOD_NAME);
-        deleteEtcFolder(METHOD_NAME);
         Log.exiting(c, METHOD_NAME);
     }
     
@@ -294,7 +294,6 @@ public class InstallServerTest extends FeatureUtilityToolTest {
                 "../../publish/repo/com/ibm/ws/userFeature/testesa1/19.0.0.8/testesa1-19.0.0.8.esa");
         
         writeToProps(minifiedRoot+ "/etc/featureUtility.properties", "featureLocalRepo", minifiedRoot + "/repo/");
-        writeToProps(minifiedRoot+ "/etc/featureUtility.properties", "enable.options", "true");
         
         String[] param1s = { "installServerFeatures", "serverX", "--featuresBOM=com.ibm.ws.userFeature:features-bom:19.0.0.8", "--verbose"};
         
@@ -308,10 +307,11 @@ public class InstallServerTest extends FeatureUtilityToolTest {
         
         assertTrue("Should contain testesa1", output.contains("testesa1"));
         assertFilesExist(filesList);
-        assertEquals("Exit code should be 0",0, po.getReturnCode());
 
         deleteUsrToExtFolder(METHOD_NAME);
         deleteEtcFolder(METHOD_NAME);
+
+		assertEquals("Exit code should be 0", 0, po.getReturnCode());
         Log.exiting(c, METHOD_NAME);
     }
 

--- a/dev/com.ibm.ws.install.featureUtility_fat/publish/tmp/plainServerXml/server.xml
+++ b/dev/com.ibm.ws.install.featureUtility_fat/publish/tmp/plainServerXml/server.xml
@@ -3,7 +3,7 @@
 
     <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.3</feature>
+        <feature>json-1.0</feature>
     </featureManager>
 
     <!-- To access this server from a remote client add a host attribute to the following element, e.g. host="*" -->


### PR DESCRIPTION

- testInvalidMultiVersionFeatures() had intermittent connection time out issue. Added a property to use local repo so that it doesn't connect to Maven central repo. 
- switched the order of assertion so that exit codes are checked later. This will help us see the error we are getting. 
- reintroduced testAlreadyInstalledFeatures() for installServerFeatureTest. It should exit with 0 even if the features are already installed. 

Things that can be improved/cleaned up:
- output.contains("[feature]") is probably not a good way to check whether the features are installed properly. We could check /lib/features/[feature].mf file 
- instead of copying json and esa file for each test case, copy once before class (if possible) 