### PR TITLE
serialization permitted if no third-party context is propagated

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2020 IBM Corporation and others.
+ * Copyright (c) 2017,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -1677,6 +1678,22 @@ public class MPConcurrentTestServlet extends FATServlet {
 
         threadName = cf7.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
         assertTrue(threadName, threadName.startsWith("Default Executor-thread-")); // managed executor uses Liberty global thread pool
+    }
+
+    /**
+     * Cast a MicroProfile ThreadContext to ContextService and attempt to invoke
+     * createContextualProxy to create a Serializable contextual proxy.
+     * Expect it to be rejected because MicroProfile thread context is not serializable.
+     */
+    @Test
+    public void testCreateContextalProxy() throws Exception {
+        ContextService contextSvc = (ContextService) stateContextPropagator;
+        try {
+            Serializable proxy = contextSvc.createContextualProxy(new SerializableContextSnapshot(), Serializable.class);
+            fail("Serializable contextual proxies should not be supported in MicroProfile Context Propagation. " + proxy);
+        } catch (UnsupportedOperationException x) {
+            // expected
+        }
     }
 
     /**

--- a/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/context/ThirdPartyContext.java
+++ b/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/context/ThirdPartyContext.java
@@ -13,6 +13,7 @@ package io.openliberty.concurrent.context;
 import java.io.IOException;
 import java.io.ObjectInputStream.GetField;
 import java.io.ObjectOutputStream;
+import java.io.ObjectOutputStream.PutField;
 import java.io.ObjectStreamField;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -62,7 +63,7 @@ public class ThirdPartyContext implements ThreadContext {
     };
 
     transient List<String> cleared, propagated, unchanged;
-    transient ThirdPartyContextCoordinator coordinator;
+    transient boolean isAnyPropagated;
     transient String remaining;
     transient ArrayList<ThreadContextRestorer> restorers;
     transient ArrayList<ThreadContextSnapshot> snapshots;
@@ -81,8 +82,6 @@ public class ThirdPartyContext implements ThreadContext {
      */
     ThirdPartyContext(ThirdPartyContextCoordinator coordinator, Map<String, String> execProps) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
-
-        this.coordinator = coordinator;
 
         cleared = propagated = unchanged = Collections.emptyList();
         remaining = "cleared";
