### PR TITLE
serialization of third-party context is not supported

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/SameThreadExecutor.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/SameThreadExecutor.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.concurrency.web;
+
+/**
+ * Runs tasks inline on the same thread.
+ * Tests can use ContextService contextualize serializable proxies for this class
+ * in order to test how context behaves after deserialization.
+ */
+public class SameThreadExecutor implements Ser2Executor {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void execute(Runnable command) {
+        command.run();
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/Ser1Executor.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/Ser1Executor.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.concurrency.web;
+
+import java.io.Serializable;
+import java.util.concurrent.Executor;
+
+/**
+ * Interface class for testing contextual proxies.
+ */
+public interface Ser1Executor extends Executor, Serializable {
+}

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/Ser2Executor.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/Ser2Executor.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.concurrency.web;
+
+/**
+ * Interface class for testing contextual proxies.
+ */
+public interface Ser2Executor extends Ser1Executor {
+}

--- a/dev/com.ibm.ws.context/src/com/ibm/ws/context/service/serializable/ThreadContextDescriptorImpl.java
+++ b/dev/com.ibm.ws.context/src/com/ibm/ws/context/service/serializable/ThreadContextDescriptorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013,2020 IBM Corporation and others.
+ * Copyright (c) 2013,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -240,6 +240,14 @@ public class ThreadContextDescriptorImpl implements ThreadContextDescriptor, Thr
     @Trivial
     public final Map<String, String> getExecutionProperties() {
         return execProps;
+    }
+
+    @Override
+    @Trivial
+    public final boolean isSerializable() {
+        // All other thread context providers should always return true
+        int i = providerNames.indexOf("io.openliberty.thirdparty.context.provider");
+        return i >= 0 && threadContext.get(i).isSerializable();
     }
 
     /**

--- a/dev/com.ibm.ws.context/src/com/ibm/ws/context/service/serializable/ThreadContextDescriptorImpl.java
+++ b/dev/com.ibm.ws.context/src/com/ibm/ws/context/service/serializable/ThreadContextDescriptorImpl.java
@@ -247,7 +247,7 @@ public class ThreadContextDescriptorImpl implements ThreadContextDescriptor, Thr
     public final boolean isSerializable() {
         // All other thread context providers should always return true
         int i = providerNames.indexOf("io.openliberty.thirdparty.context.provider");
-        return i >= 0 && threadContext.get(i).isSerializable();
+        return i < 0 || threadContext.get(i).isSerializable();
     }
 
     /**

--- a/dev/com.ibm.ws.context/src/com/ibm/wsspi/threadcontext/ThreadContext.java
+++ b/dev/com.ibm.ws.context/src/com/ibm/wsspi/threadcontext/ThreadContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2013 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,14 +13,16 @@ package com.ibm.wsspi.threadcontext;
 import java.io.Serializable;
 import java.util.concurrent.RejectedExecutionException;
 
+import com.ibm.websphere.ras.annotation.Trivial;
+
 /**
  * <p>Serializable captured thread context.
- * 
+ *
  * <p>The consumer of this interface may choose to (but is not required to) serialize it
  * (for example, to a database or file) and reuse it multiple times on any threads
  * (although only serially, never concurrently) at any future points in time, including across release
  * boundaries or on different servers.
- * 
+ *
  * <p>A thread context implementation must be capable of handling all of these usage patterns.
  */
 public interface ThreadContext extends Cloneable, Serializable {
@@ -29,19 +31,31 @@ public interface ThreadContext extends Cloneable, Serializable {
      * so that a ThreadContext instance may reliably store state information that is needed to
      * restore the previous context after the contextual operation ends.
      * The clone method should not copy state information for restoring previous thread context.
-     * 
+     *
      * @return copy of thread context.
      */
     ThreadContext clone();
 
     /**
+     * Indicates that this thread context is serializable.
+     * The default implementation returns true.
+     * Only ThirdPartyContext should override this method.
+     *
+     * @return true if serializable, otherwise false.
+     */
+    @Trivial
+    default boolean isSerializable() {
+        return true;
+    }
+
+    /**
      * <p>Establishes context on the current thread.
      * When this method is used, expect that context will later be removed and restored
      * to its previous state via taskStopping.
-     * 
+     *
      * <p>This method should fail if the context cannot be established on the thread.
      * In the event of failure, any partially applied context must be removed before this method returns.
-     * 
+     *
      * @throws RejectedExecutionException if context cannot be established on the thread.
      */
     void taskStarting() throws RejectedExecutionException;

--- a/dev/com.ibm.ws.context/src/com/ibm/wsspi/threadcontext/ThreadContextDescriptor.java
+++ b/dev/com.ibm.ws.context/src/com/ibm/wsspi/threadcontext/ThreadContextDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2014 IBM Corporation and others.
+ * Copyright (c) 2013, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ import java.util.concurrent.RejectedExecutionException;
 public interface ThreadContextDescriptor extends Cloneable {
     /**
      * Returns a copy of a thread context descriptor.
-     * 
+     *
      * @return a copy of a thread context descriptor.
      */
     ThreadContextDescriptor clone();
@@ -31,14 +31,22 @@ public interface ThreadContextDescriptor extends Cloneable {
     /**
      * Returns the execution properties.
      * Note that some properties might have been added internally by the context service implementation.
-     * 
+     *
      * @return the execution properties.
      */
     Map<String, String> getExecutionProperties();
 
     /**
+     * Indicates if it is possible to serialize all of the context that is represented by
+     * this thread context descriptor.
+     *
+     * @return true if all context can be serialized, otherwise false.
+     */
+    boolean isSerializable();
+
+    /**
      * Serializes this thread context descriptor to bytes.
-     * 
+     *
      * @return serialized bytes representing the thread context descriptor.
      * @throws IOException if a serialization error occurs.
      */
@@ -46,24 +54,24 @@ public interface ThreadContextDescriptor extends Cloneable {
 
     /**
      * Sets thread context for an already added thread context provider, otherwise adds it to the end of the list.
-     * 
+     *
      * @param providerName component name of the thread context provider.
-     * @param context new thread context.
+     * @param context      new thread context.
      */
     void set(String providerName, ThreadContext context);
 
     /**
      * Establish context on a thread before a contextual operation is started.
-     * 
+     *
      * @return list of thread context matching the order in which context has been applied to the thread.
-     * @throws IllegalStateException if the application component is not started or deployed.
+     * @throws IllegalStateException      if the application component is not started or deployed.
      * @throws RejectedExecutionException if context cannot be established on the thread.
      */
     ArrayList<ThreadContext> taskStarting() throws RejectedExecutionException;
 
     /**
      * Remove context from the thread (in reverse of the order in which is was applied) after a contextual operation completes.
-     * 
+     *
      * @param threadContext list of context previously applied to thread, ordered according to the order in which it was applied to the thread.
      */
     void taskStopping(ArrayList<ThreadContext> threadContext);

--- a/dev/com.ibm.ws.microprofile.contextpropagation.1.0/src/com/ibm/ws/microprofile/contextpropagation/ThreadContextDescriptorImpl.java
+++ b/dev/com.ibm.ws.microprofile.contextpropagation.1.0/src/com/ibm/ws/microprofile/contextpropagation/ThreadContextDescriptorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2019 IBM Corporation and others.
+ * Copyright (c) 2018,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -91,6 +91,11 @@ class ThreadContextDescriptorImpl implements ThreadContextDescriptor {
     @Trivial
     public Map<String, String> getExecutionProperties() {
         return EMPTY_MAP;
+    }
+
+    @Override
+    public boolean isSerializable() {
+        return false;
     }
 
     @Override

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance/test/util/DummyContextService.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance/test/util/DummyContextService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,6 +40,11 @@ public class DummyContextService implements WSContextService {
         @Override
         public Map<String, String> getExecutionProperties() {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isSerializable() {
+            return false;
         }
 
         @Override


### PR DESCRIPTION
The spec API does not provide any way to serialize or deserialize third-party context types that are captured for propagation, and requires that we reject the methods of ContextService that create serializable contextual proxies when such unserializable context is present.  This pull implements and tests that requirement.