### PR TITLE
resource definitions in EJB deployment descriptor

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/resources/META-INF/ejb-jar.xml
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/resources/META-INF/ejb-jar.xml
@@ -13,11 +13,40 @@
          xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/ejb-jar_4_0.xsd">
-         <!-- 
+
   <enterprise-beans>
     <session>
       <ejb-name>ExecutorBean</ejb-name>
+
+ <!-- TODO enable once working
+      <context-service>
+        <name>java:global/concurrent/dd/ejb/LPContextService</name>
+	    <cleared>Application</cleared>
+	    <propagated>List</propagated>
+	    <propagated>Priority</propagated>
+	    <unchanged>ZipCode</unchanged>
+	    <unchanged>Remaining</unchanged>
+	  </context-service>
+
+	  <managed-executor>
+	    <name>java:comp/concurrent/dd/ejb/Executor</name>
+	    <max-async>2</max-async>
+	    <hung-task-threshold>620000</hung-task-threshold>
+	  </managed-executor>
+
+	  <managed-scheduled-executor>
+	    <name>java:app/concurrent/dd/ejb/LPScheduledExecutor</name>
+	    <context-service-ref>java:global/concurrent/dd/ejb/LPContextService</context-service-ref>
+	    <max-async>3</max-async>
+	  </managed-scheduled-executor>
+
+	  <managed-thread-factory>
+	    <name>java:module/concurrent/dd/ejb/ZLThreadFactory</name>
+	    <context-service-ref>java:module/concurrent/ZLContextSvc</context-service-ref>
+	    <priority>7</priority>
+	  </managed-thread-factory>
+-->
     </session>
   </enterprise-beans>
-   -->
+
 </ejb-jar>

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/src/test/jakarta/concurrency/ejb/ExecutorBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/src/test/jakarta/concurrency/ejb/ExecutorBean.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package test.jakarta.concurrency.ejb;
 
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.ALL_REMAINING;
 import static jakarta.enterprise.concurrent.ContextServiceDefinition.APPLICATION;
 
 import java.util.concurrent.Executor;
@@ -43,6 +44,20 @@ import test.context.timing.Timestamp;
 @ManagedThreadFactoryDefinition(name = "java:module/concurrent/tf",
                                 context = "java:app/concurrent/appContextSvc",
                                 priority = 6)
+// TODO delete the following and enable the equivalent in ejb-jar.xml
+@ContextServiceDefinition(name = "java:global/concurrent/dd/ejb/LPContextService",
+                          cleared = APPLICATION,
+                          propagated = { ListContext.CONTEXT_NAME, "Priority" },
+                          unchanged = { ZipCode.CONTEXT_NAME, ALL_REMAINING })
+@ManagedExecutorDefinition(name = "java:comp/concurrent/dd/ejb/Executor",
+                           hungTaskThreshold = 620000,
+                           maxAsync = 2)
+@ManagedScheduledExecutorDefinition(name = "java:app/concurrent/dd/ejb/LPScheduledExecutor",
+                                    context = "java:global/concurrent/dd/ejb/LPContextService",
+                                    maxAsync = 3)
+@ManagedThreadFactoryDefinition(name = "java:module/concurrent/dd/ejb/ZLThreadFactory",
+                                context = "java:module/concurrent/ZLContextSvc",
+                                priority = 7)
 @Stateless
 public class ExecutorBean implements Executor {
     @Resource(lookup = "java:comp/concurrent/executor8", name = "java:app/env/concurrent/executor8ref")


### PR DESCRIPTION
Tests (disabled for now) of the Concurrency resource definitions in an EJB deployment descriptor that we can switch on when ready.