### PR TITLE
Issue 20059: Add validation for OAuth client backchannel logout URI

### DIFF
--- a/dev/com.ibm.ws.security.oauth/resources/com/ibm/ws/security/oauth20/internal/resources/OAuthMessages.nlsprops
+++ b/dev/com.ibm.ws.security.oauth/resources/com/ibm/ws/security/oauth20/internal/resources/OAuthMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2012 IBM Corporation and others.
+# Copyright (c) 2012, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@
 #NLS_ENCODING=UNICODE
 # -------------------------------------------------------------------------------------------------
 
-# Message prefix block: CWWKS1400 - CWWKS1499
+# Message prefix block: CWWKS1400 - CWWKS1499, CWWKS2300 - CWWKS2349
 OAUTH_PROVIDER_CONFIG_INVALID=CWWKS1400E: The OAuth provider {0} configuration is not valid.
 OAUTH_PROVIDER_CONFIG_INVALID.explanation=Cannot get specified oauth provider configuration.
 OAUTH_PROVIDER_CONFIG_INVALID.useraction=Specify a valid oauth provider configuration.
@@ -457,6 +457,20 @@ JAVA8_REQUIRED_FOR_AT_HASHING.useraction=Install Java version 8 or higher to use
 WRONG_TOKEN_GRANTTYPE=CWWKS1497E: The token with grant type [{0}] is not allowed. Allowed grant types are {1}.
 WRONG_TOKEN_GRANTTYPE.explanation=The token is not valid because its grant type is not allowed.
 WRONG_TOKEN_GRANTTYPE.useraction=Use a token with a grant type that is allowed.
+
+OAUTH_CLIENT_REGISTRATION_VALUE_URI_CONTAINS_FRAGMENT=CWWKS1498E: The URI [{0}] for the client registration metadata field {1} is not valid because it contains a fragment.
+OAUTH_CLIENT_REGISTRATION_VALUE_URI_CONTAINS_FRAGMENT.explanation=The request cannot be completed because the URI must not contain a fragment.
+OAUTH_CLIENT_REGISTRATION_VALUE_URI_CONTAINS_FRAGMENT.useraction=Review the property value in the request and remove the URI fragment.
+
+OAUTH_CLIENT_REGISTRATION_VALUE_URI_INVALID_SCHEME=CWWKS1499E: The URI [{0}] for the client registration metadata field {1} is not valid because it does not use the HTTP or HTTPS scheme.
+OAUTH_CLIENT_REGISTRATION_VALUE_URI_INVALID_SCHEME.explanation=The URI value must use the HTTP or HTTPS scheme.
+OAUTH_CLIENT_REGISTRATION_VALUE_URI_INVALID_SCHEME.useraction=Review the property value in the request and update it to use the HTTP or HTTPS scheme.
+
+# NOTE: Start of new message prefix CWWKS2300 - 2349
+
+OAUTH_CLIENT_REGISTRATION_VALUE_URI_HTTP_SCHEME_CLIENT_NOT_CONFIDENTIAL=CWWKS2300E: The URI [{0}] for the client registration metadata field {1} is not valid because it uses the HTTP scheme but the OAuth client [{2}] is not a confidential client.
+OAUTH_CLIENT_REGISTRATION_VALUE_URI_HTTP_SCHEME_CLIENT_NOT_CONFIDENTIAL.explanation=The URI value for the metadata field that is specified in the message may use the HTTP scheme only if the OAuth client is a confidential client. Otherwise, the HTTPS scheme must be used.
+OAUTH_CLIENT_REGISTRATION_VALUE_URI_HTTP_SCHEME_CLIENT_NOT_CONFIDENTIAL.useraction=Update the URI to use the HTTPS scheme, or update the OAuth client to be a confidential client.
 
 # html title of logout page
 LOGOUT_PAGE_TITLE=Logout

