### PR TITLE
Update issue template creating manually setting issue configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/blog_post_ga_release.md
+++ b/.github/ISSUE_TEMPLATE/blog_post_ga_release.md
@@ -32,7 +32,7 @@ Please provide the following information the week before the GA date (to allow f
 If you have previously provided this information for an Open Liberty beta blog post and nothing has changed since the beta, just provide a link to the published beta blog post and we'll take the information from there.
 
 ## What happens next?
-- Add the label for the beta you're targeting: `target:YY00X-beta`.
+- Add the label for the release you're targeting for: `target:YY00X`.
 - Make sure this blog post is linked back to the Epic for this feature/function.
 - Your paragraph will be included in the GA release blog post. It might be edited for style and consistency.
 - You will be asked to review a draft before publication.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -38,7 +38,7 @@ Before Development Starts or 8 weeks before Onboarding
 - [ ] ID Requirements identified ([Documenting Open Liberty](https://github.com/OpenLiberty/open-liberty/wiki/Documenting-Open-Liberty)). (Epic owner / Feature owner with ID focal point)
   * Note: If only trivial documentation changes are required, you may reach out to the ID Feature Focal to request a `ID Required - Trivial` label.  Unlike features with regular ID requirement, those with `ID Required - Trivial` label do not have a hard requirement for a Design/UFO.
 - [ ] SVT Requirements identified. (Epic owner / Feature owner with SVT focal point)
-- [ ] Create a child task of this epic entitled "Feature Test Summary" via [this template](https://github.com/OpenLiberty/open-liberty/issues/new?assignees=&labels=Feature+Test+Summary&template=feature_test_summary.md&title=). Add the link in above.
+- [ ] Create a child task of this epic entitled "Feature Test Summary" via [Feature Test Summary](https://github.com/OpenLiberty/open-liberty/issues/new/choose). Add the link in above.
 
 ##
 #### Before proceeding to any items below (active development), this feature MUST be [prioritized on the backlog](https://github.com/orgs/OpenLiberty/projects/2), and have been socialized (e.g., UFO Review).  Follow the Feature and UFO Approval Process.
@@ -54,7 +54,7 @@ Before Onboarding the beta
 - [ ] Beta Fence the functionality (`kind=beta`, `ibm:beta`, `ProductInfo.getBetaEdition()`)  
 
 1 week before beta GA
-- [ ] Create, populate, and link to the [Beta blog post issue](https://github.com/OpenLiberty/open-liberty/issues/new?assignees=lauracowen%2C+jakub-pomykala&labels=&template=blog_post_beta.md&title=BETA+BLOG+-+title_of_your_update)
+- [ ] Create, populate, and link to the [Open Liberty BETA blog post](https://github.com/OpenLiberty/open-liberty/issues/new/choose)
 
 ## **Legal**
 3 weeks before Onboarding
@@ -96,7 +96,7 @@ All features (both "Design Approved" and "No Design Approved")
 - [ ] Github Epic and Epic's issues are closed / complete. All PRs are committed to the release branch. (Epic owner / Feature owner / Backlog Subtribe PM)
 
 1 week before GA
-- [ ] Create, populate, and link to the [Blog post issue](https://github.com/OpenLiberty/open-liberty/issues/new?assignees=lauracowen%2C+jakub-pomykala&labels=&template=blog_post_ga_release.md&title=GA+BLOG+-+title_of_your_update)
+- [ ] Create, populate, and link to the [Open Liberty GA release blog post](https://github.com/OpenLiberty/open-liberty/issues/new/choose)
 
 ## **Other deliverbles**
 - [ ] **OL Guides** - ([Yee-Kang Chang](https://github.com/yeekangc)). Assessment for OL Guides is complete or N/A.


### PR DESCRIPTION
As template information (`assignees`, `labels`, ect) changes, explicit links in other locations (wikis, other templates, ect) that set their own values are not updated to match. This leads to incorrectly created issues (incorrect assignees, invalid labels, ect) unless every location is updated to match. Remembering to update all these locations is error prone.

Alternatively, we could just reference `https://github.com/OpenLiberty/open-liberty/issues/new/choose` and inform which template to choose. This would help create a single point of control as the templates change labels, assignees, titles

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>