### PR TITLE
resource definitions in EJB deployment descriptor are not part of EE 10

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/resources/META-INF/ejb-jar.xml
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/resources/META-INF/ejb-jar.xml
@@ -18,42 +18,9 @@
     <session>
       <ejb-name>ExecutorBean</ejb-name>
 
- <!-- TODO enable once working
-      <context-service>
-        <name>java:global/concurrent/dd/ejb/LPContextService</name>
-	    <cleared>Application</cleared>
-	    <propagated>List</propagated>
-	    <propagated>Priority</propagated>
-	    <unchanged>ZipCode</unchanged>
-	    <unchanged>Remaining</unchanged>
-	  </context-service>
+ <!-- Jakarta EE 10 does not include any updates to the Jakarta Enterprise Beans specification,
+      so there is no way to support definitions of Concurrency resources in ejb-jar.xml -->
 
-	  <managed-executor>
-	    <name>java:comp/concurrent/dd/ejb/Executor</name>
-	    <max-async>2</max-async>
-	    <hung-task-threshold>620000</hung-task-threshold>
-	  </managed-executor>
-
-	  <managed-scheduled-executor>
-	    <name>java:app/concurrent/dd/ejb/LPScheduledExecutor</name>
-	    <context-service-ref>java:global/concurrent/dd/ejb/LPContextService</context-service-ref>
-	    <max-async>3</max-async>
-	  </managed-scheduled-executor>
-
-	  <managed-thread-factory>
-	    <name>java:module/concurrent/dd/ejb/ZLThreadFactory</name>
-	    <context-service-ref>java:module/concurrent/ZLContextSvc</context-service-ref>
-	    <priority>7</priority>
-	  </managed-thread-factory>
--->
-
-<!-- TODO enable to test merging
-      <context-service>
-        <name>java:comp/concurrent/merged/ejb/PTContextService</name>
-        <propagated>Priority</propagated>
-        <propagated>Timestamp</propagated>
-      </context-service>
--->
     </session>
   </enterprise-beans>
 

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/src/test/jakarta/concurrency/ejb/ExecutorBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/src/test/jakarta/concurrency/ejb/ExecutorBean.java
@@ -38,27 +38,20 @@ import test.context.timing.Timestamp;
 @ManagedThreadFactoryDefinition(name = "java:module/concurrent/tf",
                                 context = "java:app/concurrent/appContextSvc",
                                 priority = 6)
-// TODO delete the following and enable the equivalent in ejb-jar.xml
-@ContextServiceDefinition(name = "java:global/concurrent/dd/ejb/LPContextService",
+
+@ContextServiceDefinition(name = "java:global/concurrent/anno/ejb/LPContextService",
                           cleared = APPLICATION,
                           propagated = { ListContext.CONTEXT_NAME, "Priority" },
                           unchanged = { ZipCode.CONTEXT_NAME, ALL_REMAINING })
-@ManagedExecutorDefinition(name = "java:comp/concurrent/dd/ejb/Executor",
+@ManagedExecutorDefinition(name = "java:comp/concurrent/anno/ejb/Executor",
                            hungTaskThreshold = 620000,
                            maxAsync = 2)
-@ManagedScheduledExecutorDefinition(name = "java:app/concurrent/dd/ejb/LPScheduledExecutor",
-                                    context = "java:global/concurrent/dd/ejb/LPContextService",
+@ManagedScheduledExecutorDefinition(name = "java:app/concurrent/anno/ejb/LPScheduledExecutor",
+                                    context = "java:global/concurrent/anno/ejb/LPContextService",
                                     maxAsync = 3)
-@ManagedThreadFactoryDefinition(name = "java:module/concurrent/dd/ejb/ZLThreadFactory",
+@ManagedThreadFactoryDefinition(name = "java:module/concurrent/anno/ejb/ZLThreadFactory",
                                 context = "java:module/concurrent/ZLContextSvc",
                                 priority = 7)
-
-// Merged with ejb-jar.xml
-// TODO enable in ejb-jar.xml and update the following,
-@ContextServiceDefinition(name = "java:comp/concurrent/merged/ejb/PTContextService",
-                          cleared = ListContext.CONTEXT_NAME,
-                          propagated = { "Priority", Timestamp.CONTEXT_NAME }, // TODO ALL_REMAINING, // ejb-jar.xml replaces with Priority, Timestamp
-                          unchanged = APPLICATION)
 
 @Stateless
 public class ExecutorBean implements Executor {

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/resources/WEB-INF/web.xml
@@ -73,6 +73,15 @@
     <hung-task-threshold>140000</hung-task-threshold>
   </managed-scheduled-executor>
 
+  <managed-thread-factory>
+    <name>java:comp/concurrent/merged/web/TZThreadFactory</name>
+    <context-service-ref>java:comp/concurrent/dd/web/TZContextService</context-service-ref>
+  </managed-thread-factory>
+
+  <managed-thread-factory>
+    <name>java:app/concurrent/merged/web/LTThreadFactory</name>
+    <priority>8</priority>
+  </managed-thread-factory>
 -->
 
 </web-app>

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/resources/WEB-INF/web.xml
@@ -50,6 +50,29 @@
     <propagated>Priority</propagated>
     <propagated>Timestamp</propagated>
   </context-service>
+
+  <managed-executor>
+     <name>java:module/concurrent/merged/web/ZLExecutor</name>
+     <max-async>3</max-async>
+  </managed-executor>
+
+  <managed-executor>
+    <name>java:comp/concurrent/merged/web/ZPExecutor</name>
+    <context-service-ref>java:app/concurrent/dd/ZPContextService</context-service-ref>
+    <hung-task-threshold>200000</hung-task-threshold>
+  </managed-executor>
+
+  <managed-scheduled-executor>
+    <name>java:module/concurrent/merged/web/ZLScheduledExecutor</name>
+    <max-async>1</max-async>
+  </managed-scheduled-executor>
+
+  <managed-scheduled-executor>
+    <name>java:app/concurrent/merged/web/LPScheduledExecutor</name>
+    <context-service-ref>java:global/concurrent/anno/ejb/LPContextService</context-service-ref>
+    <hung-task-threshold>140000</hung-task-threshold>
+  </managed-scheduled-executor>
+
 -->
 
 </web-app>

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/resources/WEB-INF/web.xml
@@ -20,7 +20,7 @@
 
   <managed-executor>
     <name>java:global/concurrent/dd/web/LPExecutor</name>
-    <context-service-ref>java:global/concurrent/dd/ejb/LPContextService</context-service-ref>
+    <context-service-ref>java:global/concurrent/anno/ejb/LPContextService</context-service-ref>
     <max-async>3</max-async>
   </managed-executor>
 
@@ -43,6 +43,12 @@
     <name>java:app/concurrent/merged/web/LTContextService</name>
     <cleared></cleared>
     <unchanged>Remaining</unchanged>
+  </context-service>
+
+  <context-service>
+    <name>java:comp/concurrent/merged/web/PTContextService</name>
+    <propagated>Priority</propagated>
+    <propagated>Timestamp</propagated>
   </context-service>
 -->
 


### PR DESCRIPTION
Replace tests of the Concurrency 3.0 resource definitions being used in EJB deployment descriptors because it was just determined that the ejb-jar.xml schema is NOT being updated for EE 10.  The jakartaee-schemas project erroneously indicated EE 10 support within the ejb deployment descriptor,

```
 <xsd:include schemaLocation="jakartaee_10.xsd"/>
```

causing us to write these tests, but this was found to be an error and is being removed.

All of the tests for merging deployment descriptors with annotations should be done in web module for now.