### PR TITLE
Disable context pool for better avgs on UserEnum FAT

### DIFF
--- a/dev/com.ibm.ws.security.wim.registry_fat/publish/servers/com.ibm.ws.security.wim.registry.fat.UserEnumeration/server.xml
+++ b/dev/com.ibm.ws.security.wim.registry_fat/publish/servers/com.ibm.ws.security.wim.registry.fat.UserEnumeration/server.xml
@@ -18,7 +18,8 @@
         </failoverServers>
         <ldapCache>
         <searchResultsCache enabled="false" />
-      </ldapCache>
+        </ldapCache>
+        <contextPool enabled="false" />
 	</ldapRegistry>
 
     <federatedRepository>


### PR DESCRIPTION
Averages still a little inconsistent for the disable test and making false negative failures. I disabled the searchCache, but should disable the contextPool as well so every call has to do a bind to the ldap.

RTC: 288790