### PR TITLE
Update restConnector features for mpOpenApi-3.0

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.configValidationConfigSchema-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.configValidationConfigSchema-3.0.feature
@@ -1,0 +1,12 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.configValidationConfigSchema-3.0
+visibility=private
+IBM-Provision-Capability:\
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.restConnector-2.0))",\
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.mpOpenAPI-3.0))"
+IBM-Install-Policy: when-satisfied
+-bundles=\
+ io.openliberty.rest.handler.config.openapi.2.0,\
+ io.openliberty.rest.handler.config.openapi.common.jakarta
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.configValidationValidatorSchema-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.configValidationValidatorSchema-3.0.feature
@@ -1,0 +1,11 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.configValidationValidatorSchema-3.0
+visibility=private
+IBM-Provision-Capability:\
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.mpOpenAPI-3.0))",\
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.configValidationJDBC-1.0)(osgi.identity=com.ibm.websphere.appserver.configValidationJCA-1.0)(osgi.identity=com.ibm.websphere.appserver.configValidationCloudant-1.0)))"
+IBM-Install-Policy: when-satisfied
+-bundles=\
+ io.openliberty.rest.handler.validator.openapi.2.0.jakarta
+kind=ga
+edition=core

--- a/dev/com.ibm.ws.rest.handler.config_fat/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.config_fat/bnd.bnd
@@ -42,6 +42,7 @@ tested.features: componenttest-2.0,\
                  messaging-3.0,\
                  enterprisebeanslite-4.0,\
                  messagingclient-3.0,\
+                 mpOpenApi-3.0,\
                  mpOpenApi-2.0,\
                  mpOpenApi-1.1,\
                  servlet-4.0,\

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigOpenApiSchemaTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigOpenApiSchemaTest.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.ibm.ws.rest.handler.config.fat;
 
-import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -24,7 +23,6 @@ import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.Paths;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -32,17 +30,12 @@ import com.ibm.ws.microprofile.openapi.impl.parser.OpenAPIParser;
 import com.ibm.ws.microprofile.openapi.impl.parser.core.models.SwaggerParseResult;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.MicroProfileActions;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import componenttest.topology.utils.HttpsRequest;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat(EE9_FEATURES) // TODO: Enable this once mpopenapi-2.0 (jakarta enabled) is available
 public class ConfigOpenApiSchemaTest extends FATServletClient {
 
     /**  */
@@ -50,12 +43,6 @@ public class ConfigOpenApiSchemaTest extends FATServletClient {
 
     @Server(SERVER_NAME)
     public static LibertyServer server;
-
-    @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, TestMode.FULL,
-                                                             MicroProfileActions.MP40,
-                                                             MicroProfileActions.MP30,
-                                                             MicroProfileActions.MP20);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.rest.handler.config.fat;
 
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -65,7 +66,7 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
                         .addAsModule(ejb)
                         .addAsModule(web)
                         .addAsModule(emb_rar);
-        ShrinkHelper.exportToServer(server, "apps", app);
+        ShrinkHelper.exportToServer(server, "apps", app, SERVER_ONLY);
         server.addInstalledAppForValidation(APP_NAME);
 
         ResourceAdapterArchive tca_rar = ShrinkWrap.create(ResourceAdapterArchive.class, "ConfigTestAdapter.rar")
@@ -77,7 +78,7 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
                                         .addClass("org.test.config.jmsadapter.JMSTopicConnectionImpl")
                                         .addClass("org.test.config.jmsadapter.ManagedJMSTopicConnectionFactoryImpl")
                                         .addClass("org.test.config.jmsadapter.NoOpSessionImpl"));
