### PR TITLE
integration between oidc end_session and saml logout

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/internal/OidcServerConfigImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/internal/OidcServerConfigImpl.java
@@ -1176,6 +1176,7 @@ public class OidcServerConfigImpl implements OidcServerConfig {
      */
     private Pattern handleNonOidcPattern() {
         String pattern = "/oidc/(endpoint|providers)/" + providerId + "/(end_session|check_session_iframe)"; // take off end_session check_session_iframe
+        //String pattern = "/oidc/(endpoint|providers)/" + providerId + "/(check_session_iframe)"; // @AV999 only check_session_iframe
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "Non Pattern:" + pattern);
         }

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/internal/OidcServerConfigImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/internal/OidcServerConfigImpl.java
@@ -1176,7 +1176,6 @@ public class OidcServerConfigImpl implements OidcServerConfig {
      */
     private Pattern handleNonOidcPattern() {
         String pattern = "/oidc/(endpoint|providers)/" + providerId + "/(end_session|check_session_iframe)"; // take off end_session check_session_iframe
-        //String pattern = "/oidc/(endpoint|providers)/" + providerId + "/(check_session_iframe)"; // @AV999 only check_session_iframe
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "Non Pattern:" + pattern);
         }

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/OidcEndpointServices.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/OidcEndpointServices.java
@@ -473,10 +473,11 @@ public class OidcEndpointServices extends OAuth20EndpointServices {
                     tokenCache.remove(refreshToken.getTokenString());
                 }
             }
-            if (user != null) {
-                // logout deletes ltpatoken cookie and oidc_bsc cookie.
-                request.logout();
-            }
+            //@AV999-092821
+//            if (user != null) {
+//                // logout deletes ltpatoken cookie and oidc_bsc cookie.
+//                request.logout();
+//            }
         }
 
         if (!continueLogoff) {
@@ -515,7 +516,20 @@ public class OidcEndpointServices extends OAuth20EndpointServices {
         if (tc.isDebugEnabled()) {
             Tr.debug(tc, "OIDC _SSO OP redirecting to [" + redirectUri + "]");
         }
-        response.sendRedirect(redirectUri);
+        //@AV999-092821
+        if (continueLogoff && user != null) {
+            // logout deletes ltpatoken cookie and oidc_bsc cookie.
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "save  OIDC_END_SESSION_REDIRECT uri in op end_session : " + redirectUri);
+            }
+            //if during the servlet request logout, if the other logouts are in play, then we may not want to redirect here in that case
+            request.setAttribute("OIDC_END_SESSION_REDIRECT", redirectUri);
+            request.logout();
+        }
+        if (request.getAttribute("OIDC_END_SESSION_REDIRECT") != null) {
+            response.sendRedirect(redirectUri);
+        }
+        
     }
 
     String updateRedirectUriWithTrackedOAuthClients(HttpServletRequest request, HttpServletResponse response, OAuth20Provider provider, String redirectUri) {

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/OidcEndpointServices.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/OidcEndpointServices.java
@@ -513,20 +513,21 @@ public class OidcEndpointServices extends OAuth20EndpointServices {
         if (oauth20provider.isTrackOAuthClients()) {
             redirectUri = updateRedirectUriWithTrackedOAuthClients(request, response, oauth20provider, redirectUri);
         }
-        if (tc.isDebugEnabled()) {
-            Tr.debug(tc, "OIDC _SSO OP redirecting to [" + redirectUri + "]");
-        }
         //@AV999-092821
+        request.setAttribute("OIDC_END_SESSION_REDIRECT", redirectUri);
         if (continueLogoff && user != null) {
             // logout deletes ltpatoken cookie and oidc_bsc cookie.
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "save  OIDC_END_SESSION_REDIRECT uri in op end_session : " + redirectUri);
             }
-            //if during the servlet request logout, if the other logouts are in play, then we may not want to redirect here in that case
-            request.setAttribute("OIDC_END_SESSION_REDIRECT", redirectUri);
+            //if during the servlet request logout, if the other logouts are in play, then we may not want to redirect here in that case       
             request.logout();
         }
         if (request.getAttribute("OIDC_END_SESSION_REDIRECT") != null) {
+            request.removeAttribute("OIDC_END_SESSION_REDIRECT");
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "OIDC _SSO OP redirecting to [" + redirectUri + "]");
+            }
             response.sendRedirect(redirectUri);
         }
         

