### PR TITLE
Change order of WebApp initialization during applications checkpoint

### DIFF
--- a/dev/com.ibm.ws.webcontainer.servlet.3.0.factories/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.0.factories/bnd.bnd
@@ -73,4 +73,5 @@ Import-Package: \
     com.ibm.ws.managedobject;version=latest,\
     com.ibm.ws.resource;version=latest,\
     com.ibm.ws.session;version=latest, \
-    com.ibm.ws.org.osgi.annotation.versioning;version=latest
+    com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
+	com.ibm.ws.kernel.boot.core;version=latest

--- a/dev/com.ibm.ws.webcontainer.servlet.3.0.factories/src/com/ibm/ws/webcontainer/osgi/webapp/internal/WebAppFactoryImpl.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.0.factories/src/com/ibm/ws/webcontainer/osgi/webapp/internal/WebAppFactoryImpl.java
@@ -10,7 +10,10 @@
  *******************************************************************************/
 package com.ibm.ws.webcontainer.osgi.webapp.internal;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
 
 import com.ibm.websphere.csi.J2EENameFactory;
 import com.ibm.ws.container.service.metadata.MetaDataService;
@@ -20,15 +23,23 @@ import com.ibm.ws.webcontainer.osgi.webapp.WebAppConfiguration;
 import com.ibm.ws.webcontainer.osgi.webapp.WebAppFactory;
 import com.ibm.wsspi.injectionengine.ReferenceContext;
 
-@Component(service=WebAppFactory.class, property = { "service.vendor=IBM" })
+import io.openliberty.checkpoint.spi.CheckpointPhase;
+
+
+@Component(service= WebAppFactory.class, property = { "service.vendor=IBM" })
 public class WebAppFactoryImpl implements WebAppFactory {
+	private final CheckpointPhase checkpointPhase;
+    @Activate
+    public WebAppFactoryImpl(@Reference(cardinality = ReferenceCardinality.OPTIONAL) CheckpointPhase checkpointPhase) {
+        this.checkpointPhase = checkpointPhase;
+    }
 
    /* (non-Javadoc)
     * @see com.ibm.ws.webcontainer.osgi.webapp.WebAppFactory#createWebApp(com.ibm.ws.webcontainer.osgi.webapp.WebAppConfiguration, java.lang.ClassLoader, com.ibm.wsspi.injectionengine.ReferenceContext, com.ibm.ws.container.service.metadata.MetaDataService, com.ibm.websphere.csi.J2EENameFactory)
     */
    @Override
    public WebApp createWebApp(WebAppConfiguration webAppConfig, ClassLoader moduleLoader, ReferenceContext referenceContext, MetaDataService metaDataService,
-                              J2EENameFactory j2eeNameFactory, ManagedObjectService managedObjectService) {      
-       return new WebApp(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService);
+                              J2EENameFactory j2eeNameFactory, ManagedObjectService managedObjectService) {
+	   return new WebApp(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService, checkpointPhase);
    }
 }

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1.factories/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1.factories/bnd.bnd
@@ -82,7 +82,8 @@ instrument.disabled: true
     com.ibm.ws.transport.http;version=latest,\
     com.ibm.ws.webcontainer;version=latest,\
     com.ibm.ws.webcontainer.servlet.3.1;version=latest,\
-    com.ibm.ws.org.osgi.annotation.versioning;version=latest
+    com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
+	com.ibm.ws.kernel.boot.core;version=latest
     
 -testpath: \
     org.hamcrest:hamcrest-all;version=1.3, \

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1.factories/src/com/ibm/ws/webcontainer31/osgi/webapp/factory/WebAppFactoryImpl31.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1.factories/src/com/ibm/ws/webcontainer31/osgi/webapp/factory/WebAppFactoryImpl31.java
@@ -10,7 +10,10 @@
  *******************************************************************************/
 package com.ibm.ws.webcontainer31.osgi.webapp.factory;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
 
 import com.ibm.websphere.csi.J2EENameFactory;
 import com.ibm.ws.container.service.metadata.MetaDataService;
