### PR TITLE
Follow-up changes for fixing RepositoryResolver install lists for tolerated dependencies

### DIFF
--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
@@ -82,6 +82,8 @@ public class RepositoryResolver {
 
     /**
      * Map from symbolic name to feature for all features returned as resolved by the kernel resolver
+     * <p>
+     * Keyset is mutually exclusive with {@link #featuresMissing} and {@link #requirementsFoundForOtherProducts}
      */
     Map<String, ProvisioningFeatureDefinition> resolvedFeatures;
 
@@ -89,6 +91,8 @@ public class RepositoryResolver {
      * List of requested features that were reported missing by the kernel resolver and weren't found in the repository applicable to another product.
      * <p>
      * May include sample names if they were missing
+     * <p>
+     * Mutually exclusive with {@link #resolvedFeatures} and {@link #requirementsFoundForOtherProducts}
      */
     List<String> featuresMissing;
 
@@ -101,6 +105,8 @@ public class RepositoryResolver {
      * List of requirements which couldn't be resolved but for which we found a solution that applied to the wrong product
      * <p>
      * Each requirement will be a symbolic name, feature name or sample name
+     * <p>
+     * Mutually exclusive with {@link #resolvedFeatures} and {@link #featuresMissing}
      */
     Set<String> requirementsFoundForOtherProducts;
 
@@ -547,7 +553,7 @@ public class RepositoryResolver {
                 if (feature == null) {
                     allDependenciesResolved = false;
                     // Unless we know it exists but applies to another product, note the missing requirement as well
-                    if (!requirementsFoundForOtherProducts.contains(featureName) && featuresMissing.contains(featureName)) {
+                    if (featuresMissing.contains(featureName)) {
                         missingRequirements.add(new MissingRequirement(featureName, resource));
                     }
                 } else {
@@ -593,7 +599,7 @@ public class RepositoryResolver {
         if (feature == null) {
             // Feature missing
             missingTopLevelRequirements.add(featureName);
-            if (!requirementsFoundForOtherProducts.contains(featureName) && featuresMissing.contains(featureName)) {
+            if (featuresMissing.contains(featureName)) {
                 missingRequirements.add(new MissingRequirement(featureName, null));
             }
             return Collections.emptyList();
@@ -701,7 +707,7 @@ public class RepositoryResolver {
                 // We found the dependency, continue populating the distance map
                 result &= populateMaxDistanceMap(maxDistanceMap, resolvedFeatureName, currentDistance + 1, currentStack, missingRequirements);
             } else {
-                if (!requirementsFoundForOtherProducts.contains(featureName) && featuresMissing.contains(dependency.getSymbolicName())) {
+                if (featuresMissing.contains(dependency.getSymbolicName())) {
                     // The dependency was totally missing, add it to the list of missing requirements
                     missingRequirements.add(new MissingRequirement(dependency.getSymbolicName(), getResource(feature)));
                 }

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/RepositoryResolverTest.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/RepositoryResolverTest.java
@@ -263,7 +263,6 @@ public class RepositoryResolverTest {
      */
     @Test
     public void testCreateInstallListToleratesPartiallyInstalled() {
-        @SuppressWarnings("unused")
         MockFeature base10 = new MockFeature("com.example.base-1.0");
         MockFeature base20 = new MockFeature("com.example.base-2.0");
 
@@ -282,6 +281,7 @@ public class RepositoryResolverTest {
         featureB.addRequireFeatureWithTolerates("com.example.base-2.0", Collections.emptyList());
 
         RepositoryResolver resolver = testResolver().withResolvedInstalledFeature(base20, featureA)
+                                                    .withInstalledFeature(base10, internalA10)
                                                     .withResolvedFeature(internalA20, featureB)
                                                     .build();
 
@@ -318,6 +318,11 @@ public class RepositoryResolverTest {
             for (EsaResource esa : esas) {
                 resolvedFeatures.put(esa.getProvideFeature(), new KernelResolverEsa(esa, resolutionMode));
             }
+            return this;
+        }
+
+        public ResolverBuilder withInstalledFeature(ProvisioningFeatureDefinition... definitions) {
+            installedFeatures.addAll(Arrays.asList(definitions));
             return this;
         }
 

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/FeatureResolverTest.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/FeatureResolverTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverResultMatcher.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverResultMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
A few follow up fixes:
* Fix a unit test to properly list the features which are installed (this shouldn't affect the code path under test)
* Remove some redundant checks in the resolver (one of which was using the wrong feature name anyway :facepalm:)
* Update the copyright header which was missed on a couple of files

Follow up for #19860 