### PR TITLE
Remove Java Security support with Java 18+, as per OLGH#20289

### DIFF
--- a/dev/com.ibm.ws.security.auth.data_fat/fat/src/com/ibm/ws/security/auth/data/fat/Java2SecurityTest.java
+++ b/dev/com.ibm.ws.security.auth.data_fat/fat/src/com/ibm/ws/security/auth/data/fat/Java2SecurityTest.java
@@ -20,6 +20,7 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -29,6 +30,7 @@ import componenttest.topology.utils.FATServletClient;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
+@MaximumJavaLevel(javaLevel = 17)
 public class Java2SecurityTest extends FATServletClient {
 
     private final Class<Java2SecurityTest> thisClass = Java2SecurityTest.class;

--- a/dev/com.ibm.ws.security.client_fat/fat/src/com/ibm/ws/security/client/fat/Java2Test.java
+++ b/dev/com.ibm.ws.security.client_fat/fat/src/com/ibm/ws/security/client/fat/Java2Test.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -31,384 +32,386 @@ import componenttest.topology.impl.LibertyClientFactory;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
+@MaximumJavaLevel(javaLevel = 17)
 public class Java2Test extends CommonTest {
-	private static final Class<?> c = Java2Test.class;
+    private static final Class<?> c = Java2Test.class;
 
-	public static final String JAVA2_CLIENT = "java2Client";
-	public static final String SET_PROPERTY_OPERATION = "setProperty";
-	public static final String GET_PROPERTY_OPERATION = "getProperty";
-	public static final String READ_FILE_OPERATION = "readFile";
-	public static final String WRITE_FILE_OPERATION = "writeFile";
-	public static final String ACCESS_DENIED = "access denied";
+    public static final String JAVA2_CLIENT = "java2Client";
+    public static final String SET_PROPERTY_OPERATION = "setProperty";
+    public static final String GET_PROPERTY_OPERATION = "getProperty";
+    public static final String READ_FILE_OPERATION = "readFile";
+    public static final String WRITE_FILE_OPERATION = "writeFile";
+    public static final String ACCESS_DENIED = "access denied";
 
-	/**
-	 * Test description:
-	 * - start the client which will attempt to read a file.
-	 *   Neither client.xml nor the ear have permissions defined.
-	 * 
-	 * Expected results:
-	 * - We should see access denied
-	 */
-	@Mode(TestMode.LITE)
-	@Test
-	public void testReadFileNoPermissions() {
-		testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
-		List<String> startParms = new ArrayList<String>();
-		startParms.add("--");
-		startParms.add(READ_FILE_OPERATION);
-		startParms.add(testClient.getClientRoot() + File.separator + "test.txt");
-		try {
-			String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_no_perms.xml");
-			Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
-			copyNewClientConfig(fullClientXmlPath);
-			Log.info(c, name.getMethodName(), "Starting the client ...");
-			ProgramOutput programOutput = testClient.startClientWithArgs(true,true,true,false,"run",startParms,false);
-			Log.info(c, name.getMethodName(), "Client returned.");
-			String output = programOutput.getStdout();
-			assertTrue("Did not get access denied.", output.contains(ACCESS_DENIED));
-			assertNoErrMessages(output);
-		} catch (Exception e) {
-			Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
-			fail("Exception was thrown: " + e);
-		}
-	}
+    /**
+     * Test description:
+     * - start the client which will attempt to read a file.
+     * Neither client.xml nor the ear have permissions defined.
+     * 
+     * Expected results:
+     * - We should see access denied
+     */
+    @Mode(TestMode.LITE)
+    @Test
+    public void testReadFileNoPermissions() {
+        testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
+        List<String> startParms = new ArrayList<String>();
+        startParms.add("--");
+        startParms.add(READ_FILE_OPERATION);
+        startParms.add(testClient.getClientRoot() + File.separator + "test.txt");
+        try {
+            String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_no_perms.xml");
+            Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
+            copyNewClientConfig(fullClientXmlPath);
+            Log.info(c, name.getMethodName(), "Starting the client ...");
+            ProgramOutput programOutput = testClient.startClientWithArgs(true, true, true, false, "run", startParms, false);
+            Log.info(c, name.getMethodName(), "Client returned.");
+            String output = programOutput.getStdout();
+            assertTrue("Did not get access denied.", output.contains(ACCESS_DENIED));
+            assertNoErrMessages(output);
+        } catch (Exception e) {
+            Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
+            fail("Exception was thrown: " + e);
+        }
+    }
 
-	/**
-	 * Test description:
-	 * - start the client which will attempt to write to a file.
-	 *   Neither client.xml nor the ear have permissions defined.
-	 * 
-	 * Expected results:
-	 * - We should see access denied
-	 */
-	@Test
-	public void testWriteFileNoPermissions() {
-		testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
-		List<String> startParms = new ArrayList<String>();
-		startParms.add("--");
-		startParms.add(WRITE_FILE_OPERATION);
-		startParms.add(testClient.getClientRoot() + File.separator + "test.txt");
-		try {
-			String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_no_perms.xml");
-			Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
-			copyNewClientConfig(fullClientXmlPath);
-			Log.info(c, name.getMethodName(), "Starting the client ...");
-			ProgramOutput programOutput = testClient.startClientWithArgs(true,true,true,false,"run",startParms,false);
-			Log.info(c, name.getMethodName(), "Client returned.");
-			String output = programOutput.getStdout();
-			assertTrue("Did not get access denied.", output.contains(ACCESS_DENIED));
-			assertNoErrMessages(output);
-		} catch (Exception e) {
-			Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
-			fail("Exception was thrown: " + e);
-		}
-	}
+    /**
+     * Test description:
+     * - start the client which will attempt to write to a file.
+     * Neither client.xml nor the ear have permissions defined.
+     * 
+     * Expected results:
+     * - We should see access denied
+     */
+    @Test
+    public void testWriteFileNoPermissions() {
+        testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
+        List<String> startParms = new ArrayList<String>();
+        startParms.add("--");
+        startParms.add(WRITE_FILE_OPERATION);
+        startParms.add(testClient.getClientRoot() + File.separator + "test.txt");
+        try {
+            String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_no_perms.xml");
+            Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
+            copyNewClientConfig(fullClientXmlPath);
+            Log.info(c, name.getMethodName(), "Starting the client ...");
+            ProgramOutput programOutput = testClient.startClientWithArgs(true, true, true, false, "run", startParms, false);
+            Log.info(c, name.getMethodName(), "Client returned.");
+            String output = programOutput.getStdout();
+            assertTrue("Did not get access denied.", output.contains(ACCESS_DENIED));
+            assertNoErrMessages(output);
+        } catch (Exception e) {
+            Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
+            fail("Exception was thrown: " + e);
+        }
+    }
 
-	/**
-	 * Test description:
-	 * - start the client which will attempt to get a system property.
-	 *   Neither client.xml nor the ear have permissions defined.
-	 * 
-	 * Expected results:
-	 * - We should see access denied
-	 */
-	@Test
-	public void testGetPropertyNoPermissions() {
-		testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
-		List<String> startParms = new ArrayList<String>();
-		startParms.add("--");
-		startParms.add(GET_PROPERTY_OPERATION);
-		System.setProperty("bob", "bob");
-		try {
-			String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_no_perms.xml");
-			Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
-			copyNewClientConfig(fullClientXmlPath);
-			Log.info(c, name.getMethodName(), "Starting the client ...");
-			ProgramOutput programOutput = testClient.startClientWithArgs(true,true,true,false,"run",startParms,false);
-			Log.info(c, name.getMethodName(), "Client returned.");
-			String output = programOutput.getStdout();
-			assertTrue("Did not get access denied.", output.contains(ACCESS_DENIED));
-			assertNoErrMessages(output);
-		} catch (Exception e) {
-			Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
-			fail("Exception was thrown: " + e);
-		}
-	}
+    /**
+     * Test description:
+     * - start the client which will attempt to get a system property.
+     * Neither client.xml nor the ear have permissions defined.
+     * 
+     * Expected results:
+     * - We should see access denied
+     */
+    @Test
+    public void testGetPropertyNoPermissions() {
+        testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
+        List<String> startParms = new ArrayList<String>();
+        startParms.add("--");
+        startParms.add(GET_PROPERTY_OPERATION);
+        System.setProperty("bob", "bob");
+        try {
+            String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_no_perms.xml");
+            Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
+            copyNewClientConfig(fullClientXmlPath);
+            Log.info(c, name.getMethodName(), "Starting the client ...");
+            ProgramOutput programOutput = testClient.startClientWithArgs(true, true, true, false, "run", startParms, false);
+            Log.info(c, name.getMethodName(), "Client returned.");
+            String output = programOutput.getStdout();
+            assertTrue("Did not get access denied.", output.contains(ACCESS_DENIED));
+            assertNoErrMessages(output);
+        } catch (Exception e) {
+            Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
+            fail("Exception was thrown: " + e);
+        }
+    }
 
-	/**
-	 * Test description:
-	 * - start the client which will attempt to get a system property.
-	 *   Neither client.xml nor the ear have permissions defined.
-	 * 
-	 * Expected results:
-	 * - We should see access denied
-	 */
-	@Test
-	public void testSetPropertyNoPermissions() {
-		testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
-		List<String> startParms = new ArrayList<String>();
-		startParms.add("--");
-		startParms.add(SET_PROPERTY_OPERATION);
-		try {
-			String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_no_perms.xml");
-			Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
-			copyNewClientConfig(fullClientXmlPath);
-			Log.info(c, name.getMethodName(), "Starting the client ...");
-			ProgramOutput programOutput = testClient.startClientWithArgs(true,true,true,false,"run",startParms,false);
-			Log.info(c, name.getMethodName(), "Client returned.");
-			String output = programOutput.getStdout();
-			assertTrue("Did not get access denied.", output.contains(ACCESS_DENIED));
-			assertNoErrMessages(output);
-		} catch (Exception e) {
-			Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
-			fail("Exception was thrown: " + e);
-		}
-	}
+    /**
+     * Test description:
+     * - start the client which will attempt to get a system property.
+     * Neither client.xml nor the ear have permissions defined.
+     * 
+     * Expected results:
+     * - We should see access denied
+     */
+    @Test
+    public void testSetPropertyNoPermissions() {
+        testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
+        List<String> startParms = new ArrayList<String>();
+        startParms.add("--");
+        startParms.add(SET_PROPERTY_OPERATION);
+        try {
+            String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_no_perms.xml");
+            Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
+            copyNewClientConfig(fullClientXmlPath);
+            Log.info(c, name.getMethodName(), "Starting the client ...");
+            ProgramOutput programOutput = testClient.startClientWithArgs(true, true, true, false, "run", startParms, false);
+            Log.info(c, name.getMethodName(), "Client returned.");
+            String output = programOutput.getStdout();
+            assertTrue("Did not get access denied.", output.contains(ACCESS_DENIED));
+            assertNoErrMessages(output);
+        } catch (Exception e) {
+            Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
+            fail("Exception was thrown: " + e);
+        }
+    }
 
-	/**
-	 * Test description:
-	 * - start the client which will attempt to read a file.
-	 *   client.xml has no permissions defined, the ear has permissions.xml.
-	 * 
-	 * Expected results:
-	 * - We should see the file read successfully
-	 */
-	@Test
-	public void testReadFileWithPermissionsXML() {
-		testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
-		List<String> startParms = new ArrayList<String>();
-		startParms.add("--");
-		startParms.add(READ_FILE_OPERATION);
-		startParms.add(testClient.getClientRoot() + File.separator + "test.txt");
-		try {
-			String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_app_perms.xml");
-			Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
-			copyNewClientConfig(fullClientXmlPath);
-			Log.info(c, name.getMethodName(), "Starting the client ...");
-			ProgramOutput programOutput = testClient.startClientWithArgs(true,true,true,false,"run",startParms,false);
-			Log.info(c, name.getMethodName(), "Client returned.");
-			String output = programOutput.getStdout();
-			assertTrue("File was not successfully read.", output.contains("file read"));
-			assertNoErrMessages(output);
-		} catch (Exception e) {
-			Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
-			fail("Exception was thrown: " + e);
-		}
-	}
+    /**
+     * Test description:
+     * - start the client which will attempt to read a file.
+     * client.xml has no permissions defined, the ear has permissions.xml.
+     * 
+     * Expected results:
+     * - We should see the file read successfully
+     */
+    @Test
+    public void testReadFileWithPermissionsXML() {
+        testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
+        List<String> startParms = new ArrayList<String>();
+        startParms.add("--");
+        startParms.add(READ_FILE_OPERATION);
+        startParms.add(testClient.getClientRoot() + File.separator + "test.txt");
+        try {
+            String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_app_perms.xml");
+            Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
+            copyNewClientConfig(fullClientXmlPath);
+            Log.info(c, name.getMethodName(), "Starting the client ...");
+            ProgramOutput programOutput = testClient.startClientWithArgs(true, true, true, false, "run", startParms, false);
+            Log.info(c, name.getMethodName(), "Client returned.");
+            String output = programOutput.getStdout();
+            assertTrue("File was not successfully read.", output.contains("file read"));
+            assertNoErrMessages(output);
+        } catch (Exception e) {
+            Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
+            fail("Exception was thrown: " + e);
+        }
+    }
 
-	/**
-	 * Test description:
-	 * - start the client which will attempt to write to a file.
-	 *   client.xml has no permissions defined, the ear has permissions.xml.
-	 * 
-	 * Expected results:
-	 * - We should see the file written to successfully
-	 */
-	@Mode(TestMode.LITE)
-	@Test
-	public void testWriteFileWithPermissionsXML() {
-		testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
-		List<String> startParms = new ArrayList<String>();
-		startParms.add("--");
-		startParms.add(WRITE_FILE_OPERATION);
-		startParms.add(testClient.getClientRoot() + File.separator + "test.txt");
-		try {
-			String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_app_perms.xml");
-			Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
-			copyNewClientConfig(fullClientXmlPath);
-			Log.info(c, name.getMethodName(), "Starting the client ...");
-			ProgramOutput programOutput = testClient.startClientWithArgs(true,true,true,false,"run",startParms,false);
-			Log.info(c, name.getMethodName(), "Client returned.");
-			String output = programOutput.getStdout();
-			assertTrue("File was not successfully written.", output.contains("file written"));
-			assertNoErrMessages(output);
-		} catch (Exception e) {
-			Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
-			fail("Exception was thrown: " + e);
-		}
-	}
+    /**
+     * Test description:
+     * - start the client which will attempt to write to a file.
+     * client.xml has no permissions defined, the ear has permissions.xml.
+     * 
+     * Expected results:
+     * - We should see the file written to successfully
+     */
+    @Mode(TestMode.LITE)
+    @Test
+    public void testWriteFileWithPermissionsXML() {
+        testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
+        List<String> startParms = new ArrayList<String>();
+        startParms.add("--");
+        startParms.add(WRITE_FILE_OPERATION);
+        startParms.add(testClient.getClientRoot() + File.separator + "test.txt");
+        try {
+            String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_app_perms.xml");
+            Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
+            copyNewClientConfig(fullClientXmlPath);
+            Log.info(c, name.getMethodName(), "Starting the client ...");
+            ProgramOutput programOutput = testClient.startClientWithArgs(true, true, true, false, "run", startParms, false);
+            Log.info(c, name.getMethodName(), "Client returned.");
+            String output = programOutput.getStdout();
+            assertTrue("File was not successfully written.", output.contains("file written"));
+            assertNoErrMessages(output);
+        } catch (Exception e) {
+            Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
+            fail("Exception was thrown: " + e);
+        }
+    }
 
-	/**
-	 * Test description:
-	 * - start the client which will attempt to get a system property.
-	 *   client.xml has no permissions defined, the ear has permissions.xml.
-	 * 
-	 * Expected results:
-	 * - We should see the property read successfully
-	 */
-	@Test
-	public void testGetPropertyWithPermissionsXML() {
-		testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
-		List<String> startParms = new ArrayList<String>();
-		startParms.add("--");
-		startParms.add(GET_PROPERTY_OPERATION);
-		System.setProperty("bob", "bob");
-		try {
-			String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_app_perms.xml");
-			Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
-			copyNewClientConfig(fullClientXmlPath);
-			Log.info(c, name.getMethodName(), "Starting the client ...");
-			ProgramOutput programOutput = testClient.startClientWithArgs(true,true,true,false,"run",startParms,false);
-			Log.info(c, name.getMethodName(), "Client returned.");
-			String output = programOutput.getStdout();
-			assertTrue("Property was not successfully read.", output.contains("property bob value "));
-			assertNoErrMessages(output);
-		} catch (Exception e) {
-			Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
-			fail("Exception was thrown: " + e);
-		}
-	}
+    /**
+     * Test description:
+     * - start the client which will attempt to get a system property.
+     * client.xml has no permissions defined, the ear has permissions.xml.
+     * 
+     * Expected results:
+     * - We should see the property read successfully
+     */
+    @Test
+    public void testGetPropertyWithPermissionsXML() {
+        testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
+        List<String> startParms = new ArrayList<String>();
+        startParms.add("--");
+        startParms.add(GET_PROPERTY_OPERATION);
+        System.setProperty("bob", "bob");
+        try {
+            String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_app_perms.xml");
+            Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
+            copyNewClientConfig(fullClientXmlPath);
+            Log.info(c, name.getMethodName(), "Starting the client ...");
+            ProgramOutput programOutput = testClient.startClientWithArgs(true, true, true, false, "run", startParms, false);
+            Log.info(c, name.getMethodName(), "Client returned.");
+            String output = programOutput.getStdout();
+            assertTrue("Property was not successfully read.", output.contains("property bob value "));
+            assertNoErrMessages(output);
+        } catch (Exception e) {
+            Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
+            fail("Exception was thrown: " + e);
+        }
+    }
 
-	/**
-	 * Test description:
-	 * - start the client which will attempt to set a system property.
-	 *   client.xml has no permissions defined, the ear has permissions.xml.
-	 * 
-	 * Expected results:
-	 * - We should see the property set successfully
-	 */
-	@Test
-	public void testSetPropertyWithPermissionsXML() {
-		testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
-		List<String> startParms = new ArrayList<String>();
-		startParms.add("--");
-		startParms.add(SET_PROPERTY_OPERATION);
-		try {
-			String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_app_perms.xml");
-			Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
-			copyNewClientConfig(fullClientXmlPath);
-			Log.info(c, name.getMethodName(), "Starting the client ...");
-			ProgramOutput programOutput = testClient.startClientWithArgs(true,true,true,false,"run",startParms,false);
-			Log.info(c, name.getMethodName(), "Client returned.");
-			String output = programOutput.getStdout();
-			assertTrue("Property was not successfully set.", output.contains("property bob set to: phil"));
-			assertNoErrMessages(output);
-		} catch (Exception e) {
-			Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
-			fail("Exception was thrown: " + e);
-		}
-	}
-	/**
-	 * Test description:
-	 * - start the client which will attempt to read a file.
-	 *   client.xml has permissions defined, the ear has no permissions.xml.
-	 * 
-	 * Expected results:
-	 * - We should see the file read successfully
-	 */
-	@Test
-	public void testReadFileWithClientXMLPermissions() {
-		testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
-		List<String> startParms = new ArrayList<String>();
-		startParms.add("--");
-		startParms.add(READ_FILE_OPERATION);
-		startParms.add(testClient.getClientRoot() + File.separator + "test.txt");
-		try {
-			String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_xml_perms.xml");
-			Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
-			copyNewClientConfig(fullClientXmlPath);
-			Log.info(c, name.getMethodName(), "Starting the client ...");
-			ProgramOutput programOutput = testClient.startClientWithArgs(true,true,true,false,"run",startParms,false);
-			Log.info(c, name.getMethodName(), "Client returned.");
-			String output = programOutput.getStdout();
-			assertTrue("File was not successfully read.", output.contains("file read"));
-			assertNoErrMessages(output);
-		} catch (Exception e) {
-			Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
-			fail("Exception was thrown: " + e);
-		}
-	}
+    /**
+     * Test description:
+     * - start the client which will attempt to set a system property.
+     * client.xml has no permissions defined, the ear has permissions.xml.
+     * 
+     * Expected results:
+     * - We should see the property set successfully
+     */
+    @Test
+    public void testSetPropertyWithPermissionsXML() {
+        testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
+        List<String> startParms = new ArrayList<String>();
+        startParms.add("--");
+        startParms.add(SET_PROPERTY_OPERATION);
+        try {
+            String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_app_perms.xml");
+            Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
+            copyNewClientConfig(fullClientXmlPath);
+            Log.info(c, name.getMethodName(), "Starting the client ...");
+            ProgramOutput programOutput = testClient.startClientWithArgs(true, true, true, false, "run", startParms, false);
+            Log.info(c, name.getMethodName(), "Client returned.");
+            String output = programOutput.getStdout();
+            assertTrue("Property was not successfully set.", output.contains("property bob set to: phil"));
+            assertNoErrMessages(output);
+        } catch (Exception e) {
+            Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
+            fail("Exception was thrown: " + e);
+        }
+    }
 
-	/**
-	 * Test description:
-	 * - start the client which will attempt to write to a file.
-	 *   client.xml has permissions defined, the ear has no permissions.xml.
-	 * 
-	 * Expected results:
-	 * - We should see the file written to successfully
-	 */
-	@Test
-	public void testWriteFileWithClientXMLPermissions() {
-		testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
-		List<String> startParms = new ArrayList<String>();
-		startParms.add("--");
-		startParms.add(WRITE_FILE_OPERATION);
-		startParms.add(testClient.getClientRoot() + File.separator + "test.txt");
-		try {
-			String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_xml_perms.xml");
-			Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
-			copyNewClientConfig(fullClientXmlPath);
-			Log.info(c, name.getMethodName(), "Starting the client ...");
-			ProgramOutput programOutput = testClient.startClientWithArgs(true,true,true,false,"run",startParms,false);
-			Log.info(c, name.getMethodName(), "Client returned.");
-			String output = programOutput.getStdout();
-			assertTrue("File was not successfully written.", output.contains("file written"));
-			assertNoErrMessages(output);
-		} catch (Exception e) {
-			Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
-			fail("Exception was thrown: " + e);
-		}
-	}
+    /**
+     * Test description:
+     * - start the client which will attempt to read a file.
+     * client.xml has permissions defined, the ear has no permissions.xml.
+     * 
+     * Expected results:
+     * - We should see the file read successfully
+     */
+    @Test
+    public void testReadFileWithClientXMLPermissions() {
+        testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
+        List<String> startParms = new ArrayList<String>();
+        startParms.add("--");
+        startParms.add(READ_FILE_OPERATION);
+        startParms.add(testClient.getClientRoot() + File.separator + "test.txt");
+        try {
+            String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_xml_perms.xml");
+            Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
+            copyNewClientConfig(fullClientXmlPath);
+            Log.info(c, name.getMethodName(), "Starting the client ...");
+            ProgramOutput programOutput = testClient.startClientWithArgs(true, true, true, false, "run", startParms, false);
+            Log.info(c, name.getMethodName(), "Client returned.");
+            String output = programOutput.getStdout();
+            assertTrue("File was not successfully read.", output.contains("file read"));
+            assertNoErrMessages(output);
+        } catch (Exception e) {
+            Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
+            fail("Exception was thrown: " + e);
+        }
+    }
 
-	/**
-	 * Test description:
-	 * - start the client which will attempt to get a system property.
-	 *   client.xml has permissions defined, the ear has no permissions.xml.
-	 * 
-	 * Expected results:
-	 * - We should see the property read successfully
-	 */
-	@Test
-	public void testGetPropertyWithClientXMLPermissions() {
-		testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
-		List<String> startParms = new ArrayList<String>();
-		startParms.add("--");
-		startParms.add(GET_PROPERTY_OPERATION);
-		System.setProperty("bob", "bob");
-		try {
-			String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_xml_perms.xml");
-			Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
-			copyNewClientConfig(fullClientXmlPath);
-			Log.info(c, name.getMethodName(), "Starting the client ...");
-			ProgramOutput programOutput = testClient.startClientWithArgs(true,true,true,false,"run",startParms,false);
-			Log.info(c, name.getMethodName(), "Client returned.");
-			String output = programOutput.getStdout();
-			assertTrue("Property was not successfully read.", output.contains("property bob value "));
-			assertNoErrMessages(output);
-		} catch (Exception e) {
-			Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
-			fail("Exception was thrown: " + e);
-		}
-	}
+    /**
+     * Test description:
+     * - start the client which will attempt to write to a file.
+     * client.xml has permissions defined, the ear has no permissions.xml.
+     * 
+     * Expected results:
+     * - We should see the file written to successfully
+     */
+    @Test
+    public void testWriteFileWithClientXMLPermissions() {
+        testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
+        List<String> startParms = new ArrayList<String>();
+        startParms.add("--");
+        startParms.add(WRITE_FILE_OPERATION);
+        startParms.add(testClient.getClientRoot() + File.separator + "test.txt");
+        try {
+            String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_xml_perms.xml");
+            Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
+            copyNewClientConfig(fullClientXmlPath);
+            Log.info(c, name.getMethodName(), "Starting the client ...");
+            ProgramOutput programOutput = testClient.startClientWithArgs(true, true, true, false, "run", startParms, false);
+            Log.info(c, name.getMethodName(), "Client returned.");
+            String output = programOutput.getStdout();
+            assertTrue("File was not successfully written.", output.contains("file written"));
+            assertNoErrMessages(output);
+        } catch (Exception e) {
+            Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
+            fail("Exception was thrown: " + e);
+        }
+    }
 
-	/**
-	 * Test description:
-	 * - start the client which will attempt to set a system property.
-	 *   client.xml has permissions defined, the ear has no permissions.xml.
-	 * 
-	 * Expected results:
-	 * - We should see the property set successfully
-	 */
-	@Test
-	public void testSetPropertyWithClientXMLPermissions() {
-		testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
-		List<String> startParms = new ArrayList<String>();
-		startParms.add("--");
-		startParms.add(SET_PROPERTY_OPERATION);
-		try {
-			String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_xml_perms.xml");
-			Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
-			copyNewClientConfig(fullClientXmlPath);
-			Log.info(c, name.getMethodName(), "Starting the client ...");
-			ProgramOutput programOutput = testClient.startClientWithArgs(true,true,true,false,"run",startParms,false);
-			Log.info(c, name.getMethodName(), "Client returned.");
-			String output = programOutput.getStdout();
-			assertTrue("Property was not successfully set.", output.contains("property bob set to: phil"));
-			assertNoErrMessages(output);
-		} catch (Exception e) {
-			Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
-			fail("Exception was thrown: " + e);
-		}
-	}
+    /**
+     * Test description:
+     * - start the client which will attempt to get a system property.
+     * client.xml has permissions defined, the ear has no permissions.xml.
+     * 
+     * Expected results:
+     * - We should see the property read successfully
+     */
+    @Test
+    public void testGetPropertyWithClientXMLPermissions() {
+        testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
+        List<String> startParms = new ArrayList<String>();
+        startParms.add("--");
+        startParms.add(GET_PROPERTY_OPERATION);
+        System.setProperty("bob", "bob");
+        try {
+            String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_xml_perms.xml");
+            Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
+            copyNewClientConfig(fullClientXmlPath);
+            Log.info(c, name.getMethodName(), "Starting the client ...");
+            ProgramOutput programOutput = testClient.startClientWithArgs(true, true, true, false, "run", startParms, false);
+            Log.info(c, name.getMethodName(), "Client returned.");
+            String output = programOutput.getStdout();
+            assertTrue("Property was not successfully read.", output.contains("property bob value "));
+            assertNoErrMessages(output);
+        } catch (Exception e) {
+            Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
+            fail("Exception was thrown: " + e);
+        }
+    }
+
+    /**
+     * Test description:
+     * - start the client which will attempt to set a system property.
+     * client.xml has permissions defined, the ear has no permissions.xml.
+     * 
+     * Expected results:
+     * - We should see the property set successfully
+     */
+    @Test
+    public void testSetPropertyWithClientXMLPermissions() {
+        testClient = LibertyClientFactory.getLibertyClient(JAVA2_CLIENT);
+        List<String> startParms = new ArrayList<String>();
+        startParms.add("--");
+        startParms.add(SET_PROPERTY_OPERATION);
+        try {
+            String fullClientXmlPath = buildFullClientConfigPath(testClient, "client_xml_perms.xml");
+            Log.info(c, name.getMethodName(), "Using client configuration file: " + fullClientXmlPath);
+            copyNewClientConfig(fullClientXmlPath);
+            Log.info(c, name.getMethodName(), "Starting the client ...");
+            ProgramOutput programOutput = testClient.startClientWithArgs(true, true, true, false, "run", startParms, false);
+            Log.info(c, name.getMethodName(), "Client returned.");
+            String output = programOutput.getStdout();
+            assertTrue("Property was not successfully set.", output.contains("property bob set to: phil"));
+            assertNoErrMessages(output);
+        } catch (Exception e) {
+            Log.error(c, name.getMethodName(), e, "Unexpected exception was thrown.");
+            fail("Exception was thrown: " + e);
+        }
+    }
 
 }


### PR DESCRIPTION
Delivering #20289, which disables the usability of Java Security with Java 18+.  Liberty servers running with Java 18 or later with "websphere.java.security" in `bootstrapping.properties` will produce the following error in the log:

```
[3/1/22, 11:26:55:782 CST] 00000001 com.ibm.ws.kernel.launch.internal.FrameworkManager           E CWWKE0955E: Java Security was requested in bootstrapping.properties while using JDK "18", however this option is no longer valid when using Java 18 and later.
```