### PR TITLE
transaction context for ContextServiceDefinition

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/WSManagedExecutorService.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/WSManagedExecutorService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2021 IBM Corporation and others.
+ * Copyright (c) 2017,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,7 +27,12 @@ public interface WSManagedExecutorService {
      * or creates new thread context as determined by the execution properties.
      * Do not expect the captured context to be serializable.</p>
      *
-     * @param props execution properties. Custom property keys must not begin with "javax.enterprise.concurrent."
+     * @param props execution properties. Custom property keys must not begin with
+     *                  "javax.enterprise.concurrent." or "jakarta.enterprise.concurrent.".
+     *                  Null indicates to use execution properties that are consistent with
+     *                  with the managed executor's ContextServiceDefinition, or lacking a
+     *                  ContextServiceDefinition use execution properties that suspend the
+     *                  transaction on the thread of execution.
      * @return captured thread context.
      */
     ThreadContextDescriptor captureThreadContext(Map<String, String> props);

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/AsyncMethod.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/AsyncMethod.java
@@ -39,7 +39,7 @@ public class AsyncMethod<I, T> extends ManagedCompletableFuture<T> {
      * that is returned to the application, but it has the choice of
      * returning a different stage.
      */
-    private final BiFunction<I, CompletableFuture<T>, CompletionStage<T>> action;
+    private final BiFunction<I, CompletableFuture<T>, CompletionStage<T>> asyncMethodImpl;
 
     /**
      * Thread context that is captured when the asynchronous method is requested,
@@ -80,7 +80,7 @@ public class AsyncMethod<I, T> extends ManagedCompletableFuture<T> {
 
         rejectManagedTask(invoker);
 
-        this.action = invoker;
+        this.asyncMethodImpl = invoker;
         this.contextDescriptor = ((WSManagedExecutorService) executor).captureThreadContext(XPROPS_SUSPEND_TRAN);
         this.invocation = invocation;
 
@@ -120,22 +120,22 @@ public class AsyncMethod<I, T> extends ManagedCompletableFuture<T> {
     @FFDCIgnore({ CompletionException.class, Error.class, RuntimeException.class })
     private void runIfNotStarted() {
         if (!isDone() && started.compareAndSet(false, true)) {
-            CompletionStage<T> asyncMethodResultStage = null;
             Throwable failure = null;
             ArrayList<ThreadContext> contextApplied = null;
             try {
                 if (contextDescriptor != null)
                     contextApplied = contextDescriptor.taskStarting();
-                asyncMethodResultStage = action.apply(invocation, this);
+
+                CompletionStage<T> asyncMethodResultStage = asyncMethodImpl.apply(invocation, this);
 
                 // The asynchronous method implementation can return a different stage or null if it wants to
                 if (asyncMethodResultStage != this)
                     if (asyncMethodResultStage == null) {
                         complete(null);
+                    } else if (asyncMethodResultStage instanceof ManagedCompletableFuture) {
+                        // bypass thread context capture & propagation because it is unnecessary here
+                        ((ManagedCompletableFuture<T>) asyncMethodResultStage).super_whenComplete(this::complete);
                     } else {
-                        // TODO inefficient if a ManagedCompletableFuture. Instead do:
-                        //} else if (asyncMethodResultStage instanceof ManagedCompletableFuture) {
-                        //    ((ManagedCompletableFuture) asyncMethodResultStage).super_whenComplete(this::complete);
                         asyncMethodResultStage.whenComplete(this::complete);
                     }
             } catch (CompletionException x) {

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/AsyncMethod.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/AsyncMethod.java
@@ -78,8 +78,6 @@ public class AsyncMethod<I, T> extends ManagedCompletableFuture<T> {
         if (JAVA8)
             throw new UnsupportedOperationException();
 
-        rejectManagedTask(invoker);
-
         this.asyncMethodImpl = invoker;
         this.contextDescriptor = ((WSManagedExecutorService) executor).captureThreadContext(XPROPS_SUSPEND_TRAN);
         this.invocation = invocation;

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/AsyncMethod.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/AsyncMethod.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -79,7 +79,7 @@ public class AsyncMethod<I, T> extends ManagedCompletableFuture<T> {
             throw new UnsupportedOperationException();
 
         this.asyncMethodImpl = invoker;
-        this.contextDescriptor = ((WSManagedExecutorService) executor).captureThreadContext(XPROPS_SUSPEND_TRAN);
+        this.contextDescriptor = ((WSManagedExecutorService) executor).captureThreadContext(null);
         this.invocation = invocation;
 
         ((Executor) futureRef).execute(this::runIfNotStarted);

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -141,7 +141,7 @@ public class ContextServiceImpl implements ContextService, //
      * If ContextServiceDefinition is used, the execution properties are populated upon activate
      * to control which context types are cleared vs left unchanged. Otherwise, it remains empty.
      */
-    private Map<String, String> execProps = Collections.emptyMap();
+    Map<String, String> execProps = Collections.emptyMap();
 
     /**
      * Hash code for this instance.
@@ -253,7 +253,7 @@ public class ContextServiceImpl implements ContextService, //
             // execution properties for ContextServiceDefinition
             execProps = new TreeMap<String, String>();
             execProps.put(WSContextService.DEFAULT_CONTEXT, WSContextService.UNCONFIGURED_CONTEXT_TYPES);
-            String contextToSkip = (String) props.get("context.unchanged");
+            String contextToSkip = (String) props.get("context.unchanged");// TODO check for Remaining and in that case omit above property?
             if (contextToSkip != null)
                 execProps.put(WSContextService.SKIP_CONTEXT_PROVIDERS, contextToSkip);
         }

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
@@ -137,6 +137,13 @@ public class ContextServiceImpl implements ContextService, //
     private ServiceReference<JavaEEVersion> eeVersionRef;
 
     /**
+     * Execution properties.
+     * If ContextServiceDefinition is used, the execution properties are populated upon activate
+     * to control which context types are cleared vs left unchanged. Otherwise, it remains empty.
+     */
+    private Map<String, String> execProps = Collections.emptyMap();
+
+    /**
      * Hash code for this instance.
      */
     private final int hash;
@@ -241,6 +248,15 @@ public class ContextServiceImpl implements ContextService, //
         String contextSvcName = (String) props.get(JNDI_NAME);
         if (contextSvcName == null)
             contextSvcName = (String) props.get(CONFIG_ID);
+
+        if (!"file".equals(props.get("config.source"))) {
+            // execution properties for ContextServiceDefinition
+            execProps = new TreeMap<String, String>();
+            execProps.put(WSContextService.DEFAULT_CONTEXT, WSContextService.UNCONFIGURED_CONTEXT_TYPES);
+            String contextToSkip = (String) props.get("context.unchanged");
+            if (contextToSkip != null)
+                execProps.put(WSContextService.SKIP_CONTEXT_PROVIDERS, contextToSkip);
+        }
 
         lock.writeLock().lock();
         try {
@@ -362,7 +378,7 @@ public class ContextServiceImpl implements ContextService, //
             throw new IllegalArgumentException(ContextualCallable.class.getSimpleName());
 
         @SuppressWarnings("unchecked")
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(execProps);
         return new ContextualCallable<R>(contextDescriptor, callable);
     }
 
@@ -372,7 +388,7 @@ public class ContextServiceImpl implements ContextService, //
             throw new IllegalArgumentException(ContextualBiConsumer.class.getSimpleName());
 
         @SuppressWarnings("unchecked")
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(execProps);
         return new ContextualBiConsumer<T, U>(contextDescriptor, consumer);
     }
 
@@ -382,7 +398,7 @@ public class ContextServiceImpl implements ContextService, //
             throw new IllegalArgumentException(ContextualConsumer.class.getSimpleName());
 
         @SuppressWarnings("unchecked")
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(execProps);
         return new ContextualConsumer<T>(contextDescriptor, consumer);
     }
 
