### PR TITLE
[19529] - update mpGraphQL 2.0 binaries to RC3 for 22.0.0.3 beta

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1984,7 +1984,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.graphql</groupId>
       <artifactId>microprofile-graphql-api</artifactId>
-      <version>2.0-RC1</version>
+      <version>2.0-RC3</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.health</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -392,7 +392,7 @@ org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:2.1
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:3.0
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:4.0
 org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.2
-org.eclipse.microprofile.graphql:microprofile-graphql-api:2.0-RC1
+org.eclipse.microprofile.graphql:microprofile-graphql-api:2.0-RC3
 org.eclipse.microprofile.health:microprofile-health-api:1.0
 org.eclipse.microprofile.health:microprofile-health-api:2.0.1
 org.eclipse.microprofile.health:microprofile-health-api:2.1

--- a/dev/io.openliberty.microprofile.graphql.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.graphql.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
-    Copyright (c) 2021 IBM Corporation and others. All rights reserved.
-    This program and the accompanying materials are made available under the 
-    terms of the Eclipse Public License v1.0 which accompanies this distribution, 
-    and is available at 
-        http://www.eclipse.org/legal/epl-v10.html 
-    Contributors: 
+<!--
+    Copyright (c) 2021, 2022 IBM Corporation and others. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v1.0 which accompanies this distribution,
+    and is available at
+        http://www.eclipse.org/legal/epl-v10.html
+    Contributors:
         IBM Corporation - initial API and implementation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -33,7 +33,7 @@
     <name>MicroProfile GraphQL TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.graphql.version>2.0-RC1</microprofile.graphql.version>
+        <microprofile.graphql.version>2.0-RC3</microprofile.graphql.version>
         <arquillian.version>1.7.0.Alpha10</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
@@ -57,7 +57,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            
+
             <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
             <!-- Commented out because it does not apply with EE9 -->
             <!-- <dependency>


### PR DESCRIPTION
Update to RC3 binaries to certify TCK compliance with the beta feature released in 22.0.0.3.