### PR TITLE
Minor JPA FAT cleanup

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.1_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.1_fat/build.gradle
@@ -48,13 +48,13 @@ task addJPAFATTools (type: Copy) {
 task addhibernateJPA21(type: Copy) {
   shouldRunAfter jar
   from configurations.hibernateJPA21
-  into new File(autoFvtDir, 'publish/shared/resources/jpa21_hibernate')
+  into new File(autoFvtDir, 'publish/shared/resources/jpa_beanvalidation_fat_jpa21_hibernate')
 }
 
 task addOpenJPA_JPA21(type: Copy) {
   shouldRunAfter jar
   from configurations.openjpaJPA21
-  into new File(autoFvtDir, 'publish/shared/resources/jpa21_openjpa')
+  into new File(autoFvtDir, 'publish/shared/resources/jpa_beanvalidation_fat_jpa21_openjpa')
 }
 
 task copyFAT {

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.1_fat/publish/shared/config/hibernate21-cfg.xml
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.1_fat/publish/shared/config/hibernate21-cfg.xml
@@ -10,15 +10,15 @@
     <jpa defaultPersistenceProvider="org.hibernate.jpa.HibernatePersistenceProvider" />
 
     <library id="HibernateLib">
-        <fileset dir="${shared.resource.dir}/jpa21_hibernate" includes="*.jar"/>
+        <fileset dir="${shared.resource.dir}/jpa_beanvalidation_fat_jpa21_hibernate" includes="*.jar"/>
     </library>
 
-    <javaPermission codebase="${shared.resource.dir}/jpa21_hibernate/antlr-2.7.7.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_hibernate/classmate-1.3.0.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_hibernate/dom4j-2.1.1.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_hibernate/hibernate-commons-annotations-5.0.1.Final.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_hibernate/hibernate-core-5.2.18.Final.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_hibernate/jandex-2.0.3.Final.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_hibernate/javassist-3.25.0-GA.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_hibernate/jboss-logging-3.3.1.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa21_hibernate/antlr-2.7.7.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa21_hibernate/classmate-1.3.0.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa21_hibernate/dom4j-2.1.1.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa21_hibernate/hibernate-commons-annotations-5.0.1.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa21_hibernate/hibernate-core-5.2.18.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa21_hibernate/jandex-2.0.3.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa21_hibernate/javassist-3.25.0-GA.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa21_hibernate/jboss-logging-3.3.1.Final.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.1_fat/publish/shared/config/openjpa21-cfg.xml
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.1_fat/publish/shared/config/openjpa21-cfg.xml
@@ -10,16 +10,15 @@
     <jpa defaultPersistenceProvider="org.apache.openjpa.persistence.PersistenceProviderImpl" />
 
     <library id="OpenJPALib">
-        <fileset dir="${shared.resource.dir}/jpa21_openjpa" includes="*.jar"/>
+        <fileset dir="${shared.resource.dir}/jpa_beanvalidation_fat_jpa21_openjpa" includes="*.jar"/>
     </library>
 
-    <javaPermission className="java.util.PropertyPermission" name="openjpa.serialization.class.blacklist" actions="read"/>
-    <javaPermission className="java.util.PropertyPermission" name="openjpa.serialization.class.whitelist" actions="read"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_openjpa/commons-collections-3.2.2.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_openjpa/commons-dbcp-1.4.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_openjpa/commons-logging-1.2.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_openjpa/commons-pool-1.6.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_openjpa/serp-1.15.1.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_openjpa/xbean-asm6-shaded-4.8.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_openjpa/openjpa-3.0.0.jar" className="java.security.AllPermission"/>
+    <javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa21_openjpa/commons-collections-3.2.2.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa21_openjpa/commons-dbcp-1.4.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa21_openjpa/commons-logging-1.2.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa21_openjpa/commons-pool-1.6.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa21_openjpa/serp-1.15.1.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa21_openjpa/xbean-asm6-shaded-4.8.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa21_openjpa/openjpa-3.0.0.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.2_fat/build.gradle
@@ -48,13 +48,13 @@ task addJPAFATTools (type: Copy) {
 task addhibernateJPA22(type: Copy) {
   shouldRunAfter jar
   from configurations.hibernateJPA22
-  into new File(autoFvtDir, 'publish/shared/resources/jpa22_hibernate')
+  into new File(autoFvtDir, 'publish/shared/resources/jpa_beanvalidation_fat_jpa22_hibernate')
 }
 
 task addOpenJPA_JPA22(type: Copy) {
   shouldRunAfter jar
   from configurations.openjpaJPA22
-  into new File(autoFvtDir, 'publish/shared/resources/jpa22_openjpa')
+  into new File(autoFvtDir, 'publish/shared/resources/jpa_beanvalidation_fat_jpa22_openjpa')
 }
 
 task copyFAT {

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.2_fat/publish/shared/config/hibernate22-cfg.xml
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.2_fat/publish/shared/config/hibernate22-cfg.xml
@@ -10,15 +10,15 @@
     <jpa defaultPersistenceProvider="org.hibernate.jpa.HibernatePersistenceProvider" />
 
     <library id="HibernateLib">
-        <fileset dir="${shared.resource.dir}/jpa22_hibernate" includes="*.jar"/>
+        <fileset dir="${shared.resource.dir}/jpa_beanvalidation_fat_jpa22_hibernate" includes="*.jar"/>
     </library>
 
-    <javaPermission codebase="${shared.resource.dir}/jpa22_hibernate/antlr-2.7.7.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_hibernate/byte-buddy-1.11.12.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_hibernate/classmate-1.5.1.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_hibernate/hibernate-commons-annotations-5.1.2.Final.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_hibernate/hibernate-core-5.5.7.Final.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_hibernate/jandex-2.2.3.Final.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_hibernate/javassist-3.27.0-GA.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_hibernate/jboss-logging-3.4.2.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa22_hibernate/antlr-2.7.7.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa22_hibernate/byte-buddy-1.11.12.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa22_hibernate/classmate-1.5.1.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa22_hibernate/hibernate-commons-annotations-5.1.2.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa22_hibernate/hibernate-core-5.5.7.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa22_hibernate/jandex-2.2.3.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa22_hibernate/javassist-3.27.0-GA.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa22_hibernate/jboss-logging-3.4.2.Final.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.2_fat/publish/shared/config/openjpa22-cfg.xml
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.2_fat/publish/shared/config/openjpa22-cfg.xml
@@ -10,16 +10,15 @@
     <jpa defaultPersistenceProvider="org.apache.openjpa.persistence.PersistenceProviderImpl" />
 
     <library id="OpenJPALib">
-        <fileset dir="${shared.resource.dir}/jpa22_openjpa" includes="*.jar"/>
+        <fileset dir="${shared.resource.dir}/jpa_beanvalidation_fat_jpa22_openjpa" includes="*.jar"/>
     </library>
 
-    <javaPermission className="java.util.PropertyPermission" name="openjpa.serialization.class.blacklist" actions="read"/>
-    <javaPermission className="java.util.PropertyPermission" name="openjpa.serialization.class.whitelist" actions="read"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_openjpa/commons-collections4-4.4.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_openjpa/commons-dbcp2-2.7.0.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_openjpa/commons-logging-1.2.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_openjpa/commons-pool2-2.6.0.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_openjpa/serp-1.15.1.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_openjpa/xbean-asm8-shaded-4.17.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_openjpa/openjpa-3.1.2.jar" className="java.security.AllPermission"/>
+    <javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa22_openjpa/commons-collections4-4.4.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa22_openjpa/commons-dbcp2-2.7.0.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa22_openjpa/commons-logging-1.2.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa22_openjpa/commons-pool2-2.6.0.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa22_openjpa/serp-1.15.1.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa22_openjpa/xbean-asm8-shaded-4.17.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa22_openjpa/openjpa-3.1.2.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.0_fat/build.gradle
@@ -39,7 +39,7 @@ task addJPAFATTools (type: Copy) {
 task addhibernateJPA30(type: Copy) {
   shouldRunAfter jar
   from configurations.hibernateJPA30
-  into new File(autoFvtDir, 'publish/shared/resources/jpa30_hibernate')
+  into new File(autoFvtDir, 'publish/shared/resources/jpa_beanvalidation_fat_jpa30_hibernate')
 }
 
 task copyFAT {

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.0_fat/publish/shared/config/hibernate30-cfg.xml
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.0_fat/publish/shared/config/hibernate30-cfg.xml
@@ -10,15 +10,15 @@
     <jpa defaultPersistenceProvider="org.hibernate.jpa.HibernatePersistenceProvider" />
 
     <library id="HibernateLib">
-        <fileset dir="${shared.resource.dir}/jpa30_hibernate" includes="*.jar"/>
+        <fileset dir="${shared.resource.dir}/jpa_beanvalidation_fat_jpa30_hibernate" includes="*.jar"/>
     </library>
 
-    <javaPermission codebase="${shared.resource.dir}/jpa30_hibernate/antlr-2.7.7.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa30_hibernate/byte-buddy-1.11.12.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa30_hibernate/classmate-1.5.1.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa30_hibernate/hibernate-commons-annotations-5.1.2.Final.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa30_hibernate/hibernate-core-jakarta-5.5.7.Final.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa30_hibernate/jandex-2.2.3.Final.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa30_hibernate/javassist-3.27.0-GA.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa30_hibernate/jboss-logging-3.4.2.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa30_hibernate/antlr-2.7.7.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa30_hibernate/byte-buddy-1.11.12.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa30_hibernate/classmate-1.5.1.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa30_hibernate/hibernate-commons-annotations-5.1.2.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa30_hibernate/hibernate-core-jakarta-5.5.7.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa30_hibernate/jandex-2.2.3.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa30_hibernate/javassist-3.27.0-GA.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_beanvalidation_fat_jpa30_hibernate/jboss-logging-3.4.2.Final.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.jpa.tests.eclipselink_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
@@ -216,6 +216,7 @@ public class JPAFATServletClient extends FATServletClient {
     protected static final JavaArchive buildTestAPIJar() throws Exception {
         final JavaArchive testApiJar = ShrinkWrap.create(JavaArchive.class, "TestAPI.jar");
         testApiJar.addPackage("com.ibm.ws.testtooling.database");
+        testApiJar.addPackage("com.ibm.ws.testtooling.jpaprovider");
         testApiJar.addPackage("com.ibm.ws.testtooling.msgcli");
         testApiJar.addPackage("com.ibm.ws.testtooling.msgcli.jms");
         testApiJar.addPackage("com.ibm.ws.testtooling.msgcli.msc");

--- a/dev/com.ibm.ws.jpa.tests.eclipselink_fat/test-applications/olgh19176/src/com/ibm/ws/jpa/olgh19176/testlogic/JPATestOLGH19176Logic.java
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink_fat/test-applications/olgh19176/src/com/ibm/ws/jpa/olgh19176/testlogic/JPATestOLGH19176Logic.java
@@ -19,6 +19,7 @@ import javax.persistence.EntityManager;
 import org.junit.Assert;
 
 import com.ibm.ws.jpa.olgh19176.model.WeavedEntityAOLGH19176;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
 import com.ibm.ws.testtooling.vehicle.resources.JPAResource;
@@ -50,9 +51,11 @@ public class JPATestOLGH19176Logic extends AbstractTestLogic {
             }
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         //TODO: Disable test until EclipseLink 3.0 is updated to include the fix
         //TODO: Disable test until EclipseLink 2.7 is updated to include the fix
-        if ((isUsingJPA22Feature() || isUsingJPA30Feature()) && JPAProviderImpl.ECLIPSELINK.equals(getJPAProviderImpl(jpaResource))) {
+        if ((isUsingJPA22Feature() || isUsingJPA30Feature()) && JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
             return;
         }
 

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_fat.common/test-applications/defaultproperties/src/com/ibm/ws/jpa/defaultproperties/testlogic/DefaultPropertiesLogic.java
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_fat.common/test-applications/defaultproperties/src/com/ibm/ws/jpa/defaultproperties/testlogic/DefaultPropertiesLogic.java
@@ -15,6 +15,7 @@ import javax.persistence.EntityManager;
 
 import org.junit.Assert;
 
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
 import com.ibm.ws.testtooling.tranjacket.TransactionJacket;
@@ -50,6 +51,8 @@ public class DefaultPropertiesLogic extends AbstractTestLogic {
             return;
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -73,7 +76,7 @@ public class DefaultPropertiesLogic extends AbstractTestLogic {
                                   em.getProperties().containsKey(key));
                 Object propertyValue = em.getProperties().get(key);
 
-                if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+                if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                     Assert.assertEquals("The persistence property '" + key + "' contains '" + propertyValue + "' instead of '" + intvalue + "'",
                                         intvalue, propertyValue);
                 } else {

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_fat.common/test-applications/overridepersistencecontext/src/com/ibm/ws/jpa/overridepersistencecontext/testlogic/OverridePersistenceContextLogic.java
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_fat.common/test-applications/overridepersistencecontext/src/com/ibm/ws/jpa/overridepersistencecontext/testlogic/OverridePersistenceContextLogic.java
@@ -15,6 +15,7 @@ import javax.persistence.EntityManager;
 
 import org.junit.Assert;
 
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext.PersistenceContextType;
 import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
@@ -51,6 +52,8 @@ public class OverridePersistenceContextLogic extends AbstractTestLogic {
             return;
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -77,7 +80,6 @@ public class OverridePersistenceContextLogic extends AbstractTestLogic {
                 Object propertyValue = em.getProperties().get(key);
 
                 PersistenceContextType type = jpaResource.getPcCtxInfo().getPcType();
-                JPAProviderImpl provider = getJPAProviderImpl(jpaResource);
 
                 // PersistenceContexts override the persistence property. On EclipseLink, that value overrides the JPAComponent configuration
                 // PersistenceContexts override the persistence property. On Hibernate 2.2+, that value overrides the JPAComponent configuration

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_fat.common/test-applications/overridepersistencexml/src/com/ibm/ws/jpa/overridepersistencexml/testlogic/OverridePersistenceXmlLogic.java
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_fat.common/test-applications/overridepersistencexml/src/com/ibm/ws/jpa/overridepersistencexml/testlogic/OverridePersistenceXmlLogic.java
@@ -15,6 +15,7 @@ import javax.persistence.EntityManager;
 
 import org.junit.Assert;
 
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
 import com.ibm.ws.testtooling.tranjacket.TransactionJacket;
@@ -50,6 +51,8 @@ public class OverridePersistenceXmlLogic extends AbstractTestLogic {
             return;
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -73,7 +76,7 @@ public class OverridePersistenceXmlLogic extends AbstractTestLogic {
                                   em.getProperties().containsKey(key));
                 Object propertyValue = em.getProperties().get(key);
 
-                if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+                if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                     Assert.assertEquals("The persistence property '" + key + "' contains '" + propertyValue + "' instead of '" + intvalue + "'",
                                         intvalue, propertyValue);
                 } else {

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.1_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.1_fat/build.gradle
@@ -48,13 +48,13 @@ task addJPAFATTools (type: Copy) {
 task addhibernateJPA21(type: Copy) {
   shouldRunAfter jar
   from configurations.hibernateJPA21
-  into new File(autoFvtDir, 'publish/shared/resources/jpa21_hibernate')
+  into new File(autoFvtDir, 'publish/shared/resources/jpa_jpaconfig_fat_jpa21_hibernate')
 }
 
 task addOpenJPA_JPA21(type: Copy) {
   shouldRunAfter jar
   from configurations.openjpaJPA21
-  into new File(autoFvtDir, 'publish/shared/resources/jpa21_openjpa')
+  into new File(autoFvtDir, 'publish/shared/resources/jpa_jpaconfig_fat_jpa21_openjpa')
 }
 
 task copyFAT {

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.1_fat/publish/shared/config/hibernate21-cfg.xml
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.1_fat/publish/shared/config/hibernate21-cfg.xml
@@ -14,15 +14,15 @@
     </jpa>
 
     <library id="HibernateLib">
-        <fileset dir="${shared.resource.dir}/jpa21_hibernate" includes="*.jar"/>
+        <fileset dir="${shared.resource.dir}/jpa_jpaconfig_fat_jpa21_hibernate" includes="*.jar"/>
     </library>
 
-    <javaPermission codebase="${shared.resource.dir}/jpa21_hibernate/antlr-2.7.7.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_hibernate/classmate-1.3.0.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_hibernate/dom4j-2.1.1.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_hibernate/hibernate-commons-annotations-5.0.1.Final.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_hibernate/hibernate-core-5.2.18.Final.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_hibernate/jandex-2.0.3.Final.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_hibernate/javassist-3.25.0-GA.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_hibernate/jboss-logging-3.3.1.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa21_hibernate/antlr-2.7.7.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa21_hibernate/classmate-1.3.0.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa21_hibernate/dom4j-2.1.1.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa21_hibernate/hibernate-commons-annotations-5.0.1.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa21_hibernate/hibernate-core-5.2.18.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa21_hibernate/jandex-2.0.3.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa21_hibernate/javassist-3.25.0-GA.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa21_hibernate/jboss-logging-3.3.1.Final.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.1_fat/publish/shared/config/openjpa21-cfg.xml
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.1_fat/publish/shared/config/openjpa21-cfg.xml
@@ -14,16 +14,15 @@
     </jpa>
 
     <library id="OpenJPALib">
-        <fileset dir="${shared.resource.dir}/jpa21_openjpa" includes="*.jar"/>
+        <fileset dir="${shared.resource.dir}/jpa_jpaconfig_fat_jpa21_openjpa" includes="*.jar"/>
     </library>
 
-    <javaPermission className="java.util.PropertyPermission" name="openjpa.serialization.class.blacklist" actions="read"/>
-    <javaPermission className="java.util.PropertyPermission" name="openjpa.serialization.class.whitelist" actions="read"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_openjpa/commons-collections-3.2.2.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_openjpa/commons-dbcp-1.4.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_openjpa/commons-logging-1.2.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_openjpa/commons-pool-1.6.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_openjpa/serp-1.15.1.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_openjpa/xbean-asm6-shaded-4.8.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa21_openjpa/openjpa-3.0.0.jar" className="java.security.AllPermission"/>
+    <javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa21_openjpa/commons-collections-3.2.2.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa21_openjpa/commons-dbcp-1.4.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa21_openjpa/commons-logging-1.2.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa21_openjpa/commons-pool-1.6.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa21_openjpa/serp-1.15.1.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa21_openjpa/xbean-asm6-shaded-4.8.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa21_openjpa/openjpa-3.0.0.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.2_fat/build.gradle
@@ -48,13 +48,13 @@ task addJPAFATTools (type: Copy) {
 task addhibernateJPA22(type: Copy) {
   shouldRunAfter jar
   from configurations.hibernateJPA22
-  into new File(autoFvtDir, 'publish/shared/resources/jpa22_hibernate')
+  into new File(autoFvtDir, 'publish/shared/resources/jpa_jpaconfig_fat_jpa22_hibernate')
 }
 
 task addOpenJPA_JPA22(type: Copy) {
   shouldRunAfter jar
   from configurations.openjpaJPA22
-  into new File(autoFvtDir, 'publish/shared/resources/jpa22_openjpa')
+  into new File(autoFvtDir, 'publish/shared/resources/jpa_jpaconfig_fat_jpa22_openjpa')
 }
 
 task copyFAT {

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.2_fat/publish/shared/config/hibernate22-cfg.xml
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.2_fat/publish/shared/config/hibernate22-cfg.xml
@@ -14,15 +14,15 @@
     </jpa>
 
     <library id="HibernateLib">
-        <fileset dir="${shared.resource.dir}/jpa22_hibernate" includes="*.jar"/>
+        <fileset dir="${shared.resource.dir}/jpa_jpaconfig_fat_jpa22_hibernate" includes="*.jar"/>
     </library>
 
-    <javaPermission codebase="${shared.resource.dir}/jpa22_hibernate/antlr-2.7.7.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_hibernate/byte-buddy-1.11.12.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_hibernate/classmate-1.5.1.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_hibernate/hibernate-commons-annotations-5.1.2.Final.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_hibernate/hibernate-core-5.5.7.Final.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_hibernate/jandex-2.2.3.Final.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_hibernate/javassist-3.27.0-GA.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_hibernate/jboss-logging-3.4.2.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa22_hibernate/antlr-2.7.7.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa22_hibernate/byte-buddy-1.11.12.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa22_hibernate/classmate-1.5.1.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa22_hibernate/hibernate-commons-annotations-5.1.2.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa22_hibernate/hibernate-core-5.5.7.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa22_hibernate/jandex-2.2.3.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa22_hibernate/javassist-3.27.0-GA.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa22_hibernate/jboss-logging-3.4.2.Final.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.2_fat/publish/shared/config/openjpa22-cfg.xml
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.2_fat/publish/shared/config/openjpa22-cfg.xml
@@ -14,16 +14,15 @@
     </jpa>
 
     <library id="OpenJPALib">
-        <fileset dir="${shared.resource.dir}/jpa22_openjpa" includes="*.jar"/>
+        <fileset dir="${shared.resource.dir}/jpa_jpaconfig_fat_jpa22_openjpa" includes="*.jar"/>
     </library>
 
-    <javaPermission className="java.util.PropertyPermission" name="openjpa.serialization.class.blacklist" actions="read"/>
-    <javaPermission className="java.util.PropertyPermission" name="openjpa.serialization.class.whitelist" actions="read"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_openjpa/commons-collections4-4.4.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_openjpa/commons-dbcp2-2.7.0.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_openjpa/commons-logging-1.2.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_openjpa/commons-pool2-2.6.0.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_openjpa/serp-1.15.1.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_openjpa/xbean-asm8-shaded-4.17.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa22_openjpa/openjpa-3.1.2.jar" className="java.security.AllPermission"/>
+    <javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa22_openjpa/commons-collections4-4.4.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa22_openjpa/commons-dbcp2-2.7.0.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa22_openjpa/commons-logging-1.2.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa22_openjpa/commons-pool2-2.6.0.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa22_openjpa/serp-1.15.1.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa22_openjpa/xbean-asm8-shaded-4.17.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa22_openjpa/openjpa-3.1.2.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_3.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_3.0_fat/build.gradle
@@ -39,7 +39,7 @@ task addJPAFATTools (type: Copy) {
 task addhibernateJPA30(type: Copy) {
   shouldRunAfter jar
   from configurations.hibernateJPA30
-  into new File(autoFvtDir, 'publish/shared/resources/jpa30_hibernate')
+  into new File(autoFvtDir, 'publish/shared/resources/jpa_jpaconfig_fat_jpa30_hibernate')
 }
 
 task copyFAT {

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_3.0_fat/publish/shared/config/hibernate30-cfg.xml
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_3.0_fat/publish/shared/config/hibernate30-cfg.xml
@@ -14,15 +14,15 @@
     </jpa>
 
     <library id="HibernateLib">
-        <fileset dir="${shared.resource.dir}/jpa30_hibernate" includes="*.jar"/>
+        <fileset dir="${shared.resource.dir}/jpa_jpaconfig_fat_jpa30_hibernate" includes="*.jar"/>
     </library>
 
-    <javaPermission codebase="${shared.resource.dir}/jpa30_hibernate/antlr-2.7.7.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa30_hibernate/byte-buddy-1.11.12.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa30_hibernate/classmate-1.5.1.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa30_hibernate/hibernate-commons-annotations-5.1.2.Final.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa30_hibernate/hibernate-core-jakarta-5.5.7.Final.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa30_hibernate/jandex-2.2.3.Final.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa30_hibernate/javassist-3.27.0-GA.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/jpa30_hibernate/jboss-logging-3.4.2.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa30_hibernate/antlr-2.7.7.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa30_hibernate/byte-buddy-1.11.12.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa30_hibernate/classmate-1.5.1.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa30_hibernate/hibernate-commons-annotations-5.1.2.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa30_hibernate/hibernate-core-jakarta-5.5.7.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa30_hibernate/jandex-2.2.3.Final.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa30_hibernate/javassist-3.27.0-GA.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/jpa_jpaconfig_fat_jpa30_hibernate/jboss-logging-3.4.2.Final.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/JPAFATServletClient.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/JPAFATServletClient.java
@@ -204,6 +204,7 @@ public class JPAFATServletClient extends FATServletClient {
     protected static final JavaArchive buildTestAPIJar() throws Exception {
         final JavaArchive testApiJar = ShrinkWrap.create(JavaArchive.class, "TestAPI.jar");
         testApiJar.addPackage("com.ibm.ws.testtooling.database");
+        testApiJar.addPackage("com.ibm.ws.testtooling.jpaprovider");
         testApiJar.addPackage("com.ibm.ws.testtooling.msgcli");
         testApiJar.addPackage("com.ibm.ws.testtooling.msgcli.jms");
         testApiJar.addPackage("com.ibm.ws.testtooling.msgcli.msc");

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/test-applications/embeddable/basic/src/com/ibm/ws/jpa/embeddable/basic/testlogic/EmbeddableBasicLogic.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/test-applications/embeddable/basic/src/com/ibm/ws/jpa/embeddable/basic/testlogic/EmbeddableBasicLogic.java
@@ -88,6 +88,7 @@ import com.ibm.ws.jpa.embeddable.basic.model.XMLSetLobEmbed;
 import com.ibm.ws.jpa.embeddable.basic.model.XMLSetTemporalEmbed;
 import com.ibm.ws.jpa.embeddable.basic.model.XMLTemporalFieldAccessEmbed;
 import com.ibm.ws.jpa.embeddable.basic.model.XMLTemporalPropertyAccessEmbed;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
 import com.ibm.ws.testtooling.tranjacket.TransactionJacket;
@@ -269,7 +270,7 @@ public class EmbeddableBasicLogic extends AbstractTestLogic {
             }
         }
 
-        JPAProviderImpl provider = getJPAProviderImpl(jpaResource);
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
 
         // Execute Test Case
         try {
@@ -369,9 +370,9 @@ public class EmbeddableBasicLogic extends AbstractTestLogic {
              * If an Embeddable class has only one field and that field is transient, Ecipselink doesn't
              * create an object of type Embeddable class and set its transient field null.
              */
-            if (JPAProviderImpl.ECLIPSELINK.equals(provider)) {
+            if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
                 Assert.assertNull(findEntity.getIntegerTransientEmbed());
-            } else if (JPAProviderImpl.OPENJPA.equals(provider)) {
+            } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 Assert.assertNull(findEntity.getIntegerTransientEmbed().getTransientJavaValue());
                 Assert.assertNull(findEntity.getIntegerTransientEmbed().getTransientValue());
             }
@@ -450,7 +451,7 @@ public class EmbeddableBasicLogic extends AbstractTestLogic {
              * If an Embeddable class has only one field and that field is transient, Ecipselink doesn't
              * create an object of type Embeddable class and set its transient field null.
              */
-            if (JPAProviderImpl.ECLIPSELINK.equals(provider)) {
+            if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
                 findEntity.setIntegerTransientEmbed(new IntegerTransientEmbed());
             }
             findEntity.getIntegerTransientEmbed().setTransientJavaValue(444);
@@ -535,9 +536,9 @@ public class EmbeddableBasicLogic extends AbstractTestLogic {
              * If an Embeddable class has only one field and that field is transient, Ecipselink doesn't
              * create an object of type Embeddable class and set its transient field null.
              */
-            if (JPAProviderImpl.ECLIPSELINK.equals(provider)) {
+            if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
                 Assert.assertNull(updatedFindEntity.getIntegerTransientEmbed());
-            } else if (JPAProviderImpl.OPENJPA.equals(provider)) {
+            } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 Assert.assertNull(updatedFindEntity.getIntegerTransientEmbed().getTransientJavaValue());
                 Assert.assertNull(updatedFindEntity.getIntegerTransientEmbed().getTransientValue());
             }
@@ -620,7 +621,7 @@ public class EmbeddableBasicLogic extends AbstractTestLogic {
             }
         }
 
-        JPAProviderImpl provider = getJPAProviderImpl(jpaResource);
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
 
         // Execute Test Case
         try {
@@ -722,9 +723,9 @@ public class EmbeddableBasicLogic extends AbstractTestLogic {
              * If an Embeddable class has only one field and that field is transient, Ecipselink doesn't
              * create an object of type Embeddable class and set its transient field null.
              */
-            if (JPAProviderImpl.ECLIPSELINK.equals(provider)) {
+            if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
                 Assert.assertNull(findEntity.getIntegerTransientEmbed());
-            } else if (JPAProviderImpl.OPENJPA.equals(provider)) {
+            } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 Assert.assertNull(findEntity.getIntegerTransientEmbed().getTransientJavaValue());
                 Assert.assertNull(findEntity.getIntegerTransientEmbed().getTransientValue());
             }
@@ -802,7 +803,7 @@ public class EmbeddableBasicLogic extends AbstractTestLogic {
              * If an Embeddable class has only one field and that field is transient, Ecipselink doesn't
              * create an object of type Embeddable class and set its transient field null.
              */
-            if (JPAProviderImpl.ECLIPSELINK.equals(provider)) {
+            if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
                 findEntity.setIntegerTransientEmbed(new XMLIntegerTransientEmbed());
             }
             findEntity.getIntegerTransientEmbed().setTransientJavaValue(444);
@@ -888,9 +889,9 @@ public class EmbeddableBasicLogic extends AbstractTestLogic {
              * If an Embeddable class has only one field and that field is transient, Ecipselink doesn't
              * create an object of type Embeddable class and set its transient field null.
              */
-            if (JPAProviderImpl.ECLIPSELINK.equals(provider)) {
+            if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
                 Assert.assertNull(updatedFindEntity.getIntegerTransientEmbed());
-            } else if (JPAProviderImpl.OPENJPA.equals(provider)) {
+            } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 Assert.assertNull(updatedFindEntity.getIntegerTransientEmbed().getTransientJavaValue());
                 Assert.assertNull(updatedFindEntity.getIntegerTransientEmbed().getTransientValue());
             }
@@ -2072,7 +2073,7 @@ public class EmbeddableBasicLogic extends AbstractTestLogic {
             }
         }
 
-        JPAProviderImpl provider = getJPAProviderImpl(jpaResource);
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
 
         // Execute Test Case
         try {
@@ -2175,9 +2176,9 @@ public class EmbeddableBasicLogic extends AbstractTestLogic {
              * If an Embeddable class has only one field and that field is transient, Ecipselink doesn't
              * create an object of type Embeddable class and set its transient field null.
              */
-            if (JPAProviderImpl.ECLIPSELINK.equals(provider)) {
+            if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
                 Assert.assertNull(findEntity.getIntegerTransientEmbed());
-            } else if (JPAProviderImpl.OPENJPA.equals(provider)) {
+            } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 Assert.assertNull(findEntity.getIntegerTransientEmbed().getTransientJavaValue());
                 Assert.assertNull(findEntity.getIntegerTransientEmbed().getTransientValue());
             }
@@ -2268,7 +2269,7 @@ public class EmbeddableBasicLogic extends AbstractTestLogic {
              * If an Embeddable class has only one field and that field is transient, Ecipselink doesn't
              * create an object of type Embeddable class and set its transient field null.
              */
-            if (JPAProviderImpl.ECLIPSELINK.equals(provider)) {
+            if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
                 findEntity.setIntegerTransientEmbed(new IntegerTransientEmbed());
             }
             findEntity.getIntegerTransientEmbed().setTransientJavaValue(444);
@@ -2354,9 +2355,9 @@ public class EmbeddableBasicLogic extends AbstractTestLogic {
              * If an Embeddable class has only one field and that field is transient, Ecipselink doesn't
              * create an object of type Embeddable class and set its transient field null.
              */
-            if (JPAProviderImpl.ECLIPSELINK.equals(provider)) {
+            if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
                 Assert.assertNull(updatedFindEntity.getIntegerTransientEmbed());
-            } else if (JPAProviderImpl.OPENJPA.equals(provider)) {
+            } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 Assert.assertNull(updatedFindEntity.getIntegerTransientEmbed().getTransientJavaValue());
                 Assert.assertNull(updatedFindEntity.getIntegerTransientEmbed().getTransientValue());
             }
@@ -2486,7 +2487,7 @@ public class EmbeddableBasicLogic extends AbstractTestLogic {
             }
         }
 
-        JPAProviderImpl provider = getJPAProviderImpl(jpaResource);
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
 
         // Execute Test Case
         try {
@@ -2589,9 +2590,9 @@ public class EmbeddableBasicLogic extends AbstractTestLogic {
              * If an Embeddable class has only one field and that field is transient, Ecipselink doesn't
              * create an object of type Embeddable class and set its transient field null.
              */
-            if (JPAProviderImpl.ECLIPSELINK.equals(provider)) {
+            if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
                 Assert.assertNull(findEntity.getIntegerTransientEmbed());
-            } else if (JPAProviderImpl.OPENJPA.equals(provider)) {
+            } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 Assert.assertNull(findEntity.getIntegerTransientEmbed().getTransientJavaValue());
                 Assert.assertNull(findEntity.getIntegerTransientEmbed().getTransientValue());
             }
@@ -2683,7 +2684,7 @@ public class EmbeddableBasicLogic extends AbstractTestLogic {
              * If an Embeddable class has only one field and that field is transient, Ecipselink doesn't
              * create an object of type Embeddable class and set its transient field null.
              */
-            if (JPAProviderImpl.ECLIPSELINK.equals(provider)) {
+            if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
                 findEntity.setIntegerTransientEmbed(new XMLIntegerTransientEmbed());
             }
             findEntity.getIntegerTransientEmbed().setTransientJavaValue(444);
@@ -2769,9 +2770,9 @@ public class EmbeddableBasicLogic extends AbstractTestLogic {
              * If an Embeddable class has only one field and that field is transient, Ecipselink doesn't
              * create an object of type Embeddable class and set its transient field null.
              */
-            if (JPAProviderImpl.ECLIPSELINK.equals(provider)) {
+            if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
                 Assert.assertNull(updatedFindEntity.getIntegerTransientEmbed());
-            } else if (JPAProviderImpl.OPENJPA.equals(provider)) {
+            } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 Assert.assertNull(updatedFindEntity.getIntegerTransientEmbed().getTransientJavaValue());
                 Assert.assertNull(updatedFindEntity.getIntegerTransientEmbed().getTransientValue());
             }

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_fat.common/test-applications/entity/src/com/ibm/ws/jpa/fvt/entity/testlogic/BasicAnnotationTestLogic.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_fat.common/test-applications/entity/src/com/ibm/ws/jpa/fvt/entity/testlogic/BasicAnnotationTestLogic.java
@@ -23,6 +23,7 @@ import com.ibm.ws.jpa.fvt.entity.entities.IAttributeConfigFieldEntity;
 import com.ibm.ws.jpa.fvt.entity.support.SerializableClass;
 import com.ibm.ws.jpa.fvt.entity.testlogic.enums.BasicAnnotationEntityEnum;
 import com.ibm.ws.testtooling.database.DatabaseVendor;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
 import com.ibm.ws.testtooling.vehicle.resources.JPAResource;
@@ -199,6 +200,8 @@ public class BasicAnnotationTestLogic extends AbstractTestLogic {
             }
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         final String dbProductName = (testProps == null) ? "UNKNOWN" : ((testProps.get("dbProductName") == null) ? "UNKNOWN" : (String) testProps.get("dbProductName"));
 
         final boolean isOracle = DatabaseVendor.checkDBProductName(dbProductName, DatabaseVendor.ORACLE);
@@ -266,7 +269,6 @@ public class BasicAnnotationTestLogic extends AbstractTestLogic {
             // rather then a non-negotiable dictation.
             // OpenJPA honors the lazy behavior
             // EclipseLink still loads the String. (change introduced by task 130951)
-            JPAProviderImpl provider = getJPAProviderImpl(jpaResource);
             switch (provider) {
                 case ECLIPSELINK:
                     Assert.assertTrue(targetEntityType.getEntityName() + " (id=" + id + ")'s 'StringValLazy' field is loaded.",
@@ -347,6 +349,8 @@ public class BasicAnnotationTestLogic extends AbstractTestLogic {
             return;
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         int id = 1;
         boolean onPersist = false;
         boolean onCommit = false;
@@ -382,7 +386,6 @@ public class BasicAnnotationTestLogic extends AbstractTestLogic {
             serializableClass.setSomeInt(42);
             new_entity.setNotNullable(serializableClass);
 
-            JPAProviderImpl provider = getJPAProviderImpl(jpaResource);
             try {
                 System.out.println("Persisting " + new_entity);
                 onPersist = true;
@@ -401,7 +404,7 @@ public class BasicAnnotationTestLogic extends AbstractTestLogic {
                  * TODO: EclipseLink does not throw an exception and seems to ignore '@Basic(optional = false)'
                  * This may be a bug in EclipseLink and should be investigated.
                  */
-                if (JPAProviderImpl.ECLIPSELINK.equals(provider)) {
+                if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
                     // Cleanup since there was no failure
                     System.out.println("Beginning new transaction...");
                     jpaResource.getTj().beginTransaction();
@@ -1078,6 +1081,8 @@ public class BasicAnnotationTestLogic extends AbstractTestLogic {
             return;
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         int id = 1;
         boolean onPersist = false;
         boolean onCommit = false;
@@ -1125,7 +1130,6 @@ public class BasicAnnotationTestLogic extends AbstractTestLogic {
                 } catch (AssertionError ae) {
                     throw ae;
                 } catch (Throwable t) {
-                    JPAProviderImpl provider = getJPAProviderImpl(jpaResource);
                     switch (provider) {
                         case ECLIPSELINK:
                         case OPENJPA:

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_fat.common/test-applications/entity/src/com/ibm/ws/jpa/fvt/entity/testlogic/PKGeneratorTestLogic.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_fat.common/test-applications/entity/src/com/ibm/ws/jpa/fvt/entity/testlogic/PKGeneratorTestLogic.java
@@ -24,6 +24,7 @@ import org.junit.Assert;
 
 import com.ibm.ws.jpa.fvt.entity.entities.IPKGeneratorEntity;
 import com.ibm.ws.jpa.fvt.entity.testlogic.enums.PKGeneratorEntityEnum;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
 import com.ibm.ws.testtooling.vehicle.resources.JPAResource;
@@ -76,8 +77,8 @@ public class PKGeneratorTestLogic extends AbstractTestLogic {
             return;
         }
 
-        JPAProviderImpl provider = getJPAProviderImpl(jpaResource);
-        if (JPAProviderImpl.HIBERNATE.equals(provider)) {
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+        if (JPAPersistenceProvider.HIBERNATE.equals(provider)) {
             // TODO: Hibernate fails with "SEQUENCE 'APP.HIBERNATE_SEQUENCE' does not exist" exception, even though it does exist.
             return;
         }

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_fat.common/test-applications/entity/src/com/ibm/ws/jpa/fvt/entity/testlogic/ReadOnlyTestLogic.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_fat.common/test-applications/entity/src/com/ibm/ws/jpa/fvt/entity/testlogic/ReadOnlyTestLogic.java
@@ -15,6 +15,7 @@ import org.junit.Assert;
 
 import com.ibm.ws.jpa.fvt.entity.entities.IReadOnlyEntity;
 import com.ibm.ws.jpa.fvt.entity.testlogic.enums.ReadOnlyEntityEnum;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
 import com.ibm.ws.testtooling.vehicle.resources.JPAResource;
@@ -60,8 +61,8 @@ public class ReadOnlyTestLogic extends AbstractTestLogic {
         }
 
         // TODO: Hibernate does not support "insertable=false" for primitive types as they try to populate NULL values on em.find()
-        JPAProviderImpl provider = getJPAProviderImpl(jpaResource);
-        if (JPAProviderImpl.HIBERNATE.equals(provider)) {
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+        if (JPAPersistenceProvider.HIBERNATE.equals(provider)) {
             return;
         }
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_fat.common/test-applications/entity/src/com/ibm/ws/jpa/fvt/entity/testlogic/VersioningTestLogic.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_fat.common/test-applications/entity/src/com/ibm/ws/jpa/fvt/entity/testlogic/VersioningTestLogic.java
@@ -20,6 +20,7 @@ import org.junit.Assert;
 
 import com.ibm.ws.jpa.fvt.entity.entities.IVersionedEntity;
 import com.ibm.ws.jpa.fvt.entity.testlogic.enums.EntityVersionEntityEnum;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
 import com.ibm.ws.testtooling.vehicle.resources.JPAResource;
@@ -72,8 +73,8 @@ public class VersioningTestLogic extends AbstractTestLogic {
             return;
         }
 
-        JPAProviderImpl provider = getJPAProviderImpl(jpaResource);
-        if (JPAProviderImpl.HIBERNATE.equals(provider)) {
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+        if (JPAPersistenceProvider.HIBERNATE.equals(provider)) {
             // TODO: Hibernate fails with "org.hibernate.exception.LockAcquisitionException: could not execute statement".
             return;
         }

--- a/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/entitymanager/tests/JPAFATServletClient.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/entitymanager/tests/JPAFATServletClient.java
@@ -204,6 +204,7 @@ public class JPAFATServletClient extends FATServletClient {
     protected static final JavaArchive buildTestAPIJar() throws Exception {
         final JavaArchive testApiJar = ShrinkWrap.create(JavaArchive.class, "TestAPI.jar");
         testApiJar.addPackage("com.ibm.ws.testtooling.database");
+        testApiJar.addPackage("com.ibm.ws.testtooling.jpaprovider");
         testApiJar.addPackage("com.ibm.ws.testtooling.msgcli");
         testApiJar.addPackage("com.ibm.ws.testtooling.msgcli.jms");
         testApiJar.addPackage("com.ibm.ws.testtooling.msgcli.msc");

--- a/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_fat.common/test-applications/entitymanager/src/com/ibm/ws/jpa/entitymanager/testlogic/EntityManagerLogic.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_fat.common/test-applications/entitymanager/src/com/ibm/ws/jpa/entitymanager/testlogic/EntityManagerLogic.java
@@ -19,6 +19,7 @@ import javax.persistence.EntityManager;
 import org.junit.Assert;
 
 import com.ibm.ws.jpa.entitymanager.model.JPA10EntityManagerEntityA;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
 import com.ibm.ws.testtooling.tranjacket.TransactionJacket;
@@ -158,7 +159,8 @@ public class EntityManagerLogic extends AbstractTestLogic {
         }
 
         // TODO: OpenJPA Bug: OpenJPA does not throw the exception required by the JPA specification
-        if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+        if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
             return;
         }
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_fat.common/test-applications/olgh19182/src/com/ibm/ws/jpa/olgh19182/testlogic/JPATestOLGH19182Logic.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_fat.common/test-applications/olgh19182/src/com/ibm/ws/jpa/olgh19182/testlogic/JPATestOLGH19182Logic.java
@@ -14,12 +14,11 @@ package com.ibm.ws.jpa.olgh19182.testlogic;
 import java.io.Serializable;
 import java.util.Map;
 
-import javax.persistence.EntityManager;
-
 import org.junit.Assert;
 
 import com.ibm.ws.jpa.olgh19182.model.HelmetEntityOLGH19182;
 import com.ibm.ws.jpa.olgh19182.model.ShelfEntityOLGH19182;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
 import com.ibm.ws.testtooling.vehicle.resources.JPAResource;
@@ -53,7 +52,8 @@ public class JPATestOLGH19182Logic extends AbstractTestLogic {
 
         //TODO: Disable test until EclipseLink 3.0 is updated to include the fix
         //TODO: Disable test until EclipseLink 2.7 is updated to include the fix
-        if ((isUsingJPA22Feature() || isUsingJPA30Feature()) && JPAProviderImpl.ECLIPSELINK.equals(getJPAProviderImpl(jpaResource))) {
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+        if ((isUsingJPA22Feature() || isUsingJPA30Feature()) && JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
             return;
         }
 
@@ -63,8 +63,6 @@ public class JPATestOLGH19182Logic extends AbstractTestLogic {
 
         // Execute Test Case
         try {
-            EntityManager em = jpaResource.getEm();
-
             System.out.println("Beginning new transaction...");
             jpaResource.getTj().beginTransaction();
             if (jpaResource.getTj().isApplicationManaged()) {

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/JPAFATServletClient.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/JPAFATServletClient.java
@@ -204,6 +204,7 @@ public class JPAFATServletClient extends FATServletClient {
     protected static final JavaArchive buildTestAPIJar() throws Exception {
         final JavaArchive testApiJar = ShrinkWrap.create(JavaArchive.class, "TestAPI.jar");
         testApiJar.addPackage("com.ibm.ws.testtooling.database");
+        testApiJar.addPackage("com.ibm.ws.testtooling.jpaprovider");
         testApiJar.addPackage("com.ibm.ws.testtooling.msgcli");
         testApiJar.addPackage("com.ibm.ws.testtooling.msgcli.jms");
         testApiJar.addPackage("com.ibm.ws.testtooling.msgcli.msc");

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/olgh17369/src/com/ibm/ws/jpa/olgh17369/testlogic/JPATestOLGH17369Logic.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/olgh17369/src/com/ibm/ws/jpa/olgh17369/testlogic/JPATestOLGH17369Logic.java
@@ -28,6 +28,7 @@ import org.junit.Assert;
 
 import com.ibm.ws.jpa.olgh17369.model.SimpleEntityOLGH17369;
 import com.ibm.ws.jpa.olgh17369.model.SimpleEntityOLGH17369_;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
 import com.ibm.ws.testtooling.vehicle.resources.JPAResource;
@@ -171,9 +172,9 @@ public class JPATestOLGH17369Logic extends AbstractTestLogic {
             }
         }
 
-        JPAProviderImpl provider = getJPAProviderImpl(jpaResource);
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
         // OpenJPA does not support CASE expressions where THEN & ELSE do not declare a type
-        if (JPAProviderImpl.OPENJPA.equals(provider)) {
+        if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
             return;
         }
 
@@ -444,9 +445,9 @@ public class JPATestOLGH17369Logic extends AbstractTestLogic {
             }
         }
 
-        JPAProviderImpl provider = getJPAProviderImpl(jpaResource);
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
         // OpenJPA does not support CASE expressions where THEN & ELSE do not declare a type
-        if (JPAProviderImpl.OPENJPA.equals(provider)) {
+        if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
             return;
         }
 
@@ -671,9 +672,9 @@ public class JPATestOLGH17369Logic extends AbstractTestLogic {
             }
         }
 
-        JPAProviderImpl provider = getJPAProviderImpl(jpaResource);
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
         // OpenJPA does not support CASE expressions where THEN & ELSE do not declare a type
-        if (JPAProviderImpl.OPENJPA.equals(provider)) {
+        if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
             return;
         }
 
@@ -840,9 +841,9 @@ public class JPATestOLGH17369Logic extends AbstractTestLogic {
             }
         }
 
-        JPAProviderImpl provider = getJPAProviderImpl(jpaResource);
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
         // OpenJPA does not support CASE expressions where THEN & ELSE do not declare a type
-        if (JPAProviderImpl.OPENJPA.equals(provider)) {
+        if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
             return;
         }
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/olgh17373/src/com/ibm/ws/jpa/olgh17373/testlogic/JPATestOLGH17373Logic.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/olgh17373/src/com/ibm/ws/jpa/olgh17373/testlogic/JPATestOLGH17373Logic.java
@@ -27,6 +27,7 @@ import org.junit.Assert;
 
 import com.ibm.ws.jpa.olgh17373.model.SimpleEntityOLGH17373;
 import com.ibm.ws.jpa.olgh17373.model.SimpleEntityOLGH17373_;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
 import com.ibm.ws.testtooling.vehicle.resources.JPAResource;
@@ -147,6 +148,8 @@ public class JPATestOLGH17373Logic extends AbstractTestLogic {
             }
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -190,9 +193,8 @@ public class JPATestOLGH17373Logic extends AbstractTestLogic {
             Assert.assertNotNull(dto01);
             Assert.assertEquals(0, dto01.size());
 
-            JPAProviderImpl provider = getJPAProviderImpl(jpaResource);
             // TODO: Investigate why the following query fails on OpenJPA
-            if (JPAProviderImpl.OPENJPA.equals(provider)) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 return;
             }
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/olgh19185/src/com/ibm/ws/jpa/olgh19185/testlogic/JPATestOLGH19185Logic.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/olgh19185/src/com/ibm/ws/jpa/olgh19185/testlogic/JPATestOLGH19185Logic.java
@@ -25,6 +25,7 @@ import org.junit.Assert;
 
 import com.ibm.ws.jpa.olgh19185.model.SimpleEntityOLGH19185;
 import com.ibm.ws.jpa.olgh19185.model.SimpleEntityOLGH19185_;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
 import com.ibm.ws.testtooling.vehicle.resources.JPAResource;
@@ -56,9 +57,11 @@ public class JPATestOLGH19185Logic extends AbstractTestLogic {
             }
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         //TODO: Disable test until EclipseLink 3.0 is updated to include the fix
         //TODO: Disable test until EclipseLink 2.7 is updated to include the fix
-        if ((isUsingJPA22Feature() || isUsingJPA30Feature()) && JPAProviderImpl.ECLIPSELINK.equals(getJPAProviderImpl(jpaResource))) {
+        if ((isUsingJPA22Feature() || isUsingJPA30Feature()) && JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
             return;
         }
 
@@ -174,9 +177,11 @@ public class JPATestOLGH19185Logic extends AbstractTestLogic {
             }
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         //TODO: Disable test until EclipseLink 3.0 is updated to include the fix
         //TODO: Disable test until EclipseLink 2.7 is updated to include the fix
-        if ((isUsingJPA22Feature() || isUsingJPA30Feature()) && JPAProviderImpl.ECLIPSELINK.equals(getJPAProviderImpl(jpaResource))) {
+        if ((isUsingJPA22Feature() || isUsingJPA30Feature()) && JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
             return;
         }
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/olgh19342/src/com/ibm/ws/jpa/olgh19342/testlogic/JPATestOLGH19342Logic.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/olgh19342/src/com/ibm/ws/jpa/olgh19342/testlogic/JPATestOLGH19342Logic.java
@@ -22,6 +22,7 @@ import javax.persistence.EntityManager;
 
 import org.junit.Assert;
 
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
 import com.ibm.ws.testtooling.vehicle.resources.JPAResource;
@@ -53,9 +54,11 @@ public class JPATestOLGH19342Logic extends AbstractTestLogic {
             }
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         //TODO: Disable test until EclipseLink 3.0 is updated to include the fix
         //TODO: Disable test until EclipseLink 2.7 is updated to include the fix
-        if ((isUsingJPA22Feature() || isUsingJPA30Feature()) && JPAProviderImpl.ECLIPSELINK.equals(getJPAProviderImpl(jpaResource))) {
+        if ((isUsingJPA22Feature() || isUsingJPA30Feature()) && JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
             return;
         }
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/olgh8014/src/com/ibm/ws/jpa/olgh8014/testlogic/JPATestOLGH8014Logic.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/olgh8014/src/com/ibm/ws/jpa/olgh8014/testlogic/JPATestOLGH8014Logic.java
@@ -17,13 +17,14 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
 
-import javax.persistence.Query;
 import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 
 import org.junit.Assert;
 
 import com.ibm.ws.jpa.olgh8014.model.NoResultEntityOLGH8014;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
 import com.ibm.ws.testtooling.vehicle.resources.JPAResource;
@@ -64,6 +65,8 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
             }
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -76,7 +79,7 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
 
             Query q = em.createQuery("SELECT MIN(n.itemInteger1) FROM NoResultEntityOLGH8014 n");
             Object res = q.getSingleResult();
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 /*
                  * TODO: OpenJPA bug: NULL is not returned and instead Integer(0) is returned
                  */
@@ -87,7 +90,7 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
             }
             q = em.createQuery("SELECT MIN(n.itemFloat1) FROM NoResultEntityOLGH8014 n");
             res = q.getSingleResult();
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 /*
                  * TODO: OpenJPA bug: NULL is not returned and instead Float(0) is returned
                  */
@@ -99,7 +102,7 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
 
             q = em.createQuery("SELECT MAX(n.itemInteger1) FROM NoResultEntityOLGH8014 n");
             res = q.getSingleResult();
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 /*
                  * TODO: OpenJPA bug: NULL is not returned and instead Integer(0) is returned
                  */
@@ -110,7 +113,7 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
             }
             q = em.createQuery("SELECT MAX(n.itemFloat1) FROM NoResultEntityOLGH8014 n");
             res = q.getSingleResult();
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 /*
                  * TODO: OpenJPA bug: NULL is not returned and instead Float(0) is returned
                  */
@@ -122,7 +125,7 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
 
             q = em.createQuery("SELECT AVG(n.itemInteger1) FROM NoResultEntityOLGH8014 n");
             res = q.getSingleResult();
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 /*
                  * TODO: OpenJPA bug: NULL is not returned and instead Integer(0) is returned
                  */
@@ -133,7 +136,7 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
             }
             q = em.createQuery("SELECT AVG(n.itemFloat1) FROM NoResultEntityOLGH8014 n");
             res = q.getSingleResult();
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 /*
                  * TODO: OpenJPA bug: NULL is not returned and instead Float(0) is returned
                  */
@@ -145,7 +148,7 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
 
             q = em.createQuery("SELECT SUM(n.itemInteger1) FROM NoResultEntityOLGH8014 n");
             res = q.getSingleResult();
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 /*
                  * TODO: OpenJPA bug: NULL is not returned and instead Long(0) is returned
                  */
@@ -156,7 +159,7 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
             }
             q = em.createQuery("SELECT SUM(n.itemFloat1) FROM NoResultEntityOLGH8014 n");
             res = q.getSingleResult();
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 /*
                  * TODO: OpenJPA bug: NULL is not returned and instead Float(0) is returned
                  */
@@ -213,6 +216,8 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
             }
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -225,7 +230,7 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
 
             Query q = em.createQuery("SELECT MIN(n.itemInteger2) FROM NoResultEntityOLGH8014 n");
             Object res = q.getSingleResult();
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 /*
                  * TODO: OpenJPA bug: NULL is not returned and instead Integer(0) is returned
                  */
@@ -236,7 +241,7 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
             }
             q = em.createQuery("SELECT MIN(n.itemFloat2) FROM NoResultEntityOLGH8014 n");
             res = q.getSingleResult();
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 /*
                  * TODO: OpenJPA bug: NULL is not returned and instead Float(0) is returned
                  */
@@ -248,7 +253,7 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
 
             q = em.createQuery("SELECT MAX(n.itemInteger2) FROM NoResultEntityOLGH8014 n");
             res = q.getSingleResult();
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 /*
                  * TODO: OpenJPA bug: NULL is not returned and instead Integer(0) is returned
                  */
@@ -259,7 +264,7 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
             }
             q = em.createQuery("SELECT MAX(n.itemFloat2) FROM NoResultEntityOLGH8014 n");
             res = q.getSingleResult();
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 /*
                  * TODO: OpenJPA bug: NULL is not returned and instead Float(0) is returned
                  */
@@ -271,7 +276,7 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
 
             q = em.createQuery("SELECT AVG(n.itemInteger2) FROM NoResultEntityOLGH8014 n");
             res = q.getSingleResult();
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 /*
                  * TODO: OpenJPA bug: NULL is not returned and instead Integer(0) is returned
                  */
@@ -283,7 +288,7 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
 
             q = em.createQuery("SELECT SUM(n.itemInteger2) FROM NoResultEntityOLGH8014 n");
             res = q.getSingleResult();
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 /*
                  * TODO: OpenJPA bug: NULL is not returned and instead Long(0) is returned
                  */
@@ -294,7 +299,7 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
             }
             q = em.createQuery("SELECT SUM(n.itemFloat2) FROM NoResultEntityOLGH8014 n");
             res = q.getSingleResult();
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 /*
                  * TODO: OpenJPA bug: NULL is not returned and instead Float(0) is returned
                  */
@@ -358,6 +363,8 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
             }
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -379,7 +386,7 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
 
             q = em.createQuery("SELECT AVG(se.itemInteger1) FROM SimpleEntityOLGH8014 se");
             res = q.getSingleResult();
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 /*
                  * TODO: OpenJPA bug: incorrectly returns result of type Integer when the JPA 2.0 specification
                  * clearly states the return type should be Double
@@ -391,7 +398,7 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
             }
             q = em.createQuery("SELECT AVG(se.itemFloat1) FROM SimpleEntityOLGH8014 se");
             res = q.getSingleResult();
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 /*
                  * TODO: OpenJPA bug: incorrectly returns result of type Integer when the JPA 2.0 specification
                  * clearly states the return type should be Double
@@ -407,7 +414,7 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
             Assert.assertEquals(new Long(40), res);
             q = em.createQuery("SELECT SUM(se.itemFloat1) FROM SimpleEntityOLGH8014 se");
             res = q.getSingleResult();
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 /*
                  * TODO: OpenJPA bug: incorrectly returns result of type Float when the JPA 2.0 specification
                  * clearly states the return type should be Double
@@ -464,6 +471,8 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
             }
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -500,7 +509,7 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
             // Test AVG function
             q = em.createQuery("SELECT AVG(se.itemInteger2) FROM SimpleEntityOLGH8014 se");
             res = q.getSingleResult();
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 /*
                  * TODO: OpenJPA bug: incorrectly returns result of type Integer when the JPA 2.0 specification
                  * clearly states the return type should be Double
@@ -512,7 +521,7 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
             }
             q = em.createQuery("SELECT AVG(se.itemFloat2) FROM SimpleEntityOLGH8014 se");
             res = q.getSingleResult();
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 /*
                  * TODO: OpenJPA bug: incorrectly returns result of type Integer when the JPA 2.0 specification
                  * clearly states the return type should be Double
@@ -529,7 +538,7 @@ public class JPATestOLGH8014Logic extends AbstractTestLogic {
             Assert.assertEquals(new Long(42), res);
             q = em.createQuery("SELECT SUM(se.itemFloat2) FROM SimpleEntityOLGH8014 se");
             res = q.getSingleResult();
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 /*
                  * TODO: OpenJPA bug: incorrectly returns result of type Float when the JPA 2.0 specification
                  * clearly states the return type should be Double

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/svlquery/src/com/ibm/ws/query/testlogic/JULoopQueryAnoTest.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/svlquery/src/com/ibm/ws/query/testlogic/JULoopQueryAnoTest.java
@@ -38,6 +38,7 @@ import com.ibm.ws.query.utils.DeptEmpListView;
 import com.ibm.ws.query.utils.DeptEmpView;
 import com.ibm.ws.query.utils.SimpleDeptEmpView;
 import com.ibm.ws.testtooling.database.DatabaseVendor;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
 import com.ibm.ws.testtooling.vehicle.resources.JPAResource;
@@ -12507,6 +12508,8 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
             }
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -12520,20 +12523,19 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
 //TEST203; 1 tuple
 
             // Expect an Exception
-            JPAProviderImpl pvdr = getJPAProviderImpl(em);
             try {
                 Query q = em.createQuery(qStr);
                 q.getResultList();
                 Assert.fail("Expected Exception was not thrown.");
             } catch (RuntimeException e) {
                 String eStr = e.getMessage();
-                if (pvdr == JPAProviderImpl.ECLIPSELINK) {
+                if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
                     String lookFor = "The object [0], of class [class java.lang.Integer], from mapping [org.eclipse.persistence.mappings.DirectToFieldMapping[hireDate-->JPAEmpBean.HIREDATE]] with descriptor [RelationalDescriptor(com.ibm.ws.query.entities.ano.EmpBean --> [DatabaseTable(JPAEmpBean)])], could not be converted to [class java.sql.Date]";
                     System.out.println("eStr = " + eStr);
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);
                     Assert.assertTrue("Received unexpected exception cause: " + eStr, result);
-                } else if (pvdr == JPAProviderImpl.OPENJPA) {
+                } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
 
                 } else {
                     // Other provider impl, probably Hibernate.
@@ -12574,6 +12576,8 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
             }
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -12588,20 +12592,19 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
 //TEST204; 1 tuple
 
             // Expect an Exception
-            JPAProviderImpl pvdr = getJPAProviderImpl(em);
             try {
                 Query q = em.createQuery(qStr);
                 q.getResultList();
                 Assert.fail("Expected Exception was not thrown.");
             } catch (RuntimeException e) {
                 String eStr = e.getMessage();
-                if (pvdr == JPAProviderImpl.ECLIPSELINK) {
+                if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
                     String lookFor = "The object [0], of class [class java.lang.Integer], from mapping [org.eclipse.persistence.mappings.DirectToFieldMapping[hireTime-->JPAEmpBean.HIRETIME]] with descriptor [RelationalDescriptor(com.ibm.ws.query.entities.ano.EmpBean --> [DatabaseTable(JPAEmpBean)])], could not be converted to [class java.sql.Time].";
                     System.out.println("eStr = " + eStr);
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);
                     Assert.assertTrue("Received unexpected exception cause: " + eStr, result);
-                } else if (pvdr == JPAProviderImpl.OPENJPA) {
+                } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
 
                 } else {
                     // Other provider impl, probably Hibernate.
@@ -12642,6 +12645,8 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
             }
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -12656,20 +12661,19 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
 //TEST205; 1 tuple
 
             // Expect an Exception
-            JPAProviderImpl pvdr = getJPAProviderImpl(em);
             try {
                 Query q = em.createQuery(qStr);
                 q.getResultList();
                 Assert.fail("Expected Exception was not thrown.");
             } catch (RuntimeException e) {
                 String eStr = e.getMessage();
-                if (pvdr == JPAProviderImpl.ECLIPSELINK) {
+                if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
                     String lookFor = "The object [0], of class [class java.lang.Integer], from mapping [org.eclipse.persistence.mappings.DirectToFieldMapping[hireTimestamp-->JPAEmpBean.HIRETIMESTAMP]] with descriptor [RelationalDescriptor(com.ibm.ws.query.entities.ano.EmpBean --> [DatabaseTable(JPAEmpBean)])], could not be converted to [class java.sql.Timestamp].";
                     System.out.println("eStr = " + eStr);
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);
                     Assert.assertTrue("Received unexpected exception cause: " + eStr, result);
-                } else if (pvdr == JPAProviderImpl.OPENJPA) {
+                } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
 
                 } else {
                     // Other provider impl, probably Hibernate.
@@ -28559,6 +28563,8 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
             }
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -28573,7 +28579,6 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
 //TEST478; 1 tuple
 
             // Expect an Exception
-            JPAProviderImpl pvdr = getJPAProviderImpl(em);
             try {
                 Query q = em.createQuery(qStr);
                 q.getResultList();
@@ -28583,7 +28588,7 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
                 if (eStr == null) {
                     eStr = e.toString();
                 }
-                if (pvdr == JPAProviderImpl.ECLIPSELINK) {
+                if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
 //                    String lookFor = "An exception occurred while creating a query in EntityManager: \n" +
 //                                     "Exception Description: Internal problem encountered while compiling [select new com.dw.test.Detail (e.empid, e.salary) from EmpBean e].";
                     String lookFor = "Exception Description: Internal problem encountered while compiling [select new com.dw.test.Detail (e.empid, e.salary) from EmpBean e].";
@@ -28592,7 +28597,7 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);
                     Assert.assertTrue("Received unexpected exception cause: " + eStr, result);
-                } else if (pvdr == JPAProviderImpl.OPENJPA) {
+                } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
 
                 } else {
                     // Other provider impl, probably Hibernate.
@@ -28633,6 +28638,8 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
             }
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -28647,7 +28654,6 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
 //TEST479; 1 tuple
 
             // Expect an Exception
-            JPAProviderImpl pvdr = getJPAProviderImpl(em);
             try {
                 Query q = em.createQuery(qStr);
                 q.getResultList();
@@ -28657,7 +28663,7 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
                 if (eStr == null) {
                     eStr = e.toString();
                 }
-                if (pvdr == JPAProviderImpl.ECLIPSELINK) {
+                if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
 //                    String lookFor = "An exception occurred while creating a query in EntityManager: \n" +
 //                                     "Exception Description: Internal problem encountered while compiling [select new com.dw.test.Detail (max(e.empid), max(e.salary)) from EmpBean e].";
                     String lookFor = "Exception Description: Internal problem encountered while compiling [select new com.dw.test.Detail (max(e.empid), max(e.salary)) from EmpBean e].";
@@ -28666,7 +28672,7 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);
                     Assert.assertTrue("Received unexpected exception cause: " + eStr, result);
-                } else if (pvdr == JPAProviderImpl.OPENJPA) {
+                } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
 
                 } else {
                     // Other provider impl, probably Hibernate.
@@ -28764,6 +28770,8 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
             }
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -28778,7 +28786,6 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
 //TEST481; 1 tuple
 
             // Expect an Exception
-            JPAProviderImpl pvdr = getJPAProviderImpl(em);
             try {
                 Query q = em.createQuery(qStr);
                 q.getResultList();
@@ -28788,7 +28795,7 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
                 if (eStr == null) {
                     eStr = e.toString();
                 }
-                if (pvdr == JPAProviderImpl.ECLIPSELINK) {
+                if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
 //                    String lookFor = "An exception occurred while creating a query in EntityManager: \n" +
 //                                     "Exception Description: Problem compiling [select new com.ibm.ws.query.utils.SimpleDeptEmpView (d.deptno, d.name) from DeptBean d ].";
                     String lookFor = "Exception Description: Problem compiling [select new com.ibm.ws.query.utils.SimpleDeptEmpView (d.deptno, d.name) from DeptBean d ].";
@@ -28796,7 +28803,7 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);
                     Assert.assertTrue("Received unexpected exception cause: " + eStr, result);
-                } else if (pvdr == JPAProviderImpl.OPENJPA) {
+                } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
 
                 } else {
                     // Other provider impl, probably Hibernate.
@@ -29147,6 +29154,8 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
             }
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -29161,7 +29170,6 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
 //TEST487; 1 tuple
 
             // Expect an Exception
-            JPAProviderImpl pvdr = getJPAProviderImpl(em);
             try {
                 Query q = em.createQuery(qStr);
                 q.getResultList();
@@ -29171,7 +29179,7 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
                 if (eStr == null) {
                     eStr = e.toString();
                 }
-                if (pvdr == JPAProviderImpl.ECLIPSELINK) {
+                if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
 //                    String lookFor = "Problem compiling [select new com.ibm.ws.query.utils.DeptEmpListView (d.no, d.name, d.budget, d.emps ) from DeptBean d ]. \n" +
 //                                     "[74, 80] The state field path 'd.emps' cannot be resolved to a collection type.";
                     String lookFor = "[74, 80] The state field path 'd.emps' cannot be resolved to a collection type.";
@@ -29180,7 +29188,7 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);
                     Assert.assertTrue("Received unexpected exception cause: " + eStr, result);
-                } else if (pvdr == JPAProviderImpl.OPENJPA) {
+                } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
 
                 } else {
                     // Other provider impl, probably Hibernate.

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/svlquery/src/com/ibm/ws/query/testlogic/JULoopQueryXMLTest.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/svlquery/src/com/ibm/ws/query/testlogic/JULoopQueryXMLTest.java
@@ -38,6 +38,7 @@ import com.ibm.ws.query.utils.DeptEmpListView;
 import com.ibm.ws.query.utils.DeptEmpView;
 import com.ibm.ws.query.utils.SimpleDeptEmpView;
 import com.ibm.ws.testtooling.database.DatabaseVendor;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
 import com.ibm.ws.testtooling.vehicle.resources.JPAResource;
@@ -13513,6 +13514,8 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
 
         final String lDbProductName = dbProductName.toLowerCase();
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -13526,20 +13529,19 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
 //TEST203; 1 tuple
 
             // Expect an Exception
-            JPAProviderImpl pvdr = getJPAProviderImpl(em);
             try {
                 Query q = em.createQuery(qStr);
                 List rList = q.getResultList();
                 Assert.fail("Expected Exception was not thrown.");
             } catch (RuntimeException e) {
                 String eStr = e.getMessage();
-                if (pvdr == JPAProviderImpl.ECLIPSELINK) {
+                if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
                     String lookFor = "The object [0], of class [class java.lang.Integer], from mapping [org.eclipse.persistence.mappings.DirectToFieldMapping[hireDate-->JPAEmpBean.HIREDATE]] with descriptor [RelationalDescriptor(com.ibm.ws.query.entities.xml.EmpBean --> [DatabaseTable(JPAEmpBean)])], could not be converted to [class java.sql.Date]";
                     System.out.println("eStr = " + eStr);
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);
                     Assert.assertTrue("Received unexpected exception cause: " + eStr, result);
-                } else if (pvdr == JPAProviderImpl.OPENJPA) {
+                } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
 
                 } else {
                     // Other provider impl, probably Hibernate.
@@ -13585,6 +13587,8 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
 
         final String lDbProductName = dbProductName.toLowerCase();
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -13599,20 +13603,19 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
 //TEST204; 1 tuple
 
             // Expect an Exception
-            JPAProviderImpl pvdr = getJPAProviderImpl(em);
             try {
                 Query q = em.createQuery(qStr);
                 List rList = q.getResultList();
                 Assert.fail("Expected Exception was not thrown.");
             } catch (RuntimeException e) {
                 String eStr = e.getMessage();
-                if (pvdr == JPAProviderImpl.ECLIPSELINK) {
+                if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
                     String lookFor = "The object [0], of class [class java.lang.Integer], from mapping [org.eclipse.persistence.mappings.DirectToFieldMapping[hireTime-->JPAEmpBean.HIRETIME]] with descriptor [RelationalDescriptor(com.ibm.ws.query.entities.xml.EmpBean --> [DatabaseTable(JPAEmpBean)])], could not be converted to [class java.sql.Time].";
                     System.out.println("eStr = " + eStr);
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);
                     Assert.assertTrue("Received unexpected exception cause: " + eStr, result);
-                } else if (pvdr == JPAProviderImpl.OPENJPA) {
+                } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
 
                 } else {
                     // Other provider impl, probably Hibernate.
@@ -13658,6 +13661,8 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
 
         final String lDbProductName = dbProductName.toLowerCase();
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -13672,20 +13677,19 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
 //TEST205; 1 tuple
 
             // Expect an Exception
-            JPAProviderImpl pvdr = getJPAProviderImpl(em);
             try {
                 Query q = em.createQuery(qStr);
                 List rList = q.getResultList();
                 Assert.fail("Expected Exception was not thrown.");
             } catch (RuntimeException e) {
                 String eStr = e.getMessage();
-                if (pvdr == JPAProviderImpl.ECLIPSELINK) {
+                if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
                     String lookFor = "The object [0], of class [class java.lang.Integer], from mapping [org.eclipse.persistence.mappings.DirectToFieldMapping[hireTimestamp-->JPAEmpBean.HIRETIMESTAMP]] with descriptor [RelationalDescriptor(com.ibm.ws.query.entities.xml.EmpBean --> [DatabaseTable(JPAEmpBean)])], could not be converted to [class java.sql.Timestamp].";
                     System.out.println("eStr = " + eStr);
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);
                     Assert.assertTrue("Received unexpected exception cause: " + eStr, result);
-                } else if (pvdr == JPAProviderImpl.OPENJPA) {
+                } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
 
                 } else {
                     // Other provider impl, probably Hibernate.
@@ -30918,6 +30922,8 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
 
         final String lDbProductName = dbProductName.toLowerCase();
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -30932,7 +30938,6 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
 //TEST478; 1 tuple
 
             // Expect an Exception
-            JPAProviderImpl pvdr = getJPAProviderImpl(em);
             try {
                 Query q = em.createQuery(qStr);
                 List rList = q.getResultList();
@@ -30942,7 +30947,7 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
                 if (eStr == null) {
                     eStr = e.toString();
                 }
-                if (pvdr == JPAProviderImpl.ECLIPSELINK) {
+                if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
 //                    String lookFor = "An exception occurred while creating a query in EntityManager: \n" +
 //                                     "Exception Description: Internal problem encountered while compiling [select new com.dw.test.Detail (e.empid, e.salary) from EmpBean e].";
                     String lookFor = "Exception Description: Internal problem encountered while compiling [select new com.dw.test.Detail (e.empid, e.salary) from EmpBean e].";
@@ -30950,7 +30955,7 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);
                     Assert.assertTrue("Received unexpected exception cause: " + eStr, result);
-                } else if (pvdr == JPAProviderImpl.OPENJPA) {
+                } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
 
                 } else {
                     // Other provider impl, probably Hibernate.
@@ -30996,6 +31001,8 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
 
         final String lDbProductName = dbProductName.toLowerCase();
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -31010,7 +31017,6 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
 //TEST479; 1 tuple
 
             // Expect an Exception
-            JPAProviderImpl pvdr = getJPAProviderImpl(em);
             try {
                 Query q = em.createQuery(qStr);
                 List rList = q.getResultList();
@@ -31020,7 +31026,7 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
                 if (eStr == null) {
                     eStr = e.toString();
                 }
-                if (pvdr == JPAProviderImpl.ECLIPSELINK) {
+                if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
 //                    String lookFor = "An exception occurred while creating a query in EntityManager: \n" +
 //                                     "Exception Description: Internal problem encountered while compiling [select new com.dw.test.Detail (max(e.empid), max(e.salary)) from EmpBean e].";
                     String lookFor = "Exception Description: Internal problem encountered while compiling [select new com.dw.test.Detail (max(e.empid), max(e.salary)) from EmpBean e].";
@@ -31028,7 +31034,7 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);
                     Assert.assertTrue("Received unexpected exception cause: " + eStr, result);
-                } else if (pvdr == JPAProviderImpl.OPENJPA) {
+                } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
 
                 } else {
                     // Other provider impl, probably Hibernate.
@@ -31136,6 +31142,8 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
 
         final String lDbProductName = dbProductName.toLowerCase();
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -31150,7 +31158,6 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
 //TEST481; 1 tuple
 
             // Expect an Exception
-            JPAProviderImpl pvdr = getJPAProviderImpl(em);
             try {
                 Query q = em.createQuery(qStr);
                 List rList = q.getResultList();
@@ -31160,7 +31167,7 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
                 if (eStr == null) {
                     eStr = e.toString();
                 }
-                if (pvdr == JPAProviderImpl.ECLIPSELINK) {
+                if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
 //                    String lookFor = "An exception occurred while creating a query in EntityManager: \n" +
 //                                     "Exception Description: Problem compiling [select new com.ibm.ws.query.utils.SimpleDeptEmpView (d.deptno, d.name) from DeptBean d ].";
                     String lookFor = "Exception Description: Problem compiling [select new com.ibm.ws.query.utils.SimpleDeptEmpView (d.deptno, d.name) from DeptBean d ].";
@@ -31169,7 +31176,7 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);
                     Assert.assertTrue("Received unexpected exception cause: " + eStr, result);
-                } else if (pvdr == JPAProviderImpl.OPENJPA) {
+                } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
 
                 } else {
                     // Other provider impl, probably Hibernate.
@@ -31550,6 +31557,8 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
 
         final String lDbProductName = dbProductName.toLowerCase();
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -31564,7 +31573,6 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
 //TEST487; 1 tuple
 
             // Expect an Exception
-            JPAProviderImpl pvdr = getJPAProviderImpl(em);
             try {
                 Query q = em.createQuery(qStr);
                 List rList = q.getResultList();
@@ -31574,7 +31582,7 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
                 if (eStr == null) {
                     eStr = e.toString();
                 }
-                if (pvdr == JPAProviderImpl.ECLIPSELINK) {
+                if (JPAPersistenceProvider.ECLIPSELINK.equals(provider)) {
 //                    String lookFor = "Problem compiling [select new com.ibm.ws.query.utils.DeptEmpListView (d.no, d.name, d.budget, d.emps ) from DeptBean d ]. \n" +
 //                                     "[74, 80] The state field path 'd.emps' cannot be resolved to a collection type.";
                     String lookFor = "[74, 80] The state field path 'd.emps' cannot be resolved to a collection type.";
@@ -31583,7 +31591,7 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);
                     Assert.assertTrue("Received unexpected exception cause: " + eStr, result);
-                } else if (pvdr == JPAProviderImpl.OPENJPA) {
+                } else if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
 
                 } else {
                     // Other provider impl, probably Hibernate.

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/svlquery/src/com/ibm/ws/query/utils/SetupQueryTestCase.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/svlquery/src/com/ibm/ws/query/utils/SetupQueryTestCase.java
@@ -34,6 +34,7 @@ import com.ibm.ws.query.entities.interfaces.ISupplier;
 import com.ibm.ws.query.entities.interfaces.ITaskBean;
 import com.ibm.ws.query.entities.interfaces.ITypeTestBean;
 import com.ibm.ws.query.entities.interfaces.IUsage;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
 
 /**
@@ -41,7 +42,7 @@ import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
  */
 public class SetupQueryTestCase extends AbstractTestLogic {
     protected EntityManager _em = null;
-    protected JPAProviderImpl _pvdr = null;
+    protected JPAPersistenceProvider _pvdr = null;
 
     protected static boolean isXmlOrMap = false;
 
@@ -154,7 +155,7 @@ public class SetupQueryTestCase extends AbstractTestLogic {
 
     public SetupQueryTestCase(EntityManager em, String dbVendorName, boolean ano) {
         _em = em;
-        _pvdr = getJPAProviderImpl(em);
+        _pvdr = JPAPersistenceProvider.resolveJPAPersistenceProvider(em);
         _dbVendorName = dbVendorName;
         isXmlOrMap = !ano;
     }

--- a/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/JPAFATServletClient.java
+++ b/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/JPAFATServletClient.java
@@ -204,6 +204,7 @@ public class JPAFATServletClient extends FATServletClient {
     protected static final JavaArchive buildTestAPIJar() throws Exception {
         final JavaArchive testApiJar = ShrinkWrap.create(JavaArchive.class, "TestAPI.jar");
         testApiJar.addPackage("com.ibm.ws.testtooling.database");
+        testApiJar.addPackage("com.ibm.ws.testtooling.jpaprovider");
         testApiJar.addPackage("com.ibm.ws.testtooling.msgcli");
         testApiJar.addPackage("com.ibm.ws.testtooling.msgcli.jms");
         testApiJar.addPackage("com.ibm.ws.testtooling.msgcli.msc");

--- a/dev/com.ibm.ws.jpa.tests.spec20_fat/test-applications/olgh9018/src/com/ibm/ws/jpa/olgh9018/testlogic/JPATestOLGH9018Logic.java
+++ b/dev/com.ibm.ws.jpa.tests.spec20_fat/test-applications/olgh9018/src/com/ibm/ws/jpa/olgh9018/testlogic/JPATestOLGH9018Logic.java
@@ -20,6 +20,7 @@ import javax.persistence.EntityManager;
 import org.junit.Assert;
 
 import com.ibm.ws.jpa.olgh9018.model.SimpleEntityOLGH9018;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext.PersistenceContextType;
 import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
@@ -60,12 +61,14 @@ public class JPATestOLGH9018Logic extends AbstractTestLogic {
             }
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
 
             Connection c = em.unwrap(Connection.class);
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 //OpenJPA will return a Connection even when outside of a transaction boundary
                 Assert.assertNotNull(c);
             } else {
@@ -101,6 +104,8 @@ public class JPATestOLGH9018Logic extends AbstractTestLogic {
             }
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         final boolean isAMJTA = PersistenceContextType.APPLICATION_MANAGED_JTA == jpaResource.getPcCtxInfo().getPcType();
 
         // Execute Test Case
@@ -119,7 +124,7 @@ public class JPATestOLGH9018Logic extends AbstractTestLogic {
 
             // Assert that it is no longer available when tx is done.
             c = em.unwrap(Connection.class);
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 //OpenJPA will return a Connection even when outside of a transaction boundary
                 Assert.assertNotNull(c);
             } else {
@@ -155,6 +160,8 @@ public class JPATestOLGH9018Logic extends AbstractTestLogic {
             }
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         final boolean isAMJTA = PersistenceContextType.APPLICATION_MANAGED_JTA == jpaResource.getPcCtxInfo().getPcType();
 
         // Execute Test Case
@@ -175,7 +182,7 @@ public class JPATestOLGH9018Logic extends AbstractTestLogic {
 
             // Assert that it is no longer available when tx is done.
             c = em.unwrap(Connection.class);
-            if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+            if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                 //OpenJPA will return a Connection even when outside of a transaction boundary
                 Assert.assertNotNull(c);
             } else {

--- a/dev/com.ibm.ws.jpa.tests.spec20_fat/test-applications/query/src/com/ibm/ws/jpa/query/testlogic/QueryLogic.java
+++ b/dev/com.ibm.ws.jpa.tests.spec20_fat/test-applications/query/src/com/ibm/ws/jpa/query/testlogic/QueryLogic.java
@@ -23,6 +23,7 @@ import javax.persistence.Query;
 import org.junit.Assert;
 
 import com.ibm.ws.jpa.query.model.InvalidQuerySubclass;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
 import com.ibm.ws.testtooling.tranjacket.TransactionJacket;
@@ -72,6 +73,8 @@ public class QueryLogic extends AbstractTestLogic {
             }
         }
 
+        JPAPersistenceProvider provider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaResource);
+
         // Execute Test Case
         try {
             EntityManager em = jpaResource.getEm();
@@ -82,7 +85,7 @@ public class QueryLogic extends AbstractTestLogic {
                 try {
                     Object obj = query.unwrap(Object.class);
 
-                    if (JPAProviderImpl.OPENJPA.equals(getJPAProviderImpl(jpaResource))) {
+                    if (JPAPersistenceProvider.OPENJPA.equals(provider)) {
                         // TODO: OpenJPA does not support this call
                         Assert.fail("The expected PersistenceException was not thrown and the provide returned object " + obj);
                     }

--- a/dev/com.ibm.ws.jpa.tests.spec20_fat/test-applications/util/src/com/ibm/ws/jpa/fvt/util/testlogic/UtilTestLogic.java
+++ b/dev/com.ibm.ws.jpa.tests.spec20_fat/test-applications/util/src/com/ibm/ws/jpa/fvt/util/testlogic/UtilTestLogic.java
@@ -43,6 +43,7 @@ import com.ibm.ws.jpa.fvt.util.entities.UtilEmbEntity;
 import com.ibm.ws.jpa.fvt.util.entities.UtilEmbeddable;
 import com.ibm.ws.jpa.fvt.util.entities.UtilEmbeddable2;
 import com.ibm.ws.jpa.fvt.util.entities.UtilEntity;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
 import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
 import com.ibm.ws.testtooling.vehicle.resources.JPAResource;
@@ -169,7 +170,7 @@ public class UtilTestLogic extends AbstractTestLogic {
 //            return;
 //        }
 
-        JPAProviderImpl jpaProvider = getJPAProviderImpl(jpaRW.getEm());
+        JPAPersistenceProvider jpaProvider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaRW);
 
         System.out.println(TestUtilBasic +
                            ": Verify functions provided in ProviderUtil, PersistenceUtil and PersistenceUnitUtil interfaces "
@@ -249,13 +250,13 @@ public class UtilTestLogic extends AbstractTestLogic {
                                                                 e1, null, LoadState.LOADED,
                                                                 e1, "name", LoadState.LOADED,
                                                                 e1, "notLoaded", LoadState.NOT_LOADED,
-                                                                e1, "unknown", jpaProvider == JPAProviderImpl.ECLIPSELINK ? LoadState.NOT_LOADED : LoadState.UNKNOWN),
+                                                                e1, "unknown", JPAPersistenceProvider.ECLIPSELINK.equals(jpaProvider) ? LoadState.NOT_LOADED : LoadState.UNKNOWN),
                                      // PersistenceUtil.isLoaded() tests
                                      computeExpectedIsLoaded(
                                                              e1, null, true,
                                                              e1, "name", true,
                                                              e1, "notLoaded", false,
-                                                             e1, "unknown", jpaProvider == JPAProviderImpl.OPENJPA),
+                                                             e1, "unknown", JPAPersistenceProvider.OPENJPA.equals(jpaProvider)),
                                      // PersistenceUnitUtil.isLoaded() tests
                                      computeExpectedIsLoaded(
                                                              e1, null, true,
@@ -313,7 +314,7 @@ public class UtilTestLogic extends AbstractTestLogic {
 //            return;
 //        }
 
-        JPAProviderImpl jpaProvider = getJPAProviderImpl(jpaRW.getEm());
+        JPAPersistenceProvider jpaProvider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaRW);
 
         System.out.println(TestUtilEmbeddable
                            + ": Verify functions provided in ProviderUtil, PersistenceUtil and PersistenceUnitUtil interfaces "
@@ -335,7 +336,7 @@ public class UtilTestLogic extends AbstractTestLogic {
             System.out.println("Clearing persistence context...");
             em.clear();
             Map<String, Object> hints = new TreeMap<String, Object>();
-            if (JPAProviderImpl.ECLIPSELINK == jpaProvider) {
+            if (JPAPersistenceProvider.ECLIPSELINK.equals(jpaProvider)) {
                 // For EclipseLink, use JPA 2.1 entity graphs.
                 // Must access reflectively because this bucket compiles against JPA 2.0.
 
@@ -430,7 +431,7 @@ public class UtilTestLogic extends AbstractTestLogic {
 //                        e1,  "emb.embName",          LoadState.LOADED,     // need OPENJPA-1430 feature
 //                        e1,  "emb.embNotLoaded",     LoadState.NOT_LOADED, // need OPENJPA-1430 feature
                                                                 e1, "emb1", LoadState.LOADED, // all eager fields loaded
-                                                                e1, "initNullEmb", jpaProvider == JPAProviderImpl.ECLIPSELINK ? LoadState.LOADED : LoadState.NOT_LOADED, // initNullEmb == null.
+                                                                e1, "initNullEmb", JPAPersistenceProvider.ECLIPSELINK.equals(jpaProvider) ? LoadState.LOADED : LoadState.NOT_LOADED, // initNullEmb == null.
                                                                 e1, "unknown", LoadState.UNKNOWN),
                                      // PersistenceUtil.isLoaded() tests
                                      computeExpectedIsLoaded(
@@ -440,7 +441,7 @@ public class UtilTestLogic extends AbstractTestLogic {
 //                        e1,  "emb.embName",          false,                //
 //                        e1,  "emb.embNotLoaded",     false,                //
                                                              e1, "emb1", true, // all eager fields loaded
-                                                             e1, "initNullEmb", jpaProvider == JPAProviderImpl.ECLIPSELINK, // initNullEmb == null
+                                                             e1, "initNullEmb", JPAPersistenceProvider.ECLIPSELINK.equals(jpaProvider), // initNullEmb == null
                                                              e1, "unknown", true), // All providers can't find "unknown", assume loaded
                                      // PersistenceUnitUtil.isLoaded() tests
                                      computeExpectedIsLoaded(
@@ -450,7 +451,7 @@ public class UtilTestLogic extends AbstractTestLogic {
 //                        e1,  "emb.embName",          false,                //
 //                        e1,  "emb.embNotLoaded",     false,                //
                                                              e1, "emb1", true, // all eager fields loaded
-                                                             e1, "initNullEmb", jpaProvider == JPAProviderImpl.ECLIPSELINK, // initNullEmb == null
+                                                             e1, "initNullEmb", JPAPersistenceProvider.ECLIPSELINK.equals(jpaProvider), // initNullEmb == null
                                                              e1, "unknown", false), // this providers can't find "unknown", not loaded
                                      e1, TestUtilEmbeddable_TestRow_Id, UtilEmbEntity.class, jpaProvider);
 
@@ -467,7 +468,7 @@ public class UtilTestLogic extends AbstractTestLogic {
 //                        e1,  "emb.embName",          LoadState.LOADED,     // need OPENJPA-1430 feature
 //                        e1,  "emb.embNotLoaded",     LoadState.NOT_LOADED, // need OPENJPA-1430 feature
                                                                 e1, "emb1", LoadState.LOADED, // emb1 assigned null
-                                                                e1, "initNullEmb", jpaProvider == JPAProviderImpl.ECLIPSELINK ? LoadState.LOADED : LoadState.NOT_LOADED, // initNullEmb == null
+                                                                e1, "initNullEmb", JPAPersistenceProvider.ECLIPSELINK.equals(jpaProvider) ? LoadState.LOADED : LoadState.NOT_LOADED, // initNullEmb == null
                                                                 e1, "unknown", LoadState.UNKNOWN),
                                      // PersistenceUtil.isLoaded() tests
                                      computeExpectedIsLoaded(
@@ -477,7 +478,7 @@ public class UtilTestLogic extends AbstractTestLogic {
 //                        e1,  "emb.embName",          false,                // need OPENJPA-1430 feature
 //                        e1,  "emb.embNotLoaded",     false,                // need OPENJPA-1430 feature
                                                              e1, "emb1", true, // emb1 assigned null
-                                                             e1, "initNullEmb", jpaProvider == JPAProviderImpl.ECLIPSELINK, // initNullEmb == null.
+                                                             e1, "initNullEmb", JPAPersistenceProvider.ECLIPSELINK.equals(jpaProvider), // initNullEmb == null.
                                                              e1, "unknown", true), // All providers can't find "unknown", assume loaded
                                      // PersistenceUnitUtil.isLoaded() tests
                                      computeExpectedIsLoaded(
@@ -487,7 +488,7 @@ public class UtilTestLogic extends AbstractTestLogic {
 //                        e1,  "emb.embName",          false,                // need OPENJPA-1430 feature
 //                        e1,  "emb.embNotLoaded",     false,                // need OPENJPA-1430 feature
                                                              e1, "emb1", true, // emb1 assigned null
-                                                             e1, "initNullEmb", jpaProvider == JPAProviderImpl.ECLIPSELINK, // initNullEmb == null.
+                                                             e1, "initNullEmb", JPAPersistenceProvider.ECLIPSELINK.equals(jpaProvider), // initNullEmb == null.
                                                              e1, "unknown", false), // this provider can't find "unknown", not loaded
                                      e1, TestUtilEmbeddable_TestRow_Id, UtilEmbEntity.class, jpaProvider);
 
@@ -566,7 +567,7 @@ public class UtilTestLogic extends AbstractTestLogic {
 //            return;
 //        }
 
-        JPAProviderImpl jpaProvider = getJPAProviderImpl(jpaRW.getEm());
+        JPAPersistenceProvider jpaProvider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaRW);
 
         System.out.println(TestUtil1x1
                            + ": Verify functions provided in ProviderUtil, PersistenceUtil and PersistenceUnitUtil interfaces "
@@ -774,7 +775,7 @@ public class UtilTestLogic extends AbstractTestLogic {
 //            return;
 //        }
 
-        JPAProviderImpl jpaProvider = getJPAProviderImpl(jpaRW.getEm());
+        JPAPersistenceProvider jpaProvider = JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaRW);
 
         System.out.println(TestUtil1xm
                            + ": Verify functions provided in ProviderUtil, PersistenceUtil and PersistenceUnitUtil interfaces "
@@ -840,7 +841,7 @@ public class UtilTestLogic extends AbstractTestLogic {
             }
             e1 = em.find(Util1xmLf.class, TestUtil1xm_TestRow_Id);
             Assert.assertNotNull("Found Util1xmLf(id=" + TestUtil1xm_TestRow_Id + ")", e1);
-            if (jpaProvider == JPAProviderImpl.OPENJPA) {
+            if (JPAPersistenceProvider.OPENJPA.equals(jpaProvider)) {
                 Collection<Util1xmRt> eRs = e1.uniRight;
                 Assert.assertNull("Util1xmRt uniRight == null", eRs);
             } else {
@@ -899,7 +900,7 @@ public class UtilTestLogic extends AbstractTestLogic {
             Collection<Util1xmRt> saveRightEgr = e1.getUniRightEgr();
             e1.setUniRightEgr(null);
 
-            if (jpaProvider == JPAProviderImpl.OPENJPA) {
+            if (JPAPersistenceProvider.OPENJPA.equals(jpaProvider)) {
                 Collection<Util1xmRt> eRs = e1.uniRight;
                 Assert.assertNull("Util1xmRt uniRight == null. Observed " + eRs, eRs);
             } else {
@@ -1144,16 +1145,16 @@ public class UtilTestLogic extends AbstractTestLogic {
      *
      */
     private void assertBasicNewInstanceLoadState(String desc, Object e1,
-                                                 Class<?> expectedIdClass, JPAProviderImpl jpaProvider) {
+                                                 Class<?> expectedIdClass, JPAPersistenceProvider jpaProvider) {
         // EclipseLink considers new entities constructed by the application,
         // which have never been persisted, to be loaded.
-        LoadState expectedLoadState = jpaProvider == JPAProviderImpl.ECLIPSELINK ? LoadState.LOADED : LoadState.UNKNOWN;
+        LoadState expectedLoadState = JPAPersistenceProvider.ECLIPSELINK.equals(jpaProvider) ? LoadState.LOADED : LoadState.UNKNOWN;
 
         assertBasicInvalidEntityLoadState(desc, e1, expectedIdClass, expectedLoadState, jpaProvider);
     }
 
     private void assertBasicInvalidEntityLoadState(String desc, Object e1,
-                                                   Class<?> expectedIdClass, LoadState expectedLoadState, JPAProviderImpl jpaProvider) {
+                                                   Class<?> expectedIdClass, LoadState expectedLoadState, JPAPersistenceProvider jpaProvider) {
         assertInvalidEntityLoadState(desc,
                                      // ProviderUtil.isLoaded() tests
                                      computeExpectedLoadedState(
@@ -1180,15 +1181,15 @@ public class UtilTestLogic extends AbstractTestLogic {
      *
      */
     private void assertEmbeddableNewInstanceLoadState(String desc, Object e1,
-                                                      Class<?> expectedIdClass, JPAProviderImpl jpaProvider) {
+                                                      Class<?> expectedIdClass, JPAPersistenceProvider jpaProvider) {
         // EclipseLink considers new entities constructed by the application,
         // which have never been persisted, to be loaded.
-        LoadState expectedLoadState = jpaProvider == JPAProviderImpl.ECLIPSELINK ? LoadState.LOADED : LoadState.UNKNOWN;
+        LoadState expectedLoadState = JPAPersistenceProvider.ECLIPSELINK.equals(jpaProvider) ? LoadState.LOADED : LoadState.UNKNOWN;
         assertEmbeddableInvalidEntityLoadState(desc, e1, expectedIdClass, expectedLoadState, jpaProvider);
     }
 
     private void assertEmbeddableInvalidEntityLoadState(String desc, Object e1,
-                                                        Class<?> expectedIdClass, LoadState expectedLoadState, JPAProviderImpl jpaProvider) {
+                                                        Class<?> expectedIdClass, LoadState expectedLoadState, JPAPersistenceProvider jpaProvider) {
         assertInvalidEntityLoadState(desc,
                                      // ProviderUtil.isLoaded() tests
                                      computeExpectedLoadedState(
@@ -1227,15 +1228,15 @@ public class UtilTestLogic extends AbstractTestLogic {
      *
      */
     private void assert1x1NewInstanceLoadState(String desc, Object e1, Object e2,
-                                               Class<?> expectedIdClass, JPAProviderImpl jpaProvider) {
+                                               Class<?> expectedIdClass, JPAPersistenceProvider jpaProvider) {
         // EclipseLink considers new entities constructed by the application,
         // which have never been persisted, to be loaded.
-        LoadState expectedLoadState = jpaProvider == JPAProviderImpl.ECLIPSELINK ? LoadState.LOADED : LoadState.UNKNOWN;
+        LoadState expectedLoadState = JPAPersistenceProvider.ECLIPSELINK.equals(jpaProvider) ? LoadState.LOADED : LoadState.UNKNOWN;
         assert1x1InvalidEntityLoadState(desc, e1, e2, expectedIdClass, expectedLoadState, jpaProvider);
     }
 
     private void assert1x1InvalidEntityLoadState(String desc, Object e1, Object e2,
-                                                 Class<?> expectedIdClass, LoadState expectedLoadState, JPAProviderImpl jpaProvider) {
+                                                 Class<?> expectedIdClass, LoadState expectedLoadState, JPAPersistenceProvider jpaProvider) {
         assertInvalidEntityLoadState(desc,
                                      // ProviderUtil.isLoaded() tests
                                      computeExpectedLoadedState(
@@ -1265,15 +1266,15 @@ public class UtilTestLogic extends AbstractTestLogic {
      *
      */
     private void assert1xmNewInstanceLoadState(String desc, Object e1, Object e2,
-                                               Class<?> expectedIdClass, JPAProviderImpl jpaProvider) {
+                                               Class<?> expectedIdClass, JPAPersistenceProvider jpaProvider) {
         // EclipseLink considers new entities constructed by the application,
         // which have never been persisted, to be loaded.
-        LoadState expectedLoadState = jpaProvider == JPAProviderImpl.ECLIPSELINK ? LoadState.LOADED : LoadState.UNKNOWN;
+        LoadState expectedLoadState = JPAPersistenceProvider.ECLIPSELINK.equals(jpaProvider) ? LoadState.LOADED : LoadState.UNKNOWN;
         assert1xmInvalidEntityLoadState(desc, e1, e2, expectedIdClass, expectedLoadState, jpaProvider);
     }
 
     private void assert1xmInvalidEntityLoadState(String desc, Object e1, Object e2,
-                                                 Class<?> expectedIdClass, LoadState expectedLoadState, JPAProviderImpl jpaProvider) {
+                                                 Class<?> expectedIdClass, LoadState expectedLoadState, JPAPersistenceProvider jpaProvider) {
         assertInvalidEntityLoadState(desc,
                                      // ProviderUtil.isLoaded() tests
                                      computeExpectedLoadedState(
@@ -1313,7 +1314,7 @@ public class UtilTestLogic extends AbstractTestLogic {
                                               ExpectedLoadState[] pvdrExpected,
                                               ExpectedIsLoaded[] puExpected,
                                               ExpectedIsLoaded[] puuExpected,
-                                              Object eId, Class<?> expectedIdClass, JPAProviderImpl jpaProvider) {
+                                              Object eId, Class<?> expectedIdClass, JPAPersistenceProvider jpaProvider) {
         printTestDescription(desc);
         assertAttributeLoadState(
                                  pvdrExpected,
@@ -1363,7 +1364,7 @@ public class UtilTestLogic extends AbstractTestLogic {
                                           ExpectedLoadState[] pvdrExpected,
                                           ExpectedIsLoaded[] puExpected,
                                           ExpectedIsLoaded[] puuExpected,
-                                          Object eId, Object expectedId, Class<?> expectedIdClass, JPAProviderImpl jpaProvider) {
+                                          Object eId, Object expectedId, Class<?> expectedIdClass, JPAPersistenceProvider jpaProvider) {
 
         System.out.println("  >>>----- ProviderUtil Tests -----");
         for (ExpectedLoadState loadState : pvdrExpected) {
@@ -1419,7 +1420,7 @@ public class UtilTestLogic extends AbstractTestLogic {
         }
         if (expectedFailure != null) {
 //            results.assertPass("  -> Test [null] PersistenceUnitUtil.getIdentifer(null) raises " + expectedFailure);
-        } else if (expectedId == null && jpaProvider == JPAProviderImpl.ECLIPSELINK) {
+        } else if (expectedId == null && JPAPersistenceProvider.ECLIPSELINK.equals(jpaProvider)) {
             try {
                 Object entityId = eId.getClass().getMethod("getId").invoke(eId);
                 Assert.assertEquals("  -> Test [null]=PersistenceUnitUtil.getIdentifier(" + eId + ") returned " + id + " instead of " + entityId, id, entityId);

--- a/dev/com.ibm.ws.jpa_testframework/src/com/ibm/ws/testtooling/jpaprovider/JPAPersistenceProvider.java
+++ b/dev/com.ibm.ws.jpa_testframework/src/com/ibm/ws/testtooling/jpaprovider/JPAPersistenceProvider.java
@@ -11,6 +11,10 @@
 
 package com.ibm.ws.testtooling.jpaprovider;
 
+import javax.persistence.EntityManager;
+
+import com.ibm.ws.testtooling.vehicle.resources.JPAResource;
+
 /**
  * Simple Utility class for indicating the JPA Persistence Provider
  */
@@ -47,6 +51,43 @@ public enum JPAPersistenceProvider {
         }
 
         return DEFAULT;
+    }
+
+    public static JPAPersistenceProvider resolveJPAPersistenceProvider(JPAResource jpaRsc) {
+        if (jpaRsc == null) {
+            return null;
+        }
+
+        return JPAPersistenceProvider.resolveJPAPersistenceProvider(jpaRsc.getEm());
+    }
+
+    public static JPAPersistenceProvider resolveJPAPersistenceProvider(EntityManager em) {
+        if (em == null) {
+            return null;
+        }
+
+        String delegateClassStr = em.getDelegate().getClass().getName();
+        if (delegateClassStr == null) {
+            return null;
+        }
+
+        if (delegateClassStr.toLowerCase().contains("openjpa")) {
+            return JPAPersistenceProvider.OPENJPA;
+        }
+
+        if (delegateClassStr.toLowerCase().contains("com.ibm")) {
+            return JPAPersistenceProvider.OPENJPA;
+        }
+
+        if (delegateClassStr.toLowerCase().contains("eclipse")) {
+            return JPAPersistenceProvider.ECLIPSELINK;
+        }
+
+        if (delegateClassStr.toLowerCase().contains("hibernate")) {
+            return JPAPersistenceProvider.HIBERNATE;
+        }
+
+        return JPAPersistenceProvider.DEFAULT;
     }
 
     /**

--- a/dev/com.ibm.ws.jpa_testframework/src/com/ibm/ws/testtooling/testlogic/AbstractTestLogic.java
+++ b/dev/com.ibm.ws.jpa_testframework/src/com/ibm/ws/testtooling/testlogic/AbstractTestLogic.java
@@ -191,49 +191,6 @@ public abstract class AbstractTestLogic {
         cleanupDatabase(em, tj, testEntityEnumArr);
     }
 
-    public enum JPAProviderImpl {
-        OPENJPA,
-        ECLIPSELINK,
-        HIBERNATE;
-    }
-
-    public JPAProviderImpl getJPAProviderImpl(EntityManager em) {
-        if (em == null) {
-            return null;
-        }
-
-        String delegateClassStr = em.getDelegate().getClass().getName();
-        if (delegateClassStr == null) {
-            return null;
-        }
-
-        if (delegateClassStr.toLowerCase().contains("openjpa")) {
-            return JPAProviderImpl.OPENJPA;
-        }
-
-        if (delegateClassStr.toLowerCase().contains("com.ibm")) {
-            return JPAProviderImpl.OPENJPA;
-        }
-
-        if (delegateClassStr.toLowerCase().contains("eclipse")) {
-            return JPAProviderImpl.ECLIPSELINK;
-        }
-
-        if (delegateClassStr.toLowerCase().contains("hibernate")) {
-            return JPAProviderImpl.HIBERNATE;
-        }
-
-        return null;
-    }
-
-    public JPAProviderImpl getJPAProviderImpl(JPAResource jpaRsc) {
-        if (jpaRsc == null) {
-            return null;
-        }
-
-        return getJPAProviderImpl(jpaRsc.getEm());
-    }
-
     protected String toBeanMethod(String prefix, String fieldName) {
         return prefix + Character.toUpperCase(fieldName.charAt(0)) + fieldName.substring(1, fieldName.length());
     }


### PR DESCRIPTION
Minor cleanup to several JPA FAT

1) Shared resources directory used by several JPA FAT
2) Remove duplicate JPA Provider enumerations

