### PR TITLE
add missing code from DataSourceDefinition code path

### DIFF
--- a/dev/com.ibm.ws.injection.core/src/com/ibm/wsspi/injectionengine/ComponentNameSpaceConfiguration.java
+++ b/dev/com.ibm.ws.injection.core/src/com/ibm/wsspi/injectionengine/ComponentNameSpaceConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2015 IBM Corporation and others.
+ * Copyright (c) 2007, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,12 +28,16 @@ import com.ibm.ejs.util.dopriv.SystemGetPropertyPrivileged;
 import com.ibm.websphere.csi.J2EEName;
 import com.ibm.ws.javaee.dd.common.AdministeredObject;
 import com.ibm.ws.javaee.dd.common.ConnectionFactory;
+import com.ibm.ws.javaee.dd.common.ContextService;
 import com.ibm.ws.javaee.dd.common.DataSource;
 import com.ibm.ws.javaee.dd.common.EJBRef;
 import com.ibm.ws.javaee.dd.common.EnvEntry;
 import com.ibm.ws.javaee.dd.common.JMSConnectionFactory;
 import com.ibm.ws.javaee.dd.common.JMSDestination;
 import com.ibm.ws.javaee.dd.common.JNDIEnvironmentRef;
+import com.ibm.ws.javaee.dd.common.ManagedExecutor;
+import com.ibm.ws.javaee.dd.common.ManagedScheduledExecutor;
+import com.ibm.ws.javaee.dd.common.ManagedThreadFactory;
 import com.ibm.ws.javaee.dd.common.MessageDestinationRef;
 import com.ibm.ws.javaee.dd.common.PersistenceContextRef;
 import com.ibm.ws.javaee.dd.common.PersistenceUnitRef;
@@ -818,6 +822,20 @@ public class ComponentNameSpaceConfiguration
     }
 
     /**
+     * Returns a map of context service resource definition names to resource
+     * names.
+     */
+    public Map<String, String> getContextServiceDefinitionBindings()
+    {
+        return getJNDIEnvironmentRefBindings(ContextService.class);
+    }
+
+    public void setContextServiceDefinitionBindings(Map<String, String> csDefBindings)
+    {
+        setJNDIEnvironmentRefBindings(ContextService.class, csDefBindings);
+    }
+
+    /**
      * Returns a map of data source resource definition names to resource
      * names.
      */
