### PR TITLE
Fix test failure in RTC283807.

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleRealmTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleRealmTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -220,6 +220,8 @@ public class EJBModuleRealmTest extends JavaEESecTestBase {
         String queryString;
         //create app and setup server
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
+        assumeNotWindowsEe9();
+
         Log.info(logClass, getCurrentTestName(), "-----Creating EAR app.");
 
         // create ejbinwarservlet.war,

--- a/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalLoginTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalLoginTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,6 +40,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
+@SuppressWarnings("restriction")
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class MultipleModuleGlobalLoginTest extends JavaEESecTestBase {
@@ -231,6 +232,7 @@ public class MultipleModuleGlobalLoginTest extends JavaEESecTestBase {
     @Test
     public void testMultipleModuleWarsOverrideFormHAMNoRootContext() throws Exception {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
+        assumeNotWindowsEe9();
 
         // create module1, form login, redirect, ldap1. grouponly.
         WCApplicationHelper.createWar(myServer, TEMP_DIR, WAR1_NAME, true, JAR_NAME, false, "web.jar.base", "web.war.servlets.form.get.redirect",


### PR DESCRIPTION
We have a few more tests that are failing due to windows not releasing file locks. We will be skipping them when running with the transformer in Jakarta EE9.