### PR TITLE
Update LibertyClient and LibertyServer to run with JVM option "-Djava…

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/Launcher.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/Launcher.java
@@ -71,11 +71,6 @@ public class Launcher {
         initProps.put(BootstrapConstants.LAUNCH_TIME, Long.toString(launchTime));
         initProps.put("org.apache.aries.blueprint.preemptiveShutdown", Boolean.toString(false));
 
-        // If we are running on Java 18+, then we need to explicitly enable the security manager
-        if (javaVersion() >= 18 && System.getProperty("java.security.manager") == null) {
-            System.setProperty("java.security.manager", "allow");
-        }
-
         BootstrapConfig bootProps = createBootstrapConfig();
 
         try {
@@ -462,15 +457,5 @@ public class Launcher {
         }
 
         return args;
-    }
-
-    private static int javaVersion() {
-        String version = System.getProperty("java.version");
-        String[] versionElements = version.split("\\D"); // split on non-digits
-
-        // Pre-JDK 9 the java.version is 1.MAJOR.MINOR
-        // Post-JDK 9 the java.version is MAJOR.MINOR
-        int i = Integer.valueOf(versionElements[0]) == 1 ? 1 : 0;
-        return Integer.valueOf(versionElements[i]);
     }
 }

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/cmdline/UtilityMain.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/cmdline/UtilityMain.java
@@ -78,11 +78,6 @@ public class UtilityMain {
      * @throws PrivilegedActionException
      */
     public static void internal_main(String[] args) throws IOException, ClassNotFoundException, SecurityException, NoSuchMethodException, InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, PrivilegedActionException {
-        // If we are running on Java 18+, then we need to explicitly enable the security manager
-        if (javaVersion() >= 18 && System.getProperty("java.security.manager") == null) {
-            System.setProperty("java.security.manager", "allow");
-        }
-
         // The sole element of the classpath should be the jar that was launched..
         String jarName = System.getProperty("java.class.path");
 

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/wsspi/kernel/embeddable/ServerBuilder.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/wsspi/kernel/embeddable/ServerBuilder.java
@@ -47,13 +47,6 @@ public class ServerBuilder {
     private File installDir;
     private HashMap<String, Properties> productExtensions = null;
 
-    static {
-        // If we are running on Java 18+, then we need to explicitly enable the security manager
-        if (javaVersion() >= 18 && System.getProperty("java.security.manager") == null) {
-            System.setProperty("java.security.manager", "allow");
-        }
-    }
-
     private static class InvalidInstallException extends ServerException {
 
         /**
@@ -173,9 +166,9 @@ public class ServerBuilder {
      * @return a Server instance using any attributes set on the builder.
      *
      * @throws ServerException if the named server does not exist, or if the attributes
-     *                             set using the set methods fail validation, e.g. the server name
-     *                             contains invalid characters, or the provided Files point to existing
-     *                             files in the file system instead of directories.
+     *             set using the set methods fail validation, e.g. the server name
+     *             contains invalid characters, or the provided Files point to existing
+     *             files in the file system instead of directories.
      */
     public Server build() throws ServerException {
         try {
@@ -264,15 +257,5 @@ public class ServerBuilder {
         } catch (InvocationTargetException e) {
             throw new InvalidInstallException(e);
         }
-    }
-
-    private static int javaVersion() {
-        String version = System.getProperty("java.version");
-        String[] versionElements = version.split("\\D"); // split on non-digits
-
-        // Pre-JDK 9 the java.version is 1.MAJOR.MINOR
-        // Post-JDK 9 the java.version is MAJOR.MINOR
-        int i = Integer.valueOf(versionElements[0]) == 1 ? 1 : 0;
-        return Integer.valueOf(versionElements[i]);
     }
 }

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
@@ -531,6 +531,16 @@ public class LibertyClient {
         return args;
     }
 
+    private static int javaVersion() {
+        String version = System.getProperty("java.version");
+        String[] versionElements = version.split("\\D"); // split on non-digits
+
+        // Pre-JDK 9 the java.version is 1.MAJOR.MINOR
+        // Post-JDK 9 the java.version is MAJOR.MINOR
+        int i = Integer.valueOf(versionElements[0]) == 1 ? 1 : 0;
+        return Integer.valueOf(versionElements[i]);
+    }
+
     public ProgramOutput startClientWithArgs(boolean preClean, boolean cleanStart,
                                              boolean validateApps, boolean expectStartFailure,
                                              String clientCmd, List<String> args,
@@ -622,6 +632,11 @@ public class LibertyClient {
             } else {
                 LOG.warning("The build is configured to run FAT tests with Java 2 Security enabled, but the FAT client " + getClientName() +
                             " is exempt from Java 2 Security regression testing.");
+            }
+
+            // If we are running on Java 18+, then we need to explicitly enable the security manager
+            if (javaVersion() >= 18) {
+                JVM_ARGS += " -Djava.security.manager=allow";
             }
         }
 
@@ -749,6 +764,7 @@ public class LibertyClient {
             w.write("\n".getBytes());
             w.write("websphere.java.security.norethrow=false".getBytes());
             w.write("\n".getBytes());
+
             Log.info(c, "addJava2SecurityPropertiesToBootstrapFile", "Successfully updated bootstrap.properties file with Java 2 Security properties");
         } catch (Exception e) {
             Log.info(c, "addJava2SecurityPropertiesToBootstrapFile", "Caught exception updating bootstap.properties file with Java 2 Security properties, e: ", e.getMessage());
@@ -2203,6 +2219,7 @@ public class LibertyClient {
                 optionList.add(option.toString());
             }
         }
+
         this.setJvmOptions(optionList);
     }
 

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
@@ -621,8 +621,7 @@ public class LibertyClient {
                 Log.info(c, "startClientWithArgs", "Java 2 Security enabled for client " + getClientName() + " because GLOBAL_JAVA2SECURITY=true");
 
                 // If we are running on Java 18+, then we need to explicitly enable the security manager
-                JavaInfo info = JavaInfo.forCurrentVM();
-                if (info != null && info.majorVersion() >= 18) {
+                if (javaInfo.majorVersion() >= 18) {
                     JVM_ARGS += " -Djava.security.manager=allow";
                 }
             } else {

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -1223,16 +1223,6 @@ public class LibertyServer implements LogMonitorClient {
         return args;
     }
 
-    private static int javaVersion() {
-        String version = System.getProperty("java.version");
-        String[] versionElements = version.split("\\D"); // split on non-digits
-
-        // Pre-JDK 9 the java.version is 1.MAJOR.MINOR
-        // Post-JDK 9 the java.version is MAJOR.MINOR
-        int i = Integer.valueOf(versionElements[0]) == 1 ? 1 : 0;
-        return Integer.valueOf(versionElements[i]);
-    }
-
     public ProgramOutput startServerWithArgs(boolean preClean, boolean cleanStart,
                                              boolean validateApps, boolean expectStartFailure,
                                              String serverCmd, List<String> args,
@@ -1363,7 +1353,7 @@ public class LibertyServer implements LogMonitorClient {
             Log.info(c, "startServerWithArgs", "Java 2 Security enabled for server " + getServerName() + " because " + reason + "=true");
 
             // If we are running on Java 18+, then we need to explicitly enable the security manager
-            if (javaVersion() >= 18) {
+            if (info != null && info.majorVersion() >= 18) {
                 JVM_ARGS += " -Djava.security.manager=allow";
             }
         }

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -1223,6 +1223,16 @@ public class LibertyServer implements LogMonitorClient {
         return args;
     }
 
+    private static int javaVersion() {
+        String version = System.getProperty("java.version");
+        String[] versionElements = version.split("\\D"); // split on non-digits
+
+        // Pre-JDK 9 the java.version is 1.MAJOR.MINOR
+        // Post-JDK 9 the java.version is MAJOR.MINOR
+        int i = Integer.valueOf(versionElements[0]) == 1 ? 1 : 0;
+        return Integer.valueOf(versionElements[i]);
+    }
+
     public ProgramOutput startServerWithArgs(boolean preClean, boolean cleanStart,
                                              boolean validateApps, boolean expectStartFailure,
                                              String serverCmd, List<String> args,
@@ -1351,6 +1361,11 @@ public class LibertyServer implements LogMonitorClient {
             addJava2SecurityPropertiesToBootstrapFile(f, GLOBAL_DEBUG_JAVA2SECURITY);
             String reason = GLOBAL_JAVA2SECURITY ? "GLOBAL_JAVA2SECURITY" : "GLOBAL_DEBUG_JAVA2SECURITY";
             Log.info(c, "startServerWithArgs", "Java 2 Security enabled for server " + getServerName() + " because " + reason + "=true");
+
+            // If we are running on Java 18+, then we need to explicitly enable the security manager
+            if (javaVersion() >= 18) {
+                JVM_ARGS += " -Djava.security.manager=allow";
+            }
         }
 
         Properties bootstrapProperties = getBootstrapProperties();
@@ -1665,6 +1680,7 @@ public class LibertyServer implements LogMonitorClient {
                 w.write("websphere.java.security.unique=true".getBytes());
                 w.write("\n".getBytes());
             }
+
             Log.info(c, "addJava2SecurityPropertiesToBootstrapFile", "Successfully updated bootstrap.properties file with Java 2 Security properties");
         } catch (Exception e) {
             Log.info(c, "addJava2SecurityPropertiesToBootstrapFile", "Caught exception updating bootstap.properties file with Java 2 Security properties, e: ", e.getMessage());
@@ -4100,6 +4116,7 @@ public class LibertyServer implements LogMonitorClient {
                 optionList.add(option.toString());
             }
         }
+
         this.setJvmOptions(optionList);
     }
 

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -1353,7 +1353,7 @@ public class LibertyServer implements LogMonitorClient {
             Log.info(c, "startServerWithArgs", "Java 2 Security enabled for server " + getServerName() + " because " + reason + "=true");
 
             // If we are running on Java 18+, then we need to explicitly enable the security manager
-            if (info != null && info.majorVersion() >= 18) {
+            if (info.majorVersion() >= 18) {
                 JVM_ARGS += " -Djava.security.manager=allow";
             }
         }


### PR DESCRIPTION
JDK 18 has set the Java Security Manager to be disallowed by default, so the LibertyServer and LibertyClient classes used for testing needs to set "-Djava.security.manager=allow" if using a JDK version >= 18