@@ -392,7 +408,7 @@ public class ContextServiceImpl implements ContextService, //
             throw new IllegalArgumentException(ContextualBiFunction.class.getSimpleName());
 
         @SuppressWarnings("unchecked")
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(execProps);
         return new ContextualBiFunction<T, U, R>(contextDescriptor, function);
     }
 
@@ -402,7 +418,7 @@ public class ContextServiceImpl implements ContextService, //
             throw new IllegalArgumentException(ContextualFunction.class.getSimpleName());
 
         @SuppressWarnings("unchecked")
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(execProps);
         return new ContextualFunction<T, R>(contextDescriptor, function);
     }
 
@@ -412,7 +428,7 @@ public class ContextServiceImpl implements ContextService, //
             throw new IllegalArgumentException(ContextualRunnable.class.getSimpleName());
 
         @SuppressWarnings("unchecked")
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(execProps);
         return new ContextualRunnable(contextDescriptor, runnable);
     }
 
@@ -422,7 +438,7 @@ public class ContextServiceImpl implements ContextService, //
             throw new IllegalArgumentException(ContextualSupplier.class.getSimpleName());
 
         @SuppressWarnings("unchecked")
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(execProps);
         return new ContextualSupplier<R>(contextDescriptor, supplier);
     }
 
@@ -556,7 +572,7 @@ public class ContextServiceImpl implements ContextService, //
     @Override
     public Executor currentContextExecutor() {
         @SuppressWarnings("unchecked")
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(execProps);
         return new ContextualExecutor(contextDescriptor);
     }
 

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
@@ -253,7 +253,7 @@ public class ContextServiceImpl implements ContextService, //
             // execution properties for ContextServiceDefinition
             execProps = new TreeMap<String, String>();
             execProps.put(WSContextService.DEFAULT_CONTEXT, WSContextService.UNCONFIGURED_CONTEXT_TYPES);
