### PR TITLE
Update JPA FAT Bucket for Oracle database support.

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/entity/tests/Entity_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/entity/tests/Entity_EJB.java
@@ -244,11 +244,18 @@ public class Entity_EJB extends JPAFATServletClient {
             ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
             ClassloaderElement loader = new ClassloaderElement();
             loader.getCommonLibraryRefs().add("HibernateLib");
+            loader.getCommonLibraryRefs().add("AnonymousJDBCLib");
             cel.add(loader);
         } else if (AbstractFATSuite.repeatPhase != null && AbstractFATSuite.repeatPhase.contains("openjpa")) {
             ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
             ClassloaderElement loader = new ClassloaderElement();
             loader.getCommonLibraryRefs().add("OpenJPALib");
+            loader.getCommonLibraryRefs().add("AnonymousJDBCLib");
+            cel.add(loader);
+        } else {
+            ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
+            ClassloaderElement loader = new ClassloaderElement();
+            loader.getCommonLibraryRefs().add("AnonymousJDBCLib");
             cel.add(loader);
         }
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/entity/tests/Entity_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/entity/tests/Entity_EJB.java
@@ -244,15 +244,21 @@ public class Entity_EJB extends JPAFATServletClient {
             ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
             ClassloaderElement loader = new ClassloaderElement();
             loader.getCommonLibraryRefs().add("HibernateLib");
-            loader.getCommonLibraryRefs().add("AnonymousJDBCLib");
             cel.add(loader);
         } else if (AbstractFATSuite.repeatPhase != null && AbstractFATSuite.repeatPhase.contains("openjpa")) {
             ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
             ClassloaderElement loader = new ClassloaderElement();
             loader.getCommonLibraryRefs().add("OpenJPALib");
-            loader.getCommonLibraryRefs().add("AnonymousJDBCLib");
             cel.add(loader);
-        } else {
+        } else if (AbstractFATSuite.repeatPhase != null && AbstractFATSuite.repeatPhase.contains("20") && DatabaseVendor.ORACLE.equals(getDbVendor())) {
+            /*
+             * TODO: OpenJPA 2.2.x (JPA 2.0) has hard dependencies on the Oracle JDBC driver classes and
+             * therefore requires the driver be added to the application classloader
+             *
+             * https://issues.apache.org/jira/projects/OPENJPA/issues/OPENJPA-2602
+             * https://issues.apache.org/jira/projects/OPENJPA/issues/OPENJPA-2690
+             */
+
             ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
             ClassloaderElement loader = new ClassloaderElement();
             loader.getCommonLibraryRefs().add("AnonymousJDBCLib");

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/entity/tests/Entity_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/entity/tests/Entity_Web.java
@@ -193,11 +193,18 @@ public class Entity_Web extends JPAFATServletClient {
             ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
             ClassloaderElement loader = new ClassloaderElement();
             loader.getCommonLibraryRefs().add("HibernateLib");
+            loader.getCommonLibraryRefs().add("AnonymousJDBCLib");
             cel.add(loader);
         } else if (AbstractFATSuite.repeatPhase != null && AbstractFATSuite.repeatPhase.contains("openjpa")) {
             ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
             ClassloaderElement loader = new ClassloaderElement();
             loader.getCommonLibraryRefs().add("OpenJPALib");
+            loader.getCommonLibraryRefs().add("AnonymousJDBCLib");
+            cel.add(loader);
+        } else {
+            ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
+            ClassloaderElement loader = new ClassloaderElement();
+            loader.getCommonLibraryRefs().add("AnonymousJDBCLib");
             cel.add(loader);
         }
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/entity/tests/Entity_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/entity/tests/Entity_Web.java
@@ -193,15 +193,21 @@ public class Entity_Web extends JPAFATServletClient {
             ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
             ClassloaderElement loader = new ClassloaderElement();
             loader.getCommonLibraryRefs().add("HibernateLib");
-            loader.getCommonLibraryRefs().add("AnonymousJDBCLib");
             cel.add(loader);
         } else if (AbstractFATSuite.repeatPhase != null && AbstractFATSuite.repeatPhase.contains("openjpa")) {
             ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
             ClassloaderElement loader = new ClassloaderElement();
             loader.getCommonLibraryRefs().add("OpenJPALib");
-            loader.getCommonLibraryRefs().add("AnonymousJDBCLib");
             cel.add(loader);
-        } else {
+        } else if (AbstractFATSuite.repeatPhase != null && AbstractFATSuite.repeatPhase.contains("20") && DatabaseVendor.ORACLE.equals(getDbVendor())) {
+            /*
+             * TODO: OpenJPA 2.2.x (JPA 2.0) has hard dependencies on the Oracle JDBC driver classes and
+             * therefore requires the driver be added to the application classloader
+             *
+             * https://issues.apache.org/jira/projects/OPENJPA/issues/OPENJPA-2602
+             * https://issues.apache.org/jira/projects/OPENJPA/issues/OPENJPA-2690
+             */
+
             ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
             ClassloaderElement loader = new ClassloaderElement();
             loader.getCommonLibraryRefs().add("AnonymousJDBCLib");


### PR DESCRIPTION
Looks like the bucket needs to be updated to include JDBC library in the application's classloader, in order for OpenJPA to find Oracle's Blob classes.