### PR TITLE
Update launch.xml files to set -Djava.security.manager=allow only for Java 18

### DIFF
--- a/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
@@ -107,12 +107,16 @@
 		</condition>
 		<property name="illegal.access.permit" value=""/>
 		
+		
 		<!-- Java 17 began the security manager's deprecation process (https://openjdk.java.net/jeps/411).
 			     In Java 18, the `java.security.manager` system property's default changed from `allow` to `disallow`, which causes our build process to fail.  
 				 Setting up a gated property (use.java.security.manager) so that any builds that take place on Java 15+ use the JVM override 
 				 -Djava.security.manager=allow which is needed for our build process, but older versions will be skipped --> 
 		<condition property="use.java.security.manager" value="-Djava.security.manager=allow">
-			<istrue value="${is.java15.orHigher}"/>
+			<and>
+				<istrue value="${is.java15.orHigher}"/>
+				<not><istrue value="${supports.framework.java}"/></not>
+			</and>
 		</condition>
 		<property name="use.java.security.manager" value=""/>
 		

--- a/dev/com.ibm.ws.jmx_fat/override/autoFVT/src/ant/launch.xml
+++ b/dev/com.ibm.ws.jmx_fat/override/autoFVT/src/ant/launch.xml
@@ -24,17 +24,26 @@
 	</condition>
 	<property name="illegal.access.permit.jmx.fat" value=""/>
 	
-	<!-- Java 17 began the security manager's deprecation process (https://openjdk.java.net/jeps/411).
-		     In Java 18, the `java.security.manager` system property's default changed from `allow` to `disallow`, which causes our build process to fail.  
-			 Setting up a gated property (use.java.security.manager) so that any builds that take place on Java 15+ use the JVM override 
-			 -Djava.security.manager=allow which is needed for our build process, but older versions will be skipped --> 
-	<condition property="use.java.security.manager" value="-Djava.security.manager=allow">
+	<!-- boolean for Java15+.  The assumption is that at this point forward (Java 15), we will only be building using LTS 
+	     or interium versions of Java -->
+	<condition property="is.java15.orHigher" value="true">
 		<not>
 			<or>
 				<equals arg1="11" arg2="${java.specification.version}"/>
 				<equals arg1="1.8" arg2="${java.specification.version}"/>
 			</or>
-		</not>
+	    </not>
+	</condition>
+	
+	<!-- Java 17 began the security manager's deprecation process (https://openjdk.java.net/jeps/411).
+		     In Java 18, the `java.security.manager` system property's default changed from `allow` to `disallow`, which causes our build process to fail.  
+			 Setting up a gated property (use.java.security.manager) so that any builds that take place on Java 15+ use the JVM override 
+			 -Djava.security.manager=allow which is needed for our build process, but older versions will be skipped --> 
+	<condition property="use.java.security.manager" value="-Djava.security.manager=allow">
+			<and>
+				<istrue value="${is.java15.orHigher}"/>
+				<not><istrue value="${supports.framework.java}"/></not>
+			</and>
 	</condition>
 	<property name="use.java.security.manager" value=""/>
 	

--- a/dev/com.ibm.ws.kernel.boot_fat/override/autoFVT/src/ant/launch.xml
+++ b/dev/com.ibm.ws.kernel.boot_fat/override/autoFVT/src/ant/launch.xml
@@ -23,18 +23,27 @@
 		</not>
 	</condition>
 	<property name="illegal.access.permit.kernel.boot" value=""/>
+	
+	<!-- boolean for Java15+.  The assumption is that at this point forward (Java 15), we will only be building using LTS 
+	     or interium versions of Java -->
+	<condition property="is.java15.orHigher" value="true">
+		<not>
+			<or>
+				<equals arg1="11" arg2="${java.specification.version}"/>
+				<equals arg1="1.8" arg2="${java.specification.version}"/>
+			</or>
+	    </not>
+	</condition>
 		
 	<!-- Java 17 began the security manager's deprecation process (https://openjdk.java.net/jeps/411).
 		     In Java 18, the `java.security.manager` system property's default changed from `allow` to `disallow`, which causes our build process to fail.  
 			 Setting up a gated property (use.java.security.manager) so that any builds that take place on Java 15+ use the JVM override 
 			 -Djava.security.manager=allow which is needed for our build process, but older versions will be skipped --> 
 	<condition property="use.java.security.manager" value="-Djava.security.manager=allow">
-		<not>
-			<or>
-				<equals arg1="11" arg2="${java.specification.version}"/>
-				<equals arg1="1.8" arg2="${java.specification.version}"/>
-			</or>
-		</not>
+		<and>
+			<istrue value="${is.java15.orHigher}"/>
+			<not><istrue value="${supports.framework.java}"/></not>
+		</and>
 	</condition>
 	<property name="use.java.security.manager" value=""/>
 	

--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -207,7 +207,10 @@
 				 Setting up a gated property (use.java.security.manager) so that any builds that take place on Java 15+ use the JVM override 
 				 -Djava.security.manager=allow which is needed for our build process, but older versions will be skipped --> 
 		<condition property="use.java.security.manager" value="-Djava.security.manager=allow">
-			<istrue value="${is.java15.orHigher}"/>
+			<and>
+				<istrue value="${is.java15.orHigher}"/>
+				<not><istrue value="${supports.framework.java}"/></not>
+			</and>
 		</condition>
 		<property name="use.java.security.manager" value=""/>
 		


### PR DESCRIPTION
Update the various launch.xml scripts to set `-Djava.security.manager=allow` for JDK15+ and when `supports.framework.java` is not set.