### PR TITLE
Update maven deps in MPHealth TCK

### DIFF
--- a/dev/com.ibm.ws.microprofile.health.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>27.0.1-jre</version>
+            <version>29.0-jre</version>
         </dependency>
 
         <dependency>

--- a/dev/io.openliberty.microprofile.health.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.health.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.3</version>
+            <version>2.10.5.1</version>
         </dependency>
 
         <dependency>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.3</version>
+            <version>2.10.5.1</version>
         </dependency>
 
         <dependency>

--- a/dev/io.openliberty.microprofile.health.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.health.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.3</version>
+            <version>2.10.5.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Updated the MP Health TCKs with the latest maven dependency version, according to dependabot.
fixes #19863