### PR TITLE
adding ENGLISH locale to the toUpperCase() call to prevent corruption of the function name generated

### DIFF
--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/transport/client/DataModelSerializer.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/transport/client/DataModelSerializer.java
@@ -421,7 +421,7 @@ public class DataModelSerializer {
         Method found = null;
 
         //precalc the field name as a setter to use for each method test.
-        String fieldNameAsASetter = new StringBuilder("set").append(fieldName.substring(0, 1).toUpperCase()).append(fieldName.substring(1)).toString();
+        String fieldNameAsASetter = new StringBuilder("set").append(fieldName.substring(0, 1).toUpperCase(Locale.ENGLISH)).append(fieldName.substring(1)).toString();
 
         //hunt for any matching setter in the object
         for (Method m : classToLookForFieldIn.getMethods()) {


### PR DESCRIPTION
fixes #19787 

On Turkish Systems the lower case letter `i` is uppercased to `İ` instead of `I`

This causes the failure in `internalGetClassForFieldName()` on methods that need a capital `I` and not `İ` such as `setInclusive`. 
![image](https://user-images.githubusercontent.com/26169178/149224779-6f16c741-032d-49b9-be7b-37ef4ece419f.png)
