### PR TITLE
Move TCK Results info to method in MvnUtils

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.2_fat_tck/fat/src/com/ibm/ws/concurrent/mp/v1_2/fat/tck/MPContextPropagationTCKLauncher.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.2_fat_tck/fat/src/com/ibm/ws/concurrent/mp/v1_2/fat/tck/MPContextPropagationTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2021 IBM Corporation and others.
+ * Copyright (c) 2018,2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -53,27 +53,10 @@ public class MPContextPropagationTCKLauncher {
         // TODO use this to only test with local build
         // if (FATRunner.FAT_TEST_LOCALRUN)
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.concurrency.mp.1.2_fat_tck", this.getClass() + ":launchMPContextPropagationTck");
-        Map<String, String> resultInfo = new HashMap<>();
-            try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Context Propogation");
-            resultInfo.put("feature_version", "1.2");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-            }finally{
-                MvnUtils.preparePublicationFile(resultInfo);
-            };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Context Propogation");
+        resultInfo.put("feature_version", "1.2");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 }

--- a/dev/com.ibm.ws.concurrent.mp.1.2_fat_tck/fat/src/com/ibm/ws/concurrent/mp/v1_2/fat/tck/MPContextPropagationTCKLauncher.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.2_fat_tck/fat/src/com/ibm/ws/concurrent/mp/v1_2/fat/tck/MPContextPropagationTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2021,2022 IBM Corporation and others.
+ * Copyright (c) 2018,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/fat/src/com/ibm/ws/concurrent/mp/v1_3/fat/tck/MPContextPropagationTCKLauncher.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/fat/src/com/ibm/ws/concurrent/mp/v1_3/fat/tck/MPContextPropagationTCKLauncher.java
@@ -54,29 +54,10 @@ public class MPContextPropagationTCKLauncher {
         // TODO use this to only test with local build (when tckRunner/tck.pom.xml specifies a #.#-SNAPSHOT version)
         //if (FATRunner.FAT_TEST_LOCALRUN)
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.concurrency.mp.1.3_fat_tck", this.getClass() + ":launchMPContextPropagationTck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-           
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
         resultInfo.put("results_type", "MicroProfile");
         resultInfo.put("feature_name", "Context Propogation");
         resultInfo.put("feature_version", "1.3");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-            }finally{
-                MvnUtils.preparePublicationFile(resultInfo);
-            };
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 }

--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/fat/src/com/ibm/ws/concurrent/mp/v1_3/fat/tck/MPContextPropagationTCKLauncher.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/fat/src/com/ibm/ws/concurrent/mp/v1_3/fat/tck/MPContextPropagationTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2021,2022 IBM Corporation and others.
+ * Copyright (c) 2018,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/fat/src/com/ibm/ws/concurrent/mp/v1_3/fat/tck/MPContextPropagationTCKLauncher.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/fat/src/com/ibm/ws/concurrent/mp/v1_3/fat/tck/MPContextPropagationTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2021 IBM Corporation and others.
+ * Copyright (c) 2018,2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -62,8 +62,9 @@ public class MPContextPropagationTCKLauncher {
             resultInfo.put("results_type", "MicroProfile");
             resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
             resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Context Propogation");
-            resultInfo.put("feature_version", "1.3");
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Context Propogation");
+        resultInfo.put("feature_version", "1.3");
             resultInfo.put("os_name",System.getProperty("os.name"));
             List<String> matches = server.findStringsInLogs("product =");
             if(!matches.isEmpty()){

--- a/dev/com.ibm.ws.concurrent.mp_fat_tck/fat/src/com/ibm/ws/concurrent/mp/fat/tck/MPConcurrencyTCKLauncher.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat_tck/fat/src/com/ibm/ws/concurrent/mp/fat/tck/MPConcurrencyTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2019 IBM Corporation and others.
+ * Copyright (c) 2018,2019,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -51,27 +51,12 @@ public class MPConcurrencyTCKLauncher {
     @Test
     public void launchMPConcurrency10Tck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.concurrency.mp_fat_tck", this.getClass() + ":launchMPConcurrency10Tck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Concurrency");
-            resultInfo.put("feature_version", "1.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);;
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Concurrency");
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "1.0");
+        MvnUtils.preparePublicationFile(resultInfo);
+        
     }
 }

--- a/dev/com.ibm.ws.concurrent.mp_fat_tck/fat/src/com/ibm/ws/concurrent/mp/fat/tck/MPConcurrencyTCKLauncher.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat_tck/fat/src/com/ibm/ws/concurrent/mp/fat/tck/MPConcurrencyTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2019,2022 IBM Corporation and others.
+ * Copyright (c) 2018,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -51,11 +51,10 @@ public class MPConcurrencyTCKLauncher {
     @Test
     public void launchMPConcurrency10Tck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.concurrency.mp_fat_tck", this.getClass() + ":launchMPConcurrency10Tck");
-        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);;
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
         resultInfo.put("results_type", "MicroProfile");
         resultInfo.put("feature_name", "Concurrency");
-        resultInfo.put("results_type", "MicroProfile");
-        resultInfo.put("feature_name", "1.0");
+        resultInfo.put("feature_version", "1.0");
         MvnUtils.preparePublicationFile(resultInfo);
         
     }

--- a/dev/com.ibm.ws.microprofile.config.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/config/tck/ConfigTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/config/tck/ConfigTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -54,28 +54,11 @@ public class ConfigTCKLauncher {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchConfigTck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.config_fat_tck", this.getClass() + ":launchConfig11Tck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Config");
-            resultInfo.put("feature_version", "1.1");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Config");
+        resultInfo.put("feature_version", "1.1");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/fat/src/com/ibm/ws/microprofile/config12/tck/Config12TCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/fat/src/com/ibm/ws/microprofile/config12/tck/Config12TCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -55,29 +55,11 @@ public class Config12TCKLauncher {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchConfig12Tck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.config.1.2_fat_tck", this.getClass() + ":launchConfig12Tck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-           
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Config");
-            resultInfo.put("feature_version", "1.2");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-            }finally{
-                MvnUtils.preparePublicationFile(resultInfo);
-            };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Config");
+        resultInfo.put("feature_version", "1.2");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/fat/src/com/ibm/ws/microprofile/config13/tck/Config13TCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/fat/src/com/ibm/ws/microprofile/config13/tck/Config13TCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -55,27 +55,10 @@ public class Config13TCKLauncher {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchConfig13Tck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.config.1.3_fat_tck", this.getClass() + ":launchConfig13Tck");
-        Map<String, String> resultInfo = new HashMap<>();
-            try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Config");
-            resultInfo.put("feature_version", "1.3");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-            }finally{
-                MvnUtils.preparePublicationFile(resultInfo);
-            }
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Config");
+        resultInfo.put("feature_version", "1.3");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 }

--- a/dev/com.ibm.ws.microprofile.config.1.4_fat_tck/fat/src/com/ibm/ws/microprofile/config14/tck/Config14TCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4_fat_tck/fat/src/com/ibm/ws/microprofile/config14/tck/Config14TCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -62,27 +62,10 @@ public class Config14TCKLauncher {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchConfig14Tck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.config.1.4_fat_tck", this.getClass() + ":launchConfig14Tck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Config");
-            resultInfo.put("feature_version", "1.4");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Config");
+        resultInfo.put("feature_version", "1.4");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 }