--- a/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/web/MockServletRequest.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/web/MockServletRequest.java
@@ -49,6 +49,7 @@ public class MockServletRequest implements HttpServletRequest {
     HashMap<String, ArrayList<String>> _params = new HashMap<String, ArrayList<String>>();
     Cookie[] _cookies = null;
     Principal _principal = null;
+    String attribute = null;
 
     @Override
     public String getAuthType() {
@@ -207,6 +208,9 @@ public class MockServletRequest implements HttpServletRequest {
 
     @Override
     public Object getAttribute(String arg0) {
+        if ("OIDC_END_SESSION_REDIRECT".equals(arg0)) {
+            return attribute;
+        }
         return null;
     }
 
@@ -360,10 +364,16 @@ public class MockServletRequest implements HttpServletRequest {
 
     @Override
     public void removeAttribute(String arg0) {
+        if ("OIDC_END_SESSION_REDIRECT".equals(arg0)) {
+            attribute = null;
+        }
     }
 
     @Override
     public void setAttribute(String arg0, Object arg1) {
+        if ("OIDC_END_SESSION_REDIRECT".equals(arg0)) {
+            attribute = (String)arg1;
+        }
     }
 
     @Override

--- a/dev/com.ibm.ws.security.saml.sso/src/com/ibm/ws/security/saml/sso20/internal/utils/ForwardRequestInfo.java
+++ b/dev/com.ibm.ws.security.saml.sso/src/com/ibm/ws/security/saml/sso20/internal/utils/ForwardRequestInfo.java
@@ -121,6 +121,13 @@ public class ForwardRequestInfo extends HttpRequestInfo implements Serializable 
                                          cookieName,
                                          cookieValue);
             }
+            //@AV999-092821 TODO: save this in another form also
+            if(req.getAttribute("OIDC_END_SESSION_REDIRECT") != null) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "SP Initiated SLO Request, removing OIDC_END_SESSION_REDIRECT attribute");
+                }
+                req.removeAttribute("OIDC_END_SESSION_REDIRECT");
+            }
 
             // HTTP 1.1.
             resp.setHeader("Cache-Control", "no-cache, no-store, must-revalidate, private, max-age=0");

--- a/dev/com.ibm.ws.security.saml.sso/src/com/ibm/ws/security/saml/sso20/internal/utils/HttpRequestInfo.java
+++ b/dev/com.ibm.ws.security.saml.sso/src/com/ibm/ws/security/saml/sso20/internal/utils/HttpRequestInfo.java
@@ -66,6 +66,7 @@ public class HttpRequestInfo implements Serializable {
     DateTime birthTime = new DateTime();
     @SuppressWarnings("rawtypes")
     Map savedPostParams = null;
+    String redirectAfterSPLogout = null;
 
     // same package can access to it
     HttpRequestInfo() {};
@@ -100,6 +101,13 @@ public class HttpRequestInfo implements Serializable {
                 throw new SamlException(e);
             }
         }
+        //@AV999-092821
+        if(request.getAttribute("OIDC_END_SESSION_REDIRECT") != null) {
+            redirectAfterSPLogout = (String)request.getAttribute("OIDC_END_SESSION_REDIRECT");
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "SP Initiated SLO Request, save OIDC_END_SESSION_REDIRECT uri : " + redirectAfterSPLogout);
+            }        
+        }
         if (tc.isDebugEnabled()) {
             Tr.debug(tc, "Request: method (" + this.method + ") savedParams:" + this.savedPostParams);
         }
