### PR TITLE
Prevent InjectionProcessor caching

### DIFF
--- a/dev/com.ibm.ws.injection.core/src/com/ibm/wsspi/injectionengine/InjectionProcessor.java
+++ b/dev/com.ibm.ws.injection.core/src/com/ibm/wsspi/injectionengine/InjectionProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2013 IBM Corporation and others.
+ * Copyright (c) 2006, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -170,6 +170,12 @@ public abstract class InjectionProcessor<A extends Annotation, AS extends Annota
     void initProcessor(ComponentNameSpaceConfiguration compNSConfig, InjectionProcessorContext context)
                     throws InjectionException
     {
+        // Prevent the common mistake of an InjectionProcessorProvider returning a cached instance
+        if (ivNameSpaceConfig != null || ivContext != null || !ivAllAnnotationsCollection.isEmpty()) {
+            throw new InjectionException("Internal error: " + getClass().getName() +
+                                         ".createInjectionProcessor() returned an instance with initial state; createInjectionProcessor() must return a new uninitialized instance of the InjectionProcessor");
+        }
+
         ivNameSpaceConfig = compNSConfig;
         ivContext = context;
 


### PR DESCRIPTION
Prevent the common mistake of an InjectionProcessorProvider returning a cached instance
 - for internal development of new InjectionProcessorProviders
