### PR TITLE
Update EJB Async FAT Permissions

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.async_fat/test-applications/AsyncFafRemoteApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.async_fat/test-applications/AsyncFafRemoteApp.ear/resources/META-INF/permissions.xml
@@ -9,4 +9,9 @@
         <class-name>java.lang.RuntimePermission</class-name>
         <name>getClassLoader</name>
     </permission> 
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>*</name>
+        <actions>read,write</actions>
+    </permission>
 </permissions>


### PR DESCRIPTION
Update permissions.xml file for an EJB Asyc FAT application to
grant permissions to read properties required by yoko ORB.
Only needed for local runs where Java 2 Security warnings
are logged and security exceptions are not actually thrown.
