### PR TITLE
Issue 5158: Correctly clean WASOidcNonce cookie in OIDC flows

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/CommonMessageTools.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/CommonMessageTools.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import com.gargoylesoftware.htmlunit.CookieManager;
@@ -204,10 +205,12 @@ public class CommonMessageTools {
                 Log.info(thisClass, theMethod, "Response (Title): " + AutomationTools.getResponseTitle(response));
             }
             Log.info(thisClass, theMethod, "Response (Url): " + AutomationTools.getResponseUrl(response));
-            String[] hs = AutomationTools.getResponseHeaderNames(response);
-            if (hs != null) {
-                for (String h : hs) {
-                    Log.info(thisClass, theMethod, "Response (Header): Name: " + h + " Value: " + AutomationTools.getResponseHeaderField(response, h));
+            Map<String, String[]> headers = AutomationTools.getResponseHeaders(response);
+            if (headers != null) {
+                for (Entry<String, String[]> header : headers.entrySet()) {
+                    for (String value : header.getValue()) {
+                        Log.info(thisClass, theMethod, "Response (Header): Name: " + header.getKey() + " Value: " + value);
+                    }
                 }
             }
             Log.info(thisClass, theMethod, "Response (Message): " + AutomationTools.getResponseMessage(response));

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/Constants.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/Constants.java
@@ -70,6 +70,7 @@ public class Constants {
     public static final String RESPONSE_STATUS = "status";
     public static final String RESPONSE_HEADER = "header";
     public static final String RESPONSE_URL = "url";
+    public static final String RESPONSE_COOKIE = "cookie";
     public static final String JSON_OBJECT = "jsonObject";
     public static final String EXCEPTION_MESSAGE = "exceptionMsg";
 

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/web/WebFormUtils.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/web/WebFormUtils.java
@@ -2,7 +2,9 @@ package com.ibm.ws.security.fat.common.web;
 
 import java.util.List;
 
+import com.gargoylesoftware.htmlunit.ElementNotFoundException;
 import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.html.HtmlButton;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlInput;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
@@ -13,6 +15,7 @@ public class WebFormUtils {
     public static Class<?> thisClass = WebFormUtils.class;
 
     public static final String DEFAULT_LOGIN_SUBMIT_BUTTON_VALUE = "Login";
+    public static final String DEFAULT_LOGIN_SUBMIT_BUTTON_NAME = "submitButton";
 
     /**
      * Fills out the first form found in the provided login page with the specified credentials and submits the form. An exception
@@ -78,8 +81,13 @@ public class WebFormUtils {
         if (submitButtonValue == null) {
             throw new Exception("Cannot submit HTML form because the provided submit button value is null.");
         }
-        HtmlInput submitButton = form.getInputByValue(submitButtonValue);
-        return submitButton.click();
+        try {
+            HtmlInput submitButton = form.getInputByValue(submitButtonValue);
+            return submitButton.click();
+        } catch (ElementNotFoundException e) {
+            HtmlButton submitButton = form.getButtonByName(DEFAULT_LOGIN_SUBMIT_BUTTON_NAME);
+            return submitButton.click();
+        }
     }
 
 }

--- a/dev/com.ibm.ws.security.fat.common/test/com/ibm/ws/security/fat/common/utils/AutomationToolsTest.java
+++ b/dev/com.ibm.ws.security.fat.common/test/com/ibm/ws/security/fat/common/utils/AutomationToolsTest.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.fat.common.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.gargoylesoftware.htmlunit.util.NameValuePair;
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import test.common.SharedOutputManager;
+
+public class AutomationToolsTest extends CommonTestClass {
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("com.ibm.ws.security.fat.common.*=all");
+
+    AutomationTools tools = new AutomationTools();
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void before() {
+        System.out.println("Entering test: " + testName.getMethodName());
+        tools = new AutomationTools();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.out.println("Exiting test: " + testName.getMethodName());
+        outputMgr.resetStreams();
+        mockery.assertIsSatisfied();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    @Test
+    public void test_convertHeadersListToMap_null() {
+        try {
+            List<NameValuePair> headers = null;
+            Map<String, String[]> result = AutomationTools.convertHeadersListToMap(headers);
+            assertNull("Result should have been null but was " + result, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_convertHeadersListToMap_empty() {
+        try {
+            List<NameValuePair> headers = new ArrayList<>();
+            Map<String, String[]> result = AutomationTools.convertHeadersListToMap(headers);
+            assertNotNull("Result should not have been null but was.", result);
+            assertTrue("Result should have been empty but was: " + result, result.isEmpty());
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_convertHeadersListToMap_oneEntry() {
+        try {
+            List<NameValuePair> headers = new ArrayList<>();
+            headers.add(new NameValuePair("header", "value"));
+
+            Map<String, String[]> result = AutomationTools.convertHeadersListToMap(headers);
+
+            assertNotNull("Result should not have been null but was.", result);
+            assertEquals("Result did not have expected number of entries. Result was: " + result, 1, result.size());
+            assertTrue("Result did not contain expected entry \"header\". Result was: " + result, result.containsKey("header"));
+            String[] headerValues = result.get("header");
+            assertEquals("Result value should have had one entry but did not. Result was: " + Arrays.toString(headerValues), 1, headerValues.length);
+            assertEquals("Result value did not match expected value.", "value", headerValues[0]);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_convertHeadersListToMap_multipleEntries_unique() {
+        try {
+            List<NameValuePair> headers = new ArrayList<>();
+            int numUniqueEntries = 3;
+            for (int i = 1; i <= numUniqueEntries; i++) {
+                headers.add(new NameValuePair("header" + i, "value" + i));
+            }
+
+            Map<String, String[]> result = AutomationTools.convertHeadersListToMap(headers);
+
+            assertNotNull("Result should not have been null but was.", result);
+            assertEquals("Result did not have expected number of entries. Result was: " + result, numUniqueEntries, result.size());
+            for (int i = 1; i <= numUniqueEntries; i++) {
+                String expectedEntry = "header" + i;
+                String expectedValue = "value" + i;
+                assertTrue("Result did not contain expected entry \"" + expectedEntry + "\". Result was: " + result, result.containsKey(expectedEntry));
+                String[] headerValues = result.get(expectedEntry);
+                assertEquals("Entry for \"" + expectedEntry + "\" should have had one entry but did not. Values were: " + Arrays.toString(headerValues), 1, headerValues.length);
+                assertEquals("Entry for \"" + expectedEntry + "\" did not match expected value.", expectedValue, headerValues[0]);
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_convertHeadersListToMap_multipleValuesForHeader() {
+        try {
+            String headerName = "header";
+            List<NameValuePair> headers = new ArrayList<>();
+            int numUniqueValues = 3;
+            for (int i = 1; i <= numUniqueValues; i++) {
+                headers.add(new NameValuePair(headerName, "value" + i));
+            }
+
+            Map<String, String[]> result = AutomationTools.convertHeadersListToMap(headers);
+
+            assertNotNull("Result should not have been null but was.", result);
+            assertEquals("Result did not have expected number of entries. Result was: " + result, 1, result.size());
+            assertTrue("Result did not contain expected entry \"" + headerName + "\". Result was: " + result, result.containsKey(headerName));
+            String[] headerValues = result.get(headerName);
+            assertEquals("Entry for \"" + headerName + "\" did not have the expected number of values. Values were: " + Arrays.toString(headerValues), numUniqueValues, headerValues.length);
+            for (int i = 0; i < numUniqueValues; i++) {
+                String expectedValue = "value" + (i + 1);
+                assertEquals("Value for entry " + i + " did not match expected value.", expectedValue, headerValues[i]);
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.security.fat.common/test/com/ibm/ws/security/fat/common/web/WebFormUtilsTest.java
+++ b/dev/com.ibm.ws.security.fat.common/test/com/ibm/ws/security/fat/common/web/WebFormUtilsTest.java
@@ -468,6 +468,8 @@ public class WebFormUtilsTest extends CommonTestClass {
                 {
                     one(form).getInputByValue(WebFormUtils.DEFAULT_LOGIN_SUBMIT_BUTTON_VALUE);
                     will(throwException(new ElementNotFoundException(WebFormUtils.DEFAULT_LOGIN_SUBMIT_BUTTON_VALUE, "attributeName", "attributeValue")));
+                    one(form).getButtonByName(WebFormUtils.DEFAULT_LOGIN_SUBMIT_BUTTON_NAME);
+                    will(throwException(new ElementNotFoundException(WebFormUtils.DEFAULT_LOGIN_SUBMIT_BUTTON_NAME, "attributeName", "attributeValue")));
                 }
             });
             try {
@@ -715,6 +717,8 @@ public class WebFormUtilsTest extends CommonTestClass {
                 {
                     one(form).getInputByValue(submitButtonValue);
                     will(throwException(new ElementNotFoundException(submitButtonValue, "attributeName", "attributeValue")));
+                    one(form).getButtonByName(WebFormUtils.DEFAULT_LOGIN_SUBMIT_BUTTON_NAME);
+                    will(throwException(new ElementNotFoundException(WebFormUtils.DEFAULT_LOGIN_SUBMIT_BUTTON_NAME, "attributeName", "attributeValue")));
                 }
             });
             try {

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import org.junit.runners.Suite.SuiteClasses;
 import com.ibm.ws.security.fat.common.utils.ldaputils.CommonLocalLDAPServerSuite;
 import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientBasicTests;
 import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientConsentTests;
+import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientCookieVerificationTests;
 import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientDiscoveryBasicTests;
 import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientDiscoveryErrorTests;
 import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientDiscoveryJWTBasicTests;
@@ -37,7 +38,8 @@ import componenttest.rules.repeater.RepeatTests;
         OidcClientDiscoveryBasicTests.class,
         OidcClientDiscoveryErrorTests.class,
         OidcClientDiscoveryJWTBasicTests.class,
-// OidcCertificationRPBasicProfileTests.class,
+        OidcClientCookieVerificationTests.class,
+        // OidcCertificationRPBasicProfileTests.class,
 
 })
 /**

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientCookieVerificationTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientCookieVerificationTests.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.security.openidconnect.client.fat.IBM;
+
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonTest;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonValidationTools;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.Constants;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.TestSettings;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.ValidationData.validationData;
+
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+
+@Mode(TestMode.FULL)
+@RunWith(FATRunner.class)
+public class OidcClientCookieVerificationTests extends CommonTest {
+
+    public static Class<?> thisClass = OidcClientCookieVerificationTests.class;
+
+    private String[] test_GOOD_LOGIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT;
+
+    @SuppressWarnings("serial")
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        thisClass = OidcClientCookieVerificationTests.class;
+
+        List<String> apps = new ArrayList<String>() {
+            {
+                add(Constants.OPENID_APP);
+            }
+        };
+
+        testSettings = new TestSettings();
+
+        // Set config parameters for Access token with X509 Certificate in OP config files
+        String tokenType = Constants.ACCESS_TOKEN_KEY;
+        String certType = Constants.X509_CERT;
+
+        // Start the OIDC OP server
+        testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.op", "op_server_orig.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS,
+                Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+
+        //Start the OIDC RP server and setup default values
+        testRPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.rp", "rp_server_orig.xml", Constants.OIDC_RP, apps, Constants.DO_NOT_USE_DERBY,
+                Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+
+        testSettings.setFlowType(Constants.RP_FLOW);
+
+        testRPServer.addIgnoredServerExceptions("CWWKS1859E", "CWWKS1741W");
+    }
+
+    /**
+     * Go through the golden path OIDC login flow with nonce enabled. Verify that the nonce cookie is ultimately deleted
+     * correctly.
+     */
+    @Test
+    public void test_verifyNonceCookieDeleted() throws Exception {
+        WebClient webClient = getAndSaveWebClient(true);
+
+        TestSettings updatedTestSettings = testSettings.copyTestSettings();
+        String protectedUrl = updatedTestSettings.getTestURL().replace(Constants.DEFAULT_SERVLET, "simple/nonceEnabled");
+        updatedTestSettings.setTestURL(protectedUrl);
+        updatedTestSettings.setScope("openid profile");
+        updatedTestSettings.setNonce(Constants.EXIST_WITH_ANY_VALUE);
+
+        List<validationData> expectations = vData.addSuccessStatusCodesForActions(test_GOOD_LOGIN_ACTIONS);
+        expectations = vData.addExpectation(expectations, Constants.GET_LOGIN_PAGE, Constants.RESPONSE_FULL, Constants.STRING_CONTAINS, "Did not get to the OpenID Connect login page.", null, Constants.LOGIN_PROMPT);
+        expectations = vData.addExpectation(expectations, Constants.GET_LOGIN_PAGE, Constants.RESPONSE_HEADER, Constants.STRING_DOES_NOT_CONTAIN, "Should not have seen any Set-Cookie headers in the response but did.", null, "Set-Cookie");
+        expectations = vData.addExpectation(expectations, Constants.GET_LOGIN_PAGE, Constants.RESPONSE_COOKIE, Constants.STRING_MATCHES, "Should have found a WASOidcState cookie but didn't.", null, "WASOidcState[pn][0-9]+=[^" + CommonValidationTools.COOKIE_DELIMITER + "]+");
+        expectations = vData.addExpectation(expectations, Constants.GET_LOGIN_PAGE, Constants.RESPONSE_COOKIE, Constants.STRING_MATCHES, "Should have found a WASOidcNonce cookie but didn't.", null, "WASOidcNonce[pn][0-9]+=[^" + CommonValidationTools.COOKIE_DELIMITER + "]+");
+        expectations = vData.addExpectation(expectations, Constants.LOGIN_USER, Constants.RESPONSE_HEADER, Constants.STRING_MATCHES, "Should have found a Set-Cookie header to clear the WASOidcState cookie but didn't.", null, "WASOidcState[pn][0-9]+=\"\"; Expires=Thu, 01 Dec 1994");
+        expectations = vData.addExpectation(expectations, Constants.LOGIN_USER, Constants.RESPONSE_HEADER, Constants.STRING_MATCHES, "Should have found a Set-Cookie header to clear the WASOidcNonce cookie but didn't.", null, "WASOidcNonce[pn][0-9]+=\"\"; Expires=Thu, 01 Dec 1994");
+        expectations = validationTools.addDefaultIDTokenExpectations(expectations, _testName, eSettings.getProviderType(), Constants.LOGIN_USER, updatedTestSettings);
+        expectations = validationTools.addDefaultGeneralResponseExpectations(expectations, _testName, eSettings.getProviderType(), Constants.LOGIN_USER, updatedTestSettings);
+
+        genericRP(_testName, webClient, updatedTestSettings, test_GOOD_LOGIN_ACTIONS, expectations);
+
+        // Verify all cookies that should have been deleted do not appear in the web client anymore
+        verifyNoUnexpectedCookiesStillPresent(webClient, Arrays.asList("WASOidcCode", "WASOidcState", "WASOidcNonce", "WASReqURLOidc"));
+    }
+
+    // TODO - OAuthClientTracker.TRACK_OAUTH_CLIENT_COOKIE_NAME
+
+    private void verifyNoUnexpectedCookiesStillPresent(WebClient webClient, List<String> cookiesThatShouldNotExist) {
+        List<String> unexpectedCookiesFound = new ArrayList<>();
+        Set<com.gargoylesoftware.htmlunit.util.Cookie> finalCookies = webClient.getCookieManager().getCookies();
+        for (com.gargoylesoftware.htmlunit.util.Cookie cookie : finalCookies) {
+            String cookieName = cookie.getName();
+            Log.info(thisClass, _testName, "Checking remaining cookie: " + cookieName);
+            for (String cookieThatShouldNotExist : cookiesThatShouldNotExist) {
+                if (cookieName.startsWith(cookieThatShouldNotExist)) {
+                    unexpectedCookiesFound.add(cookieName);
+                }
+            }
+        }
+        if (!unexpectedCookiesFound.isEmpty()) {
+            fail("Found the following cookies in the final result that should not have been there: " + unexpectedCookiesFound);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcUtil.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 IBM Corporation and others.
+ * Copyright (c) 2011, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.clients.common;
 
@@ -125,11 +125,7 @@ public class OidcUtil {
 
     public static void removeCookie(OidcClientRequest oidcClientRequest) {
         String cookieName = oidcClientRequest.getOidcClientCookieName();
-        Cookie c = OidcClientUtil.createCookie(cookieName,
-                "",
-                oidcClientRequest.getRequest());
-        c.setMaxAge(0);
-        oidcClientRequest.getResponse().addCookie(c);
+        OidcClientUtil.invalidateReferrerURLCookie(oidcClientRequest.getRequest(), oidcClientRequest.getResponse(), cookieName);
     }
 
     // The sujbect has to be non-null
@@ -233,11 +229,6 @@ public class OidcUtil {
         return lTimeStamp;
     }
 
-    /**
-     * @param nonceValue
-     * @param state
-     * @param clientConfig
-     */
     @Trivial
     public static void createNonceCookie(OidcClientRequest oidcClientRequest, String nonceValue, String state, ConvergedClientConfig clientConfig) {
         String cookieName = HashUtils.getCookieName(ClientConstants.WAS_OIDC_NONCE, clientConfig, state);
@@ -246,18 +237,12 @@ public class OidcUtil {
         oidcClientRequest.getResponse().addCookie(cookie);
     }
 
-    /**
-     * @param nonceInIDToken
-     * @param clientConfig
-     * @param responseState
-     * @return
-     */
     @Trivial
     public static boolean verifyNonce(OidcClientRequest oidcClientRequest, String nonceInIDToken, ConvergedClientConfig clientConfig, String responseState) {
         String cookieName = HashUtils.getCookieName(ClientConstants.WAS_OIDC_NONCE, clientConfig, responseState);
         String cookieValue = createNonceCookieValue(nonceInIDToken, responseState, clientConfig);
         String oldCookieValue = CookieHelper.getCookieValue(oidcClientRequest.getRequest().getCookies(), cookieName);
-        OidcClientUtil.invalidateReferrerURLCookie(oidcClientRequest.getRequest(), oidcClientRequest.getResponse(), ClientConstants.WAS_OIDC_NONCE);
+        OidcClientUtil.invalidateReferrerURLCookie(oidcClientRequest.getRequest(), oidcClientRequest.getResponse(), cookieName);
         return cookieValue.equals(oldCookieValue);
     }
 

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcUtilTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcUtilTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corporation and others.
+ * Copyright (c) 2016, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.clients.common;
 
@@ -29,12 +29,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
-import com.ibm.ws.security.openidconnect.clients.common.ClientConstants;
-import com.ibm.ws.security.openidconnect.clients.common.ConvergedClientConfig;
-import com.ibm.ws.security.openidconnect.clients.common.HashUtils;
-import com.ibm.ws.security.openidconnect.clients.common.OidcClientRequest;
-import com.ibm.ws.security.openidconnect.clients.common.OidcClientUtil;
-import com.ibm.ws.security.openidconnect.clients.common.OidcUtil;
 import com.ibm.ws.webcontainer.security.ReferrerURLCookieHandler;
 import com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl;
 import com.ibm.ws.webcontainer.security.WebAppSecurityConfig;
@@ -172,7 +166,7 @@ public class OidcUtilTest {
                 will(returnValue(expectedNonceCookieValue));
                 one(convClientRequest).getResponse();
                 will(returnValue(response));
-                one(referCookieHandler).createCookie(ClientConstants.WAS_OIDC_NONCE, "", request);
+                one(referCookieHandler).createCookie(expectedNonceCookieName, "", request);
                 will(returnValue(cookie2));
                 allowing(webAppSecConfig).createSSOCookieHelper();
                 allowing(webAppSecConfig).getSSODomainList();


### PR DESCRIPTION
For #5158 and #19545

I believe there's some incomplete logic for invalidating some cookies in SSO flows. This PR should correct that behavior.