### PR TITLE
tests for merging context service definitions

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/resources/META-INF/ejb-jar.xml
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/resources/META-INF/ejb-jar.xml
@@ -46,6 +46,14 @@
 	    <priority>7</priority>
 	  </managed-thread-factory>
 -->
+
+<!-- TODO enable to test merging
+      <context-service>
+        <name>java:comp/concurrent/merged/ejb/PTContextService</name>
+        <propagated>Priority</propagated>
+        <propagated>Timestamp</propagated>
+      </context-service>
+-->
     </session>
   </enterprise-beans>
 

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/src/test/jakarta/concurrency/ejb/ExecutorBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/src/test/jakarta/concurrency/ejb/ExecutorBean.java
@@ -25,6 +25,7 @@ import jakarta.enterprise.concurrent.ManagedThreadFactoryDefinition;
 
 import test.context.list.ListContext;
 import test.context.location.ZipCode;
+import test.context.timing.Timestamp;
 
 @ManagedExecutorDefinition(name = "java:comp/concurrent/executor8",
                            context = "java:app/concurrent/appContextSvc",
@@ -51,6 +52,14 @@ import test.context.location.ZipCode;
 @ManagedThreadFactoryDefinition(name = "java:module/concurrent/dd/ejb/ZLThreadFactory",
                                 context = "java:module/concurrent/ZLContextSvc",
                                 priority = 7)
+
+// Merged with ejb-jar.xml
+// TODO enable in ejb-jar.xml and update the following,
+@ContextServiceDefinition(name = "java:comp/concurrent/merged/ejb/PTContextService",
+                          cleared = ListContext.CONTEXT_NAME,
+                          propagated = { "Priority", Timestamp.CONTEXT_NAME }, // TODO ALL_REMAINING, // ejb-jar.xml replaces with Priority, Timestamp
+                          unchanged = APPLICATION)
+
 @Stateless
 public class ExecutorBean implements Executor {
     @Resource(lookup = "java:comp/concurrent/executor8", name = "java:app/env/concurrent/executor8ref")

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/resources/WEB-INF/web.xml
@@ -37,4 +37,13 @@
     <priority>10</priority>
   </managed-thread-factory>
 -->
+
+<!-- TODO enable to test merging
+  <context-service>
+    <name>java:app/concurrent/merged/web/LTContextService</name>
+    <cleared></cleared>
+    <unchanged>Remaining</unchanged>
+  </context-service>
+-->
+
 </web-app>

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/resources/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021,2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at


### PR DESCRIPTION
Tests to enable for the merging of the annotatively defined ContextServiceDefinition with a context-service definition with the same name that is defined in the web or ejb deployment descriptor.