### PR TITLE
Update to not get dirname errors in liberty scripts

### DIFF
--- a/dev/cnf/resources/bin/tool
+++ b/dev/cnf/resources/bin/tool
@@ -274,9 +274,13 @@ if [ -n "$defaultFileEncoding" ]; then
   fi
 fi
 
-JPMS_MODULE_FILE_LOCATION="${JAVA_HOME}/lib/modules"
 if [ -z "${JAVA_HOME}" ]; then
-  JPMS_MODULE_FILE_LOCATION=$(dirname $(dirname $(command -v java)))/lib/modules
+  JAVA_PATH_FROM_PATH=$(command -v java)
+  if [ -n "${JAVA_PATH_FROM_PATH}" ] ; then
+    JPMS_MODULE_FILE_LOCATION=$(dirname $(dirname $JAVA_PATH_FROM_PATH))/lib/modules
+  fi
+else
+  JPMS_MODULE_FILE_LOCATION="${JAVA_HOME}/lib/modules"
 fi
 
 # If this is a Java 9 JDK, add some JDK 9 workarounds to the JVM_ARGS

--- a/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client
+++ b/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client
@@ -424,9 +424,13 @@ clientEnvAndJVMOptions()
     mergeJVMOptions "${WLP_INSTALL_DIR}/etc/client.jvm.options"
   fi
   
-  JPMS_MODULE_FILE_LOCATION="${JAVA_HOME}/lib/modules"
   if [ -z "${JAVA_HOME}" ]; then
-    JPMS_MODULE_FILE_LOCATION=$(dirname $(dirname $(command -v java)))/lib/modules
+    JAVA_PATH_FROM_PATH=$(command -v java)
+    if [ -n "${JAVA_PATH_FROM_PATH}" ] ; then
+      JPMS_MODULE_FILE_LOCATION=$(dirname $(dirname $JAVA_PATH_FROM_PATH))/lib/modules
+    fi
+  else
+    JPMS_MODULE_FILE_LOCATION="${JAVA_HOME}/lib/modules"
   fi
 
   # If we are running on Java 9, apply Liberty's built-in java 9 options  

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -721,9 +721,13 @@ serverEnvAndJVMOptions()
     mergeJVMOptions "${WLP_INSTALL_DIR}/etc/jvm.options"
   fi
 
-  JPMS_MODULE_FILE_LOCATION="${JAVA_HOME}/lib/modules"
   if [ -z "${JAVA_HOME}" ]; then
-    JPMS_MODULE_FILE_LOCATION=$(dirname $(dirname $(command -v java)))/lib/modules
+    JAVA_PATH_FROM_PATH=$(command -v java)
+    if [ -n "${JAVA_PATH_FROM_PATH}" ] ; then
+      JPMS_MODULE_FILE_LOCATION=$(dirname $(dirname $JAVA_PATH_FROM_PATH))/lib/modules
+    fi
+  else
+    JPMS_MODULE_FILE_LOCATION="${JAVA_HOME}/lib/modules"
   fi
 
   # If we are running on Java 9, apply Liberty's built-in java 9 options  


### PR DESCRIPTION
- When JAVA_HOME is not set and java is not in the PATH, we end up calling dirname with an empty string.
- Check the output for command -v java before calling dirname on it.