-            String contextToSkip = (String) props.get("context.unchanged");// TODO check for Remaining and in that case omit above property?
+            String contextToSkip = (String) props.get("context.unchanged");
             if (contextToSkip != null)
                 execProps.put(WSContextService.SKIP_CONTEXT_PROVIDERS, contextToSkip);
         }

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedCompletableFuture.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedCompletableFuture.java
@@ -1411,6 +1411,17 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
     }
 
     /**
+     * Invokes whenComplete on the superclass, bypassing thread context capture and
+     * propagation.
+     */
+    final void super_whenComplete(BiConsumer<? super T, ? super Throwable> action) {
+        if (JAVA8)
+            throw new UnsupportedOperationException();
+        else
+            super.whenComplete(action);
+    }
+
+    /**
      * Convenience method to validate that an executor supports running asynchronously
      * and to wrap the executor, if an ExecutorService, with FutureRefExecutor.
      * This method is named supportsAsync to make failure stacks more meaningful to users.

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedCompletableFuture.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedCompletableFuture.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -116,15 +116,6 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
             super_exceptionallyCompose = exceptionallyCompose;
             super_exceptionallyComposeAsync = exceptionallyComposeAsync;
         }
-    }
-
-    /**
-     * Execution property that indicates a task should run with any previous transaction suspended.
-     */
-    static final Map<String, String> XPROPS_SUSPEND_TRAN = new TreeMap<String, String>();
-    static {
-        XPROPS_SUSPEND_TRAN.put("jakarta.enterprise.concurrent.TRANSACTION", "SUSPEND");
-        XPROPS_SUSPEND_TRAN.put("javax.enterprise.concurrent.TRANSACTION", "SUSPEND");
     }
 
     /**
@@ -466,7 +457,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
             contextDescriptor = r.getContextDescriptor();
             action = r.getAction();
         } else if (executor instanceof WSManagedExecutorService) {
-            contextDescriptor = ((WSManagedExecutorService) executor).captureThreadContext(XPROPS_SUSPEND_TRAN);
+            contextDescriptor = ((WSManagedExecutorService) executor).captureThreadContext(null);
         } else {
             contextDescriptor = null;
         }
@@ -515,7 +506,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
             contextDescriptor = s.getContextDescriptor();
             action = s.getAction();
         } else if (executor instanceof WSManagedExecutorService) {
-            contextDescriptor = ((WSManagedExecutorService) executor).captureThreadContext(XPROPS_SUSPEND_TRAN);
+            contextDescriptor = ((WSManagedExecutorService) executor).captureThreadContext(null);
         } else {
             contextDescriptor = null;
         }
@@ -697,7 +688,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (managedExecutor == null)
             return null;
 
-        return managedExecutor.captureThreadContext(XPROPS_SUSPEND_TRAN);
+        return managedExecutor.captureThreadContext(null);
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -116,6 +116,15 @@ public class ManagedExecutorServiceImpl implements ExecutorService, //
      * Java EE Concurrency execution properties that specify to suspend the current transaction.
      */
     private static final Map<String, String> JAVAX_SUSPEND_TRAN = Collections.singletonMap("javax.enterprise.concurrent.TRANSACTION", "SUSPEND");
