### PR TITLE
ContextServiceDefinition used from different EJB

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/src/test/jakarta/concurrency/ejb/ContextServiceDefinerBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/src/test/jakarta/concurrency/ejb/ContextServiceDefinerBean.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.concurrency.ejb;
+
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.APPLICATION;
+
+import jakarta.ejb.EJBException;
+import jakarta.ejb.Stateless;
+import jakarta.enterprise.concurrent.ContextService;
+import jakarta.enterprise.concurrent.ContextServiceDefinition;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import com.ibm.websphere.simplicity.config.ManagedExecutorService;
+
+import test.context.list.ListContext;
+import test.context.location.ZipCode;
+import test.context.timing.Timestamp;
+
+// Use the same name as a context service in ConcurrencyTestServlet,
+// which must be permitted because it is scoped to a different module.
+@ContextServiceDefinition(name = "java:module/concurrent/ZLContextSvc",
+                          propagated = { ZipCode.CONTEXT_NAME, ListContext.CONTEXT_NAME, APPLICATION },
+                          cleared = Timestamp.CONTEXT_NAME,
+                          unchanged = "Priority")
+@Stateless
+public class ContextServiceDefinerBean {
+    public ContextService lookup() {
+        try {
+            return InitialContext.doLookup("java:module/concurrent/ZLContextSvc");
+        } catch (NamingException x) {
+            throw new EJBException(x);
+        }
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/src/test/jakarta/concurrency/ejb/ExecutorBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/src/test/jakarta/concurrency/ejb/ExecutorBean.java
@@ -25,14 +25,7 @@ import jakarta.enterprise.concurrent.ManagedThreadFactoryDefinition;
 
 import test.context.list.ListContext;
 import test.context.location.ZipCode;
-import test.context.timing.Timestamp;
 
-// Use the same name as a context service in ConcurrencyTestServlet,
-// which must be permitted because it is scoped to a different module.
-@ContextServiceDefinition(name = "java:module/concurrent/ZLContextSvc",
-                          propagated = { ZipCode.CONTEXT_NAME, ListContext.CONTEXT_NAME, APPLICATION },
-                          cleared = Timestamp.CONTEXT_NAME,
-                          unchanged = "Priority")
 @ManagedExecutorDefinition(name = "java:comp/concurrent/executor8",
                            context = "java:app/concurrent/appContextSvc",
                            hungTaskThreshold = 480000,

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/ConcurrencyTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/ConcurrencyTestServlet.java
@@ -165,6 +165,14 @@ public class ConcurrencyTestServlet extends FATServlet {
     @Override
     public void init(ServletConfig config) throws ServletException {
         unmanagedThreads = Executors.newFixedThreadPool(5);
+
+        // This EJB needs to first be used so that its ContextServiceDefinition,
+        // which is relied upon by the other EJB, can be processed
+        try {
+            InitialContext.doLookup("java:global/ConcurrencyTestApp/ConcurrencyTestEJB/ContextServiceDefinerBean!test.jakarta.concurrency.ejb.ContextServiceDefinerBean");
+        } catch (NamingException x) {
+            throw new ServletException(x);
+        }
     }
 
     /**


### PR DESCRIPTION
Verify that a resource definition in one EJB can use a java:module resource definition from another EJB when both are in the same EJB module.