### PR TITLE
add null check for security role user's and group's name

### DIFF
--- a/dev/com.ibm.ws.security.appbnd/src/com/ibm/ws/security/appbnd/internal/authorization/AppBndAuthorizationTableService.java
+++ b/dev/com.ibm.ws.security.appbnd/src/com/ibm/ws/security/appbnd/internal/authorization/AppBndAuthorizationTableService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 IBM Corporation and others.
+ * Copyright (c) 2011, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -444,7 +444,9 @@ public class AppBndAuthorizationTableService extends BaseAuthorizationTableServi
                         }
                     } else if (!AccessIdUtil.isUserAccessId(accessIdFromRole)) {
                         accessIdFromRole = getCompleteAccessId(accessId, accessIdFromRole, AccessIdUtil.TYPE_USER, realmName);
-                        maps.userToAccessIdMap.put(userNameFromRole, accessIdFromRole);
+                        if (userNameFromRole != null) {
+                            maps.userToAccessIdMap.put(userNameFromRole, accessIdFromRole);
+                        }
                     }
 
                     if (isMatch(accessId, accessIdFromRole)) {
@@ -464,7 +466,9 @@ public class AppBndAuthorizationTableService extends BaseAuthorizationTableServi
                         }
                     } else if (!AccessIdUtil.isGroupAccessId(accessIdFromRole)) {
                         accessIdFromRole = getCompleteAccessId(accessId, accessIdFromRole, AccessIdUtil.TYPE_GROUP, realmName);
-                        maps.groupToAccessIdMap.put(groupNameFromRole, accessIdFromRole);
+                        if (groupNameFromRole != null) {
+                            maps.groupToAccessIdMap.put(groupNameFromRole, accessIdFromRole);
+                        }
                     }
 
                     if (isMatch(accessId, accessIdFromRole)) {


### PR DESCRIPTION
for #18858 

if the access-id in the user/group element does not match the user/group access id pattern, it is inserted into the userToAccessIdMap using the name of the user/group element as the key. if the name is not defined when trying to use it as a key for the map, an NPE occurs.