### PR TITLE
Asynchronous annotation conflicting with MicroProfile

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-applications/MPContextProp2_0_App/src/concurrent/mp/fat/v20/web/MPAppBean.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/test-applications/MPContextProp2_0_App/src/concurrent/mp/fat/v20/web/MPAppBean.java
@@ -13,6 +13,7 @@ package concurrent.mp.fat.v20.web;
 import java.io.Serializable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
 
 import jakarta.enterprise.concurrent.Asynchronous;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -33,12 +34,11 @@ public class MPAppBean implements Serializable {
         }
     }
 
-    // TODO also test FT async at class level and MP async on method. (requires another bean)
-    //@Asynchronous
-    //@Asynchronous FT
-    //CompletableFuture<String> doublyAsync() {
-    //    return Asynchronous.Result.complete("Should not be able to combine different @Asynchronous annotations on a method");
-    //}
+    @Asynchronous
+    @org.eclipse.microprofile.faulttolerance.Asynchronous
+    CompletionStage<String> doublyAsync() {
+        return Asynchronous.Result.complete("Should not be able to combine different @Asynchronous annotations on a method");
+    }
 
     @Asynchronous(executor = "java:module/env/defaultExecutorRef")
     CompletableFuture<Object> mpAsyncLookup(String name) {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi/resources/com/ibm/ws/microprofile/faulttolerance/cdi/resources/FaultToleranceCDI.nlsprops
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi/resources/com/ibm/ws/microprofile/faulttolerance/cdi/resources/FaultToleranceCDI.nlsprops
@@ -6,7 +6,7 @@
 #ISMESSAGEFILE true
 # #########################################################################
 ###############################################################################
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -133,6 +133,11 @@ asynchronous.method.not.returning.future.completionstage.CWMFT5020E.useraction=U
 fallback.method.not.found.CWMFT5021E=CWMFT5021E: The fallback method {0} with parameter and return types matching method {1} was not found in the class hierarchy of {2}.
 fallback.method.not.found.CWMFT5021E.explanation=A fallback method was declared but it does not exist in the declaring class, its superclasses, or the interfaces it implements.
 fallback.method.not.found.CWMFT5021E.useraction=Either remove the fallback annotation or add the missing method. If the fallback method exists but is still not being found, check that the parameter types and return type of the two methods match and that the fallback method is visible to the class which declares the annotated method.
+
+# Conflict with Concurrency's @Asynchronous
+anno.conflict.CWMFT5022E=CWMFT5022E: MicroProfile Fault Tolerance annotations cannot be used in combination with {0}.
+anno.conflict.CWMFT5022E.explanation=It is not supported to intermix MicroProfile Fault Tolerance annotations and the specified annotation.
+anno.conflict.CWMFT5022E.useraction=Remove the MicroProfile Fault Tolerance annotations or the conflicting annotation.
 
 #Generic error for internal failures. 
 internal.error.CWMFT5997E=CWMFT5997E: An internal error occurred. The exception is {0}.

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi/resources/com/ibm/ws/microprofile/faulttolerance/cdi/resources/FaultToleranceCDI.nlsprops
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi/resources/com/ibm/ws/microprofile/faulttolerance/cdi/resources/FaultToleranceCDI.nlsprops
@@ -135,8 +135,8 @@ fallback.method.not.found.CWMFT5021E.explanation=A fallback method was declared 
 fallback.method.not.found.CWMFT5021E.useraction=Either remove the fallback annotation or add the missing method. If the fallback method exists but is still not being found, check that the parameter types and return type of the two methods match and that the fallback method is visible to the class which declares the annotated method.
 
 # Conflict with Concurrency's @Asynchronous
-anno.conflict.CWMFT5022E=CWMFT5022E: MicroProfile Fault Tolerance annotations cannot be used in combination with {0}.
-anno.conflict.CWMFT5022E.explanation=It is not supported to intermix MicroProfile Fault Tolerance annotations and the specified annotation.
+anno.conflict.CWMFT5022E=CWMFT5022E: MicroProfile Fault Tolerance annotations cannot be used in combination with the {0} annotation.
+anno.conflict.CWMFT5022E.explanation=Intermixing MicroProfile Fault Tolerance annotations with the specified annotation is not supported.
 anno.conflict.CWMFT5022E.useraction=Remove the MicroProfile Fault Tolerance annotations or the conflicting annotation.
 
 #Generic error for internal failures. 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/FaultToleranceInterceptor.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/FaultToleranceInterceptor.java
@@ -61,6 +61,12 @@ public class FaultToleranceInterceptor {
 
     private static final TraceComponent tc = Tr.register(FaultToleranceInterceptor.class);
 
+    /**
+     * Class name of Jakarta EE Concurrency annotation that must not be intermixed with
+     * MicroProfile Fault Tolerance.
+     */
+    private static final String CONCURRENCY_ASYNC_ANNO = "jakarta.enterprise.concurrent.Asynchronous";
+
     @Inject
     private BeanManager beanManager;
 
@@ -244,6 +250,10 @@ public class FaultToleranceInterceptor {
             Executor<Object> executor = aggregatedFTPolicy.getExecutor();
 
             Method method = invocationContext.getMethod();
+            for (Annotation anno : method.getAnnotations())
+                if (CONCURRENCY_ASYNC_ANNO.equals(anno.annotationType().getName()))
+                    throw new UnsupportedOperationException(Tr.formatMessage(tc, "anno.conflict.CWMFT5022E", CONCURRENCY_ASYNC_ANNO));
+
             Object[] params = invocationContext.getParameters();
             ExecutionContext executionContext = executor.newExecutionContext(generateId(method), method, params);
 


### PR DESCRIPTION
Specifying the Jakarta EE Concurrency Asynchronous annotation on the same method for which MicroProfile Fault Tolerance Asynchronous applies is not supported.  Add tests to ensure this is rejected.