### PR TITLE
redeliver 19722 with updated test

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.cdi-concurrent3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.cdi-concurrent3.0.feature
@@ -1,10 +1,9 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.cdi-concurrent3.0
 visibility=private
-#TODO remove temporary API package for simulating possible additions to Jakarta Concurrency
-IBM-API-Package: prototype.enterprise.concurrent; type="ibm-api"
+#TODO remove osgi.identity=io.openliberty.cdi-3.0
 IBM-Provision-Capability: \
-  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.cdi-4.0))", \
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.cdi-4.0)(osgi.identity=io.openliberty.cdi-3.0)))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.concurrent-3.0))"
 -bundles=\
   io.openliberty.concurrent.cdi.jakarta

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.concurrency-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.concurrency-3.0.feature
@@ -2,7 +2,8 @@
 symbolicName=io.openliberty.jakarta.concurrency-3.0
 visibility=private
 singleton=true
--features=com.ibm.websphere.appserver.eeCompatible-10.0
+#TODO remove toleration of eeCompatible-9.0 once other EE 10 features are usable in beta form
+-features=com.ibm.websphere.appserver.eeCompatible-10.0; ibm.tolerates:="9.0"
 -bundles=io.openliberty.jakarta.concurrency.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="io.openliberty.jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:3.0.0.20211206"
 kind=noship
 edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-3.0/io.openliberty.concurrent-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-3.0/io.openliberty.concurrent-3.0.feature
@@ -9,14 +9,15 @@ IBM-API-Service: jakarta.enterprise.concurrent.ContextService; id="DefaultContex
   jakarta.enterprise.concurrent.ManagedExecutorService; id="DefaultManagedExecutorService", \
   jakarta.enterprise.concurrent.ManagedScheduledExecutorService; id="DefaultManagedScheduledExecutorService"
 Subsystem-Name: Jakarta Concurrency 3.0
-#TODO switch to eeCompatible-10.0 at same time as other EE 10 features, once they exist
+#TODO remove toleration of eeCompatible-9.0 once other EE 10 features are usable in beta form
+#       and also remove line after TODO in EE9FeatureCompatibilityTest.java that allows concurrent-3.0 with EE 9 features
 #TODO switch to interceptor-vNext
 #TODO decide if autofeature should be used to avoid dependency on injection
 -features=com.ibm.websphere.appserver.appLifecycle-1.0, \
   com.ibm.websphere.appserver.concurrencyPolicy-1.0, \
   com.ibm.websphere.appserver.containerServices-1.0, \
   com.ibm.websphere.appserver.contextService-1.0, \
-  com.ibm.websphere.appserver.eeCompatible-10.0, \
+  com.ibm.websphere.appserver.eeCompatible-10.0; ibm.tolerates:="9.0", \
   com.ibm.websphere.appserver.injection-2.0, \
   io.openliberty.jakartaeePlatform-10.0, \
   io.openliberty.jakarta.concurrency-3.0, \

--- a/dev/io.openliberty.jakartaee9.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.jakartaee9.internal_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2021 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -19,7 +19,8 @@ fat.project: true
 
 tested.features:\
     jakartaee-9.1, \
-    webProfile-9.1
+    webProfile-9.1, \
+    all_features
 
 -buildpath: \
 	io.openliberty.jakarta.annotation.2.0;version=latest,\

--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9FeatureCompatibilityTest.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9FeatureCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -144,6 +144,9 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
                 nonEE9JavaEEFeatures.add(feature);
             }
         }
+
+        // TODO this is temporarily tolerated with EE 9 features for the early concurrent-3.0 beta. Remove it before GA.
+        nonEE9JavaEEFeatures.remove("concurrent-3.0");
 
         incompatibleValueAddFeatures.add("openid-2.0"); // stabilized
         incompatibleValueAddFeatures.add("openapi-3.1"); // depends on mpOpenAPI


### PR DESCRIPTION
Redelivers #19722 after adding a workaround in the test case that was failing but not running under personal builds.