@@ -103,10 +102,10 @@ public class ThirdPartyContext implements ThreadContext {
      * @param execProps           execution properties
      * @param threadContextConfig configuration for context providers. Null to indicate that all third-party types should be cleared
      */
+    @SuppressWarnings("unchecked")
     ThirdPartyContext(ThirdPartyContextCoordinator coordinator, Map<String, String> execProps, Map<String, ?> threadContextConfig) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
-        this.coordinator = coordinator;
         cleared = (List<String>) threadContextConfig.get("cleared");
         propagated = (List<String>) threadContextConfig.get("propagated");
         unchanged = (List<String>) threadContextConfig.get("unchanged");
@@ -130,6 +129,7 @@ public class ThirdPartyContext implements ThreadContext {
                 snapshots.add(snapshot);
                 if (trace && tc.isDebugEnabled())
                     Tr.debug(this, tc, "will propagate " + type + " context " + snapshot);
+                isAnyPropagated = true;
             } else {
                 if (trace && tc.isDebugEnabled())
                     Tr.debug(this, tc, "will ignore " + type + " context");
@@ -140,7 +140,6 @@ public class ThirdPartyContext implements ThreadContext {
     @Override
     public ThirdPartyContext clone() {
         ThirdPartyContext clone = new ThirdPartyContext();
-        clone.coordinator = coordinator;
         clone.cleared = cleared;
         clone.propagated = propagated;
         clone.unchanged = unchanged;
@@ -150,13 +149,42 @@ public class ThirdPartyContext implements ThreadContext {
         return clone;
     }
 
+    /**
+     * This method is invoked after deserialization to initializes the context types to clear.
+     *
+     * @param coordinator coordinates all third-party context types
+     * @param execProps   execution properties
+     */
+    void initPostDeserialize(ThirdPartyContextCoordinator coordinator, Map<String, String> execProps) {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+
+        snapshots = new ArrayList<ThreadContextSnapshot>();
+        for (ThreadContextProvider provider : coordinator.getProviders()) {
+            // Context types that were previously unavailable to be captured for propagation must be cleared if available now.
+            String type = provider.getThreadContextType();
+            boolean clear = Collections.binarySearch(cleared, type) >= 0 || //
+                            Collections.binarySearch(propagated, type) >= 0 || //
+                            Collections.binarySearch(unchanged, type) < 0 && !"unchanged".equals(remaining);
+
+            if (clear) {
+                ThreadContextSnapshot snapshot = provider.clearedContext(execProps);
+                snapshots.add(snapshot);
+                if (trace && tc.isDebugEnabled())
+                    Tr.debug(this, tc, "will clear " + type + " context " + snapshot);
+            } else {
+                if (trace && tc.isDebugEnabled())
+                    Tr.debug(this, tc, "will ignore " + type + " context");
+            }
+        }
+    }
+
     @Override
     @Trivial
     public boolean isSerializable() {
         UnsupportedOperationException x = null;
-        if (!propagated.isEmpty() || "propagated".equals(remaining)) {
-            List<String> unser = new ArrayList<String>(propagated); // TODO what if configured propagated types aren't available?
-            if ("propagated".equals(remaining)) // TODO avoid failing if no remaining types were found???
+        if (isAnyPropagated) {
+            List<String> unser = new ArrayList<String>(propagated);
+            if ("propagated".equals(remaining))
                 unser.add(ContextServiceDefinition.ALL_REMAINING);
 
             x = new UnsupportedOperationException("Thread context configured for propagation is not serializable: " + unser); // TODO NLS
@@ -212,10 +240,16 @@ public class ThirdPartyContext implements ThreadContext {
      * @throws IOException
      * @throws ClassNotFoundException
      */
+    @SuppressWarnings("unchecked")
     private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
         GetField fields = in.readFields();
-        // TODO
-        throw new UnsupportedOperationException();
+        cleared = (List<String>) fields.get(CLEARED, Collections.EMPTY_LIST);
+        propagated = (List<String>) fields.get(PROPAGATED, Collections.EMPTY_LIST);
+        unchanged = (List<String>) fields.get(UNCHANGED, Collections.EMPTY_LIST);
+        remaining = (String) fields.get(REMAINING, cleared);
+
+        // ThirdPartyContextCoordinator.deserializeThreadContext continues initializing this
+        // instance after the readObject method ends.
     }
 
     /**
@@ -224,12 +258,17 @@ public class ThirdPartyContext implements ThreadContext {
      * @param outStream The stream to write the serialized data.
      *
      * @throws IOException
+     * @throws UnsupportedOperationException if not serializable
      */
     private void writeObject(ObjectOutputStream outStream) throws IOException {
-        //PutField fields = outStream.putFields();
-        //fields.put(...);
-        //outStream.writeFields();
-        // TODO
-        throw new UnsupportedOperationException();
+        if (!isSerializable())
+            throw new UnsupportedOperationException();
+
+        PutField fields = outStream.putFields();
+        fields.put(CLEARED, cleared);
+        fields.put(PROPAGATED, propagated);
+        fields.put(UNCHANGED, unchanged);
+        fields.put(REMAINING, remaining);
+        outStream.writeFields();
     }
 }

--- a/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/context/ThirdPartyContextCoordinator.java
+++ b/dev/io.openliberty.concurrent/src/io/openliberty/concurrent/context/ThirdPartyContextCoordinator.java
@@ -37,6 +37,7 @@ import com.ibm.ws.kernel.service.util.SecureAction;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 import com.ibm.wsspi.threadcontext.ThreadContext;
+import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 import com.ibm.wsspi.threadcontext.ThreadContextDeserializationInfo;
 
 import io.openliberty.concurrent.processor.ContextServiceResourceFactoryBuilder;
@@ -48,6 +49,7 @@ import jakarta.enterprise.concurrent.spi.ThreadContextProvider;
  */
 @Component(name = "io.openliberty.thirdparty.context.provider",
            configurationPolicy = ConfigurationPolicy.IGNORE)
+@SuppressWarnings("deprecation")
 public class ThirdPartyContextCoordinator implements ApplicationStateListener, //
                 com.ibm.wsspi.threadcontext.ThreadContextProvider {
     private static final TraceComponent tc = Tr.register(ThirdPartyContextCoordinator.class);
@@ -139,8 +141,8 @@ public class ThirdPartyContextCoordinator implements ApplicationStateListener, /
             in.close();
         }
 
-        context.coordinator = this;
-        // TODO recreate cleared context
+        context.initPostDeserialize(this, ((ThreadContextDescriptor) info).getExecutionProperties());
+
         return context;
     }
 


### PR DESCRIPTION
Serializable contextual proxies should still work when third-party context is present but not configured for propagation.