### PR TITLE
Update infra.buildtasks-core from 4.0.0 to 6.0.6

### DIFF
--- a/dev/ant_build.js/build.gradle
+++ b/dev/ant_build.js/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     library "commons-digester:commons-digester:1.8.1"
     library "commons-lang:commons-lang:2.6"
     library "commons-logging:commons-logging:1.1.1"
-    library "infra-buildtasks-core:infra-buildtasks-core:4.0"
+    library "com.ibm.ws.componenttest:infra.buildtasks-core:6.0.6"
     library "org.mortbay.jetty:servlet-api-2.5:6.0.0"
     library "javax.xml.bind:activation:1.0.2"
     library "javax.xml.bind:jaxb-api:2.3.0"
@@ -106,7 +106,7 @@ dependencies {
 }
 
 def dependencyToPath = [
-  "infra-buildtasks-core:infra-buildtasks-core:4.0": "lib/buildtasks/infra.buildtasks-core_4.0.jar",
+  "com.ibm.ws.componenttest:infra.buildtasks-core:6.0.6": "lib/buildtasks/infra.buildtasks-core_6.0.6.jar",
   "com.fasterxml.jackson.core:jackson-annotations:2.2.3": "lib/buildtasks/jackson-annotations-2.2.3.jar",
   "com.fasterxml.jackson.core:jackson-core:2.2.3": "lib/buildtasks/jackson-core-2.2.3.jar",
   "com.fasterxml.jackson.core:jackson-databind:2.2.3": "lib/buildtasks/jackson-databind-2.2.3.jar",

--- a/dev/ant_build.js/public_imports/js_imports.xml
+++ b/dev/ant_build.js/public_imports/js_imports.xml
@@ -21,7 +21,7 @@
 	<import file="internal_imports/fonts.xml" />
 
 	<patternset id="buildtasks.jars">
-		<include name="infra.buildtasks-core_4.0*.jar" />
+		<include name="infra.buildtasks-core_*.jar" />
 		<include name="asm-all-5.0.3.jar" />
 		<include name="org.apache.aries.util-*.jar" />
 		<include name="osgi.core.jar" />

--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -16,7 +16,7 @@ configurations {
 dependencies {
     binaries "com.ibm.ws.componenttest:mantis-collections:2.5.0"
     binaries "com.ibm.ws.componenttest:mantis-nls-standalone:2.5.0"
-    binaries "com.ibm.ws.componenttest:infra.buildtasks-core:4.0.0"
+    binaries "com.ibm.ws.componenttest:infra.buildtasks-core:6.0.6"
     binaries "com.fasterxml.jackson.core:jackson-annotations:2.11.2"
     binaries "com.fasterxml.jackson.core:jackson-core:2.11.2"
     binaries "com.fasterxml.jackson.core:jackson-databind:2.11.2"

--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     binaries "org.glassfish:javax.json:1.1.2"
     binaries "org.codehaus.plexus:plexus-utils:3.0.24"
     binaries "org.apache.ant:ant:1.10.10"
+    binaries "com.jcraft:jsch:0.1.54"
 }
 
 //TODO: move this function somewhere common

--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -237,6 +237,11 @@
       <version>1.5.10</version>
     </dependency>
     <dependency>
+      <groupId>com.jcraft</groupId>
+      <artifactId>jsch</artifactId>
+      <version>0.1.54</version>
+    </dependency>
+    <dependency>
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>
       <version>9.2.1.jre8</version>

--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -209,7 +209,7 @@
     <dependency>
       <groupId>com.ibm.ws.componenttest</groupId>
       <artifactId>infra.buildtasks-core</artifactId>
-      <version>4.0.0</version>
+      <version>6.0.6</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.ws.componenttest</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -43,6 +43,7 @@ com.ibm.ws.componenttest:mantis-nls-standalone:2.5.0
 com.ibm.ws.componenttest:provider.api:1.0.0
 com.ibm.ws.componenttest:public.api:1.0.0
 com.icegreen:greenmail:1.5.10
+com.jcraft:jsch:0.1.54
 com.microsoft.sqlserver:mssql-jdbc:9.2.1.jre8
 com.nimbusds:nimbus-jose-jwt:4.23
 com.oracle.database.jdbc.debug:ojdbc8_g:21.1.0.0

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -37,7 +37,7 @@ com.ibm.ws.componenttest:com.ibm.componenttest.common:1.0.0
 com.ibm.ws.componenttest:com.ibm.ws.topology.helper:1.0.0
 com.ibm.ws.componenttest:fat.harness:1.0.0
 com.ibm.ws.componenttest:fat.util:1.0.0
-com.ibm.ws.componenttest:infra.buildtasks-core:4.0.0
+com.ibm.ws.componenttest:infra.buildtasks-core:6.0.6
 com.ibm.ws.componenttest:mantis-collections:2.5.0
 com.ibm.ws.componenttest:mantis-nls-standalone:2.5.0
 com.ibm.ws.componenttest:provider.api:1.0.0

--- a/dev/cnf/resources/bnd/anttaskdefs.bnd
+++ b/dev/cnf/resources/bnd/anttaskdefs.bnd
@@ -27,7 +27,7 @@ repo.nlsTasks.path: ${path;\
     ${repo;com.ibm.ws.componenttest:mantis-nls-standalone;2.5.0}}
 
 repo.portSelector.path: ${path;\
-    ${repo;com.ibm.ws.componenttest:infra.buildtasks-core;4.0.0}}
+    ${repo;com.ibm.ws.componenttest:infra.buildtasks-core;6.0.6}}
 
 repo.featureTasks.path: ${path;\
     ${repo;wlp-featureTasks},\
@@ -35,7 +35,7 @@ repo.featureTasks.path: ${path;\
     ${repo;com.ibm.ws.logging.core},\
     ${repo;biz.aQute.bnd:biz.aQute.bnd;5.3.0},\
     ${repo;com.ibm.ws.org.apache.ant},\
-    ${repo;com.ibm.ws.componenttest:infra.buildtasks-core;4.0.0},\
+    ${repo;com.ibm.ws.componenttest:infra.buildtasks-core;6.0.6},\
     ${repo;org.jsoup:jsoup;1.7.2},\
     ${repo;org.apache.aries:org.apache.aries.util;1.1.3},\
     ${repo;org.osgi:org.osgi.core;6.0.0}}

--- a/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
@@ -15,6 +15,7 @@
 		<property name="inited-test-tasks" value="true" />
 		<path id="test-buildtasks-autowas">
 			<fileset dir="./build/lib/" includes="infra.buildtasks*.jar" />
+			<fileset dir="./build/lib/" includes="jsch*.jar" />
 		</path>
 		<taskdef resource="com/ibm/aries/componenttest/buildtasks/buildtasks.properties" classpathref="test-buildtasks-autowas" loaderref="test-buildtasks-autowas_ldr" />
 		<taskdef resource="com/ibm/aries/buildtasks/buildtasks.properties" classpathref="test-buildtasks-autowas" loaderref="test-buildtasks-autowas_ldr" />

--- a/dev/com.ibm.ws.jmx_fat/override/autoFVT/src/ant/launch.xml
+++ b/dev/com.ibm.ws.jmx_fat/override/autoFVT/src/ant/launch.xml
@@ -53,6 +53,7 @@
 		<path id="test-buildtasks-autowas">
 			<fileset dir="./build/lib/" includes="infra.buildtasks*.jar" />
 			<fileset dir="./build/lib/" includes="asm*.jar" />
+			<fileset dir="./build/lib/" includes="jsch*.jar" />
 		</path>
 		<taskdef resource="com/ibm/aries/componenttest/buildtasks/buildtasks.properties" classpathref="test-buildtasks-autowas" loaderref="test-buildtasks-autowas_ldr" />
 		<taskdef resource="com/ibm/aries/buildtasks/buildtasks.properties" classpathref="test-buildtasks-autowas" loaderref="test-buildtasks-autowas_ldr" />

--- a/dev/com.ibm.ws.kernel.boot_fat/override/autoFVT/src/ant/launch.xml
+++ b/dev/com.ibm.ws.kernel.boot_fat/override/autoFVT/src/ant/launch.xml
@@ -53,6 +53,7 @@
 		<path id="test-buildtasks-autowas">
 			<fileset dir="./build/lib/" includes="infra.buildtasks*.jar" />
 			<fileset dir="./build/lib/" includes="asm*.jar" />
+			<fileset dir="./build/lib/" includes="jsch*.jar" />
 		</path>
 		<taskdef resource="com/ibm/aries/componenttest/buildtasks/buildtasks.properties" classpathref="test-buildtasks-autowas" loaderref="test-buildtasks-autowas_ldr" />
 		<taskdef resource="com/ibm/aries/buildtasks/buildtasks.properties" classpathref="test-buildtasks-autowas" loaderref="test-buildtasks-autowas_ldr" />

--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -16,6 +16,7 @@
 		<path id="test-buildtasks-autowas">
 			<fileset dir="./build/lib/" includes="infra.buildtasks*.jar" />
 			<fileset dir="./build/lib/" includes="asm*.jar" />
+			<fileset dir="./build/lib/" includes="jsch*.jar" />
 		</path>
 		<taskdef resource="com/ibm/aries/componenttest/buildtasks/buildtasks.properties" classpathref="test-buildtasks-autowas" loaderref="test-buildtasks-autowas_ldr" />
 		<taskdef resource="com/ibm/aries/buildtasks/buildtasks.properties" classpathref="test-buildtasks-autowas" loaderref="test-buildtasks-autowas_ldr" />

--- a/dev/wlp-featureTasks/bnd.bnd
+++ b/dev/wlp-featureTasks/bnd.bnd
@@ -30,4 +30,4 @@ generate.replacement: false
 	com.ibm.ws.org.apache.ant;version=latest,\
 	com.ibm.ws.org.apache.aries.util;version=latest,\
 	biz.aQute.bnd:biz.aQute.bnd;version=5.3.0;packages=**,\
-	com.ibm.ws.componenttest:infra.buildtasks-core;version=4.0.0
+	com.ibm.ws.componenttest:infra.buildtasks-core;version=6.0.6

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -151,6 +151,7 @@ task autoFVT {
       include 'org.apache.aries.util-*.jar'
       include 'osgi.core*.jar'
       include 'jackson*.jar'
+      include 'jsch-*.jar'
     }
 
     // Copy the com.ibm.ws.junit.extensions jar

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -162,7 +162,7 @@ task autoFVT {
       
     // Copy the infra jar
     copy {
-      from cnf.file('mavenlibs/infra.buildtasks-core-4.0.0.jar')
+      from cnf.file('mavenlibs/infra.buildtasks-core-6.0.6.jar')
       into new File(autoFvtDir, 'build/lib')
     }
 


### PR DESCRIPTION
- Change all instances of `infra.buildtasks-core:4.0.0` to `com.ibm.ws.componenttest:infra.buildtasks-core:6.0.6`.
- Fix to add `com.jcraft:jsch:0.1.54` to classpaths since infra.buildtasks-core-6.0.6.jar adds the dependency.