### PR TITLE
Disable EE9 repeat on Windows in a couple long running OIDC Fats

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/fat/src/com/ibm/ws/security/openidconnect/client/fat/jaxrs/FATSuite.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/fat/src/com/ibm/ws/security/openidconnect/client/fat/jaxrs/FATSuite.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.client.fat.jaxrs;
 
@@ -18,6 +18,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
+import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 import com.ibm.ws.security.openidconnect.client.fat.jaxrs.IBM.OIDCTokenMappingResolverGenericTest;
 import com.ibm.ws.security.openidconnect.client.fat.jaxrs.IBM.OidcJaxRSClientAPITests;
 import com.ibm.ws.security.openidconnect.client.fat.jaxrs.IBM.OidcJaxRSClientBasicTests;
@@ -26,17 +28,16 @@ import com.ibm.ws.security.openidconnect.client.fat.jaxrs.IBM.OidcJaxRSClientReA
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.rules.repeater.EmptyAction;
-import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                AlwaysPassesTest.class,
-                OidcJaxRSClientBasicTests.class,
-                OidcJaxRSClientAPITests.class,
-                OIDCTokenMappingResolverGenericTest.class,
-                OidcJaxRSClientReAuthnTests.class,
-                OidcJaxRSClientDiscoveryBasicTests.class,
+        AlwaysPassesTest.class,
+        OidcJaxRSClientBasicTests.class,
+        OidcJaxRSClientAPITests.class,
+        OIDCTokenMappingResolverGenericTest.class,
+        OidcJaxRSClientReAuthnTests.class,
+        OidcJaxRSClientDiscoveryBasicTests.class,
 //                OidcJaxRSClientRequestFilterTests.class
 })
 /**
@@ -67,6 +68,7 @@ public class FATSuite {
     /* always add servlet-5.0 to enable EE9 in the op which had no feature versions to swap out to enable EE9 */
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
-                    .andWith(new JakartaEE9Action().removeFeatures(REMOVE).addFeatures(INSERT).alwaysAddFeature("servlet-5.0").fullFATOnly());
+            .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
+            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().removeFeatures(REMOVE).addFeatures(INSERT).alwaysAddFeature("servlet-5.0").fullFATOnly());
 
 }

--- a/dev/com.ibm.ws.security.oidc.server_fat.jaxrs.config/fat/src/com/ibm/ws/security/openidconnect/server/fat/jaxrs/config/FATSuite.java
+++ b/dev/com.ibm.ws.security.oidc.server_fat.jaxrs.config/fat/src/com/ibm/ws/security/openidconnect/server/fat/jaxrs/config/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 IBM Corporation and others.
+ * Copyright (c) 2016, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
+import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 import com.ibm.ws.security.fat.common.utils.ldaputils.CommonAltRemoteLDAPServerSuite;
 import com.ibm.ws.security.openidconnect.server.fat.jaxrs.config.OAuth.OAuthCookieAttributesInboundPropNoneNoOPToken2ServerTests;
 import com.ibm.ws.security.openidconnect.server.fat.jaxrs.config.OAuth.OAuthCookieAttributesInboundPropNoneWithOPToken2ServerTests;
@@ -51,7 +53,6 @@ import com.ibm.ws.security.openidconnect.server.fat.jaxrs.config.noOP.NoOPEncryp
 import com.ibm.ws.security.openidconnect.server.fat.jaxrs.config.noOP.NoOPSignatureRSServerTests;
 
 import componenttest.rules.repeater.EmptyAction;
-import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
@@ -112,6 +113,7 @@ public class FATSuite extends CommonAltRemoteLDAPServerSuite {
     /* always add servlet-5.0 to enable EE9 in the op which had no feature versions to swap out to enable EE9 */
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
-            .andWith(new JakartaEE9Action().alwaysAddFeature("servlet-5.0").fullFATOnly());
+            .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
+            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().alwaysAddFeature("servlet-5.0").fullFATOnly());
 
 }


### PR DESCRIPTION
We've run into some bucket timeouts with OIDC when run on Windows with EE9 enabled.  The FeatureReplacementAction process is taking in once case 55 out of the 180 allowed minutes.  The FAT ends up timing out.  I'm going to update the repeat rules for these long running projects to run without EE9 on Windows.  We have other FATs that are smaller that will test OIDC with EE9 on Windows and not time out.  The projects that are being updated will still run on Windows and will run with EE9 on all other platforms.

    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
            .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().alwaysAddFeature("servlet-5.0").fullFATOnly());