### PR TITLE
test concurrency resource definition annotations in EJBs

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/src/test/jakarta/concurrency/ejb/ExecutorBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/src/test/jakarta/concurrency/ejb/ExecutorBean.java
@@ -41,7 +41,8 @@ import test.context.timing.Timestamp;
                                     hungTaskThreshold = 540000,
                                     maxAsync = 2)
 @ManagedThreadFactoryDefinition(name = "java:module/concurrent/tf",
-                                context = "java:app/concurrent/appContextSvc")
+                                context = "java:app/concurrent/appContextSvc",
+                                priority = 6)
 @Stateless
 public class ExecutorBean implements Executor {
     @Resource(lookup = "java:comp/concurrent/executor8", name = "java:app/env/concurrent/executor8ref")


### PR DESCRIPTION
Test cases for defining `@ManagedExecutorDefinition`, `@ManagedScheduledExecutorDefinition`, `@ManagedThreadFactoryDefinition` in an EJB and using the resources that they create.  It should be noted that `@ContextServiceDefinition` was already covered under a previous pull.