### PR TITLE
Issue 9909: Add additional FAT case for OP logout endpoint

### DIFF
--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonValidationTools.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonValidationTools.java
@@ -2445,6 +2445,7 @@ public class CommonValidationTools {
      * @param onlyAllowedCookies List of cookie name prefixes or regular expressions to match against existing cookie names.
      */
     public void verifyOnlyAllowedCookiesStillPresent(WebClient webClient, List<String> onlyAllowedCookies) {
+        Log.info(thisClass, "verifyOnlyAllowedCookiesStillPresent", "Verifying that the web client contains only a subset of the following allowed cookies: " + onlyAllowedCookies);
         List<String> unexpectedCookiesFound = new ArrayList<>();
         Set<com.gargoylesoftware.htmlunit.util.Cookie> finalCookies = webClient.getCookieManager().getCookies();
         for (com.gargoylesoftware.htmlunit.util.Cookie cookie : finalCookies) {
@@ -2458,6 +2459,7 @@ public class CommonValidationTools {
                 }
             }
             if (!isCookieAllowed) {
+                Log.info(thisClass, "verifyOnlyAllowedCookiesStillPresent", "Found unexpected cookie: " + cookieName);
                 unexpectedCookiesFound.add(cookieName);
             }
         }


### PR DESCRIPTION
For #9909

Adds a test where the RP's logout endpoint redirects to the OP's /logout endpoint. A test already exists that redirects to the OP's /end_session endpoint.