### PR TITLE
EJBTimerTest fix interval countdown latch waiting in timeout

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.mdb.ra_fat/test-applications/MsgEndpointEJB.jar/src/com/ibm/ws/ejbcontainer/fat/msgendpoint/ejb/MDBTimedCMTBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.mdb.ra_fat/test-applications/MsgEndpointEJB.jar/src/com/ibm/ws/ejbcontainer/fat/msgendpoint/ejb/MDBTimedCMTBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1017,8 +1017,8 @@ public class MDBTimedCMTBean implements MessageListener {
 
         if (timerIndex >= 0) {
 
-            if (svTimeoutCounts[timerIndex] == 1) {
-                // Don't run the 2nd interval until test is ready
+            if (svTimeoutCounts[timerIndex] > 1) {
+                // Don't run the 2nd & 3rd interval until test is ready
                 try {
                     svTimerIntervalWaitLatch.await(MAX_TIMER_WAIT, TimeUnit.MILLISECONDS);
                 } catch (InterruptedException e) {

--- a/dev/com.ibm.ws.ejbcontainer.timer.np_fat/test-applications/NpTimerOperationsEJB.jar/src/com/ibm/ws/ejbcontainer/timer/np/operations/ejb/SingletonTimedBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.np_fat/test-applications/NpTimerOperationsEJB.jar/src/com/ibm/ws/ejbcontainer/timer/np/operations/ejb/SingletonTimedBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -717,8 +717,8 @@ public class SingletonTimedBean implements SingletonTimedLocal {
 
         if (timerIndex >= 0) {
 
-            if (timeoutCounts[timerIndex] == 1) {
-                // Don't run the 2nd interval until test is ready
+            if (timeoutCounts[timerIndex] > 1) {
+                // Don't run the 2nd & 3rd interval until test is ready
                 try {
                     timerIntervalWaitLatch.await(MAX_TIMER_WAIT, TimeUnit.MILLISECONDS);
                 } catch (InterruptedException e) {

--- a/dev/com.ibm.ws.ejbcontainer.timer.np_fat/test-applications/NpTimerOperationsEJB.jar/src/com/ibm/ws/ejbcontainer/timer/np/operations/ejb/StatelessTimedBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.np_fat/test-applications/NpTimerOperationsEJB.jar/src/com/ibm/ws/ejbcontainer/timer/np/operations/ejb/StatelessTimedBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -843,8 +843,8 @@ public class StatelessTimedBean implements StatelessTimedLocal {
 
         if (timerIndex >= 0) {
 
-            if (timeoutCounts[timerIndex] == 1) {
-                // Don't run the 2nd interval until test is ready
+            if (timeoutCounts[timerIndex] > 1) {
+                // Don't run the 2nd & 3rd interval until test is ready
                 try {
                     timerIntervalWaitLatch.await(MAX_TIMER_WAIT, TimeUnit.MILLISECONDS);
                 } catch (InterruptedException e) {


### PR DESCRIPTION
if statement caused it to only wait on the 2nd interval and not the 3rd one I had added to fix a build break.