### PR TITLE
unchanged context for version 2.0 managed executor methods

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/DependentScopedBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/DependentScopedBean.java
@@ -22,6 +22,8 @@ import java.util.concurrent.CompletionStage;
 
 import jakarta.enterprise.concurrent.Asynchronous;
 import jakarta.enterprise.concurrent.ContextServiceDefinition;
+import jakarta.enterprise.concurrent.ManagedExecutorDefinition;
+import jakarta.enterprise.concurrent.ManagedScheduledExecutorDefinition;
 import jakarta.enterprise.context.Dependent;
 import jakarta.transaction.SystemException;
 import jakarta.transaction.UserTransaction;
@@ -37,6 +39,10 @@ import javax.naming.NamingException;
                           propagated = SECURITY,
                           cleared = {},
                           unchanged = ALL_REMAINING)
+@ManagedExecutorDefinition(name = "java:comp/concurrent/appcontextclearedexecutor",
+                           context = "java:module/concurrent/appcontextcleared")
+@ManagedScheduledExecutorDefinition(name = "java:comp/concurrent/remainingcontextunchangedexecutor",
+                                    context = "java:module/concurrent/remainingcontextunchanged")
 @Dependent
 public class DependentScopedBean {
     private boolean value;

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ResourcesProducer.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ResourcesProducer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2020 IBM Corporation and others.
+ * Copyright (c) 2017,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,11 +12,14 @@ package concurrent.cdi.web;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Resource;
+import jakarta.enterprise.concurrent.ManagedExecutorDefinition;
 import jakarta.enterprise.concurrent.ManagedExecutorService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 
 @ApplicationScoped
+@ManagedExecutorDefinition(name = "java:global/concurrent/allcontextclearedexecutor",
+                           context = "java:global/concurrent/allcontextcleared")
 public class ResourcesProducer {
 
     @PostConstruct


### PR DESCRIPTION
Honor the configuration of unchanged context on a ContextServiceDefinition that is used to run version 2.0 methods (such as invokeAll and submit) of ManagedExecutorService and ManagedScheduledExecutorService.  These methods are currently creating their own execution properties or merging with provided execution properties and need to made instead merge in execution properties that correspond to the ContextServiceDefinition configuration.