### PR TITLE
fix NPE taglib notfound w skipmetainf

### DIFF
--- a/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,7 @@ import com.ibm.ws.jsp23.fat.tests.JSPCdiTest;
 import com.ibm.ws.jsp23.fat.tests.JSPJava8Test;
 import com.ibm.ws.jsp23.fat.tests.JSPPrepareJSPThreadCountDefaultValueTests;
 import com.ibm.ws.jsp23.fat.tests.JSPPrepareJSPThreadCountNonDefaultValueTests;
+import com.ibm.ws.jsp23.fat.tests.JSPSkipMetaInfTests;
 import com.ibm.ws.jsp23.fat.tests.JSPTests;
 import com.ibm.ws.jsp23.fat.tests.JSTLTests;
 
@@ -37,6 +38,7 @@ import componenttest.rules.repeater.RepeatTests;
 @RunWith(Suite.class)
 @SuiteClasses({
                 JSPTests.class,
+                JSPSkipMetaInfTests.class,
                 JSPJava8Test.class,
                 JSPCdiTest.class,
                 JSP23JSP22ServerTest.class,

--- a/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSPSkipMetaInfTests.java
+++ b/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSPSkipMetaInfTests.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jsp23.fat.tests;
+
+import java.util.logging.Logger;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.jsp23.fat.JSPUtils;
+import com.meterware.httpunit.GetMethodWebRequest;
+import com.meterware.httpunit.WebConversation;
+import com.meterware.httpunit.WebRequest;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * Tests to execute on the jspServer that use HttpUnit/HttpClient along with
+ * wc property skipMetaInfResourcesProcessing is true.
+ */
+
+@SkipForRepeat("CDI-2.0")
+@RunWith(FATRunner.class)
+public class JSPSkipMetaInfTests {
+    private static final Logger LOG = Logger.getLogger(JSPTests.class.getName());
+    private static final String TestEDR_APP_NAME = "TestEDR";
+
+    @Server("jspSkipMetaInfServer")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        ShrinkHelper.defaultDropinApp(server, TestEDR_APP_NAME + ".war");
+
+        server.startServer(JSPSkipMetaInfTests.class.getSimpleName() + ".log");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    /**
+     * Verify a taglib under WEB-INF that's suppressed by
+     * skipMetaInfResourcesProcessing=true doesn't
+     * cause a Null Pointer Exception per issue 20247.
+     *
+     * @throws Exception
+     */
+    @Test
+    @Mode(TestMode.FULL)
+    public void testTLD() throws Exception {
+        String orgEdrFile = "headerEDR1.jsp";
+        String relEdrPath = "../../shared/config/ExtendedDocumentRoot/";
+        server.copyFileToLibertyServerRoot(relEdrPath, orgEdrFile);
+        String url = JSPUtils.createHttpUrlString(server, TestEDR_APP_NAME, "index.jsp");
+        LOG.info("url: " + url);
+        WebConversation wc1 = new WebConversation();
+        WebRequest request1 = new GetMethodWebRequest(url);
+        wc1.getResponse(request1);
+
+        server.deleteFileFromLibertyServerRoot(relEdrPath + orgEdrFile); // cleanup
+        Thread.sleep(500L); // ensure file is deleted
+        //This test doesn't need to assert anything since the NPE if it happens would be caught by simplicity.
+    }
+
+}

--- a/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/jspSkipMetaInfServer/bootstrap.properties
+++ b/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/jspSkipMetaInfServer/bootstrap.properties
@@ -1,0 +1,13 @@
+###############################################################################
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+osgi.console=7777
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.webcontainer*=all:com.ibm.wsspi.webcontainer*=all:HTTPChannel=all:TCPChannel=all:GenericBNF=all:com.ibm.ws.jsp*=all

--- a/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/jspSkipMetaInfServer/server.xml
+++ b/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/jspSkipMetaInfServer/server.xml
@@ -1,0 +1,22 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Server for testing JavaServer Pages 2.3">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>jsp-2.3</feature>
+    </featureManager>
+
+    <logging traceSpecification="*=info=enabled:com.ibm.ws.webcontainer*=all:com.ibm.wsspi.webcontainer*=all:HTTPChannel=all:TCPChannel=all:GenericBNF=all:com.ibm.ws.jsp*=all" maxFileSize="32" maxFiles="24" traceFormat="BASIC"/>
+    <applicationManager autoExpand="false"/> <!-- for TestTLD -->
+    <webContainer skipMetaInfResourcesProcessing="true" /> <!-- for issue 20247 -->
+</server>


### PR DESCRIPTION
fixes #20247 
An NPE can result if a taglib refers to a file where the path is under WEB-INF and the webContainer property skipMetaInfResourcesProcessing="true".
