### PR TITLE
persistent executor timers bucket fails to run on Java 8 with features that require Java 11

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_timers/fat/src/com/ibm/ws/concurrent/persistent/fat/timers/PersistentExecutorTimersWithFailoverEnabledTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_timers/fat/src/com/ibm/ws/concurrent/persistent/fat/timers/PersistentExecutorTimersWithFailoverEnabledTest.java
@@ -23,6 +23,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.PersistentExecutor;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 
+import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.database.container.DatabaseContainerFactory;
@@ -38,6 +39,7 @@ import web.PersistentTimersTestServlet;
  * Tests for persistent scheduled executor via persistent EJB timers
  */
 @RunWith(FATRunner.class)
+@MinimumJavaLevel(javaLevel = 11)
 public class PersistentExecutorTimersWithFailoverEnabledTest extends FATServletClient {
 
     private static final String APP_NAME = "timersapp";


### PR DESCRIPTION
fixes #20154