### PR TITLE
Script for ws-schemagen.jar plus update help

### DIFF
--- a/dev/com.ibm.ws.config.schemagen.schemagen/bnd.bnd
+++ b/dev/com.ibm.ws.config.schemagen.schemagen/bnd.bnd
@@ -27,3 +27,5 @@ Command-Class: com.ibm.ws.config.schemagen.internal.Generator
 -outputmask: ws-schemagen.jar
 
 publish.tool.jar=ws-schemagen.jar
+publish.tool.script=schemaGen
+ 

--- a/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/Generator.java
+++ b/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/Generator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -45,7 +45,7 @@ public class Generator {
     public static final ResourceBundle messages = ResourceBundle.getBundle(XMLConfigConstants.NLS_PROPS);
     public static final ResourceBundle options = ResourceBundle.getBundle(XMLConfigConstants.NLS_OPTIONS);
 
-    private static final String JAR_NAME = "ws-schemagen.jar";
+    private static final String SCRIPT_NAME = "schemaGen";
 
     /**
      * Pick and use a consistent set of return codes across all
@@ -142,7 +142,7 @@ public class Generator {
                     break;
                 case HELP_ACTION:
                     // Only show command-line-style brief usage -help or --help invoked from command line
-                    System.out.println(MessageFormat.format(options.getString("briefUsage"), JAR_NAME));
+                    System.out.println(MessageFormat.format(options.getString("briefUsageScript"), SCRIPT_NAME));
                     System.out.println();
                     showUsageInfo();
 

--- a/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigOptions.nlsprops
+++ b/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigOptions.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010 IBM Corporation and others.
+# Copyright (c) 2010,2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,9 @@
 #------------------------------\n at 72 chars -- leading tab-----------\n\#
 briefUsage=\
 Usage: java [JVM options] -jar {0} [options] outputFile  
+briefUsageScript=\
+Usage: ./{0} [options] outputFile
+
 
 use.options=Options:
 # -------- OPTIONS ----------------------------------------------------#
@@ -37,3 +40,18 @@ The product extension name to be processed.                            \n\
 If the product extension is installed in the default user location,    \n\
 use the keyword: usr.                                                  \n\
 If this option is not specified, the action is taken on Liberty core.
+
+option-key.schemaVersion=--schemaVersion
+
+# "schemaVersion=1.1" is not translated.  "xsd:any" is not translated
+option-desc.schemaVersion=\
+If schemaVersion=1.1 is specified, then both explicitly named child \n\
+elements and the xsd:any element are written to the output file.
+
+option-key.outputVersion=--outputVersion
+
+# "outputVersion=2.0" is not translated.  "xsd:any" is not translated
+option-desc.outputVersion=\
+If outputVersion=2.0 is specified, only the xsd:any element is used \n\
+in the output file, so that unknown elements pass XSD validation at \n\
+the expense of losing validation for known elements.


### PR DESCRIPTION
Adds a schemaGen script in wlp/bin.    This is a front-end script for wlp/bin/tools/ws-schemagen.jar

Also updated the help so that it displays usage for the script, rather than help for running the jar directly. 

The bnd.bnd change causes the script to be generated.

The other 2 files are for the --help option.