### PR TITLE
enable development snapshot concurrency 3.0 TCK build

### DIFF
--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncher.java
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncher.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.PortType;
@@ -81,7 +82,7 @@ public class ConcurrentTckLauncher {
     /**
      * Run the TCK (controlled by autoFVT/publish/tckRunner/tck/*)
      */
-    //@Test //TODO Enable once TCK is published on maven central
+    @Test
     @AllowedFFDC // The tested exceptions cause FFDC so we have to allow for this.
     public void launchConcurrentTCK() throws Exception {
         String suiteXmlFile;

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -20,7 +20,7 @@
         <jakarta.concurrent.version>3.0.0</jakarta.concurrent.version>
         
         <!-- TODO: Update this once TCK is GAed -->
-        <jakarta.concurrent.tck.version>3.0.0-RC1</jakarta.concurrent.tck.version>
+        <jakarta.concurrent.tck.version>3.0.0.20220118</jakarta.concurrent.tck.version>
         
         <arquillian.version>1.6.0.Final</arquillian.version>
         <arquillian-wlp.version>2.0.2</arquillian-wlp.version>
@@ -36,6 +36,22 @@
         
         <targetDirectory>${project.basedir}/target</targetDirectory>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>ibmdhe</id>
+            <name>IBM_DHE File Server</name>
+            <url>http://public.dhe.ibm.com/ibmdl/export/pub/software/olrepo</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
+        </repository>
+    </repositories>
 
     <dependencyManagement>
         <dependencies>
@@ -60,7 +76,8 @@
         </dependency>
         <!-- TCK Dependency -->
         <dependency>
-		    <groupId>jakarta.enterprise.concurrent</groupId>
+            <!-- TODO: Update this once TCK is available on maven -->
+		    <groupId>io.openliberty.jakarta.enterprise.concurrent</groupId>
 		    <artifactId>jakarta.enterprise.concurrent-tck</artifactId>
 		    <version>${jakarta.concurrent.tck.version}</version>
         </dependency>


### PR DESCRIPTION
Enable the Concurrency 3.0 TCK, running against a development snapshot build of the Concurrency 3.0 TCK as of 2022-01-18.