### PR TITLE
Fix RepositoryResolver install lists for tolerated dependencies

### DIFF
--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/ProductRequirementInformation.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/ProductRequirementInformation.java
@@ -41,6 +41,12 @@ public class ProductRequirementInformation {
 
     /**
      * Construct an instance of this class supplying the relevant information.
+     *
+     * @param versionRange the version range for this product requirement using the versioning rules of Liberty product versions
+     * @param productId the ID of the product
+     * @param installType the install type of the product, or {@code null}
+     * @param licenseType the license type of the product, or {@code null}
+     * @param editions the editions for the product (may be empty but not {@code null})
      */
     public ProductRequirementInformation(String versionRange, String productId, String installType, String licenseType, List<String> editions) {
         super();

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolutionException.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolutionException.java
@@ -43,8 +43,9 @@ public class RepositoryResolutionException extends RepositoryException {
      * @param cause
      * @param topLevelFeaturesNotResolved
      * @param allRequirementsNotFound
-     * @param missingProductInformation        all the product information requirements that could not be found. Can be empty but must not be <code>null</code>
+     * @param missingProductInformation all the product information requirements that could not be found. Can be empty but must not be <code>null</code>
      * @param allRequirementsResourcesNotFound The {@link MissingRequirement} objects that were not found. Must not be <code>null</code>.
+     * @param featureConflicts the details of any feature conflicts which occurred during feature resolution, as returned from {@link Result#getConflicts()}
      */
     public RepositoryResolutionException(ResolutionException cause, Collection<String> topLevelFeaturesNotResolved, Collection<String> allRequirementsNotFound,
                                          Collection<ProductRequirementInformation> missingProductInformation, Collection<MissingRequirement> allRequirementsResourcesNotFound,
@@ -60,7 +61,7 @@ public class RepositoryResolutionException extends RepositoryException {
     /**
      * Returns a collection of top level feature names that were not resolved.
      *
-     * @return
+     * @return the feature names which were not resolved
      */
     public Collection<String> getTopLevelFeaturesNotResolved() {
         return topLevelFeaturesNotResolved;
@@ -69,7 +70,7 @@ public class RepositoryResolutionException extends RepositoryException {
     /**
      * Returns a collection of requirements that were not found during the resolution process.
      *
-     * @return
+     * @return the requirements which were not found
      * @deprecated use {@link #getAllRequirementsResourcesNotFound()} instead as this includes information about the resource that is held the requirement
      */
     @Deprecated
@@ -103,9 +104,9 @@ public class RepositoryResolutionException extends RepositoryException {
      * on a {@link ProductRequirementInformation} is not in the form digit.digit.digit.digit then it will be ignored.
      *
      * @param productId The product ID to find the minimum missing version for or <code>null</code> to match to all products
-     * @param version   The version to find the minimum missing version for by matching the first three parts so if you supply "9.0.0.0" and this item applies to version "8.5.5.3"
-     *                      and "9.0.0.1" then "9.0.0.1" will be returned. Supply <code>null</code> to match all versions
-     * @param edition   The edition to find the minimum missing version for or <code>null</code> to match to all products
+     * @param version The version to find the minimum missing version for by matching the first three parts so if you supply "9.0.0.0" and this item applies to version "8.5.5.3"
+     *            and "9.0.0.1" then "9.0.0.1" will be returned. Supply <code>null</code> to match all versions
+     * @param edition The edition to find the minimum missing version for or <code>null</code> to match to all products
      * @return The minimum missing version or <code>null</code> if there were no relevant matches
      */
     public String getMinimumVersionForMissingProduct(String productId, String version, String edition) {
@@ -149,9 +150,9 @@ public class RepositoryResolutionException extends RepositoryException {
      * This method will iterate through the missingProductInformation and returned a filtered collection of all the {@link ProductRequirementInformation#versionRange}s.
      *
      * @param productId The product ID to find the version for or <code>null</code> to match to all products
-     * @param edition   The edition to find the version for or <code>null</code> to match to all editions
+     * @param edition The edition to find the version for or <code>null</code> to match to all editions
      *
-     * @return
+     * @return the version ranges which apply to the given product ID and edition
      */
     private Collection<LibertyVersionRange> filterVersionRanges(String productId, String edition) {
         Collection<LibertyVersionRange> filteredRanges = new HashSet<LibertyVersionRange>();
@@ -182,9 +183,9 @@ public class RepositoryResolutionException extends RepositoryException {
      * indicate a fairly odd repository setup.</p>
      *
      * @param productId The product ID to find the maximum missing version for or <code>null</code> to match to all products
-     * @param version   The version to find the maximum missing version for by matching the first three parts so if you supply "8.5.5.2" and this item applies to version "8.5.5.3"
-     *                      and "9.0.0.1" then "8.5.5.3" will be returned. Supply <code>null</code> to match all versions
-     * @param edition   The edition to find the maximum missing version for or <code>null</code> to match to all products
+     * @param version The version to find the maximum missing version for by matching the first three parts so if you supply "8.5.5.2" and this item applies to version "8.5.5.3"
+     *            and "9.0.0.1" then "8.5.5.3" will be returned. Supply <code>null</code> to match all versions
+     * @param edition The edition to find the maximum missing version for or <code>null</code> to match to all products
      * @return The maximum missing version or <code>null</code> if there were no relevant matches or the maximum version is unbounded
      */
     public String getMaximumVersionForMissingProduct(String productId, String version, String edition) {

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
@@ -583,7 +583,14 @@ public class RepositoryResolver {
      * @return the ordered list of resources to install, will be empty if the feature cannot be found or is already installed
      */
     List<RepositoryResource> createInstallList(String featureName) {
+        // Find the feature by name (featureName may be the short or the symbolic name, so we need to use resolverRepository)
         ProvisioningFeatureDefinition feature = resolverRepository.getFeature(featureName);
+        
+        // Check that the requested feature was actually resolved
+        if (feature != null) {
+            feature = resolvedFeatures.get(feature.getSymbolicName());
+        }
+        
         if (feature == null) {
             // Feature missing
             missingTopLevelRequirements.add(featureName);

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
@@ -741,16 +741,19 @@ public class RepositoryResolver {
         }
 
         String baseName = getFeatureBaseName(featureResource.getSymbolicName());
-        for (String toleratedVersion : featureResource.getTolerates()) {
-            String featureName = baseName + toleratedVersion;
+        List<String> tolerates = featureResource.getTolerates();
+        if (tolerates != null) {
+            for (String toleratedVersion : tolerates) {
+                String featureName = baseName + toleratedVersion;
 
-            feature = resolvedFeatures.get(featureName);
-            if (feature != null) {
-                return new ResolvedFeatureSearchResult(ResultCategory.FOUND, feature.getSymbolicName());
-            }
+                feature = resolvedFeatures.get(featureName);
+                if (feature != null) {
+                    return new ResolvedFeatureSearchResult(ResultCategory.FOUND, feature.getSymbolicName());
+                }
 
-            if (requirementsFoundForOtherProducts.contains(featureName)) {
-                return new ResolvedFeatureSearchResult(ResultCategory.FOUND_WRONG_PRODUCT, featureName);
+                if (requirementsFoundForOtherProducts.contains(featureName)) {
+                    return new ResolvedFeatureSearchResult(ResultCategory.FOUND_WRONG_PRODUCT, featureName);
+                }
             }
         }
 

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/LibertyVersion.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/LibertyVersion.java
@@ -15,23 +15,25 @@ import java.util.regex.Pattern;
 
 /**
  * <p>This stores a liberty product version, this looks very similar to an OSGi version but don't be fooled! It is actually of the form:</p>
- * 
+ *
  * <code>d.d.d.d</code>
- * 
+ *
  * <p>Where "d" is an integer digit. OSGi versions are of the form:</p>
- * 
+ *
  * <code>d.d.d.s</code>
- * 
+ *
  * <p>where "s" is a string. This means that 8.5.5.10 is higher than 8.5.5.2 in Liberty but lower in OSGi.</p>
- * 
+ *
  * <p>To follow OSGi's definition:</p>
- * 
- * <pre>version ::=
+ *
+ * <pre>
+ * version ::=
  * major'.'minor'.'micro'.'qualifier
  * major ::= number // See 1.3.2
  * minor ::= number
  * micro ::= number
- * qualifier ::= number</pre>
+ * qualifier ::= number
+ * </pre>
  */
 public class LibertyVersion implements Comparable<LibertyVersion> {
 
@@ -43,7 +45,7 @@ public class LibertyVersion implements Comparable<LibertyVersion> {
 
     /**
      * Parses the supplied string into a LibertyVersion. Will return <code>null</code> if the string is not a valid version string.
-     * 
+     *
      * @param versionString The string to parse
      * @return The version
      */
@@ -56,7 +58,8 @@ public class LibertyVersion implements Comparable<LibertyVersion> {
         if (!versionMatcher.matches()) {
             return null;
         }
-        return new LibertyVersion(Integer.parseInt(versionMatcher.group(1)), Integer.parseInt(versionMatcher.group(2)), Integer.parseInt(versionMatcher.group(3)), Integer.parseInt(versionMatcher.group(4)));
+        return new LibertyVersion(Integer.parseInt(versionMatcher.group(1)), Integer.parseInt(versionMatcher.group(2)), Integer.parseInt(versionMatcher.group(3)),
+                                  Integer.parseInt(versionMatcher.group(4)));
     }
 
     /**
@@ -75,9 +78,9 @@ public class LibertyVersion implements Comparable<LibertyVersion> {
 
     /**
      * Matches the major, minor and micro parts of this version to the other version
-     * 
+     *
      * @param other The other version, can be <code>null</code> in which case this returns true.
-     * @return
+     * @return {@code true} if the major, minor and micro parts of the versions are equal, otherwise {@code false}
      */
     public boolean matchesToMicros(LibertyVersion other) {
         if (other == null) {

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/CapabilityMatching.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/CapabilityMatching.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.repository.resolver.internal.kernel;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.aries.util.manifest.ManifestHeaderProcessor;
+import org.apache.aries.util.manifest.ManifestHeaderProcessor.GenericMetadata;
+import org.osgi.framework.Filter;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.namespace.IdentityNamespace;
+import org.osgi.service.subsystem.SubsystemConstants;
+
+import com.ibm.ws.kernel.feature.provisioning.ProvisioningFeatureDefinition;
+
+/**
+ * Static methods for evaluating and matching the IBM-Provision-Capability header on features
+ */
+public class CapabilityMatching {
+
+    /**
+     * Find which of the passed features are used to satisfy the ProvisionCapability of a feature.
+     * <p>
+     * The returned list will be a subset of {@code features}
+     * <p>
+     * If the feature has no ProvisionCapability requirements, then an empty list will be returned.
+     *
+     * @param feature the feature with the ProvisionCapability header
+     * @param features the features which are available be used to satisfy the ProvisionCapabiliy requirements
+     * @return a list of features which were actually used to satisfy the ProvisionCapability requirements
+     */
+    public static List<ProvisioningFeatureDefinition> findFeaturesSatisfyingCapability(ProvisioningFeatureDefinition feature,
+                                                                                       Collection<? extends ProvisioningFeatureDefinition> features) {
+        String capabilityString;
+        if (feature instanceof KernelResolverEsa) {
+            capabilityString = ((KernelResolverEsa) feature).getResource().getProvisionCapability();
+        } else {
+            capabilityString = feature.getHeader("IBM-Provision-Capability");
+        }
+
+        return matchCapability(capabilityString, features).getFeatures();
+    }
+
+    /**
+     * Attempt to match ProvisionCapability requirements against a list of features
+     *
+     * @param capabilityString the ProvisionCapability requirements
+     * @param features the list of features to match against
+     * @return a {@link CapabilityMatchingResult} specifying whether all requirements were satisfied and which features were used to satisfy them
+     */
+    public static CapabilityMatchingResult matchCapability(String capabilityString, Collection<? extends ProvisioningFeatureDefinition> features) {
+
+        if (capabilityString == null) {
+            CapabilityMatchingResult result = new CapabilityMatchingResult();
+            result.capabilitySatisfied = true;
+            result.features = Collections.emptyList();
+            return result;
+        }
+
+        CapabilityMatchingResult result = new CapabilityMatchingResult();
+        result.capabilitySatisfied = true;
+        result.features = new ArrayList<>();
+
+        List<FeatureCapabilityInfo> capabilityMaps = createCapabilityMaps(features);
+        for (Filter filter : createFilterList(capabilityString)) {
+            boolean matched = false;
+            for (FeatureCapabilityInfo capabilityInfo : capabilityMaps) {
+                if (filter.matches(capabilityInfo.capabilities)) {
+                    matched = true;
+                    result.getFeatures().add(capabilityInfo.feature);
+                    break;
+                }
+            }
+
+            // If any of the filters in the provision capability header don't match, we're not satisfied
+            if (!matched) {
+                result.capabilitySatisfied = false;
+            }
+        }
+
+        return result;
+    }
+
+    private static List<FeatureCapabilityInfo> createCapabilityMaps(Collection<? extends ProvisioningFeatureDefinition> features) {
+        List<FeatureCapabilityInfo> result = new ArrayList<>();
+
+        for (ProvisioningFeatureDefinition feature : features) {
+            FeatureCapabilityInfo capabilityInfo = new FeatureCapabilityInfo();
+            capabilityInfo.feature = feature;
+            capabilityInfo.capabilities = new HashMap<>();
+            capabilityInfo.capabilities.put(IdentityNamespace.IDENTITY_NAMESPACE, feature.getSymbolicName());
+            capabilityInfo.capabilities.put(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE, SubsystemConstants.SUBSYSTEM_TYPE_FEATURE);
+            result.add(capabilityInfo);
+        }
+
+        return result;
+    }
+
+    private static List<Filter> createFilterList(String capabilityHeader) {
+        List<GenericMetadata> metadatas = ManifestHeaderProcessor.parseCapabilityString(capabilityHeader);
+        List<Filter> result = new ArrayList<>();
+
+        for (GenericMetadata metadata : metadatas) {
+            String filterString = metadata.getDirectives().get(IdentityNamespace.REQUIREMENT_FILTER_DIRECTIVE);
+            if (IdentityNamespace.IDENTITY_NAMESPACE.equals(metadata.getNamespace()) && filterString != null) {
+                try {
+                    result.add(FrameworkUtil.createFilter(filterString));
+                } catch (InvalidSyntaxException e) {
+                    throw new IllegalArgumentException("invalid provisionCapabiliy requirement: " + filterString, e);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    public static class CapabilityMatchingResult {
+        private List<ProvisioningFeatureDefinition> features;
+        private boolean capabilitySatisfied;
+
+        /**
+         * @return whether the provision capability string was satisfied by the supplied features
+         */
+        public boolean isCapabilitySatisfied() {
+            return capabilitySatisfied;
+        }
+
+        /**
+         * @return the features used to satisfy the capability string
+         */
+        public List<ProvisioningFeatureDefinition> getFeatures() {
+            return features;
+        }
+    }
+
+    private static class FeatureCapabilityInfo {
+        ProvisioningFeatureDefinition feature;
+        Map<String, String> capabilities;
+    }
+}

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverEsa.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverEsa.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,20 +15,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.aries.util.manifest.ManifestHeaderProcessor;
-import org.apache.aries.util.manifest.ManifestHeaderProcessor.GenericMetadata;
-import org.osgi.framework.Filter;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.Version;
-import org.osgi.framework.namespace.IdentityNamespace;
-import org.osgi.service.subsystem.SubsystemConstants;
 
 import com.ibm.ws.kernel.feature.AppForceRestart;
 import com.ibm.ws.kernel.feature.ProcessType;
@@ -47,16 +38,6 @@ import com.ibm.ws.repository.resources.EsaResource;
  * Wraps an {@link EsaResource} and implements {@link ProvisioningFeatureDefinition} to allow a repository feature to be resolved using the kernel resolver
  */
 public class KernelResolverEsa implements ProvisioningFeatureDefinition {
-
-    public static class CapabilityMatchingResult {
-        List<ProvisioningFeatureDefinition> features;
-        boolean capabilitySatisfied;
-    }
-
-    public static class FeatureCapabilityInfo {
-        ProvisioningFeatureDefinition feature;
-        Map<String, String> capabilities;
-    }
 
     private final EsaResource esaResource;
     private final ResolutionMode resolutionMode;
@@ -165,7 +146,7 @@ public class KernelResolverEsa implements ProvisioningFeatureDefinition {
 
     @Override
     public boolean isCapabilitySatisfied(Collection<ProvisioningFeatureDefinition> features) {
-        return matchCapability(features).capabilitySatisfied;
+        return CapabilityMatching.matchCapability(esaResource.getProvisionCapability(), features).isCapabilitySatisfied();
     }
 
     @Override
@@ -175,93 +156,6 @@ public class KernelResolverEsa implements ProvisioningFeatureDefinition {
         } catch (IllegalArgumentException ex) {
             return Version.emptyVersion;
         }
-    }
-
-    /**
-     * Find which of the passed features are used to satisfy the ProvisionCapability of this feature.
-     * <p>
-     * The returned list will be a subset of {@code features}
-     * <p>
-     * If this feature has no ProvisionCapability requirements, then an empty list will be returned.
-     *
-     * @param features the features which are available be used to satisfy the ProvisionCapabiliy requirements
-     * @return a list of features which were actually used to satisfy the ProvisionCapability requirements
-     */
-    public List<ProvisioningFeatureDefinition> findFeaturesSatisfyingCapability(Collection<? extends ProvisioningFeatureDefinition> features) {
-        return matchCapability(features).features;
-    }
-
-    /**
-     * Attempt to match the ProvisionCapability requirements against the given list of features
-     *
-     * @param features the list of features to match against
-     * @return a {@link CapabilityMatchingResult} specifying whether all requirements were satisfied and which features were used to satisfy them
-     */
-    private CapabilityMatchingResult matchCapability(Collection<? extends ProvisioningFeatureDefinition> features) {
-
-        String capabilityString = esaResource.getProvisionCapability();
-        if (capabilityString == null) {
-            CapabilityMatchingResult result = new CapabilityMatchingResult();
-            result.capabilitySatisfied = true;
-            result.features = Collections.emptyList();
-            return result;
-        }
-
-        CapabilityMatchingResult result = new CapabilityMatchingResult();
-        result.capabilitySatisfied = true;
-        result.features = new ArrayList<>();
-
-        List<FeatureCapabilityInfo> capabilityMaps = createCapabilityMaps(features);
-        for (Filter filter : createFilterList()) {
-            boolean matched = false;
-            for (FeatureCapabilityInfo capabilityInfo : capabilityMaps) {
-                if (filter.matches(capabilityInfo.capabilities)) {
-                    matched = true;
-                    result.features.add(capabilityInfo.feature);
-                    break;
-                }
-            }
-
-            // If any of the filters in the provision capability header don't match, we're not satisfied
-            if (!matched) {
-                result.capabilitySatisfied = false;
-            }
-        }
-
-        return result;
-    }
-
-    private List<FeatureCapabilityInfo> createCapabilityMaps(Collection<? extends ProvisioningFeatureDefinition> features) {
-        List<FeatureCapabilityInfo> result = new ArrayList<>();
-
-        for (ProvisioningFeatureDefinition feature : features) {
-            FeatureCapabilityInfo capabilityInfo = new FeatureCapabilityInfo();
-            capabilityInfo.feature = feature;
-            capabilityInfo.capabilities = new HashMap<>();
-            capabilityInfo.capabilities.put(IdentityNamespace.IDENTITY_NAMESPACE, feature.getSymbolicName());
-            capabilityInfo.capabilities.put(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE, SubsystemConstants.SUBSYSTEM_TYPE_FEATURE);
-            result.add(capabilityInfo);
-        }
-
-        return result;
-    }
-
-    private List<Filter> createFilterList() {
-        List<GenericMetadata> metadatas = ManifestHeaderProcessor.parseCapabilityString(esaResource.getProvisionCapability());
-        List<Filter> result = new ArrayList<>();
-
-        for (GenericMetadata metadata : metadatas) {
-            String filterString = metadata.getDirectives().get(IdentityNamespace.REQUIREMENT_FILTER_DIRECTIVE);
-            if (IdentityNamespace.IDENTITY_NAMESPACE.equals(metadata.getNamespace()) && filterString != null) {
-                try {
-                    result.add(FrameworkUtil.createFilter(filterString));
-                } catch (InvalidSyntaxException e) {
-                    throw new IllegalArgumentException("Esa " + esaResource.getProvideFeature() + " contains invalid provisionCapabiliy requirement: " + filterString, e);
-                }
-            }
-        }
-
-        return result;
     }
 
     @Override

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepository.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepository.java
@@ -132,7 +132,7 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
      * Checks whether {@code featureList} contains a feature with the same name and version as {@code feature}.
      *
      * @param featureList the list of features
-     * @param feature     the feature
+     * @param feature the feature
      * @return {@code true} if {@code featureList} contains a feature with the same symbolic name and version as {@code feature}, otherwise {@code false}
      */
     private boolean listContainsDuplicate(List<ProvisioningFeatureDefinition> featureList, ProvisioningFeatureDefinition feature) {
@@ -189,6 +189,8 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
      * Get a feature by name, but without going and checking the remote repository if we don't know about it
      *
      * @see #getFeature(String)
+     * @param featureName the feature name
+     * @return the feature with the given name, or {@code null} if we don't know about it
      */
     private ProvisioningFeatureDefinition getCachedFeature(String featureName) {
         List<ProvisioningFeatureDefinition> featureList = symbolicNameToFeature.get(featureName);
@@ -319,7 +321,7 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
      * When a preferred version is set, {@link #getFeature(String)} will return the preferred version if available, unless another version is already installed.
      *
      * @param featureName the short or symbolic feature name
-     * @param version     the version
+     * @param version the version
      */
     public void setPreferredVersion(String featureName, String version) {
         if (!symbolicNameToFeature.containsKey(featureName)) {
@@ -351,7 +353,7 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
      * If no preferred version has been configured for this symbolic name, or if the preferred version cannot be found in the list, return the latest version.
      *
      * @param symbolicName the symbolic name of the feature
-     * @param featureList  the list of features, which should all have the same symbolic name
+     * @param featureList the list of features, which should all have the same symbolic name
      * @return the best feature from the list
      */
     private ProvisioningFeatureDefinition getPreferredVersion(String symbolicName, List<ProvisioningFeatureDefinition> featureList) {

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRequirement.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRequirement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,7 +34,11 @@ public class KernelResolverRequirement implements FeatureResource {
 
     public KernelResolverRequirement(String symbolicName, Collection<String> tolerates) {
         this.symbolicName = symbolicName;
-        this.tolerates = Collections.unmodifiableList(new ArrayList<>(tolerates));
+        if (tolerates.isEmpty()) {
+            this.tolerates = null;
+        } else {
+            this.tolerates = Collections.unmodifiableList(new ArrayList<>(tolerates));
+        }
     }
 
     @Override

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/MissingRequirementMatcher.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/MissingRequirementMatcher.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.repository.resolver;
+
+import java.util.Objects;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+import com.ibm.ws.repository.resolver.RepositoryResolutionException.MissingRequirement;
+import com.ibm.ws.repository.resources.RepositoryResource;
+
+/**
+ * Verify a {@link MissingRequirement}
+ */
+public class MissingRequirementMatcher extends TypeSafeMatcher<MissingRequirement> {
+
+    private final String requirementName;
+
+    private final RepositoryResource owningResource;
+
+    public static MissingRequirementMatcher missingRequirement(String requirementName, RepositoryResource owningResource) {
+        return new MissingRequirementMatcher(requirementName, owningResource);
+    }
+
+    private MissingRequirementMatcher(String requirementName, RepositoryResource owningResource) {
+        this.requirementName = requirementName;
+        this.owningResource = owningResource;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void describeTo(Description desc) {
+        desc.appendText("MissingRequirement [");
+        desc.appendText("name = ").appendValue(requirementName);
+        desc.appendText(", ");
+        desc.appendText("owning resource = ").appendValue(owningResource);
+        desc.appendText("]");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void describeMismatchSafely(MissingRequirement item, Description desc) {
+        desc.appendText("MissingRequirement [");
+        desc.appendText("name = ").appendValue(item.getRequirementName());
+        desc.appendText(", ");
+        desc.appendText("owning resource = ").appendValue(item.getOwningResource());
+        desc.appendText("]");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected boolean matchesSafely(MissingRequirement other) {
+        return Objects.equals(requirementName, other.getRequirementName())
+               && Objects.equals(owningResource, other.getOwningResource());
+    }
+
+}

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/MockFeature.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/MockFeature.java
@@ -1,0 +1,200 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.repository.resolver;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+
+import org.osgi.framework.Version;
+
+import com.ibm.ws.kernel.feature.AppForceRestart;
+import com.ibm.ws.kernel.feature.ProcessType;
+import com.ibm.ws.kernel.feature.Visibility;
+import com.ibm.ws.kernel.feature.provisioning.FeatureResource;
+import com.ibm.ws.kernel.feature.provisioning.HeaderElementDefinition;
+import com.ibm.ws.kernel.feature.provisioning.ProvisioningFeatureDefinition;
+import com.ibm.ws.kernel.feature.provisioning.SubsystemContentType;
+import com.ibm.ws.repository.resolver.internal.kernel.CapabilityMatching;
+import com.ibm.ws.repository.resolver.internal.kernel.KernelResolverRequirement;
+
+/**
+ *
+ */
+public class MockFeature implements ProvisioningFeatureDefinition {
+
+    private final String symbolicName;
+    private Visibility visibility = Visibility.PRIVATE;
+    private final List<FeatureResource> featureDependencies = new ArrayList<>();
+    private String provisionCapability;
+
+    public MockFeature(String symbolicName) {
+        this.symbolicName = symbolicName;
+    }
+
+    /**
+     * @param visibility the visibility to set
+     */
+    public void setVisibility(Visibility visibility) {
+        this.visibility = visibility;
+    }
+
+    /**
+     * Add a dependency on another feature
+     *
+     * @param symbolicName the symbolic name of the dependency
+     * @param tolerates the tolerated versions of the dependency
+     */
+    public void addDependency(String symbolicName, String... tolerates) {
+        featureDependencies.add(new KernelResolverRequirement(symbolicName, Arrays.asList(tolerates)));
+    }
+
+    public void setProvisionCapability(String provisionCapability) {
+        this.provisionCapability = provisionCapability;
+    }
+
+    @Override
+    public String getSymbolicName() {
+        return symbolicName;
+    }
+
+    @Override
+    public String getFeatureName() {
+        return symbolicName;
+    }
+
+    @Override
+    public Visibility getVisibility() {
+        return visibility;
+    }
+
+    @Override
+    public Collection<FeatureResource> getConstituents(SubsystemContentType type) {
+        if (type != SubsystemContentType.FEATURE_TYPE) {
+            return Collections.emptySet();
+        }
+        return featureDependencies;
+    }
+
+    @Override
+    public Version getVersion() {
+        return Version.emptyVersion;
+    }
+
+    @Override
+    public EnumSet<ProcessType> getProcessTypes() {
+        return EnumSet.of(ProcessType.SERVER);
+    }
+
+    @Override
+    public boolean isKernel() {
+        return false;
+    }
+
+    @Override
+    public String getBundleRepositoryType() {
+        return "";
+    }
+
+    @Override
+    public String getIbmShortName() {
+        return null;
+    }
+
+    @Override
+    public boolean isCapabilitySatisfied(Collection<ProvisioningFeatureDefinition> featureDefinitionsToCheck) {
+        return CapabilityMatching.matchCapability(provisionCapability, featureDefinitionsToCheck).isCapabilitySatisfied();
+    }
+
+    @Override
+    public boolean isAutoFeature() {
+        return provisionCapability != null;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+
+    @Override
+    public String getApiServices() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AppForceRestart getAppForceRestart() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public File getFeatureChecksumFile() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public File getFeatureDefinitionFile() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getHeader(String arg0, Locale arg1) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getHeader(String header) {
+        if ("IBM-Provision-Capability".equals(header)) {
+            return provisionCapability;
+        }
+        return null;
+    }
+
+    @Override
+    public Collection<HeaderElementDefinition> getHeaderElements(String arg0) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getIbmFeatureVersion() {
+        return 0;
+    }
+
+    @Override
+    public Collection<String> getIcons() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection<File> getLocalizationFiles() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getSupersededBy() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSuperseded() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSupportedFeatureVersion() {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/ResolutionTests.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/ResolutionTests.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -56,19 +55,14 @@ import com.ibm.ws.repository.resources.IfixResource;
 import com.ibm.ws.repository.resources.RepositoryResource;
 import com.ibm.ws.repository.resources.SampleResource;
 import com.ibm.ws.repository.resources.writeable.EsaResourceWritable;
-import com.ibm.ws.repository.resources.writeable.IfixResourceWritable;
 import com.ibm.ws.repository.resources.writeable.SampleResourceWritable;
 import com.ibm.ws.repository.resources.writeable.WritableResourceFactory;
 
 /**
  * Tests for {@link RepositoryResolver}
  */
+@SuppressWarnings("deprecation")
 public class ResolutionTests {
-
-    /**
-     * Used to autogenerate unique names
-     */
-    private int _count = 0;
 
     /**
      * Features which should be returned from the repository for the test. Tests should modify the list before calling {@link #createConnectionList()}.
@@ -1925,6 +1919,7 @@ public class ResolutionTests {
      * Actual: Feature X, Feature Y, Feature I1.0
      * This test case works as expected.
      */
+    @SuppressWarnings("unchecked")
     @Test
     public void testSet() throws RepositoryException {
         // initialize all of the features
@@ -2034,6 +2029,7 @@ public class ResolutionTests {
      *
      * Expected: resolution succeeds because although Feature B does not tolerate Feature I 1.0, Feature I is private.
      */
+    @SuppressWarnings("unchecked")
     @Test
     public void testSetTransitivePrivate() throws RepositoryException {
         // initialize all the features
@@ -2097,6 +2093,7 @@ public class ResolutionTests {
      *
      * Expected: resolution succeeds because although Feature B does not tolerate Feature I 1.1, Feature I is private.
      */
+    @SuppressWarnings("unchecked")
     @Test
     public void testSetTransitivePrivateTolerateNewer() throws RepositoryException {
         // initialize all the features
@@ -2159,6 +2156,7 @@ public class ResolutionTests {
      * <p>
      * Expected: featureA-1.0 and autoFeature are both resolved
      */
+    @SuppressWarnings("unchecked")
     @Test
     public void testAutofeatureDependsOnKernelFeature() throws RepositoryException {
         Mockery mockery = new Mockery();
@@ -2187,8 +2185,8 @@ public class ResolutionTests {
     /**
      * Run a test to make sure that a sample with an applies to set is resolved correctly
      *
-     * @param name           The name of the sample
-     * @param appliesTo      The applies to to put onto the sample
+     * @param name The name of the sample
+     * @param appliesTo The applies to to put onto the sample
      * @param productVersion The product version to be
      * @throws RepositoryResourceException
      * @throws RepositoryBackendException
@@ -2209,9 +2207,9 @@ public class ResolutionTests {
     /**
      * Run a test against a product definition with the supplied version and expect a single result back.
      *
-     * @param name           The name to resolve
+     * @param name The name to resolve
      * @param productVersion The product version to use
-     * @param testResource   The resource to expect
+     * @param testResource The resource to expect
      * @throws IOException
      * @throws ProductInfoParseException
      * @throws RepositoryException
@@ -2256,8 +2254,8 @@ public class ResolutionTests {
      * Creates an {@link EsaResourceWritable} and adds it to the list of features in the repo with just the core fields set.
      *
      * @param symbolicName The symbolic name of the resource
-     * @param shortName    The short name of the resource
-     * @param version      The version of the resource
+     * @param shortName The short name of the resource
+     * @param version The version of the resource
      * @return The resource
      * @throws RepositoryResourceException
      * @throws RepositoryBackendException
@@ -2267,26 +2265,13 @@ public class ResolutionTests {
     }
 
     /**
-     * Creates an ESA resource with a set of required iFixes, only the symbolic name will be set from the core fields.
-     *
-     * @param symbolicName
-     * @param singleton
-     * @return
-     * @throws RepositoryResourceException
-     * @throws RepositoryBackendException
-     */
-    private EsaResourceWritable createEsaResource(String symbolicName, Collection<String> fixes) throws RepositoryResourceException, RepositoryBackendException {
-        return createEsaResource(symbolicName, null, null, null, null, null, false, fixes);
-    }
-
-    /**
      * Creates an {@link EsaResourceWritable} and adds it to the list of features in the repo
      *
-     * @param symbolicName           The symbolic name of the resource
-     * @param shortName              The short name of the resource
-     * @param version                The version of the resource
+     * @param symbolicName The symbolic name of the resource
+     * @param shortName The short name of the resource
+     * @param version The version of the resource
      * @param dependencySymoblicName The symbolic names of dependencies
-     * @param appliesTo              The product this feature applies to
+     * @param appliesTo The product this feature applies to
      * @return The resource
      * @throws RepositoryBackendException
      */
@@ -2298,14 +2283,14 @@ public class ResolutionTests {
     /**
      * Creates an {@link EsaResourceWritable} and adds it to the list of features in the repo.
      *
-     * @param symbolicName           The symbolic name of the resource
-     * @param shortName              The short name of the resource
-     * @param version                The version of the resource
-     * @param appliesTo              The product this feature applies to
+     * @param symbolicName The symbolic name of the resource
+     * @param shortName The short name of the resource
+     * @param version The version of the resource
+     * @param appliesTo The product this feature applies to
      * @param dependencySymoblicName The symbolic names of dependencies
      * @param provisionSymbolicNames The symbolic name(s) of the capability required for this feature to be auto provision
-     * @param autoInstallable        The autoInstallable value to use
-     * @param requiredFixes          fixes required by this feature
+     * @param autoInstallable The autoInstallable value to use
+     * @param requiredFixes fixes required by this feature
      * @return The resource
      * @throws RepositoryBackendException
      */
@@ -2345,27 +2330,6 @@ public class ResolutionTests {
         }
         repoFeatures.add(testResource);
         return testResource;
-    }
-
-    /**
-     * Creates and uploads a new IfixResource in Massive
-     *
-     * @param fixId
-     * @param appliesTo
-     * @param lastUpdateDate
-     * @return
-     * @throws RepositoryResourceException
-     * @throws RepositoryBackendException
-     */
-    private IfixResourceWritable createIFixResource(String fixId, String appliesTo, Date lastUpdateDate) throws RepositoryResourceException, RepositoryBackendException {
-        IfixResourceWritable iFixResource = WritableResourceFactory.createIfix(null);
-        iFixResource.setProvideFix(Collections.singleton(fixId));
-        iFixResource.setAppliesTo(appliesTo);
-        iFixResource.setDate(lastUpdateDate);
-        iFixResource.setName("ifix " + _count++);
-        iFixResource.setProviderName("IBM");
-        repoIfixes.add(iFixResource);
-        return iFixResource;
     }
 
     /**

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/ResolutionTests.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/ResolutionTests.java
@@ -16,6 +16,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
@@ -2415,9 +2416,7 @@ public class ResolutionTests {
                 fail("No resolution exception thrown. Result: " + resolved);
             } catch (RepositoryResolutionException e) {
                 assertThat(e.getFeatureConflicts().keySet(), contains("com.example.featureA"));
-                assertThat(e.getAllRequirementsResourcesNotFound(),
-                           containsInAnyOrder(missingRequirement("com.example.featureA-1.0", featureB10),
-                                              missingRequirement("com.example.featureA-2.0", featureC20)));
+                assertThat(e.getAllRequirementsResourcesNotFound(), empty());
             }
         } else {
             Collection<List<RepositoryResource>> resolved = resolve(resolver, Arrays.asList("featureB-1.0", "featureC-2.0"));
@@ -2446,9 +2445,7 @@ public class ResolutionTests {
             if (testType == TestType.RESOLVE_AS_SET) {
                 // Fails due to conflict
                 assertThat(e.getFeatureConflicts().keySet(), contains("com.example.featureA"));
-                assertThat(e.getAllRequirementsResourcesNotFound(),
-                           containsInAnyOrder(missingRequirement("featureA-1.0", null),
-                                              missingRequirement("featureA-2.0", null)));
+                assertThat(e.getAllRequirementsResourcesNotFound(), empty());
             } else {
                 // Fails due to missing dependency
                 assertThat(e.getFeatureConflicts().entrySet(), hasSize(0));

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/ResolutionTests.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/ResolutionTests.java
@@ -2456,6 +2456,22 @@ public class ResolutionTests {
         }
     }
 
+    @Test
+    public void testUnsatisfiedInstalledFeature() throws RepositoryException {
+        ArrayList<ProvisioningFeatureDefinition> installedFeatures = new ArrayList<>();
+
+        MockFeature unsatisfied = new MockFeature("com.example.unsatisfied-1.0");
+        unsatisfied.setVisibility(com.ibm.ws.kernel.feature.Visibility.PUBLIC);
+        unsatisfied.addDependency("com.example.nonExistant-1.0");
+        installedFeatures.add(unsatisfied);
+
+        EsaResourceWritable featureA10 = createEsaResource("com.example.featureA-1.0", "featureA-1.0", "1.0");
+
+        RepositoryResolver resolver = createResolver(installedFeatures);
+        Collection<List<RepositoryResource>> resolved = resolve(resolver, Arrays.asList(featureA10.getShortName()));
+        assertThat(resolved, contains(contains(featureA10)));
+    }
+
     /**
      * Run a test to make sure that a sample with an applies to set is resolved correctly
      *

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/FeatureResolverTest.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/FeatureResolverTest.java
@@ -10,10 +10,11 @@
  *******************************************************************************/
 package com.ibm.ws.repository.resolver.internal.kernel;
 
+import static com.ibm.ws.repository.resolver.internal.ResolutionMode.DETECT_CONFLICTS;
 import static com.ibm.ws.repository.resolver.internal.ResolutionMode.IGNORE_CONFLICTS;
 import static com.ibm.ws.repository.resolver.internal.kernel.KernelResolverResultMatcher.result;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -213,6 +214,58 @@ public class FeatureResolverTest {
         // Test we don't get the autofeature when requesting only featureB
         Result result2 = resolver.resolveFeatures(repo, Arrays.asList("com.example.featureB"), Collections.<String> emptySet(), false);
         assertThat(result2, is(result().withResolvedFeatures("com.example.featureB")));
+    }
+
+    @Test
+    public void testFeatureMissing() {
+        FeatureResolver resolver = new FeatureResolverImpl();
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, DETECT_CONFLICTS);
+
+        EsaResourceWritable featureB = WritableResourceFactory.createEsa(null);
+        featureB.setProvideFeature("com.example.featureB-1.0");
+        featureB.setVisibility(Visibility.PUBLIC);
+        featureB.addRequireFeatureWithTolerates("com.example.featureA-1.0", Arrays.asList("1.1", "2.0"));
+        repo.addFeature(featureB);
+
+        Result result = resolver.resolveFeatures(repo, Arrays.asList("com.example.featureB-1.0"), Collections.<String> emptySet(), false);
+
+        assertThat(result, is(result().withResolvedFeatures("com.example.featureB-1.0").withMissingFeatures("com.example.featureA-1.0")));
+    }
+
+    @Test
+    public void testConflict() {
+        FeatureResolver resolver = new FeatureResolverImpl();
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, DETECT_CONFLICTS);
+
+        EsaResourceWritable featureA1 = WritableResourceFactory.createEsa(null);
+        featureA1.setProvideFeature("com.example.featureA-1.0");
+        featureA1.setVisibility(Visibility.PUBLIC);
+        featureA1.setSingleton("true");
+        repo.addFeature(featureA1);
+
+        EsaResourceWritable featureA2 = WritableResourceFactory.createEsa(null);
+        featureA2.setProvideFeature("com.example.featureA-2.0");
+        featureA2.setVisibility(Visibility.PUBLIC);
+        featureA2.setSingleton("true");
+        repo.addFeature(featureA2);
+
+        EsaResourceWritable featureB = WritableResourceFactory.createEsa(null);
+        featureB.setProvideFeature("com.example.featureB");
+        featureB.setVisibility(Visibility.PUBLIC);
+        featureB.addRequireFeatureWithTolerates("com.example.featureA-1.0", Collections.<String> emptyList());
+        repo.addFeature(featureB);
+
+        EsaResourceWritable featureC = WritableResourceFactory.createEsa(null);
+        featureC.setProvideFeature("com.example.featureC");
+        featureC.setVisibility(Visibility.PUBLIC);
+        featureC.addRequireFeatureWithTolerates("com.example.featureA-2.0", Collections.<String> emptyList());
+        repo.addFeature(featureC);
+
+        Result result = resolver.resolveFeatures(repo, Arrays.asList("com.example.featureB", "com.example.featureC"), Collections.<String> emptySet(), false);
+
+        assertThat(result, is(result().withResolvedFeatures("com.example.featureB", "com.example.featureC")
+                                      .withMissingFeatures() // No features reported missing
+                                      .withConflicts("com.example.featureA")));
     }
 
 }

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/FeatureResourceMatcher.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/FeatureResourceMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -61,8 +61,12 @@ public class FeatureResourceMatcher extends TypeSafeMatcher<FeatureResource> {
     protected void describeMismatchSafely(FeatureResource item, Description mismatchDescription) {
         mismatchDescription.appendText("FeatureResource with symbolic name ")
                            .appendText(item.getSymbolicName())
-                           .appendText(" and tolerates ")
-                           .appendValueList("<", ", ", ">", item.getTolerates());
+                           .appendText(" and tolerates ");
+        if (item.getTolerates() == null) {
+            mismatchDescription.appendValue(null);
+        } else {
+            mismatchDescription.appendValueList("<", ", ", ">", item.getTolerates());
+        }
     }
 
 }

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverEsaTest.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverEsaTest.java
@@ -116,7 +116,7 @@ public class KernelResolverEsaTest {
         assertThat(resolverAutoFeature.isCapabilitySatisfied(Collections.<ProvisioningFeatureDefinition> emptySet()), is(false));
         assertThat(resolverAutoFeature.isCapabilitySatisfied(Arrays.<ProvisioningFeatureDefinition> asList(resolverFeatureA, resolverFeatureB)), is(true));
 
-        assertThat(resolverAutoFeature.findFeaturesSatisfyingCapability(Arrays.asList(resolverFeatureA, resolverFeatureB, resolverAutoFeature)),
+        assertThat(CapabilityMatching.findFeaturesSatisfyingCapability(resolverAutoFeature, Arrays.asList(resolverFeatureA, resolverFeatureB, resolverAutoFeature)),
                    Matchers.<ProvisioningFeatureDefinition> containsInAnyOrder(resolverFeatureA, resolverFeatureB));
     }
 

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverResultMatcher.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverResultMatcher.java
@@ -28,10 +28,12 @@ import com.ibm.ws.kernel.feature.resolver.FeatureResolver.Result;
  * <p>
  * E.g. {@code result().withErrors().withResolvedFeatures("a")}
  */
-public class KernelResolverResultMatcher extends TypeSafeMatcher<FeatureResolver.Result> {
+public class KernelResolverResultMatcher extends TypeSafeMatcher<Result> {
 
     private boolean hasErrors = false;
+    private Collection<String> conflicts;
     private Collection<String> resolvedFeatures;
+    private Collection<String> missingFeatures;
 
     public static KernelResolverResultMatcher result() {
         return new KernelResolverResultMatcher();
@@ -47,6 +49,18 @@ public class KernelResolverResultMatcher extends TypeSafeMatcher<FeatureResolver
         return this;
     }
 
+    public KernelResolverResultMatcher withMissingFeatures(String... missingFeatures) {
+        this.missingFeatures = Arrays.asList(missingFeatures);
+        this.hasErrors = true;
+        return this;
+    }
+
+    public KernelResolverResultMatcher withConflicts(String... conflicts) {
+        this.conflicts = Arrays.asList(conflicts);
+        this.hasErrors = true;
+        return this;
+    }
+
     @Override
     public void describeTo(Description description) {
         description.appendText("Result")
@@ -56,6 +70,16 @@ public class KernelResolverResultMatcher extends TypeSafeMatcher<FeatureResolver
         if (resolvedFeatures != null) {
             description.appendText("\n\tResolved features: ")
                        .appendValueList("[", ", ", "]", resolvedFeatures);
+        }
+
+        if (missingFeatures != null) {
+            description.appendText("\n\tMissing features: ")
+                       .appendValueList("[", ", ", "]", missingFeatures);
+        }
+
+        if (conflicts != null) {
+            description.appendText("\n\tConflicts: ")
+                       .appendValueList("[", ", ", "]", conflicts);
         }
     }
 
@@ -69,12 +93,20 @@ public class KernelResolverResultMatcher extends TypeSafeMatcher<FeatureResolver
             return false;
         }
 
+        if (missingFeatures != null && !containsInAnyOrder(missingFeatures.toArray()).matches(item.getMissing())) {
+            return false;
+        }
+
+        if (conflicts != null && !containsInAnyOrder(conflicts.toArray()).matches(item.getConflicts().keySet())) {
+            return false;
+        }
+
         return true;
     }
 
     @Override
     protected void describeMismatchSafely(Result item, Description description) {
-        description.appendText("Result")
+        description.appendText("was Result")
                    .appendText("\n\tHas errors: ")
                    .appendValue(item.hasErrors())
                    .appendText("\n\tResolved features: ")
@@ -82,7 +114,9 @@ public class KernelResolverResultMatcher extends TypeSafeMatcher<FeatureResolver
                    .appendText("\n\tMissing features: ")
                    .appendValueList("[", ", ", "]", item.getMissing())
                    .appendText("\n\tNon public roots: ")
-                   .appendValueList("[", ", ", "]", item.getNonPublicRoots());
+                   .appendValueList("[", ", ", "]", item.getNonPublicRoots())
+                   .appendText("\n\tConflicts: ")
+                   .appendValueList("[", ", ", "]", item.getConflicts().keySet());
     }
 
 }


### PR DESCRIPTION
Fix the creation of install lists when a feature is installed but its
dependencies aren't. This can happen when a feature tolerates two
versions of a dependency, only one of which is installed, and the
solution from the kernel resolver uses the other one.

This situation is common in Liberty where we have a single feature which
supports both EE8 and EE9 by having a private feature for each and
tolerating both of them. The eeCompatible singleton features will ensure
that the correct one is used, depending on which other features are
enabled on the server.

This fix includes the following changes:
* When building an install list, recurse through the dependencies of any
  installed features rather than stopping. The installed features are
  removed later when features are mapped to EsaResources.
* Refactor the code for finding the features used to satisfy the
  ProvisionCapability header of an auto-feature so that it can be used
  for features which are installed as well as features in the
  repository.
* When building an install list for samples, don't try to build an
  install list for a feature which wasn't found.
* Accept `ProvisioningFeatureDefinition.getTolerates()` returning `null`
* Ensure we don't try to build install lists for features which didn't resolve
  * Previously this wasn't a problem since we'd detect that we didn't have an `EsaResource` and assume it was already installed
* Ensure we don't report conflicting features as missing

The following tests were added:
* unit test for `createInstallList` where a feature is installed but its dependency is not
* unit tests for `RepositoryResolver` where:
  * a feature is already installed but resolution requires its tolerated dependency to be satisfied by a feature which is not installed
  * an auto-feature is already installed but resolution requires its tolerated dependency to be satisfied by a feature which is not installed
the cases where the feature with the tolerated dependency is a regular feature and an auto-feature
  * two requested features conflict
  * two requested features have dependencies which conflict
  * two requested features conflict and also have dependencies which are missing from the repository
  * an unrelated feature which is already installed does not have its dependencies satisfied (i.e. the existing runtime is broken, but not in a way that affects the features requested for install)
* Repeat all basic unit tests for `RepositoryResolver` for both the `resolve()` method and the `resolveAsSet()` method
  * In most situations, both methods should give the same result
* unit tests to verify the behaviour of the kernel resolver when a feature is missing and when features conflict

Fixes #19860 