-        ShrinkHelper.exportToServer(server, "connectors", tca_rar);
+        ShrinkHelper.exportToServer(server, "connectors", tca_rar, SERVER_ONLY);
 
         FATSuite.setupServerSideAnnotations(server);
 

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerJCATest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerJCATest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.rest.handler.config.fat;
 
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -47,12 +48,12 @@ public class ConfigRESTHandlerJCATest extends FATServletClient {
         ResourceAdapterArchive tca_rar = ShrinkWrap.create(ResourceAdapterArchive.class, "TestConfigAdapter.rar")
                         .addAsLibraries(ShrinkWrap.create(JavaArchive.class)
                                         .addPackage("org.test.config.adapter"));
-        ShrinkHelper.exportToServer(server, "connectors", tca_rar);
+        ShrinkHelper.exportToServer(server, "connectors", tca_rar, SERVER_ONLY);
 
         ResourceAdapterArchive ata_rar = ShrinkWrap.create(ResourceAdapterArchive.class, "AnotherTestAdapter.rar")
                         .addAsLibraries(ShrinkWrap.create(JavaArchive.class)
                                         .addPackage("org.test.config.adapter"));
-        ShrinkHelper.exportToServer(server, "connectors", ata_rar);
+        ShrinkHelper.exportToServer(server, "connectors", ata_rar, SERVER_ONLY);
 
         FATSuite.setupServerSideAnnotations(server);
 

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerJMSTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerJMSTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.rest.handler.config.fat;
 
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -49,7 +50,7 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
                         .addAsLibraries(ShrinkWrap.create(JavaArchive.class)
                                         .addPackage("org.test.config.adapter")
                                         .addPackage("org.test.config.jmsadapter"));
-        ShrinkHelper.exportToServer(server, "connectors", rar);
+        ShrinkHelper.exportToServer(server, "connectors", rar, SERVER_ONLY);
 
         FATSuite.setupServerSideAnnotations(server);
 

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/FATSuite.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
@@ -33,8 +35,9 @@ import componenttest.topology.utils.HttpUtils;
 public class FATSuite {
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification() // run all tests as-is (e.g. EE8 features)
-                    .andWith(new JakartaEE9Action()); // run all tests again with EE9 features+packages
+    public static RepeatTests r = MicroProfileActions.repeat(null, TestMode.FULL,
+                                                             MicroProfileActions.MP50, // EE9
+                                                             MicroProfileActions.MP40); // EE8
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2021 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,15 +20,22 @@ src: \
 fat.project: true
 
 tested.features: mpOpenApi-2.0,\
+                 mpOpenApi-3.0,\
                  servlet-4.0,\
                  servlet-5.0,\
+                 concurrent-2.0,\
                  mpConfig-2.0,\
+                 mpConfig-3.0,\
                  jsonp-1.1,\
+                 jsonp-2.0,\
                  jaxrsclient-2.1,\
                  jaxrs-2.1,\
+                 restfulws-3.0,\
                  componenttest-2.0,\
                  appSecurity-4.0,\
                  messaging-3.0,\
+                 messagingserver-3.0,\
+                 messagingclient-3.0,\
                  connectors-2.0,\
                  appsecurity-3.0,\
                  cdi-2.0,\

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/FATSuite.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.rest.handler.validator.fat;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -17,6 +19,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE9PackageReplacementHelper;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
@@ -34,15 +37,14 @@ import componenttest.topology.utils.HttpUtils;
 
 public class FATSuite {
 
-    @ClassRule
-    public static RepeatTests r1 = MicroProfileActions.repeat(null, TestMode.FULL,
-                                                              MicroProfileActions.MP40,
-                                                              MicroProfileActions.MP30,
-                                                              MicroProfileActions.MP20);
+    private static final EE9PackageReplacementHelper packageReplacementHelper = new EE9PackageReplacementHelper();
 
     @ClassRule
-    public static RepeatTests r2 = RepeatTests.withoutModification() // run all tests as-is (e.g. EE8 features)
-                    .andWith(new JakartaEE9Action()); // run all tests again with EE9 features+package
+    public static RepeatTests r1 = MicroProfileActions.repeat(null, TestMode.FULL,
+                                                              MicroProfileActions.MP50, // EE9
+                                                              MicroProfileActions.MP40, // EE8
+                                                              MicroProfileActions.MP30,
+                                                              MicroProfileActions.MP20);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -66,6 +68,21 @@ public class FATSuite {
             server.addEnvVar("QUEUE_INTERFACE", "javax.jms.Queue");
             server.addEnvVar("TOPIC_INTERFACE", "javax.jms.Topic");
             server.addEnvVar("DESTINATION_INTERFACE", "javax.jms.Destination");
+        }
+    }
+
+    public static void assertClassEquals(String message, String expected, String actual) {
+        if (JakartaEE9Action.isActive()) {
+            expected = packageReplacementHelper.replacePackages(expected);
+        }
+        assertEquals(message, expected, actual);
+    }
+
+    public static String expectedJmsProviderSpecVersion() {
+        if (JakartaEE9Action.isActive()) {
+            return "3.0";
+        } else {
+            return "2.0";
         }
     }
 }

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.ibm.ws.rest.handler.validator.fat;
 
-import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -33,14 +32,12 @@ import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import componenttest.topology.utils.HttpsRequest;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat(EE9_FEATURES) // TODO: Enable this once mpopenapi-2.0 (jakarta enabled) is available
 public class ValidateDataSourceTest extends FATServletClient {
 
     private static final Class<?> c = ValidateDataSourceTest.class;

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJMSTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJMSTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.rest.handler.validator.fat;
 
-import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static com.ibm.ws.rest.handler.validator.fat.FATSuite.assertClassEquals;
+import static com.ibm.ws.rest.handler.validator.fat.FATSuite.expectedJmsProviderSpecVersion;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -30,14 +31,12 @@ import org.junit.runner.RunWith;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import componenttest.topology.utils.HttpsRequest;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat(EE9_FEATURES) // TODO: Enable this once mpopenapi-2.0 (jakarta enabled) is available
 public class ValidateJMSTest extends FATServletClient {
     @Server("com.ibm.ws.rest.handler.validator.jms.fat")
     public static LibertyServer server;
@@ -77,7 +76,7 @@ public class ValidateJMSTest extends FATServletClient {
         assertNotNull(err, json = json.getJsonObject("info"));
         assertEquals(err, "IBM", json.getString("jmsProviderName"));
         assertEquals(err, "1.0", json.getString("jmsProviderVersion"));
-        assertEquals(err, "2.0", json.getString("jmsProviderSpecVersion"));
+        assertEquals(err, expectedJmsProviderSpecVersion(), json.getString("jmsProviderSpecVersion"));
         assertEquals(err, "TestClient1", json.getString("clientID"));
     }
 
@@ -106,7 +105,7 @@ public class ValidateJMSTest extends FATServletClient {
 
         assertNotNull(err, json = json.getJsonObject("failure"));
         assertEquals(err, "CWSIA0241", json.getString("errorCode"));
-        assertEquals(err, "javax.jms.JMSException", json.getString("class"));
+        assertClassEquals(err, "javax.jms.JMSException", json.getString("class"));
         assertTrue(err, json.getString("message").contains("CWSIA0241E"));
         assertNotNull(err, stack = json.getJsonArray("stack"));
         assertTrue(err, stack.size() > 10); // stack is actually much longer, but size could vary
@@ -116,7 +115,7 @@ public class ValidateJMSTest extends FATServletClient {
 
         assertNotNull(err, json = json.getJsonObject("cause"));
         assertNull(err, json.get("errorCode"));
-        assertEquals(err, "com.ibm.websphere.sib.exception.SIResourceException", json.getString("class"));
+        assertClassEquals(err, "com.ibm.websphere.sib.exception.SIResourceException", json.getString("class"));
         assertTrue(err, json.getString("message").contains("CWSIT0127E"));
         assertNotNull(err, stack = json.getJsonArray("stack"));
         assertTrue(err, stack.size() > 10); // stack is actually much longer, but size could vary
@@ -171,7 +170,7 @@ public class ValidateJMSTest extends FATServletClient {
         assertNotNull(err, j = j.getJsonObject("info"));
         assertEquals(err, "IBM", j.getString("jmsProviderName"));
         assertEquals(err, "1.0", j.getString("jmsProviderVersion"));
-        assertEquals(err, "2.0", j.getString("jmsProviderSpecVersion"));
+        assertEquals(err, expectedJmsProviderSpecVersion(), j.getString("jmsProviderSpecVersion"));
         assertEquals(err, "clientID", j.getString("clientID"));
 
         // [1]: config.displayId=jmsConnectionFactory[jmscf1]
@@ -215,7 +214,7 @@ public class ValidateJMSTest extends FATServletClient {
         assertNotNull(err, json = json.getJsonObject("info"));
         assertEquals(err, "IBM", json.getString("jmsProviderName"));
         assertEquals(err, "1.0", json.getString("jmsProviderVersion"));
-        assertEquals(err, "2.0", json.getString("jmsProviderSpecVersion"));
+        assertEquals(err, expectedJmsProviderSpecVersion(), json.getString("jmsProviderSpecVersion"));
         assertNull(err, json.get("clientID"));
     }
 
@@ -240,7 +239,7 @@ public class ValidateJMSTest extends FATServletClient {
         assertNotNull(err, json = json.getJsonObject("info"));
         assertEquals(err, "IBM", json.getString("jmsProviderName"));
         assertEquals(err, "1.0", json.getString("jmsProviderVersion"));
-        assertEquals(err, "2.0", json.getString("jmsProviderSpecVersion"));
+        assertEquals(err, expectedJmsProviderSpecVersion(), json.getString("jmsProviderSpecVersion"));
         assertEquals(err, "clientID", json.getString("clientID"));
 
         assertNotNull(err, json = tcfs.getJsonObject(1));
@@ -252,7 +251,7 @@ public class ValidateJMSTest extends FATServletClient {
         assertNotNull(err, json = json.getJsonObject("info"));
         assertEquals(err, "IBM", json.getString("jmsProviderName"));
         assertEquals(err, "1.0", json.getString("jmsProviderVersion"));
-        assertEquals(err, "2.0", json.getString("jmsProviderSpecVersion"));
+        assertEquals(err, expectedJmsProviderSpecVersion(), json.getString("jmsProviderSpecVersion"));
         assertEquals(err, "tcf2id", json.getString("clientID"));
 
         assertNotNull(err, json = tcfs.getJsonObject(2));
@@ -264,7 +263,7 @@ public class ValidateJMSTest extends FATServletClient {
         assertNotNull(err, json = json.getJsonObject("info"));
         assertEquals(err, "IBM", json.getString("jmsProviderName"));
         assertEquals(err, "1.0", json.getString("jmsProviderVersion"));
-        assertEquals(err, "2.0", json.getString("jmsProviderSpecVersion"));
+        assertEquals(err, expectedJmsProviderSpecVersion(), json.getString("jmsProviderSpecVersion"));
         assertEquals(err, "tcf3id", json.getString("clientID"));
     }
 
@@ -283,7 +282,7 @@ public class ValidateJMSTest extends FATServletClient {
         assertNotNull(err, json = json.getJsonObject("info"));
         assertEquals(err, "IBM", json.getString("jmsProviderName"));
         assertEquals(err, "1.0", json.getString("jmsProviderVersion"));
-        assertEquals(err, "2.0", json.getString("jmsProviderSpecVersion"));
+        assertEquals(err, expectedJmsProviderSpecVersion(), json.getString("jmsProviderSpecVersion"));
         assertNull(err, json.get("clientID"));
     }
 
@@ -302,7 +301,7 @@ public class ValidateJMSTest extends FATServletClient {
         assertNotNull(err, json = json.getJsonObject("info"));
         assertEquals(err, "IBM", json.getString("jmsProviderName"));
         assertEquals(err, "1.0", json.getString("jmsProviderVersion"));
-        assertEquals(err, "2.0", json.getString("jmsProviderSpecVersion"));
+        assertEquals(err, expectedJmsProviderSpecVersion(), json.getString("jmsProviderSpecVersion"));
         assertEquals(err, "clientID", json.getString("clientID"));
     }
 }

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2019, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -65,6 +65,11 @@
   <javaPermission codebase="${server.config.dir}/dropins/TestValidationAdapter.rar"
                   className="javax.security.auth.PrivateCredentialPermission"
                   signedBy="javax.resource.spi.security.PasswordCredential"
+                  principalType="*" principalName="*" actions="read"/>
+
+  <javaPermission codebase="${server.config.dir}/dropins/TestValidationAdapter.rar"
+                  className="javax.security.auth.PrivateCredentialPermission"
+                  signedBy="jakarta.resource.spi.security.PasswordCredential"
                   principalType="*" principalName="*" actions="read"/>
 
   <javaPermission codebase="${server.config.dir}/customLoginModule.jar"

--- a/dev/io.openliberty.rest.handler.config.openapi.common/bnd.bnd
+++ b/dev/io.openliberty.rest.handler.config.openapi.common/bnd.bnd
@@ -25,6 +25,8 @@ OL-VirtualHost: ${admin.virtual.host}
 IBM-Authorization-Roles: com.ibm.ws.management
 IBM-Web-Extension-Processing-Disabled: true
 
+jakartaeeMe: true
+
 Include-Resource: \
     WEB-INF=resources/WEB-INF
 

--- a/dev/io.openliberty.rest.handler.validator.openapi.2.0/bnd.bnd
+++ b/dev/io.openliberty.rest.handler.validator.openapi.2.0/bnd.bnd
@@ -25,6 +25,8 @@ Private-Package:\
 DynamicImport-Package:\
   javax.jms
 
+jakartaeeMe: true
+
 Include-Resource: \
   META-INF=resources/META-INF
   

--- a/dev/io.openliberty.rest.handler.validator.openapi.2.0/src/io/openliberty/rest/handler/validator/openapi20/ValidatorSchemaRESTHandler.java
+++ b/dev/io.openliberty.rest.handler.validator.openapi.2.0/src/io/openliberty/rest/handler/validator/openapi20/ValidatorSchemaRESTHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -200,8 +200,14 @@ public class ValidatorSchemaRESTHandler implements RESTHandler {
             try {
                 return getClass().getClassLoader().loadClass("javax.jms.ConnectionFactory");
             } catch (ClassNotFoundException e) {
-                return null;
             }
+
+            try {
+                return getClass().getClassLoader().loadClass("jakarta.jms.ConnectionFactory");
+            } catch (ClassNotFoundException e) {
+            }
+
+            return null;
         });
         return jmsClass != null;
     }

--- a/dev/io.openliberty.rest.handler.validator.openapi.2.0/src/io/openliberty/rest/handler/validator/openapi20/package-info.java
+++ b/dev/io.openliberty.rest.handler.validator.openapi.2.0/src/io/openliberty/rest/handler/validator/openapi20/package-info.java
@@ -1,0 +1,12 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+@com.ibm.websphere.ras.annotation.TraceOptions(traceGroup = "rest.validation")
+package io.openliberty.rest.handler.validator.openapi20;


### PR DESCRIPTION
Make the OpenAPI documentation for the restconnector config and validation endpoints work with mpOpenApi-3.0.

This was missed during the development of mpOpenApi-3.0.

Fixes #19796 