### PR TITLE
Revert "temporarily tolerate EE 9 features for beta"

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.cdi-concurrent3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.cdi-concurrent3.0.feature
@@ -1,9 +1,10 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.cdi-concurrent3.0
 visibility=private
-#TODO remove osgi.identity=io.openliberty.cdi-3.0
+#TODO remove temporary API package for simulating possible additions to Jakarta Concurrency
+IBM-API-Package: prototype.enterprise.concurrent; type="ibm-api"
 IBM-Provision-Capability: \
-  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.cdi-4.0)(osgi.identity=io.openliberty.cdi-3.0)))", \
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.cdi-4.0))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.concurrent-3.0))"
 -bundles=\
   io.openliberty.concurrent.cdi.jakarta

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.concurrency-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.concurrency-3.0.feature
@@ -2,8 +2,7 @@
 symbolicName=io.openliberty.jakarta.concurrency-3.0
 visibility=private
 singleton=true
-#TODO remove toleration of eeCompatible-9.0 once other EE 10 features are usable in beta form
--features=com.ibm.websphere.appserver.eeCompatible-10.0; ibm.tolerates:="9.0"
+-features=com.ibm.websphere.appserver.eeCompatible-10.0
 -bundles=io.openliberty.jakarta.concurrency.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="io.openliberty.jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:3.0.0.20211206"
 kind=noship
 edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-3.0/io.openliberty.concurrent-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-3.0/io.openliberty.concurrent-3.0.feature
@@ -9,14 +9,14 @@ IBM-API-Service: jakarta.enterprise.concurrent.ContextService; id="DefaultContex
   jakarta.enterprise.concurrent.ManagedExecutorService; id="DefaultManagedExecutorService", \
   jakarta.enterprise.concurrent.ManagedScheduledExecutorService; id="DefaultManagedScheduledExecutorService"
 Subsystem-Name: Jakarta Concurrency 3.0
-#TODO remove toleration of eeCompatible-9.0 once other EE 10 features are usable in beta form
+#TODO switch to eeCompatible-10.0 at same time as other EE 10 features, once they exist
 #TODO switch to interceptor-vNext
 #TODO decide if autofeature should be used to avoid dependency on injection
 -features=com.ibm.websphere.appserver.appLifecycle-1.0, \
   com.ibm.websphere.appserver.concurrencyPolicy-1.0, \
   com.ibm.websphere.appserver.containerServices-1.0, \
   com.ibm.websphere.appserver.contextService-1.0, \
-  com.ibm.websphere.appserver.eeCompatible-10.0; ibm.tolerates:="9.0", \
+  com.ibm.websphere.appserver.eeCompatible-10.0, \
   com.ibm.websphere.appserver.injection-2.0, \
   io.openliberty.jakartaeePlatform-10.0, \
   io.openliberty.jakarta.concurrency-3.0, \


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#19722

Causing a hard break in io.openliberty.jakartaee9.internal_fat: testJsonP20Feature due to the expectation that concurrency-3.0 would conflict with EE9