### PR TITLE
Issue 20058 and 20060: Add initial logout token validation

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/AccessTokenAuthenticator.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/AccessTokenAuthenticator.java
@@ -11,7 +11,6 @@
 package com.ibm.ws.security.openidconnect.client;
 
 import java.io.IOException;
-import java.security.Key;
 import java.util.Date;
 import java.util.Hashtable;
 import java.util.Map;
@@ -30,10 +29,8 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.util.EntityUtils;
-import org.jose4j.jws.JsonWebSignature;
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.consumer.JwtContext;
-import org.jose4j.jwx.JsonWebStructure;
 
 import com.google.gson.JsonParser;
 import com.ibm.json.java.JSONObject;
@@ -53,7 +50,6 @@ import com.ibm.ws.security.openidconnect.clients.common.OidcClientRequest;
 import com.ibm.ws.security.openidconnect.clients.common.OidcClientUtil;
 import com.ibm.ws.security.openidconnect.clients.common.UserInfoHelper;
 import com.ibm.ws.security.openidconnect.common.Constants;
-import com.ibm.ws.security.openidconnect.jose4j.Jose4jValidator;
 import com.ibm.ws.security.openidconnect.token.JsonTokenUtil;
 import com.ibm.ws.webcontainer.security.AuthResult;
 import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