+
+    /**
+     * Execution properties that specify to suspend the current transaction.
+     */
+    private static final Map<String, String> XPROPS_SUSPEND_TRAN = new TreeMap<String, String>();
+    static {
+        XPROPS_SUSPEND_TRAN.putAll(JAKARTA_SUSPEND_TRAN);
+        XPROPS_SUSPEND_TRAN.putAll(JAVAX_SUSPEND_TRAN);
+    }
 
     private final boolean allowLifeCycleMethods;
 
@@ -302,11 +311,14 @@ public class ManagedExecutorServiceImpl implements ExecutorService, //
 
     @Override
     public ThreadContextDescriptor captureThreadContext(Map<String, String> props) {
-        WSContextService contextSvc;
+        ContextServiceImpl contextSvc;
         if (mpContextService == null)
-            contextSvc = contextSvcRef.getServiceWithException();
+            contextSvc = (ContextServiceImpl) contextSvcRef.getServiceWithException();
         else
             contextSvc = mpContextService;
+
+        if (props == null)
+            props = contextSvc.execProps.isEmpty() ? XPROPS_SUSPEND_TRAN : contextSvc.execProps;
 
         @SuppressWarnings("unchecked")
         ThreadContextDescriptor threadContext = contextSvc.captureThreadContext(props);

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ApplicationScopedBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ApplicationScopedBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2021 IBM Corporation and others.
+ * Copyright (c) 2017,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -81,13 +81,12 @@ public class ApplicationScopedBean implements Serializable {
      * Obtain the transaction key and status and then commit the active transaction.
      */
     @Asynchronous(executor = "java:module/concurrent/txexecutor")
-    public CompletableFuture<Entry<Object, Integer>> getTransactionInfoAndCommit() {
+    public CompletableFuture<Entry<Object, Integer>> getTransactionInfoAndCommit(TransactionSynchronizationRegistry tranSyncRegistry,
+                                                                                 UserTransaction tx) {
         try {
-            TransactionSynchronizationRegistry tranSyncRegistry = InitialContext.doLookup("java:comp/TransactionSynchronizationRegistry");
             Object txKey = tranSyncRegistry.getTransactionKey();
             int txStatus = tranSyncRegistry.getTransactionStatus();
 
-            UserTransaction tx = InitialContext.doLookup("java:comp/UserTransaction");
             tx.commit();
 
             return Asynchronous.Result.complete(new SimpleEntry<Object, Integer>(txKey, txStatus));

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ConcurrentCDIServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ConcurrentCDIServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2021 IBM Corporation and others.
+ * Copyright (c) 2017,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1194,7 +1194,7 @@ public class ConcurrentCDIServlet extends HttpServlet {
      * Verify that transaction context is propagated to an asynchronous method,
      * per configuration of the ManagedExecutorService's ContextServiceDefinition.
      */
-    // TODO @Test
+    @Test
     public void testTransactionContextPropagatedToAsyncMethod() throws Exception {
         // Use up maxAsync (1) for the managed executor so that the subsequent asynchronous
         // method can run upon join that is attempted from a different transaction.
@@ -1208,7 +1208,7 @@ public class ConcurrentCDIServlet extends HttpServlet {
             tran.begin();
             try {
                 tx1key = tranSyncRegistry.getTransactionKey();
-                future = appScopedBean.getTransactionInfoAndCommit();
+                future = appScopedBean.getTransactionInfoAndCommit(tranSyncRegistry, tran);
 
                 tm.suspend();
             } finally {
@@ -1329,7 +1329,7 @@ public class ConcurrentCDIServlet extends HttpServlet {
      * Verify that transaction context is propagated to a completion stage action,
      * per the configuration of the managed executor's ContextServiceDefinition.
      */
-    // TODO @Test
+    @Test
     public void testTransactionContextPropagatedToCompletableFuture() throws Exception {
         ManagedExecutorService executor = InitialContext.doLookup("java:module/concurrent/txexecutor");
         Object txKey;
@@ -1365,7 +1365,7 @@ public class ConcurrentCDIServlet extends HttpServlet {
      * Verify that transaction context is propagated to completion stages that
      * obtained via ContextService.withContextCapture.
      */
-    // TODO @Test
+    @Test
     public void testTransactionContextPropagatedWithContextCapture() throws Exception {
         ContextService contextSvc = InitialContext.doLookup("java:app/concurrent/txcontext");
 
@@ -1429,7 +1429,7 @@ public class ConcurrentCDIServlet extends HttpServlet {
      * Verify that transaction context is left unchanged per the ContextServiceDefinition configuration,
      * and allows an inline completion stage action to run in the transaction that is already on the thread.
      */
-    //TODO @Test
+    @Test
     public void testTransactionContextUnchangedForInlineCompletionStageAction() throws Exception {
         ManagedScheduledExecutorService executor = InitialContext.doLookup("java:comp/concurrent/appContextExecutor");
 

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/DependentScopedBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/DependentScopedBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2021 IBM Corporation and others.
+ * Copyright (c) 2017,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,10 @@
  *******************************************************************************/
 package concurrent.cdi.web;
 
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.ALL_REMAINING;
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.APPLICATION;
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.SECURITY;
+
 import java.util.AbstractMap;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
@@ -17,6 +21,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 
 import jakarta.enterprise.concurrent.Asynchronous;
+import jakarta.enterprise.concurrent.ContextServiceDefinition;
 import jakarta.enterprise.context.Dependent;
 import jakarta.transaction.SystemException;
 import jakarta.transaction.UserTransaction;
@@ -24,6 +29,14 @@ import jakarta.transaction.UserTransaction;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
+@ContextServiceDefinition(name = "java:module/concurrent/appcontextcleared",
+                          propagated = SECURITY,
+                          cleared = APPLICATION,
+                          unchanged = ALL_REMAINING)
+@ContextServiceDefinition(name = "java:module/concurrent/remainingcontextunchanged",
+                          propagated = SECURITY,
+                          cleared = {},
+                          unchanged = ALL_REMAINING)
 @Dependent
 public class DependentScopedBean {
     private boolean value;

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/SessionScopedBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/SessionScopedBean.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package concurrent.cdi.web;
 
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.SECURITY;
+
 import java.io.Serializable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -19,12 +21,19 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.enterprise.concurrent.Asynchronous;
+import jakarta.enterprise.concurrent.ContextServiceDefinition;
 import jakarta.enterprise.concurrent.ManagedExecutorService;
 import jakarta.enterprise.context.SessionScoped;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
+// When ALL_REMAINING isn't specified for any category (cleared/propagated/unchanged),
+// it is automatically added to cleared
+@ContextServiceDefinition(name = "java:global/concurrent/allcontextcleared",
+                          cleared = SECURITY,
+                          propagated = {},
+                          unchanged = {})
 @SessionScoped
 public class SessionScopedBean implements Serializable {
     private static final long serialVersionUID = -3903544320641023668L;

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/ConcurrencyTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/ConcurrencyTestServlet.java
@@ -207,7 +207,7 @@ public class ConcurrencyTestServlet extends FATServlet {
      * Look up an application-defined ContextService that is configured to
      * propagate some third-party context (ZipCode and List),
      * clear other third-party context (Priority and Timestamp),
-     * and lave other types of context, such as Application, unchanged.
+     * and leave other types of context, such as Application, unchanged.
      * Verify that the ContextService behaves as configured.
      */
     @Test
@@ -244,7 +244,7 @@ public class ConcurrencyTestServlet extends FATServlet {
                 };
             });
 
-            // Alter soem of the context on the current thread
+            // Alter some of the context on the current thread
             ZipCode.set(55906);
             ListContext.newList();
             ListContext.add(5);

--- a/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ContextServiceResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ContextServiceResourceFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -219,9 +219,6 @@ public class ContextServiceResourceFactoryBuilder implements ResourceFactoryBuil
                 }
             } // TODO else error for duplicate usage
 
-        if (skip.length() > 0)
-            contextSvcProps.put("context.unchanged", skip.toString());
-
         // propagated
         TreeSet<String> propagated3PCtx = new TreeSet<String>();
         int propagateCount = 0;
@@ -243,7 +240,9 @@ public class ContextServiceResourceFactoryBuilder implements ResourceFactoryBuil
                 }
             } // TODO else error for duplicate usage
 
-        if ("propagated".equals(remaining))
+        if (remaining == null)
+            remaining = "cleared";
+        else if ("propagated".equals(remaining))
             for (Map.Entry<String, String[]> entry : BUILT_IN_CONTEXT_PIDS.entrySet()) {
                 String type = entry.getKey();
                 if (!used.contains(type)) {
@@ -253,20 +252,30 @@ public class ContextServiceResourceFactoryBuilder implements ResourceFactoryBuil
                         contextSvcProps.put("threadContextConfigRef." + (propagateCount++) + ".config.referenceType", pid);
                 }
             }
+        else if ("unchanged".equals(remaining))
+            for (Map.Entry<String, String[]> entry : BUILT_IN_CONTEXT_PIDS.entrySet()) {
+                String type = entry.getKey();
+                if (!used.contains(type)) {
+                    used.add(type);
+                    String[] pids = entry.getValue();
+                    for (String pid : pids)
+                        skip.append(skip.length() == 0 ? "" : ",").append(pid).append(".provider");
+                }
+            }
+
+        if (skip.length() > 0)
+            contextSvcProps.put("context.unchanged", skip.toString());
 
         // Add Transaction context provider
-        if (transaction != null) {
-            String prefix = "threadContextConfigRef." + (propagateCount++);
-            contextSvcProps.put(prefix + ".config.referenceType", "com.ibm.ws.transaction.context");
-            contextSvcProps.put(prefix + ".transaction", transaction);
-        }
-
-        if (remaining == null)
-            remaining = "cleared";
+        if (transaction == null)
+            transaction = remaining;
+        String prefix = "threadContextConfigRef." + (propagateCount++);
+        contextSvcProps.put(prefix + ".config.referenceType", "com.ibm.ws.transaction.context");
+        contextSvcProps.put(prefix + ".transaction", transaction);
 
         // Add a ThreadContextProvider that handles third-party context types
         if (remaining.equals("propagated") || remaining.equals("unchanged") || !propagated3PCtx.isEmpty() || !unchanged3PCtx.isEmpty()) {
-            String prefix = "threadContextConfigRef." + (propagateCount++);
+            prefix = "threadContextConfigRef." + (propagateCount++);
             contextSvcProps.put(prefix + ".config.referenceType", "io.openliberty.thirdparty.context");
             contextSvcProps.put(prefix + ".cleared", new Vector<String>(cleared3PCtx));
             contextSvcProps.put(prefix + ".propagated", new Vector<String>(propagated3PCtx));

--- a/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ContextServiceResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ContextServiceResourceFactoryBuilder.java
@@ -31,6 +31,7 @@ import org.osgi.service.component.annotations.Reference;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrent.WSManagedExecutorService;
 import com.ibm.ws.resource.ResourceFactory;
 import com.ibm.ws.resource.ResourceFactoryBuilder;
@@ -38,7 +39,6 @@ import com.ibm.wsspi.kernel.service.location.VariableRegistry;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 import com.ibm.wsspi.kernel.service.utils.FilterUtils;
 import com.ibm.wsspi.kernel.service.utils.OnErrorUtil;
-import com.ibm.wsspi.threadcontext.WSContextService;
 
 import jakarta.enterprise.concurrent.ContextServiceDefinition;
 
@@ -214,13 +214,13 @@ public class ContextServiceResourceFactoryBuilder implements ResourceFactoryBuil
                         skip.append(skip.length() == 0 ? "" : ",").append(type);
                     } else {
                         for (String pid : pids)
-                            skip.append(skip.length() == 0 ? "" : ",").append(pid);
+                            skip.append(skip.length() == 0 ? "" : ",").append(pid).append(".provider");
                     }
                 }
             } // TODO else error for duplicate usage
 
         if (skip.length() > 0)
-            contextSvcProps.put(WSContextService.SKIP_CONTEXT_PROVIDERS, skip.toString());
+            contextSvcProps.put("context.unchanged", skip.toString());
 
         // propagated
         TreeSet<String> propagated3PCtx = new TreeSet<String>();
@@ -419,6 +419,7 @@ public class ContextServiceResourceFactoryBuilder implements ResourceFactoryBuil
     /**
      * Convert map to text, fully expanding String[] values to make them visible in trace.
      */
+    @Trivial
     private static final String toString(Map<String, Object> map) {
         boolean first = true;
         StringBuilder b = new StringBuilder(200).append('{');


### PR DESCRIPTION
Get transaction context working for ContextServiceDefinition, including when used by a managed executor.  Also, this involved finishing up various aspects of built-in context types when configured on a ContextServiceDefinition.