### PR TITLE
Issue 18669: Add concurrency test testEJBAnnoManagedThreadFactoryInitialization.

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/src/test/jakarta/concurrency/ejb/MTFDBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestEJB/src/test/jakarta/concurrency/ejb/MTFDBean.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.concurrency.ejb;
+
+import jakarta.ejb.Stateless;
+import jakarta.enterprise.concurrent.ManagedThreadFactoryDefinition;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+/**
+ * Only use for testEJBAnnoManagedThreadFactoryInitialization. This bean is used to verify behavior when looking
+ * up a ManagedThreadFactory that is defined on the bean via annotation, when the bean hasn't been previously used/initialized.
+ */
+@ManagedThreadFactoryDefinition(name = "java:module/concurrent/testInitTF")
+@Stateless
+public class MTFDBean {
+    public Object lookupThreadFactory() throws NamingException {
+        return InitialContext.doLookup("java:module/concurrent/testInitTF");
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/ConcurrencyTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/ConcurrencyTestServlet.java
@@ -58,6 +58,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import jakarta.annotation.Resource;
+import jakarta.ejb.EJB;
 import jakarta.ejb.EJBException;
 import jakarta.enterprise.concurrent.ContextService;
 import jakarta.enterprise.concurrent.ContextServiceDefinition;
@@ -88,6 +89,7 @@ import componenttest.app.FATServlet;
 import test.context.list.ListContext;
 import test.context.location.ZipCode;
 import test.context.timing.Timestamp;
+import test.jakarta.concurrency.ejb.MTFDBean;
 
 @ContextServiceDefinition(name = "java:app/concurrent/appContextSvc",
                           propagated = APPLICATION,
@@ -217,6 +219,10 @@ public class ConcurrencyTestServlet extends FATServlet {
 
     @Resource(lookup = "java:app/concurrent/lowPriorityThreads")
     ManagedThreadFactory lowPriorityThreads;
+
+    //Do not use for any other tests
+    @EJB
+    MTFDBean testEJBAnnoManagedThreadFactoryInitializationBean;
 
     private ExecutorService unmanagedThreads;
 
@@ -791,6 +797,16 @@ public class ConcurrencyTestServlet extends FATServlet {
                 throw new EJBException(x);
             }
         });
+    }
+
+    /**
+     * Use a ManagedThreadFactory from a ManagedThreadFactoryDefinition that is defined in an EJB that has
+     * not been previously initialized/invoked.
+     */
+    @Test
+    public void testEJBAnnoManagedThreadFactoryInitialization() throws Exception {
+        Object resultOfLookup = testEJBAnnoManagedThreadFactoryInitializationBean.lookupThreadFactory();
+        assertTrue(resultOfLookup.toString(), resultOfLookup instanceof ManagedThreadFactory);
     }
 
     /**


### PR DESCRIPTION
This test is intended to prevent regression of the issue outlined below. If Liberty is not matching on resource factories, this test itself doesn't fail, but it triggers intermittent failures in other tests.


AppDefinedResourceFactory for Concurrency 3.0 resource definitions is accidentally matching some very similar services which aren't resource factories, resulting in an intermittent ClassCastException, such as

`java.lang.ClassCastException: com.ibm.ws.concurrent.internal.ManagedThreadFactoryService$ManagedThreadFactoryImpl`