### PR TITLE
tests for app-defined Concurrency resources in web.xml

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/resources/WEB-INF/web.xml
@@ -10,7 +10,31 @@
         IBM Corporation - initial API and implementation
  -->
 <web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"> 
+<!-- TODO enable when ready
+  <context-service>
+    <name>java:comp/concurrent/dd/web/TZContextService</name>
+    <propagated>Timestamp</propagated>
+    <propagated>ZipCode</propagated>
+    <unchanged>Remaining</unchanged>
+  </context-service>
 
+  <managed-executor>
+    <name>java:global/concurrent/dd/web/LPExecutor</name>
+    <context-service-ref>java:global/concurrent/dd/ejb/LPContextService</context-service-ref>
+    <max-async>3</max-async>
+  </managed-executor>
 
+  <managed-scheduled-executor>
+    <name>java:comp/concurrent/dd/web/TZScheduledExecutor</name>
+    <context-service-ref>java:comp/concurrent/dd/web/TZContextService</context-service-ref>
+    <max-async>1</max-async>
+    <hung-task-threshold>190000</hung-task-threshold>
+  </managed-scheduled-executor>
 
+  <managed-thread-factory>
+    <name>java:comp/concurrent/dd/web/TZThreadFactory</name>
+    <context-service-ref>java:comp/concurrent/dd/web/TZContextService</context-service-ref>
+    <priority>10</priority>
+  </managed-thread-factory>
+-->
 </web-app>


### PR DESCRIPTION
Write tests to cover app-defined resources in the web.xml deployment descriptor for
`<context-service>`, `<managed-executor>`, `<managed-scheduled-executor>`, and `<managed-thread-factory>`
which we can enable once ready