### PR TITLE
Delete renamed private feature.

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.messaging-3.0.internal.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.messaging-3.0.internal.feature
@@ -1,9 +1,0 @@
--include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=io.openliberty.messaging-3.0.internal
-singleton=true
-IBM-App-ForceRestart: uninstall
--features=io.openliberty.messaging.internal-3.0, \
-  com.ibm.websphere.appserver.transaction-2.0
-kind=ga
-edition=base
-WLP-Activation-Type: parallel


### PR DESCRIPTION
- io.openliberty.messaging-3.0.internal was renamed to io.openliberty.messaging.internal-3.0 in order for tolerates to work correctly.  Now that it isn't referenced any more, it can be removed.