### PR TITLE
OIDC Back-channel logout: New metatype and RP logout endpoint

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/samlWeb-2.0/com.ibm.websphere.appserver.samlWeb-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/samlWeb-2.0/com.ibm.websphere.appserver.samlWeb-2.0.feature
@@ -14,7 +14,6 @@ Subsystem-Name: SAML Web Single Sign-On 2.0
   io.openliberty.org.apache.commons.logging, \
   com.ibm.json4j, \
   io.openliberty.org.apache.commons.codec, \
-  com.ibm.ws.org.jose4j, \
-  com.ibm.ws.com.google.gson.2.2.4
+  com.ibm.ws.org.jose4j
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/samlWeb-2.0/com.ibm.websphere.appserver.samlWeb-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/samlWeb-2.0/com.ibm.websphere.appserver.samlWeb-2.0.feature
@@ -14,6 +14,7 @@ Subsystem-Name: SAML Web Single Sign-On 2.0
   io.openliberty.org.apache.commons.logging, \
   com.ibm.json4j, \
   io.openliberty.org.apache.commons.codec, \
-  com.ibm.ws.org.jose4j
+  com.ibm.ws.org.jose4j, \
+  com.ibm.ws.com.google.gson.2.2.4
 kind=ga
 edition=core

--- a/dev/com.ibm.ws.security.common.jsonwebkey/resources/com/ibm/ws/security/common/jwk/internal/resources/JWKCommonMessages.nlsprops
+++ b/dev/com.ibm.ws.security.common.jsonwebkey/resources/com/ibm/ws/security/common/jwk/internal/resources/JWKCommonMessages.nlsprops
@@ -15,4 +15,4 @@
 #NLS_MESSAGEFORMAT_VAR
 #NLS_ENCODING=UNICODE
 # -------------------------------------------------------------------------------------------------
-# Message prefix block: CWWKS6201 - CWWKS6300
+# Message prefix block: CWWKS6210 - CWWKS6300

--- a/dev/com.ibm.ws.security.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.common/bnd.bnd
@@ -70,8 +70,7 @@ instrument.classesExcludes: com/ibm/ws/security/common/internal/resources/*.clas
     com.ibm.ws.security.authentication;version=latest, \
     com.ibm.json4j;version=latest, \
     com.ibm.ws.webcontainer.security;version=latest, \
-    com.ibm.ws.org.apache.httpcomponents;version=latest, \
-    com.ibm.ws.kernel.boot.core;version=latest
+    com.ibm.ws.org.apache.httpcomponents;version=latest
 
 -testpath: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.security.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.common/bnd.bnd
@@ -70,7 +70,8 @@ instrument.classesExcludes: com/ibm/ws/security/common/internal/resources/*.clas
     com.ibm.ws.security.authentication;version=latest, \
     com.ibm.json4j;version=latest, \
     com.ibm.ws.webcontainer.security;version=latest, \
-    com.ibm.ws.org.apache.httpcomponents;version=latest
+    com.ibm.ws.org.apache.httpcomponents;version=latest, \
+    com.ibm.ws.kernel.boot.core;version=latest
 
 -testpath: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.security.common/src/io/openliberty/security/common/serialization/Beta.java
+++ b/dev/com.ibm.ws.security.common/src/io/openliberty/security/common/serialization/Beta.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.common.serialization;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Beta {
+}

--- a/dev/com.ibm.ws.security.common/src/io/openliberty/security/common/serialization/GsonStrategies.java
+++ b/dev/com.ibm.ws.security.common/src/io/openliberty/security/common/serialization/GsonStrategies.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.common.serialization;
+
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+import com.ibm.ws.kernel.productinfo.ProductInfo;
+
+public class GsonStrategies {
+
+    /**
+     * Strategy used to avoid serializing member variables with the @Beta annotation unless we're using a beta image.
+     */
+    public static ExclusionStrategy BETA_STRATEGY = new ExclusionStrategy() {
+        @Override
+        public boolean shouldSkipClass(Class<?> clazz) {
+            return false;
+        }
+
+        @Override
+        public boolean shouldSkipField(FieldAttributes field) {
+            boolean hasBetaAnnotation = field.getAnnotation(Beta.class) != null;
+            boolean isRunningBeta = ProductInfo.getBetaEdition();
+            return hasBetaAnnotation && !isRunningBeta;
+        }
+    };
+
+}

--- a/dev/com.ibm.ws.security.common/src/io/openliberty/security/common/serialization/package-info.java
+++ b/dev/com.ibm.ws.security.common/src/io/openliberty/security/common/serialization/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+package io.openliberty.security.common.serialization;

--- a/dev/com.ibm.ws.security.oauth/bnd.bnd
+++ b/dev/com.ibm.ws.security.oauth/bnd.bnd
@@ -153,8 +153,8 @@ Include-Resource: \
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.security.openidconnect.clients.common;version=latest,\
 	com.ibm.ws.org.eclipse.equinox.metatype;version=latest,\
-	com.ibm.ws.security.jwt;version=latest
-
+	com.ibm.ws.security.jwt;version=latest,\
+	com.ibm.ws.kernel.boot.core;version=latest
 
 -testpath: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OidcBaseClient.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OidcBaseClient.java
@@ -22,6 +22,8 @@ import com.ibm.ws.security.oauth20.api.OidcOAuth20Client;
 import com.ibm.ws.security.oauth20.util.HashSecretUtils;
 import com.ibm.ws.security.oauth20.util.OIDCConstants;
 
