### PR TITLE
Update FeatureList for Java 18

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
+++ b/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
@@ -88,7 +88,7 @@ public class FeatureList {
             addJVM(possibleJavaVersions, "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
             addJVM(possibleJavaVersions, "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
             addJVM(possibleJavaVersions, "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
-            addJVM(possibleJavaVersions, "17", "16", "15", "14", "13", "12", "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
+            addJVM(possibleJavaVersions, "18", "17", "16", "15", "14", "13", "12", "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
 
             List<GenericMetadata> mostGeneralRange = ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=1.7))\"");
 
@@ -101,6 +101,7 @@ public class FeatureList {
             eeToCapability.put("JavaSE-1.8", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=1.8))\""));
             eeToCapability.put("JavaSE-11", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=11))\""));
             eeToCapability.put("JavaSE-17", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=17))\""));
+            eeToCapability.put("JavaSE-18", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=18))\""));
         }
 
         gaBuild = isGABuild();

--- a/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
+++ b/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
@@ -88,6 +88,7 @@ public class FeatureList {
             addJVM(possibleJavaVersions, "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
             addJVM(possibleJavaVersions, "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
             addJVM(possibleJavaVersions, "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
+            addJVM(possibleJavaVersions, "17", "16", "15", "14", "13", "12", "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
             addJVM(possibleJavaVersions, "18", "17", "16", "15", "14", "13", "12", "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
 
             List<GenericMetadata> mostGeneralRange = ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=1.7))\"");

--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/internal/EsaResourceImpl.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/internal/EsaResourceImpl.java
@@ -232,9 +232,9 @@ public class EsaResourceImpl extends RepositoryResourceImpl implements EsaResour
             return;
         }
 
-        String minJava17 = "Java SE 17 and Java SE 18";
-        String minJava11 = "Java SE 11, Java SE 17";
-        String minJava8 = "Java SE 8, Java SE 11, Java SE 17";
+        String minJava17 = "Java SE 17, Java SE 18";
+        String minJava11 = "Java SE 11, Java SE 17, Java SE 18";
+        String minJava8 = "Java SE 8, Java SE 11, Java SE 17, Java SE 18";
 
         // The min version should have been validated when the ESA was constructed
         // so checking for the version string should be safe
@@ -256,8 +256,7 @@ public class EsaResourceImpl extends RepositoryResourceImpl implements EsaResour
             minVersion.startsWith("14.") ||
             minVersion.startsWith("15.") ||
             minVersion.startsWith("16.") ||
-            minVersion.startsWith("17.") ||
-            minVersion.startsWith("18.")) {
+            minVersion.startsWith("17.")) {
             // If a feature requires a min of Java 12/13/14/15/16/17, state Java 17 is required because
             // Liberty does not officially support Java 12-16
             reqs.setVersionDisplayString(minJava17);

--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/internal/EsaResourceImpl.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/internal/EsaResourceImpl.java
@@ -232,7 +232,7 @@ public class EsaResourceImpl extends RepositoryResourceImpl implements EsaResour
             return;
         }
 
-        String minJava17 = "Java SE 17";
+        String minJava17 = "Java SE 17 and Java SE 18";
         String minJava11 = "Java SE 11, Java SE 17";
         String minJava8 = "Java SE 8, Java SE 11, Java SE 17";
 
@@ -256,7 +256,8 @@ public class EsaResourceImpl extends RepositoryResourceImpl implements EsaResour
             minVersion.startsWith("14.") ||
             minVersion.startsWith("15.") ||
             minVersion.startsWith("16.") ||
-            minVersion.startsWith("17.")) {
+            minVersion.startsWith("17.") ||
+            minVersion.startsWith("18.")) {
             // If a feature requires a min of Java 12/13/14/15/16/17, state Java 17 is required because
             // Liberty does not officially support Java 12-16
             reqs.setVersionDisplayString(minJava17);


### PR DESCRIPTION
Update FeatureList and EsaResourceImpl to add the new non-LTS release of Java 18.

Previous version for reference -> https://github.com/OpenLiberty/open-liberty/pull/13782 https://github.com/OpenLiberty/open-liberty/pull/18163