### PR TITLE
Revert "Update infra-buildtasks-core from 4.0.0 to 6.0.6"

### DIFF
--- a/dev/ant_build.js/build.gradle
+++ b/dev/ant_build.js/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     library "commons-digester:commons-digester:1.8.1"
     library "commons-lang:commons-lang:2.6"
     library "commons-logging:commons-logging:1.1.1"
-    library "com.ibm.ws.componenttest:infra.buildtasks-core:6.0.6"
+    library "infra-buildtasks-core:infra-buildtasks-core:4.0"
     library "org.mortbay.jetty:servlet-api-2.5:6.0.0"
     library "javax.xml.bind:activation:1.0.2"
     library "javax.xml.bind:jaxb-api:2.3.0"
@@ -106,7 +106,7 @@ dependencies {
 }
 
 def dependencyToPath = [
-  "com.ibm.ws.componenttest:infra.buildtasks-core:6.0.6": "lib/buildtasks/infra.buildtasks-core_6.0.6.jar",
+  "infra-buildtasks-core:infra-buildtasks-core:4.0": "lib/buildtasks/infra.buildtasks-core_4.0.jar",
   "com.fasterxml.jackson.core:jackson-annotations:2.2.3": "lib/buildtasks/jackson-annotations-2.2.3.jar",
   "com.fasterxml.jackson.core:jackson-core:2.2.3": "lib/buildtasks/jackson-core-2.2.3.jar",
   "com.fasterxml.jackson.core:jackson-databind:2.2.3": "lib/buildtasks/jackson-databind-2.2.3.jar",

--- a/dev/ant_build.js/public_imports/js_imports.xml
+++ b/dev/ant_build.js/public_imports/js_imports.xml
@@ -21,7 +21,7 @@
 	<import file="internal_imports/fonts.xml" />
 
 	<patternset id="buildtasks.jars">
-		<include name="infra.buildtasks-core_*.jar" />
+		<include name="infra.buildtasks-core_4.0*.jar" />
 		<include name="asm-all-5.0.3.jar" />
 		<include name="org.apache.aries.util-*.jar" />
 		<include name="osgi.core.jar" />

--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -16,7 +16,7 @@ configurations {
 dependencies {
     binaries "com.ibm.ws.componenttest:mantis-collections:2.5.0"
     binaries "com.ibm.ws.componenttest:mantis-nls-standalone:2.5.0"
-    binaries "com.ibm.ws.componenttest:infra.buildtasks-core:6.0.6"
+    binaries "com.ibm.ws.componenttest:infra.buildtasks-core:4.0.0"
     binaries "com.fasterxml.jackson.core:jackson-annotations:2.11.2"
     binaries "com.fasterxml.jackson.core:jackson-core:2.11.2"
     binaries "com.fasterxml.jackson.core:jackson-databind:2.11.2"

--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -209,7 +209,7 @@
     <dependency>
       <groupId>com.ibm.ws.componenttest</groupId>
       <artifactId>infra.buildtasks-core</artifactId>
-      <version>6.0.6</version>
+      <version>4.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.ws.componenttest</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -37,7 +37,7 @@ com.ibm.ws.componenttest:com.ibm.componenttest.common:1.0.0
 com.ibm.ws.componenttest:com.ibm.ws.topology.helper:1.0.0
 com.ibm.ws.componenttest:fat.harness:1.0.0
 com.ibm.ws.componenttest:fat.util:1.0.0
-com.ibm.ws.componenttest:infra.buildtasks-core:6.0.6
+com.ibm.ws.componenttest:infra.buildtasks-core:4.0.0
 com.ibm.ws.componenttest:mantis-collections:2.5.0
 com.ibm.ws.componenttest:mantis-nls-standalone:2.5.0
 com.ibm.ws.componenttest:provider.api:1.0.0

--- a/dev/cnf/resources/bnd/anttaskdefs.bnd
+++ b/dev/cnf/resources/bnd/anttaskdefs.bnd
@@ -27,7 +27,7 @@ repo.nlsTasks.path: ${path;\
     ${repo;com.ibm.ws.componenttest:mantis-nls-standalone;2.5.0}}
 
 repo.portSelector.path: ${path;\
-    ${repo;com.ibm.ws.componenttest:infra.buildtasks-core;6.0.6}}
+    ${repo;com.ibm.ws.componenttest:infra.buildtasks-core;4.0.0}}
 
 repo.featureTasks.path: ${path;\
     ${repo;wlp-featureTasks},\
@@ -35,7 +35,7 @@ repo.featureTasks.path: ${path;\
     ${repo;com.ibm.ws.logging.core},\
     ${repo;biz.aQute.bnd:biz.aQute.bnd;5.3.0},\
     ${repo;com.ibm.ws.org.apache.ant},\
-    ${repo;com.ibm.ws.componenttest:infra.buildtasks-core;6.0.6},\
+    ${repo;com.ibm.ws.componenttest:infra.buildtasks-core;4.0.0},\
     ${repo;org.jsoup:jsoup;1.7.2},\
     ${repo;org.apache.aries:org.apache.aries.util;1.1.3},\
     ${repo;org.osgi:org.osgi.core;6.0.0}}

--- a/dev/wlp-featureTasks/bnd.bnd
+++ b/dev/wlp-featureTasks/bnd.bnd
@@ -30,4 +30,4 @@ generate.replacement: false
 	com.ibm.ws.org.apache.ant;version=latest,\
 	com.ibm.ws.org.apache.aries.util;version=latest,\
 	biz.aQute.bnd:biz.aQute.bnd;version=5.3.0;packages=**,\
-	com.ibm.ws.componenttest:infra.buildtasks-core;version=6.0.6
+	com.ibm.ws.componenttest:infra.buildtasks-core;version=4.0.0

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -162,7 +162,7 @@ task autoFVT {
       
     // Copy the infra jar
     copy {
-      from cnf.file('mavenlibs/infra.buildtasks-core-6.0.6.jar')
+      from cnf.file('mavenlibs/infra.buildtasks-core-4.0.0.jar')
       into new File(autoFvtDir, 'build/lib')
     }
 


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#20099

Seems to have introduced a dependency on jsch which is missing
```
BUILD FAILED
C:\Users\078112866\liberty\open-liberty\dev\com.ibm.ws.anno_fat\build\libs\autoFVT\src\ant\launch.xml:21: taskdef A class needed by class com.ibm.liberty.tasks.DownloadRemoteFilesViaSFTP cannot be found: com.jcraft.jsch.JSchException
 using the classloader AntClassLoader[C:\Users\078112866\liberty\open-liberty\dev\com.ibm.ws.anno_fat\build\libs\autoFVT\build\lib\infra.buildtasks-core-6.0.6.jar;C:\Users\078112866\liberty\open-liberty\dev\com.ibm.ws.anno_fat\build\libs\autoFVT\build\lib\asm-all-5.2.jar]
 ```