+import io.openliberty.security.common.serialization.Beta;
+
 public class OidcBaseClient extends BaseClient implements Serializable, OidcOAuth20Client {
 
     public static final String SN_CLIENT_ID_ISSUED_AT = OIDCConstants.OIDC_CLIENTREG_ISSUED_AT;
@@ -111,10 +113,10 @@ public class OidcBaseClient extends BaseClient implements Serializable, OidcOAut
 
     @Expose
     private boolean proofKeyForCodeExchange = false;
-    
+
     @Expose
     private boolean publicClient = false;
-    
+
     @Expose
     private boolean appPasswordAllowed = false;
 
@@ -137,9 +139,13 @@ public class OidcBaseClient extends BaseClient implements Serializable, OidcOAut
     @SerializedName(OAuth20Constants.HASH_LENGTH)
     private int length = HashSecretUtils.DEFAULT_KEYSIZE;
 
+    @Expose
+    @Beta
     @SerializedName(SN_BACKCHANNEL_LOGOUT_URI)
     private String backchannelLogoutUri = null;
 
+    @Expose
+    @Beta
     @SerializedName(SN_BACKCHANNEL_LOGOUT_SESSION_REQUIRED)
     private boolean backchannelLogoutSessionRequired = false;
 

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/GsonStrategies.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/GsonStrategies.java
@@ -8,11 +8,13 @@
  * Contributors:
  * IBM Corporation - initial API and implementation
  *******************************************************************************/
-package io.openliberty.security.common.serialization;
+package com.ibm.ws.security.oauth20.util;
 
 import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
 import com.ibm.ws.kernel.productinfo.ProductInfo;
+
+import io.openliberty.security.common.serialization.Beta;
 
 public class GsonStrategies {
 

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/OidcOAuth20Util.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/OidcOAuth20Util.java
@@ -31,6 +31,8 @@ import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.security.oauth20.TraceConstants;
 
+import io.openliberty.security.common.serialization.GsonStrategies;
+
 /**
  *
  */
@@ -191,6 +193,7 @@ public class OidcOAuth20Util extends OAuth20Util {
 
     public static final Gson GSON_RAW = new GsonBuilder()
             .excludeFieldsWithoutExposeAnnotation()
+            .addSerializationExclusionStrategy(GsonStrategies.BETA_STRATEGY)
             .create();
 
     public static final Gson GSON_RAWEST = new GsonBuilder().create();

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/OidcOAuth20Util.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/OidcOAuth20Util.java
@@ -31,8 +31,6 @@ import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.security.oauth20.TraceConstants;
 
-import io.openliberty.security.common.serialization.GsonStrategies;
-
 /**
  *
  */

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/RegistrationEndpointServices.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/RegistrationEndpointServices.java
@@ -50,10 +50,9 @@ import com.ibm.ws.security.oauth20.plugins.OidcBaseClient;
 import com.ibm.ws.security.oauth20.plugins.OidcBaseClientSerializer;
 import com.ibm.ws.security.oauth20.plugins.OidcBaseClientValidator;
 import com.ibm.ws.security.oauth20.util.Base64;
+import com.ibm.ws.security.oauth20.util.GsonStrategies;
 import com.ibm.ws.security.oauth20.util.OIDCConstants;
 import com.ibm.ws.security.oauth20.util.OidcOAuth20Util;
-
-import io.openliberty.security.common.serialization.GsonStrategies;
 
 /**
  *

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/RegistrationEndpointServices.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/RegistrationEndpointServices.java
@@ -53,6 +53,8 @@ import com.ibm.ws.security.oauth20.util.Base64;
 import com.ibm.ws.security.oauth20.util.OIDCConstants;
 import com.ibm.ws.security.oauth20.util.OidcOAuth20Util;
 
+import io.openliberty.security.common.serialization.GsonStrategies;
+
 /**
  *
  */
@@ -73,6 +75,7 @@ public class RegistrationEndpointServices extends AbstractOidcEndpointServices {
     // Configured GSON (De)Serializer for OidcBaseClient objects (Thread Safe according to documentation)
     public static final Gson GSON = new GsonBuilder()
             .excludeFieldsWithoutExposeAnnotation()
+            .addSerializationExclusionStrategy(GsonStrategies.BETA_STRATEGY)
             .registerTypeAdapter(OidcBaseClient.class, new OidcBaseClientSerializer())
             .create();
 

--- a/dev/com.ibm.ws.security.openidconnect.client/bnd.bnd
+++ b/dev/com.ibm.ws.security.openidconnect.client/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2021 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -78,7 +78,8 @@ Include-Resource: \
     OSGI-INF=resources/OSGI-INF
 
 -dsannotations=com.ibm.ws.security.openidconnect.client.internal.OidcClientWebappConfigImpl,\
-    com.ibm.ws.security.openidconnect.client.internal.OidcClientConfigImpl
+    com.ibm.ws.security.openidconnect.client.internal.OidcClientConfigImpl,\
+    com.ibm.ws.security.openidconnect.client.web.OidcBackchannelLogoutServlet
 
 -buildpath: \
 	com.ibm.websphere.appserver.spi.logging;version=latest,\

--- a/dev/com.ibm.ws.security.openidconnect.client/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2019, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -10,30 +10,47 @@
         IBM Corporation - initial API and implementation
 -->
 <web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	     xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:javaee="http://java.sun.com/xml/ns/javaee"
-	     xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
-	     xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
-	     id="WebApp_ID" version="2.4">
-	
+		 xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:javaee="http://java.sun.com/xml/ns/javaee"
+		 xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+		 xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
+		 id="WebApp_ID" version="2.4">
+
 	<display-name>OpenID Connect Client Redirect Servlet</display-name>
-	
+
 	<servlet>
 		<description>OpenID Connect Client Redirect Servlet</description>
 		<display-name>OpenID Connect Client Redirect Servlet</display-name>
 		<servlet-name>OpenIdConnectClientRedirectServlet</servlet-name>
 		<servlet-class>com.ibm.ws.security.openidconnect.client.web.OidcRedirectServlet</servlet-class>
 	</servlet>
-	
+	<servlet>
+		<description>OpenID Connect Client Backchannel Logout Servlet</description>
+		<display-name>OpenID Connect Client Backchannel Logout Servlet</display-name>
+		<servlet-name>OidcBackchannelLogoutServlet</servlet-name>
+		<servlet-class>com.ibm.ws.security.openidconnect.client.web.OidcBackchannelLogoutServlet</servlet-class>
+	</servlet>
+
 	<servlet-mapping>
 		<servlet-name>OpenIdConnectClientRedirectServlet</servlet-name>
 		<url-pattern>/redirect/*</url-pattern>
 	</servlet-mapping>
-	
+	<servlet-mapping>
+		<servlet-name>OidcBackchannelLogoutServlet</servlet-name>
+		<url-pattern>/backchannel_logout/*</url-pattern>
+	</servlet-mapping>
+
 	<security-constraint>
 		<web-resource-collection>
 			<web-resource-name>OpenID Connect Client Redirect Servlet</web-resource-name>
 			<url-pattern>/redirect/*</url-pattern>
 			<http-method>*</http-method>
+		</web-resource-collection>
+	</security-constraint>
+	<security-constraint>
+		<web-resource-collection>
+			<web-resource-name>OpenID Connect Client Backchannel Logout Servlet</web-resource-name>
+			<url-pattern>/backchannel_logout/*</url-pattern>
+			<http-method>POST</http-method>
 		</web-resource-collection>
 	</security-constraint>
 

--- a/dev/com.ibm.ws.security.openidconnect.client/resources/com/ibm/ws/security/openidconnect/client/internal/resources/OidcClientMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/com/ibm/ws/security/openidconnect/client/internal/resources/OidcClientMessages.nlsprops
@@ -288,6 +288,6 @@ OIDC_CLIENT_BAD_REQUEST_MALFORMED_URL_IN_COOKIE=CWWKS1532E: A request to [{0}] i
 OIDC_CLIENT_BAD_REQUEST_MALFORMED_URL_IN_COOKIE.explanation=A request was received that includes a malformed cookie.
 OIDC_CLIENT_BAD_REQUEST_MALFORMED_URL_IN_COOKIE.useraction=Verify the OpenID Connect provider and client configurations. The malformed cookie can be caused by cookie modification at the user agent with a host name that differs from the host name of the redirect that is registered with the provider. If the host name is expected, then add it to the wasReqURLRedirectDomainNames attribute of the webAppSecurity element in server.xml.
 
-# 1533-1540 used in clients.common bundle, do not use here.
+# 1533-1544 used in clients.common bundle, do not use here.
 
 # STOP HERE, OIDC SERVER HAS RESERVED 1600 - 1649

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/web/OidcBackchannelLogoutServlet.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/web/OidcBackchannelLogoutServlet.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.openidconnect.client.web;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.ibm.ws.security.openidconnect.backchannellogout.BackchannelLogoutHelper;
+
+/**
+ * Servlet for OpenID Connect Back-Channel Logout (https://openid.net/specs/openid-connect-backchannel-1_0.html)
+ */
+public class OidcBackchannelLogoutServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        BackchannelLogoutHelper logoutHelper = new BackchannelLogoutHelper(request, response);
+        logoutHelper.handleBackchannelLogoutRequest();
+    }
+
+}

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/web/OidcBackchannelLogoutServlet.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/web/OidcBackchannelLogoutServlet.java
@@ -11,25 +11,75 @@
 package com.ibm.ws.security.openidconnect.client.web;
 
 import java.io.IOException;
+import java.util.Iterator;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.security.openidconnect.backchannellogout.BackchannelLogoutHelper;
+import com.ibm.ws.security.openidconnect.clients.common.OidcClientConfig;
+import com.ibm.wsspi.kernel.service.utils.ConcurrentServiceReferenceSet;
+import com.ibm.wsspi.kernel.service.utils.ServiceAndServiceReferencePair;
 
 /**
  * Servlet for OpenID Connect Back-Channel Logout (https://openid.net/specs/openid-connect-backchannel-1_0.html)
  */
+@Component(name = "com.ibm.ws.security.openidconnect.client.web.OidcBackchannelLogoutServlet", service = {}, property = { "service.vendor=IBM" })
 public class OidcBackchannelLogoutServlet extends HttpServlet {
+
+    private static TraceComponent tc = Tr.register(OidcBackchannelLogoutServlet.class);
 
     private static final long serialVersionUID = 1L;
 
+    private static final ConcurrentServiceReferenceSet<OidcClientConfig> oidcClientConfigRef = new ConcurrentServiceReferenceSet<OidcClientConfig>("oidcClientConfigService");
+
+    @Reference(name = "oidcClientConfigService", service = OidcClientConfig.class, policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MULTIPLE)
+    protected void setOidcClientConfigService(ServiceReference<OidcClientConfig> reference) {
+        oidcClientConfigRef.addReference(reference);
+    }
+
+    protected void unsetOidcClientConfigService(ServiceReference<OidcClientConfig> reference) {
+        oidcClientConfigRef.removeReference(reference);
+    }
+
+    public void activate(ComponentContext cc) {
+        oidcClientConfigRef.activate(cc);
+    }
+
+    public void deactivate(ComponentContext cc) {
+        oidcClientConfigRef.deactivate(cc);
+    }
+
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        BackchannelLogoutHelper logoutHelper = new BackchannelLogoutHelper(request, response);
+        String requestUri = request.getRequestURI();
+        OidcClientConfig matchingConfig = getMatchingConfig(requestUri);
+        BackchannelLogoutHelper logoutHelper = new BackchannelLogoutHelper(request, response, matchingConfig);
         logoutHelper.handleBackchannelLogoutRequest();
+    }
+
+    private OidcClientConfig getMatchingConfig(String requestUri) {
+        Iterator<ServiceAndServiceReferencePair<OidcClientConfig>> servicesWithRefs = oidcClientConfigRef.getServicesWithReferences();
+        while (servicesWithRefs.hasNext()) {
+            ServiceAndServiceReferencePair<OidcClientConfig> configServiceAndRef = servicesWithRefs.next();
+            OidcClientConfig config = configServiceAndRef.getService();
+            String configId = config.getId();
+            if (requestUri.endsWith("/" + configId)) {
+                return config;
+            }
+        }
+        return null;
     }
 
 }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/bnd.bnd
@@ -35,6 +35,7 @@ WS-TraceGroup: \
 # for the exported API.
 
 Export-Package: \
+    com.ibm.ws.security.openidconnect.backchannellogout, \
     com.ibm.ws.security.openidconnect.clients.common, \
     com.ibm.ws.security.openidconnect.client.jose4j.util.*, \
     com.ibm.ws.security.openidconnect.jose4j.*, \

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
@@ -258,4 +258,12 @@ BACKCHANNEL_LOGOUT_REQUEST_MISSING_PARAMETER=CWWKS1542E: The back-channel logout
 BACKCHANNEL_LOGOUT_REQUEST_MISSING_PARAMETER.explanation=The back-channel logout request must include a logout_token parameter whose value is a valid logout token.
 BACKCHANNEL_LOGOUT_REQUEST_MISSING_PARAMETER.useraction=Update the request to include a logout token.
 
+BACKCHANNEL_LOGOUT_TOKEN_ERROR=CWWKS1543E: The logout token in the back-channel logout request cannot be validated: {0}
+BACKCHANNEL_LOGOUT_TOKEN_ERROR.explanation=The logout token might be malformed, the token might be in an unexpected format, or another error occurred validating the signature or claims of the token.
+BACKCHANNEL_LOGOUT_TOKEN_ERROR.useraction=See the user action for the error that is included in this message.
+
+BACKCHANNEL_LOGOUT_REQUEST_NO_MATCHING_CONFIG=CWWKS1544E: The back-channel logout request is not valid because there is no OpenID Connect client that matches the request.
+BACKCHANNEL_LOGOUT_REQUEST_NO_MATCHING_CONFIG.explanation=The OpenID Connect feature expects the back-channel request URI to include an OpenID Connect client ID to determine which client to log out.
+BACKCHANNEL_LOGOUT_REQUEST_NO_MATCHING_CONFIG.useraction=Verify that the request URI includes the OpenID Connect client ID to use for logging out the user.
+
 # STOP HERE, OIDC SERVER HAS RESERVED 1600 - 1649

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2013, 2021 IBM Corporation and others.
+# Copyright (c) 2013, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -249,5 +249,13 @@ JWT_RESPONSE_STRING_NOT_IN_JWT_FORMAT.useraction=Ensure that the web response is
 ERROR_GETTING_USERINFO_OR_EXTRACTING_CLAIMS=CWWKS1540E: The {0} OpenID Connect client cannot retrieve information about the access token from the UserInfo endpoint: {1}
 ERROR_GETTING_USERINFO_OR_EXTRACTING_CLAIMS.explanation=The response from the UserInfo endpoint might not be in a format that is expected. The OpenID Connect client might have encountered an error while submitting the UserInfo request.
 ERROR_GETTING_USERINFO_OR_EXTRACTING_CLAIMS.useraction=Check the error message for more information. Verify that the content of the UserInfo response matches the Content-Type HTTP header.
+
+BACKCHANNEL_LOGOUT_REQUEST_FAILED=CWWKS1541E: The back-channel logout request sent to [{0}] encountered an error. {1}
+BACKCHANNEL_LOGOUT_REQUEST_FAILED.explanation=The request does not use the HTTP POST method, the request is missing a logout token or the logout token cannot be validated, or the logout request did not complete successfully.
+BACKCHANNEL_LOGOUT_REQUEST_FAILED.useraction=Verify that the HTTP POST method is used to submit the back-channel logout request. Otherwise, see the user action for the error that is included in this message.
+
+BACKCHANNEL_LOGOUT_REQUEST_MISSING_PARAMETER=CWWKS1542E: The back-channel logout request is not valid because the logout_token parameter is missing or empty.
+BACKCHANNEL_LOGOUT_REQUEST_MISSING_PARAMETER.explanation=The back-channel logout request must include a logout_token parameter whose value is a valid logout token.
+BACKCHANNEL_LOGOUT_REQUEST_MISSING_PARAMETER.useraction=Update the request to include a logout token.
 
 # STOP HERE, OIDC SERVER HAS RESERVED 1600 - 1649

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutException.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutException.java
@@ -24,7 +24,11 @@ public class BackchannelLogoutException extends Exception {
     }
 
     public BackchannelLogoutException(String errorMsg) {
-        super(errorMsg);
+        this(errorMsg, HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    public BackchannelLogoutException(String errorMsg, Throwable cause) {
+        super(errorMsg, cause);
         this.responseCode = HttpServletResponse.SC_BAD_REQUEST;
     }
 

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutException.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutException.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.openidconnect.backchannellogout;
+
+import javax.servlet.http.HttpServletResponse;
+
+public class BackchannelLogoutException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    private final int responseCode;
+
+    public BackchannelLogoutException(int responseCode) {
+        super();
+        this.responseCode = responseCode;
+    }
+
+    public BackchannelLogoutException(String errorMsg) {
+        super(errorMsg);
+        this.responseCode = HttpServletResponse.SC_BAD_REQUEST;
+    }
+
+    public BackchannelLogoutException(String errorMsg, int responseCode) {
+        super(errorMsg);
+        this.responseCode = responseCode;
+    }
+
+    public int getResponseCode() {
+        return responseCode;
+    }
+
+}

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutHelper.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutHelper.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.openidconnect.backchannellogout;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.kernel.productinfo.ProductInfo;
+
+public class BackchannelLogoutHelper {
+
+    private static TraceComponent tc = Tr.register(BackchannelLogoutHelper.class);
+
+    public static final String LOGOUT_TOKEN_PARAM_NAME = "logout_token";
+
+    private final HttpServletRequest request;
+    private final HttpServletResponse response;
+
+    public BackchannelLogoutHelper(HttpServletRequest request, HttpServletResponse response) {
+        this.request = request;
+        this.response = response;
+    }
+
+    public void handleBackchannelLogoutRequest() {
+        if (!ProductInfo.getBetaEdition()) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+        String httpMethod = request.getMethod();
+        if (!"POST".equalsIgnoreCase(httpMethod)) {
+            response.setStatus(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+            return;
+        }
+
+        String logoutTokenParameter = request.getParameter(LOGOUT_TOKEN_PARAM_NAME);
+        if (logoutTokenParameter == null || logoutTokenParameter.isEmpty()) {
+            // TODO
+            Tr.formatMessage(tc, "", new Object[] { request.getPathInfo() });
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        // TODO
+
+        response.setHeader("Cache-Control", "no-cache, no-store");
+        response.setHeader("Pragma", "no-cache=");
+    }
+
+}

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutHelper.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutHelper.java
@@ -18,6 +18,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.security.jwt.JwtToken;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.productinfo.ProductInfo;
+import com.ibm.ws.security.openidconnect.clients.common.ConvergedClientConfig;
 
 public class BackchannelLogoutHelper {
 
@@ -27,15 +28,21 @@ public class BackchannelLogoutHelper {
 
     private final HttpServletRequest request;
     private final HttpServletResponse response;
+    private final ConvergedClientConfig clientConfig;
 
-    public BackchannelLogoutHelper(HttpServletRequest request, HttpServletResponse response) {
+    public BackchannelLogoutHelper(HttpServletRequest request, HttpServletResponse response, ConvergedClientConfig clientConfig) {
         this.request = request;
         this.response = response;
+        this.clientConfig = clientConfig;
     }
 
     @FFDCIgnore({ BackchannelLogoutException.class })
     public void handleBackchannelLogoutRequest() {
         try {
+            if (clientConfig == null) {
+                String errorMsg = Tr.formatMessage(tc, "BACKCHANNEL_LOGOUT_REQUEST_NO_MATCHING_CONFIG");
+                throw new BackchannelLogoutException(errorMsg);
+            }
             String logoutTokenParameter = validateRequestAndGetLogoutTokenParameter();
             validateLogoutToken(logoutTokenParameter);
             performLogout();

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidator.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidator.java
@@ -15,7 +15,7 @@ import com.ibm.websphere.security.jwt.JwtToken;
 public class LogoutTokenValidator {
 
     public JwtToken validateToken(String logoutTokenString) throws BackchannelLogoutException {
-        // TODO;
+        // TODO
         return null;
     }
 

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidator.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidator.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.openidconnect.backchannellogout;
+
+import com.ibm.websphere.security.jwt.JwtToken;
+
+public class LogoutTokenValidator {
+
+    public JwtToken validateToken(String logoutTokenString) throws BackchannelLogoutException {
+        // TODO;
+        return null;
+    }
+
+}

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/package-info.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/package-info.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+@TraceOptions(traceGroup = TraceConstants.TRACE_GROUP, messageBundle = TraceConstants.MESSAGE_BUNDLE)
+package com.ibm.ws.security.openidconnect.backchannellogout;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;
+import com.ibm.ws.security.openidconnect.clients.common.TraceConstants;

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
@@ -203,7 +203,7 @@ public class Jose4jUtil {
         return clientConfig.getUseAccessTokenAsIdToken();
     }
 
-    void checkJwtFormatAgainstConfigRequirements(String jwtString, ConvergedClientConfig clientConfig) throws JWTTokenValidationFailedException {
+    public void checkJwtFormatAgainstConfigRequirements(String jwtString, ConvergedClientConfig clientConfig) throws JWTTokenValidationFailedException {
         if (JweHelper.isJwsRequired(clientConfig) && !JweHelper.isJws(jwtString)) {
             String errorMsg = Tr.formatMessage(tc, "OIDC_CLIENT_JWS_REQUIRED_BUT_TOKEN_NOT_JWS", new Object[] { clientConfig.getId() });
             throw new JWTTokenValidationFailedException(errorMsg);

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/token/JsonTokenUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/token/JsonTokenUtil.java
@@ -63,6 +63,10 @@ public class JsonTokenUtil {
         return new Gson().toJson(json);
     }
 
+    public static String toJsonFromObj(Gson gson, Object json) {
+        return gson.toJson(json);
+    }
+
     public static String convertToBase64(String source) {
         return Base64.encodeBase64URLSafeString(StringUtils.getBytesUtf8(source));
     }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutHelperTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutHelperTest.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.openidconnect.backchannellogout;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jmock.Expectations;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.ws.kernel.productinfo.ProductInfo;
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import test.common.SharedOutputManager;
+
+public class BackchannelLogoutHelperTest extends CommonTestClass {
+
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("com.ibm.ws.security.openidconnect.common.*=all=enabled");
+
+    private final String CWWKS1542E_BACKCHANNEL_LOGOUT_REQUEST_MISSING_PARAMETER = "CWWKS1542E";
+    private final String REQUEST_URI = "/oidcclient/backchannel_logout/myClient";
+
+    final HttpServletRequest request = mockery.mock(HttpServletRequest.class);
+    final HttpServletResponse response = mockery.mock(HttpServletResponse.class);
+
+    BackchannelLogoutHelper helper;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+        System.setProperty(ProductInfo.BETA_EDITION_JVM_PROPERTY, "true");
+    }
+
+    @Before
+    public void before() {
+        System.out.println("Entering test: " + testName.getMethodName());
+        helper = new BackchannelLogoutHelper(request, response);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.out.println("Exiting test: " + testName.getMethodName());
+        outputMgr.resetStreams();
+        mockery.assertIsSatisfied();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        System.clearProperty(ProductInfo.BETA_EDITION_JVM_PROPERTY);
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    @Test
+    public void test_handleBackchannelLogoutRequest_error() {
+        mockery.checking(new Expectations() {
+            {
+                one(request).getMethod();
+                will(returnValue("POST"));
+                one(request).getParameter(BackchannelLogoutHelper.LOGOUT_TOKEN_PARAM_NAME);
+                will(returnValue(null));
+                one(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                one(request).getRequestURI();
+                will(returnValue(REQUEST_URI));
+                one(response).setHeader("Cache-Control", "no-cache, no-store");
+                one(response).setHeader("Pragma", "no-cache");
+            }
+        });
+        helper.handleBackchannelLogoutRequest();
+    }
+
+    @Test
+    public void test_validateRequestAndGetLogoutTokenParameter_httpMethodNotPost() {
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    one(request).getMethod();
+                    will(returnValue("GET"));
+                }
+            });
+            String token = helper.validateRequestAndGetLogoutTokenParameter();
+            fail("Should have thrown an exception but didn't. Got token: [" + token + "].");
+        } catch (BackchannelLogoutException e) {
+            assertEquals("Did not get the expected status code in the response. Error message: " + e.getMessage(), HttpServletResponse.SC_METHOD_NOT_ALLOWED, e.getResponseCode());
+        }
+    }
+
+    @Test
+    public void test_validateRequestAndGetLogoutTokenParameter_missingLogoutTokenParameter() {
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    one(request).getMethod();
+                    will(returnValue("POST"));
+                    one(request).getParameter(BackchannelLogoutHelper.LOGOUT_TOKEN_PARAM_NAME);
+                    will(returnValue(null));
+                }
+            });
+            String token = helper.validateRequestAndGetLogoutTokenParameter();
+            fail("Should have thrown an exception but didn't. Got token: [" + token + "].");
+        } catch (BackchannelLogoutException e) {
+            assertEquals("Did not get the expected status code in the response. Error message: " + e.getMessage(), HttpServletResponse.SC_BAD_REQUEST, e.getResponseCode());
+            verifyException(e, CWWKS1542E_BACKCHANNEL_LOGOUT_REQUEST_MISSING_PARAMETER);
+        }
+    }
+
+    @Test
+    public void test_validateRequestAndGetLogoutTokenParameter_emptyLogoutTokenParameter() {
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    one(request).getMethod();
+                    will(returnValue("POST"));
+                    one(request).getParameter(BackchannelLogoutHelper.LOGOUT_TOKEN_PARAM_NAME);
+                    will(returnValue(""));
+                }
+            });
+            String token = helper.validateRequestAndGetLogoutTokenParameter();
+            fail("Should have thrown an exception but didn't. Got token: [" + token + "].");
+        } catch (BackchannelLogoutException e) {
+            assertEquals("Did not get the expected status code in the response. Error message: " + e.getMessage(), HttpServletResponse.SC_BAD_REQUEST, e.getResponseCode());
+            verifyException(e, CWWKS1542E_BACKCHANNEL_LOGOUT_REQUEST_MISSING_PARAMETER);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutHelperTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutHelperTest.java
@@ -24,6 +24,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.ibm.ws.kernel.productinfo.ProductInfo;
+import com.ibm.ws.security.openidconnect.clients.common.ConvergedClientConfig;
 import com.ibm.ws.security.test.common.CommonTestClass;
 
 import test.common.SharedOutputManager;
@@ -37,6 +38,7 @@ public class BackchannelLogoutHelperTest extends CommonTestClass {
 
     final HttpServletRequest request = mockery.mock(HttpServletRequest.class);
     final HttpServletResponse response = mockery.mock(HttpServletResponse.class);
+    final ConvergedClientConfig clientConfig = mockery.mock(ConvergedClientConfig.class);
 
     BackchannelLogoutHelper helper;
 
@@ -49,7 +51,7 @@ public class BackchannelLogoutHelperTest extends CommonTestClass {
     @Before
     public void before() {
         System.out.println("Entering test: " + testName.getMethodName());
-        helper = new BackchannelLogoutHelper(request, response);
+        helper = new BackchannelLogoutHelper(request, response, clientConfig);
     }
 
     @After

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidatorTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidatorTest.java
@@ -17,6 +17,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.ibm.websphere.security.jwt.JwtToken;
+import com.ibm.ws.security.openidconnect.clients.common.ConvergedClientConfig;
 import com.ibm.ws.security.test.common.CommonTestClass;
 
 import test.common.SharedOutputManager;
@@ -24,6 +25,8 @@ import test.common.SharedOutputManager;
 public class LogoutTokenValidatorTest extends CommonTestClass {
 
     static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("com.ibm.ws.security.openidconnect.common.*=all=enabled");
+
+    final ConvergedClientConfig clientConfig = mockery.mock(ConvergedClientConfig.class);
 
     LogoutTokenValidator validator;
 

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidatorTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidatorTest.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.openidconnect.backchannellogout;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.websphere.security.jwt.JwtToken;
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import test.common.SharedOutputManager;
+
+public class LogoutTokenValidatorTest extends CommonTestClass {
+
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("com.ibm.ws.security.openidconnect.common.*=all=enabled");
+
+    LogoutTokenValidator validator;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void before() {
+        System.out.println("Entering test: " + testName.getMethodName());
+        validator = new LogoutTokenValidator();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.out.println("Exiting test: " + testName.getMethodName());
+        outputMgr.resetStreams();
+        mockery.assertIsSatisfied();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    @Test
+    public void test_validateToken_nullString() {
+        String logoutTokenString = null;
+        try {
+            JwtToken result = validator.validateToken(logoutTokenString);
+        } catch (BackchannelLogoutException e) {
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019, 2021 IBM Corporation and others.
+    Copyright (c) 2019, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -78,6 +78,7 @@
          <AD id="protectedEndpoints" name="internal" description="internal use only" required="false" type="String" default="authorize registration app-passwords app-tokens personalTokenManagement usersTokenManagement clientManagement" /> <!-- separated by space -->
          <AD id="requireOpenidScopeForUserInfo" name="internal" description="internal use only" required="false" type="Boolean" default="true" />
          <AD id="oidcEndpoint" name="internal" description="internal use only" required="false" type="String" ibm:type="pid" ibm:reference="com.ibm.ws.security.oidc.endpoint" cardinality="20" />
+         <AD id="backchannelLogoutSupported" name="internal" description="internal use only" required="false" type="Boolean" default="false" />
      </OCD>
 
     <Designate factoryPid="com.ibm.ws.security.openidconnect.server.oidcServerConfig">

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/internal/OidcServerConfigImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/internal/OidcServerConfigImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -109,6 +109,7 @@ public class OidcServerConfigImpl implements OidcServerConfig {
     public static final String CFG_KEY_AUTH_PROXY_ENDPOINT_URL = "authProxyEndpointUrl";
     public static final String CFG_KEY_REQUIRE_OPENID_SCOPE_FOR_USERINFO = "requireOpenidScopeForUserInfo";
     public static final String CFG_KEY_OIDC_ENDPOINT = "oidcEndpoint";
+    public static final String CFG_KEY_BACKCHANNEL_LOGOUT_SUPPORTED = "backchannelLogoutSupported";
 
     public static final String CFG_KEY_JWK_ENABLED = "jwkEnabled";
     public static final String CFG_KEY_JWK_ROTATION = "jwkRotationTime";
@@ -183,6 +184,7 @@ public class OidcServerConfigImpl implements OidcServerConfig {
     private int jwkSigningKeySize = 0;
     private boolean allowLtpaToken2Name = false;
     private boolean requireOpenidScopeForUserInfo = true;
+    private boolean backchannelLogoutSupported = false;
     // End of OIDC Discovery Configuration Metadata
     private OidcEndpointSettings oidcEndpointSettings;
 
@@ -352,6 +354,9 @@ public class OidcServerConfigImpl implements OidcServerConfig {
         if (props.containsKey(CFG_KEY_REQUIRE_OPENID_SCOPE_FOR_USERINFO)) {
             requireOpenidScopeForUserInfo = (Boolean) props.get(CFG_KEY_REQUIRE_OPENID_SCOPE_FOR_USERINFO);
         }
+        if (props.containsKey(CFG_KEY_BACKCHANNEL_LOGOUT_SUPPORTED)) {
+            backchannelLogoutSupported = (Boolean) props.get(CFG_KEY_BACKCHANNEL_LOGOUT_SUPPORTED);
+        }
 
         jwkEnabled = (Boolean) props.get(CFG_KEY_JWK_ENABLED);
         jwkRotationTime = (Long) props.get(CFG_KEY_JWK_ROTATION);
@@ -390,6 +395,7 @@ public class OidcServerConfigImpl implements OidcServerConfig {
             Tr.debug(tc, "jwkEnabled: " + jwkEnabled);
             Tr.debug(tc, "allowLtpaToken2Name: " + this.allowLtpaToken2Name);
             Tr.debug(tc, "cacheIDToken: " + cacheIDToken);
+            Tr.debug(tc, "backchannelLogoutSupported: " + backchannelLogoutSupported);
 
             //TODO: Joe Add debug statements for Discovery Properties
         }
@@ -1128,6 +1134,11 @@ public class OidcServerConfigImpl implements OidcServerConfig {
     @Override
     public boolean isOpenidScopeRequiredForUserInfo() {
         return requireOpenidScopeForUserInfo;
+    }
+
+    @Override
+    public boolean isBackchannelLogoutSupported() {
+        return backchannelLogoutSupported;
     }
 
     /**

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/OIDCAbstractDiscoveryModel.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/OIDCAbstractDiscoveryModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,12 @@ package com.ibm.ws.security.openidconnect.server.plugins;
 
 import java.util.Arrays;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.ibm.ws.security.openidconnect.token.JsonTokenUtil;
+
+import io.openliberty.security.common.serialization.Beta;
+import io.openliberty.security.common.serialization.GsonStrategies;
 
 /**
  * OIDC Discovery Service Bean
@@ -23,6 +28,9 @@ import com.ibm.ws.security.openidconnect.token.JsonTokenUtil;
  * Note that several properties have been commented out because they are currently not being utilized.
  */
 public abstract class OIDCAbstractDiscoveryModel {
+
+    public static final Gson GSON = new GsonBuilder().addSerializationExclusionStrategy(GsonStrategies.BETA_STRATEGY).create();
+
     private String issuer;
     private String authorization_endpoint;
     private String token_endpoint;
@@ -52,6 +60,8 @@ public abstract class OIDCAbstractDiscoveryModel {
     private String users_token_mgmt_endpoint;
     private String client_mgmt_endpoint;
     private String[] code_challenge_methods_supported;
+    @Beta
+    private boolean backchannel_logout_supported;
 
     /**
      * OIDC Properties not utilized in implementation
@@ -481,11 +491,20 @@ public abstract class OIDCAbstractDiscoveryModel {
         this.code_challenge_methods_supported = defensiveCopy(pkceCodeChallengeMethodsSupported);
     }
 
+    public boolean isBackchannelLogoutSupported() {
+        return this.backchannel_logout_supported;
+    }
+
+    public void setBackchannelLogoutSupported(boolean backchannelLogoutSupported) {
+        this.backchannel_logout_supported = backchannelLogoutSupported;
+    }
+
     private String[] defensiveCopy(String[] strArr) {
         return Arrays.copyOf(strArr, strArr.length);
     }
 
     public String toJSONString() {
-        return JsonTokenUtil.toJsonFromObj(this);
+        return JsonTokenUtil.toJsonFromObj(GSON, this);
     }
+
 }

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/OIDCAbstractDiscoveryModel.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/OIDCAbstractDiscoveryModel.java
@@ -14,10 +14,10 @@ import java.util.Arrays;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.ibm.ws.security.oauth20.util.GsonStrategies;
 import com.ibm.ws.security.openidconnect.token.JsonTokenUtil;
 
 import io.openliberty.security.common.serialization.Beta;
-import io.openliberty.security.common.serialization.GsonStrategies;
 
 /**
  * OIDC Discovery Service Bean

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/Discovery.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/Discovery.java
@@ -99,6 +99,8 @@ public class Discovery {
 
         discoveryObj.setPkceCodeChallengeMethodsSupported(OIDCConstants.OIDC_DISC_PKCE_CODE_CHALLENGE_METHODS_SUPPORTED);
 
+        discoveryObj.setBackchannelLogoutSupported(provider.isBackchannelLogoutSupported());
+
         String discoverJSONString = discoveryObj.toJSONString();
 
         if (tc.isDebugEnabled()) {

--- a/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/web/DiscoveryTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/web/DiscoveryTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 
 import com.ibm.ws.security.openidconnect.server.internal.HttpUtils;
+import com.ibm.ws.security.openidconnect.server.plugins.OIDCAbstractDiscoveryModel;
 import com.ibm.ws.security.openidconnect.server.plugins.OIDCWASDiscoveryModel;
 import com.ibm.ws.security.openidconnect.token.JsonTokenUtil;
 import com.ibm.ws.webcontainer.security.openidconnect.OidcServerConfig;
@@ -266,6 +267,8 @@ public class DiscoveryTest {
                 will(returnValue(BACKING_IDP_PREFIX_URI));
                 one(provider).getAuthProxyEndpointUrl();
                 will(returnValue(PROXY_URI));
+                one(provider).isBackchannelLogoutSupported();
+                will(returnValue(false));
             }
         });
 
@@ -274,7 +277,7 @@ public class DiscoveryTest {
 
     private static String getExpectedDiscoveryModelJsonString() {
 
-        return JsonTokenUtil.toJsonFromObj(getExpectedDiscoveryModel());
+        return JsonTokenUtil.toJsonFromObj(OIDCAbstractDiscoveryModel.GSON, getExpectedDiscoveryModel());
 
     }
 

--- a/dev/com.ibm.ws.security.social/resources/com/ibm/ws/security/social/resources/SocialMessages.nlsprops
+++ b/dev/com.ibm.ws.security.social/resources/com/ibm/ws/security/social/resources/SocialMessages.nlsprops
@@ -16,7 +16,7 @@
 #NLS_MESSAGEFORMAT_VAR
 #NLS_ENCODING=UNICODE
 # -------------------------------------------------------------------------------------------------
-# Message prefix block: CWWKS5370 - CWWKS5499
+# Message prefix block: CWWKS5370 - CWWKS5499, CWWKS2350 - CWWKS2399
 ADD_ID={0} ({1})
 ADD_ID.explanation=Internal use only.
 ADD_ID.useraction=No action is required.
@@ -646,3 +646,9 @@ INVALID_CONFIG_PARAM.useraction=Check the missing parameter in the configuration
 OIDC_CLIENT_DISCOVERY_SSL_ERROR=CWWKS5501E: The social login client [{0}] failed to obtain OpenID Connect provider endpoint information through the discovery endpoint URL of [{1}]. Update the configuration for the Social Login (oidcLogin configuration) with the correct HTTPS discovery endpoint URL. 
 OIDC_CLIENT_DISCOVERY_SSL_ERROR.explanation=The oidcLogin configuration is configured to discover the OpenID Connect provider endpoints through the discovery URL, but the discovery process failed. The client is unable to process the authentication requests until the configuration of the discoveryEndpoint is corrected or the discovery is successful.
 OIDC_CLIENT_DISCOVERY_SSL_ERROR.useraction=Correct the oidcLogin configuration to ensure that 1) the discovery endpoint URL refers to the correct OpenID Connect provider, 2) the discovery endpoint URL is HTTPS and 3) the SSL feature and keystore elements are configured correctly with trust for OpenID Connect provider 4) ensure that the OpenID Connect provider discovery endpoint is functional.
+
+# NOTE: Start of new message prefix CWWKS2350 - 2399
+
+BACKCHANNEL_REQUEST_NOT_SUPPORTED_CONFIG=CWWKS2350E: The back-channel logout request sent to [{0}] is not supported by the social media login configuration [{1}].
+BACKCHANNEL_REQUEST_NOT_SUPPORTED_CONFIG.explanation=The social media login configuration is not an OpenID Connect client, so it does not support back-channel logout.
+BACKCHANNEL_REQUEST_NOT_SUPPORTED_CONFIG.useraction=Use the logout endpoint that is appropriate for the social media login configuration.

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/utils/SocialLoginRequest.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/utils/SocialLoginRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corporation and others.
+ * Copyright (c) 2016, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -94,6 +94,10 @@ public class SocialLoginRequest {
 
     public boolean isLogout() {
         return socialUrlType.equals(RequestFilter.LOGOUT);
+    }
+
+    public boolean isBackchannelLogout() {
+        return socialUrlType.equals(RequestFilter.BACKCHANNEL_LOGOUT);
     }
 
     public boolean isWellknownConfig() {

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/web/EndpointServices.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/web/EndpointServices.java
@@ -120,7 +120,8 @@ public class EndpointServices {
             if (tc.isDebugEnabled()) {
                 Tr.debug(tc, "backchannel logout:" + socialLoginRequest.getRequestUrl());
             }
-            handleBackchannelLogoutRequest(request, response);
+            SocialLoginConfig config = socialLoginRequest.getSocialLoginConfig();
+            handleBackchannelLogoutRequest(request, response, config);
         } else if (socialLoginRequest.isWellknownConfig()) {
             // handle /.well-known/config
             if (tc.isDebugEnabled()) {
@@ -387,8 +388,13 @@ public class EndpointServices {
         writeToResponse(json, response);
     }
 
-    protected void handleBackchannelLogoutRequest(HttpServletRequest request, HttpServletResponse response) {
-        BackchannelLogoutHelper logoutHelper = new BackchannelLogoutHelper(request, response);
+    protected void handleBackchannelLogoutRequest(HttpServletRequest request, HttpServletResponse response, SocialLoginConfig config) {
+        if (config != null && !(config instanceof ConvergedClientConfig)) {
+            Tr.error(tc, "BACKCHANNEL_REQUEST_NOT_SUPPORTED_CONFIG", new Object[] { request.getRequestURI(), config.getUniqueId() });
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+        BackchannelLogoutHelper logoutHelper = new BackchannelLogoutHelper(request, response, (ConvergedClientConfig) config);
         logoutHelper.handleBackchannelLogoutRequest();
     }
 

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/web/RequestFilter.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/web/RequestFilter.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 
 package com.ibm.ws.security.social.web;
@@ -39,10 +39,9 @@ public class RequestFilter implements Filter {
             TraceConstants.TRACE_GROUP,
             TraceConstants.MESSAGE_BUNDLE);
     public static final String REDIRECT = "/redirect/";
-    public static final int REDIRECT_LEN = REDIRECT.length();
     public static final String WELLKNOWN_CONFIG = "/.well-known/configuration";
     public static final String LOGOUT = "/logout";
-    public static final String BACKCHANNEL_LOGOUT = "/backchannel_logout";
+    public static final String BACKCHANNEL_LOGOUT = "/backchannel_logout/";
     public static final String UNKNOWN = "UNKNOWN";
 
     /**
@@ -69,32 +68,36 @@ public class RequestFilter implements Filter {
         SocialLoginRequest socialLoginRequest = null;
         String pathInfo = request.getPathInfo();
         if (pathInfo.startsWith(REDIRECT)) {
-            String provider = pathInfo.substring(REDIRECT_LEN);
-            SocialLoginConfig socialLoginConfig = RequestUtil.getSocialLoginConfig(provider);
-            if (socialLoginConfig != null) {
-                if (tc.isDebugEnabled()) {
-                    Tr.debug(tc, "doFilter redirect providerId:" + socialLoginConfig.getUniqueId());
-                }
-                socialLoginRequest = new SocialLoginRequest(socialLoginConfig, REDIRECT, request, response);
-            } else {
-                // note that if we could not get a socialLoginConfig, we will try to dig the error out when we handle the redirect.
-                // in EndpointServices.
-                if (tc.isDebugEnabled()) {
-                    Tr.debug(tc, "Failed to find a social login configuration for ID [" + provider + "]");
-                }
-                socialLoginRequest = new SocialLoginRequest(REDIRECT, request, response);
-            }
+            socialLoginRequest = createSocialLoginRequestWithAssociatedConfig(request, response, pathInfo, REDIRECT);
         } else if (pathInfo.startsWith(WELLKNOWN_CONFIG)) {
             socialLoginRequest = new SocialLoginRequest(WELLKNOWN_CONFIG, request, response);
         } else if (pathInfo.startsWith(LOGOUT)) {
             socialLoginRequest = new SocialLoginRequest(LOGOUT, request, response);
         } else if (pathInfo.startsWith(BACKCHANNEL_LOGOUT)) {
-            socialLoginRequest = new SocialLoginRequest(BACKCHANNEL_LOGOUT, request, response);
+            socialLoginRequest = createSocialLoginRequestWithAssociatedConfig(request, response, pathInfo, BACKCHANNEL_LOGOUT);
         } else {
             socialLoginRequest = new SocialLoginRequest(UNKNOWN, request, response);
         }
         request.setAttribute(Constants.ATTRIBUTE_SOCIALMEDIA_REQUEST, socialLoginRequest);
         chain.doFilter(request, response);
+    }
+
+    protected SocialLoginRequest createSocialLoginRequestWithAssociatedConfig(HttpServletRequest request, HttpServletResponse response, String pathInfo, String requestType) {
+        String provider = pathInfo.substring(requestType.length());
+        SocialLoginConfig socialLoginConfig = RequestUtil.getSocialLoginConfig(provider);
+        if (socialLoginConfig != null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "doFilter redirect providerId:" + socialLoginConfig.getUniqueId());
+            }
+            return new SocialLoginRequest(socialLoginConfig, requestType, request, response);
+        } else {
+            // note that if we could not get a socialLoginConfig, we will try to dig the error out when we handle the request
+            // in EndpointServices.
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Failed to find a social login configuration for ID [" + provider + "]");
+            }
+            return new SocialLoginRequest(requestType, request, response);
+        }
     }
 
     protected String getProviderNameFromUrl(Matcher m) {

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/web/RequestFilter.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/web/RequestFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2018 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -42,6 +42,7 @@ public class RequestFilter implements Filter {
     public static final int REDIRECT_LEN = REDIRECT.length();
     public static final String WELLKNOWN_CONFIG = "/.well-known/configuration";
     public static final String LOGOUT = "/logout";
+    public static final String BACKCHANNEL_LOGOUT = "/backchannel_logout";
     public static final String UNKNOWN = "UNKNOWN";
 
     /**
@@ -87,6 +88,8 @@ public class RequestFilter implements Filter {
             socialLoginRequest = new SocialLoginRequest(WELLKNOWN_CONFIG, request, response);
         } else if (pathInfo.startsWith(LOGOUT)) {
             socialLoginRequest = new SocialLoginRequest(LOGOUT, request, response);
+        } else if (pathInfo.startsWith(BACKCHANNEL_LOGOUT)) {
+            socialLoginRequest = new SocialLoginRequest(BACKCHANNEL_LOGOUT, request, response);
         } else {
             socialLoginRequest = new SocialLoginRequest(UNKNOWN, request, response);
         }

--- a/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/web/EndpointServicesTest.java
+++ b/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/web/EndpointServicesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 IBM Corporation and others.
+ * Copyright (c) 2016, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -466,6 +466,8 @@ public class EndpointServicesTest extends CommonTestClass {
                     will(returnValue(false));
                     one(socialLoginRequest).isLogout();
                     will(returnValue(false));
+                    one(socialLoginRequest).isBackchannelLogout();
+                    will(returnValue(false));
                     one(socialLoginRequest).isWellknownConfig();
                     will(returnValue(true));
                     one(socialLoginRequest).getRequestUrl();
@@ -490,6 +492,8 @@ public class EndpointServicesTest extends CommonTestClass {
                     one(socialLoginRequest).isRedirect();
                     will(returnValue(false));
                     one(socialLoginRequest).isLogout();
+                    will(returnValue(false));
+                    one(socialLoginRequest).isBackchannelLogout();
                     will(returnValue(false));
                     one(socialLoginRequest).isWellknownConfig();
                     will(returnValue(false));
@@ -523,6 +527,8 @@ public class EndpointServicesTest extends CommonTestClass {
                     one(socialLoginRequest).isRedirect();
                     will(returnValue(false));
                     one(socialLoginRequest).isLogout();
+                    will(returnValue(false));
+                    one(socialLoginRequest).isBackchannelLogout();
                     will(returnValue(false));
                     one(socialLoginRequest).isWellknownConfig();
                     will(returnValue(false));

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/openidconnect/OidcServerConfig.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/openidconnect/OidcServerConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -135,5 +135,7 @@ public interface OidcServerConfig {
     String getKeyStoreRef();
 
     String getKeyAliasName();
+
+    boolean isBackchannelLogoutSupported();
 
 }


### PR DESCRIPTION
- Adds support for the following OAuth client registration properties:
    - `backchannel_logout_uri`
    - `backchannel_logout_session_required`
- Adds support for the following OP discovery document property:
    - `backchannel_logout_supported`
    
    All of those properties are beta-guarded, so the OAuth client properties should not show up in client registration requests and should not be able to be registered, and the OP discovery document should not include the new property unless the server is running in beta mode.

- Adds the OP config attribute:
    - `backchannelLogoutSupported`
- Adds support for the `/backchannel_logout/*` endpoint in the OIDC and social RPs
    - Can only be accessed through HTTP POST calls
    - Verifies that a non-empty `logout_token` parameter is provided (not other validation done yet)
- Lays the groundwork for logout token validation and performing logout actions

For #20058
For #20059
For #20060