### PR TITLE
Update Concurrecy TCK for JSP tests

### DIFF
--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncher.java
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncher.java
@@ -25,6 +25,7 @@ import com.ibm.websphere.simplicity.PortType;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
@@ -40,6 +41,7 @@ import componenttest.topology.utils.MvnUtils;
  * location.
  */
 @RunWith(FATRunner.class)
+@MinimumJavaLevel(javaLevel = 11)
 public class ConcurrentTckLauncher {
 
     final static Map<String, String> additionalProps = new HashMap<>();

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/servers/ConcurrentTCKServer/server.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/servers/ConcurrentTCKServer/server.xml
@@ -16,6 +16,8 @@
 		<feature>jdbc-4.2</feature>
 		<feature>enterpriseBeans-4.0</feature>
 		<feature>cdi-3.0</feature>
+		<feature>pages-3.0</feature>
+		<feature>appSecurity-4.0</feature>
 	    <!-- Supporting features -->
 	    <feature>jndi-1.0</feature> 
 	    <!-- Required by test infrastructure -->
@@ -59,6 +61,10 @@
 	<javaPermission codeBase="${shared.resource.dir}/derbyclient/derbyclient.jar" className="java.security.AllPermission"/>
 	<javaPermission codeBase="${shared.resource.dir}/derbyclient/derbynet.jar" className="java.security.AllPermission"/>
 	
+	<!-- Ensure JSP can handle lamdas -->
+	<jspEngine jdkSourceLevel="18"/>
+	
+	<!-- Security role(s) needed for TCK tests -->
 	<basicRegistry id="basic" realm="default">       
 	    <user name="javajoe" password="javajoe"/>
 	    <group name="Manager">

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/pom.xml
@@ -26,8 +26,8 @@
     <properties>
         <arquillian.version>1.3.0.Final</arquillian.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <modules>
@@ -54,8 +54,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>2.3.2</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <source>11</source>
+                        <target>11</target>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -28,8 +28,8 @@
         <testng.version>6.14.3</testng.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
 
         <!--  the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>
@@ -127,8 +127,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Allows the newest tests added to the TCK to run on Liberty.
See PR: https://github.com/eclipse-ee4j/concurrency-api/pull/168