### PR TITLE
RM: fix kafka container version

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/containers/KafkaSaslPlainContainer.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/containers/KafkaSaslPlainContainer.java
@@ -50,7 +50,7 @@ public class KafkaSaslPlainContainer extends GenericContainer<KafkaSaslPlainCont
      * @param confluentPlatformVersion
      */
     public KafkaSaslPlainContainer(String confluentPlatformVersion) {
-        super(TestcontainersConfiguration.getInstance().getKafkaImage() + ":" + confluentPlatformVersion);
+        super("confluentinc/cp-kafka:" + confluentPlatformVersion);
 
         network = Network.newNetwork();
 


### PR DESCRIPTION
Requesting the kafka image from testcontainers results in a container
name with :latest.

We only want to move up to latest versions after testing them as they
may need changes in the test setup.

For RTC 288260