### PR TITLE
Add OAuth client metatype for backchannel logout

### DIFF
--- a/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019, 2021 IBM Corporation and others.
+    Copyright (c) 2019, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -428,6 +428,8 @@
            <AD id="proofKeyForCodeExchange" name="%proofKeyForCodeExchange" description="%proofKeyForCodeExchange.desc" required="false" type="Boolean" default="false" />
 
            <AD id="publicClient" name="%publicClient" description="%publicClient.desc" required="false" type="Boolean" default="false" />
+
+           <AD id="backchannelLogoutUri" name="internal" description="internal use only" required="false" type="String" ibm:beta="true" />
 
     </OCD>
     

--- a/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/metatype/metatype.xml
@@ -431,6 +431,8 @@
 
            <AD id="backchannelLogoutUri" name="internal" description="internal use only" required="false" type="String" ibm:beta="true" />
 
+           <AD id="backchannelLogoutSessionRequired" name="internal" description="internal use only" required="false" type="Boolean" default="false" ibm:beta="true" />
+
     </OCD>
     
     <Designate factoryPid="com.ibm.ws.security.oauth20.client">

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/api/OidcOAuth20Client.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/api/OidcOAuth20Client.java
@@ -100,4 +100,6 @@ public interface OidcOAuth20Client extends OAuth20Client {
 
     public String getBackchannelLogoutUri();
 
+    public boolean isBackchannelLogoutSessionRequired();
+
 }

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/api/OidcOAuth20Client.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/api/OidcOAuth20Client.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -97,5 +97,7 @@ public interface OidcOAuth20Client extends OAuth20Client {
     public boolean isProofKeyForCodeExchangeEnabled();
     
     public boolean isPublicClient();
+
+    public String getBackchannelLogoutUri();
 
 }

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/internal/LibertyOAuth20Provider.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/internal/LibertyOAuth20Provider.java
@@ -238,6 +238,7 @@ public class LibertyOAuth20Provider implements OAuth20Provider, ConfigurationLis
     public static final String KEY_CLIENT_PROOF_KEY_FOR_CODE_EXCHANGE = "proofKeyForCodeExchange";
     public static final String KEY_CLIENT_PUBLIC_CLIENT = "publicClient";
     public static final String KEY_CLIENT_BACKCHANNEL_LOGOUT_URI = "backchannelLogoutUri";
+    public static final String KEY_CLIENT_BACKCHANNEL_LOGOUT_SESSION_REQUIRED = "backchannelLogoutSessionRequired";
 
     public static final String KEY_ROPC_PREFER_USERSECURITYNAME = "ropcPreferUserSecurityName";
     public static final String KEY_ROPC_PREFER_USERPRINCIPALNAME = "ropcPreferUserPrincipalName";
@@ -1274,6 +1275,11 @@ public class LibertyOAuth20Provider implements OAuth20Provider, ConfigurationLis
         }
         newClient.setPublicClient(publicClient);
         newClient.setBackchannelLogoutUri((String) props.get(KEY_CLIENT_BACKCHANNEL_LOGOUT_URI));
+        boolean isBackchannelLogoutSessionRequired = false;
+        if (props.get(KEY_CLIENT_BACKCHANNEL_LOGOUT_SESSION_REQUIRED) != null) {
+            isBackchannelLogoutSessionRequired = ((Boolean) props.get(KEY_CLIENT_BACKCHANNEL_LOGOUT_SESSION_REQUIRED)).booleanValue();
+        }
+        newClient.setBackchannelLogoutSessionRequired(isBackchannelLogoutSessionRequired);
         // newClient.setAppPasswordLifetime(((Long) props.get(KEY_CLIENT_APP_PASSWORD_LIFETIME)).longValue());
         // newClient.setAppTokenLifetime(((Long) props.get(KEY_CLIENT_APP_TOKEN_LIFETIME)).longValue());
         // newClient.setAppTokenOrPasswordLimit(((Long) props.get(KEY_APP_TOKEN_OR_PASSWORD_LIMIT)).longValue());

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/internal/LibertyOAuth20Provider.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/internal/LibertyOAuth20Provider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -237,6 +237,7 @@ public class LibertyOAuth20Provider implements OAuth20Provider, ConfigurationLis
 
     public static final String KEY_CLIENT_PROOF_KEY_FOR_CODE_EXCHANGE = "proofKeyForCodeExchange";
     public static final String KEY_CLIENT_PUBLIC_CLIENT = "publicClient";
+    public static final String KEY_CLIENT_BACKCHANNEL_LOGOUT_URI = "backchannelLogoutUri";
 
     public static final String KEY_ROPC_PREFER_USERSECURITYNAME = "ropcPreferUserSecurityName";
     public static final String KEY_ROPC_PREFER_USERPRINCIPALNAME = "ropcPreferUserPrincipalName";
@@ -1272,6 +1273,7 @@ public class LibertyOAuth20Provider implements OAuth20Provider, ConfigurationLis
             publicClient = ((Boolean) props.get(KEY_CLIENT_PUBLIC_CLIENT)).booleanValue();
         }
         newClient.setPublicClient(publicClient);
