### PR TITLE
Move com.ibm.ws.componenttest:infra.buildtasks-core:6.0.6

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -208,11 +208,6 @@
     </dependency>
     <dependency>
       <groupId>com.ibm.ws.componenttest</groupId>
-      <artifactId>infra.buildtasks-core</artifactId>
-      <version>6.0.6</version>
-    </dependency>
-    <dependency>
-      <groupId>com.ibm.ws.componenttest</groupId>
       <artifactId>mantis-collections</artifactId>
       <version>2.5.0</version>
     </dependency>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -37,7 +37,6 @@ com.ibm.ws.componenttest:com.ibm.componenttest.common:1.0.0
 com.ibm.ws.componenttest:com.ibm.ws.topology.helper:1.0.0
 com.ibm.ws.componenttest:fat.harness:1.0.0
 com.ibm.ws.componenttest:fat.util:1.0.0
-com.ibm.ws.componenttest:infra.buildtasks-core:6.0.6
 com.ibm.ws.componenttest:mantis-collections:2.5.0
 com.ibm.ws.componenttest:mantis-nls-standalone:2.5.0
 com.ibm.ws.componenttest:provider.api:1.0.0

--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -1,6 +1,7 @@
 com.googlecode.jsontoken:jsontoken:1.1.0-ibm-s20140416-2113
 com.ibm.ws.com.icegreen:greenmail:2.0.0.fd826131f671b0d3230b0d0e1638d8c4
 com.ibm.ws.commons-collections:commons-collections:3.2.1
+com.ibm.ws.componenttest:infra.buildtasks-core:6.0.6
 com.ibm.ws.internal.prereq.java:java.ibmjgssprovider:1.8.0
 com.ibm.ws.internal.prereq.java:java.rtSunKrb5:1.8.0
 com.ibm.ws.javax.j2ee:connector:1.6


### PR DESCRIPTION
- Move `com.ibm.ws.componenttest:infra.buildtasks-core:6.0.6` dependency from oss_dependencies.maven to oss_ibm.maven.