@@ -21,22 +24,30 @@ import com.ibm.ws.webcontainer.osgi.webapp.WebAppFactory;
 import com.ibm.ws.webcontainer31.osgi.webapp.WebApp31;
 import com.ibm.wsspi.injectionengine.ReferenceContext;
 
+import io.openliberty.checkpoint.spi.CheckpointPhase;
+
 /**
  *
  */
 @Component(service = WebAppFactory.class, property = { "service.vendor=IBM" })
 public class WebAppFactoryImpl31 implements WebAppFactory {
+    private final CheckpointPhase checkpointPhase;
+
+    @Activate
+    public WebAppFactoryImpl31(@Reference(cardinality = ReferenceCardinality.OPTIONAL) CheckpointPhase checkpointPhase) {
+        this.checkpointPhase = checkpointPhase;
+    }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.ws.webcontainer.osgi.webapp.WebAppFactory#createWebApp(com.ibm.ws.webcontainer.osgi.webapp.WebAppConfiguration, java.lang.ClassLoader,
      * com.ibm.wsspi.injectionengine.ReferenceContext, com.ibm.ws.container.service.metadata.MetaDataService, com.ibm.websphere.csi.J2EENameFactory)
      */
     @Override
     public WebApp createWebApp(WebAppConfiguration webAppConfig, ClassLoader moduleLoader, ReferenceContext referenceContext, MetaDataService metaDataService,
                                J2EENameFactory j2eeNameFactory, ManagedObjectService managedObjectService) {
-        return new WebApp31(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService);
+        return new WebApp31(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService, checkpointPhase);
     }
 
 }

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/bnd.bnd
@@ -110,7 +110,8 @@ jakartaeeMe: true
     com.ibm.ws.session;version=latest,\
     com.ibm.ws.org.apache.commons.fileupload;version=latest,\
     com.ibm.ws.anno;version=latest, \
-    com.ibm.ws.org.osgi.annotation.versioning;version=latest
+    com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+	com.ibm.ws.kernel.boot.core;version=latest
 
 -testpath: \
     org.hamcrest:hamcrest-all;version=1.3, \

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/osgi/webapp/WebApp31.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/osgi/webapp/WebApp31.java
@@ -57,6 +57,8 @@ import com.ibm.ws.webcontainer31.upgrade.H2UpgradeHandlerWrapper;
 import com.ibm.wsspi.injectionengine.InjectionException;
 import com.ibm.wsspi.injectionengine.ReferenceContext;
 
+import io.openliberty.checkpoint.spi.CheckpointPhase;
+
 
 /**
  */
@@ -86,8 +88,9 @@ public class WebApp31 extends com.ibm.ws.webcontainer.osgi.webapp.WebApp
                   ReferenceContext referenceContext,
                   MetaDataService metaDataService,
                   J2EENameFactory j2eeNameFactory,
-                  ManagedObjectService managedObjectService) {
-        super(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService);
+                  ManagedObjectService managedObjectService,
+                  CheckpointPhase checkpointPhase) {
+        super(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService, checkpointPhase);
     }
 
     public <T extends HttpUpgradeHandler> T createHttpUpgradeHandler(Class<T> classToCreate) throws ServletException {

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/test/com/ibm/ws/webcontainer/webapp/MethodsForProgrammaticConfigurationOfServletsTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/test/com/ibm/ws/webcontainer/webapp/MethodsForProgrammaticConfigurationOfServletsTest.java
@@ -61,7 +61,7 @@ public class MethodsForProgrammaticConfigurationOfServletsTest {
         final J2EENameFactory jnf = context.mock(J2EENameFactory.class);
 
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null);
+        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null, null);
 
         webApp.withinContextInitOfProgAddListener = true;
 
@@ -83,7 +83,7 @@ public class MethodsForProgrammaticConfigurationOfServletsTest {
         final J2EENameFactory jnf = context.mock(J2EENameFactory.class);
 
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null);
+        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null, null);
 
         webApp.withinContextInitOfProgAddListener = true;
 
