### PR TITLE
need separate processor instances

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/src/test/jakarta/concurrency/ejb/ExecutorBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/src/test/jakarta/concurrency/ejb/ExecutorBean.java
@@ -19,15 +19,16 @@ import jakarta.ejb.Stateless;
 import jakarta.enterprise.concurrent.ContextServiceDefinition;
 import jakarta.enterprise.concurrent.ManagedExecutorDefinition;
 import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.enterprise.concurrent.ManagedScheduledExecutorDefinition;
 import jakarta.enterprise.concurrent.ManagedThreadFactoryDefinition;
 
 import test.context.list.ListContext;
 import test.context.location.ZipCode;
 import test.context.timing.Timestamp;
 
-// TODO use the same name as a context service in ConcurrencyTestServlet,
+// Use the same name as a context service in ConcurrencyTestServlet,
 // which must be permitted because it is scoped to a different module.
-@ContextServiceDefinition(name = "java:module/concurrent/ZLContextSvcTODO",
+@ContextServiceDefinition(name = "java:module/concurrent/ZLContextSvc",
                           propagated = { ZipCode.CONTEXT_NAME, ListContext.CONTEXT_NAME, APPLICATION },
                           cleared = Timestamp.CONTEXT_NAME,
                           unchanged = "Priority")
@@ -35,14 +36,10 @@ import test.context.timing.Timestamp;
                            context = "java:app/concurrent/appContextSvc",
                            hungTaskThreshold = 480000,
                            maxAsync = 1)
-// TODO need to determine what bug is causing this behavior:
-// Switching the following from @ManagedExecutorDefinition to @ManagedScheduledExecutorDefinition
-// causes a failure if and only if the ConcurrencyTestServlet has a ManagedScheduledExecutorDefinition
-// with a java:comp name!
-@ManagedExecutorDefinition(name = "java:module/concurrent/executor9",
-                           context = "java:module/concurrent/ZLContextSvcTODO",
-                           hungTaskThreshold = 540000,
-                           maxAsync = 2)
+@ManagedScheduledExecutorDefinition(name = "java:module/concurrent/executor9",
+                                    context = "java:module/concurrent/ZLContextSvc",
+                                    hungTaskThreshold = 540000,
+                                    maxAsync = 2)
 @ManagedThreadFactoryDefinition(name = "java:module/concurrent/tf",
                                 context = "java:app/concurrent/appContextSvc")
 @Stateless

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/ConcurrencyTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/ConcurrencyTestServlet.java
@@ -412,7 +412,7 @@ public class ConcurrencyTestServlet extends FATServlet {
         assertNotNull(bean);
         bean.execute(() -> {
             try {
-                ContextService contextSvc = InitialContext.doLookup("java:module/concurrent/ZLContextSvcTODO");
+                ContextService contextSvc = InitialContext.doLookup("java:module/concurrent/ZLContextSvc");
 
                 // Put some fake context onto the thread:
                 Timestamp.set();

--- a/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ContextServiceDefinitionProvider.java
+++ b/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ContextServiceDefinitionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -39,8 +39,6 @@ public class ContextServiceDefinitionProvider extends InjectionProcessorProvider
     private static final List<Class<? extends JNDIEnvironmentRef>> REF_CLASSES = //
                     Collections.<Class<? extends JNDIEnvironmentRef>> singletonList(ContextService.class);
 
-    private final InjectionProcessor<ContextServiceDefinition, ContextServiceDefinition.List> processor = new Processor();
-
     @Override
     @Trivial
     public Class<ContextServiceDefinition> getAnnotationClass() {
@@ -61,7 +59,7 @@ public class ContextServiceDefinitionProvider extends InjectionProcessorProvider
 
     @Override
     public InjectionProcessor<ContextServiceDefinition, ContextServiceDefinition.List> createInjectionProcessor() {
-        return processor;
+        return new Processor();
     }
 
     class Processor extends InjectionProcessor<ContextServiceDefinition, ContextServiceDefinition.List> {

--- a/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedExecutorDefinitionProvider.java
+++ b/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedExecutorDefinitionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -39,8 +39,6 @@ public class ManagedExecutorDefinitionProvider extends InjectionProcessorProvide
     private static final List<Class<? extends JNDIEnvironmentRef>> REF_CLASSES = //
                     Collections.<Class<? extends JNDIEnvironmentRef>> singletonList(ManagedExecutor.class);
 
-    private final InjectionProcessor<ManagedExecutorDefinition, ManagedExecutorDefinition.List> processor = new Processor();
-
     @Override
     @Trivial
     public Class<ManagedExecutorDefinition> getAnnotationClass() {
@@ -61,7 +59,7 @@ public class ManagedExecutorDefinitionProvider extends InjectionProcessorProvide
 
     @Override
     public InjectionProcessor<ManagedExecutorDefinition, ManagedExecutorDefinition.List> createInjectionProcessor() {
-        return processor;
+        return new Processor();
     }
 
     class Processor extends InjectionProcessor<ManagedExecutorDefinition, ManagedExecutorDefinition.List> {

--- a/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedScheduledExecutorDefinitionProvider.java
+++ b/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedScheduledExecutorDefinitionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -39,8 +39,6 @@ public class ManagedScheduledExecutorDefinitionProvider extends InjectionProcess
     private static final List<Class<? extends JNDIEnvironmentRef>> REF_CLASSES = //
                     Collections.<Class<? extends JNDIEnvironmentRef>> singletonList(ManagedScheduledExecutor.class);
 
-    private final InjectionProcessor<ManagedScheduledExecutorDefinition, ManagedScheduledExecutorDefinition.List> processor = new Processor();
-
     @Override
     @Trivial
     public Class<ManagedScheduledExecutorDefinition> getAnnotationClass() {
@@ -61,7 +59,7 @@ public class ManagedScheduledExecutorDefinitionProvider extends InjectionProcess
 
     @Override
     public InjectionProcessor<ManagedScheduledExecutorDefinition, ManagedScheduledExecutorDefinition.List> createInjectionProcessor() {
-        return processor;
+        return new Processor();
     }
 
     class Processor extends InjectionProcessor<ManagedScheduledExecutorDefinition, ManagedScheduledExecutorDefinition.List> {

--- a/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedThreadFactoryDefinitionProvider.java
+++ b/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedThreadFactoryDefinitionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -61,7 +61,7 @@ public class ManagedThreadFactoryDefinitionProvider extends InjectionProcessorPr
 
     @Override
     public InjectionProcessor<ManagedThreadFactoryDefinition, ManagedThreadFactoryDefinition.List> createInjectionProcessor() {
-        return processor;
+        return new Processor();
     }
 
     class Processor extends InjectionProcessor<ManagedThreadFactoryDefinition, ManagedThreadFactoryDefinition.List> {


### PR DESCRIPTION
fixes #19755

This was failing because a single Processor instance was being used for each annotation type, so the java:comp name that was already processed for the web module was attempting to also be applied to the EJB module where there was no such component, leading to the NullPointerException.  This also fixed the issue where java:module wasn't properly scoped.

This pull includes the fix and enables both test scenarios.