--- a/dev/com.ibm.ws.security.oauth/resources/com/ibm/ws/security/oauth20/internal/resources/OAuthMessages.nlsprops
+++ b/dev/com.ibm.ws.security.oauth/resources/com/ibm/ws/security/oauth20/internal/resources/OAuthMessages.nlsprops
@@ -458,17 +458,17 @@ WRONG_TOKEN_GRANTTYPE=CWWKS1497E: The token with grant type [{0}] is not allowed
 WRONG_TOKEN_GRANTTYPE.explanation=The token is not valid because its grant type is not allowed.
 WRONG_TOKEN_GRANTTYPE.useraction=Use a token with a grant type that is allowed.
 
-OAUTH_CLIENT_REGISTRATION_VALUE_URI_CONTAINS_FRAGMENT=CWWKS1498E: The URI [{0}] for the client registration metadata field {1} is not valid because it contains a fragment.
+OAUTH_CLIENT_REGISTRATION_VALUE_URI_CONTAINS_FRAGMENT=CWWKS1498E: The [{0}] URI for the {1} client registration metadata field is not valid because it contains a fragment.
 OAUTH_CLIENT_REGISTRATION_VALUE_URI_CONTAINS_FRAGMENT.explanation=The request cannot be completed because the URI must not contain a fragment.
 OAUTH_CLIENT_REGISTRATION_VALUE_URI_CONTAINS_FRAGMENT.useraction=Review the property value in the request and remove the URI fragment.
 
-OAUTH_CLIENT_REGISTRATION_VALUE_URI_INVALID_SCHEME=CWWKS1499E: The URI [{0}] for the client registration metadata field {1} is not valid because it does not use the HTTP or HTTPS scheme.
+OAUTH_CLIENT_REGISTRATION_VALUE_URI_INVALID_SCHEME=CWWKS1499E: The [{0}] URI for the {1} client registration metadata field is not valid because it does not use the HTTP or HTTPS scheme.
 OAUTH_CLIENT_REGISTRATION_VALUE_URI_INVALID_SCHEME.explanation=The URI value must use the HTTP or HTTPS scheme.
 OAUTH_CLIENT_REGISTRATION_VALUE_URI_INVALID_SCHEME.useraction=Review the property value in the request and update it to use the HTTP or HTTPS scheme.
 
 # NOTE: Start of new message prefix CWWKS2300 - 2349
 
-OAUTH_CLIENT_REGISTRATION_VALUE_URI_HTTP_SCHEME_CLIENT_NOT_CONFIDENTIAL=CWWKS2300E: The URI [{0}] for the client registration metadata field {1} is not valid because it uses the HTTP scheme but the OAuth client [{2}] is not a confidential client.
+OAUTH_CLIENT_REGISTRATION_VALUE_URI_HTTP_SCHEME_CLIENT_NOT_CONFIDENTIAL=CWWKS2300E: The [{0}] URI for the {1} client registration metadata field is not valid because it uses the HTTP scheme but the [{2}] OAuth client is not a confidential client.
 OAUTH_CLIENT_REGISTRATION_VALUE_URI_HTTP_SCHEME_CLIENT_NOT_CONFIDENTIAL.explanation=The URI value for the metadata field that is specified in the message may use the HTTP scheme only if the OAuth client is a confidential client. Otherwise, the HTTPS scheme must be used.
 OAUTH_CLIENT_REGISTRATION_VALUE_URI_HTTP_SCHEME_CLIENT_NOT_CONFIDENTIAL.useraction=Update the URI to use the HTTPS scheme, or update the OAuth client to be a confidential client.
 


### PR DESCRIPTION
Validates the `backchannelLogoutUri` OAuth client server.xml attribute and `backchannel_logout_uri` OAuth client registration parameter per Section 2.2 of https://openid.net/specs/openid-connect-backchannel-1_0.html:
1. The back-channel logout URI MUST be an absolute URI as defined by Section 4.3 of [RFC3986].
1. The back-channel logout URI MAY include an application/x-www-form-urlencoded formatted query component, per Section 3.4 of [RFC3986], which MUST be retained when adding additional query parameters.
1. The back-channel logout URI MUST NOT include a fragment component.
1. This URL SHOULD use the https scheme and MAY contain port, path, and query parameter components; however, it MAY use the http scheme, provided that the Client Type is confidential, as defined in Section 2.1 of OAuth 2.0 [RFC6749], and provided the OP allows the use of http RP URIs.


For #20059