@@ -126,6 +134,10 @@ public class HttpRequestInfo implements Serializable {
 
     public String getInResponseToId() {
         return this.strInResponseToId;
+    }
+    
+    public String getRedirectAfterSPLogout() {
+        return this.redirectAfterSPLogout;
     }
 
     /**

--- a/dev/com.ibm.ws.security.saml.sso/src/com/ibm/ws/security/saml/sso20/slo/SPInitiatedSLO.java
+++ b/dev/com.ibm.ws.security.saml.sso/src/com/ibm/ws/security/saml/sso20/slo/SPInitiatedSLO.java
@@ -358,7 +358,13 @@ public class SPInitiatedSLO {
 //        } catch (ServletException e1) {
 //            //throw new SamlException(e1); //TODO
 //        }
-        resp.setStatus(javax.servlet.http.HttpServletResponse.SC_OK);
+        //@AV999-092821 
+        if(req.getAttribute("OIDC_END_SESSION_REDIRECT") != null) {
+            resp.setStatus(javax.servlet.http.HttpServletResponse.SC_ACCEPTED);
+        } else {
+            resp.setStatus(javax.servlet.http.HttpServletResponse.SC_OK);
+        }
+        
 
         ForwardRequestInfo requestInfo = new ForwardRequestInfo(idpUrl);
         requestInfo.setFragmentCookieId(cachingRequestInfo.getFragmentCookieId());

--- a/dev/com.ibm.ws.security.saml.sso/test/com/ibm/ws/security/saml/sso20/internal/InitiatorTest.java
+++ b/dev/com.ibm.ws.security.saml.sso/test/com/ibm/ws/security/saml/sso20/internal/InitiatorTest.java
@@ -283,6 +283,8 @@ public class InitiatorTest {
             {
                 allowing(request).getAttribute("FormLogoutExitPage");
                 will(returnValue(null));
+                allowing(request).getAttribute("OIDC_END_SESSION_REDIRECT");
+                will(returnValue(null));
                 allowing(request).setAttribute("SpSLOInProgress", "true"); // why no work?
                 one(ssoConfig).getLoginPageURL();
                 will(returnValue(null));

--- a/dev/com.ibm.ws.security.saml.sso/test/com/ibm/ws/security/saml/sso20/internal/utils/RequestInfoTest.java
+++ b/dev/com.ibm.ws.security.saml.sso/test/com/ibm/ws/security/saml/sso20/internal/utils/RequestInfoTest.java
@@ -111,6 +111,8 @@ public class RequestInfoTest {
                 allowing(HTTP_SERVLET_REQUEST_MCK).setAttribute("SpSLOInProgress", "true");
                 allowing(HTTP_SERVLET_REQUEST_MCK).getAttribute("FormLogoutExitPage");
                 will(returnValue(null));
+                allowing(HTTP_SERVLET_REQUEST_MCK).getAttribute("OIDC_END_SESSION_REDIRECT");
+                will(returnValue(null));
             }
         });
 
@@ -147,6 +149,8 @@ public class RequestInfoTest {
                 allowing(HTTP_SERVLET_REQUEST_MCK).setAttribute("SpSLOInProgress", "true");
                 allowing(HTTP_SERVLET_REQUEST_MCK).getAttribute("FormLogoutExitPage");
                 will(returnValue(null));
+                allowing(HTTP_SERVLET_REQUEST_MCK).getAttribute("OIDC_END_SESSION_REDIRECT");
+                will(returnValue("oidc_redirect_uri"));
             }
         });
 
@@ -160,6 +164,7 @@ public class RequestInfoTest {
         Assert.assertEquals(HTTP_SERVLET_REQUEST_REQUEST_URL_WITH_QUERY.toString(), requestInfo.getReqUrl());
         Assert.assertEquals(ForwardRequestInfo.METHOD_GET, requestInfo.method); //No getter for method field
         Assert.assertEquals(33, requestInfo.getInResponseToId().length()); //Should be any string with 33 characters
+        Assert.assertEquals("oidc_redirect_uri", requestInfo.getRedirectAfterSPLogout());
     }
 
     /**
@@ -432,6 +437,9 @@ public class RequestInfoTest {
 
                 one(HTTP_SERVLET_RESPONSE_MCK).setDateHeader(with(any(String.class)), with(any(Long.class)));
                 one(HTTP_SERVLET_RESPONSE_MCK).setContentType(with(any(String.class)));
+                
+                allowing(HTTP_SERVLET_REQUEST_MCK).getAttribute("OIDC_END_SESSION_REDIRECT");
+                will(returnValue(null));
             }
         });
 
@@ -463,6 +471,9 @@ public class RequestInfoTest {
 
                 one(HTTP_SERVLET_RESPONSE_MCK).getWriter();
                 will(returnValue(new PrintWriter(baos)));
+                
+                allowing(HTTP_SERVLET_REQUEST_MCK).getAttribute("OIDC_END_SESSION_REDIRECT");
+                will(returnValue(null));
             }
         });
 
@@ -499,6 +510,9 @@ public class RequestInfoTest {
 
                 one(HTTP_SERVLET_RESPONSE_MCK).getWriter();
                 will(returnValue(new PrintWriter(baos)));
+                
+                allowing(HTTP_SERVLET_REQUEST_MCK).getAttribute("OIDC_END_SESSION_REDIRECT");
+                will(returnValue(null));
             }
         });
 

--- a/dev/com.ibm.ws.security.saml.sso/test/com/ibm/ws/security/saml/sso20/sp/SolicitedTest.java
+++ b/dev/com.ibm.ws.security.saml.sso/test/com/ibm/ws/security/saml/sso20/sp/SolicitedTest.java
@@ -314,6 +314,8 @@ public class SolicitedTest {
             {
                 allowing(request).getAttribute("FormLogoutExitPage");
                 will(returnValue(null));
+                allowing(request).getAttribute("OIDC_END_SESSION_REDIRECT");
+                will(returnValue(null));
                 one(basicMessageContext).getMetadataProvider();
                 will(returnValue(metadataProvider));
                 one(ssoConfig).isAuthnRequestsSigned();
@@ -390,6 +392,8 @@ public class SolicitedTest {
 
                 allowing(request).getAttribute("FormLogoutExitPage");
                 will(returnValue(null));
+                allowing(request).getAttribute("OIDC_END_SESSION_REDIRECT");
+                will(returnValue(null));
             }
         });
 
@@ -445,6 +449,8 @@ public class SolicitedTest {
 
                 allowing(request).getAttribute("FormLogoutExitPage");
                 will(returnValue(null));
+                allowing(request).getAttribute("OIDC_END_SESSION_REDIRECT");
+                will(returnValue(null));
             }
         });
 
@@ -466,6 +472,8 @@ public class SolicitedTest {
                 atMost(2).of(ssoConfig).getIdpMetadata();
                 will(returnValue(null));
                 allowing(request).getAttribute("FormLogoutExitPage");
+                will(returnValue(null));
+                allowing(request).getAttribute("OIDC_END_SESSION_REDIRECT");
                 will(returnValue(null));
             }
         });
@@ -491,6 +499,8 @@ public class SolicitedTest {
                 will(throwException(e));
                 allowing(request).getAttribute("FormLogoutExitPage");
                 will(returnValue(null));
+                allowing(request).getAttribute("OIDC_END_SESSION_REDIRECT");
+                will(returnValue(null));
             }
         });
 
@@ -515,6 +525,8 @@ public class SolicitedTest {
                 atMost(2).of(ssoConfig).getIdpMetadata();
                 will(returnValue(null));
                 allowing(request).getAttribute("FormLogoutExitPage");
+                will(returnValue(null));
+                allowing(request).getAttribute("OIDC_END_SESSION_REDIRECT");
                 will(returnValue(null));
             }
         });
@@ -588,6 +600,8 @@ public class SolicitedTest {
                 one(badParserPool).newDocument();
                 will(throwException(e));
                 allowing(request).getAttribute("FormLogoutExitPage");
+                will(returnValue(null));
+                allowing(request).getAttribute("OIDC_END_SESSION_REDIRECT");
                 will(returnValue(null));
                 allowing(ssoService).getPrivateKey();
                 //will(returnValue(null));

--- a/dev/com.ibm.ws.webcontainer.security.feature/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.security.feature/bnd.bnd
@@ -50,7 +50,7 @@ Service-Component: \
     locationAdmin=com.ibm.wsspi.kernel.service.location.WsLocationAdmin; \
     authenticatorFactory=com.ibm.ws.webcontainer.security.WebAuthenticatorFactory; \
     unauthenticatedSubjectService=com.ibm.ws.security.authentication.UnauthenticatedSubjectService; \
-    unprotectedResourceService=com.ibm.ws.webcontainer.security.UnprotectedResourceService; \
+    unprotectedResourceService='com.ibm.ws.webcontainer.security.UnprotectedResourceService(id=SAML20RequestTAI)'; \
     kernelProvisioner=com.ibm.ws.kernel.feature.FeatureProvisioner; \
     multiple:='interceptorService,webAuthenticator'; \
     greedy:='ssoAuthFilter,interceptorService,webAuthenticator,unprotectedResourceService,authenticatorFactory'; \

--- a/dev/com.ibm.ws.webcontainer.security.feature/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.security.feature/bnd.bnd
@@ -50,11 +50,12 @@ Service-Component: \
     locationAdmin=com.ibm.wsspi.kernel.service.location.WsLocationAdmin; \
     authenticatorFactory=com.ibm.ws.webcontainer.security.WebAuthenticatorFactory; \
     unauthenticatedSubjectService=com.ibm.ws.security.authentication.UnauthenticatedSubjectService; \
+    unprotectedResourceService=com.ibm.ws.webcontainer.security.UnprotectedResourceService; \
     kernelProvisioner=com.ibm.ws.kernel.feature.FeatureProvisioner; \
     multiple:='interceptorService,webAuthenticator'; \
-    greedy:='ssoAuthFilter,interceptorService,webAuthenticator,authenticatorFactory'; \
-    optional:='taiService,interceptorService,webAuthenticator'; \
-    dynamic:='securityService,ssoAuthFilter,taiService,interceptorService,webAuthenticator,authenticatorFactory'; \
+    greedy:='ssoAuthFilter,interceptorService,webAuthenticator,unprotectedResourceService,authenticatorFactory'; \
+    optional:='taiService,interceptorService,webAuthenticator,unprotectedResourceService'; \
+    dynamic:='securityService,ssoAuthFilter,taiService,interceptorService,webAuthenticator,unprotectedResourceService,authenticatorFactory'; \
     properties:="service.vendor=IBM,com.ibm.ws.security.type=com.ibm.ws.feature"
 
 instrument.classesExcludes: com/ibm/ws/webcontainer/security/feature/resources/*.class


### PR DESCRIPTION
Update OIDC OP end_session and SAML SP single logout flows, so when we are processing the end_session request, we can propagate the logout to the IdP (this needs to be done especially when the IdP is providing the authentication)