### PR TITLE
Fix Feature Info Output

### DIFF
--- a/dev/com.ibm.ws.product.utility/src/com/ibm/ws/product/utility/extension/FeatureInfoCommandTask.java
+++ b/dev/com.ibm.ws.product.utility/src/com/ibm/ws/product/utility/extension/FeatureInfoCommandTask.java
@@ -78,6 +78,7 @@ public class FeatureInfoCommandTask extends BaseCommandTask {
                         int colonIndex = featureName.indexOf(":");
                         commandConsole.printInfoMessage(featureName.substring(colonIndex + 1));
                     }
+                    commandConsole.printlnInfoMessage("");
                 }
             }
         }


### PR DESCRIPTION
fixes #19831 

**Describe the bug**  
The output of `./wlp/bin/productInfo featureInfo` is missing some new line chars
```
acmeCA-2.0adminCenter-1.0appClientSupport-1.0appSecurity-1.0appSecurity-2.0appSecurity-3.0appSecurityClient-1.0audit-1.0batch-1.0batchManagement-1.0beanValidation-1.1beanValidation-2.0bells-1.0cdi-1.2cdi-2.0cloudant-1.0concurrent-1.0constra ...
```

**Steps to Reproduce**  
Run `./wlp/bin/productInfo featureInfo`

**Expected behavior** 
Output should be
```
acmeCA-2.0
adminCenter-1.0
appClientSupport-1.0
appSecurity-1.0
appSecurity-2.0
appSecurity-3.0
appSecurityClient-1.0
...
```

**Diagnostic information:**  
 - OpenLiberty Version: 22.0.0.1
 - Affected feature(s): productInfo command

**Additional context**  
The issue was caused by https://github.com/OpenLiberty/open-liberty/pull/19034
When the feature version was removed from the output, the new line was also removed by accident