@@ -105,7 +105,7 @@ public class MethodsForProgrammaticConfigurationOfServletsTest {
         final J2EENameFactory jnf = context.mock(J2EENameFactory.class);
 
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null);
+        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null, null);
 
         webApp.withinContextInitOfProgAddListener = true;
 
@@ -127,7 +127,7 @@ public class MethodsForProgrammaticConfigurationOfServletsTest {
         final J2EENameFactory jnf = context.mock(J2EENameFactory.class);
 
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null);
+        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null, null);
 
         webApp.withinContextInitOfProgAddListener = true;
 
@@ -149,7 +149,7 @@ public class MethodsForProgrammaticConfigurationOfServletsTest {
         final J2EENameFactory jnf = context.mock(J2EENameFactory.class);
 
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null);
+        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null, null);
 
         webApp.withinContextInitOfProgAddListener = true;
 
@@ -171,7 +171,7 @@ public class MethodsForProgrammaticConfigurationOfServletsTest {
         final J2EENameFactory jnf = context.mock(J2EENameFactory.class);
 
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null);
+        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null, null);
 
         webApp.withinContextInitOfProgAddListener = true;
 
@@ -193,7 +193,7 @@ public class MethodsForProgrammaticConfigurationOfServletsTest {
         final J2EENameFactory jnf = context.mock(J2EENameFactory.class);
 
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null);
+        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null, null);
 
         webApp.withinContextInitOfProgAddListener = true;
 
@@ -215,7 +215,7 @@ public class MethodsForProgrammaticConfigurationOfServletsTest {
         final J2EENameFactory jnf = context.mock(J2EENameFactory.class);
 
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null);
+        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null, null);
 
         webApp.withinContextInitOfProgAddListener = true;
 
@@ -237,7 +237,7 @@ public class MethodsForProgrammaticConfigurationOfServletsTest {
         final J2EENameFactory jnf = context.mock(J2EENameFactory.class);
 
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null);
+        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null, null);
 
         webApp.withinContextInitOfProgAddListener = true;
 

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0.factories/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0.factories/bnd.bnd
@@ -96,5 +96,6 @@ jakartaeeMe: true
     com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
     com.ibm.ws.webcontainer.servlet.4.0;version=latest,\
     com.ibm.websphere.javaee.servlet.4.0;version=latest,\
-    com.ibm.ws.resource;version=latest
+    com.ibm.ws.resource;version=latest, \
+	com.ibm.ws.kernel.boot.core;version=latest
 

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0.factories/src/com/ibm/ws/webcontainer40/osgi/webapp/factory/WebAppFactory40Impl.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0.factories/src/com/ibm/ws/webcontainer40/osgi/webapp/factory/WebAppFactory40Impl.java
@@ -10,7 +10,10 @@
  *******************************************************************************/
 package com.ibm.ws.webcontainer40.osgi.webapp.factory;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
 
 import com.ibm.websphere.csi.J2EENameFactory;
 import com.ibm.ws.container.service.metadata.MetaDataService;
@@ -21,11 +24,19 @@ import com.ibm.ws.webcontainer.osgi.webapp.WebAppFactory;
 import com.ibm.ws.webcontainer40.osgi.webapp.WebApp40;
 import com.ibm.wsspi.injectionengine.ReferenceContext;
 