@@ -441,10 +437,7 @@ public class AccessTokenAuthenticator {
         JwtContext jwtContext = Jose4jUtil.parseJwtWithoutValidation(responseString);
         if (jwtContext != null) {
             // Validate the JWS signature only; extract the claims so they can be verified elsewhere
-            JsonWebStructure jwsStructure = jose4jUtil.getJsonWebStructureFromJwtContext(jwtContext);
-            Key signingKey = jose4jUtil.getSignatureVerificationKeyFromJsonWebStructure(jwsStructure, clientConfig, oidcClientRequest);
-            Jose4jValidator validator = new Jose4jValidator(signingKey, clientConfig.getClockSkewInSeconds(), null, clientConfig.getClientId(), clientConfig.getSignatureAlgorithm(), oidcClientRequest);
-            JwtClaims claims = validator.validateJwsSignature((JsonWebSignature) jwsStructure, responseString);
+            JwtClaims claims = jose4jUtil.validateJwsSignature(jwtContext, clientConfig, oidcClientRequest);
             if (claims != null) {
                 return JSONObject.parse(claims.toJson());
             }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/bnd.bnd
@@ -55,6 +55,8 @@ Private-Package: \
     com.ibm.ws.common.internal.encoder.*, \
     com.ibm.ws.config.xml.internal.nester
 
+-dsannotations=com.ibm.ws.security.openidconnect.backchannellogout.LogoutTokenValidator
+
 -buildpath: \
 	com.ibm.websphere.appserver.spi.logging;version=latest,\
 	com.ibm.websphere.appserver.api.json;version=latest,\
@@ -105,4 +107,5 @@ Private-Package: \
 	com.ibm.json4j;version=latest,\
 	io.openliberty.org.apache.commons.logging;version=latest,\
 	com.ibm.ws.logging;version=latest,\
-	com.ibm.ws.container.service.compat;version=latest
+	com.ibm.ws.container.service.compat;version=latest,\
+	org.slf4j:slf4j-api;strategy=exact;version=1.7.30

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutHelper.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutHelper.java
@@ -78,7 +78,7 @@ public class BackchannelLogoutHelper {
     }
 
     JwtToken validateLogoutToken(String logoutTokenString) throws BackchannelLogoutException {
-        LogoutTokenValidator validator = new LogoutTokenValidator();
+        LogoutTokenValidator validator = new LogoutTokenValidator(clientConfig);
         return validator.validateToken(logoutTokenString);
     }
 

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidator.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidator.java
@@ -10,12 +10,67 @@
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.backchannellogout;
 
-import com.ibm.websphere.security.jwt.JwtToken;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.consumer.JwtContext;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.security.jwt.JwtToken;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.security.openidconnect.client.jose4j.util.Jose4jUtil;
+import com.ibm.ws.security.openidconnect.clients.common.ConvergedClientConfig;
+import com.ibm.wsspi.ssl.SSLSupport;
+
+@Component(name = "com.ibm.ws.security.openidconnect.backchannellogout.LogoutTokenValidator", service = {}, property = { "service.vendor=IBM" })
 public class LogoutTokenValidator {
 
+    private static TraceComponent tc = Tr.register(LogoutTokenValidator.class);
+
+    private static SSLSupport SSL_SUPPORT = null;
+
+    private ConvergedClientConfig config = null;
+    private Jose4jUtil jose4jUtil = null;
+
+    @Reference
+    protected void setSslSupport(SSLSupport sslSupport) {
+        SSL_SUPPORT = sslSupport;
+    }
+
+    protected void unsetSslSupport() {
+        SSL_SUPPORT = null;
+    }
+
+    /**
+     * Do not use; needed for this to be a valid @Component object.
+     */
+    public LogoutTokenValidator() {
+    }
+
+    public LogoutTokenValidator(ConvergedClientConfig config) {
+        this.config = config;
+        jose4jUtil = new Jose4jUtil(SSL_SUPPORT);
+    }
+
+    /**
+     * Valides an OIDC back-channel logout token per https://openid.net/specs/openid-connect-backchannel-1_0.html.
+     */
+    @FFDCIgnore(Exception.class)
     public JwtToken validateToken(String logoutTokenString) throws BackchannelLogoutException {
-        // TODO
+        try {
+            JwtContext jwtContext = jose4jUtil.validateJwtStructureAndGetContext(logoutTokenString, config);
+            JwtClaims claims = jose4jUtil.validateJwsSignature(jwtContext, config);
+            // TODO;
+            // 3. Validate the iss, aud, and iat Claims in the same way they are validated in ID Tokens
+            // 4. Verify that the Logout Token contains a sub Claim, a sid Claim, or both.
+            // 5. Verify that the Logout Token contains an events Claim whose value is JSON object containing the member name http://schemas.openid.net/event/backchannel-logout.
+            // 6. Verify that the Logout Token does not contain a nonce Claim.
+
+        } catch (Exception e) {
+            String errorMsg = Tr.formatMessage(tc, "BACKCHANNEL_LOGOUT_TOKEN_ERROR", new Object[] { e });
+            throw new BackchannelLogoutException(errorMsg, e);
+        }
         return null;
     }
 

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
@@ -98,13 +98,8 @@ public class Jose4jUtil {
                 Tr.error(tc, "OIDC_CLIENT_IDTOKEN_REQUEST_FAILURE", new Object[] { clientId, clientConfig.getTokenEndpointUrl() });
                 return new ProviderAuthenticationResult(AuthResult.SEND_401, HttpServletResponse.SC_UNAUTHORIZED);
             }
-            checkJwtFormatAgainstConfigRequirements(tokenStr, clientConfig);
-            if (JweHelper.isJwe(tokenStr)) {
-                tokenStr = JweHelper.extractJwsFromJweToken(tokenStr, clientConfig, null);
-            }
-
-            JwtContext jwtContext = parseJwtWithoutValidation(tokenStr);
-            JwtClaims jwtClaims = parseJwtWithValidation(clientConfig, tokenStr, jwtContext, oidcClientRequest);
+            JwtContext jwtContext = validateJwtStructureAndGetContext(tokenStr, clientConfig);
+            JwtClaims jwtClaims = parseJwtWithValidation(clientConfig, jwtContext.getJwt(), jwtContext, oidcClientRequest);
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "post jwtClaims: " + jwtClaims + " firstPass jwtClaims=" + jwtContext.getJwtClaims());
             }
@@ -283,13 +278,17 @@ public class Jose4jUtil {
             if (caughtException != null) {
                 objs = new Object[] { clientConfig.getSignatureAlgorithm(), caughtException.getLocalizedMessage() };
             }
-            oidcClientRequest.setRsFailMsg(OidcClientRequest.NO_KEY, Tr.formatMessage(tc, "OIDC_CLIENT_NO_VERIFYING_KEY", objs));
-            throw oidcClientRequest.error(true, tc, "OIDC_CLIENT_NO_VERIFYING_KEY", objs);
+            if (oidcClientRequest != null) {
+                oidcClientRequest.setRsFailMsg(OidcClientRequest.NO_KEY, Tr.formatMessage(tc, "OIDC_CLIENT_NO_VERIFYING_KEY", objs));
+                throw oidcClientRequest.error(true, tc, "OIDC_CLIENT_NO_VERIFYING_KEY", objs);
+            } else {
+                throw JWTTokenValidationFailedException.format(tc, "OIDC_CLIENT_NO_VERIFYING_KEY", objs);
+            }
         }
         return key;
     }
 
