### PR TITLE
Update features to work with el-3.0 feature in the same server.xml

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.el-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.el-2.2.feature
@@ -2,7 +2,7 @@
 symbolicName=com.ibm.websphere.appserver.javax.el-2.2
 WLP-DisableAllFeatures-OnConflict: false
 singleton=true
--features=com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0, 8.0"
+-features=com.ibm.websphere.appserver.eeCompatible-6.0
 -bundles=io.openliberty.el.internal.cdi, \
  com.ibm.websphere.javaee.el.2.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.el:el-api:2.2"
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jsp-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jsp-2.2.feature
@@ -3,7 +3,7 @@ symbolicName=com.ibm.websphere.appserver.javax.jsp-2.2
 WLP-DisableAllFeatures-OnConflict: false
 singleton=true
 -features=io.openliberty.servlet.api-3.0; apiJar=false; ibm.tolerates:="3.1", \
-  com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0,8.0", \
+  com.ibm.websphere.appserver.eeCompatible-6.0, \
   com.ibm.websphere.appserver.javax.el-2.2; apiJar=false
 -bundles=com.ibm.websphere.javaee.jsp.2.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet.jsp:javax.servlet.jsp-api:2.2.1"
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.adminCenter1.0.internal.ee-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.adminCenter1.0.internal.ee-6.0.feature
@@ -4,7 +4,8 @@ WLP-DisableAllFeatures-OnConflict: false
 visibility=private
 singleton=true
 -features=\
-  com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0"
+  com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0", \
+  com.ibm.websphere.appserver.javax.jsp-2.2; ibm.tolerates:="2.3"
 -bundles=\
   com.ibm.ws.ui, \
   com.ibm.ws.org.owasp.esapi.2.1.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.oauth2.0.internal.ee-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.oauth2.0.internal.ee-6.0.feature
@@ -4,6 +4,7 @@ singleton=true
 WLP-DisableAllFeatures-OnConflict: false
 visibility = private
 -features=com.ibm.websphere.appserver.appSecurity-2.0; ibm.tolerates:="3.0", \
+  com.ibm.websphere.appserver.javax.jsp-2.2; ibm.tolerates:="2.3", \
   com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0"
 -bundles=\
   com.ibm.ws.security.oauth.2.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.openidConnectClient1.0.internal.ee-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.openidConnectClient1.0.internal.ee-6.0.feature
@@ -4,6 +4,7 @@ singleton=true
 WLP-DisableAllFeatures-OnConflict: false
 visibility = private
 -features=com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0", \
+  com.ibm.websphere.appserver.javax.jsp-2.2; ibm.tolerates:="2.3", \
   com.ibm.websphere.appserver.javax.cdi-1.0; apiJar=false; ibm.tolerates:="1.2,2.0"
 -bundles=\
   com.ibm.ws.security.openidconnect.client, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.openidConnectServer1.0.internal.ee-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.openidConnectServer1.0.internal.ee-6.0.feature
@@ -4,6 +4,7 @@ singleton=true
 WLP-DisableAllFeatures-OnConflict: false
 visibility = private
 -features=com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0", \
+  com.ibm.websphere.appserver.javax.jsp-2.2; ibm.tolerates:="2.3", \
   com.ibm.websphere.appserver.javax.cdi-1.0; apiJar=false; ibm.tolerates:="1.2,2.0"
 -bundles=\
   com.ibm.ws.security.common, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webCache1.0.internal.ee-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webCache1.0.internal.ee-6.0.feature
@@ -3,7 +3,8 @@ symbolicName=io.openliberty.webCache1.0.internal.ee-6.0
 singleton=true
 WLP-DisableAllFeatures-OnConflict: false
 visibility=private
--features=com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1, 4.0"
+-features=com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1, 4.0", \
+  com.ibm.websphere.appserver.javax.jsp-2.2; ibm.tolerates:="2.3"
 -bundles=\
   com.ibm.ws.dynacache.web
 kind=ga


### PR DESCRIPTION
- Add javax.jsp-2.2 tolerates 2.3 dependency in the feature1.0.internal.ee-6.0 feature
- Also update javax.jsp-2.2 and javax.el-2.2 to only have eeCompatible-6.0 and not tolerate 7.0 and 8.0 to match jsp-2.2 public features eeCompatible settings.

Previously adminCenter and other features depended on jsp-2.2 and tolerated 2.3, but when adding EE 9 support, we had to move it to an auto feature.  By adding the javax.jsp private features in the main ee 6 through 8 private feature we will pick servlet 3.1 and then can support the expected jsp level.
