### PR TITLE
Issue 20165: Update the json container features to include the BELLS feature.

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonbImpl-2.0.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonbImpl-2.0.0.feature
@@ -1,15 +1,14 @@
-# This private impl feature corresponds to JSON-B 2.0 with the Yasson implementation
+# This private impl feature corresponds to JjsonbContainer-2.0, which gives you
+# JSON-B 2.0 spec with the ability to choose the default provider via a bell.
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.jsonbImpl-2.0.0
 singleton=true
 visibility=private
--features=com.ibm.websphere.appserver.eeCompatible-9.0, \
-  com.ibm.websphere.appserver.classloading-1.0, \
-  io.openliberty.jakarta.cdi-3.0, \
-  io.openliberty.jsonp-2.0
--bundles=\
-  com.ibm.ws.org.eclipse.yasson.2.0, \
-  io.openliberty.jakarta.jsonb.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.json.bind:jakarta.json.bind-api:2.0.0"
+-features=io.openliberty.jsonp-2.0, \
+  com.ibm.websphere.appserver.bells-1.0, \
+  com.ibm.websphere.appserver.eeCompatible-9.0, \
+  io.openliberty.jakarta.cdi-3.0
+-bundles=io.openliberty.jakarta.jsonb.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.json.bind:jakarta.json.bind-api:2.0.0"
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonbImpl-2.0.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonbImpl-2.0.0.feature
@@ -1,4 +1,4 @@
-# This private impl feature corresponds to JjsonbContainer-2.0, which gives you
+# This private impl feature corresponds to jsonbContainer-2.0, which gives you
 # JSON-B 2.0 spec with the ability to choose the default provider via a bell.
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.jsonbImpl-2.0.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonbImpl-2.0.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonbImpl-2.0.1.feature
@@ -1,0 +1,15 @@
+# This private impl feature corresponds to JSON-B 2.0 with the Yasson implementation
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.jsonbImpl-2.0.1
+singleton=true
+visibility=private
+-features=com.ibm.websphere.appserver.eeCompatible-9.0, \
+  com.ibm.websphere.appserver.classloading-1.0, \
+  io.openliberty.jakarta.cdi-3.0, \
+  io.openliberty.jsonp-2.0
+-bundles=\
+  com.ibm.ws.org.eclipse.yasson.2.0, \
+  io.openliberty.jakarta.jsonb.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.json.bind:jakarta.json.bind-api:2.0.0"
+kind=ga
+edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonbInternal-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonbInternal-2.0.feature
@@ -3,7 +3,7 @@ symbolicName=io.openliberty.jsonbInternal-2.0
 visibility=private
 singleton=true
 -features=, \
-  io.openliberty.jsonbImpl-2.0.0
+  io.openliberty.jsonbImpl-2.0.1; ibm.tolerates:="2.0.0"
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpImpl-2.0.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpImpl-2.0.0.feature
@@ -1,11 +1,12 @@
-# This private impl feature corresponds to JSON-P 2.0 with the Glassfish implementation
+# This private impl feature corresponds to jsonpContainer-1.1, which gives you
+# JSON-P 1.1 spec with the ability to choose the default provider via a bell.
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.jsonpImpl-2.0.0
 singleton=true
 visibility=private
--features=com.ibm.websphere.appserver.eeCompatible-9.0
--bundles=io.openliberty.jakarta.jsonp.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.json:jakarta.json-api:2.0.0", \
- com.ibm.ws.org.glassfish.json.2.0
+-features=com.ibm.websphere.appserver.bells-1.0, \
+  com.ibm.websphere.appserver.eeCompatible-9.0
+-bundles=io.openliberty.jakarta.jsonp.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.json:jakarta.json-api:2.0.0"
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpImpl-2.0.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpImpl-2.0.1.feature
@@ -1,0 +1,11 @@
+# This private impl feature corresponds to JSON-P 2.0 with the Glassfish implementation
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.jsonpImpl-2.0.1
+singleton=true
+visibility=private
+-features=com.ibm.websphere.appserver.eeCompatible-9.0
+-bundles=io.openliberty.jakarta.jsonp.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.json:jakarta.json-api:2.0.0", \
+ com.ibm.ws.org.glassfish.json.2.0
+kind=ga
+edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpInternal-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpInternal-2.0.feature
@@ -2,7 +2,7 @@
 symbolicName=io.openliberty.jsonpInternal-2.0
 visibility=private
 singleton=true
