### PR TITLE
Avoid FFDC by waiting for LTPA to start

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta/fat/src/test/jakarta/concurrency/ConcurrencyJSPTest.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/fat/src/test/jakarta/concurrency/ConcurrencyJSPTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package test.jakarta.concurrency;
 
+import static org.junit.Assert.assertNotNull;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -44,6 +46,10 @@ public class ConcurrencyJSPTest extends FATServletClient {
         ShrinkHelper.defaultApp(server, "ConcurrencyJSPTestApp", "test.jakarta.concurrency.jsp");
 
         server.startServer();
+
+        // wait for LTPA key to be available to avoid CWWKS4000E
+        assertNotNull("CWWKS4105I.* not received on server",
+                      server.waitForStringInLog("CWWKS4105I.*"));
     }
 
     /**
@@ -73,6 +79,6 @@ public class ConcurrencyJSPTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer("CWWKS4000E"); //Ignore CWWKS4000E just in case.
     }
 }


### PR DESCRIPTION
Tests can start running before the server is fully configured.
Ensure we wait for the LTPA service before trying to run any tests.
