### PR TITLE
avoid matching services that are not resource factories

### DIFF
--- a/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ContextServiceResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ContextServiceResourceFactoryBuilder.java
@@ -285,9 +285,11 @@ public class ContextServiceResourceFactoryBuilder implements ResourceFactoryBuil
 
         BundleContext bundleContext = ContextServiceDefinitionProvider.priv.getBundleContext(FrameworkUtil.getBundle(WSManagedExecutorService.class));
 
+        // jndiName is included in the filter to avoid matching similar services reregistered
+        // as non-ResourceFactories by the JNDI implementation
         StringBuilder contextServiceFilter = new StringBuilder(200);
         contextServiceFilter.append("(&").append(FilterUtils.createPropertyFilter(ID, contextServiceID));
-        contextServiceFilter.append("(component.name=com.ibm.ws.context.service))");
+        contextServiceFilter.append("(component.name=com.ibm.ws.context.service)(jndiName=*))");
 
         ResourceFactory factory = new AppDefinedResourceFactory(this, bundleContext, contextServiceID, contextServiceFilter.toString(), declaringApplication);
         try {

--- a/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedExecutorResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedExecutorResourceFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -163,9 +163,11 @@ public class ManagedExecutorResourceFactoryBuilder implements ResourceFactoryBui
         execSvcProps.put("LongRunningPolicy.target", "(service.pid=unbound)");
         execSvcProps.put("LongRunningPolicy.cardinality.minimum", 0);
 
+        // jndiName is included in the filter to avoid matching similar services reregistered
+        // as non-ResourceFactories by the JNDI implementation
         StringBuilder managedExecutorSvcFilter = new StringBuilder(200);
         managedExecutorSvcFilter.append("(&").append(FilterUtils.createPropertyFilter(ID, managedExecutorServiceID));
-        managedExecutorSvcFilter.append("(component.name=com.ibm.ws.concurrent.internal.ManagedExecutorServiceImpl))");
+        managedExecutorSvcFilter.append("(component.name=com.ibm.ws.concurrent.internal.ManagedExecutorServiceImpl)(jndiName=*))");
 
         // TODO errors for invalid config such as max=0 or -20
         concurrencyPolicyProps.put(ID, concurrencyPolicyId);

--- a/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedScheduledExecutorResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedScheduledExecutorResourceFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -166,9 +166,11 @@ public class ManagedScheduledExecutorResourceFactoryBuilder implements ResourceF
         execSvcProps.put("LongRunningPolicy.target", "(service.pid=unbound)");
         execSvcProps.put("LongRunningPolicy.cardinality.minimum", 0);
 
+        // jndiName is included in the filter to avoid matching similar services reregistered
+        // as non-ResourceFactories by the JNDI implementation
         StringBuilder managedScheduledExecutorSvcFilter = new StringBuilder(200);
         managedScheduledExecutorSvcFilter.append("(&").append(FilterUtils.createPropertyFilter(ID, managedScheduledExecutorServiceID));
-        managedScheduledExecutorSvcFilter.append("(component.name=com.ibm.ws.concurrent.internal.ManagedScheduledExecutorServiceImpl))");
+        managedScheduledExecutorSvcFilter.append("(component.name=com.ibm.ws.concurrent.internal.ManagedScheduledExecutorServiceImpl)(jndiName=*))");
 
         // TODO errors for invalid config such as max=0 or -20
         concurrencyPolicyProps.put(ID, concurrencyPolicyId);

--- a/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedThreadFactoryResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/processor/ManagedThreadFactoryResourceFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -158,9 +158,11 @@ public class ManagedThreadFactoryResourceFactoryBuilder implements ResourceFacto
 
         BundleContext bundleContext = ContextServiceDefinitionProvider.priv.getBundleContext(FrameworkUtil.getBundle(WSManagedExecutorService.class));
 
+        // jndiName is included in the filter to avoid matching similar services reregistered
+        // as non-ResourceFactories by the JNDI implementation
         StringBuilder managedThreadFactorySvcFilter = new StringBuilder(200);
         managedThreadFactorySvcFilter.append("(&").append(FilterUtils.createPropertyFilter(ID, managedThreadFactoryID));
-        managedThreadFactorySvcFilter.append("(component.name=com.ibm.ws.concurrent.managedThreadFactory))");
+        managedThreadFactorySvcFilter.append("(component.name=com.ibm.ws.concurrent.managedThreadFactory)(jndiName=*))");
 
         ResourceFactory factory = new AppDefinedResourceFactory(this, bundleContext, managedThreadFactoryID, managedThreadFactorySvcFilter.toString(), declaringApplication);
         try {


### PR DESCRIPTION
AppDefinedResourceFactory for Concurrency 3.0 resource definitions is accidentally matching some very similar services which aren't resource factories, resulting in an intermittent ClassCastException, such as

```
java.lang.ClassCastException: com.ibm.ws.concurrent.internal.ManagedThreadFactoryService$ManagedThreadFactoryImpl incompatible with com.ibm.wsspi.resource.ResourceFactory io.openliberty.concurrent.processor.AppDefinedResourceFactory 
```

Here is what the correct service would look like,

provides
com.ibm.wsspi.application.lifecycle.ApplicationRecycleComponent,
com.ibm.wsspi.resource.ResourceFactory
with properties
```
  service.id=494,
  contextService.target=(id=application[ConcurrencyTestApp]/module[ConcurrencyTestEJB.jar]/contextService[java:module/concurrent/ZLContextSvc]),
  service.bundleid=66, service.scope=bundle, contextService.cardinality.minimum=1,
  component.name=com.ibm.ws.concurrent.managedThreadFactory,
+ creates.objectClass=[java.util.concurrent.ThreadFactory,jakarta.enterprise.concurrent.ManagedThreadFactory],
  component.id=347, jndiName.unique=application[ConcurrencyTestApp]/module[ConcurrencyTestEJB.jar]/managedThreadFactory[java:module/concurrent/dd/ejb/ZLThreadFactory],
  createDaemonThreads=false,
  service.factoryPid=com.ibm.ws.concurrent.managedThreadFactory, application=ConcurrencyTestApp,
+ jndiName=java:module/concurrent/dd/ejb/ZLThreadFactory,
  defaultPriority=7, id=application[ConcurrencyTestApp]/module[ConcurrencyTestEJB.jar]/managedThreadFactory[java:module/concurrent/dd/ejb/ZLThreadFactory],
  module=ConcurrencyTestEJB.jar,
  service.pid=com.ibm.ws.concurrent.managedThreadFactory_93,
  config.displayId=application[ConcurrencyTestApp]/module[ConcurrencyTestEJB.jar]/managedThreadFactory[java:module/concurrent/dd/ejb/ZLThreadFactory]}
```

In the above, + denotes properties that are unique to the correct service and not present in the incorrect one.

Here is what an incorrect match looks like:

provides
java.util.concurrent.ThreadFactory,
jakarta.enterprise.concurrent.ManagedThreadFactory
with properties
```
  service.id=495,
  contextService.target=(id=application[ConcurrencyTestApp]/module[ConcurrencyTestEJB.jar]/contextService[java:module/concurrent/ZLContextSvc]),
  service.bundleid=66, service.scope=bundle, contextService.cardinality.minimum=1,
  component.name=com.ibm.ws.concurrent.managedThreadFactory,
  component.id=347, jndiName.unique=application[ConcurrencyTestApp]/module[ConcurrencyTestEJB.jar]/managedThreadFactory[java:module/concurrent/dd/ejb/ZLThreadFactory], osgi.jndi.service.name=java:module/concurrent/dd/ejb/ZLThreadFactory, com.ibm.wsspi.resource.ResourceFactory=true,
  createDaemonThreads=false,
  service.factoryPid=com.ibm.ws.concurrent.managedThreadFactory, application=ConcurrencyTestApp,
  module=ConcurrencyTestEJB.jar,
  defaultPriority=7, id=application[ConcurrencyTestApp]/module[ConcurrencyTestEJB.jar]/managedThreadFactory[java:module/concurrent/dd/ejb/ZLThreadFactory],
  config.displayId=application[ConcurrencyTestApp]/module[ConcurrencyTestEJB.jar]/managedThreadFactory[java:module/concurrent/dd/ejb/ZLThreadFactory],
  service.pid=com.ibm.ws.concurrent.managedThreadFactory_93}
```

We can fix this by adjusting the filter to include `jndiName`