--features=io.openliberty.jsonpImpl-2.0.1
+-features=io.openliberty.jsonpImpl-2.0.1; ibm.tolerates:="2.0.0"
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpInternal-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpInternal-2.0.feature
@@ -2,7 +2,7 @@
 symbolicName=io.openliberty.jsonpInternal-2.0
 visibility=private
 singleton=true
--features=io.openliberty.jsonpImpl-2.0.0
+-features=io.openliberty.jsonpImpl-2.0.1
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.ws.jsonb_fat/fat/src/com/ibm/ws/jsonb/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsonb_fat/fat/src/com/ibm/ws/jsonb/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -85,6 +85,17 @@ public class FATSuite {
                 Log.info(c, "beforeSuite", "Transformed bundle " + bundleFile + " to " + newBundleFile);
                 server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/" + bundle + ".jakarta.jar");
             }
+            // Transform Johnzon to use Jakarta APIs
+            Path johnzonCoreFile = Paths.get("publish/shared/resources/johnzon/1.1.5/johnzon-core-1.1.5.jar");
+            Path newjohnzonCoreFile = Paths.get("publish/shared/resources/johnzon/1.1.5/ee9-johnzon-core-1.1.5.jar");
+            Path johnzonJsonbFile = Paths.get("publish/shared/resources/johnzon/1.1.5/johnzon-jsonb-1.1.5.jar");
+            Path newjohnzonJsonbFile = Paths.get("publish/shared/resources/johnzon/1.1.5/ee9-johnzon-jsonb-1.1.5.jar");
+            Path johnzonMapperFile = Paths.get("publish/shared/resources/johnzon/1.1.5/johnzon-mapper-1.1.5.jar");
+            Path newjohnzonMapperFile = Paths.get("publish/shared/resources/johnzon/1.1.5/ee9-johnzon-mapper-1.1.5.jar");
+            JakartaEE9Action.transformApp(johnzonCoreFile, newjohnzonCoreFile);
+            JakartaEE9Action.transformApp(johnzonJsonbFile, newjohnzonJsonbFile);
+            JakartaEE9Action.transformApp(johnzonMapperFile, newjohnzonMapperFile);
+
             // Install jakartaee user features
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/testFeatureUsingJsonp-2.0.mf");
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/testFeatureUsingJsonb-2.0.mf");

--- a/dev/com.ibm.ws.jsonb_fat/fat/src/com/ibm/ws/jsonb/fat/JSONBContainerTest.java
+++ b/dev/com.ibm.ws.jsonb_fat/fat/src/com/ibm/ws/jsonb/fat/JSONBContainerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package com.ibm.ws.jsonb.fat;
 import static com.ibm.ws.jsonb.fat.FATSuite.CDI_APP;
 import static com.ibm.ws.jsonb.fat.FATSuite.JSONB_APP;
 import static com.ibm.ws.jsonb.fat.FATSuite.PROVIDER_JOHNZON;
