### PR TITLE
Logged out token cache initialization results in AccessControlException when cache has not been initialized prior to application driven logout

### DIFF
--- a/dev/com.ibm.ws.dynacache/src/com/ibm/ws/cache/util/FieldInitializer.java
+++ b/dev/com.ibm.ws.dynacache/src/com/ibm/ws/cache/util/FieldInitializer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2008 IBM Corporation and others.
+ * Copyright (c) 1997, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,8 @@ package com.ibm.ws.cache.util;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Enumeration;
 import java.util.Properties;
 
@@ -21,19 +23,19 @@ public class FieldInitializer {
 
     /*
      * initFromSystemProperties - initializes *static* fields in a Class based
-     *    on system properties.  For example, given class com.company.Foo with
-     *    static field name.  The following system property would change the field
-     *      -Dcom.company.Foo.name=myName
+     * on system properties. For example, given class com.company.Foo with
+     * static field name. The following system property would change the field
+     * -Dcom.company.Foo.name=myName
      */
-    static public void initFromSystemProperties(Class c) {
+    static public void initFromSystemProperties(Class<?> c) {
         updateFieldsFromSystemProperties(c, null);
     }
 
     /*
      * initFromSystemProperties - initializes fields (static and non-static) in an Object based
-     *    on system properties.  For example, given Object o of class com.company.Foo
-     *    with field cacheSize. The following system property would change the field
-     *      -Dcom.company.Foo.cacheSize=100
+     * on system properties. For example, given Object o of class com.company.Foo
+     * with field cacheSize. The following system property would change the field
+     * -Dcom.company.Foo.cacheSize=100
      */
     static public void initFromSystemProperties(Object o) {
         updateFieldsFromSystemProperties(o.getClass(), o);
@@ -41,66 +43,66 @@ public class FieldInitializer {
 
     /*
      * initFromProperties - initializes *static* fields in a Class based
-     *    on system properties.  For example, given class com.company.Foo with
-     *    static field name.  The following system property would change the field
-     *      -Dcom.company.Foo.name=myName
+     * on system properties. For example, given class com.company.Foo with
+     * static field name. The following system property would change the field
+     * -Dcom.company.Foo.name=myName
      */
-    static public void initFromSystemProperties(Class c, Properties prop) {
+    static public void initFromSystemProperties(Class<?> c, Properties prop) {
         updateFieldsFromProperties(c, null, prop);
     }
 
     /*
      * initFromProperties - initializes fields (static and non-static) in an Object based
-     *    on system properties.  For example, given Object o of class com.company.Foo
-     *    with field cacheSize. The following system property would change the field
-     *      -Dcom.company.Foo.cacheSize=100
+     * on system properties. For example, given Object o of class com.company.Foo
+     * with field cacheSize. The following system property would change the field
+     * -Dcom.company.Foo.cacheSize=100
      */
     static public void initFromSystemProperties(Object o, Properties prop) {
         updateFieldsFromProperties(o.getClass(), o, prop);
     }
 
-    static private void updateFieldsFromSystemProperties(final Class c, final Object o) {
+    static private void updateFieldsFromSystemProperties(final Class<?> c, final Object o) {
         updateFieldsFromProperties(c, o, System.getProperties());
     }
 
-    static private void updateFieldsFromProperties(final Class c, final Object o, final Properties prop) {
-        Enumeration propNames = prop.propertyNames();
+    static private void updateFieldsFromProperties(final Class<?> c, final Object o, final Properties prop) {
+        Enumeration<?> propNames = prop.propertyNames();
         String prefix = c.getName();
         Field[] fields = c.getDeclaredFields();
-        while ( propNames.hasMoreElements() ) {
+        while (propNames.hasMoreElements()) {
             String propName = (String) propNames.nextElement();
-            if ( isClassProperty( fields, propName, prefix ) ) {
+            if (isClassProperty(fields, propName, prefix)) {
                 Field field = null;
                 try {
                     String fieldName = propName.substring(propName.lastIndexOf('.') + 1);
                     field = getDeclaredField(c, fieldName);
                     // if we don't have an instance, make sure field is static
-                    if ( field != null && o == null ) {
+                    if (field != null && o == null) {
                         int modifiers = field.getModifiers();
-                        if ( !Modifier.isStatic(modifiers) )
+                        if (!Modifier.isStatic(modifiers))
                             field = null;
                     }
-                    if ( field != null ) {
-                        field.setAccessible(true);
+                    if (field != null) {
+                        AccessController.doPrivileged(new SetAccessibleAction(field, true));
                         String val = (String) prop.get(propName);
-                        Class fClass = field.getType();
-                        if ( fClass == String.class )
+                        Class<?> fClass = field.getType();
+                        if (fClass == String.class)
                             field.set(o, val);
-                        else if ( fClass == Integer.TYPE )
+                        else if (fClass == Integer.TYPE)
                             field.setInt(o, Integer.parseInt(val));
-                        else if ( fClass == Boolean.TYPE )
+                        else if (fClass == Boolean.TYPE)
                             field.setBoolean(o, Boolean.valueOf(val).booleanValue());
-                        else if ( fClass == Long.TYPE )
+                        else if (fClass == Long.TYPE)
                             field.setLong(o, Long.parseLong(val));
-                        else if ( fClass == Byte.TYPE )
+                        else if (fClass == Byte.TYPE)
                             field.setByte(o, Byte.parseByte(val));
-                        else if ( fClass == Character.TYPE )
+                        else if (fClass == Character.TYPE)
                             field.setChar(o, val.charAt(0));
-                        else if ( fClass == Float.TYPE )
+                        else if (fClass == Float.TYPE)
                             field.setFloat(o, Float.parseFloat(val));
-                        else if ( fClass == Double.TYPE )
+                        else if (fClass == Double.TYPE)
                             field.setDouble(o, Double.parseDouble(val));
-                        else if ( fClass == Short.TYPE )
+                        else if (fClass == Short.TYPE)
                             field.setShort(o, Short.parseShort(val));
                         else {
                             // Tr.error unsupported type
@@ -108,65 +110,83 @@ public class FieldInitializer {
                     } else {
                         // Tr.error unrecognized field
                     }
-            // Start of lines changed for defect 491585
-                } catch ( IllegalAccessException iae ) {
-                      FFDCFilter.processException(iae, "com.ibm.ws.util.FieldInitializer", "110");
-                } catch ( IllegalArgumentException iae ) {
-                	FFDCFilter.processException(iae, "com.ibm.ws.util.FieldInitializer", "113");
-                } catch ( NullPointerException npe ) {
-                	FFDCFilter.processException(npe, "com.ibm.ws.util.FieldInitializer", "116");
-                } catch ( ExceptionInInitializerError eiie ) {
-                	FFDCFilter.processException(eiie, "com.ibm.ws.util.FieldInitializer", "119");
+                    // Start of lines changed for defect 491585
+                } catch (IllegalAccessException iae) {
+                    FFDCFilter.processException(iae, "com.ibm.ws.util.FieldInitializer", "110");
+                } catch (IllegalArgumentException iae) {
+                    FFDCFilter.processException(iae, "com.ibm.ws.util.FieldInitializer", "113");
+                } catch (NullPointerException npe) {
+                    FFDCFilter.processException(npe, "com.ibm.ws.util.FieldInitializer", "116");
+                } catch (ExceptionInInitializerError eiie) {
+                    FFDCFilter.processException(eiie, "com.ibm.ws.util.FieldInitializer", "119");
                 }
-            // End of lines changed for defect 491585
-                if ( field != null )
-                    field.setAccessible(false);
+                // End of lines changed for defect 491585
+                if (field != null) {
+                    AccessController.doPrivileged(new SetAccessibleAction(field, false));
+                }
             }
         }
     }
 
-    static private Field getDeclaredField(Class c, String fieldName) {
+    static private Field getDeclaredField(Class<?> c, String fieldName) {
         Field f = null;
         do {
             try {
                 f = c.getDeclaredField(fieldName);
-         // Start of lines changed for defect 491585
-            } catch ( NoSuchFieldException nsfe ) {
+                // Start of lines changed for defect 491585
+            } catch (NoSuchFieldException nsfe) {
                 // No FFDC code needed - we do not need to FFDC unless we've reached Object.class
                 // (the field we want could be in the superclass!)
                 if (c == Object.class) {
-                   FFDCFilter.processException(nsfe, "com.ibm.ws.util.FieldInitializer", "133"); // 477704
-                   c = null; // Stop the loop
+                    FFDCFilter.processException(nsfe, "com.ibm.ws.util.FieldInitializer", "133"); // 477704
+                    c = null; // Stop the loop
+                } else {
+                    c = c.getSuperclass(); // Move to the superclass
                 }
-                else {
-                  c = c.getSuperclass(); // Move to the superclass
-                }
-            } catch ( NullPointerException npe) {
-                FFDCFilter.processException(npe,  "com.ibm.ws.util.FieldInitializer", "137");
+            } catch (NullPointerException npe) {
+                FFDCFilter.processException(npe, "com.ibm.ws.util.FieldInitializer", "137");
                 c = null; // Stop the loop
-            } catch ( SecurityException se ) {
-                FFDCFilter.processException(se,  "com.ibm.ws.util.FieldInitializer", "140");
+            } catch (SecurityException se) {
+                FFDCFilter.processException(se, "com.ibm.ws.util.FieldInitializer", "140");
                 c = null; // Stop the loop
-         // End of lines changed for defect 491585
+                // End of lines changed for defect 491585
             }
-        } while ( f == null && c!=null );
+        } while (f == null && c != null);
         return f;
     }
 
-    static private boolean isClassProperty( Field[] fields, String propName, String className ) {
-        
-        try {
-        	if ( propName.startsWith(className) ) {
-        		propName = propName.substring(propName.lastIndexOf('.') + 1);
-        	}
-        	for (Field field : fields) {
-				if (field.getName().equals(propName)){
-					return true;
-				}
-			}
-		} catch (Exception e) {	}
+    static private boolean isClassProperty(Field[] fields, String propName, String className) {
 
-		return false;
+        try {
+            if (propName.startsWith(className)) {
+                propName = propName.substring(propName.lastIndexOf('.') + 1);
+            }
+            for (Field field : fields) {
+                if (field.getName().equals(propName)) {
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+        }
+
+        return false;
     }
 
+    private static class SetAccessibleAction implements PrivilegedAction<Void> {
+
+        private final Field field;
+        private final boolean accessible;
+
+        SetAccessibleAction(Field field, boolean accessible) {
+            this.field = field;
+            this.accessible = accessible;
+        }
+
+        @Override
+        public Void run() {
+            this.field.setAccessible(accessible);
+            return null;
+        }
+
+    }
 }


### PR DESCRIPTION
When the logged out token cache has not been initialized, and an application driven logout call is made, an AccessControlException similar to the following can result.

```
java.security.AccessControlException: Access denied ("java.lang.reflect.ReflectPermission" "suppressAccessChecks")
>    at java.base/java.security.AccessController.throwACE(AccessController.java:176)
>    at java.base/java.security.AccessController.checkPermissionHelper(AccessController.java:238)
>    at java.base/java.security.AccessController.checkPermission(AccessController.java:385)
>    at java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:322)
>    at java.base/java.lang.reflect.AccessibleObject.checkPermission(AccessibleObject.java:83)
>    at java.base/java.lang.reflect.Field.setAccessible(Field.java:169)
>    at com.ibm.ws.cache.util.FieldInitializer.updateFieldsFromProperties(FieldInitializer.java:84)
>    at com.ibm.ws.cache.util.FieldInitializer.initFromSystemProperties(FieldInitializer.java:59)
>    at com.ibm.ws.cache.CacheConfig.overrideCacheConfig(CacheConfig.java:526)
>    at com.ibm.wsspi.cache.DistributedObjectCacheFactory.createDistributedObjectCache(DistributedObjectCacheFactory.java:414)
>    at com.ibm.wsspi.cache.DistributedObjectCacheFactory.getMap(DistributedObjectCacheFactory.java:372)
>    at com.ibm.ws.webcontainer.security.LoggedOutTokenCacheImpl.getDistrubedMap(LoggedOutTokenCacheImpl.java:162)
>    at com.ibm.ws.webcontainer.security.LoggedOutTokenCacheImpl.getDMLoggedOutTokenMap(LoggedOutTokenCacheImpl.java:149)
>    at com.ibm.ws.webcontainer.security.LoggedOutTokenCacheImpl.putDistributedObjectLoggedOutToken(LoggedOutTokenCacheImpl.java:97)
>    at com.ibm.ws.webcontainer.security.LoggedOutTokenCacheImpl.addTokenToDistributedMap(LoggedOutTokenCacheImpl.java:140)
>    at com.ibm.ws.webcontainer.security.AuthenticateApi.addToLoggedOutTokenCache(AuthenticateApi.java:325)
>    at com.ibm.ws.webcontainer.security.AuthenticateApi.removeEntryFromAuthCacheForToken(AuthenticateApi.java:376)
>    at com.ibm.ws.webcontainer.security.AuthenticateApi.removeEntryFromAuthCache(AuthenticateApi.java:342)
>    at com.ibm.ws.webcontainer.security.AuthenticateApi.logout(AuthenticateApi.java:200)
>    at com.ibm.ws.webcontainer.security.AuthenticateApi.logoutServlet30(AuthenticateApi.java:622)
>    at com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl.logout(WebAppSecurityCollaboratorImpl.java:1191)
>    at com.ibm.ws.webcontainer.srt.SRTServletRequest.logout(SRTServletRequest.java:3956)
>    at web.LogoutServlet.doGet(LogoutServlet.java:26)
>    at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:500)
>    at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:587)
>    at com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1258)
>    at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:746)
>    at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:443)
>    at com.ibm.ws.webcontainer.filter.WebAppFilterChain.invokeTarget(WebAppFilterChain.java:193)
>    at com.ibm.ws.webcontainer.filter.WebAppFilterChain.doFilter(WebAppFilterChain.java:98)
>    at com.ibm.ws.security.jaspi.JaspiServletFilter.doFilter(JaspiServletFilter.java:56)
>    at com.ibm.ws.webcontainer.filter.FilterInstanceWrapper.doFilter(FilterInstanceWrapper.java:201)
>    at com.ibm.ws.webcontainer.filter.WebAppFilterChain.doFilter(WebAppFilterChain.java:91)
>    at com.ibm.ws.webcontainer.filter.WebAppFilterManager.doFilter(WebAppFilterManager.java:1002)
>    at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1140)
>    at com.ibm.ws.webcontainer.webapp.WebApp.handleRequest(WebApp.java:5049)
>    at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.handleRequest(DynamicVirtualHost.java:316)
>    at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:1007)
>    at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:281)
>    at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1184)
>    at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:453)
>    at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:412)
>    at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:566)
>    at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:500)
>    at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:360)
>    at com.ibm.ws.http.channel.internal.inbound.HttpICLReadCallback.complete(HttpICLReadCallback.java:70)
>    at com.ibm.ws.channel.ssl.internal.SSLReadServiceContext$SSLReadCompletedCallback.complete(SSLReadServiceContext.java:1824)
>    at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:514)
>    at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:584)
>    at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:968)
>    at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1057)
>    at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:245)
>    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
>    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
>    at java.base/java.lang.Thread.run(Thread.java:866)
```