### PR TITLE
candidate builds for final release of 3.0 spec

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -67,7 +67,7 @@ com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.jpa:2.6.9.WAS-c34c592
 com.ibm.ws.org.objenesis:objenesis:1.0
 com.ibm.ws:geronimo-validation:1.1
 com.ibm.ws:nekohtml:1.9.18
-io.openliberty.jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:3.0.0.20211206
+io.openliberty.jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:3.0.0.20220120
 net.sf.jtidy:jtidy:9.3.8
 org.apache.aries.blueprint:org.apache.aries.blueprint:1.3.0-ibm-s20170710-0926
 org.apache.cxf:cxf-rt-ws-mex:2.6.2-ibm-s20180529-1900

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.concurrency-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.concurrency-3.0.feature
@@ -4,7 +4,7 @@ visibility=private
 singleton=true
 #TODO remove toleration of eeCompatible-9.0 once other EE 10 features are usable in beta form
 -features=com.ibm.websphere.appserver.eeCompatible-10.0; ibm.tolerates:="9.0"
--bundles=io.openliberty.jakarta.concurrency.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="io.openliberty.jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:3.0.0.20211206"
+-bundles=io.openliberty.jakarta.concurrency.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="io.openliberty.jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:3.0.0.20220120"
 kind=noship
 edition=full
 WLP-Activation-Type: parallel

--- a/dev/io.openliberty.jakarta.concurrency.3.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.concurrency.3.0/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021,2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -27,11 +27,11 @@ Import-Package:
   *
 
 Include-Resource: \
-  @${repo;io.openliberty.jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api;3.0.0.20211206;EXACT}!/META-INF/NOTICE
+  @${repo;io.openliberty.jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api;3.0.0.20220120;EXACT}!/META-INF/NOTICE
 
 instrument.disabled: true
 
 publish.wlp.jar.suffix: dev/api/spec
 
 -buildpath: \
-  io.openliberty.jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api;version=3.0.0.20211206
+  io.openliberty.jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api;version=3.0.0.20220120

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -20,7 +20,7 @@
         <jakarta.concurrent.version>3.0.0</jakarta.concurrent.version>
         
         <!-- TODO: Update this once TCK is GAed -->
-        <jakarta.concurrent.tck.version>3.0.0.20220118</jakarta.concurrent.tck.version>
+        <jakarta.concurrent.tck.version>3.0.0.20220120</jakarta.concurrent.tck.version>
         
         <arquillian.version>1.6.0.Final</arquillian.version>
         <arquillian-wlp.version>2.0.2</arquillian-wlp.version>


### PR DESCRIPTION
Switch to using the candidate release build for the Concurrency 3.0 spec, built on Jan 20, 2022.