-import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -26,25 +25,23 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 
-import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.custom.junit.runner.Mode;
-import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.FATServletClient;
 import jsonb.cdi.web.JsonbCDITestServlet;
 import web.jsonbtest.JSONBTestServlet;
 import web.jsonbtest.JohnzonTestServlet;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
 public class JSONBContainerTest extends FATServletClient {
 
-    @Server("com.ibm.ws.jsonb.container.fat")
+    private static final String javaeeServer = "com.ibm.ws.jsonb.container.fat";
+    private static final String jakartaee9Server = "com.ibm.ws.jsonb.container.ee9.fat";
+
     @TestServlets({
                     @TestServlet(servlet = JSONBTestServlet.class, contextRoot = JSONB_APP),
                     @TestServlet(servlet = JohnzonTestServlet.class, contextRoot = JSONB_APP),
@@ -54,6 +51,11 @@ public class JSONBContainerTest extends FATServletClient {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        if (JakartaEE9Action.isActive()) {
+            server = LibertyServerFactory.getLibertyServer(jakartaee9Server);
+        } else {
+            server = LibertyServerFactory.getLibertyServer(javaeeServer);
+        }
         FATSuite.jsonbApp(server);
         FATSuite.cdiApp(server);
         server.startServer();
@@ -68,9 +70,6 @@ public class JSONBContainerTest extends FATServletClient {
     // as a declarative service. Validate the expected provider is used, and that it can succesfully
     // marshall/unmarshall to/from classes from the bundle.
     @Test
-    @SkipForRepeat(EE9_FEATURES)
-    //Skipping the test for jakartaee testing since it is beyond the scope of what is needed
-    //TODO for jakartaee testing: Transform the johnzon jars in AUTO_FVT/publish/shared/resources folder, solve the classloader problems with yasson and jonhzon provider impls
     public void testUserFeature() throws Exception {
         String found;
         server.resetLogMarks();

--- a/dev/com.ibm.ws.jsonb_fat/fat/src/com/ibm/ws/jsonb/fat/JSONBInAppTest.java
+++ b/dev/com.ibm.ws.jsonb_fat/fat/src/com/ibm/ws/jsonb/fat/JSONBInAppTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,11 +16,12 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
-import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.FATServletClient;
 import web.jsonbtest.JSONBTestServlet;
 import web.jsonbtest.JohnzonTestServlet;
@@ -28,7 +29,9 @@ import web.jsonbtest.JohnzonTestServlet;
 @RunWith(FATRunner.class)
 public class JSONBInAppTest extends FATServletClient {
 
-    @Server("com.ibm.ws.jsonb.inapp")
+    private static final String javaeeServer = "com.ibm.ws.jsonb.inapp";
+    private static final String jakartaee9Server = "com.ibm.ws.jsonb.ee9.inapp";
+
     @TestServlets({
                     @TestServlet(servlet = JSONBTestServlet.class, contextRoot = JSONB_APP),
                     @TestServlet(servlet = JohnzonTestServlet.class, contextRoot = JSONB_APP) // TODO: once https://github.com/eclipse-ee4j/jsonp/issues/78 is resolved, switch back to Yasson
@@ -37,6 +40,11 @@ public class JSONBInAppTest extends FATServletClient {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        if (JakartaEE9Action.isActive()) {
+            server = LibertyServerFactory.getLibertyServer(jakartaee9Server);
+        } else {
+            server = LibertyServerFactory.getLibertyServer(javaeeServer);
+        }
         FATSuite.jsonbApp(server);
         server.startServer();
     }

--- a/dev/com.ibm.ws.jsonb_fat/fat/src/com/ibm/ws/jsonb/fat/JSONPContainerTest.java
+++ b/dev/com.ibm.ws.jsonb_fat/fat/src/com/ibm/ws/jsonb/fat/JSONPContainerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package com.ibm.ws.jsonb.fat;
 
-import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -19,13 +17,13 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
-import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.FATServletClient;
 import web.jsonptest.JSONPTestServlet;
 
@@ -38,13 +36,19 @@ import web.jsonptest.JSONPTestServlet;
 public class JSONPContainerTest extends FATServletClient {
 
     private static final String appName = "jsonpapp";
+    private static final String javaeeServer = "com.ibm.ws.jsonp.container.fat";
+    private static final String jakartaee9Server = "com.ibm.ws.jsonp.container.ee9.fat";
 
-    @Server("com.ibm.ws.jsonp.container.fat")
     @TestServlet(servlet = JSONPTestServlet.class, contextRoot = appName)
     public static LibertyServer server;
 
     @BeforeClass
     public static void setUp() throws Exception {
+        if (JakartaEE9Action.isActive()) {
+            server = LibertyServerFactory.getLibertyServer(jakartaee9Server);
+        } else {
+            server = LibertyServerFactory.getLibertyServer(javaeeServer);
+        }
         ShrinkHelper.defaultApp(server, appName, "web.jsonptest");
         server.startServer();
     }
@@ -55,9 +59,6 @@ public class JSONPContainerTest extends FATServletClient {
     }
 
     @Test
-    @SkipForRepeat(EE9_FEATURES)
-    //Skipping the test for jakartaee testing since it is beyond the scope of what is needed
-    //TODO for jakartaee testing: Transform the johnzon jars in AUTO_FVT/publish/shared/resources folder, solve the classloader problems with yasson and jonhzon provider impls
     public void testJsonpProviderAvailableJohnzon() throws Exception {
         runTest(server, appName + "/JSONPTestServlet", "testJsonpProviderAvailable&JsonpProvider=" + FATSuite.PROVIDER_JOHNZON_JSONP);
     }

--- a/dev/com.ibm.ws.jsonb_fat/publish/servers/com.ibm.ws.jsonb.container.ee9.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.jsonb_fat/publish/servers/com.ibm.ws.jsonb.container.ee9.fat/bootstrap.properties
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all:org.apache.johnzon.*=all:com.ibm.ws.classloading.internal.ClassLoadingServiceImpl=all:com.ibm.ws.classloading.internal.ThreadContextClassLoader=all
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+ds.loglevel=debug
+bootstrap.include=../testports.properties
+# TODO: Enable server to run w/ j2sec once feature work is completed
+websphere.java.security.exempt=true

--- a/dev/com.ibm.ws.jsonb_fat/publish/servers/com.ibm.ws.jsonb.container.ee9.fat/server.xml
+++ b/dev/com.ibm.ws.jsonb_fat/publish/servers/com.ibm.ws.jsonb.container.ee9.fat/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017, 2022 IBM Corporation and others.
+    Copyright (c) 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -10,17 +10,17 @@
  -->
 <server>
     <featureManager>
-      <feature>componenttest-1.0</feature>
-      <feature>jsonbContainer-1.0</feature>
-      <feature>servlet-4.0</feature>
-      <feature>cdi-2.0</feature>
-      <feature>usr:testFeatureUsingJsonb-1.0</feature>
+      <feature>componenttest-2.0</feature>
+      <feature>jsonbContainer-2.0</feature>
+      <feature>servlet-5.0</feature>
+      <feature>cdi-3.0</feature>
+      <feature>usr:testFeatureUsingJsonb-2.0</feature>
     </featureManager>
 
 	<include location="../fatTestPorts.xml"/>
 
     <library id="johnzon">
-      <fileset dir="${shared.resource.dir}/johnzon/1.1.5" includes="johnzon-*.jar"/>
+      <fileset dir="${shared.resource.dir}/johnzon/1.1.5" includes="ee9-*.jar"/>
     </library>
 
     <bell libraryRef="johnzon"/>

--- a/dev/com.ibm.ws.jsonb_fat/publish/servers/com.ibm.ws.jsonb.ee9.inapp/bootstrap.properties
+++ b/dev/com.ibm.ws.jsonb_fat/publish/servers/com.ibm.ws.jsonb.ee9.inapp/bootstrap.properties
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all:org.apache.johnzon.*=all:com.ibm.ws.classloading.internal.ClassLoadingServiceImpl=all:com.ibm.ws.classloading.internal.ThreadContextClassLoader=all
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+ds.loglevel=debug
+bootstrap.include=../testports.properties
+# TODO: Enable server to run w/ j2sec once feature work is completed
+websphere.java.security.exempt=true

--- a/dev/com.ibm.ws.jsonb_fat/publish/servers/com.ibm.ws.jsonb.ee9.inapp/server.xml
+++ b/dev/com.ibm.ws.jsonb_fat/publish/servers/com.ibm.ws.jsonb.ee9.inapp/server.xml
@@ -1,0 +1,33 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+    <featureManager>
+      <feature>componenttest-2.0</feature>
+      <feature>servlet-5.0</feature>
+      <feature>jsonbContainer-2.0</feature>
+      <feature>jsonpContainer-2.0</feature>
+    </featureManager>
+
+	<include location="../fatTestPorts.xml"/>
+	
+	<application location="jsonbapp.war">
+	  <classloader commonLibraryRef="json"/>
+	</application>
+
+    <library id="json">
+      <fileset dir="${shared.resource.dir}/johnzon/1.1.5" includes="ee9-*.jar"/>
+      <!-- Use Yasson for JSON-B and Johnzon for JSON-P -->
+      <!--  TODO: once https://github.com/eclipse-ee4j/jsonp/issues/78 is resolved, switch back to Yasson for JSON-B and Johnzon for JSON-P
+      <fileset dir="${shared.resource.dir}/refImpls" includes="yasson-*.jar"/>
+      <fileset dir="${shared.resource.dir}/johnzon" includes="johnzon-core-*.jar"/>
+      -->
+    </library>
+</server>

--- a/dev/com.ibm.ws.jsonb_fat/publish/servers/com.ibm.ws.jsonp.container.ee9.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.jsonb_fat/publish/servers/com.ibm.ws.jsonp.container.ee9.fat/bootstrap.properties
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all:org.apache.johnzon.*=all:com.ibm.ws.classloading.internal.ClassLoadingServiceImpl=all:com.ibm.ws.classloading.internal.ThreadContextClassLoader=all
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+ds.loglevel=debug
+bootstrap.include=../testports.properties
+# TODO: Enable server to run w/ j2sec once feature work is completed
+websphere.java.security.exempt=true

--- a/dev/com.ibm.ws.jsonb_fat/publish/servers/com.ibm.ws.jsonp.container.ee9.fat/server.xml
+++ b/dev/com.ibm.ws.jsonb_fat/publish/servers/com.ibm.ws.jsonp.container.ee9.fat/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017, 2022 IBM Corporation and others.
+    Copyright (c) 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -10,23 +10,20 @@
  -->
 <server>
     <featureManager>
-      <feature>componenttest-1.0</feature>
-      <feature>jsonbContainer-1.0</feature>
-      <feature>servlet-4.0</feature>
-      <feature>cdi-2.0</feature>
-      <feature>usr:testFeatureUsingJsonb-1.0</feature>
+      <feature>componenttest-2.0</feature>
+      <feature>jsonpContainer-2.0</feature>
+      <feature>servlet-5.0</feature>
     </featureManager>
 
 	<include location="../fatTestPorts.xml"/>
 
-    <library id="johnzon">
-      <fileset dir="${shared.resource.dir}/johnzon/1.1.5" includes="johnzon-*.jar"/>
+    <library id="json-p-johnzon">
+      <fileset dir="${shared.resource.dir}/johnzon/1.1.5" includes="ee9-johnzon-core-*.jar"/>
     </library>
 
-    <bell libraryRef="johnzon"/>
+    <bell libraryRef="json-p-johnzon"/>
 
-    <application location="jsonbapp.war"/>
-    <application location="jsonbCDIapp.war"/>
+    <application location="jsonpapp.war"/>
 
     <variable name="onError" value="FAIL"/>
 </server>

--- a/dev/com.ibm.ws.jsonb_fat/test-applications/jsonbapp/src/web/jsonbtest/JohnzonTestServlet.java
+++ b/dev/com.ibm.ws.jsonb_fat/test-applications/jsonbapp/src/web/jsonbtest/JohnzonTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package web.jsonbtest;
 
-import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 import static web.jsonbtest.JSONBTestServlet.PROVIDER_JOHNZON;
 import static web.jsonbtest.JSONBTestServlet.PROVIDER_YASSON;
 
@@ -18,34 +17,28 @@ import javax.servlet.annotation.WebServlet;
 
 import org.junit.Test;
 
-import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/JohnzonTestServlet")
 public class JohnzonTestServlet extends FATServlet {
 
-    //TODO: Transform the johnzon jars in AUTO_FVT/publish/shared/resources folder, solve the classloader problems with yasson and jonhzon provider impls
     @Test
-    @SkipForRepeat(EE9_FEATURES)
     public void testApplicationClasses() throws Exception {
         JSONBTestServlet.testApplicationClasses(PROVIDER_JOHNZON);
     }
 
     @Test
-    @SkipForRepeat(EE9_FEATURES)
     public void testJsonbProviderAvailable() throws Exception {
         JSONBTestServlet.testJsonbProviderAvailable(PROVIDER_JOHNZON);
     }
 
     @Test
-    @SkipForRepeat(EE9_FEATURES)
     public void testJsonbProviderNotAvailable() throws Exception {
         JSONBTestServlet.testJsonbProviderNotAvailable(PROVIDER_YASSON);
     }
 
     @Test
-    @SkipForRepeat(EE9_FEATURES)
     public void testThreadContextClassLoader() throws Exception {
         JSONBTestServlet.testThreadContextClassLoader(PROVIDER_JOHNZON);
     }


### PR DESCRIPTION
Update the json container 2.0 features to include the BELLS feature and remove Liberty's default implementations of JSON-P and JSON-B from the json container 2.0 features. This allows for a user to include their own third party library for these JSON technologies. Additionally this PR updates the JSON container FAT tests to run against the 2.0 json container features (Jakarta EE 9) to verify this fixed functionality.

Features fixed:
`jsonpContainer-2.0`
`jsonbContainer-2.0`

If the previous (incorrect) behavior is desired, the following features provide this functionality:
`jsonp-2.0`
`jsonb-2.0`

fixes  #20165