--- a/dev/com.ibm.ws.microprofile.config_git_fat_tck/fat/src/com/ibm/ws/microprofile/config/tck/ConfigGitTckLauncher.java
+++ b/dev/com.ibm.ws.microprofile.config_git_fat_tck/fat/src/com/ibm/ws/microprofile/config/tck/ConfigGitTckLauncher.java
@@ -110,28 +110,11 @@ public class ConfigGitTckLauncher {
 
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.config_fat_tck", this
                         .getClass() + ":launchConfigTCK", MvnUtils.DEFAULT_SUITE_FILENAME, addedProps, versionedLibraries);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Config");
-            resultInfo.put("feature_version", "1.4");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Config");
+        resultInfo.put("feature_version", "1.4");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
     @Mode(TestMode.LITE)

--- a/dev/com.ibm.ws.microprofile.config_git_fat_tck/fat/src/com/ibm/ws/microprofile/config/tck/ConfigGitTckLauncher.java
+++ b/dev/com.ibm.ws.microprofile.config_git_fat_tck/fat/src/com/ibm/ws/microprofile/config/tck/ConfigGitTckLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTck11Launcher.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTck11Launcher.java
@@ -117,28 +117,11 @@ public class FaultToleranceTck11Launcher {
 
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck", this.getClass() + ":launchFaultToleranceTCK", suiteFileName,
                               Collections.emptyMap(), Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Fault Tolerance");
-            resultInfo.put("feature_version", "1.1");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Fault Tolerance");
+        resultInfo.put("feature_version", "1.1");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTck11Launcher.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTck11Launcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTck20Launcher.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTck20Launcher.java
@@ -151,27 +151,10 @@ public class FaultToleranceTck20Launcher {
 
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck", this.getClass() + ":launchFaultToleranceTCK", suiteFileName,
                               Collections.emptyMap(), Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Fault Tolerance");
-            resultInfo.put("feature_version", "2.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Fault Tolerance");
+        resultInfo.put("feature_version", "2.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTck20Launcher.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTck20Launcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTck21Launcher.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTck21Launcher.java
@@ -119,28 +119,11 @@ public class FaultToleranceTck21Launcher {
 
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck", this.getClass() + ":launchFaultToleranceTCK", suiteFileName,
                               Collections.emptyMap(), Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Fault Tolerance");
-            resultInfo.put("feature_version", "2.1");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Fault Tolerance");
+        resultInfo.put("feature_version", "2.1");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTck21Launcher.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTck21Launcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTckLauncher.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTckLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTckLauncher.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTckLauncher.java
@@ -111,28 +111,11 @@ public class FaultToleranceTckLauncher {
 
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.faulttolerance_fat_tck", this.getClass() + ":launchFaultToleranceTCK", suiteFileName,
                               Collections.emptyMap(), Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Fault Tolerance");
-            resultInfo.put("feature_version", "1.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };;
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Fault Tolerance");
+        resultInfo.put("feature_version", "1.0");
+        MvnUtils.preparePublicationFile(resultInfo);;
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance_git_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceGitTckLauncher.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_git_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceGitTckLauncher.java
@@ -140,28 +140,11 @@ public class FaultToleranceGitTckLauncher {
 
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.faulttolerance_fat_tck", this
                         .getClass() + ":launchFaultToleranceTCK", MvnUtils.DEFAULT_SUITE_FILENAME, addedProps, versionedLibraries);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Fault Tolerance");
-            resultInfo.put("feature_version", "1.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Fault Tolerance");
+        resultInfo.put("feature_version", "1.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
     @Mode(TestMode.LITE)

--- a/dev/com.ibm.ws.microprofile.faulttolerance_git_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceGitTckLauncher.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_git_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceGitTckLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/fat/src/org/eclipse/microprofile/graphql/tck/GraphQLTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/fat/src/org/eclipse/microprofile/graphql/tck/GraphQLTckPackageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -57,28 +57,11 @@ public class GraphQLTckPackageTest {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void testRestClientTck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.graphql_fat_tck", this.getClass() + ":testGraphQLTck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Graph QL");
-            resultInfo.put("feature_version", "1.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Graph QL");
+        resultInfo.put("feature_version", "1.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.health.1.0_fat_tck/fat/src/com/ibm/ws/microprofile/health/tck/HealthTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.health.1.0_fat_tck/fat/src/com/ibm/ws/microprofile/health/tck/HealthTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -62,28 +62,11 @@ public class HealthTCKLauncher {
         additionalProps.put("test.url", protocol + "://" + host + ":" + port);
 
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.health.1.0_fat_tck", this.getClass() + ":launchHealthTck", additionalProps);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Health");
-            resultInfo.put("feature_version", "1.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Health");
+        resultInfo.put("feature_version", "1.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/fat/src/com/ibm/ws/microprofile/health20/tck/Health20TCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/fat/src/com/ibm/ws/microprofile/health20/tck/Health20TCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -61,28 +61,11 @@ public class Health20TCKLauncher {
         additionalProps.put("test.url", protocol + "://" + host + ":" + port);
 
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.health.2.0_fat_tck", this.getClass() + ":launchHealth20Tck", additionalProps);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Health");
-            resultInfo.put("feature_version", "2.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Health");
+        resultInfo.put("feature_version", "2.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.health.2.1_fat_tck/fat/src/com/ibm/ws/microprofile/health21/tck/Health21TCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.health.2.1_fat_tck/fat/src/com/ibm/ws/microprofile/health21/tck/Health21TCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -61,28 +61,11 @@ public class Health21TCKLauncher {
         additionalProps.put("test.url", protocol + "://" + host + ":" + port);
 
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.health.2.1_fat_tck", this.getClass() + ":launchHealth21Tck", additionalProps);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Health");
-            resultInfo.put("feature_version", "2.1");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Health");
+        resultInfo.put("feature_version", "2.1");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.health.2.2_fat_tck/fat/src/com/ibm/ws/microprofile/health22/tck/Health22TCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.health.2.2_fat_tck/fat/src/com/ibm/ws/microprofile/health22/tck/Health22TCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -61,28 +61,11 @@ public class Health22TCKLauncher {
         additionalProps.put("test.url", protocol + "://" + host + ":" + port);
 
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.health.2.2_fat_tck", this.getClass() + ":launchHealth22Tck", additionalProps);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Health");
-            resultInfo.put("feature_version", "2.2");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Health");
+        resultInfo.put("feature_version", "2.2");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.metrics.1.1.noAuth_fat_tck/fat/src/com/ibm/ws/microprofile/metrics11/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1.noAuth_fat_tck/fat/src/com/ibm/ws/microprofile/metrics11/tck/launcher/MetricsTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -62,28 +62,11 @@ public class MetricsTCKLauncher {
         additionalProps.put("test.pwd", "thePassword");
 
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.metrics.1.1.noAuth_fat_tck", "launchTck", additionalProps);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Metrics");
-            resultInfo.put("feature_version", "1.1");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };;
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Metrics");
+        resultInfo.put("feature_version", "1.1");
+        MvnUtils.preparePublicationFile(resultInfo);;
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/metrics11/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/metrics11/tck/launcher/MetricsTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2020 IBM Corporation and others.
+ * Copyright (c) 2018,2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -69,27 +69,11 @@ public class MetricsTCKLauncher {
         additionalProps.put("test.pwd", "thePassword");
 
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.metrics.1.1_fat_tck", "launchTck", additionalProps);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Metrics");
-            resultInfo.put("feature_version", "1.1");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Metrics");
+        resultInfo.put("feature_version", "1.1");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/metrics11/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/metrics11/tck/launcher/MetricsTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2020,2022 IBM Corporation and others.
+ * Copyright (c) 2018,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/fat/src/com/ibm/ws/microprofile/metrics20/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/fat/src/com/ibm/ws/microprofile/metrics20/tck/launcher/MetricsTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019,2020,2022 IBM Corporation and others.
+ * Copyright (c) 2019,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/fat/src/com/ibm/ws/microprofile/metrics20/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/fat/src/com/ibm/ws/microprofile/metrics20/tck/launcher/MetricsTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019,2020 IBM Corporation and others.
+ * Copyright (c) 2019,2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -67,27 +67,11 @@ public class MetricsTCKLauncher {
         additionalProps.put("test.pwd", "thePassword");
 
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.metrics.2.0_fat_tck", "launchTck", additionalProps);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Metrics");
-            resultInfo.put("feature_version", "2.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Metrics");
+        resultInfo.put("feature_version", "2.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/fat/src/com/ibm/ws/microprofile/metrics22/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/fat/src/com/ibm/ws/microprofile/metrics22/tck/launcher/MetricsTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019,2020 IBM Corporation and others.
+ * Copyright (c) 2019,2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -68,27 +68,12 @@ public class MetricsTCKLauncher {
         additionalProps.put("test.pwd", "thePassword");
 
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.metrics.2.2_fat_tck", "launchTck", additionalProps);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Metrics");
-            resultInfo.put("feature_version", "2.2");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Metrics");
+        resultInfo.put("feature_version", "2.2");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/fat/src/com/ibm/ws/microprofile/metrics22/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/fat/src/com/ibm/ws/microprofile/metrics22/tck/launcher/MetricsTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019,2020,2022 IBM Corporation and others.
+ * Copyright (c) 2019,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.metrics.2.3_fat_tck/fat/src/com/ibm/ws/microprofile/metrics23/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.3_fat_tck/fat/src/com/ibm/ws/microprofile/metrics23/tck/launcher/MetricsTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,7 +28,6 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.utils.MvnUtils;
 
 /**
@@ -69,27 +68,11 @@ public class MetricsTCKLauncher {
         additionalProps.put("test.pwd", "thePassword");
 
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.metrics.2.3_fat_tck", "launchTck", additionalProps);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Metrics");
-            resultInfo.put("feature_version", "2.3");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Metrics");
+        resultInfo.put("feature_version", "2.3");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.metrics_fat_tck/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.metrics_fat_tck/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -63,28 +63,11 @@ public class MetricsTCKLauncher {
         additionalProps.put("test.pwd", "thePassword");
 
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.metrics_fat_tck", "launchTck", additionalProps);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Metrics");
-            resultInfo.put("feature_version", "1.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher = olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Metrics");
+        resultInfo.put("feature_version", "1.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_aud_env.java
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_aud_env.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -58,27 +58,10 @@ public class Mpjwt11TCKLauncher_aud_env {
     public void launchMpjwt11TCKLauncher_aud_env() throws Exception {
         String bucketAndTestName = this.getClass().getCanonicalName();
         MvnUtils.runTCKMvnCmd(server, bucketAndTestName, bucketAndTestName, "tck_suite_aud_env.xml", Collections.emptyMap(), Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "JWT Auth");
-            resultInfo.put("feature_version", "1.1");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "JWT Auth");
+        resultInfo.put("feature_version", "1.1");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 }

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_aud_noenv.java
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_aud_noenv.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -63,28 +63,11 @@ public class Mpjwt11TCKLauncher_aud_noenv {
         // need to pass the correct url for PublicKeyAsPEMLocationURLTest
         additionalProps.put("mp.jwt.tck.jwks.baseURL", "http://localhost:" + port + "/PublicKeyAsPEMLocationURLTest/");
         MvnUtils.runTCKMvnCmd(server, bucketAndTestName, bucketAndTestName, "tck_suite_aud_noenv.xml", additionalProps, Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "JWT Auth");
-            resultInfo.put("feature_version", "1.1");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "JWT Auth");
+        resultInfo.put("feature_version", "1.1");
+        MvnUtils.preparePublicationFile(resultInfo);
 
     }
 }

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_aud_noenv2.java
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_aud_noenv2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -64,27 +64,10 @@ public class Mpjwt11TCKLauncher_aud_noenv2 {
         // need to pass the correct url for PublicKeyAsJWKLocationURLTest
         additionalProps.put("mp.jwt.tck.jwks.baseURL", "http://localhost:" + port + "/PublicKeyAsJWKLocationURLTest/");
         MvnUtils.runTCKMvnCmd(server, bucketAndTestName, bucketAndTestName, "tck_suite_aud_noenv2.xml", additionalProps, Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "JWT Auth");
-            resultInfo.put("feature_version", "1.1");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "JWT Auth");
+        resultInfo.put("feature_version", "1.1");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 }

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_noaud_env.java
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_noaud_env.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -57,28 +57,11 @@ public class Mpjwt11TCKLauncher_noaud_env {
     public void launchMpjwt11TCKLauncher_noaud_env() throws Exception {
         String bucketAndTestName = this.getClass().getCanonicalName();
         MvnUtils.runTCKMvnCmd(server, bucketAndTestName, bucketAndTestName, "tck_suite_noaud_env.xml", Collections.emptyMap(), Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "JWT Auth");
-            resultInfo.put("feature_version", "1.1");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "JWT Auth");
+        resultInfo.put("feature_version", "1.1");
+        MvnUtils.preparePublicationFile(resultInfo);
 
     }
 }

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_noaud_noenv.java
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_noaud_noenv.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -57,28 +57,11 @@ public class Mpjwt11TCKLauncher_noaud_noenv {
     public void launchMpjwt11TCKLauncher_noaud_noenv() throws Exception {
         String bucketAndTestName = this.getClass().getCanonicalName();
         MvnUtils.runTCKMvnCmd(server, bucketAndTestName, bucketAndTestName, "tck_suite_noaud_noenv.xml", Collections.emptyMap(), Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "JWT Auth");
-            resultInfo.put("feature_version", "1.1");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "JWT Auth");
+        resultInfo.put("feature_version", "1.1");
+        MvnUtils.preparePublicationFile(resultInfo);
 
     }
 }

--- a/dev/com.ibm.ws.microprofile.openapi.1.1_fat_tck/fat/src/org/eclipse/microprofile/openapi/fat/tck/OpenAPITckTest.java
+++ b/dev/com.ibm.ws.microprofile.openapi.1.1_fat_tck/fat/src/org/eclipse/microprofile/openapi/fat/tck/OpenAPITckTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.openapi.1.1_fat_tck/fat/src/org/eclipse/microprofile/openapi/fat/tck/OpenAPITckTest.java
+++ b/dev/com.ibm.ws.microprofile.openapi.1.1_fat_tck/fat/src/org/eclipse/microprofile/openapi/fat/tck/OpenAPITckTest.java
@@ -60,28 +60,11 @@ public class OpenAPITckTest {
         additionalProps.put("test.url", protocol + "://" + host + ":" + port);
 
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.openapi.1.1_fat_tck", "testOpenAPITck", additionalProps);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Open API");
-            resultInfo.put("feature_version", "1.1");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Open API");
+        resultInfo.put("feature_version", "1.1");
+        MvnUtils.preparePublicationFile(resultInfo);
    }
 
 }

--- a/dev/com.ibm.ws.microprofile.openapi_fat_tck/fat/src/org/eclipse/microprofile/openapi/fat/tck/OpenAPITckTest.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat_tck/fat/src/org/eclipse/microprofile/openapi/fat/tck/OpenAPITckTest.java
@@ -60,28 +60,11 @@ public class OpenAPITckTest {
         additionalProps.put("test.url", protocol + "://" + host + ":" + port);
 
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.openapi_fat_tck", "testOpenAPITck", additionalProps);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Open API");
-            resultInfo.put("feature_version", "1.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Open API");
+        resultInfo.put("feature_version", "1.0");
+        MvnUtils.preparePublicationFile(resultInfo);
    }
 
 }

--- a/dev/com.ibm.ws.microprofile.openapi_fat_tck/fat/src/org/eclipse/microprofile/openapi/fat/tck/OpenAPITckTest.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat_tck/fat/src/org/eclipse/microprofile/openapi/fat/tck/OpenAPITckTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/opentracing11/tck/OpentracingTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/opentracing11/tck/OpentracingTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020,2022 IBM Corporation and others.
+ * Copyright (c) 2018,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/opentracing11/tck/OpentracingTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/opentracing11/tck/OpentracingTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -64,27 +64,10 @@ public class OpentracingTCKLauncher {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchOpentracingTck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.opentracing.1.1_fat", this.getClass() + ":launchOpentracingTck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Open Tracing");
-            resultInfo.put("feature_version", "1.1");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Open Tracing");
+        resultInfo.put("feature_version", "1.1");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 }

--- a/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/fat/src/com/ibm/ws/microprofile/opentracing12/tck/OpentracingTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/fat/src/com/ibm/ws/microprofile/opentracing12/tck/OpentracingTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -54,27 +54,10 @@ public class OpentracingTCKLauncher {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchOpentracingTck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.opentracing.1.2_fat", this.getClass() + ":launchOpentracingTck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Open Tracing");
-            resultInfo.put("feature_version", "1.2");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Open Tracing");
+        resultInfo.put("feature_version", "1.2");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 }

--- a/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/fat/src/com/ibm/ws/microprofile/opentracing12/tck/OpentracingTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/fat/src/com/ibm/ws/microprofile/opentracing12/tck/OpentracingTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020,2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/fat/src/com/ibm/ws/microprofile/opentracing13/tck/OpentracingRestClientTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/fat/src/com/ibm/ws/microprofile/opentracing13/tck/OpentracingRestClientTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020,2022 IBM Corporation and others.
+ * Copyright (c) 2019,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/fat/src/com/ibm/ws/microprofile/opentracing13/tck/OpentracingRestClientTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/fat/src/com/ibm/ws/microprofile/opentracing13/tck/OpentracingRestClientTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -64,27 +64,10 @@ public class OpentracingRestClientTCKLauncher {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchOpentracingRestClientTck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.opentracing.1.3_fat", this.getClass() + ":launchOpentracingRestClientTck", "rest-client-tck-suite.xml", Collections.emptyMap(), Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Open Tracing");
-            resultInfo.put("feature_version", "1.3");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Open Tracing");
+        resultInfo.put("feature_version", "1.3");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 }

--- a/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/fat/src/com/ibm/ws/microprofile/opentracing13/tck/OpentracingTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/fat/src/com/ibm/ws/microprofile/opentracing13/tck/OpentracingTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -55,27 +55,10 @@ public class OpentracingTCKLauncher {
     public void launchOpentracingTck() throws Exception {
         // Use default tck-suite.xml
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.opentracing.1.3_fat", this.getClass() + ":launchOpentracingTck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Open Tracing");
-            resultInfo.put("feature_version", "1.3");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };;
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Open Tracing");
+        resultInfo.put("feature_version", "1.3");
+        MvnUtils.preparePublicationFile(resultInfo);;
     }
 }

--- a/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/fat/src/com/ibm/ws/microprofile/opentracing13/tck/OpentracingTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/fat/src/com/ibm/ws/microprofile/opentracing13/tck/OpentracingTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020,2022 IBM Corporation and others.
+ * Copyright (c) 2018,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/fat/src/com/ibm/ws/microprofile/opentracing13/tck/OpentracingTCKLauncherMicroProfile.java
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/fat/src/com/ibm/ws/microprofile/opentracing13/tck/OpentracingTCKLauncherMicroProfile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -57,28 +57,11 @@ public class OpentracingTCKLauncherMicroProfile {
         // Use default tck-suite.xml
         
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.opentracing.1.3_fat", this.getClass() + ":launchOpentracingRestClientTck", "tck-and-rest-client-tck.xml", Collections.emptyMap(), Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Open Tracing");
-            resultInfo.put("feature_version", "1.3");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Open Tracing");
+        resultInfo.put("feature_version", "1.3");
+        MvnUtils.preparePublicationFile(resultInfo);
 
     }
 }

--- a/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/fat/src/com/ibm/ws/microprofile/opentracing13/tck/OpentracingTCKLauncherMicroProfile.java
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/fat/src/com/ibm/ws/microprofile/opentracing13/tck/OpentracingTCKLauncherMicroProfile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020,2022 IBM Corporation and others.
+ * Copyright (c) 2018,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.opentracing_fat_tck/fat/src/org/eclipse/microprofile/opentracing/fat/tck/OpentracingTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.opentracing_fat_tck/fat/src/org/eclipse/microprofile/opentracing/fat/tck/OpentracingTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020,2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.opentracing_fat_tck/fat/src/org/eclipse/microprofile/opentracing/fat/tck/OpentracingTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.opentracing_fat_tck/fat/src/org/eclipse/microprofile/opentracing/fat/tck/OpentracingTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -54,27 +54,10 @@ public class OpentracingTCKLauncher {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchOpentracingTck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.opentracing_fat", this.getClass() + ":launchOpentracingTck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Open Tracing");
-            resultInfo.put("feature_version", "1.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Open Tracing");
+        resultInfo.put("feature_version", "1.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat_tck/fat/src/com/ibm/ws/microprofile/reactive/messaging/tck/ReactiveMessagingTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat_tck/fat/src/com/ibm/ws/microprofile/reactive/messaging/tck/ReactiveMessagingTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -54,28 +54,11 @@ public class ReactiveMessagingTCKLauncher {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchReactiveMessagingTck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.reactive.messaging_fat_tck", this.getClass() + ":launchReactiveMessagingTck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Reactive Messaging");
-            resultInfo.put("feature_version", "1.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Reactive Messaging");
+        resultInfo.put("feature_version", "1.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_git_fat_tck/fat/src/com/ibm/ws/microprofile/messaging/tck/ReactiveStreamsMessageingGitTckLauncher.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_git_fat_tck/fat/src/com/ibm/ws/microprofile/messaging/tck/ReactiveStreamsMessageingGitTckLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_git_fat_tck/fat/src/com/ibm/ws/microprofile/messaging/tck/ReactiveStreamsMessageingGitTckLauncher.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_git_fat_tck/fat/src/com/ibm/ws/microprofile/messaging/tck/ReactiveStreamsMessageingGitTckLauncher.java
@@ -123,28 +123,11 @@ public class ReactiveStreamsMessageingGitTckLauncher {
 
         MvnUtils.runTCKMvnCmd(server, "org.eclipse.microprofile.reactive.messaging.tck", this
                         .getClass() + ":launchReactiveMessagingTCK", MvnUtils.DEFAULT_SUITE_FILENAME, addedProps, versionedLibraries);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Reactive Messaging");
-            resultInfo.put("feature_version", "1.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };;
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Reactive Messaging");
+        resultInfo.put("feature_version", "1.0");
+        MvnUtils.preparePublicationFile(resultInfo);;
     }
 
     @Mode(TestMode.LITE)

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat_tck/fat/src/com/ibm/ws/microprofile/reactive/streams/operators/tck/ReactiveStreamsTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat_tck/fat/src/com/ibm/ws/microprofile/reactive/streams/operators/tck/ReactiveStreamsTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -60,28 +60,11 @@ public class ReactiveStreamsTCKLauncher {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchReactiveStreamsTck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.reactive.streams.operators_fat_tck", this.getClass() + ":launchReactiveStreamsTck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Reactive Streams");
-            resultInfo.put("feature_version", "1.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Reactive Streams");
+        resultInfo.put("feature_version", "1.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -58,28 +58,11 @@ public class RestClientTckPackageTest {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void testRestClientTck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.rest.client_fat_tck", this.getClass() + ":testRestClientTck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Rest Client");
-            resultInfo.put("feature_version", "1.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Rest Client");
+        resultInfo.put("feature_version", "1.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -50,28 +50,11 @@ public class RestClientTckPackageTest {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void testRestClientTck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.rest.client_fat_tck", this.getClass() + ":testRestClientTck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Rest Client");
-            resultInfo.put("feature_version", "1.2");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Rest Client");
+        resultInfo.put("feature_version", "1.2");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -50,28 +50,11 @@ public class RestClientTckPackageTest {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void testRestClientTck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.rest.client_fat_tck", this.getClass() + ":testRestClientTck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Rest Client");
-            resultInfo.put("feature_version", "1.3");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Rest Client");
+        resultInfo.put("feature_version", "1.3");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -50,28 +50,11 @@ public class RestClientTckPackageTest {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void testRestClientTck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.rest.client_fat_tck", this.getClass() + ":testRestClientTck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Rest Client");
-            resultInfo.put("feature_version", "1.4");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Rest Client");
+        resultInfo.put("feature_version", "1.4");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -56,28 +56,11 @@ public class RestClientTckPackageTest {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void testRestClientTck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.rest.client_fat_tck", this.getClass() + ":testRestClientTck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Rest Client");
-            resultInfo.put("feature_version", "1.1");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Rest Client");
+        resultInfo.put("feature_version", "1.1");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/MvnUtils.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/MvnUtils.java
@@ -1288,6 +1288,33 @@ public class MvnUtils {
         return returnArray;
     }
 
+    public static Map<String, String> getResultInfo(LibertyServer server){
+        Map<String, String> resultInfo = new HashMap<>();
+        JavaInfo javaInfo = JavaInfo.forCurrentVM();
+        String productVersion = "";
+        resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
+        resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
+        resultInfo.put("os_name",System.getProperty("os.name"));
+        try{
+            List<String> matches = server.findStringsInLogs("product =");
+            if(!matches.isEmpty()){
+                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
+                Pattern wasVersionPattern = Pattern.compile("WebSphere Application Server (.*?) \\(", Pattern.DOTALL);
+                Matcher olNameMatcher = olVersionPattern.matcher(matches.get(0));
+                Matcher wasNameMatcher = wasVersionPattern.matcher(matches.get(0));
+                if (olNameMatcher.find()) {
+                    productVersion = olNameMatcher.group(1);
+                }
+                else if(wasNameMatcher.find()){
+                    productVersion = wasNameMatcher.group(1);
+                }
+                resultInfo.put("product_version", productVersion);
+            }
+        }finally{
+            return resultInfo;
+        }
+    }
+
     public static String capitalise(String spec) {
         char[] charArray = spec.toCharArray();
         boolean foundSpace = true;

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncher.java
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncher.java
@@ -113,29 +113,10 @@ public class ConcurrentTckLauncher {
                                            Collections.emptySet() //additional jars
         );  
 
-        try{
-            Map<String, String> resultInfo = new HashMap<>();
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "Jakarta EE");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Concurrency");
-            resultInfo.put("feature_version", "3.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-                MvnUtils.preparePublicationFile(resultInfo);
-            }
-            finally{
-                assertEquals(0, result);
-            }
+        resultInfo.put("results_type", "Jakarta");
+        resultInfo.put("feature_name", "Concurrency");
+        resultInfo.put("feature_version", "3.0");
+        MvnUtils.preparePublicationFile(resultInfo);
+        assertEquals(0, result);
     }
 }

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncher.java
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncher.java
@@ -98,6 +98,7 @@ public class ConcurrentTckLauncher {
             Log.info(getClass(), "launchConcurrentTCK", "Running lite tests");
             suiteXmlFile = "tck-suite-lite.xml";
         }
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
 
         /**
          * The runTCKMvnCmd will set the following properties for use by arquillian
@@ -112,7 +113,7 @@ public class ConcurrentTckLauncher {
                                            additionalProps, //additional props
                                            Collections.emptySet() //additional jars
         );  
-
+        
         resultInfo.put("results_type", "Jakarta");
         resultInfo.put("feature_name", "Concurrency");
         resultInfo.put("feature_version", "3.0");

--- a/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/config/internal_fat_tck/Config20TCKLauncher.java
+++ b/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/config/internal_fat_tck/Config20TCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -68,27 +68,10 @@ public class Config20TCKLauncher {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchConfig20Tck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "io.openliberty.microprofile.config.2.0.internal_fat_tck", this.getClass() + ":launchConfig20Tck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Config");
-            resultInfo.put("feature_version", "2.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Config");
+        resultInfo.put("feature_version", "2.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 }

--- a/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/config/internal_fat_tck/Config20TCKLauncher.java
+++ b/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/config/internal_fat_tck/Config20TCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020,2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.config.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/config/internal_fat_tck/Config30TCKLauncher.java
+++ b/dev/io.openliberty.microprofile.config.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/config/internal_fat_tck/Config30TCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021,2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.config.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/config/internal_fat_tck/Config30TCKLauncher.java
+++ b/dev/io.openliberty.microprofile.config.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/config/internal_fat_tck/Config30TCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -59,27 +59,10 @@ public class Config30TCKLauncher {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchConfig30Tck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "io.openliberty.microprofile.config.3.0.internal_fat_tck", this.getClass() + ":launchConfig30Tck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Config");
-            resultInfo.put("feature_version", "3.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Config");
+        resultInfo.put("feature_version", "3.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 }

--- a/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/faulttolerance/tck/FaultToleranceTck30Launcher.java
+++ b/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/faulttolerance/tck/FaultToleranceTck30Launcher.java
@@ -126,28 +126,11 @@ public class FaultToleranceTck30Launcher {
 
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.faulttolerance.3.0_fat_tck", this.getClass() + ":launchFaultToleranceTCK", suiteFileName,
                               additionalProps, Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Fault Tolerance");
-            resultInfo.put("feature_version", "3.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Fault Tolerance");
+        resultInfo.put("feature_version", "3.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/faulttolerance/tck/FaultToleranceTck30Launcher.java
+++ b/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/faulttolerance/tck/FaultToleranceTck30Launcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.faulttolerance.4.0.internal_fat_tck/fat/src/io/openliberty/microprofile/faulttolerance40/tck/FaultToleranceTck40Launcher.java
+++ b/dev/io.openliberty.microprofile.faulttolerance.4.0.internal_fat_tck/fat/src/io/openliberty/microprofile/faulttolerance40/tck/FaultToleranceTck40Launcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.faulttolerance.4.0.internal_fat_tck/fat/src/io/openliberty/microprofile/faulttolerance40/tck/FaultToleranceTck40Launcher.java
+++ b/dev/io.openliberty.microprofile.faulttolerance.4.0.internal_fat_tck/fat/src/io/openliberty/microprofile/faulttolerance40/tck/FaultToleranceTck40Launcher.java
@@ -126,28 +126,11 @@ public class FaultToleranceTck40Launcher {
 
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.faulttolerance.4.0_fat_tck", this.getClass() + ":launchFaultToleranceTCK", suiteFileName,
                               additionalProps, Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Fault Tolerance");
-            resultInfo.put("feature_version", "4.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Fault Tolerance");
+        resultInfo.put("feature_version", "4.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/io.openliberty.microprofile.health.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/health30/tck/Health30TCKLauncher.java
+++ b/dev/io.openliberty.microprofile.health.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/health30/tck/Health30TCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -61,28 +61,11 @@ public class Health30TCKLauncher {
         additionalProps.put("test.url", protocol + "://" + host + ":" + port);
 
         MvnUtils.runTCKMvnCmd(server, "io.openliberty.microprofile.health.3.0.internal_fat_tck", this.getClass() + ":launchHealth30Tck", additionalProps);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Health");
-            resultInfo.put("feature_version", "3.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Health");
+        resultInfo.put("feature_version", "3.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat_tck/fat/src/io/openliberty/microprofile/health31/tck/Health31TCKLauncher.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat_tck/fat/src/io/openliberty/microprofile/health31/tck/Health31TCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -61,28 +61,11 @@ public class Health31TCKLauncher {
         additionalProps.put("test.url", protocol + "://" + host + ":" + port);
 
         MvnUtils.runTCKMvnCmd(server, "io.openliberty.microprofile.health.3.1.internal_fat_tck", this.getClass() + ":launchHealth31Tck", additionalProps);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Health");
-            resultInfo.put("feature_version", "3.1");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Health");
+        resultInfo.put("feature_version", "3.1");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/io.openliberty.microprofile.health.4.0.internal_fat_tck/fat/src/io/openliberty/microprofile/health40/tck/Health40TCKLauncher.java
+++ b/dev/io.openliberty.microprofile.health.4.0.internal_fat_tck/fat/src/io/openliberty/microprofile/health40/tck/Health40TCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -61,28 +61,11 @@ public class Health40TCKLauncher {
         additionalProps.put("test.url", protocol + "://" + host + ":" + port);
 
         MvnUtils.runTCKMvnCmd(server, "io.openliberty.microprofile.health.4.0.internal_fat_tck", this.getClass() + ":launchHealth40Tck", additionalProps);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Health");
-            resultInfo.put("feature_version", "4.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Health");
+        resultInfo.put("feature_version", "4.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt12/tck/Mpjwt12TCKLauncher_aud_env.java
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt12/tck/Mpjwt12TCKLauncher_aud_env.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -58,27 +58,10 @@ public class Mpjwt12TCKLauncher_aud_env {
     public void launchMpjwt12TCKLauncher_aud_env() throws Exception {
         String bucketAndTestName = this.getClass().getCanonicalName();
         MvnUtils.runTCKMvnCmd(server, bucketAndTestName, bucketAndTestName, "tck_suite_aud_env.xml", Collections.emptyMap(), Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "JWT Auth");
-            resultInfo.put("feature_version", "1.2");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "JWT Auth");
+        resultInfo.put("feature_version", "1.2");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 }

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt12/tck/Mpjwt12TCKLauncher_aud_noenv.java
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt12/tck/Mpjwt12TCKLauncher_aud_noenv.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -63,28 +63,11 @@ public class Mpjwt12TCKLauncher_aud_noenv {
         // need to pass the correct url for PublicKeyAsPEMLocationURLTest
         additionalProps.put("mp.jwt.tck.jwks.baseURL", "http://localhost:" + port + "/PublicKeyAsPEMLocationURLTest/");
         MvnUtils.runTCKMvnCmd(server, bucketAndTestName, bucketAndTestName, "tck_suite_aud_noenv.xml", additionalProps, Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "JWT Auth");
-            resultInfo.put("feature_version", "1.2");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "JWT Auth");
+        resultInfo.put("feature_version", "1.2");
+        MvnUtils.preparePublicationFile(resultInfo);
 
     }
 }

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt12/tck/Mpjwt12TCKLauncher_aud_noenv2.java
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt12/tck/Mpjwt12TCKLauncher_aud_noenv2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -64,28 +64,11 @@ public class Mpjwt12TCKLauncher_aud_noenv2 {
         // need to pass the correct url for PublicKeyAsJWKLocationURLTest
         additionalProps.put("mp.jwt.tck.jwks.baseURL", "http://localhost:" + port + "/PublicKeyAsJWKLocationURLTest/");
         MvnUtils.runTCKMvnCmd(server, bucketAndTestName, bucketAndTestName, "tck_suite_aud_noenv2.xml", additionalProps, Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "JWT Auth");
-            resultInfo.put("feature_version", "1.2");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "JWT Auth");
+        resultInfo.put("feature_version", "1.2");
+        MvnUtils.preparePublicationFile(resultInfo);
 
     }
 }

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt12/tck/Mpjwt12TCKLauncher_noaud_env.java
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt12/tck/Mpjwt12TCKLauncher_noaud_env.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -62,28 +62,11 @@ public class Mpjwt12TCKLauncher_noaud_env {
     public void launchMpjwt12TCKLauncher_noaud_env() throws Exception {
         String bucketAndTestName = this.getClass().getCanonicalName();
         MvnUtils.runTCKMvnCmd(server, bucketAndTestName, bucketAndTestName, "tck_suite_noaud_env.xml", Collections.emptyMap(), Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "JWT Auth");
-            resultInfo.put("feature_version", "1.2");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "JWT Auth");
+        resultInfo.put("feature_version", "1.2");
+        MvnUtils.preparePublicationFile(resultInfo);
 
     }
 }

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt12/tck/Mpjwt12TCKLauncher_noaud_noenv.java
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt12/tck/Mpjwt12TCKLauncher_noaud_noenv.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -57,28 +57,11 @@ public class Mpjwt12TCKLauncher_noaud_noenv {
     public void launchMpjwt12TCKLauncher_noaud_noenv() throws Exception {
         String bucketAndTestName = this.getClass().getCanonicalName();
         MvnUtils.runTCKMvnCmd(server, bucketAndTestName, bucketAndTestName, "tck_suite_noaud_noenv.xml", Collections.emptyMap(), Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "JWT Auth");
-            resultInfo.put("feature_version", "1.2");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "JWT Auth");
+        resultInfo.put("feature_version", "1.2");
+        MvnUtils.preparePublicationFile(resultInfo);
 
     }
 }

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt20/tck/Mpjwt20TCKLauncher_aud_env.java
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt20/tck/Mpjwt20TCKLauncher_aud_env.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt20/tck/Mpjwt20TCKLauncher_aud_env.java
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt20/tck/Mpjwt20TCKLauncher_aud_env.java
@@ -58,27 +58,10 @@ public class Mpjwt20TCKLauncher_aud_env {
     public void launchMpjwt20TCKLauncher_aud_env() throws Exception {
         String bucketAndTestName = this.getClass().getCanonicalName();
         MvnUtils.runTCKMvnCmd(server, bucketAndTestName, bucketAndTestName, "tck_suite_aud_env.xml", Collections.emptyMap(), Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "JWT Auth");
-            resultInfo.put("feature_version", "2.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "JWT Auth");
+        resultInfo.put("feature_version", "2.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 }

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt20/tck/Mpjwt20TCKLauncher_aud_noenv.java
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt20/tck/Mpjwt20TCKLauncher_aud_noenv.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt20/tck/Mpjwt20TCKLauncher_aud_noenv.java
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt20/tck/Mpjwt20TCKLauncher_aud_noenv.java
@@ -63,28 +63,11 @@ public class Mpjwt20TCKLauncher_aud_noenv {
         // need to pass the correct url for PublicKeyAsPEMLocationURLTest
         additionalProps.put("mp.jwt.tck.jwks.baseURL", "http://localhost:" + port + "/PublicKeyAsPEMLocationURLTest/");
         MvnUtils.runTCKMvnCmd(server, bucketAndTestName, bucketAndTestName, "tck_suite_aud_noenv.xml", additionalProps, Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "JWT Auth");
-            resultInfo.put("feature_version", "2.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "JWT Auth");
+        resultInfo.put("feature_version", "2.0");
+        MvnUtils.preparePublicationFile(resultInfo);
 
     }
 }

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt20/tck/Mpjwt20TCKLauncher_aud_noenv2.java
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt20/tck/Mpjwt20TCKLauncher_aud_noenv2.java
@@ -64,28 +64,11 @@ public class Mpjwt20TCKLauncher_aud_noenv2 {
         // need to pass the correct url for PublicKeyAsJWKLocationURLTest
         additionalProps.put("mp.jwt.tck.jwks.baseURL", "http://localhost:" + port + "/PublicKeyAsJWKLocationURLTest/");
         MvnUtils.runTCKMvnCmd(server, bucketAndTestName, bucketAndTestName, "tck_suite_aud_noenv2.xml", additionalProps, Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "JWT Auth");
-            resultInfo.put("feature_version", "2.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "JWT Auth");
+        resultInfo.put("feature_version", "2.0");
+        MvnUtils.preparePublicationFile(resultInfo);
 
     }
 }

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt20/tck/Mpjwt20TCKLauncher_aud_noenv2.java
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt20/tck/Mpjwt20TCKLauncher_aud_noenv2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt20/tck/Mpjwt20TCKLauncher_noaud_env.java
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt20/tck/Mpjwt20TCKLauncher_noaud_env.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt20/tck/Mpjwt20TCKLauncher_noaud_env.java
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt20/tck/Mpjwt20TCKLauncher_noaud_env.java
@@ -62,28 +62,11 @@ public class Mpjwt20TCKLauncher_noaud_env {
     public void launchMpjwt20TCKLauncher_noaud_env() throws Exception {
         String bucketAndTestName = this.getClass().getCanonicalName();
         MvnUtils.runTCKMvnCmd(server, bucketAndTestName, bucketAndTestName, "tck_suite_noaud_env.xml", Collections.emptyMap(), Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "JWT Auth");
-            resultInfo.put("feature_version", "2.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "JWT Auth");
+        resultInfo.put("feature_version", "2.0");
+        MvnUtils.preparePublicationFile(resultInfo);
 
     }
 }

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt20/tck/Mpjwt20TCKLauncher_noaud_noenv.java
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt20/tck/Mpjwt20TCKLauncher_noaud_noenv.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt20/tck/Mpjwt20TCKLauncher_noaud_noenv.java
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt20/tck/Mpjwt20TCKLauncher_noaud_noenv.java
@@ -57,28 +57,11 @@ public class Mpjwt20TCKLauncher_noaud_noenv {
     public void launchMpjwt20TCKLauncher_noaud_noenv() throws Exception {
         String bucketAndTestName = this.getClass().getCanonicalName();
         MvnUtils.runTCKMvnCmd(server, bucketAndTestName, bucketAndTestName, "tck_suite_noaud_noenv.xml", Collections.emptyMap(), Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "JWT Auth");
-            resultInfo.put("feature_version", "2.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "JWT Auth");
+        resultInfo.put("feature_version", "2.0");
+        MvnUtils.preparePublicationFile(resultInfo);
 
     }
 }

--- a/dev/io.openliberty.microprofile.lra.1.0.internal_fat_tck/fat/src/io/openliberty/microprofile/lra/tck/LraTckLauncher.java
+++ b/dev/io.openliberty.microprofile.lra.1.0.internal_fat_tck/fat/src/io/openliberty/microprofile/lra/tck/LraTckLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.lra.1.0.internal_fat_tck/fat/src/io/openliberty/microprofile/lra/tck/LraTckLauncher.java
+++ b/dev/io.openliberty.microprofile.lra.1.0.internal_fat_tck/fat/src/io/openliberty/microprofile/lra/tck/LraTckLauncher.java
@@ -90,28 +90,11 @@ public class LraTckLauncher {
         additionalProps.put("test", "TckTests#*LRA*+join*");
 
         MvnUtils.runTCKMvnCmd(server, "io.openliberty.microprofile.lra.1.0.internal_fat_tck", this.getClass() + ":launchLRATCK", additionalProps);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "LRA");
-            resultInfo.put("feature_version", "1.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "LRA");
+        resultInfo.put("feature_version", "1.0");
+        MvnUtils.preparePublicationFile(resultInfo);
 
     }
 
@@ -135,28 +118,11 @@ public class LraTckLauncher {
         additionalProps.put("lraTestsToRun", "**/*Test*.java");
 
         MvnUtils.runTCKMvnCmd(server, "io.openliberty.microprofile.lra.1.0.internal_fat_tck", this.getClass() + ":launchLRATCK", additionalProps);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "LRA");
-            resultInfo.put("feature_version", "1.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "LRA");
+        resultInfo.put("feature_version", "1.0");
+        MvnUtils.preparePublicationFile(resultInfo);
 
     }
 }

--- a/dev/io.openliberty.microprofile.metrics.internal.3.0_fat_tck/fat/src/io/openliberty/microprofile/metrics30/internal/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0_fat_tck/fat/src/io/openliberty/microprofile/metrics30/internal/tck/launcher/MetricsTCKLauncher.java
@@ -70,12 +70,7 @@ public class MetricsTCKLauncher {
         additionalProps.put("test.pwd", "thePassword");
 
         MvnUtils.runTCKMvnCmd(server, "io.openliberty.microprofile.metrics.internal.3.0_fat_tck", "launchTck", additionalProps);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
         resultInfo.put("results_type", "MicroProfile");
         resultInfo.put("feature_name", "Metrics");
         resultInfo.put("feature_version", "3.0");

--- a/dev/io.openliberty.microprofile.metrics.internal.3.0_fat_tck/fat/src/io/openliberty/microprofile/metrics30/internal/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0_fat_tck/fat/src/io/openliberty/microprofile/metrics30/internal/tck/launcher/MetricsTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -76,21 +76,10 @@ public class MetricsTCKLauncher {
             resultInfo.put("results_type", "MicroProfile");
             resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
             resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Metrics");
-            resultInfo.put("feature_version", "3.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Metrics");
+        resultInfo.put("feature_version", "3.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/io.openliberty.microprofile.metrics.internal.3.0_fat_tck/fat/src/io/openliberty/microprofile/metrics30/internal/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0_fat_tck/fat/src/io/openliberty/microprofile/metrics30/internal/tck/launcher/MetricsTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021,2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.metrics.internal.4.0_fat_tck/fat/src/io/openliberty/microprofile/metrics30/internal/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.0_fat_tck/fat/src/io/openliberty/microprofile/metrics30/internal/tck/launcher/MetricsTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021,2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.metrics.internal.4.0_fat_tck/fat/src/io/openliberty/microprofile/metrics30/internal/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.0_fat_tck/fat/src/io/openliberty/microprofile/metrics30/internal/tck/launcher/MetricsTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -76,21 +76,10 @@ public class MetricsTCKLauncher {
             resultInfo.put("results_type", "MicroProfile");
             resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
             resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Metrics");
-            resultInfo.put("feature_version", "4.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Metrics");
+        resultInfo.put("feature_version", "4.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/io.openliberty.microprofile.metrics.internal.4.0_fat_tck/fat/src/io/openliberty/microprofile/metrics30/internal/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.0_fat_tck/fat/src/io/openliberty/microprofile/metrics30/internal/tck/launcher/MetricsTCKLauncher.java
@@ -70,12 +70,7 @@ public class MetricsTCKLauncher {
         additionalProps.put("test.pwd", "thePassword");
 
         MvnUtils.runTCKMvnCmd(server, "io.openliberty.microprofile.metrics.internal.4.0_fat_tck", "launchTck", additionalProps);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
         resultInfo.put("results_type", "MicroProfile");
         resultInfo.put("feature_name", "Metrics");
         resultInfo.put("feature_version", "4.0");

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/openapi20/fat/tck/OpenAPITckTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/openapi20/fat/tck/OpenAPITckTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -61,28 +61,12 @@ public class OpenAPITckTest {
         additionalProps.put("test.url", protocol + "://" + host + ":" + port);
 
         MvnUtils.runTCKMvnCmd(server, "io.openliberty.microprofile.openapi.2.0.internal_fat_tck", "testOpenAPITck", additionalProps);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Open API");
-            resultInfo.put("feature_version", "2.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);;
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Open API");
+        resultInfo.put("feature_version", "2.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }
+

--- a/dev/io.openliberty.microprofile.openapi.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/openapi30/fat/tck/OpenAPITckTest.java
+++ b/dev/io.openliberty.microprofile.openapi.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/openapi30/fat/tck/OpenAPITckTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.openapi.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/openapi30/fat/tck/OpenAPITckTest.java
+++ b/dev/io.openliberty.microprofile.openapi.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/openapi30/fat/tck/OpenAPITckTest.java
@@ -61,28 +61,11 @@ public class OpenAPITckTest {
         additionalProps.put("test.url", protocol + "://" + host + ":" + port);
 
         MvnUtils.runTCKMvnCmd(server, "io.openliberty.microprofile.openapi.3.0.internal_fat_tck", "testOpenAPITck", additionalProps);
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Open API");
-            resultInfo.put("feature_version", "3.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Open API");
+        resultInfo.put("feature_version", "3.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingRestClientTCKLauncher.java
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingRestClientTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021,2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingRestClientTCKLauncher.java
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingRestClientTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -62,27 +62,10 @@ public class OpentracingRestClientTCKLauncher {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchOpentracingRestClientTck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "io.openliberty.opentracing.2.0.internal_fat", this.getClass() + ":launchOpentracingRestClientTck", "rest-client-tck-suite.xml", Collections.emptyMap(), Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Open Tracing");
-            resultInfo.put("feature_version", "2.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Open Tracing");
+        resultInfo.put("feature_version", "2.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 }

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingTCKLauncher.java
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021,2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingTCKLauncher.java
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -55,27 +55,10 @@ public class OpentracingTCKLauncher {
     public void launchOpentracingTck() throws Exception {
         // Use default tck-suite.xml
         MvnUtils.runTCKMvnCmd(server, "io.openliberty.opentracing.2.0.internal_fat", this.getClass() + ":launchOpentracingTck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Open Tracing");
-            resultInfo.put("feature_version", "2.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Open Tracing");
+        resultInfo.put("feature_version", "2.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 }

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingTCKLauncherMicroProfile.java
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingTCKLauncherMicroProfile.java
@@ -57,28 +57,11 @@ public class OpentracingTCKLauncherMicroProfile {
         // Use default tck-suite.xml
         
         MvnUtils.runTCKMvnCmd(server, "io.openliberty.opentracing.2.0.internal_fat", this.getClass() + ":launchOpentracingRestClientTck", "tck-and-rest-client-tck.xml", Collections.emptyMap(), Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Open Tracing");
-            resultInfo.put("feature_version", "2.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Open Tracing");
+        resultInfo.put("feature_version", "2.0");
+        MvnUtils.preparePublicationFile(resultInfo);
 
     }
 }

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingTCKLauncherMicroProfile.java
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingTCKLauncherMicroProfile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingRestClientTCKLauncher.java
+++ b/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingRestClientTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -57,27 +57,10 @@ public class OpentracingRestClientTCKLauncher {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchOpentracingRestClientTck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "io.openliberty.opentracing.3.0.internal_fat", this.getClass() + ":launchOpentracingRestClientTck", "rest-client-tck-suite.xml", Collections.emptyMap(), Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Open Tracing");
-            resultInfo.put("feature_version", "3.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Open Tracing");
+        resultInfo.put("feature_version", "3.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 }

--- a/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingRestClientTCKLauncher.java
+++ b/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingRestClientTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021,2022 IBM Corporation and others.
+ * Copyright (c) 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingTCKLauncher.java
+++ b/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -55,27 +55,10 @@ public class OpentracingTCKLauncher {
     public void launchOpentracingTck() throws Exception {
         // Use default tck-suite.xml
         MvnUtils.runTCKMvnCmd(server, "io.openliberty.opentracing.3.0.internal_fat", this.getClass() + ":launchOpentracingTck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Open Tracing");
-            resultInfo.put("feature_version", "3.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Open Tracing");
+        resultInfo.put("feature_version", "3.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 }

--- a/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingTCKLauncher.java
+++ b/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021,2022 IBM Corporation and others.
+ * Copyright (c) 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingTCKLauncherMicroProfile.java
+++ b/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingTCKLauncherMicroProfile.java
@@ -55,27 +55,10 @@ public class OpentracingTCKLauncherMicroProfile {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchOpentracingTckMP() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "io.openliberty.opentracing.3.0.internal_fat", this.getClass() + ":launchOpentracingRestClientTck", "tck-and-rest-client-tck.xml", Collections.emptyMap(), Collections.emptySet());
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Open Tracing");
-            resultInfo.put("feature_version", "3.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Open Tracing");
+        resultInfo.put("feature_version", "3.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 }

--- a/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingTCKLauncherMicroProfile.java
+++ b/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingTCKLauncherMicroProfile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -71,28 +71,11 @@ public class RestClientTckPackageTest {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void testRestClientTck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "io.openliberty.microprofile.rest.client.2.0.internal_fat_tck", this.getClass() + ":testRestClientTck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Rest Client");
-            resultInfo.put("feature_version", "2.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Rest Client");
+        resultInfo.put("feature_version", "2.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -80,28 +80,11 @@ public class RestClientTckPackageTest {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void testRestClientTck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "io.openliberty.microprofile.rest.client.3.0.internal_fat_tck", this.getClass() + ":testRestClientTck");
-        Map<String, String> resultInfo = new HashMap<>();
-        try{
-            JavaInfo javaInfo = JavaInfo.forCurrentVM();
-            String productVersion = "";
-            resultInfo.put("results_type", "MicroProfile");
-            resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") +')');
-            resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
-            resultInfo.put("feature_name", "Rest Client");
-            resultInfo.put("feature_version", "3.0");
-            resultInfo.put("os_name",System.getProperty("os.name"));
-            List<String> matches = server.findStringsInLogs("product =");
-            if(!matches.isEmpty()){
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Matcher nameMatcher =olVersionPattern.matcher(matches.get(0));
-                if (nameMatcher.find()) {
-                    productVersion = nameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        }finally{
-            MvnUtils.preparePublicationFile(resultInfo);
-        };
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "Rest Client");
+        resultInfo.put("feature_version", "3.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 
 }


### PR DESCRIPTION
The info required for the TCK Results generator had previously been generated in the TCK launchers but has now been moved to a single method in the MvnUtils file. 