### PR TITLE
Update test for abandon debugging

### DIFF
--- a/dev/com.ibm.ws.jbatch.open_fat/fat/src/batch/fat/junit/BatchJobOperatorApiWithAppSecurityTest.java
+++ b/dev/com.ibm.ws.jbatch.open_fat/fat/src/batch/fat/junit/BatchJobOperatorApiWithAppSecurityTest.java
@@ -181,17 +181,59 @@ public class BatchJobOperatorApiWithAppSecurityTest {
     @ExpectedFFDC({ "com.ibm.jbatch.container.exception.BatchContainerRuntimeException",
                     "java.lang.Exception" })
     public void testAbandonAsSubmitterNotOwner() throws Exception {
+        
+        //Add some additional trace for debug to look at in the future
+        String newTraceSpec = "*=info=enabled"
+                              + ":test=all=enabled"
+                              + ":com.ibm.jbatch.*=finer"
+                              + ":com.ibm.jbatch.*=all=enabled"
+                              + ":jsr352.test.servlet.*=all=enabled"
+                              + ":com.ibm.ws.jbatch.*=all=enabled"
+                              + ":BonusPayout=all=enabled"
+                              + ":com.ibm.ws.webcontainer*=all:com.ibm.wsspi.webcontainer*=all:HTTPChannel=all:GenericBNF=all:HTTPDispatcher=all"
+                              + ":batch.security.*=all=enabled"
+                              + ":batch.fat.*=all=enabled";
+        
+        
         Long jobinstance = submitJob(true);
         JsonObject jobExec = waitForFirstJobExecution(jobinstance);
         JsonObject completedJobExecution = waitForJobExecutionToFinish(jobExec);
         Long jobexecution = completedJobExecution.getJsonNumber("executionId").longValue();
 
         // Abandon the job...
-        HttpURLConnection con = getConnection("/batchSecurity/jobservlet?action=abandon&executionId=" + jobexecution,
-                                              HttpURLConnection.HTTP_UNAUTHORIZED,
-                                              HTTPRequestMethod.GET,
-                                              null,
-                                              submitter2HeaderMap);
+        HttpURLConnection con = null;
+
+        //Update config with new trace spec here, save config for restore after abandon command
+        server.saveServerConfiguration();
+        ServerConfiguration serverConfiguration = server.getServerConfiguration();
+        serverConfiguration.getLogging().setTraceSpecification(newTraceSpec);
+        server.updateServerConfiguration(serverConfiguration);
+
+        // Check that configuration updated successfully
+        assertNotNull(server.waitForStringInLogUsingMark("CWWKG0017I"));
+
+        try {
+            // Abandon the job...
+            con = getConnection("/batchSecurity/jobservlet?action=abandon&executionId=" + jobexecution,
+                                HttpURLConnection.HTTP_UNAUTHORIZED,
+                                HTTPRequestMethod.GET,
+                                null,
+                                submitter2HeaderMap);
+        } catch (AssertionError assertionError) { //just to log something we can search for
+
+            //Rarely, the job is abandoned as expected, but for a yet-to-be-determined reason,
+            //the abandon call by our job servlet (part of the test app) is done twice
+            //
+            //The runtime is behaving as expected, preventing the 2nd abandon attempt so lets
+            //not fail the test for that
+            if (con.getResponseMessage().contains("ABANDONED to ABANDONED"))
+                logError("testAbandonAsSubmitterNotOwner", "Job abandoned twice", assertionError);
+
+            throw assertionError;
+        } finally {
+            //restore to original config before the trace spec change
+            server.restoreServerConfiguration();
+        }
 
         BufferedReader br = HttpUtils.getErrorStream(con);
         String body = org.apache.commons.io.IOUtils.toString(br);
@@ -1004,6 +1046,13 @@ public class BatchJobOperatorApiWithAppSecurityTest {
 
     public void testStopWithNoBatchRoles() throws Exception {
 
+    }
+    
+    /**
+     * helper for simple logging.
+     */
+    private static void logError(String method, String msg, Throwable error) {
+        Log.error(BatchJobOperatorApiWithAppSecurityTest.class, method, error, msg);
     }
 
     private static String getPort() {


### PR DESCRIPTION
Same change made in WL, looks like we have the test both places

Personal build:
https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.build.viewResult&id=_ftBOUJNFEey6A5GqctIefw&tab=com.ibm.team.build.web.ui.internal.editors.result.overview.OverviewPage
