### PR TITLE
Jakarta EE and MicroProfile context providers enabled at same time

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/.classpath
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/.classpath
@@ -2,6 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/MPContextProp1_3_App/src"/>
+	<classpathentry kind="src" path="test-applications/MPContextProp2_0_App/src"/>
 	<classpathentry kind="src" path="test-contextproviders/threadprioritycontext/src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>

--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/bnd.bnd
@@ -30,6 +30,7 @@ tested.features: mpConfig-2.0
 	io.openliberty.jakarta.servlet.5.0;version=latest,\
 	io.openliberty.jakarta.transaction.2.0;version=latest,\
 	io.openliberty.org.eclipse.microprofile.contextpropagation.1.3;version=latest,\
+	io.openliberty.org.eclipse.microprofile.faulttolerance.4.0;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.websphere.security;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\

--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021,2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ bVersion=1.0
 src: \
 	fat/src,\
 	test-applications/MPContextProp1_3_App/src,\
+	test-applications/MPContextProp2_0_App/src,\
 	test-contextproviders/threadprioritycontext/src
 
 fat.project: true
@@ -25,6 +26,7 @@ tested.features: mpConfig-2.0
 	com.ibm.tx.core;version=latest,\
 	io.openliberty.jakarta.annotation.2.0;version=latest,\
 	io.openliberty.jakarta.cdi.3.0;version=latest,\
+	io.openliberty.jakarta.concurrency.3.0;version=latest,\
 	io.openliberty.jakarta.servlet.5.0;version=latest,\
 	io.openliberty.jakarta.transaction.2.0;version=latest,\
 	io.openliberty.org.eclipse.microprofile.contextpropagation.1.3;version=latest,\

--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/fat/src/com/ibm/ws/concurrent/mp/fat/jakarta/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/fat/src/com/ibm/ws/concurrent/mp/fat/jakarta/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,16 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                MPContextProp1_3_Test.class
+                MPContextProp1_3_Test.class,
+
+                // TODO eventually, this is intended to test a Jakarta EE 10 server
+                // with MicroProfile Context Propagation 2.0.
+                // In the mean time, we are using it to test the combination of
+                // Concurrency 3.0 (an EE 10 feature) with MP Context Propagation enabled.
+                // At some point, Concurrency 3.0 will be prevented from running with EE 9
+                // features, and this test will need to be disabled for a time, until
+                // the EE 10 compatible version of MP Context Propagation becomes available.
+                MPContextProp2_0_Test.class
 })
 public class FATSuite {
 }

--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/publish/servers/com.ibm.ws.concurrent.mp.fat.2.0/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/publish/servers/com.ibm.ws.concurrent.mp.fat.2.0/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:concurrent=all

--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/publish/servers/com.ibm.ws.concurrent.mp.fat.2.0/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/publish/servers/com.ibm.ws.concurrent.mp.fat.2.0/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/publish/servers/com.ibm.ws.concurrent.mp.fat.2.0/server.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/publish/servers/com.ibm.ws.concurrent.mp.fat.2.0/server.xml
@@ -1,0 +1,48 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+  <!-- TODO eventually, this is intended to be an Jakarta EE 10 server 
+       with MicroProfile Context Propagation 2.0.
+       In the mean time, we are using it to test the combination of
+       Concurrency 3.0 (an EE 10 feature) with MP Context Propagation enabled.
+       At some point, Concurrency 3.0 will be prevented from running with EE 9
+       features, and this test will need to be disabled for a time, until
+       the EE 10 compatible version of MP Context Propagation becomes available. -->
+  <featureManager>
+    <feature>bells-1.0</feature>
+    <feature>cdi-3.0</feature> <!-- TODO 4.0 -->
+    <feature>componenttest-2.0</feature>
+    <feature>concurrent-3.0</feature>
+    <feature>jndi-1.0</feature>
+    <feature>mpContextPropagation-1.3</feature> <!-- TODO 2.0 -->
+    <feature>mpFaultTolerance-4.0</feature> <!-- TODO EE 10 compatible version -->
+    <feature>servlet-5.0</feature> <!-- TODO 6.0 -->
+  </featureManager>
+
+  <include location="../fatTestPorts.xml"/>
+    
+  <application location="MPContextProp2_0_App.war"/>
+
+  <!-- For processing of custom thread context providers that are defined in META-INF/services -->
+  <bell>
+    <library id="CustomThreadContextProvidersLib">
+      <file name="${server.config.dir}/lib/customContextProviders2.jar"/>
+    </library>
+  </bell>
+
+  <!-- Needed for application to use a ForkJoinPool, access the thread context class loader, and shut down an unmanaged ExecutorService that the test application creates -->
+  <javaPermission codebase="${server.config.dir}/apps/MPContextProp2_0_App.war" className="java.lang.RuntimePermission" name="getClassLoader"/>
+  <javaPermission codebase="${server.config.dir}/apps/MPContextProp2_0_App.war" className="java.lang.RuntimePermission" name="modifyThread"/>
+  <javaPermission codebase="${server.config.dir}/apps/MPContextProp2_0_App.war" className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+  <javaPermission codebase="${server.config.dir}/apps/MPContextProp2_0_App.war" className="java.util.PropertyPermission" name="java.util.concurrent.ForkJoinPool.*" actions="read"/>
+
+</server>