+import io.openliberty.checkpoint.spi.CheckpointPhase;
+
 /**
 *
 */
 @Component(service = WebAppFactory.class, property = { "service.vendor=IBM" })
 public class WebAppFactory40Impl implements WebAppFactory {
+    private final CheckpointPhase checkpointPhase;
+
+    @Activate
+    public WebAppFactory40Impl(@Reference(cardinality = ReferenceCardinality.OPTIONAL) CheckpointPhase checkpointPhase) {
+        this.checkpointPhase = checkpointPhase;
+    }
 
     /*
      * (non-Javadoc)
@@ -36,6 +47,6 @@ public class WebAppFactory40Impl implements WebAppFactory {
     @Override
     public WebApp createWebApp(WebAppConfiguration webAppConfig, ClassLoader moduleLoader, ReferenceContext referenceContext, MetaDataService metaDataService,
                                J2EENameFactory j2eeNameFactory, ManagedObjectService managedObjectService) {
-        return new WebApp40(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService);
+        return new WebApp40(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService, checkpointPhase);
     }
 }

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/bnd.bnd
@@ -73,7 +73,8 @@ Import-Package: \
     com.ibm.ws.org.apache.commons.fileupload;version=latest,\
     com.ibm.ws.session;version=latest,\
     com.ibm.ws.javaee.dd.common;version=latest,\
-    com.ibm.ws.javaee.dd;version=latest
+    com.ibm.ws.javaee.dd;version=latest,\
+	com.ibm.ws.kernel.boot.core;version=latest
 
 -testpath: \
     org.hamcrest:hamcrest-all;version=1.3, \

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/webapp/WebApp40.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/webapp/WebApp40.java
@@ -25,8 +25,8 @@ import com.ibm.ws.container.service.metadata.MetaDataService;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.managedobject.ManagedObjectService;
 import com.ibm.ws.session.SessionManager;
-import com.ibm.ws.webcontainer.osgi.webapp.WebAppConfiguration;
 import com.ibm.ws.webcontainer.osgi.WebContainer;
+import com.ibm.ws.webcontainer.osgi.webapp.WebAppConfiguration;
 import com.ibm.ws.webcontainer.webapp.WebApp;
 import com.ibm.ws.webcontainer.webapp.WebAppDispatcherContext;
 import com.ibm.ws.webcontainer.webapp.WebAppRequestDispatcher;
@@ -37,6 +37,8 @@ import com.ibm.wsspi.session.ISessionManagerCustomizer;
 import com.ibm.wsspi.webcontainer.RequestProcessor;
 import com.ibm.wsspi.webcontainer.servlet.IServletConfig;
 import com.ibm.wsspi.webcontainer.util.EncodingUtils;
+
+import io.openliberty.checkpoint.spi.CheckpointPhase;
 
 public class WebApp40 extends com.ibm.ws.webcontainer31.osgi.webapp.WebApp31 implements ServletContext {
     private final static TraceComponent tc = Tr.register(WebApp40.class, WebContainerConstants.TR_GROUP, WebContainerConstants.NLS_PROPS);
@@ -61,8 +63,9 @@ public class WebApp40 extends com.ibm.ws.webcontainer31.osgi.webapp.WebApp31 imp
                     ReferenceContext referenceContext,
                     MetaDataService metaDataService,
                     J2EENameFactory j2eeNameFactory,
-                    ManagedObjectService managedObjectService) {
-        super(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService);
+                    ManagedObjectService managedObjectService,
+                    CheckpointPhase checkpointPhase) {
+        super(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService, checkpointPhase);
     }
 
     /*
@@ -408,5 +411,4 @@ public class WebApp40 extends com.ibm.ws.webcontainer31.osgi.webapp.WebApp31 imp
 
         return sconfig;
     }
-
 }

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/webapp/WebApp.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/webapp/WebApp.java
@@ -67,7 +67,6 @@ import com.ibm.ws.webcontainer.osgi.extension.DefaultExtensionProcessor;
 import com.ibm.ws.webcontainer.osgi.extension.InvokerExtensionProcessor;
 import com.ibm.ws.webcontainer.osgi.filter.WebAppFilterManagerImpl;
 import com.ibm.ws.webcontainer.osgi.managed.WCManagedObjectImpl;
-import com.ibm.ws.webcontainer.osgi.mbeans.GeneratePluginConfigMBean;
 import com.ibm.ws.webcontainer.osgi.metadata.WebComponentMetaDataImpl;
 import com.ibm.ws.webcontainer.servlet.DirectoryBrowsingServlet;
 import com.ibm.ws.webcontainer.servlet.H2Handler;
@@ -99,6 +98,8 @@ import com.ibm.wsspi.webcontainer.metadata.WebComponentMetaData;
 import com.ibm.wsspi.webcontainer.metadata.WebModuleMetaData;
 import com.ibm.wsspi.webcontainer.servlet.IServletConfig;
 import com.ibm.wsspi.webcontainer.util.ThreadContextHelper;
+
+import io.openliberty.checkpoint.spi.CheckpointPhase;
  
 /**
  */
@@ -133,9 +134,10 @@ public class WebApp extends com.ibm.ws.webcontainer.webapp.WebApp implements Com
                 ReferenceContext referenceContext,
                 MetaDataService metaDataService,
                 J2EENameFactory j2eeNameFactory,
-                ManagedObjectService managedObjectService)
+                ManagedObjectService managedObjectService,
+                CheckpointPhase checkpointPhase)
   {
-    super(webAppConfig, null);
+    super(webAppConfig, null, checkpointPhase);
     this.webAppConfig = webAppConfig;
     this.moduleLoader = moduleLoader;
     this.referenceContext = referenceContext;

--- a/dev/com.ibm.ws.webcontainer/test/com/ibm/ws/webcontainer/webapp/SRTServletRequestTest.java
+++ b/dev/com.ibm.ws.webcontainer/test/com/ibm/ws/webcontainer/webapp/SRTServletRequestTest.java
@@ -202,7 +202,7 @@ public class SRTServletRequestTest {
         Hashtable bundleHeaders = new Hashtable(1);
         bundleHeaders.put("IBM-Authorization-Roles", "com.ibm.ws.management");
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp webApp = new WebApp(webAppConfig, null, null, mds, jnf, null);
+        WebApp webApp = new WebApp(webAppConfig, null, null, mds, jnf, null, null);
         webAppConfig.setWebApp(webApp);
         webAppConfig.setBundleHeaders(bundleHeaders);
         webApp.setCollaboratorHelper(new CollaboratorHelperImpl(webApp, null));
@@ -258,7 +258,7 @@ public class SRTServletRequestTest {
         Hashtable bundleHeaders = new Hashtable(1);
         bundleHeaders.put("IBM-Authorization-Roles", "default");
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp webApp = new WebApp(webAppConfig, null, null, mds, jnf, null);
+        WebApp webApp = new WebApp(webAppConfig, null, null, mds, jnf, null, null);
         webAppConfig.setWebApp(webApp);
         webAppConfig.setBundleHeaders(bundleHeaders);
         webApp.setCollaboratorHelper(new CollaboratorHelperImpl(webApp, null));
@@ -311,7 +311,7 @@ public class SRTServletRequestTest {
         Hashtable bundleHeaders = new Hashtable(1);
         bundleHeaders.put("IBM-Authorization-Roles", "com.ibm.ws.management");
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp webApp = new WebApp(webAppConfig, null, null, mds, jnf, null);
+        WebApp webApp = new WebApp(webAppConfig, null, null, mds, jnf, null, null);
         webAppConfig.setWebApp(webApp);
         webAppConfig.setBundleHeaders(bundleHeaders);
         webApp.setCollaboratorHelper(new CollaboratorHelperImpl(webApp, null));


### PR DESCRIPTION
Checkpoint restore testing uncovered a large performance gain in first request time by changing the order of these method calls in com.ibm.ws.webcontainer.webapp.WebApp.initialize:

           if (moduleConfig instanceof com.ibm.ws.webcontainer.osgi.container.DeployedModule) {
                // complete the notification here for app manager
                ((com.ibm.ws.webcontainer.osgi.container.DeployedModule) moduleConfig).initTaskComplete();

                if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
                    logger.logp(Level.FINE, CLASS_NAME, "initialize", "set future done for deployedModule -->" + moduleConfig);
                }
            }

                commonInitializationFinally(extensionFactories); // NEVER INVOKED BY

Calling commonInitalizationFinally before moduleConfig.initTaskComplete during an applications checkpoint lowers the restore time to first request from 255ms to 131ms for pingperf and 356ms to 215ms for rest crud. 