### PR TITLE
Fix Ldap registry config

### DIFF
--- a/dev/com.ibm.ws.security.oidc.server_fat.claimPropagation/publish/files/serversettings/LdapRegistry.xml
+++ b/dev/com.ibm.ws.security.oidc.server_fat.claimPropagation/publish/files/serversettings/LdapRegistry.xml
@@ -14,20 +14,20 @@
 	<ldapRegistry
 		id="ldap"
 		realm="BasicRealm"
-		host="${ldap.server.10.name}"
-		port="${ldap.server.10.port}"
+		host="${ldap.server.4.name}"
+		port="${ldap.server.4.port}"
 		ignoreCase="true"
 		baseDN="o=ibm,c=us"
-		bindDN="${ldap.server.10.bindDN}"
-		bindPassword="${ldap.server.10.bindPassword}"
+		bindDN="${ldap.server.4.bindDN}"
+		bindPassword="${ldap.server.4.bindPassword}"
 		ldapType="Custom"
 		idsFilters="ibm_dir_server"
 		searchTimeout="8m"
 	>
 		<failoverServers name="failoverLdapServers">
 			<server
-				host="${ldap.server.12.name}"
-				port="${ldap.server.12.port}" />
+				host="${ldap.server.7.name}"
+				port="${ldap.server.7.port}" />
 		</failoverServers>
 	</ldapRegistry>
 


### PR DESCRIPTION
Fix the LDAP registry config - have it point to the correct real servers.
z/OS can't use the in memory servers, and ldap's 10 and 12 do not have the user that we need