### PR TITLE
Explore tool accessibility fixes

### DIFF
--- a/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/jsShared/utils/imgUtils.js
+++ b/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/jsShared/utils/imgUtils.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -45,7 +45,7 @@
     return svgResource + name + '-small';
   },
   
-  imgUtils.__getSVGObject = function(name, Class, size, ariaLabel) {
+  imgUtils.__getSVGObject = function(name, Class, size, ariaLabel, ariaLabelledBy) {
     name = imgUtils.normalizeName(name);
     var svgNS = "http://www.w3.org/2000/svg";
     var xlinkNS = "http://www.w3.org/1999/xlink";
@@ -60,11 +60,12 @@
     svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
     svg.setAttribute('viewBox', '0 0 64 64');
     svg.setAttribute('role', 'img');
-    if (ariaLabel) {
+    if (ariaLabelledBy) {
+      svg.setAttribute('aria-labelledby', ariaLabelledBy);
+    } else if (ariaLabel) {
       svg.setAttribute('aria-label', ariaLabel);
       svg.setAttribute("alt", ariaLabel);
-    }
-    else{
+    } else{
       svg.setAttribute("alt", name);
     }
     if (size) {
@@ -80,10 +81,10 @@
     return svg;
   }
 
-  imgUtils.__getSVGIcon = function(name, Class, size, title, ariaLabel) {
+  imgUtils.__getSVGIcon = function(name, Class, size, title, ariaLabel, ariaLabelledBy) {
     // IE doesn't support outerHTML on SVG objects, so need div to grab SVG text
     var svgHolderSpan = document.createElement('span');
-    var svg = this.__getSVGObject(name, Class, size, ariaLabel ? title : null);    
+    var svg = this.__getSVGObject(name, Class, size, ariaLabel ? title : null, ariaLabelledBy);
     svgHolderSpan.appendChild(svg);
 
     if (title) {
@@ -110,7 +111,23 @@
    * @return {String} the <svg> text, without the <span> if no title specified
    */
   imgUtils.getSVG = function(name, Class, title, ariaLabel) {
-    return this.__getSVGIcon(name, Class, '', title, ariaLabel);
+    return this.__getSVGIcon(name, Class, '', title, ariaLabel, null);
+  };
+
+  /**
+   * Obtain the SVG icon in text format.
+   *
+   * @method
+   * @param {String}
+   *          name - the name of the icon without any file extensions or platform modifiers. e.g. 'toolbox'
+   * @param {String}
+   *          size - either empty string (default size) or small
+   * @param {String}
+   *          ariaLabelledBy - the id of the label field
+   * @return {String} the <svg> text
+   */
+  imgUtils.getSVGWithAriaLabelledBy = function(name, size, ariaLabelledBy) {
+    return this.__getSVGIcon(name, null, size, null, null, ariaLabelledBy);
   };
 
   imgUtils.getSVGSmall = function(name, Class, title, ariaLabel) {

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/DashboardPane.js
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/DashboardPane.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -46,6 +46,7 @@ define([
         collection : null,
         templateString : template,
         dashboardIconId : '',
+        dashboardIconLabelId: '',
         dashboardResourceLabel : '',
         viewAllLabel : '',   // Button title/aria-label for left side
         totalLabel : i18n.TOTAL,
@@ -61,6 +62,9 @@ define([
         dashboardResourceUnknownButtonNumberId : '',
         dashboardResourceRunningButtonNumberId : '',
         dashboardResourceStoppedButtonNumberId : '',
+        dashboardResourceUnknownLabelId: '',
+        dashboardResourceRunningLabelId: '',
+        dashboardResourceStoppedLabelId: '',
 
         constructor : function(params) {              // collectionType, label
             this.collectionType = params[0];          // Host, Application, Server, etc
@@ -68,12 +72,16 @@ define([
             
             this.id = this.view + this.collectionType + '-DashboardPane';
             this.dashboardIconId = this.view + this.collectionType + '-Icon';
+            this.dashboardIconLabelId = this.view + this.collectionType + '-Icon-Label';
             this.dashboardResourceId = this.view + this.collectionType + '-OverviewPane';
             this.dashboardGraphPaneId = this.view + this.collectionType + '-GraphPane';
             this.dashboardResourceNumberId = this.view + this.collectionType + '-OverviewPane' + '-Number';
             this.dashboardResourceUnknownButtonNumberId = this.view + this.collectionType + '-Unknown-Count';
             this.dashboardResourceRunningButtonNumberId = this.view + this.collectionType + '-Running-Count';
             this.dashboardResourceStoppedButtonNumberId = this.view + this.collectionType + '-Stopped-Count';
+            this.dashboardResourceUnknownLabelId = this.view + this.collectionType + '-Unknown-Label';
+            this.dashboardResourceRunningLabelId = this.view + this.collectionType + '-Running-Label';
+            this.dashboardResourceStoppedLabelId = this.view + this.collectionType + '-Stopped-Label';
             
             this.__setViewAllLabel();
             // initialize the labels for the states (like 'Running' vs. 'Started')
@@ -98,11 +106,11 @@ define([
             this.inherited(arguments);
 
             if(this.iconTypeNode){
-              this.iconTypeNode.innerHTML = imgUtils.getSVG(this.collectionType.toLowerCase() + '-dashboard');
+              this.iconTypeNode.innerHTML = imgUtils.getSVGWithAriaLabelledBy(this.collectionType.toLowerCase() + '-dashboard', '', this.dashboardIconLabelId);
             
-              this.runIcon.innerHTML = imgUtils.getSVG("status-running");
-              this.stopIcon.innerHTML = imgUtils.getSVG("status-stopped");
-              this.unknownIcon.innerHTML = imgUtils.getSVGSmall("unknown-white");
+              this.runIcon.innerHTML = imgUtils.getSVGWithAriaLabelledBy("status-running", '', this.dashboardResourceRunningLabelId);
+              this.stopIcon.innerHTML = imgUtils.getSVGWithAriaLabelledBy("status-stopped", '', this.dashboardResourceStoppedLabelId);
+              this.unknownIcon.innerHTML = imgUtils.getSVGWithAriaLabelledBy("unknown-white", 'small', this.dashboardResourceUnknownLabelId);
             }                        
         },
         

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/ObjectViewHeaderPane.js
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/ObjectViewHeaderPane.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -94,7 +94,7 @@ define(['dojo/_base/declare', 'dojo/_base/lang', 'dojo/dom', 'dojo/has', 'jsExpl
     },
 
     postCreate: function() {
-      this.iconNode.innerHTML = imgUtils.getSVG(getResourceIcon(this.resource));
+      this.iconNode.innerHTML = imgUtils.getSVGWithAriaLabelledBy(getResourceIcon(this.resource), '', this.resourceId + "-ResourceName");
 
       /* Set the StateIcon if needed */
       if ((this.resource.type !== 'host') && (this.resource.type !== 'standaloneServer') && (this.resource.type !== 'runtime')) {
@@ -568,10 +568,10 @@ define(['dojo/_base/declare', 'dojo/_base/lang', 'dojo/dom', 'dojo/has', 'jsExpl
         // If server running and apiDiscovery enabled, enable button
         // If a standAlone server, the feature is enabled since we don't track the state of
         // a standAlone server.  It is assumed to be up.
-        enableServerApiButton(serverApiButton, apiDefIcon, explorerURL);
+        enableServerApiButton(serverApiButton, apiDefIcon, explorerURL, id);
       } else {
         // If server not started and apiDiscovery enabled, grey out button
-        disableServerApiButton(serverApiButton, apiDefIcon);
+        disableServerApiButton(serverApiButton, apiDefIcon, id);
       }
     } else {
       // If no apiDiscovery, don't display.
@@ -579,9 +579,9 @@ define(['dojo/_base/declare', 'dojo/_base/lang', 'dojo/dom', 'dojo/has', 'jsExpl
     }
   }
 
-  function disableServerApiButton(element, apiDefIcon) {
+  function disableServerApiButton(element, apiDefIcon, containerId) {
     // Set image
-    apiDefIcon.innerHTML = imgUtils.getSVGSmall('apiDefDisabled');
+    apiDefIcon.innerHTML = imgUtils.getSVGWithAriaLabelledBy('apiDefDisabled', 'snall', containerId + "UrlDisabled");
 
     // Disable link
     var link = element.getElementsByTagName("a")[0];
@@ -594,9 +594,9 @@ define(['dojo/_base/declare', 'dojo/_base/lang', 'dojo/dom', 'dojo/has', 'jsExpl
     element.style.display = "inline-block";
   }
 
-  function enableServerApiButton(element, apiDefIcon, explorerURL) {
+  function enableServerApiButton(element, apiDefIcon, explorerURL, containerId) {
     // Set image
-    apiDefIcon.innerHTML = imgUtils.getSVGSmall('apiDefEnabled');
+    apiDefIcon.innerHTML = imgUtils.getSVGWithAriaLabelledBy('apiDefEnabled', 'small', containerId + "UrlEnabled");
 
     // Disable span
     var span = element.getElementsByTagName("span")[0];
@@ -628,12 +628,13 @@ define(['dojo/_base/declare', 'dojo/_base/lang', 'dojo/dom', 'dojo/has', 'jsExpl
       if (server.cluster) {
         server.getCluster().then(function(cluster) {
           var clusterButton;
+          var clusterButtonLabel = ResourceButton.getResourceButtonLabelId([ 'AppInst', appOnServer.id, cluster.name, 'Cluster']);
           if (cluster.scalingPolicy) {
             // Set icon to scalingPolicy cluster one.
-            iconPane.innerHTML = imgUtils.getSVGSmall("cluster-autoscaled-OVHP");
+            iconPane.innerHTML = imgUtils.getSVGWithAriaLabelledBy("cluster-autoscaled-OVHP", "small", clusterButtonLabel);
           } else {
             // Set icon to normal cluster one.
-            iconPane.innerHTML = imgUtils.getSVG("cluster-dashboard");
+            iconPane.innerHTML = imgUtils.getSVGWithAriaLabelledBy("cluster-dashboard", "", clusterButtonLabel);
           }
           clusterButton = ResourceButton.createResourceButton([ 'AppInst', appOnServer.id, cluster.name, 'Cluster']);
 
@@ -654,12 +655,13 @@ define(['dojo/_base/declare', 'dojo/_base/lang', 'dojo/dom', 'dojo/has', 'jsExpl
     if (server.cluster) {
       var clusterName = server.cluster;
       var clusterButton;
+      var clusterButtonLabel = ResourceButton.getResourceButtonLabelId([ 'Server', server.id, clusterName, 'Cluster']);
       if (server.scalingPolicy) {
         // Set icon to scalingPolicy cluster one.
-        iconPane.innerHTML = imgUtils.getSVGSmall("cluster-autoscaled-OVHP");
+        iconPane.innerHTML = imgUtils.getSVGWithAriaLabelledBy("cluster-autoscaled-OVHP", "small", clusterButtonLabel);
       } else {
         // Set icon to normal cluster one.
-        iconPane.innerHTML = imgUtils.getSVG("cluster-dashboard");
+        iconPane.innerHTML = imgUtils.getSVGWithAriaLabelledBy("cluster-dashboard", "", clusterButtonLabel);
       }
       clusterButton = ResourceButton.createResourceButton([ 'Server', server.id, clusterName, 'Cluster']);
 

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/ObjectViewHeaderPane.js
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/ObjectViewHeaderPane.js
@@ -581,7 +581,7 @@ define(['dojo/_base/declare', 'dojo/_base/lang', 'dojo/dom', 'dojo/has', 'jsExpl
 
   function disableServerApiButton(element, apiDefIcon, containerId) {
     // Set image
-    apiDefIcon.innerHTML = imgUtils.getSVGWithAriaLabelledBy('apiDefDisabled', 'snall', containerId + "UrlDisabled");
+    apiDefIcon.innerHTML = imgUtils.getSVGWithAriaLabelledBy('apiDefDisabled', 'small', containerId + "UrlDisabled");
 
     // Disable link
     var link = element.getElementsByTagName("a")[0];

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/ResourceButton.js
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/ResourceButton.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -65,7 +65,10 @@ define([
        });
 	     
        return new ResourceButton(params);
-     } 
+     },
 
+     getResourceButtonLabelId: function(params) {
+      return __getId(params) + "_label";
+     }
    };
 });

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/ResourcePane.js
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/ResourcePane.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -91,6 +91,9 @@ define([
                 this.resourceStateUnknownNumber = this.view + this.resourceName + "-" + this.resourceType + this.paneType + "-Unknown-Count" + "-StateNumber";
                 this.resourceStateRunningNumber = this.view + this.resourceName + "-" + this.resourceType + this.paneType + "-Running-Count" + "-StateNumber";
                 this.resourceStateStoppedNumber = this.view + this.resourceName + "-" + this.resourceType + this.paneType + "-Stopped-Count" + "-StateNumber";
+                this.resourceStateUnknownLabel = this.view + this.resourceName + "-" + this.resourceType + this.paneType + "-Unknown-Label";
+                this.resourceStateRunningLabel = this.view + this.resourceName + "-" + this.resourceType + this.paneType + "-Running-Label";
+                this.resourceStateStoppedLabel = this.view + this.resourceName + "-" + this.resourceType + this.paneType + "-Stopped-Label";
                 
                 this.resourceNumber = this.collection.up + (this.collection.partial ? this.collection.partial : 0 ) + this.collection.down + (this.collection.unknown ? this.collection.unknown : 0);
            
@@ -112,15 +115,18 @@ define([
              resourceStateUnknownNumber : '',
              resourceStateRunningNumber : '',
              resourceStateStoppedNumber : '',
+             resourceStateUnknownLabel: '',
+             resourceStateRunningLabel: '',
+             resourceStateStoppedLabel: '',
              sideTabPane : null,
              
              postCreate : function() {
                this.inherited(arguments);
                
-               this.iconNode.innerHTML = imgUtils.getSVG(this.paneType);
-               this.runIcon.innerHTML = imgUtils.getSVG("status-running");
-               this.stopIcon.innerHTML = imgUtils.getSVG("status-stopped");
-               this.unknownIcon.innerHTML = imgUtils.getSVG("unknown");
+               this.iconNode.innerHTML = imgUtils.getSVGWithAriaLabelledBy(this.paneType, '', this.resourceId);
+               this.runIcon.innerHTML = imgUtils.getSVGWithAriaLabelledBy("status-running", '', this.resourceStateRunningLabel); // , null, i18n.RUNNING, true);
+               this.stopIcon.innerHTML = imgUtils.getSVGWithAriaLabelledBy("status-stopped", '', this.resourceStateStoppedLabel) // , null, i18n.STOPPED, true);
+               this.unknownIcon.innerHTML = imgUtils.getSVGWithAriaLabelledBy("unknown", '', this.resourceStateUnknownLabel);
                
                this._buildStates();
              },

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/cardFactory.js
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/cardFactory.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,7 +40,8 @@ define([ "jsExplore/widgets/AppOnClusterCard",
           onClick : onclick,
           tabindex : 0,
           role : "button",
-          'aria-label' : label
+          //'aria-label' : label,
+          cardAltText : label
         }, "card");
         break;
       case "appOnServer":
@@ -53,7 +54,7 @@ define([ "jsExplore/widgets/AppOnClusterCard",
           onClick : onclick,
           tabindex : 0,
           role : "button",
-          'aria-label' : label
+          cardAltText : label
         }, "card");
         break;
       case "cluster":
@@ -66,7 +67,7 @@ define([ "jsExplore/widgets/AppOnClusterCard",
           onClick : onclick,
           tabindex : 0,
           role : "button",
-          'aria-label' : label
+          cardAltText : label
         }, "card");
         break;
       case "host":
@@ -79,7 +80,7 @@ define([ "jsExplore/widgets/AppOnClusterCard",
           onClick : onclick,
           tabindex : 0,
           role : "button",
-          'aria-label' : label
+          cardAltText : label
         }, "card");
         break;
       case "runtime":
@@ -92,7 +93,7 @@ define([ "jsExplore/widgets/AppOnClusterCard",
           onClick : onclick,
           tabindex : 0,
           role : "button",
-          'aria-label' : label
+          cardAltText : label
         }, "card");
         break;
       case "server":
@@ -105,7 +106,7 @@ define([ "jsExplore/widgets/AppOnClusterCard",
           onClick : onclick,
           tabindex : 0,
           role : "button",
-          'aria-label' : label
+          cardAltText : label
         }, "card");
         break;
       default:

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/shared/BaseCard.js
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/shared/BaseCard.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -56,6 +56,7 @@ define(['jsExplore/widgets/shared/ScalingPolicyIcon',
     id : "",
     label : "",
     resource: "",
+    cardAltText: "",
     serverListProcessor : null,
     appListProcessor : null,
     statusIcon: '',

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/shared/StateIcon.js
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/shared/StateIcon.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -190,25 +190,25 @@ define([ 'dojo/_base/declare', 'dojo/dom', 'dojo/dom-construct', 'dojo/on', 'doj
     },
 
     __getStartedIcon: function () {
-      return imgUtils.getSVG('status-running');
+      return imgUtils.getSVG('status-running', null, i18n.RUNNING, true);
     },
 
     __getStartingIcon: function() {
       var extension = 'gif';
       if (this.size === '14') {
-        return imgUtils.getSVG('status-starting');
+        return imgUtils.getSVG('status-starting', null, i18n.STARTING, true);
       }
       return lang.replace(htmlTemplate, [this.platformIconSeparator, 'starting', this.platformString, this.size, i18n.STARTING, extension]);
     },
 
     __getStoppedIcon: function() {
-        return imgUtils.getSVG('status-stopped');
+        return imgUtils.getSVG('status-stopped', null, i18n.STOPPED, true);
     },
 
     __getStoppingIcon: function() {
       var extension = 'gif';
       if (this.size === '14') {
-        return imgUtils.getSVG('status-stopping');
+        return imgUtils.getSVG('status-stopping', null, i18n.STOPPING, true);
       }
       return lang.replace(htmlTemplate, [this.platformIconSeparator, 'stopping', this.platformString, this.size, i18n.STOPPING, extension]);
     },    
@@ -219,7 +219,7 @@ define([ 'dojo/_base/declare', 'dojo/dom', 'dojo/dom-construct', 'dojo/on', 'doj
       if (util.getResourceDisplayedState(this.resource) == "STARTED") {
         return this.__getStartedIcon();
       } else {
-        return imgUtils.getSVG('status-some-running');
+        return imgUtils.getSVG('status-some-running', null, i18n.PARTIALLY_RUNNING, true);
       }
     },
 

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/shared/StateIcon.js
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/shared/StateIcon.js
@@ -31,7 +31,7 @@ define([ 'dojo/_base/declare', 'dojo/dom', 'dojo/dom-construct', 'dojo/on', 'doj
    * These images should probably be moved to css.
    */
   var htmlTemplate = '<img src="images/status{0}{1}{2}.{5}" height="{3}" width="{3}" style="vertical-align:middle;" alt="{4}" title="{4}">';
-  var labelHtmlTemplate = '<span class="{0}">{1}</span>';
+  var labelHtmlTemplate = '<span class="{0}" id="{2}">{1}</span>';
   var actionHtmlTemplate = '<img src="imagesShared/card-action{0}.png" height="{2}" width="{2}" style="vertical-align:top;" alt="{3}" title="{1}">';
   var labelCardHtmlTemplate = '<span title="{0}">{0}</span>';
 
@@ -190,25 +190,41 @@ define([ 'dojo/_base/declare', 'dojo/dom', 'dojo/dom-construct', 'dojo/on', 'doj
     },
 
     __getStartedIcon: function () {
-      return imgUtils.getSVG('status-running', null, i18n.RUNNING, true);
+      if (this.showLabel) {
+        return imgUtils.getSVGWithAriaLabelledBy('status-running', '', this.id + "-label");
+      } else {
+        return imgUtils.getSVG('status-running', null, i18n.RUNNING, true);
+      }
     },
 
     __getStartingIcon: function() {
       var extension = 'gif';
       if (this.size === '14') {
-        return imgUtils.getSVG('status-starting', null, i18n.STARTING, true);
+        if (this.showLabel) {
+          return imgUtils.getSVGWithAriaLabelledBy('status-starting', '', this.id + "-label");
+        } else {
+          return imgUtils.getSVG('status-starting', null, i18n.STARTING, true);
+        }
       }
       return lang.replace(htmlTemplate, [this.platformIconSeparator, 'starting', this.platformString, this.size, i18n.STARTING, extension]);
     },
 
     __getStoppedIcon: function() {
+      if (this.showLabel) {
+        return imgUtils.getSVGWithAriaLabelledBy('status-stopped', '', this.id + "-label");
+      } else {
         return imgUtils.getSVG('status-stopped', null, i18n.STOPPED, true);
+      }
     },
 
     __getStoppingIcon: function() {
       var extension = 'gif';
       if (this.size === '14') {
-        return imgUtils.getSVG('status-stopping', null, i18n.STOPPING, true);
+        if (this.showLabel) {
+          return imgUtils.getSVGWithAriaLabelledBy('status-stopping', '', this.id + "-label");
+        } else {
+          return imgUtils.getSVG('status-stopping', null, i18n.STOPPING, true);
+        }
       }
       return lang.replace(htmlTemplate, [this.platformIconSeparator, 'stopping', this.platformString, this.size, i18n.STOPPING, extension]);
     },    
@@ -219,13 +235,21 @@ define([ 'dojo/_base/declare', 'dojo/dom', 'dojo/dom-construct', 'dojo/on', 'doj
       if (util.getResourceDisplayedState(this.resource) == "STARTED") {
         return this.__getStartedIcon();
       } else {
-        return imgUtils.getSVG('status-some-running', null, i18n.PARTIALLY_RUNNING, true);
+        if (this.showLabel) {
+          return imgUtils.getSVGWithAriaLabelledBy('status-some-running', '', this.id + "-label");
+        } else {
+          return imgUtils.getSVG('status-some-running', null, i18n.PARTIALLY_RUNNING, true);
+        }
       }
     },
 
     __getUnknownIcon: function() {
 //      return lang.replace(htmlTemplate, [this.platformIconSeparator, 'unknown', this.platformString, this.size, i18n.UNKNOWN, 'png']);
-      return imgUtils.getSVGSmall('unknown');
+      if (this.showLabel) {
+        return imgUtils.getSVGWithAriaLabelledBy('unknown', 'small', this.id + "-label");
+      } else {
+        return imgUtils.getSVGSmall('unknown', null, i18n.UNKNOWN, true);
+      }
     },
 
     __getActionIcon: function() {
@@ -237,7 +261,7 @@ define([ 'dojo/_base/declare', 'dojo/dom', 'dojo/dom-construct', 'dojo/on', 'doj
     },
 
     __getLabel: function() {
-      return lang.replace(labelHtmlTemplate, [this.labelClass, this.label]);
+      return lang.replace(labelHtmlTemplate, [this.labelClass, this.label, this.id + "-label"]);
     },
 
     __getCardLabel: function() {

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/templates/AppOnClusterCard.html
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/templates/AppOnClusterCard.html
@@ -1,6 +1,6 @@
-<div class="cardInner">
+<div class="cardInner"  alt="${cardAltText}">
 <!--
-    Copyright (c) 2016, 2017 IBM Corporation and others.
+    Copyright (c) 2016, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/templates/AppOnServerCard.html
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/templates/AppOnServerCard.html
@@ -1,6 +1,6 @@
-<div class="cardInner">
+<div class="cardInner"  alt="${cardAltText}">
 <!--
-    Copyright (c) 2016, 2017 IBM Corporation and others.
+    Copyright (c) 2016, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/templates/ApplicationCard.html
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/templates/ApplicationCard.html
@@ -1,6 +1,6 @@
-<div class="cardInner">
+<div class="cardInner" alt="${cardAltText}">
 <!--
-    Copyright (c) 2016, 2017 IBM Corporation and others.
+    Copyright (c) 2016, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/templates/ClusterCard.html
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/templates/ClusterCard.html
@@ -1,6 +1,6 @@
-<div class="cardInner">
+<div class="cardInner" alt="${cardAltText}">
 <!--
-    Copyright (c) 2016, 2017 IBM Corporation and others.
+    Copyright (c) 2016, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/templates/DashboardPane.html
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/templates/DashboardPane.html
@@ -1,6 +1,6 @@
 <table class="container dashboard-table" role="presentation">
 <!--
-    Copyright (c) 2016 IBM Corporation and others.
+    Copyright (c) 2016, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -11,13 +11,13 @@
  	-->
 	<tr>
 		<td class="dashboard-row-header" tabindex="0">
-  			<div class="resource-icon" id="${dashboardIconId}" data-dojo-attach-point="iconTypeNode"></div>
-   			<p> ${dashboardResourceLabel} </p>
+			<div class="resource-icon" id="${dashboardIconId}" data-dojo-attach-point="iconTypeNode"></div>
+			<p id="${dashboardIconLabelId}"> ${dashboardResourceLabel} </p>
 		</td>
 	</tr>										
 	<tr> 			
 		<td class="dashboard-row-detail detail-total"> 
-			<button title="${viewAllLabel}" aria-label="${viewAllLabel}" class="button-total" id="${dashboardResourceId}" type="button" data-dojo-attach-event="ondijitclick:_onClick, onkeydown:_onKey">				
+			<button title="${viewAllLabel}" class="button-total" id="${dashboardResourceId}" type="button" data-dojo-attach-event="ondijitclick:_onClick, onkeydown:_onKey">
 			   	<div class="detail-graph" id="${dashboardGraphPaneId}" data-dojo-attach-point="graphNode">
    			   	</div>
 				<div class="total-detail">
@@ -32,17 +32,17 @@
 			<div role="button" tabindex="0" data-dojo-attach-point="unknownNode"
  				 class="list-count unknown" data-dojo-attach-event="ondijitclick: onUnknown">
 				<div data-dojo-attach-point="unknownIcon" class="status-icon"></div>
-				<div class="status-info" title="${unknownLabel}">${unknownLabel}</div>
+				<div id=${dashboardResourceUnknownLabelId} class="status-info" title="${unknownLabel}">${unknownLabel}</div>
 				<div id=${dashboardResourceUnknownButtonNumberId} class="list-number"></div>
 			</div>	
 			<div role="button" tabindex="0" class="list-count running" data-dojo-attach-event="ondijitclick: onRunning">
 				<div data-dojo-attach-point="runIcon" class="status-icon"></div>
-				<div class="status-info" title="${runningLabel}">${runningLabel}</div>
+				<div id=${dashboardResourceRunningLabelId} class="status-info" title="${runningLabel}">${runningLabel}</div>
  				<div id=${dashboardResourceRunningButtonNumberId} class="list-number"></div>
 			</div>
 			<div role="button" tabindex="0" class="list-count stopped" data-dojo-attach-event="ondijitclick: onStopped">
 				<div data-dojo-attach-point="stopIcon" class="status-icon"></div>				
-				<div class="status-info" title="${stoppedLabel}">${stoppedLabel}</div>
+				<div id=${dashboardResourceStoppedLabelId} class="status-info" title="${stoppedLabel}">${stoppedLabel}</div>
  				<div id=${dashboardResourceStoppedButtonNumberId} class="list-number"></div>
 			</div>
 		</td>

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/templates/HostCard.html
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/templates/HostCard.html
@@ -1,6 +1,6 @@
-<div class="cardInner">
+<div class="cardInner" alt="${cardAltText}">
 <!--
-    Copyright (c) 2016, 2017 IBM Corporation and others.
+    Copyright (c) 2016, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/templates/ResourcePane.html
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/templates/ResourcePane.html
@@ -1,6 +1,6 @@
 <div class="${resourcePaneClass}">
 <!--
-    Copyright (c) 2016 IBM Corporation and others.
+    Copyright (c) 2016, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -22,19 +22,19 @@
 
     <div class="subLabelStatePane" id="${resourceStatePaneId}">
       <div data-dojo-type="dijit/layout/ContentPane" data-dojo-attach-point="unknownPane" style="margin-bottom: 18px;">
-    	<div data-dojo-attach-point="unknownIcon" class="resourcePaneStateIcon"></div>
-       	<span class="resourcePaneStateLabel">${stateLabels.unknown}</span>
-    	<span id="${resourceStateUnknownNumber}" class="resourcePaneStateNumber unknownNumber" data-dojo-attach-point="unknownNumberNode">0</span>
+        <div data-dojo-attach-point="unknownIcon" class="resourcePaneStateIcon"></div>
+        <span id="${resourceStateUnknownLabel}" class="resourcePaneStateLabel">${stateLabels.unknown}</span>
+        <span id="${resourceStateUnknownNumber}" class="resourcePaneStateNumber unknownNumber" data-dojo-attach-point="unknownNumberNode">0</span>
       </div>
       <div style="margin-bottom: 18px;">
        	<div data-dojo-attach-point="runIcon" class="resourcePaneStateIcon"></div>
-       	<span class="resourcePaneStateLabel">${stateLabels.up}</span>
-    	<span id="${resourceStateRunningNumber}" class="resourcePaneStateNumber runningNumber" data-dojo-attach-point="runningNumberNode">0</span>
+        <span id="${resourceStateRunningLabel}" class="resourcePaneStateLabel">${stateLabels.up}</span>
+        <span id="${resourceStateRunningNumber}" class="resourcePaneStateNumber runningNumber" data-dojo-attach-point="runningNumberNode">0</span>
       </div>
       <div>
        	<div data-dojo-attach-point="stopIcon" class="resourcePaneStateIcon"></div>
-       	<span class="resourcePaneStateLabel">${stateLabels.down}</span>
-    	<span id="${resourceStateStoppedNumber}" class="resourcePaneStateNumber stoppedNumber" data-dojo-attach-point="stoppedNumberNode">0</span>
+        <span id="${resourceStateStoppedLabel}" class="resourcePaneStateLabel">${stateLabels.down}</span>
+        <span id="${resourceStateStoppedNumber}" class="resourcePaneStateNumber stoppedNumber" data-dojo-attach-point="stoppedNumberNode">0</span>
       </div>	 
     </div>
 </div>

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/templates/RuntimeOnHostCard.html
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/templates/RuntimeOnHostCard.html
@@ -1,6 +1,6 @@
-<div class="cardInner">
+<div class="cardInner" alt="${cardAltText}">
 <!--
-    Copyright (c) 2016, 2017 IBM Corporation and others.
+    Copyright (c) 2016, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/templates/ServerCard.html
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/templates/ServerCard.html
@@ -1,6 +1,6 @@
-<div class="cardInner">
+<div class="cardInner" alt="${cardAltText}">
 <!--
-    Copyright (c) 2016, 2017 IBM Corporation and others.
+    Copyright (c) 2016, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at


### PR DESCRIPTION
This PR fixes the following accessibility issues in Explore admin center tool:

- img role with no label
  - use aria-labelledby attribute to point to an existing label
  - otherwise use aria-label
- accessible name not matching visible label text
  - replace aria-label with aria-labelledby attribute to point to an existing label
  - replace aria-label with alt attribute
  - remove unnecessary aria-label when there is visible text or title attribute

The Explore dashboard (for both collective and standalone server), collective view, and object view panels are all scanned with no accessibility violation. In addition, those panels are read by the JAWS screen reader to ensure the correct info is provided to users with disabilities.