### PR TITLE
include Concurrency 3.0 TCK bucket in test lists

### DIFF
--- a/.github/test-categories/CONCURRENT_3
+++ b/.github/test-categories/CONCURRENT_3
@@ -14,3 +14,4 @@ com.ibm.ws.concurrent_fat_work
 com.ibm.ws.context_fat
 com.ibm.ws.context_fat_customproviders
 com.ibm.ws.context_fat_serialization
+io.openliberty.jakarta.concurrency.3.0_fat_tck


### PR DESCRIPTION
The Concurrency 3.0 TCK test bucket should be included in the list of concurrency-related tests