### PR TITLE
Asynchronously attempt to load ThreadPoolStats

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.2.0.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
@@ -38,8 +38,6 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.microprofile.metrics.impl.SharedMetricRegistries;
 
-import io.openliberty.microprofile.metrics.internal.monitor.MonitorMetricsHandler;
-
 @Component(name = "com.ibm.ws.microprofile.metrics.monitor.MonitorMetricsHandler", property = { "service.vendor=IBM"})
 public class MonitorMetricsHandler {
 	

--- a/dev/com.ibm.ws.microprofile.metrics.2.0.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
@@ -14,7 +14,6 @@ import java.lang.management.ManagementFactory;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
@@ -56,14 +55,22 @@ public class MonitorMetricsHandler {
         Tr.info(tc, "FEATURE_REGISTERED");
     }
 
-	@Reference
-    public void getSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistry) {
+    @Reference
+    public void setSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistry) {
         this.sharedMetricRegistry = sharedMetricRegistry;
     }
-	
+    
+    public void unsetSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistry) {
+        this.sharedMetricRegistry = null;
+    }
+       
     @Reference
-    public void getExecutorService(ExecutorService execServ) {
+    public void setExecutorService(ExecutorService execServ) {
         this.execServ = execServ;
+    }
+    
+    public void unsetExecutorService(ExecutorService execServ) {
+        this.execServ = null;
     }
     
     @Deactivate
@@ -136,7 +143,7 @@ public class MonitorMetricsHandler {
             Set<ObjectInstance> mBeanObjectInstanceSet;
             try {
                 mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
-                if (sName.contains("ThreadPoolStats") && mBeanObjectInstanceSet.isEmpty()) {
+                if (sName.contains("ThreadPoolStats") && mBeanObjectInstanceSet.isEmpty() && execServ != null) {
                     execServ.execute(() -> {
                         final int MAX_TIME_OUT = 5000;
                         int currentTimeOut = 0;

--- a/dev/com.ibm.ws.microprofile.metrics.2.0.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,9 @@ package com.ibm.ws.microprofile.metrics.monitor;
 import java.lang.management.ManagementFactory;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
@@ -34,6 +37,8 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.microprofile.metrics.impl.SharedMetricRegistries;
+
+import io.openliberty.microprofile.metrics.internal.monitor.MonitorMetricsHandler;
 
 @Component(name = "com.ibm.ws.microprofile.metrics.monitor.MonitorMetricsHandler", property = { "service.vendor=IBM"})
 public class MonitorMetricsHandler {
@@ -123,35 +128,70 @@ public class MonitorMetricsHandler {
 	}
 
     protected void register() {
-		MBeanServer	mbs = ManagementFactory.getPlatformMBeanServer();
-		for (String sName : mappingTable.getKeys() ) {
-			Set<ObjectInstance> mBeanObjectInstanceSet;
-			try {
-				mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
-				if (sName.contains("ThreadPoolStats")) {
-					final int MAX_TIME_OUT = 5000;
-					int currentTimeOut = 0;
-					while (mBeanObjectInstanceSet.isEmpty() && currentTimeOut <= MAX_TIME_OUT) {
-						Thread.sleep(50);
-						mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
-						currentTimeOut+=50;
-					}
-				}
-		        for (ObjectInstance objInstance : mBeanObjectInstanceSet) {
-		            String objectName = objInstance.getObjectName().toString();
-		            String[][] data = mappingTable.getData(objectName);
-					if (data != null) {
-						register(objectName, data);
-		            }
-		        }
-			} catch (Exception e) {
-	            if (tc.isDebugEnabled()) {
-	                Tr.debug(tc, "register exception message: ", e.getMessage());
-	                FFDCFilter.processException(e, MonitorMetricsHandler.class.getSimpleName(), "register:Exception");
-	            }
-			}
-		}
-	}
+        MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+        ReentrantLock lock = new ReentrantLock();
+        for (String sName : mappingTable.getKeys()) {
+            Set<ObjectInstance> mBeanObjectInstanceSet;
+
+            try {
+                lock.lock();
+                try {
+                    /*
+                     * ThreadPoolStats is launched in a separate thread. It will invoke
+                     * queryMbeans() as well Lock just in case.
+                     */
+                    mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
+                } finally {
+                    lock.unlock();
+                }
+
+                if (sName.contains("ThreadPoolStats") && mBeanObjectInstanceSet.isEmpty()) {
+                    ExecutorService execServ = Executors.newSingleThreadExecutor();
+                    execServ.execute(() -> {
+                        final int MAX_TIME_OUT = 5000;
+                        int currentTimeOut = 0;
+                        Set<ObjectInstance> mBeanObjectInstanceSetTemp = mBeanObjectInstanceSet;
+                        while (mBeanObjectInstanceSet.isEmpty() && currentTimeOut <= MAX_TIME_OUT) {
+                            try {
+                                Thread.sleep(50);
+                                lock.lock();
+                                try {
+                                    mBeanObjectInstanceSetTemp = mbs.queryMBeans(new ObjectName(sName), null);
+                                } finally {
+                                    lock.unlock();
+                                }
+                                currentTimeOut += 50;
+                            } catch (Exception e) {
+                                if (tc.isDebugEnabled()) {
+                                    Tr.debug(tc, "register exception message: ", e.getMessage());
+                                    FFDCFilter.processException(e, MonitorMetricsHandler.class.getSimpleName(),
+                                            "register:Exception");
+                                }
+                            }
+                        }
+                        registerMbeanObjects(mBeanObjectInstanceSetTemp);
+                    });
+                    execServ.shutdown();
+                }
+                registerMbeanObjects(mBeanObjectInstanceSet);
+            } catch (Exception e) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "register exception message: ", e.getMessage());
+                    FFDCFilter.processException(e, MonitorMetricsHandler.class.getSimpleName(), "register:Exception");
+                }
+            }
+        }
+    }
+    
+    private synchronized void registerMbeanObjects(Set<ObjectInstance> mBeanObjectInstanceSet) {
+        for (ObjectInstance objInstance : mBeanObjectInstanceSet) {
+            String objectName = objInstance.getObjectName().toString();
+            String[][] data = mappingTable.getData(objectName);
+            if (data != null) {
+                register(objectName, data);
+            }
+        }
+    }
     
 	protected void register(String objectName, String[][] data) {
         MonitorMetrics metrics = null;

--- a/dev/com.ibm.ws.microprofile.metrics.2.0.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
@@ -43,6 +43,7 @@ public class MonitorMetricsHandler {
 	private static final TraceComponent tc = Tr.register(MonitorMetricsHandler.class);
 	
 	protected SharedMetricRegistries sharedMetricRegistry;
+	protected ExecutorService execServ;
     protected MappingTable mappingTable;
     protected Set<MonitorMetrics> metricsSet = new HashSet<MonitorMetrics>();
     protected NotificationListener listener;
@@ -58,6 +59,11 @@ public class MonitorMetricsHandler {
 	@Reference
     public void getSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistry) {
         this.sharedMetricRegistry = sharedMetricRegistry;
+    }
+	
+    @Reference
+    public void getExecutorService(ExecutorService execServ) {
+        this.execServ = execServ;
     }
     
     @Deactivate
@@ -131,7 +137,6 @@ public class MonitorMetricsHandler {
             try {
                 mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
                 if (sName.contains("ThreadPoolStats") && mBeanObjectInstanceSet.isEmpty()) {
-                    ExecutorService execServ = Executors.newSingleThreadExecutor();
                     execServ.execute(() -> {
                         final int MAX_TIME_OUT = 5000;
                         int currentTimeOut = 0;
@@ -157,7 +162,6 @@ public class MonitorMetricsHandler {
                         }
                         registerMbeanObjects(mBeanObjectInstanceSetTemp);
                     });
-                    execServ.shutdown();
                 }
                 registerMbeanObjects(mBeanObjectInstanceSet);
             } catch (Exception e) {

--- a/dev/com.ibm.ws.microprofile.metrics.2.0.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.locks.ReentrantLock;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
@@ -127,37 +126,21 @@ public class MonitorMetricsHandler {
 
     protected void register() {
         MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-        ReentrantLock lock = new ReentrantLock();
         for (String sName : mappingTable.getKeys()) {
             Set<ObjectInstance> mBeanObjectInstanceSet;
-
             try {
-                lock.lock();
-                try {
-                    /*
-                     * ThreadPoolStats is launched in a separate thread. It will invoke
-                     * queryMbeans() as well Lock just in case.
-                     */
-                    mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
-                } finally {
-                    lock.unlock();
-                }
-
+                mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
                 if (sName.contains("ThreadPoolStats") && mBeanObjectInstanceSet.isEmpty()) {
                     ExecutorService execServ = Executors.newSingleThreadExecutor();
                     execServ.execute(() -> {
                         final int MAX_TIME_OUT = 5000;
                         int currentTimeOut = 0;
                         Set<ObjectInstance> mBeanObjectInstanceSetTemp = mBeanObjectInstanceSet;
-                        while (mBeanObjectInstanceSet.isEmpty() && currentTimeOut <= MAX_TIME_OUT) {
+                        while (mBeanObjectInstanceSetTemp.isEmpty() && currentTimeOut <= MAX_TIME_OUT) {
                             try {
                                 Thread.sleep(50);
-                                lock.lock();
-                                try {
-                                    mBeanObjectInstanceSetTemp = mbs.queryMBeans(new ObjectName(sName), null);
-                                } finally {
-                                    lock.unlock();
-                                }
+
+                                mBeanObjectInstanceSetTemp = mbs.queryMBeans(new ObjectName(sName), null);
                                 currentTimeOut += 50;
                             } catch (Exception e) {
                                 if (tc.isDebugEnabled()) {
@@ -165,6 +148,11 @@ public class MonitorMetricsHandler {
                                     FFDCFilter.processException(e, MonitorMetricsHandler.class.getSimpleName(),
                                             "register:Exception");
                                 }
+                                /*
+                                 * Interruption Exception or RuntimeOperationException from malformed query exit
+                                 * thread.
+                                 */
+                                break;
                             }
                         }
                         registerMbeanObjects(mBeanObjectInstanceSetTemp);

--- a/dev/com.ibm.ws.microprofile.metrics.2.3.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.3.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
@@ -38,8 +38,6 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.microprofile.metrics.impl.SharedMetricRegistries;
 
-import io.openliberty.microprofile.metrics.internal.monitor.MonitorMetricsHandler;
-
 @Component(name = "com.ibm.ws.microprofile.metrics.monitor.MonitorMetricsHandler", property = { "service.vendor=IBM"})
 public class MonitorMetricsHandler {
 	

--- a/dev/com.ibm.ws.microprofile.metrics.2.3.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.3.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
@@ -14,7 +14,6 @@ import java.lang.management.ManagementFactory;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
@@ -56,14 +55,22 @@ public class MonitorMetricsHandler {
         Tr.info(tc, "FEATURE_REGISTERED");
     }
 
-	@Reference
-    public void getSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistry) {
+    @Reference
+    public void setSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistry) {
         this.sharedMetricRegistry = sharedMetricRegistry;
     }
-	
+    
+    public void unsetSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistry) {
+        this.sharedMetricRegistry = null;
+    }
+       
     @Reference
-    public void getExecutorService(ExecutorService execServ) {
+    public void setExecutorService(ExecutorService execServ) {
         this.execServ = execServ;
+    }
+    
+    public void unsetExecutorService(ExecutorService execServ) {
+        this.execServ = null;
     }
     
     @Deactivate
@@ -136,7 +143,7 @@ public class MonitorMetricsHandler {
             Set<ObjectInstance> mBeanObjectInstanceSet;
             try {
                 mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
-                if (sName.contains("ThreadPoolStats") && mBeanObjectInstanceSet.isEmpty()) {
+                if (sName.contains("ThreadPoolStats") && mBeanObjectInstanceSet.isEmpty() && execServ != null) {
                     execServ.execute(() -> {
                         final int MAX_TIME_OUT = 5000;
                         int currentTimeOut = 0;

--- a/dev/com.ibm.ws.microprofile.metrics.2.3.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.3.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,9 @@ package com.ibm.ws.microprofile.metrics.monitor;
 import java.lang.management.ManagementFactory;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
@@ -34,6 +37,8 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.microprofile.metrics.impl.SharedMetricRegistries;
+
+import io.openliberty.microprofile.metrics.internal.monitor.MonitorMetricsHandler;
 
 @Component(name = "com.ibm.ws.microprofile.metrics.monitor.MonitorMetricsHandler", property = { "service.vendor=IBM"})
 public class MonitorMetricsHandler {
@@ -123,35 +128,70 @@ public class MonitorMetricsHandler {
 	}
 
     protected void register() {
-		MBeanServer	mbs = ManagementFactory.getPlatformMBeanServer();
-		for (String sName : mappingTable.getKeys() ) {
-			Set<ObjectInstance> mBeanObjectInstanceSet;
-			try {
-				mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
-				if (sName.contains("ThreadPoolStats")) {
-					final int MAX_TIME_OUT = 5000;
-					int currentTimeOut = 0;
-					while (mBeanObjectInstanceSet.isEmpty() && currentTimeOut <= MAX_TIME_OUT) {
-						Thread.sleep(50);
-						mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
-						currentTimeOut+=50;
-					}
-				}
-		        for (ObjectInstance objInstance : mBeanObjectInstanceSet) {
-		            String objectName = objInstance.getObjectName().toString();
-		            String[][] data = mappingTable.getData(objectName);
-					if (data != null) {
-						register(objectName, data);
-		            }
-		        }
-			} catch (Exception e) {
-	            if (tc.isDebugEnabled()) {
-	                Tr.debug(tc, "register exception message: ", e.getMessage());
-	                FFDCFilter.processException(e, MonitorMetricsHandler.class.getSimpleName(), "register:Exception");
-	            }
-			}
-		}
-	}
+        MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+        ReentrantLock lock = new ReentrantLock();
+        for (String sName : mappingTable.getKeys()) {
+            Set<ObjectInstance> mBeanObjectInstanceSet;
+
+            try {
+                lock.lock();
+                try {
+                    /*
+                     * ThreadPoolStats is launched in a separate thread. It will invoke
+                     * queryMbeans() as well Lock just in case.
+                     */
+                    mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
+                } finally {
+                    lock.unlock();
+                }
+
+                if (sName.contains("ThreadPoolStats") && mBeanObjectInstanceSet.isEmpty()) {
+                    ExecutorService execServ = Executors.newSingleThreadExecutor();
+                    execServ.execute(() -> {
+                        final int MAX_TIME_OUT = 5000;
+                        int currentTimeOut = 0;
+                        Set<ObjectInstance> mBeanObjectInstanceSetTemp = mBeanObjectInstanceSet;
+                        while (mBeanObjectInstanceSet.isEmpty() && currentTimeOut <= MAX_TIME_OUT) {
+                            try {
+                                Thread.sleep(50);
+                                lock.lock();
+                                try {
+                                    mBeanObjectInstanceSetTemp = mbs.queryMBeans(new ObjectName(sName), null);
+                                } finally {
+                                    lock.unlock();
+                                }
+                                currentTimeOut += 50;
+                            } catch (Exception e) {
+                                if (tc.isDebugEnabled()) {
+                                    Tr.debug(tc, "register exception message: ", e.getMessage());
+                                    FFDCFilter.processException(e, MonitorMetricsHandler.class.getSimpleName(),
+                                            "register:Exception");
+                                }
+                            }
+                        }
+                        registerMbeanObjects(mBeanObjectInstanceSetTemp);
+                    });
+                    execServ.shutdown();
+                }
+                registerMbeanObjects(mBeanObjectInstanceSet);
+            } catch (Exception e) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "register exception message: ", e.getMessage());
+                    FFDCFilter.processException(e, MonitorMetricsHandler.class.getSimpleName(), "register:Exception");
+                }
+            }
+        }
+    }
+    
+    private synchronized void registerMbeanObjects(Set<ObjectInstance> mBeanObjectInstanceSet) {
+        for (ObjectInstance objInstance : mBeanObjectInstanceSet) {
+            String objectName = objInstance.getObjectName().toString();
+            String[][] data = mappingTable.getData(objectName);
+            if (data != null) {
+                register(objectName, data);
+            }
+        }
+    }
     
 	protected void register(String objectName, String[][] data) {
         MonitorMetrics metrics = null;

--- a/dev/com.ibm.ws.microprofile.metrics.2.3.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.3.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
@@ -43,6 +43,7 @@ public class MonitorMetricsHandler {
 	private static final TraceComponent tc = Tr.register(MonitorMetricsHandler.class);
 	
 	protected SharedMetricRegistries sharedMetricRegistry;
+	protected ExecutorService execServ;
     protected MappingTable mappingTable;
     protected Set<MonitorMetrics> metricsSet = new HashSet<MonitorMetrics>();
     protected NotificationListener listener;
@@ -58,6 +59,11 @@ public class MonitorMetricsHandler {
 	@Reference
     public void getSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistry) {
         this.sharedMetricRegistry = sharedMetricRegistry;
+    }
+	
+    @Reference
+    public void getExecutorService(ExecutorService execServ) {
+        this.execServ = execServ;
     }
     
     @Deactivate
@@ -131,7 +137,6 @@ public class MonitorMetricsHandler {
             try {
                 mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
                 if (sName.contains("ThreadPoolStats") && mBeanObjectInstanceSet.isEmpty()) {
-                    ExecutorService execServ = Executors.newSingleThreadExecutor();
                     execServ.execute(() -> {
                         final int MAX_TIME_OUT = 5000;
                         int currentTimeOut = 0;
@@ -157,7 +162,6 @@ public class MonitorMetricsHandler {
                         }
                         registerMbeanObjects(mBeanObjectInstanceSetTemp);
                     });
-                    execServ.shutdown();
                 }
                 registerMbeanObjects(mBeanObjectInstanceSet);
             } catch (Exception e) {

--- a/dev/com.ibm.ws.microprofile.metrics.2.3.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.3.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.locks.ReentrantLock;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
@@ -127,37 +126,21 @@ public class MonitorMetricsHandler {
 
     protected void register() {
         MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-        ReentrantLock lock = new ReentrantLock();
         for (String sName : mappingTable.getKeys()) {
             Set<ObjectInstance> mBeanObjectInstanceSet;
-
             try {
-                lock.lock();
-                try {
-                    /*
-                     * ThreadPoolStats is launched in a separate thread. It will invoke
-                     * queryMbeans() as well Lock just in case.
-                     */
-                    mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
-                } finally {
-                    lock.unlock();
-                }
-
+                mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
                 if (sName.contains("ThreadPoolStats") && mBeanObjectInstanceSet.isEmpty()) {
                     ExecutorService execServ = Executors.newSingleThreadExecutor();
                     execServ.execute(() -> {
                         final int MAX_TIME_OUT = 5000;
                         int currentTimeOut = 0;
                         Set<ObjectInstance> mBeanObjectInstanceSetTemp = mBeanObjectInstanceSet;
-                        while (mBeanObjectInstanceSet.isEmpty() && currentTimeOut <= MAX_TIME_OUT) {
+                        while (mBeanObjectInstanceSetTemp.isEmpty() && currentTimeOut <= MAX_TIME_OUT) {
                             try {
                                 Thread.sleep(50);
-                                lock.lock();
-                                try {
-                                    mBeanObjectInstanceSetTemp = mbs.queryMBeans(new ObjectName(sName), null);
-                                } finally {
-                                    lock.unlock();
-                                }
+
+                                mBeanObjectInstanceSetTemp = mbs.queryMBeans(new ObjectName(sName), null);
                                 currentTimeOut += 50;
                             } catch (Exception e) {
                                 if (tc.isDebugEnabled()) {
@@ -165,6 +148,11 @@ public class MonitorMetricsHandler {
                                     FFDCFilter.processException(e, MonitorMetricsHandler.class.getSimpleName(),
                                             "register:Exception");
                                 }
+                                /*
+                                 * Interruption Exception or RuntimeOperationException from malformed query exit
+                                 * thread.
+                                 */
+                                break;
                             }
                         }
                         registerMbeanObjects(mBeanObjectInstanceSetTemp);

--- a/dev/com.ibm.ws.microprofile.metrics.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
@@ -38,8 +38,6 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.microprofile.metrics.impl.SharedMetricRegistries;
 
-import io.openliberty.microprofile.metrics.internal.monitor.MonitorMetricsHandler;
-
 @Component(name = "com.ibm.ws.microprofile.metrics.monitor.MonitorMetricsHandler", property = { "service.vendor=IBM"})
 public class MonitorMetricsHandler {
 	

--- a/dev/com.ibm.ws.microprofile.metrics.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
@@ -14,7 +14,6 @@ import java.lang.management.ManagementFactory;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
@@ -56,14 +55,22 @@ public class MonitorMetricsHandler {
         Tr.info(tc, "FEATURE_REGISTERED");
     }
 
-	@Reference
-    public void getSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistry) {
+    @Reference
+    public void setSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistry) {
         this.sharedMetricRegistry = sharedMetricRegistry;
     }
-	
+    
+    public void unsetSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistry) {
+        this.sharedMetricRegistry = null;
+    }
+       
     @Reference
-    public void getExecutorService(ExecutorService execServ) {
+    public void setExecutorService(ExecutorService execServ) {
         this.execServ = execServ;
+    }
+    
+    public void unsetExecutorService(ExecutorService execServ) {
+        this.execServ = null;
     }
     
     @Deactivate
@@ -136,7 +143,7 @@ public class MonitorMetricsHandler {
             Set<ObjectInstance> mBeanObjectInstanceSet;
             try {
                 mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
-                if (sName.contains("ThreadPoolStats") && mBeanObjectInstanceSet.isEmpty()) {
+                if (sName.contains("ThreadPoolStats") && mBeanObjectInstanceSet.isEmpty() && execServ != null) {
                     execServ.execute(() -> {
                         final int MAX_TIME_OUT = 5000;
                         int currentTimeOut = 0;

--- a/dev/com.ibm.ws.microprofile.metrics.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
@@ -43,6 +43,7 @@ public class MonitorMetricsHandler {
 	private static final TraceComponent tc = Tr.register(MonitorMetricsHandler.class);
 	
     private SharedMetricRegistries sharedMetricRegistry;
+    private ExecutorService execServ;
     private MappingTable mappingTable;
     private Set<MonitorMetrics> metricsSet = new HashSet<MonitorMetrics>();
 	private NotificationListener listener;
@@ -58,6 +59,11 @@ public class MonitorMetricsHandler {
 	@Reference
     public void getSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistry) {
         this.sharedMetricRegistry = sharedMetricRegistry;
+    }
+	
+    @Reference
+    public void getExecutorService(ExecutorService execServ) {
+        this.execServ = execServ;
     }
     
     @Deactivate
@@ -131,7 +137,6 @@ public class MonitorMetricsHandler {
             try {
                 mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
                 if (sName.contains("ThreadPoolStats") && mBeanObjectInstanceSet.isEmpty()) {
-                    ExecutorService execServ = Executors.newSingleThreadExecutor();
                     execServ.execute(() -> {
                         final int MAX_TIME_OUT = 5000;
                         int currentTimeOut = 0;
@@ -157,7 +162,6 @@ public class MonitorMetricsHandler {
                         }
                         registerMbeanObjects(mBeanObjectInstanceSetTemp);
                     });
-                    execServ.shutdown();
                 }
                 registerMbeanObjects(mBeanObjectInstanceSet);
             } catch (Exception e) {

--- a/dev/com.ibm.ws.microprofile.metrics.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.locks.ReentrantLock;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
@@ -127,37 +126,21 @@ public class MonitorMetricsHandler {
 
     protected void register() {
         MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-        ReentrantLock lock = new ReentrantLock();
         for (String sName : mappingTable.getKeys()) {
             Set<ObjectInstance> mBeanObjectInstanceSet;
-
             try {
-                lock.lock();
-                try {
-                    /*
-                     * ThreadPoolStats is launched in a separate thread. It will invoke
-                     * queryMbeans() as well Lock just in case.
-                     */
-                    mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
-                } finally {
-                    lock.unlock();
-                }
-
+                mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
                 if (sName.contains("ThreadPoolStats") && mBeanObjectInstanceSet.isEmpty()) {
                     ExecutorService execServ = Executors.newSingleThreadExecutor();
                     execServ.execute(() -> {
                         final int MAX_TIME_OUT = 5000;
                         int currentTimeOut = 0;
                         Set<ObjectInstance> mBeanObjectInstanceSetTemp = mBeanObjectInstanceSet;
-                        while (mBeanObjectInstanceSet.isEmpty() && currentTimeOut <= MAX_TIME_OUT) {
+                        while (mBeanObjectInstanceSetTemp.isEmpty() && currentTimeOut <= MAX_TIME_OUT) {
                             try {
                                 Thread.sleep(50);
-                                lock.lock();
-                                try {
-                                    mBeanObjectInstanceSetTemp = mbs.queryMBeans(new ObjectName(sName), null);
-                                } finally {
-                                    lock.unlock();
-                                }
+
+                                mBeanObjectInstanceSetTemp = mbs.queryMBeans(new ObjectName(sName), null);
                                 currentTimeOut += 50;
                             } catch (Exception e) {
                                 if (tc.isDebugEnabled()) {
@@ -165,6 +148,11 @@ public class MonitorMetricsHandler {
                                     FFDCFilter.processException(e, MonitorMetricsHandler.class.getSimpleName(),
                                             "register:Exception");
                                 }
+                                /*
+                                 * Interruption Exception or RuntimeOperationException from malformed query exit
+                                 * thread.
+                                 */
+                                break;
                             }
                         }
                         registerMbeanObjects(mBeanObjectInstanceSetTemp);

--- a/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/MonitorMetricsHandler.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/MonitorMetricsHandler.java
@@ -14,7 +14,6 @@ import java.lang.management.ManagementFactory;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
@@ -57,13 +56,21 @@ public class MonitorMetricsHandler {
     }
 
 	@Reference
-    public void getSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistry) {
+    public void setSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistry) {
         this.sharedMetricRegistry = sharedMetricRegistry;
+    }
+	
+    public void unsetSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistry) {
+        this.sharedMetricRegistry = null;
     }
 	   
     @Reference
-    public void getExecutorService(ExecutorService execServ) {
+    public void setExecutorService(ExecutorService execServ) {
         this.execServ = execServ;
+    }
+    
+    public void unsetExecutorService(ExecutorService execServ) {
+        this.execServ = null;
     }
 	
     @Deactivate
@@ -136,7 +143,7 @@ public class MonitorMetricsHandler {
             Set<ObjectInstance> mBeanObjectInstanceSet;
             try {
                 mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
-                if (sName.contains("ThreadPoolStats") && mBeanObjectInstanceSet.isEmpty()) {
+                if (sName.contains("ThreadPoolStats") && mBeanObjectInstanceSet.isEmpty() && execServ != null) {
                     execServ.execute(() -> {
                         final int MAX_TIME_OUT = 5000;
                         int currentTimeOut = 0;

--- a/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/MonitorMetricsHandler.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/MonitorMetricsHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,9 @@ package io.openliberty.microprofile.metrics.internal.monitor;
 import java.lang.management.ManagementFactory;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
@@ -123,36 +126,71 @@ public class MonitorMetricsHandler {
 	}
 
     protected void register() {
-		MBeanServer	mbs = ManagementFactory.getPlatformMBeanServer();
-		for (String sName : mappingTable.getKeys() ) {
-			Set<ObjectInstance> mBeanObjectInstanceSet;
-			try {
-				mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
-				if (sName.contains("ThreadPoolStats")) {
-					final int MAX_TIME_OUT = 5000;
-					int currentTimeOut = 0;
-					while (mBeanObjectInstanceSet.isEmpty() && currentTimeOut <= MAX_TIME_OUT) {
-						Thread.sleep(50);
-						mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
-						currentTimeOut+=50;
-					}
-				}
-		        for (ObjectInstance objInstance : mBeanObjectInstanceSet) {
-		            String objectName = objInstance.getObjectName().toString();
-		            String[][] data = mappingTable.getData(objectName);
-					if (data != null) {
-						register(objectName, data);
-		            }
-		        }
-			} catch (Exception e) {
-	            if (tc.isDebugEnabled()) {
-	                Tr.debug(tc, "register exception message: ", e.getMessage());
-	                FFDCFilter.processException(e, MonitorMetricsHandler.class.getSimpleName(), "register:Exception");
-	            }
-			}
-		}
-	}
-    
+        MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+        ReentrantLock lock = new ReentrantLock();
+        for (String sName : mappingTable.getKeys()) {
+            Set<ObjectInstance> mBeanObjectInstanceSet;
+
+            try {
+                lock.lock();
+                try {
+                    /*
+                     * ThreadPoolStats is launched in a separate thread. It will invoke
+                     * queryMbeans() as well Lock just in case.
+                     */
+                    mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
+                } finally {
+                    lock.unlock();
+                }
+
+                if (sName.contains("ThreadPoolStats") && mBeanObjectInstanceSet.isEmpty()) {
+                    ExecutorService execServ = Executors.newSingleThreadExecutor();
+                    execServ.execute(() -> {
+                        final int MAX_TIME_OUT = 5000;
+                        int currentTimeOut = 0;
+                        Set<ObjectInstance> mBeanObjectInstanceSetTemp = mBeanObjectInstanceSet;
+                        while (mBeanObjectInstanceSet.isEmpty() && currentTimeOut <= MAX_TIME_OUT) {
+                            try {
+                                Thread.sleep(50);
+                                lock.lock();
+                                try {
+                                    mBeanObjectInstanceSetTemp = mbs.queryMBeans(new ObjectName(sName), null);
+                                } finally {
+                                    lock.unlock();
+                                }
+                                currentTimeOut += 50;
+                            } catch (Exception e) {
+                                if (tc.isDebugEnabled()) {
+                                    Tr.debug(tc, "register exception message: ", e.getMessage());
+                                    FFDCFilter.processException(e, MonitorMetricsHandler.class.getSimpleName(),
+                                            "register:Exception");
+                                }
+                            }
+                        }
+                        registerMbeanObjects(mBeanObjectInstanceSetTemp);
+                    });
+                    execServ.shutdown();
+                }
+                registerMbeanObjects(mBeanObjectInstanceSet);
+            } catch (Exception e) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "register exception message: ", e.getMessage());
+                    FFDCFilter.processException(e, MonitorMetricsHandler.class.getSimpleName(), "register:Exception");
+                }
+            }
+        }
+    }
+
+    private synchronized void registerMbeanObjects(Set<ObjectInstance> mBeanObjectInstanceSet) {
+        for (ObjectInstance objInstance : mBeanObjectInstanceSet) {
+            String objectName = objInstance.getObjectName().toString();
+            String[][] data = mappingTable.getData(objectName);
+            if (data != null) {
+                register(objectName, data);
+            }
+        }
+    }
+
 	protected void register(String objectName, String[][] data) {
         MonitorMetrics metrics = null;
 		if (!containMetrics(objectName))  {

--- a/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/MonitorMetricsHandler.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/MonitorMetricsHandler.java
@@ -43,6 +43,7 @@ public class MonitorMetricsHandler {
 	private static final TraceComponent tc = Tr.register(MonitorMetricsHandler.class);
 	
 	protected SharedMetricRegistries sharedMetricRegistry;
+	protected ExecutorService execServ;
     protected MappingTable mappingTable;
     protected Set<MonitorMetrics> metricsSet = new HashSet<MonitorMetrics>();
     protected NotificationListener listener;
@@ -59,7 +60,12 @@ public class MonitorMetricsHandler {
     public void getSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistry) {
         this.sharedMetricRegistry = sharedMetricRegistry;
     }
-    
+	   
+    @Reference
+    public void getExecutorService(ExecutorService execServ) {
+        this.execServ = execServ;
+    }
+	
     @Deactivate
     protected void deactivate(ComponentContext context) {
     	MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
@@ -131,7 +137,6 @@ public class MonitorMetricsHandler {
             try {
                 mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
                 if (sName.contains("ThreadPoolStats") && mBeanObjectInstanceSet.isEmpty()) {
-                    ExecutorService execServ = Executors.newSingleThreadExecutor();
                     execServ.execute(() -> {
                         final int MAX_TIME_OUT = 5000;
                         int currentTimeOut = 0;
@@ -157,7 +162,6 @@ public class MonitorMetricsHandler {
                         }
                         registerMbeanObjects(mBeanObjectInstanceSetTemp);
                     });
-                    execServ.shutdown();
                 }
                 registerMbeanObjects(mBeanObjectInstanceSet);
             } catch (Exception e) {


### PR DESCRIPTION
As we are unable to read the server.xml faithfully during runtime. This PR will attempt to asynchronously load the ThreadPoolStats related MBeans in a separate thread. As a result it will not affect the sequential start-up of the bundle and hence the server.

Fixes #19780

The issue in #19780 is that there is a 5 second wait time in monitor metrics for the retrieval and registration of the `ThreadpoolStat` Mbeans as MP metrics. The 5 second was provided as it may take some time for the Mbean to be created and present in the Mbean server and the thread pool metrics are important for the MP metric feature. The 5 seconds is a worst-case scenario as normally it shouldn't take that long.  

  However, this is an issue when the `monitor-1.0` filter has filtered out the `ThreadpoolStats`. This forces the server to always wait 5 seconds at start-up.
  
  As we are unable to read the configuration values of other features from the monitor metrics bundle,  this PR opts to change the dynamic of how the `ThreadpoolStats` (and ultimately threadpool metrics) are loaded. Typically a for loop is created and goes through a table of values we expect to load up on start-up. This is a simple and quick process for each item in the table unless it is the Threadpool stats, which has its own unique logic (which blocks the for loop until it is done). To avoid the hard 5 second impact to the start-up of the bundle and hence the server, we will execute the loading of the thread pool metric in a separate thread.