### PR TITLE
Improve windows installation performance with IBM IM

### DIFF
--- a/dev/com.ibm.ws.install/bnd.bnd
+++ b/dev/com.ibm.ws.install/bnd.bnd
@@ -51,25 +51,26 @@ instrument.disabled: true
 
 
 -testpath: \
-    com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
-    org.hamcrest:hamcrest-all;version=1.3, \
-    ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
-    com.ibm.ws.junit.extensions;version=latest, \
-    org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
-    org.jmock:jmock;strategy=exact;version=2.5.1, \
-    org.jmock:jmock-legacy;version=2.5.0, \
-    com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-    cglib:cglib-nodep;version=3.3.0, \
-    com.ibm.ws.logging;version=latest, \
-    com.ibm.websphere.org.osgi.core;version=latest, \
-    com.ibm.ws.logging.core;version=latest,\
-    com.ibm.ws.kernel.boot;version=latest,\
-    com.ibm.ws.kernel.feature;version=latest,\
-    com.ibm.ws.kernel.service;version=latest,\
-    com.ibm.ws.product.utility;version=latest,\
-    com.ibm.ws.repository;version=latest,\
-    com.ibm.ws.repository.liberty;version=latest,\
-    com.ibm.ws.repository.resolver;version=latest,\
-    wlp.lib.extract;version=latest,\
-    com.ibm.websphere.org.osgi.service.component;version=latest,\
-    com.ibm.wsspi.org.osgi.service.component.annotations
+	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
+	org.hamcrest:hamcrest-all;version='1.3',\
+	../build.sharedResources/lib/junit/old/junit.jar;version=file,\
+	com.ibm.ws.junit.extensions;version=latest,\
+	org.jmock:jmock-junit4;strategy=exact;version='2.5.1',\
+	org.jmock:jmock;strategy=exact;version='2.5.1',\
+	org.jmock:jmock-legacy;version='2.5.0',\
+	com.ibm.ws.org.objenesis:objenesis;version='1.0',\
+	cglib:cglib-nodep;version='3.3.0',\
+	com.ibm.ws.logging;version=latest,\
+	com.ibm.websphere.org.osgi.core;version=latest,\
+	com.ibm.ws.logging.core;version=latest,\
+	com.ibm.ws.kernel.boot;version=latest,\
+	com.ibm.ws.kernel.feature;version=latest,\
+	com.ibm.ws.kernel.service;version=latest,\
+	com.ibm.ws.product.utility;version=latest,\
+	com.ibm.ws.repository;version=latest,\
+	com.ibm.ws.repository.liberty;version=latest,\
+	com.ibm.ws.repository.resolver;version=latest,\
+	wlp.lib.extract;version=latest,\
+	com.ibm.websphere.org.osgi.service.component;version=latest,\
+	com.ibm.wsspi.org.osgi.service.component.annotations,\
+	org.mockito:mockito-all;version=1.9.5

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/InstallConstants.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/InstallConstants.java
@@ -31,9 +31,9 @@ public class InstallConstants {
     public static final String IGNORE_FILE_PROPERTY = "com.ibm.websphere.install.utility.ignoreWhenFileExists";
     public static final String IGNORE_FILE_OPTION = System.getProperty(IGNORE_FILE_PROPERTY);
 
-    // Uninstall request sent from startSecondJVM_JVMCallCIKuninstallProductFeatures
-    public static final String UNINSTALL_REQUEST_FROM_JVMCALLCIKUPF_PROPERTY = "com.ibm.websphere.install.utility.jvmCallCikUPF";
-    public static final boolean UNINSTALL_REQUEST_FROM_JVMCALLCIKUPF_OPTION = Boolean.parseBoolean(System.getProperty(UNINSTALL_REQUEST_FROM_JVMCALLCIKUPF_PROPERTY));
+    // Uninstall request sent from startSecondJVM_JVMCallCIKAPIFeature
+    public static final String REQUEST_FROM_JVMCALLCIKAF_PROPERTY = "com.ibm.websphere.install.utility.jvmCallCikAF";
+    public static final boolean REQUEST_FROM_JVMCALLCIKAF_OPTION = Boolean.parseBoolean(System.getProperty(REQUEST_FROM_JVMCALLCIKAF_PROPERTY));
 
     public static final String DEFAULT_REPO_PROPERTIES_LOCATION = File.separator + "etc" + File.separator
                                                                   + "repositories.properties";

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/InstallConstants.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/InstallConstants.java
@@ -31,6 +31,10 @@ public class InstallConstants {
     public static final String IGNORE_FILE_PROPERTY = "com.ibm.websphere.install.utility.ignoreWhenFileExists";
     public static final String IGNORE_FILE_OPTION = System.getProperty(IGNORE_FILE_PROPERTY);
 
+    // Uninstall request sent from startSecondJVM_JVMCallCIKuninstallProductFeatures
+    public static final String UNINSTALL_REQUEST_FROM_JVMCALLCIKUPF_PROPERTY = "com.ibm.websphere.install.utility.jvmCallCikUPF";
+    public static final boolean UNINSTALL_REQUEST_FROM_JVMCALLCIKUPF_OPTION = Boolean.parseBoolean(System.getProperty(UNINSTALL_REQUEST_FROM_JVMCALLCIKUPF_PROPERTY));
+
     public static final String DEFAULT_REPO_PROPERTIES_LOCATION = File.separator + "etc" + File.separator
                                                                   + "repositories.properties";
     public static final String OVERRIDE_PROPS_LOCATION_ENV_VAR = "WLP_REPOSITORIES_PROPS";

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/InstallConstants.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/InstallConstants.java
@@ -31,10 +31,6 @@ public class InstallConstants {
     public static final String IGNORE_FILE_PROPERTY = "com.ibm.websphere.install.utility.ignoreWhenFileExists";
     public static final String IGNORE_FILE_OPTION = System.getProperty(IGNORE_FILE_PROPERTY);
 
-    // Uninstall request sent from startSecondJVM_JVMCallCIKAPIFeature
-    public static final String REQUEST_FROM_JVMCALLCIKAF_PROPERTY = "com.ibm.websphere.install.utility.jvmCallCikAF";
-    public static final boolean REQUEST_FROM_JVMCALLCIKAF_OPTION = Boolean.parseBoolean(System.getProperty(REQUEST_FROM_JVMCALLCIKAF_PROPERTY));
-
     public static final String DEFAULT_REPO_PROPERTIES_LOCATION = File.separator + "etc" + File.separator
                                                                   + "repositories.properties";
     public static final String OVERRIDE_PROPS_LOCATION_ENV_VAR = "WLP_REPOSITORIES_PROPS";

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/UninstallDirector.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/UninstallDirector.java
@@ -12,9 +12,13 @@ package com.ibm.ws.install.internal;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -22,7 +26,9 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
+import com.ibm.ws.install.InstallConstants;
 import com.ibm.ws.install.InstallException;
 import com.ibm.ws.install.InstallProgressEvent;
 import com.ibm.ws.install.internal.InstallLogUtils.Messages;
@@ -62,8 +68,8 @@ class UninstallDirector extends AbstractDirector {
      * Creates array and calls method below
      *
      * @param checkDependency if uninstall should check for dependencies
-     * @param productId product id to uninstall
-     * @param toBeDeleted Collection of files to uninstall
+     * @param productId       product id to uninstall
+     * @param toBeDeleted     Collection of files to uninstall
      * @throws InstallException
      */
     void uninstall(boolean checkDependency, String productId, Collection<File> toBeDeleted) throws InstallException {
@@ -88,27 +94,38 @@ class UninstallDirector extends AbstractDirector {
      * Uninstalls product depending on dependencies
      *
      * @param checkDependency if uninstall should check for dependencies
-     * @param productIds product ids to uninstall
-     * @param toBeDeleted Collection of files to uninstall
+     * @param productIds      product ids to uninstall
+     * @param toBeDeleted     Collection of files to uninstall
      * @throws InstallException
      */
     void uninstall(boolean checkDependency, String[] productIds, Collection<File> toBeDeleted) throws InstallException {
         if (uninstallAssets.isEmpty())
             return;
 
-        // Run file checking only on Windows
+        // On Windows specifically, we need to do a file lock check before attempting to uninstall assets.
         if (InstallUtils.isWindows) {
             // check any file is locked
             fireProgressEvent(InstallProgressEvent.CHECK, 10, Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("STATE_CHECKING"));
+            Set<File> baseDirs = new HashSet<>();
             for (UninstallAsset uninstallAsset : uninstallAssets) {
-                retrieveUninstallFileList(uninstallAsset, checkDependency);
-                engine.preCheck(uninstallAsset);
+                baseDirs.addAll(getAssetBaseDirectories(uninstallAsset));
             }
-            if (toBeDeleted != null) {
-                for (File f : toBeDeleted) {
-                    for (String productId : productIds) {
-                        InstallUtils.isFileLocked("ERROR_UNINSTALL_PRODUCT_FILE_LOCKED", productId, f);
+
+            if (!InstallConstants.UNINSTALL_REQUEST_FROM_JVMCALLCIKUPF_OPTION) {
+                // filter out /bin directory as this uninstall request may have come from a command line utility in /bin and will be locked.
+                // /bin should be checked if this invocation comes from startSecondJVM_JVMCallCIKuninstallProductFeatures
+                baseDirs = baseDirs.stream().filter(p -> !p.toString().endsWith("bin")).collect(Collectors.toSet());
+            }
+
+            // For each uninstall asset's base directory, validate no files are locked recursively.
+            for (File baseDir : baseDirs) {
+                try {
+                    List<Path> allPathsFromBaseDir = Files.walk(baseDir.toPath()).collect(Collectors.toList());
+                    for (Path path : allPathsFromBaseDir) {
+                        InstallUtils.isFileLocked("ERROR_UNINSTALL_FEATURE_FILE_LOCKED", path.toString(), path.toFile());
                     }
+                } catch (IOException e) {
+                    throw ExceptionUtils.create(e);
                 }
             }
         }
@@ -144,6 +161,75 @@ class UninstallDirector extends AbstractDirector {
         }
     }
 
+    /**
+     *
+     * @param uninstallAsset the uninstall asset to derive a base directory from
+     * @return the uninstallAsset's base directories derived from uninstallAsset. For example, if the uninstallAsset location is dev/spi/ibm and baseDir is
+     *         /opt/IBM/WebSphere/AppServer, this will return 'Set[/opt/IBM/WebSphere/AppServer/dev]' iff the path exists, an empty Set otherwise.
+     * @throws InstallException
+     */
+    private Set<File> getAssetBaseDirectories(UninstallAsset uninstallAsset) throws InstallException {
+
+        Set<File> baseDirs = new HashSet<>();
+        File baseDir = engine.getBaseDir(uninstallAsset.getProvisioningFeatureDefinition());
+        Set<String> assetLocations = getAssetLocations(uninstallAsset);
+
+        // For each asset location, construct a list of locations containing the first child directory appended
+        // to the base directory iff that directory exists.
+        for (String assetLocation : assetLocations) {
+            List<String> subDirs = getFirstChildSubdirectoryFromLocations(assetLocation);
+            for (String subDir : subDirs) {
+                File base = new File(baseDir + File.separator + subDir);
+                if (base.exists()) {
+                    baseDirs.add(base);
+                }
+            }
+        }
+        return baseDirs;
+    }
+
+    /**
+     * @param uninstallAsset the asset to process for relevant location data
+     * @return a set of strings that are the location data derived from uninstallAsset. This set my be empty if the asset is not BUNDLE_TYPE, JAR_TYPE, BOOT_JAR_TYPE or FILE_TYPE.
+     *         It could also be empty if the getLocation() call returns null or an empty string.
+     */
+    private Set<String> getAssetLocations(UninstallAsset uninstallAsset) {
+        // Only process BUNDLE, JAR, BOOT and FILE subsystem types.
+        final List<SubsystemContentType> resourceFilter = Arrays.asList(SubsystemContentType.BUNDLE_TYPE, SubsystemContentType.JAR_TYPE, SubsystemContentType.BOOT_JAR_TYPE,
+                                                                        SubsystemContentType.FILE_TYPE);
+        // From the collection of FeatureResources, filter out types we don't wish to process and then collect all location strings from them.
+        return uninstallAsset.getProvisioningFeatureDefinition().getConstituents(null).stream().filter(s -> resourceFilter.contains(s.getType())
+                                                                                                            && s.getLocation() != null).map(s -> s.getLocation()).collect(Collectors.toSet());
+    }
+
+    /**
+     *
+     * @param locString the location string to parse, may be null and may contain more than one location separated by `,`.
+     * @return A list of the parent directories specified in the locString. For example, if the locString is "bin/tools/tools.zip", this method will return ["bin"].
+     *         if locString contains "bin/tools/tools.zip,etc/files/files.zip" this method would return ["bin","etc"]
+     *
+     */
+    private List<String> getFirstChildSubdirectoryFromLocations(String locString) {
+        List<String> subdirectories = new ArrayList<>();
+        if (locString != null) {
+            String[] locs = locString.contains(",") ? locString.split(",") : new String[] { locString };
+            for (String loc : locs) {
+                File fle = new File(loc);
+                String fileStr = fle.toString();
+                // skip a leading separator
+                if (fileStr.charAt(0) == File.separatorChar) {
+                    fileStr = fileStr.substring(1);
+                }
+                int index = fileStr.indexOf(File.separator);
+                if (index > 0) {
+                    fileStr = fileStr.substring(0, fileStr.indexOf(File.separator));
+                }
+                subdirectories.add(fileStr);
+            }
+        }
+        return subdirectories;
+    }
+
     void uninstall(Collection<String> ids, boolean force) throws InstallException {
         Collection<ProvisioningFeatureDefinition> installedFeatureDefinitions = product.getAllFeatureDefinitions().values();
         Collection<String> featureNames = new ArrayList<String>();
@@ -172,7 +258,7 @@ class UninstallDirector extends AbstractDirector {
      *
      * @param featureNames a list of the feature names and feature symbolic names to uninstall
      * @throws InstallException if there is a feature not installed or
-     *             there is another feature still requires the uninstalling features.
+     *                              there is another feature still requires the uninstalling features.
      */
     void uninstallFeatures(Collection<String> featureNames, Collection<String> uninstallInstallFeatures, boolean force) {
         product.refresh();
@@ -209,7 +295,7 @@ class UninstallDirector extends AbstractDirector {
     /**
      * Creates array and calls method below
      *
-     * @param productId product id to uninstall
+     * @param productId              product id to uninstall
      * @param exceptPlatfromFeatuers If platform features should be ignored
      * @throws InstallException
      */
@@ -222,7 +308,7 @@ class UninstallDirector extends AbstractDirector {
     /**
      * Uninstalls features by product id
      *
-     * @param productIds product ids to uninstall
+     * @param productIds             product ids to uninstall
      * @param exceptPlatfromFeatuers If platform features should be ignored
      * @throws InstallException
      */

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/UninstallDirector.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/UninstallDirector.java
@@ -111,7 +111,7 @@ class UninstallDirector extends AbstractDirector {
                 baseDirs.addAll(getAssetBaseDirectories(uninstallAsset));
             }
 
-            if (!InstallConstants.UNINSTALL_REQUEST_FROM_JVMCALLCIKUPF_OPTION) {
+            if (!InstallConstants.REQUEST_FROM_JVMCALLCIKAF_OPTION) {
                 // filter out /bin directory as this uninstall request may have come from a command line utility in /bin and will be locked.
                 // /bin should be checked if this invocation comes from startSecondJVM_JVMCallCIKuninstallProductFeatures
                 baseDirs = baseDirs.stream().filter(p -> !p.toString().endsWith("bin")).collect(Collectors.toSet());

--- a/dev/com.ibm.ws.install/test/com/ibm/ws/install/UninstallDirectorTest.java
+++ b/dev/com.ibm.ws.install/test/com/ibm/ws/install/UninstallDirectorTest.java
@@ -1,0 +1,206 @@
+/*******************************************************************************n * Copyright (c) 2022 IBM Corporation and others.n * All rights reserved. This program and the accompanying materialsn * are made available under the terms of the Eclipse Public License v1.0n * which accompanies this distribution, and is available atn * http://www.eclipse.org/legal/epl-v10.htmln *n * Contributors:n *     IBM Corporation - initial API and implementationn *******************************************************************************/
+package com.ibm.ws.install;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+
+import com.ibm.ws.install.internal.UninstallDirector;
+import com.ibm.ws.install.internal.asset.UninstallAsset;
+import com.ibm.ws.kernel.feature.provisioning.FeatureResource;
+import com.ibm.ws.kernel.feature.provisioning.ProvisioningFeatureDefinition;
+import com.ibm.ws.kernel.feature.provisioning.SubsystemContentType;
+
+import test.common.SharedOutputManager;
+
+/**
+ *
+ */
+public class UninstallDirectorTest {
+    @Rule
+    public static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("*=all");
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.restoreStreams();
+    }
+
+    @Before
+    public void mockitoSetup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testLocationParsing() {
+        UninstallDirector ud = new UninstallDirector(null, null, null, null);
+        String locations = null;
+        List<String> output = ud.getFirstChildSubdirectoryFromLocations(locations);
+        assertTrue(output.isEmpty());
+
+        locations = "";
+        output = ud.getFirstChildSubdirectoryFromLocations(locations);
+        assertTrue(output.isEmpty());
+
+        locations = "/";
+        output = ud.getFirstChildSubdirectoryFromLocations(locations);
+        assertTrue(output.size() == 1);
+        assertEquals("", output.get(0));
+
+        locations = "/home";
+        output = ud.getFirstChildSubdirectoryFromLocations(locations);
+        assertTrue(output.size() == 1);
+        assertEquals("home", output.get(0));
+
+        locations = "/home/test";
+        output = ud.getFirstChildSubdirectoryFromLocations(locations);
+        assertTrue(output.size() == 1);
+        assertEquals("home", output.get(0));
+
+        locations = "/home/test/script.sh";
+        output = ud.getFirstChildSubdirectoryFromLocations(locations);
+        assertTrue(output.size() == 1);
+        assertEquals("home", output.get(0));
+
+        locations = "/home/test/script.sh,";
+        output = ud.getFirstChildSubdirectoryFromLocations(locations);
+        assertTrue(output.size() == 1);
+        assertEquals("home", output.get(0));
+    }
+
+    @Test
+    public void testMultipleLocationString() {
+        UninstallDirector ud = new UninstallDirector(null, null, null, null);
+
+        String locations = "bin/tools/tools.zip,etc/files/files.zip";
+        List<String> output = ud.getFirstChildSubdirectoryFromLocations(locations);
+        assertTrue(output.size() == 2);
+        assertEquals("bin", output.get(0));
+        assertEquals("etc", output.get(1));
+
+        locations = "/home/test/script.sh,etc/files/files.zip,bin/installUtility.sh";
+        output = ud.getFirstChildSubdirectoryFromLocations(locations);
+        assertTrue(output.size() == 3);
+        assertEquals("home", output.get(0));
+        assertEquals("etc", output.get(1));
+        assertEquals("bin", output.get(2));
+
+    }
+
+    @Test
+    public void testGetAssetLocations() {
+        SubsystemContentType[] allowedTypes = new SubsystemContentType[] { SubsystemContentType.BOOT_JAR_TYPE, SubsystemContentType.BUNDLE_TYPE, SubsystemContentType.FILE_TYPE,
+                                                                           SubsystemContentType.JAR_TYPE };
+        UninstallDirector ud = new UninstallDirector(null, null, null, null);
+
+        UninstallAsset uninstallAsset = mock(UninstallAsset.class);
+        ProvisioningFeatureDefinition featureDef = mock(ProvisioningFeatureDefinition.class);
+
+        Collection<FeatureResource> resources = new ArrayList<FeatureResource>();
+
+        for (SubsystemContentType type : SubsystemContentType.values()) {
+            FeatureResource resource = mock(FeatureResource.class);
+            when(resource.getType()).thenReturn(type);
+            when(resource.getLocation()).thenReturn(generateLocationString(type));
+            resources.add(resource);
+        }
+
+        when(uninstallAsset.getProvisioningFeatureDefinition()).thenReturn(featureDef);
+        when(featureDef.getConstituents(null)).thenReturn(resources);
+
+        Set<String> assetLocations = ud.getAssetLocations(uninstallAsset);
+
+        for (SubsystemContentType allowed : allowedTypes) {
+            assertTrue(assetLocations.contains(generateLocationString(allowed)));
+        }
+        assertEquals(allowedTypes.length, assetLocations.size());
+
+    }
+
+    @Test
+    public void testGetAssetLocationsSubdirectory() {
+        final SubsystemContentType[] allowedTypes = new SubsystemContentType[] { SubsystemContentType.BOOT_JAR_TYPE, SubsystemContentType.BUNDLE_TYPE,
+                                                                                 SubsystemContentType.FILE_TYPE,
+                                                                                 SubsystemContentType.JAR_TYPE };
+        UninstallDirector ud = new UninstallDirector(null, null, null, null);
+
+        UninstallAsset uninstallAsset = mock(UninstallAsset.class);
+        ProvisioningFeatureDefinition featureDef = mock(ProvisioningFeatureDefinition.class);
+
+        Collection<FeatureResource> resources = new ArrayList<FeatureResource>();
+
+        for (SubsystemContentType type : SubsystemContentType.values()) {
+            FeatureResource resource = mock(FeatureResource.class);
+            when(resource.getType()).thenReturn(type);
+            when(resource.getLocation()).thenReturn(generateLocationString(type));
+            resources.add(resource);
+        }
+
+        when(uninstallAsset.getProvisioningFeatureDefinition()).thenReturn(featureDef);
+        when(featureDef.getConstituents(null)).thenReturn(resources);
+
+        Set<String> assetLocations = ud.getAssetLocations(uninstallAsset);
+        Set<String> allChildSubdirs = new HashSet<String>();
+        for (String asset : assetLocations) {
+            allChildSubdirs.addAll(ud.getFirstChildSubdirectoryFromLocations(asset));
+        }
+
+        assertEquals(allowedTypes.length + 2, allChildSubdirs.size());
+        assertTrue(allChildSubdirs.contains("etc"));
+        assertTrue(allChildSubdirs.contains("bin"));
+        for (SubsystemContentType type : allowedTypes) {
+            assertTrue(allChildSubdirs.contains(type.name()));
+        }
+    }
+
+    @Test
+    public void testRemovePathExceptions() {
+        UninstallDirector ud = new UninstallDirector(null, null, null, null);
+        String[] testPaths = new String[] { "/test/script.sh", "etc/files/files.zip", "bin/installUtility.sh", "bin/installUtility.bat", "bin", "bin/featureUtility.bat",
+                                            "bin/featureManager.bat", "bin/tools/ws-featureManager.jar", "bin/tools/ws-featureUtility.jar",
+                                            "bin/tools/whatever/ws-featureUtility.jar", "bin/", "bin" };
+        List<Path> paths = new ArrayList<>();
+        for (String test : testPaths) {
+            Path path = FileSystems.getDefault().getPath(test);
+            System.out.println("testPath: " + path.toString());
+            paths.add(path);
+        }
+        paths = ud.removePathExceptions(paths);
+        List<Path> expectedPaths = new ArrayList<Path>();
+        expectedPaths.add(FileSystems.getDefault().getPath("/test/script.sh"));
+        expectedPaths.add(FileSystems.getDefault().getPath("etc/files/files.zip"));
+        expectedPaths.add(FileSystems.getDefault().getPath("bin/installUtility.sh"));
+        assertEquals(expectedPaths.size(), paths.size());
+        assertTrue(expectedPaths.containsAll(paths));
+
+    }
+
+    /**
+     * @param type
+     * @return
+     */
+    private String generateLocationString(SubsystemContentType type) {
+        return "/" + type.name() + "/test/script.sh,etc/files/files.zip,bin/installUtility.sh";
+    }
+
+}


### PR DESCRIPTION
We now check locks in windows on all files excluding the bin directory and jars related to external installation tools such as installUtility. Doing a single lock check on all files in the installation directory proves faster than following the previous logic which could check locks on the same files repeatedly, causing serious performance issues on Windows Installation Manager installs.

