### PR TITLE
Reduce AccessController.doPriv calls

### DIFF
--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipFileData.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipFileData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@ package com.ibm.ws.artifact.zip.cache.internal;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.function.Function;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
@@ -589,6 +590,13 @@ ZipFile [Path]
     private long zipLength;
     private long zipLastModified;
 
+    private static final Function<File, long[]> lengthAndModifiedAction = new Function<File, long[]>() {
+        @Override
+        public long[] apply(File target) {
+            return new long[] {target.length(), target.lastModified()};
+        }
+    };
+
     /**
      * Re-acquire the ZIP file.
      * 
@@ -611,8 +619,9 @@ ZipFile [Path]
         String methodName = "reacquireZipFile";
 
         File rawZipFile = new File(path);
-        long newZipLength = FileUtils.fileLength(rawZipFile);
-        long newZipLastModified = FileUtils.fileLastModified(rawZipFile);
+        long[] lengthAndModified = FileUtils.fileAction(rawZipFile, lengthAndModifiedAction);
+        long newZipLength = lengthAndModified[0];
+        long newZipLastModified = lengthAndModified[1];
 
         boolean zipFileChanged = false;
 
@@ -729,8 +738,9 @@ ZipFile [Path]
 
         if ( useZipLength == UNKNOWN_ZIP_LENGTH ) {
             File rawZipFile = new File(path);
-            useZipLength = FileUtils.fileLength(rawZipFile);
-            useZipLastModified = FileUtils.fileLastModified(rawZipFile);
+            long[] lengthAndModified = FileUtils.fileAction(rawZipFile, lengthAndModifiedAction);
+            useZipLength = lengthAndModified[0];
+            useZipLastModified = lengthAndModified[1];
         }
 
         zipLength = useZipLength;

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipFileReaper.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipFileReaper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -450,7 +450,7 @@ public class ZipFileReaper {
                         break;
                     }
 
-                    nextReapAt = SystemUtils.getNanoTime();
+                    nextReapAt = System.nanoTime();
 
                     if ( doDebug ) {
                         Tr.debug(tc, methodName + " Reap [ " + reaper.fromInitial_s(nextReapAt) + " ]");
@@ -521,7 +521,7 @@ public class ZipFileReaper {
                 reaper.reaperLock.releaseWriteLock();
             }
 
-            long shutdownAt = SystemUtils.getNanoTime();
+            long shutdownAt = System.nanoTime();
             if ( doDebug ) {
                 Tr.debug(tc, methodName + " Shutting down [ " + reaper.fromInitial_s(shutdownAt) + " ]");
             }
@@ -532,7 +532,7 @@ public class ZipFileReaper {
                 reaper.reaperLock.releaseWriteLock();
             }
 
-            long stopAt = SystemUtils.getNanoTime();
+            long stopAt = System.nanoTime();
             if ( doDebug ) {
                 Tr.debug(tc, methodName + " Stop [ " + reaper.fromInitial_s(stopAt) + " ]");
             }
@@ -543,7 +543,7 @@ public class ZipFileReaper {
 
     @Trivial
     public ZipFileReaper(String reaperName) {
-        this( reaperName, SystemUtils.getNanoTime() );
+        this( reaperName, System.nanoTime() );
     }
 
     @Trivial
@@ -575,7 +575,7 @@ public class ZipFileReaper {
               quickPendMin, quickPendMax,
               slowPendMin, slowPendMax,
               errorHandler,
-              SystemUtils.getNanoTime() );
+              System.nanoTime() );
     }
 
     @Trivial
@@ -590,7 +590,7 @@ public class ZipFileReaper {
               quickPendMin, quickPendMax,
               slowPendMin, slowPendMax,
               ZipFileReaper.NULL_ERROR_HANDLER,
-              SystemUtils.getNanoTime() );
+              System.nanoTime() );
     }
 
     private static void validate(
@@ -1526,7 +1526,7 @@ public class ZipFileReaper {
 
     @Trivial
     public ZipFile open(String path) throws IOException, ZipException {
-        return open( path, SystemUtils.getNanoTime() );
+        return open( path, System.nanoTime() );
     }
 
     @Trivial
@@ -1641,7 +1641,7 @@ public class ZipFileReaper {
     }
 
     public ZipFileData.ZipFileState close(String path) {
-        return close( path, SystemUtils.getNanoTime() );
+        return close( path, System.nanoTime() );
     }
 
     public ZipFileData.ZipFileState close(String path, long closeAt) {

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/SystemUtils.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/SystemUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,25 +36,6 @@ public class SystemUtils {
                 }
 
             } );
-        } finally {
-            ThreadIdentityManager.reset(token);
-        }
-    }
-
-    /**
-     * Run {@link System#getNanoTime} as a privileged action.
-     *
-     * @return The system time in nano-seconds.
-     */
-    public static long getNanoTime() {
-        Object token = ThreadIdentityManager.runAsServer();
-        try {
-            return AccessController.doPrivileged( new PrivilegedAction<Long>() {
-                @Override
-                public Long run() {
-                    return System.nanoTime();
-                }
-            } ).longValue();
         } finally {
             ThreadIdentityManager.reset(token);
         }


### PR DESCRIPTION
- System.nanoTime does not need to be in a doPriv call.
- Combine File utils doPriv calls so only do one doPriv instead of multiple ones.
