### PR TITLE
Wait for token and userinfo test endpoints to be ready

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/Constants.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/Constants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -180,8 +180,6 @@ public class Constants {
 
     public static final String OPENID_APP = "formlogin";
     public static final String DEFAULT_SERVLET = "SimpleServlet";
-    public static final String TOKENENDPT_APP = "TokenEndpointServlet";
-    public static final String USERINFOENDPT_APP = "UserinfoEndpointServlet";
 
     public static final String LTPA_TOKEN = "LtpaToken2";
     public static final String JWT_SSO_COOKIE_NAME = "JWT";

--- a/dev/com.ibm.ws.security.oidc.client_fat.2/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientConsumeUserinfoTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.2/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientConsumeUserinfoTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -81,9 +81,10 @@ public class OidcClientConsumeUserinfoTests extends CommonTest {
         };
 
         // apps are taking too long to start up for the normal app check, but, we need to be sure that they're ready before we try to use them.
-        List<String> extraMsgs = new ArrayList<String>() {
+        List<String> opExtraMsgs = new ArrayList<String>() {
             {
                 add("CWWKZ0001I.*" + JwtConstants.JWT_SIMPLE_BUILDER_SERVLET);
+                add("CWWKZ0001I.*" + Constants.TOKEN_ENDPOINT_SERVLET);
                 add("CWWKZ0001I.*" + Constants.USERINFO_ENDPOINT_SERVLET);
             }
         };
@@ -95,7 +96,7 @@ public class OidcClientConsumeUserinfoTests extends CommonTest {
         String certType = Constants.X509_CERT;
 
         // Start the OIDC OP server
-        testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.opWithStub", "op_server_userinfo.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, extraMsgs, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+        testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.opWithStub", "op_server_userinfo.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, opExtraMsgs, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
         SecurityFatHttpUtils.saveServerPorts(testOPServer.getServer(), Constants.BVT_SERVER_1_PORT_NAME_ROOT);
 
         //Start the OIDC RP server and setup default values

--- a/dev/com.ibm.ws.security.oidc.client_fat.2/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientEncryptionTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.2/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientEncryptionTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -79,6 +79,13 @@ public class OidcClientEncryptionTests extends CommonTest {
             }
         };
 
+        // apps are taking too long to start up for the normal app check, but, we need to be sure that they're ready before we try to use them.
+        List<String> opExtraMsgs = new ArrayList<String>() {
+            {
+                add("CWWKZ0001I.*" + Constants.TOKEN_ENDPOINT_SERVLET);
+            }
+        };
+
         testSettings = new TestSettings();
 
         // Set config parameters for Access token with X509 Certificate in OP config files
@@ -86,7 +93,7 @@ public class OidcClientEncryptionTests extends CommonTest {
         String certType = Constants.X509_CERT;
 
         // Start the OIDC OP server
-        testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.opWithStub", "op_server_encrypt.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+        testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.opWithStub", "op_server_encrypt.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, opExtraMsgs, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
 
         //Start the OIDC RP server and setup default values
         testRPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.rp", "rp_server_withOpStub_encrypt.xml", Constants.OIDC_RP, apps, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);

--- a/dev/com.ibm.ws.security.oidc.client_fat.2/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientSignatureAlgTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.2/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientSignatureAlgTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.security.fat.common.jwt.JwtConstants;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonTest;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.Constants;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.EndpointSettings.endpointSettings;
@@ -76,6 +77,13 @@ public class OidcClientSignatureAlgTests extends CommonTest {
             }
         };
 
+        // apps are taking too long to start up for the normal app check, but, we need to be sure that they're ready before we try to use them.
+        List<String> opExtraMsgs = new ArrayList<String>() {
+            {
+                add("CWWKZ0001I.*" + Constants.TOKEN_ENDPOINT_SERVLET);
+            }
+        };
+
         testSettings = new TestSettings();
 
         // Set config parameters for Access token with X509 Certificate in OP config files
@@ -84,7 +92,7 @@ public class OidcClientSignatureAlgTests extends CommonTest {
 
         // Start the OIDC OP server
         testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.opWithStub", "op_server_sigAlg.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS,
-                Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+                Constants.DO_NOT_USE_DERBY, opExtraMsgs, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
 
         //Start the OIDC RP server and setup default values
         testRPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.rp", "rp_server_withOpStub_sigAlg.xml", Constants.OIDC_RP, apps, Constants.DO_NOT_USE_DERBY,

--- a/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/fat/src/com/ibm/ws/security/openidconnect/client/fat/jaxrs/IBM/OidcJaxRSClientAPITests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/fat/src/com/ibm/ws/security/openidconnect/client/fat/jaxrs/IBM/OidcJaxRSClientAPITests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,7 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
+import com.ibm.ws.security.fat.common.jwt.JwtConstants;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.Constants;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.EndpointSettings.endpointSettings;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.MessageConstants;
@@ -91,9 +92,12 @@ public class OidcJaxRSClientAPITests extends JaxRSClientAPITests {
                 add(Constants.HELLOWORLD_SERVLET);
             }
         };
-        List<String> op_apps = new ArrayList<String>() {
+
+        // apps are taking too long to start up for the normal app check, but, we need to be sure that they're ready before we try to use them.
+        List<String> extraMsgs = new ArrayList<String>() {
             {
-                add(Constants.TOKENENDPT_APP);
+                add("CWWKZ0001I.*" + Constants.TOKEN_ENDPOINT_SERVLET);
+                add("CWWKZ0001I.*" + Constants.USERINFO_ENDPOINT_SERVLET);
             }
         };
 
@@ -165,7 +169,7 @@ public class OidcJaxRSClientAPITests extends JaxRSClientAPITests {
         genericTestServer.addIgnoredServerException(MessageConstants.CWWKG0033W_CONFIG_REFERENCE_NOT_FOUND);
 
         // Start the OIDC OP server - tell it to generate JWT access tokens
-        testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.jaxrs.opWithStub", "op_server_encrypt.xml", Constants.OIDC_OP, op_apps, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, null, null, true, true, tokenType, Constants.X509_CERT);
+        testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.jaxrs.opWithStub", "op_server_encrypt.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, extraMsgs, null, null, true, true, tokenType, Constants.X509_CERT);
         //Start the OIDC RP server and setup default values
         testRPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.jaxrs.rp", "rp_server_api_orig.xml", Constants.OIDC_RP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, Constants.X509_CERT);
         testRPServer.addIgnoredServerException(MessageConstants.CWWKG0033W_CONFIG_REFERENCE_NOT_FOUND);

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/fat/src/com/ibm/ws/security/social/fat/LibertyOP/LibertyOP_Encryption_oidc_usingSocialConfig.java
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/fat/src/com/ibm/ws/security/social/fat/LibertyOP/LibertyOP_Encryption_oidc_usingSocialConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -57,6 +57,7 @@ public class LibertyOP_Encryption_oidc_usingSocialConfig extends Social_Encrypti
 
         List<String> opStartMsgs = new ArrayList<String>();
         opStartMsgs.add("CWWKS1631I.*");
+        opStartMsgs.add("CWWKZ0001I.*" + Constants.TOKEN_ENDPOINT_SERVLET);
 
         List<String> opExtraApps = new ArrayList<String>();
         opExtraApps.add(SocialConstants.OP_SAMPLE_APP);

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/fat/src/com/ibm/ws/security/social/fat/LibertyOP/LibertyOP_SignatureAlg_oidc_usingSocialConfig.java
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/fat/src/com/ibm/ws/security/social/fat/LibertyOP/LibertyOP_SignatureAlg_oidc_usingSocialConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -63,6 +63,7 @@ public class LibertyOP_SignatureAlg_oidc_usingSocialConfig extends Social_Signat
 
         List<String> opStartMsgs = new ArrayList<String>();
         opStartMsgs.add("CWWKS1631I.*");
+        opStartMsgs.add("CWWKZ0001I.*" + Constants.TOKEN_ENDPOINT_SERVLET);
 
         List<String> opExtraApps = new ArrayList<String>();
         opExtraApps.add(SocialConstants.OP_SAMPLE_APP);


### PR DESCRIPTION
In order to test encryption and additional signature algorithm for OIDC and Social configs, we need token and userinfo endpoints that can handle them.  Some of the test classes were not waiting for the test apps that are providing that endpoint support to start.  In most cases, they start pretty quickly, but that's not always the case.  So, I'm adding checks (with embedded waits) for those test apps.