### PR TITLE
add new thirdpartycontext spi for oidc

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/spi/ThirdPartyContext​.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/spi/ThirdPartyContext​.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.openidconnect.spi;
+
+/**
+ * SPI to be used by the com.ibm.wsspi.security.openidconnect.IDTokenMediator SPI
+ * implementations to be able to obtain the third-party ID token and fully customize
+ * the new ID token using the third-party token claims.
+ */
+public interface ThirdPartyContext​ {
+
+    /**
+     * This method should return the third-party ID token.
+     *
+     * @return The third-party ID token.
+     */
+    public String getIdToken();
+}

--- a/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/spi/package-info.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/spi/package-info.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+@TraceOptions(traceGroup = TraceConstants.TRACE_GROUP, messageBundle = TraceConstants.MESSAGE_BUNDLE)
+package io.openliberty.security.openidconnect.spi;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;
+import com.ibm.ws.security.openidconnect.web.TraceConstants;


### PR DESCRIPTION
for #20076

adding a new `io.openliberty.security.openidconnect.spi.ThirdPartyContext​` SPI to be used by the `com.ibm.wsspi.security.openidconnect.IDTokenMediator` SPI implementations. this will allow the `IDTokenMediator` to be able to obtain the 3rd party ID token and fully customize the new ID token using the 3rd party token claims.​

