### PR TITLE
fix conditions to run 3rd party id token prop

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/IDTokenHandler.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/IDTokenHandler.java
@@ -375,12 +375,10 @@ public class IDTokenHandler implements OAuth20TokenTypeHandler {
         if (oidcServerConfig.isCustomClaimsEnabled()) {
             Map<String, Object> userClaims = getUserClaims(tokenMap, oidcServerConfig);
             customClaims.putAll(userClaims);
+
+            Map<String, Object> thirdPartyClaims = getThirdPartyIDTokenClaims(thirdPartyIDToken, oidcServerConfig);
+            customClaims.putAll(thirdPartyClaims);
         }
-
-        // TODO: see if we need some condition to get third party claims
-        Map<String, Object> thirdPartyClaims = getThirdPartyIDTokenClaims(thirdPartyIDToken, oidcServerConfig);
-        customClaims.putAll(thirdPartyClaims);
-
         return customClaims;
     }
 

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/IDTokenHandler.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/IDTokenHandler.java
@@ -177,9 +177,9 @@ public class IDTokenHandler implements OAuth20TokenTypeHandler {
             }
 
             if (jsonFromSpi == null) {
-                Map<String, Object> userClaims = getCustomClaims(tokenMap, thirdPartyIDToken, oidcServerConfig);
+                Map<String, Object> customClaims = getCustomClaims(tokenMap, thirdPartyIDToken, oidcServerConfig);
                 if (accessTokenHash != null) {
-                    userClaims.put(AT_HASH, accessTokenHash);
+                    customClaims.put(AT_HASH, accessTokenHash);
                 }
                 OAuth20Provider oauth20Provider = ProvidersService.getOAuth20Provider(componentId);
                 boolean useMicroProfileTokenFormat = false;//oauth20Provider == null? false: oauth20Provider.isMpJwt(); //Aruna TODO:
@@ -190,7 +190,7 @@ public class IDTokenHandler implements OAuth20TokenTypeHandler {
                                                              scopes,
                                                              lifetime,
                                                              tokenMap,
-                                                             userClaims,
+                                                             customClaims,
                                                              jwtData,
                                                              useMicroProfileTokenFormat);
             }

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/IDTokenHandler.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/IDTokenHandler.java
@@ -222,6 +222,12 @@ public class IDTokenHandler implements OAuth20TokenTypeHandler {
         if (idMediators.hasNext()) {
             IDTokenMediator idMediator = idMediators.next();
 
+            // remove third party id token from token map if not running in beta mode
+            // while feature is still being developed (issue 16298)
+            if (tokenMap.containsKey(OAuth20Constants.THIRD_PARTY_ID_TOKEN) && !isRunningBetaMode()) {
+                tokenMap.remove(OAuth20Constants.THIRD_PARTY_ID_TOKEN);
+            }
+
             idStr = idMediator.mediateToken(tokenMap);
         }
         return idStr;


### PR DESCRIPTION
for #16298 

only add 3rd party id token to token cache if it is used later (if there are claims to propagate specified in the server config or if the IDTokenMediator SPI is setup). also, 3rd party id token claims should only be returned by `getCustomClaims` if custom claims is enabled. lastly, adding a beta guard check for the IDTokenMediator SPI path.
