### PR TITLE
Add additional port check on stop for AcmeClientTest

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeClientTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeClientTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -161,6 +161,8 @@ public class AcmeClientTest {
 			challengeServer.stop();
 			challengeServer = null;
 		}
+
+		AcmeFatUtils.checkPortOpen(pebble.getHttpPort(), 120000);
 	}
 
 	/**

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/HttpChallengeServer.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/HttpChallengeServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -138,7 +138,9 @@ public class HttpChallengeServer {
 	 */
 	public void stop() throws InterruptedException {
 		if (server != null) {
-			server.shutdown(10, TimeUnit.SECONDS);
+			Log.info(HttpChallengeServer.class, "stop", "Start shutdown on HttpChallengeServer.");
+			server.shutdown(60, TimeUnit.SECONDS);
+			Log.info(HttpChallengeServer.class, "stop", "Shutdown returned on HttpChallengeServer.");
 			server = null;
 		}
 	}


### PR DESCRIPTION
Having problems with port 5002 not being open after `AcmeClientTest`, had a couple issues where `AcmeSimpleTest` fails to get the port but later tests are fine, add a longer grace period on the `HTTPServer` shutdown and add a port check after the HTTP server stop in `AcmeClientTest` with an extra long wait time.

RTC 288792