-    protected Key getVerifyKey(ConvergedClientConfig clientConfig, String kid, String x5t) throws Exception {
+    public Key getVerifyKey(ConvergedClientConfig clientConfig, String kid, String x5t) throws Exception {
         Key keyValue = null;
         String signatureAlgorithm = clientConfig.getSignatureAlgorithm();
         if (signatureAlgorithm == null) {
@@ -427,6 +426,33 @@ public class Jose4jUtil {
             return new ProviderAuthenticationResult(AuthResult.SEND_401, HttpServletResponse.SC_UNAUTHORIZED);
         }
         return null;
+    }
+
+    /**
+     * Verifies that the JWT is either a JWS or a JWE, depending on the client configuration, and does simple parsing of the
+     * token to ensure it is formatted correctly. If the token is a JWE, this decrypts and extracts the JWS payload from the
+     * token.
+     */
+    public JwtContext validateJwtStructureAndGetContext(String logoutTokenString, ConvergedClientConfig clientConfig) throws Exception {
+        checkJwtFormatAgainstConfigRequirements(logoutTokenString, clientConfig);
+        if (JweHelper.isJwe(logoutTokenString)) {
+            logoutTokenString = JweHelper.extractJwsFromJweToken(logoutTokenString, clientConfig, null);
+        }
+        return Jose4jUtil.parseJwtWithoutValidation(logoutTokenString);
+    }
+
+    public JwtClaims validateJwsSignature(JwtContext jwtContext, ConvergedClientConfig clientConfig) throws Exception {
+        return validateJwsSignature(jwtContext, clientConfig, null);
+
+    }
+
+    public JwtClaims validateJwsSignature(JwtContext jwtContext, ConvergedClientConfig clientConfig, OidcClientRequest oidcClientRequest) throws Exception {
+        JsonWebStructure jwStructure = getJsonWebStructureFromJwtContext(jwtContext);
+        Key key = getSignatureVerificationKeyFromJsonWebStructure(jwStructure, clientConfig, oidcClientRequest);
+
+        // Clock skew and issuer aren't needed to validate the signature
+        Jose4jValidator validator = new Jose4jValidator(key, 0L, null, clientConfig.getClientId(), clientConfig.getSignatureAlgorithm(), oidcClientRequest);
+        return validator.validateJwsSignature((JsonWebSignature) jwStructure, jwtContext.getJwt());
     }
 
 }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/UserInfoHelper.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/UserInfoHelper.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.clients.common;
 
-import java.security.Key;
 import java.util.Map;
 
 import javax.net.ssl.SSLSocketFactory;
@@ -19,10 +18,8 @@ import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
-import org.jose4j.jws.JsonWebSignature;
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.consumer.JwtContext;
-import org.jose4j.jwx.JsonWebStructure;
 
 import com.ibm.json.java.JSONObject;
 import com.ibm.websphere.ras.Tr;
@@ -32,7 +29,6 @@ import com.ibm.ws.security.jwt.utils.JweHelper;
 import com.ibm.ws.security.openidconnect.client.jose4j.util.Jose4jUtil;
 import com.ibm.ws.security.openidconnect.client.jose4j.util.OidcTokenImplBase;
 import com.ibm.ws.security.openidconnect.common.Constants;
-import com.ibm.ws.security.openidconnect.jose4j.Jose4jValidator;
 import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 import com.ibm.wsspi.ssl.SSLSupport;
 
@@ -247,10 +243,7 @@ public class UserInfoHelper {
         JwtContext jwtContext = Jose4jUtil.parseJwtWithoutValidation(responseString);
         if (jwtContext != null) {
             // Validate the JWS signature only; extract the claims so they can be verified elsewhere
-            JsonWebStructure jwsStructure = jose4jUtil.getJsonWebStructureFromJwtContext(jwtContext);
-            Key signingKey = jose4jUtil.getSignatureVerificationKeyFromJsonWebStructure(jwsStructure, clientConfig, oidcClientRequest);
-            Jose4jValidator validator = new Jose4jValidator(signingKey, clientConfig.getClockSkewInSeconds(), null, clientConfig.getClientId(), clientConfig.getSignatureAlgorithm(), oidcClientRequest);
-            JwtClaims claims = validator.validateJwsSignature((JsonWebSignature) jwsStructure, responseString);
+            JwtClaims claims = jose4jUtil.validateJwsSignature(jwtContext, clientConfig, oidcClientRequest);
             if (claims != null) {
                 return claims.toJson();
             }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidatorTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidatorTest.java
@@ -10,13 +10,16 @@
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.backchannellogout;
 
+import static org.junit.Assert.fail;
+
+import org.jmock.Expectations;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.ibm.websphere.security.jwt.JwtToken;
+import com.ibm.ws.security.jwt.config.ConsumerUtils;
 import com.ibm.ws.security.openidconnect.clients.common.ConvergedClientConfig;
 import com.ibm.ws.security.test.common.CommonTestClass;
 
@@ -26,7 +29,16 @@ public class LogoutTokenValidatorTest extends CommonTestClass {
 
     static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("com.ibm.ws.security.openidconnect.common.*=all=enabled");
 
+    final String CWWKS1536E_OIDC_CLIENT_JWS_REQUIRED_BUT_TOKEN_NOT_JWS = "CWWKS1536E";
+    final String CWWKS1537E_OIDC_CLIENT_JWE_REQUIRED_BUT_TOKEN_NOT_JWE = "CWWKS1537E";
+    final String CWWKS1543E_BACKCHANNEL_LOGOUT_TOKEN_ERROR = "CWWKS1543E";
+    final String CWWKS1778E_OIDC_JWT_SIGNATURE_VERIFY_MISSING_SIGNATURE_ERR = "CWWKS1778E";
+
+    final String CONFIG_ID = "myConfigId";
+    final String CLIENT_ID = "client01";
+
     final ConvergedClientConfig clientConfig = mockery.mock(ConvergedClientConfig.class);
+    final ConsumerUtils consumerUtils = mockery.mock(ConsumerUtils.class);
 
     LogoutTokenValidator validator;
 
@@ -38,7 +50,7 @@ public class LogoutTokenValidatorTest extends CommonTestClass {
     @Before
     public void before() {
         System.out.println("Entering test: " + testName.getMethodName());
-        validator = new LogoutTokenValidator();
+        validator = new LogoutTokenValidator(clientConfig);
     }
 
     @After
@@ -55,11 +67,188 @@ public class LogoutTokenValidatorTest extends CommonTestClass {
     }
 
     @Test
-    public void test_validateToken_nullString() {
+    public void test_validateToken_nullString() throws Exception {
         String logoutTokenString = null;
         try {
-            JwtToken result = validator.validateToken(logoutTokenString);
+            mockery.checking(new Expectations() {
+                {
+                    one(clientConfig).getKeyManagementKeyAlias();
+                    will(returnValue(null));
+                    one(clientConfig).getId();
+                    will(returnValue(CONFIG_ID));
+                }
+            });
+            validator.validateToken(logoutTokenString);
+            fail("Should have thrown an exception but didn't.");
         } catch (BackchannelLogoutException e) {
+            verifyException(e, CWWKS1543E_BACKCHANNEL_LOGOUT_TOKEN_ERROR + ".*" + CWWKS1536E_OIDC_CLIENT_JWS_REQUIRED_BUT_TOKEN_NOT_JWS);
+        }
+    }
+
+    @Test
+    public void test_validateToken_emptyString() throws Exception {
+        String logoutTokenString = "";
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    one(clientConfig).getKeyManagementKeyAlias();
+                    will(returnValue(null));
+                    one(clientConfig).getId();
+                    will(returnValue(CONFIG_ID));
+                }
+            });
+            validator.validateToken(logoutTokenString);
+            fail("Should have thrown an exception but didn't.");
+        } catch (BackchannelLogoutException e) {
+            verifyException(e, CWWKS1543E_BACKCHANNEL_LOGOUT_TOKEN_ERROR + ".*" + CWWKS1536E_OIDC_CLIENT_JWS_REQUIRED_BUT_TOKEN_NOT_JWS);
+        }
+    }
+
+    @Test
+    public void test_validateToken_notAJwt() throws Exception {
+        String logoutTokenString = "This is not a jwt.";
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    one(clientConfig).getKeyManagementKeyAlias();
+                    will(returnValue(null));
+                    one(clientConfig).getId();
+                    will(returnValue(CONFIG_ID));
+                }
+            });
+            validator.validateToken(logoutTokenString);
+            fail("Should have thrown an exception but didn't.");
+        } catch (BackchannelLogoutException e) {
+            verifyException(e, CWWKS1543E_BACKCHANNEL_LOGOUT_TOKEN_ERROR + ".*" + CWWKS1536E_OIDC_CLIENT_JWS_REQUIRED_BUT_TOKEN_NOT_JWS);
+        }
+    }
+
+    @Test
+    public void test_validateToken_jwsRequired_jweFormat() throws Exception {
+        String logoutTokenString = "aaa.bbb.ccc.ddd.eee";
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    allowing(clientConfig).getKeyManagementKeyAlias();
+                    will(returnValue(null));
+                    one(clientConfig).getId();
+                    will(returnValue(CONFIG_ID));
+                }
+            });
+            validator.validateToken(logoutTokenString);
+            fail("Should have thrown an exception but didn't.");
+        } catch (BackchannelLogoutException e) {
+            verifyException(e, CWWKS1543E_BACKCHANNEL_LOGOUT_TOKEN_ERROR + ".*" + CWWKS1536E_OIDC_CLIENT_JWS_REQUIRED_BUT_TOKEN_NOT_JWS);
+        }
+    }
+
+    @Test
+    public void test_validateToken_jweRequired_jwsFormat() throws Exception {
+        String logoutTokenString = "aaa.bbb.ccc";
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    allowing(clientConfig).getKeyManagementKeyAlias();
+                    will(returnValue("someAlias"));
+                    one(clientConfig).getId();
+                    will(returnValue(CONFIG_ID));
+                }
+            });
+            validator.validateToken(logoutTokenString);
+            fail("Should have thrown an exception but didn't.");
+        } catch (BackchannelLogoutException e) {
+            verifyException(e, CWWKS1543E_BACKCHANNEL_LOGOUT_TOKEN_ERROR + ".*" + CWWKS1537E_OIDC_CLIENT_JWE_REQUIRED_BUT_TOKEN_NOT_JWE);
+        }
+    }
+
+    @Test
+    public void test_validateToken_jwsUnsigned_configAlgHs256() throws Exception {
+        String logoutTokenString = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.e30.";
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    allowing(clientConfig).getKeyManagementKeyAlias();
+                    will(returnValue(null));
+                    allowing(clientConfig).getSignatureAlgorithm();
+                    will(returnValue("HS256"));
+                    one(clientConfig).getSharedKey();
+                    will(returnValue("secret"));
+                    one(clientConfig).getClientId();
+                    will(returnValue(CLIENT_ID));
+                }
+            });
+            validator.validateToken(logoutTokenString);
+            fail("Should have thrown an exception but didn't.");
+        } catch (BackchannelLogoutException e) {
+            verifyException(e, CWWKS1543E_BACKCHANNEL_LOGOUT_TOKEN_ERROR + ".*" + CWWKS1778E_OIDC_JWT_SIGNATURE_VERIFY_MISSING_SIGNATURE_ERR);
+        }
+    }
+
+    @Test
+    public void test_validateToken_jwsUnsigned_configAlgNone() throws Exception {
+        String logoutTokenString = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.e30.";
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    allowing(clientConfig).getKeyManagementKeyAlias();
+                    will(returnValue(null));
+                    allowing(clientConfig).getSignatureAlgorithm();
+                    will(returnValue("none"));
+                    one(clientConfig).getClientId();
+                    will(returnValue(CLIENT_ID));
+                }
+            });
+            validator.validateToken(logoutTokenString);
+        } catch (BackchannelLogoutException e) {
+            fail("Caught an exception but shouldn't have: " + e);
+        }
+    }
+
+    @Test
+    public void test_validateToken_hs256_keyMismatch() throws Exception {
+        // Signed using "secret2" as the key
+        String logoutTokenString = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.e30.Uj2QmdsSiazCsMcLY2bZifMmTOVmvxNmh3j3GnslIbA";
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    allowing(clientConfig).getKeyManagementKeyAlias();
+                    will(returnValue(null));
+                    allowing(clientConfig).getSignatureAlgorithm();
+                    will(returnValue("HS256"));
+                    one(clientConfig).getSharedKey();
+                    will(returnValue("secret"));
+                    one(clientConfig).getClientId();
+                    will(returnValue(CLIENT_ID));
+                }
+            });
+            validator.validateToken(logoutTokenString);
+            fail("Should have thrown an exception but didn't.");
+        } catch (BackchannelLogoutException e) {
+            verifyException(e, CWWKS1543E_BACKCHANNEL_LOGOUT_TOKEN_ERROR + ".*" + "Invalid JWS Signature");
+        }
+    }
+
+    @Test
+    public void test_validateToken_hs256_emptyClaims() throws Exception {
+        String logoutTokenString = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.e30.DMCAvRgzrcf5w0Z879BsqzcrnDFKBY_GN6c3qKOUFtQ";
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    allowing(clientConfig).getKeyManagementKeyAlias();
+                    will(returnValue(null));
+                    allowing(clientConfig).getSignatureAlgorithm();
+                    will(returnValue("HS256"));
+                    one(clientConfig).getSharedKey();
+                    will(returnValue("secret"));
+                    one(clientConfig).getClientId();
+                    will(returnValue(CLIENT_ID));
+                }
+            });
+            validator.validateToken(logoutTokenString);
+            // TODO
+            //            fail("Should have thrown an exception but didn't.");
+        } catch (BackchannelLogoutException e) {
+            //            verifyException(e, CWWKS1543E_BACKCHANNEL_LOGOUT_TOKEN_ERROR + ".*" + "Invalid JWS Signature");
         }
     }
 


### PR DESCRIPTION
Adds validation of the logout token format and signature. Specifically, this verifies that:
- The logout token is in JWS format if the client configuration requires it (namely, there is no `keyManagementKeyAlias` configured)
- The logout token is in JWE format if the client configuration requires it (in this case, there _is_ a `keyManagementKeyAlias` configured)
- The JWT can be parsed successfully (either as a JWS or a JWE)
    - In the case of a JWE, the token is decrypted and the nested JWS is extracted
- The signature of the token is valid

For #20058
For #20060