@@ -829,6 +847,48 @@ public class ComponentNameSpaceConfiguration
     public void setDataSourceDefinitionBindings(Map<String, String> dsDefBindings) // F743-33811
     {
         setJNDIEnvironmentRefBindings(DataSource.class, dsDefBindings);
+    }
+
+    /**
+     * Returns a map of managed executor resource definition names to resource
+     * names.
+     */
+    public Map<String, String> getManagedExecutorDefinitionBindings()
+    {
+        return getJNDIEnvironmentRefBindings(ManagedExecutor.class);
+    }
+
+    public void setManagedExecutorDefinitionBindings(Map<String, String> mxDefBindings)
+    {
+        setJNDIEnvironmentRefBindings(ManagedExecutor.class, mxDefBindings);
+    }
+
+    /**
+     * Returns a map of managed scheduled executor resource definition names to resource
+     * names.
+     */
+    public Map<String, String> getManagedScheduledExecutorDefinitionBindings()
+    {
+        return getJNDIEnvironmentRefBindings(ManagedScheduledExecutor.class);
+    }
+
+    public void setManagedScheduledExecutorDefinitionBindings(Map<String, String> msxDefBindings)
+    {
+        setJNDIEnvironmentRefBindings(ManagedScheduledExecutor.class, msxDefBindings);
+    }
+
+    /**
+     * Returns a map of managed thread factory resource definition names to resource
+     * names.
+     */
+    public Map<String, String> getManagedThreadFactoryDefinitionBindings()
+    {
+        return getJNDIEnvironmentRefBindings(ManagedThreadFactory.class);
+    }
+
+    public void setManagedThreadFactoryDefinitionBindings(Map<String, String> mtfDefBindings)
+    {
+        setJNDIEnvironmentRefBindings(ManagedThreadFactory.class, mtfDefBindings);
     }
 
     /**

--- a/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ContextServiceDefinitionBinding.java
+++ b/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ContextServiceDefinitionBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -44,6 +44,8 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
     private String description;
     private boolean XMLDescription;
 
+    private final String ivBinding;
+
     private String[] propagated;
     private boolean XMLpropagated;
 
@@ -56,6 +58,9 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
     public ContextServiceDefinitionBinding(String jndiName, ComponentNameSpaceConfiguration nameSpaceConfig) {
         super(null, nameSpaceConfig);
         setJndiName(jndiName);
+
+        Map<String, String> msxBindings = nameSpaceConfig.getContextServiceDefinitionBindings();
+        ivBinding = msxBindings == null ? null : msxBindings.get(getJndiName());
     }
 
     @Override
@@ -116,11 +121,15 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
     public void mergeSaved(InjectionBinding<ContextServiceDefinition> injectionBinding) throws InjectionException {
         ContextServiceDefinitionBinding contextServiceBinding = (ContextServiceDefinitionBinding) injectionBinding;
 
-        mergeSavedValue(cleared, contextServiceBinding.cleared, "cleared");
-        mergeSavedValue(description, contextServiceBinding.description, "description");
-        mergeSavedValue(propagated, contextServiceBinding.propagated, "propagated");
-        mergeSavedValue(properties, contextServiceBinding.properties, "properties");
-        mergeSavedValue(unchanged, contextServiceBinding.unchanged, "unchanged");
+        if (ivBinding != null) {
+            mergeSavedValue(ivBinding, contextServiceBinding.ivBinding, "binding-name");
+        } else {
+            mergeSavedValue(cleared, contextServiceBinding.cleared, "cleared");
+            mergeSavedValue(description, contextServiceBinding.description, "description");
+            mergeSavedValue(propagated, contextServiceBinding.propagated, "propagated");
+            mergeSavedValue(properties, contextServiceBinding.properties, "properties");
+            mergeSavedValue(unchanged, contextServiceBinding.unchanged, "unchanged");
+        }
     }
 
     void resolve() throws InjectionException {
@@ -136,6 +145,6 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
         addOrRemoveProperty(props, KEY_PROPAGATED, propagated);
         addOrRemoveProperty(props, KEY_UNCHANGED, unchanged);
 
-        setObjects(null, createDefinitionReference(null, jakarta.enterprise.concurrent.ContextService.class.getName(), props));
+        setObjects(null, createDefinitionReference(ivBinding, jakarta.enterprise.concurrent.ContextService.class.getName(), props));
     }
 }

--- a/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedExecutorDefinitionBinding.java
+++ b/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedExecutorDefinitionBinding.java
@@ -48,6 +48,8 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
     private Long hungTaskThreshold;
     private boolean XMLHungTaskThreshold;
 
+    private final String ivBinding;
+
     private Integer maxAsync;
     private boolean XMLMaxAsync;
 
@@ -57,6 +59,9 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
     public ManagedExecutorDefinitionBinding(String jndiName, ComponentNameSpaceConfiguration nameSpaceConfig) {
         super(null, nameSpaceConfig);
         setJndiName(jndiName);
+
+        Map<String, String> msxBindings = nameSpaceConfig.getManagedExecutorDefinitionBindings();
+        ivBinding = msxBindings == null ? null : msxBindings.get(getJndiName());
     }
 
     @Override
@@ -115,11 +120,15 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
     public void mergeSaved(InjectionBinding<ManagedExecutorDefinition> injectionBinding) throws InjectionException {
         ManagedExecutorDefinitionBinding managedExecutorBinding = (ManagedExecutorDefinitionBinding) injectionBinding;
 
-        mergeSavedValue(contextServiceJndiName, managedExecutorBinding.contextServiceJndiName, "context-service-ref");
-        mergeSavedValue(description, managedExecutorBinding.description, "description");
-        mergeSavedValue(hungTaskThreshold, managedExecutorBinding.hungTaskThreshold, "hung-task-threshold");
-        mergeSavedValue(maxAsync, managedExecutorBinding.maxAsync, "max-async");
-        mergeSavedValue(properties, managedExecutorBinding.properties, "properties");
+        if (ivBinding != null) {
+            mergeSavedValue(ivBinding, managedExecutorBinding.ivBinding, "binding-name");
+        } else {
+            mergeSavedValue(contextServiceJndiName, managedExecutorBinding.contextServiceJndiName, "context-service-ref");
+            mergeSavedValue(description, managedExecutorBinding.description, "description");
+            mergeSavedValue(hungTaskThreshold, managedExecutorBinding.hungTaskThreshold, "hung-task-threshold");
+            mergeSavedValue(maxAsync, managedExecutorBinding.maxAsync, "max-async");
+            mergeSavedValue(properties, managedExecutorBinding.properties, "properties");
+        }
     }
 
     void resolve() throws InjectionException {
@@ -135,6 +144,6 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
         addOrRemoveProperty(props, KEY_HUNG_TASK_THRESHOLD, hungTaskThreshold);
         addOrRemoveProperty(props, KEY_MAX_ASYNC, maxAsync);
 
-        setObjects(null, createDefinitionReference(null, ManagedExecutorService.class.getName(), props));
+        setObjects(null, createDefinitionReference(ivBinding, ManagedExecutorService.class.getName(), props));
     }
 }

--- a/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedScheduledExecutorDefinitionBinding.java
+++ b/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedScheduledExecutorDefinitionBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -48,6 +48,8 @@ public class ManagedScheduledExecutorDefinitionBinding extends InjectionBinding<
     private Long hungTaskThreshold;
     private boolean XMLHungTaskThreshold;
 
+    private final String ivBinding;
+
     private Integer maxAsync;
     private boolean XMLMaxAsync;
 
@@ -57,6 +59,9 @@ public class ManagedScheduledExecutorDefinitionBinding extends InjectionBinding<
     public ManagedScheduledExecutorDefinitionBinding(String jndiName, ComponentNameSpaceConfiguration nameSpaceConfig) {
         super(null, nameSpaceConfig);
         setJndiName(jndiName);
+
+        Map<String, String> msxBindings = nameSpaceConfig.getManagedScheduledExecutorDefinitionBindings();
+        ivBinding = msxBindings == null ? null : msxBindings.get(getJndiName());
     }
 
     @Override
@@ -115,11 +120,15 @@ public class ManagedScheduledExecutorDefinitionBinding extends InjectionBinding<
     public void mergeSaved(InjectionBinding<ManagedScheduledExecutorDefinition> injectionBinding) throws InjectionException {
         ManagedScheduledExecutorDefinitionBinding managedScheduledExecutorBinding = (ManagedScheduledExecutorDefinitionBinding) injectionBinding;
 
-        mergeSavedValue(contextServiceJndiName, managedScheduledExecutorBinding.contextServiceJndiName, "context-service-ref");
-        mergeSavedValue(description, managedScheduledExecutorBinding.description, "description");
-        mergeSavedValue(hungTaskThreshold, managedScheduledExecutorBinding.hungTaskThreshold, "hung-task-threshold");
-        mergeSavedValue(maxAsync, managedScheduledExecutorBinding.maxAsync, "max-async");
-        mergeSavedValue(properties, managedScheduledExecutorBinding.properties, "properties");
+        if (ivBinding != null) {
+            mergeSavedValue(ivBinding, managedScheduledExecutorBinding.ivBinding, "binding-name");
+        } else {
+            mergeSavedValue(contextServiceJndiName, managedScheduledExecutorBinding.contextServiceJndiName, "context-service-ref");
+            mergeSavedValue(description, managedScheduledExecutorBinding.description, "description");
+            mergeSavedValue(hungTaskThreshold, managedScheduledExecutorBinding.hungTaskThreshold, "hung-task-threshold");
+            mergeSavedValue(maxAsync, managedScheduledExecutorBinding.maxAsync, "max-async");
+            mergeSavedValue(properties, managedScheduledExecutorBinding.properties, "properties");
+        }
     }
 
     void resolve() throws InjectionException {
@@ -135,6 +144,6 @@ public class ManagedScheduledExecutorDefinitionBinding extends InjectionBinding<
         addOrRemoveProperty(props, KEY_HUNG_TASK_THRESHOLD, hungTaskThreshold);
         addOrRemoveProperty(props, KEY_MAX_ASYNC, maxAsync);
 
-        setObjects(null, createDefinitionReference(null, ManagedScheduledExecutorService.class.getName(), props));
+        setObjects(null, createDefinitionReference(ivBinding, ManagedScheduledExecutorService.class.getName(), props));
     }
 }

--- a/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedThreadFactoryDefinitionBinding.java
+++ b/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedThreadFactoryDefinitionBinding.java
@@ -43,6 +43,8 @@ public class ManagedThreadFactoryDefinitionBinding extends InjectionBinding<Mana
     private String description;
     private boolean XMLDescription;
 
+    private final String ivBinding;
+
     private Integer priority;
     private boolean XMLPriority;
 
@@ -52,6 +54,9 @@ public class ManagedThreadFactoryDefinitionBinding extends InjectionBinding<Mana
     public ManagedThreadFactoryDefinitionBinding(String jndiName, ComponentNameSpaceConfiguration nameSpaceConfig) {
         super(null, nameSpaceConfig);
         setJndiName(jndiName);
+
+        Map<String, String> msxBindings = nameSpaceConfig.getManagedThreadFactoryDefinitionBindings();
+        ivBinding = msxBindings == null ? null : msxBindings.get(getJndiName());
     }
 
     @Override
@@ -104,10 +109,14 @@ public class ManagedThreadFactoryDefinitionBinding extends InjectionBinding<Mana
     public void mergeSaved(InjectionBinding<ManagedThreadFactoryDefinition> injectionBinding) throws InjectionException {
         ManagedThreadFactoryDefinitionBinding managedThreadFactoryBinding = (ManagedThreadFactoryDefinitionBinding) injectionBinding;
 
-        mergeSavedValue(contextServiceJndiName, managedThreadFactoryBinding.contextServiceJndiName, "context-service-ref");
-        mergeSavedValue(description, managedThreadFactoryBinding.description, "description");
-        mergeSavedValue(priority, managedThreadFactoryBinding.priority, "priority");
-        mergeSavedValue(properties, managedThreadFactoryBinding.properties, "properties");
+        if (ivBinding != null) {
+            mergeSavedValue(ivBinding, managedThreadFactoryBinding.ivBinding, "binding-name");
+        } else {
+            mergeSavedValue(contextServiceJndiName, managedThreadFactoryBinding.contextServiceJndiName, "context-service-ref");
+            mergeSavedValue(description, managedThreadFactoryBinding.description, "description");
+            mergeSavedValue(priority, managedThreadFactoryBinding.priority, "priority");
+            mergeSavedValue(properties, managedThreadFactoryBinding.properties, "properties");
+        }
     }
 
     void resolve() throws InjectionException {
@@ -122,6 +131,6 @@ public class ManagedThreadFactoryDefinitionBinding extends InjectionBinding<Mana
         addOrRemoveProperty(props, KEY_DESCRIPTION, description);
         addOrRemoveProperty(props, KEY_PRIORITY, priority);
 
-        setObjects(null, createDefinitionReference(null, jakarta.enterprise.concurrent.ManagedThreadFactory.class.getName(), props));
+        setObjects(null, createDefinitionReference(ivBinding, jakarta.enterprise.concurrent.ManagedThreadFactory.class.getName(), props));
     }
 }


### PR DESCRIPTION
Implementation for the Concurrency 3.0 resource definitions (like ContextServiceDefinition) was based on ConnectionFactoryDefinition, but I recently noticed that DataSourceDefinition has some additional code path. This pull adds that code path, illustrating the differences.  The decision to merge this or not merge it should be made by the team with expertise in the injection engine, which I'll ask to review.