### PR TITLE
Update kafka containers to latest

### DIFF
--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/fat/src/com/ibm/ws/microprofile/health20/fat/ApplicationStateHealthCheckTest.java
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/fat/src/com/ibm/ws/microprofile/health20/fat/ApplicationStateHealthCheckTest.java
@@ -35,6 +35,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
@@ -84,7 +85,7 @@ public class ApplicationStateHealthCheckTest {
         SUCCESS, FAILURE;
     }
 
-    public static KafkaContainer kafkaContainer = new KafkaContainer();
+    public static KafkaContainer kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.0.1"));
 
     final static String SERVER_NAME = "ApplicationStateHealthCheck";
     final static String FAILS_TO_START_SERVER_NAME = "FailedApplicationStateHealthCheck";

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/containers/KafkaSaslPlainContainer.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/containers/KafkaSaslPlainContainer.java
@@ -3,18 +3,19 @@ package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.containers;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Stream;
 
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.SocatContainer;
 import org.testcontainers.utility.Base58;
-import org.testcontainers.utility.TestcontainersConfiguration;
+import org.testcontainers.utility.DockerImageName;
 
 /**
  * This class is a modification of the <code>org.testcontainers.containers.KafkaContainer</code> class to add SASL+TLS support
  */
 public class KafkaSaslPlainContainer extends GenericContainer<KafkaSaslPlainContainer> {
+
+    private static final DockerImageName IMAGE_NAME = DockerImageName.parse("confluentinc/cp-kafka:7.0.1");
 
     private final Network network;
 
@@ -42,15 +43,11 @@ public class KafkaSaslPlainContainer extends GenericContainer<KafkaSaslPlainCont
 
     protected SocatContainer proxy;
 
-    public KafkaSaslPlainContainer() {
-        this("4.0.0");
-    }
-
     /**
      * @param confluentPlatformVersion
      */
-    public KafkaSaslPlainContainer(String confluentPlatformVersion) {
-        super("confluentinc/cp-kafka:" + confluentPlatformVersion);
+    public KafkaSaslPlainContainer() {
+        super(IMAGE_NAME);
 
         network = Network.newNetwork();
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/containers/KafkaTlsContainer.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/containers/KafkaTlsContainer.java
@@ -8,11 +8,14 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.SocatContainer;
 import org.testcontainers.utility.Base58;
+import org.testcontainers.utility.DockerImageName;
 
 /**
  * This class is a modification of the <code>org.testcontainers.containers.KafkaContainer</code> class to add TLS support
  */
 public class KafkaTlsContainer extends GenericContainer<KafkaTlsContainer> {
+
+    private static final DockerImageName IMAGE_NAME = DockerImageName.parse("confluentinc/cp-kafka:7.0.1");
 
     private final Network network;
 
@@ -30,15 +33,11 @@ public class KafkaTlsContainer extends GenericContainer<KafkaTlsContainer> {
 
     protected SocatContainer proxy;
 
-    public KafkaTlsContainer() {
-        this("4.0.0");
-    }
-
     /**
      * @param confluentPlatformVersion
      */
-    public KafkaTlsContainer(String confluentPlatformVersion) {
-        super("confluentinc/cp-kafka:" + confluentPlatformVersion);
+    public KafkaTlsContainer() {
+        super(IMAGE_NAME);
 
         network = Network.newNetwork();
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/PlaintextTests.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/PlaintextTests.java
@@ -18,6 +18,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.utility.DockerImageName;
 
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.ack.auto.KafkaAutoAckTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.delivery.KafkaAcknowledgementTest;
@@ -56,6 +57,8 @@ import componenttest.containers.ExternalTestServiceDockerClientStrategy;
 })
 public class PlaintextTests {
 
+    private static final DockerImageName IMAGE_NAME = DockerImageName.parse("confluentinc/cp-kafka:7.0.1");
+
     //Required to ensure we calculate the correct strategy each run even when
     //switching between local and remote docker hosts.
     static {
@@ -66,7 +69,7 @@ public class PlaintextTests {
     public static Network network = Network.newNetwork();
 
     @ClassRule
-    public static KafkaContainer kafkaContainer = new KafkaContainer()
+    public static KafkaContainer kafkaContainer = new KafkaContainer(IMAGE_NAME)
                     .withNetwork(network)
                     .withStartupTimeout(Duration.ofMinutes(2))
                     .withStartupAttempts(3);


### PR DESCRIPTION
In an effort to keep better control over test containers that are potentially vulnerable to log4shell we should ensure that we are only using one version of the image `confluentrinc/cp-kafka` which does not currently use log4j 2.x, but is still using the out of date log4j 1.x versions.  