### PR TITLE
Fix MDB RA FAT synchronization

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.mdb.ra_fat/test-applications/MsgEndpointEJB.jar/src/com/ibm/ws/ejbcontainer/fat/msgendpoint/ejb/ConcurBMTException.java
+++ b/dev/com.ibm.ws.ejbcontainer.mdb.ra_fat/test-applications/MsgEndpointEJB.jar/src/com/ibm/ws/ejbcontainer/fat/msgendpoint/ejb/ConcurBMTException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -81,7 +81,8 @@ public class ConcurBMTException implements MessageListener {
             concurrentInfo.decreaseConcurrentMsgNumber();
             System.out.println("--ConcurBMTException (" + message + "): after decreaseConcurrentMsgNumber");
 
-            synchronized (syncObject) {
+            Object currentSyncObject = syncObject;
+            synchronized (currentSyncObject) {
                 System.out.println("--ConcurBMTException (" + message + "): in the synchronized block");
 
                 while (concurrentInfo.getConcurrentMsgNumber() > 0) {
@@ -93,7 +94,7 @@ public class ConcurBMTException implements MessageListener {
                         throw new RuntimeException();
                     }
                 }
-                syncObject.notifyAll();
+                currentSyncObject.notifyAll();
                 System.out.println("--ConcurBMTException (" + message + "): after notifyAll() in the synchronized block");
             }
 

--- a/dev/com.ibm.ws.ejbcontainer.mdb.ra_fat/test-applications/MsgEndpointEJB.jar/src/com/ibm/ws/ejbcontainer/fat/msgendpoint/ejb/ConcurBMTNonJMS.java
+++ b/dev/com.ibm.ws.ejbcontainer.mdb.ra_fat/test-applications/MsgEndpointEJB.jar/src/com/ibm/ws/ejbcontainer/fat/msgendpoint/ejb/ConcurBMTNonJMS.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -79,7 +79,8 @@ public class ConcurBMTNonJMS implements MessageListener {
         concurrentInfo.decreaseConcurrentMsgNumber();
         System.out.println("--ConcurBMTNonJMS (" + message + "): after decreaseConcurrentMsgNumber");
 
-        synchronized (syncObject) {
+        Object currentSyncObject = syncObject;
+        synchronized (currentSyncObject) {
             System.out.println("--ConcurBMTNonJMS (" + message + "): in the synchronized block");
 
             while (concurrentInfo.getConcurrentMsgNumber() > 0) {
@@ -91,7 +92,7 @@ public class ConcurBMTNonJMS implements MessageListener {
                     throw new RuntimeException();
                 }
             }
-            syncObject.notifyAll();
+            currentSyncObject.notifyAll();
             System.out.println("--ConcurBMTNonJMS (" + message + "): after notifyAll() in the synchronized block");
         }
 

--- a/dev/com.ibm.ws.ejbcontainer.mdb.ra_fat/test-applications/MsgEndpointEJB.jar/src/com/ibm/ws/ejbcontainer/fat/msgendpoint/ejb/ConcurCMTException.java
+++ b/dev/com.ibm.ws.ejbcontainer.mdb.ra_fat/test-applications/MsgEndpointEJB.jar/src/com/ibm/ws/ejbcontainer/fat/msgendpoint/ejb/ConcurCMTException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -81,7 +81,8 @@ public class ConcurCMTException implements MessageListener {
             concurrentInfo.decreaseConcurrentMsgNumber();
             System.out.println("--ConcurCMTException (" + message + "): after decreaseConcurrentMsgNumber");
 
-            synchronized (syncObject) {
+            Object currentSyncObject = syncObject;
+            synchronized (currentSyncObject) {
                 System.out.println("--ConcurCMTException (" + message + "): in the synchronized block");
 
                 while (concurrentInfo.getConcurrentMsgNumber() > 0) {
@@ -93,7 +94,7 @@ public class ConcurCMTException implements MessageListener {
                         throw new RuntimeException();
                     }
                 }
-                syncObject.notifyAll();
+                currentSyncObject.notifyAll();
                 System.out.println("--ConcurCMTException (" + message + "): after notifyAll() in the synchronized block");
             }
 

--- a/dev/com.ibm.ws.ejbcontainer.mdb.ra_fat/test-applications/MsgEndpointEJB.jar/src/com/ibm/ws/ejbcontainer/fat/msgendpoint/ejb/ConcurCMTNonJMS.java
+++ b/dev/com.ibm.ws.ejbcontainer.mdb.ra_fat/test-applications/MsgEndpointEJB.jar/src/com/ibm/ws/ejbcontainer/fat/msgendpoint/ejb/ConcurCMTNonJMS.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -79,7 +79,8 @@ public class ConcurCMTNonJMS implements MessageListener {
         concurrentInfo.decreaseConcurrentMsgNumber();
         System.out.println("--ConcurCMTNonJMS (" + message + "): after decreaseConcurrentMsgNumber");
 
-        synchronized (syncObject) {
+        Object currentSyncObject = syncObject;
+        synchronized (currentSyncObject) {
             System.out.println("--ConcurCMTNonJMS (" + message + "): in the synchronized block");
 
             while (concurrentInfo.getConcurrentMsgNumber() > 0) {
@@ -91,7 +92,7 @@ public class ConcurCMTNonJMS implements MessageListener {
                     throw new RuntimeException();
                 }
             }
-            syncObject.notifyAll();
+            currentSyncObject.notifyAll();
             System.out.println("--ConcurCMTNonJMS (" + message + "): after notifyAll() in the synchronized block");
         }
 


### PR DESCRIPTION
Make a local copy of static synchronization object in MDB FAT to
ensure notifyAll is called on same object that is synchronized.
