### PR TITLE
test currentContextExecutor and getExecutionProperties

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/RequestScopedBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/RequestScopedBean.java
@@ -29,7 +29,7 @@ import jakarta.enterprise.context.RequestScoped;
 
 @ContextServiceDefinition(name = "java:comp/concurrent/txcontextunchanged",
                           propagated = APPLICATION,
-                          unchanged = TRANSACTION,
+                          unchanged = { "MyUnavailableContextType", TRANSACTION },
                           cleared = ALL_REMAINING)
 @ManagedScheduledExecutorDefinition(name = "java:comp/concurrent/appContextExecutor",
                                     context = "java:comp/concurrent/txcontextunchanged")

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/ConcurrencyTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/ConcurrencyTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -32,6 +34,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Exchanger;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
@@ -58,6 +61,7 @@ import jakarta.enterprise.concurrent.ManagedExecutorDefinition;
 import jakarta.enterprise.concurrent.ManagedExecutorService;
 import jakarta.enterprise.concurrent.ManagedScheduledExecutorDefinition;
 import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
+import jakarta.enterprise.concurrent.ManagedTask;
 import jakarta.enterprise.concurrent.ManagedThreadFactory;
 import jakarta.enterprise.concurrent.ManagedThreadFactoryDefinition;
 import jakarta.enterprise.concurrent.ZonedTrigger;
@@ -342,6 +346,64 @@ public class ConcurrencyTestServlet extends FATServlet {
     }
 
     /**
+     * Use currentContextExecutor to capture a snapshot of the current thread context and apply
+     * it elsewhere at later points in time.
+     */
+    @Test
+    public void testCurrentContextExecutor() throws Exception {
+        ContextService contextSvc = InitialContext.doLookup("java:module/concurrent/ZLContextSvc");
+
+        try {
+            Thread.currentThread().setPriority(7);
+
+            ZipCode.set(55901);
+            Executor nwRochesterExecutor = contextSvc.currentContextExecutor();
+
+            ZipCode.set(55902);
+            Executor swRochesterExecutor = contextSvc.currentContextExecutor();
+
+            ZipCode.set(55906);
+            Thread.currentThread().setPriority(6);
+            Timestamp.set();
+            Long timestamp1 = Timestamp.get();
+
+            nwRochesterExecutor.execute(() -> {
+                assertEquals(55901, ZipCode.get()); // propagated
+                assertEquals(null, Timestamp.get()); // cleared
+                assertEquals(Thread.NORM_PRIORITY, Thread.currentThread().getPriority()); // cleared
+                try {
+                    assertNotNull(InitialContext.doLookup("java:module/concurrent/ZLContextSvc")); // unchanged
+                } catch (NamingException x) {
+                    throw new AssertionError(x);
+                }
+            });
+
+            assertEquals(55906, ZipCode.get());
+            assertEquals(timestamp1, Timestamp.get());
+            assertEquals(6, Thread.currentThread().getPriority());
+
+            swRochesterExecutor.execute(() -> {
+                assertEquals(55902, ZipCode.get()); // propagated
+                assertEquals(null, Timestamp.get()); // cleared
+                assertEquals(Thread.NORM_PRIORITY, Thread.currentThread().getPriority()); // cleared
+                try {
+                    assertNotNull(InitialContext.doLookup("java:module/concurrent/ZLContextSvc")); // unchanged
+                } catch (NamingException x) {
+                    throw new AssertionError(x);
+                }
+            });
+
+            assertEquals(55906, ZipCode.get());
+            assertEquals(timestamp1, Timestamp.get());
+            assertEquals(6, Thread.currentThread().getPriority());
+        } finally {
+            Thread.currentThread().setPriority(Thread.NORM_PRIORITY);
+            Timestamp.clear();
+            ZipCode.clear();
+        }
+    }
+
+    /**
      * Verify that a ManagedExecutorService propagates context to dependent stages that are
      * created from a failedFuture().
      */
@@ -462,6 +524,40 @@ public class ConcurrencyTestServlet extends FATServlet {
             assertTrue(result.toString(), result instanceof ManagedScheduledExecutorService);
         } finally {
             blocker.countDown();
+        }
+    }
+
+    /**
+     * Per the spec JavaDoc, ContextService.getExecutionProperties can be used on a
+     * contextual proxy obtained by createContextualProxy, but otherwise raises
+     * IllegalArgumentException.
+     */
+    @Test
+    public void testGetExecutionProperties() throws Exception {
+        ContextService contextSvc = InitialContext.doLookup("java:app/concurrent/appContextSvc");
+        Function<Integer, Integer> triple = i -> i * 3;
+        Map<String, String> execProps = Collections.singletonMap(ManagedTask.IDENTITY_NAME, "testGetExecutionProperties");
+
+        @SuppressWarnings("unchecked")
+        Function<Integer, Integer> proxyFn = contextSvc.createContextualProxy(triple, execProps, Function.class);
+        assertEquals(execProps, contextSvc.getExecutionProperties(proxyFn));
+
+        Function<Integer, Integer> contextFn = contextSvc.contextualFunction(triple);
+        try {
+            Map<String, String> unexpected = contextSvc.getExecutionProperties(contextFn);
+            fail("getExecutionProperties must raise IllegalArgumentException when the proxy is " +
+                 "not created by createContextualProxy. Result: " + unexpected);
+        } catch (IllegalArgumentException x) {
+            // expected
+        }
+
+        Executor contextExecutor = contextSvc.currentContextExecutor();
+        try {
+            Map<String, String> unexpected = contextSvc.getExecutionProperties(contextExecutor);
+            fail("getExecutionProperties must raise IllegalArgumentException when the proxy is " +
+                 "not created by createContextualProxy. Result: " + unexpected);
+        } catch (IllegalArgumentException x) {
+            // expected
         }
     }
 


### PR DESCRIPTION
Add tests for the new currentContextExecutor method.
Also test what happens when a contextualized function created with one of the new API methods is supplied to the existing getExecutionProperties API method.  The spec JavaDoc indicates it must raise IllegalArgumentException.
Also, include an unrecognized context type under the configured `unchanged` list for `ContextServiceDefinition`. This should have no impact and not cause a failure.