+        newClient.setBackchannelLogoutUri((String) props.get(KEY_CLIENT_BACKCHANNEL_LOGOUT_URI));
         // newClient.setAppPasswordLifetime(((Long) props.get(KEY_CLIENT_APP_PASSWORD_LIFETIME)).longValue());
         // newClient.setAppTokenLifetime(((Long) props.get(KEY_CLIENT_APP_TOKEN_LIFETIME)).longValue());
         // newClient.setAppTokenOrPasswordLimit(((Long) props.get(KEY_APP_TOKEN_OR_PASSWORD_LIMIT)).longValue());

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OidcBaseClient.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OidcBaseClient.java
@@ -40,6 +40,7 @@ public class OidcBaseClient extends BaseClient implements Serializable, OidcOAut
     public static final String SN_FUNCTIONAL_USER_ID = "functional_user_id";
     public static final String SN_FUNCTIONAL_USER_GROUP_IDS = OIDCConstants.JSA_CLIENTREG_FUNCTIONAL_USER_GROUP_IDS;
     public static final String SN_BACKCHANNEL_LOGOUT_URI = "backchannel_logout_uri";
+    public static final String SN_BACKCHANNEL_LOGOUT_SESSION_REQUIRED = "backchannel_logout_session_required";
 
     private static final long serialVersionUID = -2407700528170555986L;
 
@@ -139,6 +140,10 @@ public class OidcBaseClient extends BaseClient implements Serializable, OidcOAut
     @Expose
     @SerializedName(SN_BACKCHANNEL_LOGOUT_URI)
     private String backchannelLogoutUri = null;
+
+    @Expose
+    @SerializedName(SN_BACKCHANNEL_LOGOUT_SESSION_REQUIRED)
+    private boolean backchannelLogoutSessionRequired = false;
 
     public OidcBaseClient(String clientId,
             @Sensitive String clientSecret,
@@ -439,6 +444,16 @@ public class OidcBaseClient extends BaseClient implements Serializable, OidcOAut
         this.backchannelLogoutUri = backchannelLogoutUri;
     }
 
+    @Override
+    public boolean isBackchannelLogoutSessionRequired() {
+        return backchannelLogoutSessionRequired;
+    }
+
+    @Trivial
+    public void setBackchannelLogoutSessionRequired(boolean backchannelLogoutSessionRequired) {
+        this.backchannelLogoutSessionRequired = backchannelLogoutSessionRequired;
+    }
+
     @Trivial
     public OidcBaseClient getDeepCopy() {
         // RTC246290
@@ -476,6 +491,7 @@ public class OidcBaseClient extends BaseClient implements Serializable, OidcOAut
         dc.setIterations(this.getIterations());
         dc.setLength(this.getLength());
         dc.setBackchannelLogoutUri(this.backchannelLogoutUri);
+        dc.setBackchannelLogoutSessionRequired(this.backchannelLogoutSessionRequired);
         return dc;
     }
 

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OidcBaseClient.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OidcBaseClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -39,6 +39,7 @@ public class OidcBaseClient extends BaseClient implements Serializable, OidcOAut
     public static final String SN_RESOURCE_IDS = "resource_ids";
     public static final String SN_FUNCTIONAL_USER_ID = "functional_user_id";
     public static final String SN_FUNCTIONAL_USER_GROUP_IDS = OIDCConstants.JSA_CLIENTREG_FUNCTIONAL_USER_GROUP_IDS;
+    public static final String SN_BACKCHANNEL_LOGOUT_URI = "backchannel_logout_uri";
 
     private static final long serialVersionUID = -2407700528170555986L;
 
@@ -134,6 +135,10 @@ public class OidcBaseClient extends BaseClient implements Serializable, OidcOAut
     @Expose
     @SerializedName(OAuth20Constants.HASH_LENGTH)
     private int length = HashSecretUtils.DEFAULT_KEYSIZE;
+
+    @Expose
+    @SerializedName(SN_BACKCHANNEL_LOGOUT_URI)
+    private String backchannelLogoutUri = null;
 
     public OidcBaseClient(String clientId,
             @Sensitive String clientSecret,
@@ -424,6 +429,16 @@ public class OidcBaseClient extends BaseClient implements Serializable, OidcOAut
         this.publicClient = publicClient;
     }
 
+    @Override
+    public String getBackchannelLogoutUri() {
+        return backchannelLogoutUri;
+    }
+
+    @Trivial
+    public void setBackchannelLogoutUri(String backchannelLogoutUri) {
+        this.backchannelLogoutUri = backchannelLogoutUri;
+    }
+
     @Trivial
     public OidcBaseClient getDeepCopy() {
         // RTC246290
@@ -460,6 +475,7 @@ public class OidcBaseClient extends BaseClient implements Serializable, OidcOAut
         dc.setAlgorithm(this.getAlgorithm());
         dc.setIterations(this.getIterations());
         dc.setLength(this.getLength());
+        dc.setBackchannelLogoutUri(this.backchannelLogoutUri);
         return dc;
     }
 

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OidcBaseClient.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OidcBaseClient.java
@@ -137,11 +137,9 @@ public class OidcBaseClient extends BaseClient implements Serializable, OidcOAut
     @SerializedName(OAuth20Constants.HASH_LENGTH)
     private int length = HashSecretUtils.DEFAULT_KEYSIZE;
 
-    @Expose
     @SerializedName(SN_BACKCHANNEL_LOGOUT_URI)
     private String backchannelLogoutUri = null;
 
-    @Expose
     @SerializedName(SN_BACKCHANNEL_LOGOUT_SESSION_REQUIRED)
     private boolean backchannelLogoutSessionRequired = false;
 


### PR DESCRIPTION
- Adds the `backchannelLogoutUri` and `backchannelLogoutSessionRequired` attributes to the OAuth client metatype.
- Adds the foundation for RPs dynamically registering the `backchannel_logout_uri` and `backchannel_logout_session_required` attributes.
    **Note:** Actual support for registering those attributes is not ready yet; those attributes need to be exposed in the OidcBaseClient before clients can register with those attributes.