### PR TITLE
Update LibertyClient and LibertyServer simplicity classes to better h…

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
@@ -628,6 +628,34 @@ public class LibertyClient {
                 LOG.warning("The build is configured to run FAT tests with Java 2 Security enabled, but the FAT client " + getClientName() +
                             " is exempt from Java 2 Security regression testing.");
             }
+        } else {
+            // Check if "websphere.java.security" has been added to bootstrapping.properties
+            // as some tests will add it for their own security enable tests
+            boolean bootstrapHasJava2SecProps = false;
+            RemoteFile f = getClientBootstrapPropertiesFile();
+            java.io.BufferedReader reader = null;
+            try {
+                reader = new java.io.BufferedReader(new java.io.InputStreamReader(f.openForReading()));
+                String line = reader.readLine();
+                while (line != null) {
+                    if (line != null && line.trim().equals("websphere.java.security")) {
+                        bootstrapHasJava2SecProps = true;
+                        break;
+                    }
+                    line = reader.readLine();
+                }
+            } catch (Exception e) {
+                Log.info(c, "startClientWithArgs", "caught exception checking bootstap.properties file for Java 2 Security properties, e: ", e.getMessage());
+            } finally {
+                if (reader != null)
+                    reader.close();
+            }
+
+            if (bootstrapHasJava2SecProps) {
+                // If we are running on Java 18+, then we need to explicitly enable the security manager
+                Log.info(c, "startClientWithArgs", "Java 18 + Java2Sec requested, setting -Djava.security.manager=allow");
+                JVM_ARGS += " -Djava.security.manager=allow";
+            }
         }
 
         // Look for forced client trace..

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
@@ -622,13 +622,14 @@ public class LibertyClient {
 
                 // If we are running on Java 18+, then we need to explicitly enable the security manager
                 if (javaInfo.majorVersion() >= 18) {
+                    Log.info(c, "startClientWithArgs", "Java 18 + and java2security is global, setting -Djava.security.manager=allow");
                     JVM_ARGS += " -Djava.security.manager=allow";
                 }
             } else {
                 LOG.warning("The build is configured to run FAT tests with Java 2 Security enabled, but the FAT client " + getClientName() +
                             " is exempt from Java 2 Security regression testing.");
             }
-        } else {
+        } else if (javaInfo.majorVersion() >= 18) {
             // Check if "websphere.java.security" has been added to bootstrapping.properties
             // as some tests will add it for their own security enable tests
             boolean bootstrapHasJava2SecProps = false;

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -1426,6 +1426,34 @@ public class LibertyServer implements LogMonitorClient {
             if (info.majorVersion() >= 18) {
                 JVM_ARGS += " -Djava.security.manager=allow";
             }
+        } else if (info.majorVersion() >= 18) {
+            boolean bootstrapHasJava2SecProps = false;
+            // Check if "websphere.java.security" has been added to bootstrapping.properties
+            // as some tests will add it for their own security enable tests
+            RemoteFile f = getServerBootstrapPropertiesFile();
+            java.io.BufferedReader reader = null;
+            try {
+                reader = new java.io.BufferedReader(new java.io.InputStreamReader(f.openForReading()));
+                String line = reader.readLine();
+                while (line != null) {
+                    if (line != null && line.trim().equals("websphere.java.security")) {
+                        bootstrapHasJava2SecProps = true;
+                        break;
+                    }
+                    line = reader.readLine();
+                }
+            } catch (Exception e) {
+                Log.info(c, "startServerWithArgs", "caught exception checking bootstap.properties file for Java 2 Security properties, e: ", e.getMessage());
+            } finally {
+                if (reader != null)
+                    reader.close();
+            }
+
+            if (bootstrapHasJava2SecProps) {
+                // If we are running on Java 18+, then we need to explicitly enable the security manager
+                Log.info(c, "startServerWithArgs", "Java 18 + Java2Sec requested, setting -Djava.security.manager=allow");
+                JVM_ARGS += " -Djava.security.manager=allow";
+            }
         }
 
         Properties bootstrapProperties = getBootstrapProperties();

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -1424,6 +1424,7 @@ public class LibertyServer implements LogMonitorClient {
 
             // If we are running on Java 18+, then we need to explicitly enable the security manager
             if (info.majorVersion() >= 18) {
+                Log.info(c, "startServerWithArgs", "Java 18 + and java2security is global, setting -Djava.security.manager=allow");
                 JVM_ARGS += " -Djava.security.manager=allow";
             }
         } else if (info.majorVersion() >= 18) {


### PR DESCRIPTION
LibertyServer and LibertyClient need further changes for JDK 18 support, as tests which manage their own java 2 security settings were falling through the cracks in the first implementation.