--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/src/concurrent/mp/fat/v13/web/MPContextProp1_3_TestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/src/concurrent/mp/fat/v13/web/MPContextProp1_3_TestServlet.java
@@ -1,0 +1,326 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.mp.fat.v13.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.annotation.Resource;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.eclipse.microprofile.context.ThreadContext;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/MPContextProp1_3_TestServlet")
+public class MPContextProp1_3_TestServlet extends FATServlet {
+    // Create some exceptions here to keep the test method name out of the stack.
+    // Tests can then check for the presence of their method name in the stack to verify
+    // that the completable future is including the caller stack when raising exceptions.
+
+    private static final CancellationException CANCELLATION_X_CAUSED_BY_ARRAY_X = //
+                    (CancellationException) new CancellationException("Testing cancellation")
+                                    .initCause(new ArrayIndexOutOfBoundsException("Provides a reason to cancel"));
+
+    private static final CompletionException COMPLETION_X_CAUSED_BY_NAMING_X = new CompletionException(new NamingException("Testing exceptional completion"));
+
+    /**
+     * 2 minutes. Maximum number of nanoseconds to wait for a task or action to complete.
+     */
+    private static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
+
+    @Resource(name = "java:app/env/defaultExecutorRef")
+    private ManagedExecutor defaultManagedExecutor;
+
+    /**
+     * Executor that can be used when tests don't want to tie up threads from the Liberty global thread pool to perform test logic
+     */
+    private ExecutorService testThreads;
+
+    @Override
+    public void destroy() {
+        AccessController.doPrivileged((PrivilegedAction<List<Runnable>>) () -> testThreads.shutdownNow());
+    }
+
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        testThreads = Executors.newFixedThreadPool(10);
+    }
+
+    /**
+     * ManagedExecutor.copy was added in 1.2 and should still be working in 1.3.
+     * With this method, you should be able to copy from an unmanaged completion stage
+     * that lacks context propagation to create a copied stage that uses the
+     * managed executor to propagate thread context.
+     */
+    @Test
+    public void testCopy() throws Exception {
+        CompletableFuture<StringBuilder> unmanagedStage = CompletableFuture.supplyAsync(() -> new StringBuilder());
+
+        CompletableFuture<StringBuilder> managedStage = defaultManagedExecutor
+                        .copy(unmanagedStage)
+                        .thenApplyAsync(b -> {
+                            try {
+                                return b.append((ManagedExecutor) InitialContext.doLookup("java:app/env/defaultExecutorRef"));
+                            } catch (NamingException x) {
+                                throw new CompletionException(x);
+                            }
+                        });
+        StringBuilder b = managedStage.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+
+        assertTrue(b.toString(), b.toString().startsWith("ManagedExecutor@"));
+    }
+
+    /**
+     * Verify that custom thread context types are not propagated by the default ManagedExecutorService.
+     */
+    @Test
+    public void testCustomContextIsNotPropagatedByDefault() throws Exception {
+        int defaultPriority = Thread.currentThread().getPriority();
+        Thread.currentThread().setPriority(defaultPriority - 1);
+        try {
+            CompletableFuture<Integer> executorThreadPriority = defaultManagedExecutor.completedFuture(0)
+                            .thenApplyAsync(i -> i + Thread.currentThread().getPriority());
+            assertEquals(Integer.valueOf(defaultPriority), executorThreadPriority.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        } finally {
+            Thread.currentThread().setPriority(defaultPriority);
+        }
+    }
+
+    /**
+     * Verify that custom thread context types are propagated if configured on the builder.
+     */
+    @Test
+    public void testCustomContextIsPropagatedWhenConfigured() throws Exception {
+        ManagedExecutor executor = ManagedExecutor.builder()
+                        .cleared(ThreadContext.SECURITY, ThreadContext.TRANSACTION)
+                        .propagated(ThreadContext.ALL_REMAINING)
+                        .build();
+        try {
+            CompletableFuture<String> initialStage = executor.newIncompleteFuture();
+            CompletableFuture<String> executorThreadPriorities;
+
+            int defaultPriority = Thread.currentThread().getPriority();
+            Thread.currentThread().setPriority(defaultPriority - 1);
+            try {
+                executorThreadPriorities = initialStage.thenApplyAsync(s -> s + Thread.currentThread().getPriority());
+
+                Thread.currentThread().setPriority(defaultPriority - 2);
+
+                executorThreadPriorities = executorThreadPriorities.thenApply(s -> s + ' ' + Thread.currentThread().getPriority());
+            } finally {
+                Thread.currentThread().setPriority(defaultPriority);
+            }
+            initialStage.complete("");
+
+            String expected = (defaultPriority - 1) + " " + (defaultPriority - 2);
+            assertEquals(expected, executorThreadPriorities.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    /**
+     * When CompletionException is raised from the getNow method, it should show the
+     * stack of the getNow attempt along with the chained exception for the actual error.
+     */
+    @Test
+    public void testFailureStackShowsCallerOfGetNow() throws Exception {
+        CompletableFuture<String> future = defaultManagedExecutor.failedFuture(CANCELLATION_X_CAUSED_BY_ARRAY_X);
+
+        try {
+            String result = future.getNow("result-if-not-done");
+            fail("Got result " + result + " for a failed future");
+        } catch (CancellationException x) {
+            boolean foundInStack = false;
+            for (StackTraceElement line : x.getStackTrace())
+                foundInStack |= "testFailureStackShowsCallerOfGetNow".equals(line.getMethodName());
+            if (!foundInStack || x.getCause() != CANCELLATION_X_CAUSED_BY_ARRAY_X.getCause())
+                throw x;
+        }
+
+        future = defaultManagedExecutor.failedFuture(COMPLETION_X_CAUSED_BY_NAMING_X);
+
+        try {
+            String result = future.getNow("result-if-not-done");
+            fail("Got result " + result + " for a failed future");
+        } catch (CompletionException x) {
+            boolean foundInStack = false;
+            for (StackTraceElement line : x.getStackTrace())
+                foundInStack |= "testFailureStackShowsCallerOfGetNow".equals(line.getMethodName());
+            if (!foundInStack || x.getCause() != COMPLETION_X_CAUSED_BY_NAMING_X.getCause())
+                throw x;
+        }
+    }
+
+    /**
+     * When CompletionException is raised from the join method, it should show the
+     * stack of the join attempt along with the chained exception for the actual error.
+     */
+    @Test
+    public void testFailureStackShowsCallerOfJoin() throws Exception {
+        CompletableFuture<?> future = defaultManagedExecutor.failedFuture(CANCELLATION_X_CAUSED_BY_ARRAY_X);
+
+        try {
+            Object result = future.join();
+            fail("Got result " + result + " by joining a failed future");
+        } catch (CancellationException x) {
+            boolean foundInStack = false;
+            for (StackTraceElement line : x.getStackTrace())
+                foundInStack |= "testFailureStackShowsCallerOfJoin".equals(line.getMethodName());
+            if (!foundInStack || x.getCause() != CANCELLATION_X_CAUSED_BY_ARRAY_X.getCause())
+                throw x;
+        }
+
+        future = defaultManagedExecutor.failedFuture(COMPLETION_X_CAUSED_BY_NAMING_X);
+
+        try {
+            Object result = future.join();
+            fail("Got result " + result + " by joining a failed future");
+        } catch (CompletionException x) {
+            boolean foundInStack = false;
+            for (StackTraceElement line : x.getStackTrace())
+                foundInStack |= "testFailureStackShowsCallerOfJoin".equals(line.getMethodName());
+            if (!foundInStack || x.getCause() != COMPLETION_X_CAUSED_BY_NAMING_X.getCause())
+                throw x;
+        }
+    }
+
+    /**
+     * When CompletionException is raised from the timed get method, it should show the
+     * stack of the get attempt along with the chained exception for the actual error.
+     */
+    @Test
+    public void testFailureStackShowsCallerOfTimedGet() throws Exception {
+        CompletableFuture<String> future = defaultManagedExecutor.failedFuture(COMPLETION_X_CAUSED_BY_NAMING_X);
+
+        try {
+            String result = future.get(3, TimeUnit.MILLISECONDS);
+            fail("Got result " + result + " for a failed future");
+        } catch (ExecutionException x) {
+            boolean foundInStack = false;
+            for (StackTraceElement line : x.getStackTrace())
+                foundInStack |= "testFailureStackShowsCallerOfTimedGet".equals(line.getMethodName());
+            if (!foundInStack || x.getCause() != COMPLETION_X_CAUSED_BY_NAMING_X.getCause())
+                throw x;
+        }
+
+        future = defaultManagedExecutor.failedFuture(CANCELLATION_X_CAUSED_BY_ARRAY_X);
+
+        try {
+            String result = future.get(4, TimeUnit.MILLISECONDS);
+            fail("Got result " + result + " for a failed future");
+        } catch (CancellationException x) {
+            boolean foundInStack = false;
+            for (StackTraceElement line : x.getStackTrace())
+                foundInStack |= "testFailureStackShowsCallerOfTimedGet".equals(line.getMethodName());
+            if (!foundInStack || x.getCause() != CANCELLATION_X_CAUSED_BY_ARRAY_X.getCause())
+                throw x;
+        }
+    }
+
+    /**
+     * When CompletionException is raised from the untimed get method, it should show the
+     * stack of the get attempt along with the chained exception for the actual error.
+     */
+    @Test
+    public void testFailureStackShowsCallerOfUntimedGet() throws Exception {
+        CompletableFuture<String> future = defaultManagedExecutor.failedFuture(COMPLETION_X_CAUSED_BY_NAMING_X);
+
+        try {
+            String result = future.get();
+            fail("Got result " + result + " for a failed future");
+        } catch (ExecutionException x) {
+            boolean foundInStack = false;
+            for (StackTraceElement line : x.getStackTrace())
+                foundInStack |= "testFailureStackShowsCallerOfUntimedGet".equals(line.getMethodName());
+            if (!foundInStack || x.getCause() != COMPLETION_X_CAUSED_BY_NAMING_X.getCause())
+                throw x;
+        }
+
+        future = defaultManagedExecutor.failedFuture(CANCELLATION_X_CAUSED_BY_ARRAY_X);
+
+        try {
+            String result = future.get();
+            fail("Got result " + result + " for a failed future");
+        } catch (CancellationException x) {
+            boolean foundInStack = false;
+            for (StackTraceElement line : x.getStackTrace())
+                foundInStack |= "testFailureStackShowsCallerOfUntimedGet".equals(line.getMethodName());
+            if (!foundInStack || x.getCause() != CANCELLATION_X_CAUSED_BY_ARRAY_X.getCause())
+                throw x;
+        }
+    }
+
+    /**
+     * ThreadContext.withContextCapture was enhanced in 1.2 to enable the copied completion stages
+     * to have async dependent stages that run on the product's default executor,
+     * which for us is the Liberty global thread pool.
+     * This enhancement should continue to be in place for 1.3.
+     */
+    @Test
+    public void testWithContextCapture() throws Exception {
+        ThreadContext contextualizer = ThreadContext.builder()
+                        .propagated(ThreadContext.APPLICATION, "Priority")
+                        .cleared(ThreadContext.TRANSACTION)
+                        .unchanged(ThreadContext.ALL_REMAINING)
+                        .build();
+
+        CompletableFuture<StringBuilder> unmanagedStage = new CompletableFuture<StringBuilder>();
+        CompletableFuture<Void> managedStage;
+
+        int originalPriority = Thread.currentThread().getPriority();
+        Thread.currentThread().setPriority(2);
+        try {
+            managedStage = contextualizer
+                            .withContextCapture(unmanagedStage)
+                            .thenAcceptAsync(b -> {
+                                try {
+                                    b.append("priority ")
+                                                    .append(Thread.currentThread().getPriority())
+                                                    .append(", looked up ")
+                                                    .append((ManagedExecutor) InitialContext.doLookup("java:app/env/defaultExecutorRef"));
+                                } catch (NamingException x) {
+                                    throw new CompletionException(x);
+                                }
+                            });
+        } finally {
+            Thread.currentThread().setPriority(originalPriority);
+        }
+
+        StringBuilder b = new StringBuilder();
+        unmanagedStage.complete(b);
+
+        managedStage.join();
+
+        assertTrue(b.toString(), b.toString().startsWith("priority 2, looked up ManagedExecutor@"));
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-applications/MPContextProp1_3_App/src/concurrent/mp/fat/v13/web/MPContextProp1_3_TestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-applications/MPContextProp1_3_App/src/concurrent/mp/fat/v13/web/MPContextProp1_3_TestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-applications/MPContextProp2_0_App/src/concurrent/mp/fat/v20/web/AsyncClassBean.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-applications/MPContextProp2_0_App/src/concurrent/mp/fat/v20/web/AsyncClassBean.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.mp.fat.v20.web;
+
+import java.io.Serializable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import jakarta.enterprise.concurrent.Asynchronous;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+@ApplicationScoped
+@Asynchronous(executor = "java:comp/eeExecutor") // Should not be allowed at this location
+public class AsyncClassBean implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    CompletableFuture<Object> asyncLookup(String name) {
+        try {
+            return Asynchronous.Result.complete(InitialContext.doLookup(name));
+        } catch (NamingException x) {
+            throw new CompletionException(x);
+        }
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-applications/MPContextProp2_0_App/src/concurrent/mp/fat/v20/web/MPAppBean.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-applications/MPContextProp2_0_App/src/concurrent/mp/fat/v20/web/MPAppBean.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.mp.fat.v20.web;
+
+import java.io.Serializable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import jakarta.enterprise.concurrent.Asynchronous;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+@ApplicationScoped
+public class MPAppBean implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Asynchronous(executor = "java:comp/eeExecutor")
+    CompletableFuture<Object> eeAsyncLookup(String name) {
+        try {
+            return Asynchronous.Result.complete(InitialContext.doLookup(name));
+        } catch (NamingException x) {
+            throw new CompletionException(x);
+        }
+    }
+
+    // TODO also test FT async at class level and MP async on method. (requires another bean)
+    //@Asynchronous
+    //@Asynchronous FT
+    //CompletableFuture<String> doublyAsync() {
+    //    return Asynchronous.Result.complete("Should not be able to combine different @Asynchronous annotations on a method");
+    //}
+
+    @Asynchronous(executor = "java:module/env/defaultExecutorRef")
+    CompletableFuture<Object> mpAsyncLookup(String name) {
+        try {
+            return Asynchronous.Result.complete(InitialContext.doLookup(name));
+        } catch (NamingException x) {
+            throw new CompletionException(x);
+        }
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-applications/MPContextProp2_0_App/src/concurrent/mp/fat/v20/web/MPContextProp2_0_TestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-applications/MPContextProp2_0_App/src/concurrent/mp/fat/v20/web/MPContextProp2_0_TestServlet.java
@@ -1,0 +1,247 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.mp.fat.v20.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+
+import jakarta.annotation.Resource;
+import jakarta.enterprise.concurrent.ContextServiceDefinition;
+import jakarta.enterprise.concurrent.ManagedExecutorDefinition;
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.transaction.Status;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.UserTransaction;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.eclipse.microprofile.context.ThreadContext;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@ContextServiceDefinition(name = "java:module/AppAndPriorityContext",
+                          cleared = ContextServiceDefinition.SECURITY,
+                          propagated = { ContextServiceDefinition.APPLICATION, "Priority" },
+                          unchanged = ContextServiceDefinition.TRANSACTION)
+@ManagedExecutorDefinition(name = "java:comp/eeExecutor",
+                           context = "java:module/AppAndPriorityContext",
+                           maxAsync = 2)
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/MPContextProp2_0_TestServlet")
+public class MPContextProp2_0_TestServlet extends FATServlet {
+    /**
+     * 2 minutes. Maximum number of nanoseconds to wait for a task or action to complete.
+     */
+    private static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
+
+    @Resource(name = "java:module/env/defaultExecutorRef")
+    private ManagedExecutor defaultExecutor;
+
+    @Resource(lookup = "java:comp/eeExecutor")
+    ManagedExecutorService eeExecutor;
+
+    ManagedExecutor mpExecutor;
+
+    /**
+     * Executor that can be used when tests don't want to tie up threads from the Liberty global thread pool to perform test logic
+     */
+    private ExecutorService testThreads;
+
+    @Resource
+    UserTransaction tx;
+
+    @Override
+    public void destroy() {
+        AccessController.doPrivileged((PrivilegedAction<List<Runnable>>) () -> testThreads.shutdownNow());
+    }
+
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        testThreads = Executors.newFixedThreadPool(10);
+        mpExecutor = ManagedExecutor.builder()
+                        .cleared(ThreadContext.SECURITY, ThreadContext.TRANSACTION)
+                        .propagated(ThreadContext.ALL_REMAINING)
+                        .maxAsync(3)
+                        .build();
+    }
+
+    /**
+     * ManagedExecutor.copy was added in 1.2 and should still be working.
+     * With this method, you should be able to copy from an unmanaged completion stage
+     * that lacks context propagation to create a copied stage that uses the
+     * managed executor to propagate thread context.
+     */
+    @Test
+    public void testCopy() throws Exception {
+        CompletableFuture<StringBuilder> unmanagedStage = CompletableFuture.supplyAsync(() -> new StringBuilder());
+
+        CompletableFuture<StringBuilder> managedStage = defaultExecutor
+                        .copy(unmanagedStage)
+                        .thenApplyAsync(b -> {
+                            try {
+                                return b.append((ManagedExecutor) InitialContext.doLookup("java:module/env/defaultExecutorRef"));
+                            } catch (NamingException x) {
+                                throw new CompletionException(x);
+                            }
+                        });
+        StringBuilder b = managedStage.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+
+        assertTrue(b.toString(), b.toString().startsWith("ManagedExecutor@"));
+    }
+
+    /**
+     * Verify that custom thread context types are not propagated by the default ManagedExecutorService.
+     */
+    @Test
+    public void testCustomContextIsNotPropagatedByDefault() throws Exception {
+        int defaultPriority = Thread.currentThread().getPriority();
+        Thread.currentThread().setPriority(defaultPriority - 1);
+        try {
+            CompletableFuture<Integer> executorThreadPriority = defaultExecutor.completedFuture(0)
+                            .thenApplyAsync(i -> i + Thread.currentThread().getPriority());
+            assertEquals(Integer.valueOf(defaultPriority), executorThreadPriority.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        } finally {
+            Thread.currentThread().setPriority(defaultPriority);
+        }
+    }
+
+    /**
+     * Verify that custom thread context types are propagated if configured on the ContextServiceDefinition.
+     */
+    // TODO @Test this should start working once mpContextPropagation-2.0 is added
+    public void testCustomEEContextIsPropagatedWhenConfigured() throws Exception {
+        CompletableFuture<String> initialStage = eeExecutor.newIncompleteFuture();
+        CompletableFuture<String> executorThreadPriorities;
+
+        int defaultPriority = Thread.currentThread().getPriority();
+        Thread.currentThread().setPriority(defaultPriority - 1);
+        try {
+            executorThreadPriorities = initialStage.thenApplyAsync(s -> s + Thread.currentThread().getPriority());
+
+            Thread.currentThread().setPriority(defaultPriority - 2);
+
+            executorThreadPriorities = executorThreadPriorities.thenApply(s -> s + ' ' + Thread.currentThread().getPriority());
+        } finally {
+            Thread.currentThread().setPriority(defaultPriority);
+        }
+        initialStage.complete("");
+
+        String expected = (defaultPriority - 1) + " " + (defaultPriority - 2);
+        assertEquals(expected, executorThreadPriorities.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+    }
+
+    /**
+     * Verify that custom thread context types are propagated if configured on the builder.
+     */
+    @Test
+    public void testCustomMPContextIsPropagatedWhenConfigured() throws Exception {
+        CompletableFuture<String> initialStage = mpExecutor.newIncompleteFuture();
+        CompletableFuture<String> executorThreadPriorities;
+
+        int defaultPriority = Thread.currentThread().getPriority();
+        Thread.currentThread().setPriority(defaultPriority - 1);
+        try {
+            executorThreadPriorities = initialStage.thenApplyAsync(s -> s + Thread.currentThread().getPriority());
+
+            Thread.currentThread().setPriority(defaultPriority - 2);
+
+            executorThreadPriorities = executorThreadPriorities.thenApply(s -> s + ' ' + Thread.currentThread().getPriority());
+        } finally {
+            Thread.currentThread().setPriority(defaultPriority);
+        }
+        initialStage.complete("");
+
+        String expected = (defaultPriority - 1) + " " + (defaultPriority - 2);
+        assertEquals(expected, executorThreadPriorities.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+    }
+
+    /**
+     * java:comp/DefaultManagedExecutorService can be used interchangeably as a MicroProfile ManagedExecutor
+     * or as a Jakarta EE ManagedExecutorService.
+     */
+    @Test
+    public void testDefaultManagedExecutorService() throws Exception {
+        assertTrue(defaultExecutor.toString(), defaultExecutor instanceof ManagedExecutorService);
+
+        Object executor = InitialContext.doLookup("java:module/env/defaultExecutorRef");
+
+        assertTrue(executor.toString(), executor instanceof ManagedExecutor);
+        assertTrue(executor.toString(), executor instanceof ManagedExecutorService);
+    }
+
+    /**
+     * Use a MicroProfile ManagedExecutor and a Jakarta EE ManagedExecutorService
+     * to create completion stages and combine the two to create dependent stages,
+     * ensuring that each dependent stage runs with the configured context propagation
+     * of the managed executor of the stage that creates the dependent stage.
+     */
+    @Test
+    public void testIntermixMicroProfileAndJakartaEECompletionStages() throws Exception {
+        CompletableFuture<String> eeStage1 = eeExecutor.supplyAsync(() -> {
+            try {
+                return InitialContext.doLookup("java:comp/eeExecutor").toString();
+            } catch (NamingException x) {
+                throw new CompletionException(x);
+            }
+        });
+
+        CompletableFuture<String> mpStage1 = mpExecutor.supplyAsync(() -> {
+            try {
+                return InitialContext.doLookup("java:module/env/defaultExecutorRef").toString();
+            } catch (NamingException x) {
+                throw new CompletionException(x);
+            }
+        });
+
+        assertNotNull(eeStage1.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertNotNull(mpStage1.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        CompletableFuture<Integer> eeStage2;
+        CompletableFuture<Integer> mpStage2;
+
+        BiFunction<String, String, Integer> getTransactionStatus = (s1, s2) -> {
+            try {
+                UserTransaction tx1 = InitialContext.doLookup("java:comp/UserTransaction");
+                return tx1.getStatus();
+            } catch (NamingException | SystemException x) {
+                throw new CompletionException(x);
+            }
+        };
+
+        tx.begin();
+        try {
+            eeStage2 = eeStage1.thenCombine(mpStage1, getTransactionStatus);
+            mpStage2 = mpStage1.thenCombine(eeStage1, getTransactionStatus);
+        } finally {
+            tx.rollback();
+        }
+
+        assertEquals(Integer.valueOf(Status.STATUS_ACTIVE), eeStage2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertEquals(Integer.valueOf(Status.STATUS_NO_TRANSACTION), mpStage2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-applications/MPContextProp2_0_App/src/concurrent/mp/fat/v20/web/MPFTBean.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-applications/MPContextProp2_0_App/src/concurrent/mp/fat/v20/web/MPFTBean.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.mp.fat.v20.web;
+
+import java.io.Serializable;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+
+import jakarta.enterprise.concurrent.Asynchronous;
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+@ApplicationScoped
+@org.eclipse.microprofile.faulttolerance.Asynchronous
+public class MPFTBean implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Asynchronous
+    CompletionStage<String> doublyAsync() {
+        return Asynchronous.Result.complete("Should not be able to combine Jakarta Concurrency @Asynchronous on a method " +
+                                            "with MicroProfile Fault Tolerance @Asynchronous on the class");
+    }
+
+    CompletionStage<Object> ftAsyncLookup(String name) {
+        try {
+            ManagedExecutorService executor = (ManagedExecutorService) InitialContext.doLookup(name);
+            return executor.completedFuture(executor);
+        } catch (NamingException x) {
+            throw new CompletionException(x);
+        }
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-contextproviders/threadprioritycontext/src/org/test/ee/context/priority/PriorityContextProvider.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-contextproviders/threadprioritycontext/src/org/test/ee/context/priority/PriorityContextProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,12 +8,12 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package org.test.context.priority;
+package org.test.ee.context.priority;
 
 import java.util.Map;
 
-import org.eclipse.microprofile.context.spi.ThreadContextProvider;
-import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
+import jakarta.enterprise.concurrent.spi.ThreadContextProvider;
+import jakarta.enterprise.concurrent.spi.ThreadContextSnapshot;
 
 /**
  * Example third-party thread context provider, to be used for testing purposes.

--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-contextproviders/threadprioritycontext/src/org/test/ee/context/priority/PriorityContextRestorer.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-contextproviders/threadprioritycontext/src/org/test/ee/context/priority/PriorityContextRestorer.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.ee.context.priority;
+
+import jakarta.enterprise.concurrent.spi.ThreadContextRestorer;
+
+/**
+ * Example third-party thread context restorer, to be used for testing purposes.
+ * This context propagates the current thread priority to the task or action.
+ */
+public class PriorityContextRestorer implements ThreadContextRestorer {
+    private boolean restored = false;
+    private final int priorityToRestore;
+
+    PriorityContextRestorer(int priorityToRestore) {
+        this.priorityToRestore = priorityToRestore;
+    }
+
+    @Override
+    public void endContext() {
+        if (restored)
+            throw new IllegalStateException("thread context was already restored");
+        Thread.currentThread().setPriority(priorityToRestore);
+        restored = true;
+    }
+
+    @Override
+    public String toString() {
+        return "PriorityContextRestorer@" + Integer.toHexString(hashCode()) + "(" + priorityToRestore + ")";
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-contextproviders/threadprioritycontext/src/org/test/ee/context/priority/PriorityContextSnapshot.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-contextproviders/threadprioritycontext/src/org/test/ee/context/priority/PriorityContextSnapshot.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,10 +8,10 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package org.test.context.priority;
+package org.test.ee.context.priority;
 
-import org.eclipse.microprofile.context.spi.ThreadContextController;
-import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
+import jakarta.enterprise.concurrent.spi.ThreadContextRestorer;
+import jakarta.enterprise.concurrent.spi.ThreadContextSnapshot;
 
 /**
  * Example third-party thread context snapshot, to be used for testing purposes.
@@ -33,9 +33,9 @@ public class PriorityContextSnapshot implements ThreadContextSnapshot {
     }
 
     @Override
-    public ThreadContextController begin() {
+    public ThreadContextRestorer begin() {
         Thread thread = Thread.currentThread();
-        ThreadContextController priorityContextRestorer = new PriorityContextRestorer(thread.getPriority());
+        ThreadContextRestorer priorityContextRestorer = new PriorityContextRestorer(thread.getPriority());
         thread.setPriority(priorityForPropagation);
         return priorityContextRestorer;
     }

--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-contextproviders/threadprioritycontext/src/org/test/mp/context/priority/PriorityContextProvider.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-contextproviders/threadprioritycontext/src/org/test/mp/context/priority/PriorityContextProvider.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2018,2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.mp.context.priority;
+
+import java.util.Map;
+
+import org.eclipse.microprofile.context.spi.ThreadContextProvider;
+import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
+
+/**
+ * Example third-party thread context provider, to be used for testing purposes.
+ * This context propagates the current thread priority to the task or action.
+ */
+public class PriorityContextProvider implements ThreadContextProvider {
+    @Override
+    public ThreadContextSnapshot clearedContext(Map<String, String> props) {
+        return new PriorityContextSnapshot(Thread.NORM_PRIORITY);
+    }
+
+    @Override
+    public ThreadContextSnapshot currentContext(Map<String, String> props) {
+        return new PriorityContextSnapshot(Thread.currentThread().getPriority());
+    }
+
+    @Override
+    public String getThreadContextType() {
+        return "Priority";
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-contextproviders/threadprioritycontext/src/org/test/mp/context/priority/PriorityContextRestorer.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-contextproviders/threadprioritycontext/src/org/test/mp/context/priority/PriorityContextRestorer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package org.test.context.priority;
+package org.test.mp.context.priority;
 
 import org.eclipse.microprofile.context.spi.ThreadContextController;
 

--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-contextproviders/threadprioritycontext/src/org/test/mp/context/priority/PriorityContextSnapshot.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-contextproviders/threadprioritycontext/src/org/test/mp/context/priority/PriorityContextSnapshot.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.mp.context.priority;
+
+import org.eclipse.microprofile.context.spi.ThreadContextController;
+import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
+
+/**
+ * Example third-party thread context snapshot, to be used for testing purposes.
+ * This context propagates the current thread priority to the task or action.
+ */
+public class PriorityContextSnapshot implements ThreadContextSnapshot {
+    /**
+     * The thread priority value to propagate to contextual tasks or actions.
+     */
+    private final int priorityForPropagation;
+
+    /**
+     * Construct a snapshot of the specified thread priority.
+     *
+     * @param priority thread priority value to propagate to contextual tasks or actions.
+     */
+    PriorityContextSnapshot(int priority) {
+        this.priorityForPropagation = priority;
+    }
+
+    @Override
+    public ThreadContextController begin() {
+        Thread thread = Thread.currentThread();
+        ThreadContextController priorityContextRestorer = new PriorityContextRestorer(thread.getPriority());
+        thread.setPriority(priorityForPropagation);
+        return priorityContextRestorer;
+    }
+
+    @Override
+    public String toString() {
+        return "PriorityContextSnapshot@" + Integer.toHexString(hashCode()) + "(" + priorityForPropagation + ")";
+    }
+}


### PR DESCRIPTION
Add tests demonstrating that MicroProfile thread context providers and Jakarta EE thread context providers can be enabled at the same time.  These tests are temporarily using EE 9 features (apart from Concurrency) so that MicroProfile 5.0 features can be used.  One test had to be disabled for that reason.  Eventually all will be switched to MP 6.0 and EE 10.

Also, add tests that ensure MicroProfile Fault Tolerance Asynchronous and Jakarta Concurrency Asynchronous can work alongside each other.  Later, this same bucket will add tests that the these annotations cannot be mixed on the same method or between class/method.