### PR TITLE
remove atomic service reference again with an explicit mandatory

### DIFF
--- a/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/managedobject/CDIManagedObjectService.java
+++ b/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/managedobject/CDIManagedObjectService.java
@@ -17,6 +17,7 @@ import javax.servlet.jsp.HttpJspPage;
 
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
@@ -36,76 +37,40 @@ import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
                                                                                                                                                         "service.ranking:Integer=9999" })
 public class CDIManagedObjectService implements ManagedObjectService {
 
-    private final AtomicServiceReference<CDIService> cdiServiceRef = new AtomicServiceReference<CDIService>("cdiService");
-    private final AtomicServiceReference<DefaultManagedObjectService> defaultMOSRef = new AtomicServiceReference<DefaultManagedObjectService>("defaultManagedObjectService");
-
+    private final DefaultManagedObjectService defaultMOS;
     private CDIRuntime cdiRuntime;
 
-    public void activate(ComponentContext cc) {
-        cdiServiceRef.activate(cc);
-        defaultMOSRef.activate(cc);
+    @Activate
+    public CDIManagedObjectService(@Reference DefaultManagedObjectService defaultMOS) {
+
+        this.defaultMOS = defaultMOS;
     }
 
-    public void deactivate(ComponentContext cc) {
-        cdiServiceRef.deactivate(cc);
-        defaultMOSRef.deactivate(cc);
-        cdiRuntime = null;
+    @Reference
+    protected void setCDIRuntime(CDIService cdiService) {
+        this.cdiRuntime = (CDIRuntime) cdiService;
     }
 
-    @Reference(name = "defaultManagedObjectService", service = DefaultManagedObjectService.class, policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MANDATORY)
-    protected void setDefaultManagedObjectService(ServiceReference<DefaultManagedObjectService> ref) {
-        defaultMOSRef.setReference(ref);
-    }
-
-    protected void unsetDefaultManagedObjectService(ServiceReference<DefaultManagedObjectService> ref) {
-        defaultMOSRef.unsetReference(ref);
-    }
-
-    private DefaultManagedObjectService getDefaultManagedObjectService() {
-        return defaultMOSRef.getServiceWithException();
-    }
-
-    @Reference(name = "cdiService", service = CDIService.class, policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MANDATORY)
-    protected void setCDIService(ServiceReference<CDIService> ref) {
-        cdiServiceRef.setReference(ref);
-    }
-
-    protected void unsetCDIService(ServiceReference<CDIService> ref) {
-        cdiServiceRef.unsetReference(ref);
-    }
-
-    private CDIService getCDIService() {
-        return AccessController.doPrivileged(new PrivilegedAction<CDIService>() {
-            @Override
-            public CDIService run() {
-                return cdiServiceRef.getServiceWithException();
-            }
-        });
-
-    }
-
-    private CDIRuntime getCDIRuntime() {
-        if (this.cdiRuntime == null) {
-            this.cdiRuntime = (CDIRuntime) getCDIService();
-        }
-        return this.cdiRuntime;
+    //CDIRuntime can get deactivated after this object is created, so we need to track that and ensure we do not send calls towards it after it is deactivated.
+    protected void unsetCDIRuntime(CDIService cdiService) {
+        this.cdiRuntime = null;
     }
 
     @Override
     public <T> ManagedObjectFactory<T> createManagedObjectFactory(ModuleMetaData mmd, Class<T> klass,
                                                                   boolean requestManagingInjectionAndInterceptors) throws ManagedObjectException {
         if (!HttpJspPage.class.isAssignableFrom(klass) && isCDIEnabled(mmd)) {
-            return new CDIManagedObjectFactoryImpl<T>(klass, getCDIRuntime(), requestManagingInjectionAndInterceptors);
+            return new CDIManagedObjectFactoryImpl<T>(klass, cdiRuntime, requestManagingInjectionAndInterceptors);
         } else {
-            return getDefaultManagedObjectService().createManagedObjectFactory(mmd, klass, requestManagingInjectionAndInterceptors);
+            return defaultMOS.createManagedObjectFactory(mmd, klass, requestManagingInjectionAndInterceptors);
         }
     }
 
     @Override
     public <T> ManagedObjectFactory<T> createEJBManagedObjectFactory(ModuleMetaData mmd, Class<T> klass, String ejbName) throws ManagedObjectException {
-        ManagedObjectFactory<T> defaultEJBManagedObjectFactory = getDefaultManagedObjectService().createEJBManagedObjectFactory(mmd, klass, ejbName);
+        ManagedObjectFactory<T> defaultEJBManagedObjectFactory = defaultMOS.createEJBManagedObjectFactory(mmd, klass, ejbName);
         if (isCDIEnabled(mmd)) {
-            return new CDIEJBManagedObjectFactoryImpl<T>(klass, ejbName, getCDIRuntime(), defaultEJBManagedObjectFactory);
+            return new CDIEJBManagedObjectFactoryImpl<T>(klass, ejbName, cdiRuntime, defaultEJBManagedObjectFactory);
         } else {
             return defaultEJBManagedObjectFactory;
         }
@@ -114,14 +79,14 @@ public class CDIManagedObjectService implements ManagedObjectService {
     @Override
     public <T> ManagedObjectFactory<T> createInterceptorManagedObjectFactory(ModuleMetaData mmd, Class<T> klass) throws ManagedObjectException {
         if (isCDIEnabled(mmd)) {
-            return new CDIInterceptorManagedObjectFactoryImpl<T>(klass, getCDIRuntime());
+            return new CDIInterceptorManagedObjectFactoryImpl<T>(klass, cdiRuntime);
         } else {
-            return getDefaultManagedObjectService().createInterceptorManagedObjectFactory(mmd, klass);
+            return defaultMOS.createInterceptorManagedObjectFactory(mmd, klass);
         }
     }
 
     private boolean isCDIEnabled(ModuleMetaData mmd) {
-        return getCDIRuntime() != null && getCDIRuntime().isModuleCDIEnabled(mmd);
+        return cdiRuntime != null && cdiRuntime.isModuleCDIEnabled(mmd);
     }
 
     /** {@inheritDoc} */
@@ -129,9 +94,9 @@ public class CDIManagedObjectService implements ManagedObjectService {
     public <T> ManagedObjectFactory<T> createManagedObjectFactory(ModuleMetaData mmd, Class<T> klass, boolean requestManagingInjectionAndInterceptors,
                                                                   ReferenceContext referenceContext) throws ManagedObjectException {
         if (isCDIEnabled(mmd)) {
-            return new CDIManagedObjectFactoryImpl<T>(klass, getCDIRuntime(), requestManagingInjectionAndInterceptors, referenceContext);
+            return new CDIManagedObjectFactoryImpl<T>(klass, cdiRuntime, requestManagingInjectionAndInterceptors, referenceContext);
         } else {
-            return getDefaultManagedObjectService().createManagedObjectFactory(mmd, klass, requestManagingInjectionAndInterceptors, referenceContext);
+            return defaultMOS.createManagedObjectFactory(mmd, klass, requestManagingInjectionAndInterceptors, referenceContext);
         }
     }
 }


### PR DESCRIPTION
The previous attempt to deliver this fix failed with an NPE inside AbstractCDIRuntime. To prevent this we null out the reference when the CDIRuntime is deactivated and go down the if null codepath.