### PR TITLE
Add additional check to wait for Shibboleth readiness

### DIFF
--- a/dev/com.ibm.ws.security.saml.sso_fat.common/build.gradle
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -304,10 +304,16 @@ task updateIdp_4_1_x_WAR(type: Zip, dependsOn: copy_41x_IDP) {
     include 'rhino-1.7.13.jar', 'idp-plugin-scripting-api-1.0.0.jar', 'idp-plugin-rhino-impl-1.0.0.jar'
     into 'WEB-INF/lib'
   }
-   from (fixed410Files) {
+  from (fixed410Files) {
     include 'web.xml'
     into 'WEB-INF'
   }
+  // update the status.jsp to work around "'<>' operator is not allowed for source level below 1.7" failure
+  from (fixed410Files) {
+    include 'jsp/status.jsp'
+    into 'WEB-INF'
+  }
+  
 }
 
 assemble.dependsOn SAML_Demo_EAR

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/fixedFiles/jsp/status.jsp
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/fixedFiles/jsp/status.jsp
@@ -1,0 +1,166 @@
+<%@ page language="java" contentType="text/plain; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@ page trimDirectiveWhitespaces="true" %>
+<%@ page import="java.util.ArrayList" %>
+<%@ page import="java.util.Map" %>
+<%@ page import="java.util.Set" %>
+<%@ page import="java.util.Map.Entry" %>
+<%@ page import="java.util.Collection" %>
+<%@ page import="java.util.Collections" %>
+<%@ page import="java.util.Optional" %>
+<%@ page import="java.util.ServiceLoader" %>
+<%@ page import="java.util.ServiceLoader.Provider" %>
+<%@ page import="java.time.Duration" %>
+<%@ page import="java.time.Instant" %>
+<%@ page import="java.time.format.DateTimeFormatter" %>
+<%@ page import="org.springframework.core.env.Environment" %>
+<%@ page import="org.springframework.webflow.execution.RequestContext" %>
+<%@ page import="net.shibboleth.idp.Version" %>
+<%@ page import="com.codahale.metrics.MetricSet" %>
+<%@ page import="com.codahale.metrics.Gauge" %>
+<%@ page import="net.shibboleth.idp.module.IdPModule" %>
+<%@ page import="net.shibboleth.idp.plugin.IdPPlugin" %>
+<%@ page import="net.shibboleth.idp.module.ModuleContext" %>
+<%@ page import="net.shibboleth.idp.saml.metadata.impl.ReloadingRelyingPartyMetadataProvider" %>
+<%@ page import="net.shibboleth.idp.attribute.resolver.AttributeResolver" %>
+<%@ page import="net.shibboleth.idp.attribute.resolver.impl.AttributeResolverImpl" %>
+<%@ page import="net.shibboleth.idp.attribute.resolver.DataConnector" %>
+<%@ page import="net.shibboleth.utilities.java.support.component.IdentifiedComponent" %>
+<%@ page import="net.shibboleth.utilities.java.support.service.ReloadableService" %>
+<%@ page import="net.shibboleth.utilities.java.support.service.ServiceableComponent" %>
+<%
+final RequestContext requestContext = (RequestContext) request.getAttribute("flowRequestContext");
+final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ISO_INSTANT;
+final Instant now = Instant.now();
+final Instant startupTime = Instant.ofEpochMilli(requestContext.getActiveFlow().getApplicationContext().getStartupDate());
+%>### Operating Environment Information
+operating_system: <%= System.getProperty("os.name") %>
+operating_system_version: <%= System.getProperty("os.version") %>
+operating_system_architecture: <%= System.getProperty("os.arch") %>
+jdk_version: <%= System.getProperty("java.version") %>
+available_cores: <%= Runtime.getRuntime().availableProcessors() %>
+used_memory: <%= (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / 1048576 %> MB
+maximum_memory: <%= Runtime.getRuntime().maxMemory() / 1048576 %> MB
+
+### Identity Provider Information
+idp_version: <%= Version.getVersion() %>
+start_time: <%= dateTimeFormatter.format(startupTime) %>
+current_time: <%= dateTimeFormatter.format(now) %>
+uptime: <%= Duration.ofMillis(now.toEpochMilli() - startupTime.toEpochMilli()).toString() %>
+
+<%
+out.println();
+out.println();
+out.println("enabled modules: ");
+final ModuleContext moduleContext =
+    new ModuleContext(((Environment) request.getAttribute("environment")).getProperty("idp.home"));
+for (final IdPModule module : ServiceLoader.load(IdPModule.class)) {
+    if (module.isEnabled(moduleContext)) {
+        out.println("\t" + module.getId() + " (" + module.getName(moduleContext) + ")");
+    }
+}
+out.println();
+
+out.println("installed plugins: ");
+for (final IdPPlugin plugin : ServiceLoader.load(IdPPlugin.class)) {
+    out.println("\t" + plugin.getPluginId() + " Version " + plugin.getMajorVersion() + "." + plugin.getMinorVersion() + "." + plugin.getPatchVersion());
+}
+out.println();
+
+
+for (final ReloadableService service : (Collection<ReloadableService>) request.getAttribute("services")) {
+    final Instant successfulReload = service.getLastSuccessfulReloadInstant();
+    final Instant lastReload = service.getLastReloadAttemptInstant();
+    final Throwable cause = service.getReloadFailureCause();
+
+    out.println("service: " + ((IdentifiedComponent) service).getId());
+    if (successfulReload != null) {
+        out.println("last successful reload attempt: " + dateTimeFormatter.format(successfulReload));
+    }
+    if (lastReload != null) {
+        out.println("last reload attempt: " + dateTimeFormatter.format(lastReload));
+    }
+    if (cause != null) {
+        out.println("last failure cause: " + cause.getClass().getName() + ": " + cause.getMessage());
+    }
+    
+    out.println();
+    
+    if (((IdentifiedComponent) service).getId().contains("Metadata")) {
+    
+    	final MetricSet metrics = (MetricSet) request.getAttribute("metadataResolverGaugeSet");
+    	if (metrics == null || metrics.getMetrics().get("net.shibboleth.idp.metadata.refresh") == null) {
+    		out.println("No Metadata Resolver Gauge Set Found");
+    		continue;
+    	}
+    	final Gauge<Map<String,Instant>> refreshes = (Gauge<Map<String,Instant>>) metrics.getMetrics().get("net.shibboleth.idp.metadata.refresh");
+    	final Gauge<Map<String,Instant>> updates = (Gauge<Map<String,Instant>>) metrics.getMetrics().get("net.shibboleth.idp.metadata.update");
+    	final Gauge<Map<String,Instant>> successes = (Gauge<Map<String,Instant>>) metrics.getMetrics().get("net.shibboleth.idp.metadata.successfulRefresh");
+    	final Gauge<Map<String,Instant>> rootValids = (Gauge<Map<String,Instant>>) metrics.getMetrics().get("net.shibboleth.idp.metadata.rootValidUntil");
+    	final Gauge<Map<String,String>> errors = (Gauge<Map<String,String>>) metrics.getMetrics().get("net.shibboleth.idp.metadata.error");
+    	
+		Set<Entry<String, Instant>> entrySet = refreshes.getValue().entrySet();
+    	if (entrySet.isEmpty()) {
+	    	out.println("\tNo Metadata Resolver has ever attempted a reload");
+			out.println();
+			continue;
+		}
+		for (final Entry<String, Instant> mr : entrySet) {
+			final String resolverId = mr.getKey();
+			final Instant lastRefresh = mr.getValue();
+            final Instant lastUpdate = updates == null ? null : updates.getValue().get(resolverId);
+			final Instant lastSuccessfulRefresh = successes == null ? null : successes.getValue().get(resolverId);
+			final Instant rootValidUntil = rootValids == null ? null : rootValids.getValue().get(resolverId);
+		    final String lastError = errors == null ? null : errors.getValue().get(resolverId);
+ 
+            out.println("\tmetadata source: " + resolverId);
+            if (lastRefresh != null) {
+                out.println("\tlast refresh attempt: " + dateTimeFormatter.format(lastRefresh));
+            }
+            if (lastSuccessfulRefresh != null) {
+                out.println("\tlast successful refresh: " + dateTimeFormatter.format(lastSuccessfulRefresh));
+            }
+            if (lastUpdate != null) {
+                out.println("\tlast update: " + dateTimeFormatter.format(lastUpdate));
+            }
+            if (lastError != null) {
+                out.println("\tlast error: " + lastError);
+            }
+            if (rootValidUntil != null) {
+                out.println("\troot validUntil: " + dateTimeFormatter.format(rootValidUntil));
+            }
+            out.println();
+		}		    
+    } else if (((IdentifiedComponent) service).getId().contains("AttributeResolver")) {
+    
+    	final MetricSet metrics = (MetricSet) request.getAttribute("attributeResolverGaugeSet");
+    	if (metrics == null || metrics.getMetrics().get("net.shibboleth.idp.attribute.resolver.failure") == null) {
+    		out.println("No Attribute Resolver Gauge Set Found");
+    		continue;
+    	}
+    	final Gauge<Map<String,Instant>> failGauge =
+    	        (Gauge<Map<String,Instant>>) metrics.getMetrics().get("net.shibboleth.idp.attribute.resolver.failure");
+    	final Set<Entry<String,Instant>> failSet = failGauge.getValue().entrySet();
+    	if (failSet.isEmpty()) {
+	    	out.println("\tNo Data Connector has ever failed");
+			out.println();
+			continue;
+		}
+        final Gauge<Map<String,Instant>> successGauge =
+                (Gauge<Map<String,Instant>>) metrics.getMetrics().get("net.shibboleth.idp.attribute.resolver.success");
+        final Map<String,Instant> successMap = successGauge.getValue();
+        final ArrayList<String> failingConnectors = new ArrayList<String>();
+    	for (final Entry<String, Instant> en : failSet) {
+			final String connectorId = en.getKey();
+            final Instant lastFail = en.getValue();
+			out.println("\tDataConnector " +  connectorId + ": last failed at " + dateTimeFormatter.format(lastFail));
+            out.println();
+            final Instant lastSuccess = successMap.get(connectorId);
+            if (lastSuccess == null || lastSuccess.isBefore(lastFail)) {
+                failingConnectors.add(connectorId);
+            }
+        }
+        out.println("\tCurrently failing: " + failingConnectors);
+        out.println();
+    }
+}
+%>

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTest.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1095,6 +1095,7 @@ public class SAMLCommonTest extends CommonTest {
         if (cipherMayExceed128) {
             addToAllowableTimeoutCount(1);
         }
+	helpers.pingExternalServer(_testName, idpServer.getHttpString() + "/idp/status", null, 30);
     }
 
     public static void startSPWithIDPServer(String spServer, String spServerCfg, List<String> spExtraMsgs, List<String> spExtraApps, Boolean spCopyDataFlag) throws Exception {

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTestHelpers.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTestHelpers.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1910,7 +1910,9 @@ public class SAMLCommonTestHelpers extends TestHelpers {
                 } else {
                     keepChecking = false;
                     status = true;
-                    Log.info(thisClass, thisMethod, "The title in the reqponse was NOT validated - the actual title was: " + title);
+                    Log.info(thisClass, thisMethod, "The title in the response was NOT validated - the actual title was: " + title);
+                    Log.info(thisClass, thisMethod, "Caller is just checking to make sure that we can successfully access the requested url.");
+                    msgUtils.printResponseParts(thePage, testcase, thisMethod + " response");
                 }
                 Log.info(thisClass, thisMethod, "**********************************************************");
             } catch (Exception e) {


### PR DESCRIPTION
We've had a few instances where it appears that the Shibboleth IDP is not ready for use when either the Liberty SP or our test case tries to use it for the first time after the idp.war is started.
I'm adding a call to the status.jsp and will wait up to 30 seconds for that to be successful.  I can increase that time if necessary.
I can't repro the failure that we're seeing in continuous test - I can't see how the status.jsp will behave in the same condition - making a best guess on how it'll respond and how we can wait for it to be ready.