### PR TITLE
refactor 3rd party id token code flow path

### DIFF
--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/oauth/core/internal/oauth20/OAuth20Constants.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/oauth/core/internal/oauth20/OAuth20Constants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 IBM Corporation and others.
+ * Copyright (c) 2011, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -206,6 +206,6 @@ public interface OAuth20Constants extends OAuthConstants {
 
     // constants for identifying third party tokens
     public static final String THIRD_PARTY_ID_TOKEN = "third_party_idtoken";
-    public static final String THIRD_PARTY_ID_TOKEN_SUFFIX = "_" + THIRD_PARTY_ID_TOKEN;
+    public static final String THIRD_PARTY_ID_TOKEN_PREFIX = THIRD_PARTY_ID_TOKEN + ":";
 
 }

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/OIDCGrantTypeHandlerCodeImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/OIDCGrantTypeHandlerCodeImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -102,7 +102,7 @@ public class OIDCGrantTypeHandlerCodeImpl extends OAuth20GrantTypeHandlerCodeImp
                                     BuildResponseTypeUtil.putIssuerIdentifierInMap(idTokenMap, attributeList);
 
                                     OAuth20TokenCache tokenCache = tokenFactory.getOAuth20ComponentInternal().getTokenCache();
-                                    String thirdPartyIDTokenCacheKey = code.getTokenString() + OAuth20Constants.THIRD_PARTY_ID_TOKEN_SUFFIX;
+                                    String thirdPartyIDTokenCacheKey = OAuth20Constants.THIRD_PARTY_ID_TOKEN_PREFIX + code.getTokenString();
                                     OAuth20Token thirdPartyIDToken = tokenCache.get(thirdPartyIDTokenCacheKey);
                                     if (thirdPartyIDToken != null) {
                                         idTokenMap.put(OAuth20Constants.THIRD_PARTY_ID_TOKEN, new String[] { thirdPartyIDToken.getTokenString() });

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/OIDCResponseTypeHandlerCodeImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/OIDCResponseTypeHandlerCodeImpl.java
@@ -53,7 +53,6 @@ public class OIDCResponseTypeHandlerCodeImpl extends OAuth20ResponseTypeHandlerC
             String thirdPartyIdTokenId = OAuth20Constants.THIRD_PARTY_ID_TOKEN_PREFIX + code.getTokenString();
             String thirdPartyIdTokenString = (String) hashtableFromRunAsSubject.get(OAuth20Constants.ID_TOKEN);
             if (thirdPartyIdTokenString != null) {
-                int lifetimeSeconds = getLifetimeSeconds(thirdPartyIdTokenString);
                 OAuth20Token tokenCacheEntry = new IDTokenImpl(
                         thirdPartyIdTokenId,
                         thirdPartyIdTokenString,
@@ -63,31 +62,13 @@ public class OIDCResponseTypeHandlerCodeImpl extends OAuth20ResponseTypeHandlerC
                         code.getRedirectUri(),
                         code.getStateId(),
                         code.getScope(),
-                        lifetimeSeconds,
+                        code.getLifetimeSeconds(),
                         null,
                         OAuth20Constants.GRANT_TYPE_AUTHORIZATION_CODE);
 
                 // save third-party token in token cache to pick up when token endpoint is called
                 tokenCache.add(tokenCacheEntry.getId(), tokenCacheEntry, tokenCacheEntry.getLifetimeSeconds());
             }
-        }
-    }
-
-    private int getLifetimeSeconds(String jwtString) {
-        try {
-            JwtContext context = Jose4jUtil.parseJwtWithoutValidation(jwtString);
-            JwtClaims claims = context.getJwtClaims();
-
-            long now = System.currentTimeMillis();
-            long expiresAt = claims.getExpirationTime().getValueInMillis();
-            long expiresIn = expiresAt - now;
-
-            if (expiresIn < 0) {
-                return 0;
-            }
-            return (int) expiresIn / 1000;
-        } catch (Exception e) {
-            return 0;
         }
     }
 

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/OIDCResponseTypeHandlerCodeImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/OIDCResponseTypeHandlerCodeImpl.java
@@ -50,7 +50,7 @@ public class OIDCResponseTypeHandlerCodeImpl extends OAuth20ResponseTypeHandlerC
         SubjectHelper subjectHelper = new SubjectHelper();
         Hashtable<String, ?> hashtableFromRunAsSubject = subjectHelper.getHashtableFromRunAsSubject();
         if (hashtableFromRunAsSubject != null) {
-            String thirdPartyIdTokenId = code.getTokenString() + OAuth20Constants.THIRD_PARTY_ID_TOKEN_SUFFIX;
+            String thirdPartyIdTokenId = OAuth20Constants.THIRD_PARTY_ID_TOKEN_PREFIX + code.getTokenString();
             String thirdPartyIdTokenString = (String) hashtableFromRunAsSubject.get(OAuth20Constants.ID_TOKEN);
             if (thirdPartyIdTokenString != null) {
                 int lifetimeSeconds = getLifetimeSeconds(thirdPartyIdTokenString);

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/OIDCResponseTypeHandlerCodeImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/OIDCResponseTypeHandlerCodeImpl.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.openidconnect.server.plugins;
+
+import java.util.Hashtable;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.consumer.JwtContext;
+
+import com.ibm.oauth.core.api.attributes.AttributeList;
+import com.ibm.oauth.core.api.oauth20.token.OAuth20Token;
+import com.ibm.oauth.core.api.oauth20.token.OAuth20TokenCache;
+import com.ibm.oauth.core.internal.oauth20.OAuth20Constants;
+import com.ibm.oauth.core.internal.oauth20.responsetype.impl.OAuth20ResponseTypeHandlerCodeImpl;
+import com.ibm.oauth.core.internal.oauth20.token.OAuth20TokenFactory;
+import com.ibm.ws.security.authentication.utility.SubjectHelper;
+import com.ibm.ws.security.openidconnect.client.jose4j.util.Jose4jUtil;
+
+public class OIDCResponseTypeHandlerCodeImpl extends OAuth20ResponseTypeHandlerCodeImpl {
+
+    private static final String CLASS = OIDCResponseTypeHandlerCodeImpl.class.getName();
+    private static Logger log = Logger.getLogger(CLASS);
+
+    @Override
+    public List<OAuth20Token> buildTokensResponseType(AttributeList attributeList, OAuth20TokenFactory tokenFactory, String redirectUri) {
+        String methodName = "buildTokensResponseType";
+        log.entering(CLASS, methodName);
+
+        List<OAuth20Token> tokens = super.buildTokensResponseType(attributeList, tokenFactory, redirectUri);
+        
+        OAuth20Token code = tokens.get(0);
+        OAuth20TokenCache tokenCache = tokenFactory.getOAuth20ComponentInternal().getTokenCache();
+        cacheThirdPartyIDToken(code, tokenCache);
+
+        log.exiting(CLASS, methodName);
+        return tokens;
+    }
+
+    private void cacheThirdPartyIDToken(OAuth20Token code, OAuth20TokenCache tokenCache) {
+        SubjectHelper subjectHelper = new SubjectHelper();
+        Hashtable<String, ?> hashtableFromRunAsSubject = subjectHelper.getHashtableFromRunAsSubject();
+        if (hashtableFromRunAsSubject != null) {
+            String thirdPartyIdTokenId = code.getTokenString() + OAuth20Constants.THIRD_PARTY_ID_TOKEN_SUFFIX;
+            String thirdPartyIdTokenString = (String) hashtableFromRunAsSubject.get(OAuth20Constants.ID_TOKEN);
+            if (thirdPartyIdTokenString != null) {
+                int lifetimeSeconds = getLifetimeSeconds(thirdPartyIdTokenString);
+                OAuth20Token tokenCacheEntry = new IDTokenImpl(
+                        thirdPartyIdTokenId,
+                        thirdPartyIdTokenString,
+                        code.getComponentId(),
+                        code.getClientId(),
+                        code.getUsername(),
+                        code.getRedirectUri(),
+                        code.getStateId(),
+                        code.getScope(),
+                        lifetimeSeconds,
+                        null,
+                        OAuth20Constants.GRANT_TYPE_AUTHORIZATION_CODE);
+
+                // save third-party token in token cache to pick up when token endpoint is called
+                tokenCache.add(tokenCacheEntry.getId(), tokenCacheEntry, tokenCacheEntry.getLifetimeSeconds());
+            }
+        }
+    }
+
+    private int getLifetimeSeconds(String jwtString) {
+        try {
+            JwtContext context = Jose4jUtil.parseJwtWithoutValidation(jwtString);
+            JwtClaims claims = context.getJwtClaims();
+
+            long now = System.currentTimeMillis();
+            long expiresAt = claims.getExpirationTime().getValueInMillis();
+            long expiresIn = expiresAt - now;
+
+            if (expiresIn < 0) {
+                return 0;
+            }
+            return (int) expiresIn / 1000;
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/OIDCResponseTypeHandlerFactoryImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/OIDCResponseTypeHandlerFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,6 @@ import com.ibm.oauth.core.internal.oauth20.OAuth20Constants;
 import com.ibm.oauth.core.internal.oauth20.config.OAuth20ConfigProvider;
 import com.ibm.oauth.core.internal.oauth20.responsetype.OAuth20ResponseTypeHandler;
 import com.ibm.oauth.core.internal.oauth20.responsetype.OAuth20ResponseTypeHandlerFactory;
-import com.ibm.oauth.core.internal.oauth20.responsetype.impl.OAuth20ResponseTypeHandlerCodeImpl;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.security.oauth20.api.OAuth20Provider;
@@ -81,7 +80,7 @@ public class OIDCResponseTypeHandlerFactoryImpl implements OAuth20ResponseTypeHa
                             { OAuth20Constants.GRANT_TYPE_AUTHORIZATION_CODE, allowedGrantTypesAsString });
                             throw new OAuthConfigurationException(OAuthComponentConfigurationConstants.OAUTH20_GRANT_TYPES_ALLOWED, responseType, null);
                         }
-                        result = new OAuth20ResponseTypeHandlerCodeImpl();
+                        result = new OIDCResponseTypeHandlerCodeImpl();
                     }
                 } else if (OAuth20Constants.RESPONSE_TYPE_TOKEN.equals(rType) ||
                            OIDCConstants.RESPONSE_TYPE_ID_TOKEN.equals(rType)) {

--- a/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/server/plugins/OIDCGrantTypeHandlerCodeImplTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/server/plugins/OIDCGrantTypeHandlerCodeImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -161,7 +161,7 @@ public class OIDCGrantTypeHandlerCodeImplTest {
                     will(returnValue(oauth20ConfigProvider));
                     allowing(componentInternal).getTokenCache();
                     will(returnValue(tokenCache));
-                    allowing(tokenCache).get("authorization_code_string" + OAuth20Constants.THIRD_PARTY_ID_TOKEN_SUFFIX);
+                    allowing(tokenCache).get(OAuth20Constants.THIRD_PARTY_ID_TOKEN_PREFIX + "authorization_code_string");
                     will(returnValue(null));
                     allowing(oauth20ConfigProvider).getMaxAuthGrantLifetimeSeconds();
                     will(returnValue(3600)); // 1 hour


### PR DESCRIPTION
for #16298 

* cache the 3rd party id token in auth code path for the same duration as the auth code lifetime, since it can only be picked up using the associated auth code. processing the id token is left for the IDTokenHandler
* move oidc related stuff out of OAuth20ResponseTypeHandlerCodeImpl and into its own oidc handler which extends the oauth handler
* change the 3rd party id token identifier to be used as a prefix instead of as a suffix