### PR TITLE
suppress printed 405 stack trace in messages.log for jaxrs-2.0 and jaxrs-2.1

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/providers/customexceptionmapper/CustomExceptionMapperRegister.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/providers/customexceptionmapper/CustomExceptionMapperRegister.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -39,7 +39,9 @@ public class CustomExceptionMapperRegister implements JaxRsProviderRegister {
         if (!clientSide) {
             if (getAddCustomExceptionMapperFlag(providers))
             {
-                providers.add(new CustomWebApplicationExceptionMapper());
+                CustomWebApplicationExceptionMapper customExceptionMapper = new CustomWebApplicationExceptionMapper();
+                customExceptionMapper.setPrintStackTrace(false); // set to 'false' to avoid printing response errors to Messages.log
+                providers.add(customExceptionMapper);
             }
         }
 

--- a/dev/com.ibm.ws.jaxrs.2.1.common/src/com/ibm/ws/jaxrs20/providers/customexceptionmapper/CustomExceptionMapperRegister.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.common/src/com/ibm/ws/jaxrs20/providers/customexceptionmapper/CustomExceptionMapperRegister.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -39,7 +39,9 @@ public class CustomExceptionMapperRegister implements JaxRsProviderRegister {
         if (!clientSide) {
             if (getAddCustomExceptionMapperFlag(providers))
             {
-                providers.add(new CustomWebApplicationExceptionMapper());
+                CustomWebApplicationExceptionMapper customExceptionMapper = new CustomWebApplicationExceptionMapper();
+                customExceptionMapper.setPrintStackTrace(false); // set to 'false' to avoid printing response errors to Messages.log
+                providers.add(customExceptionMapper);
             }
         }
 


### PR DESCRIPTION
If the server throws an HTTP 405 from either the `jaxrs-2.0` or `jaxrs-2.1` (CXF) features it prints the error stack to the `messages.log` regardless of trace level.

We extend CXF's `WebApplicationExceptionMapper` with our own `CustomWebApplicationExceptionMapper`, so all I had to do was call `WebApplicationExceptionMapper.setPrintStackTrace(false);` to disable printing the stack trace without pulling in more overlay files.