### PR TITLE
Update to use 2 threads when running in a 2 CPU environment

### DIFF
--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9FeatureCompatibilityTest.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9FeatureCompatibilityTest.java
@@ -359,7 +359,11 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
         int threadCount = Runtime.getRuntime().availableProcessors() - 1;
         if (threadCount > 4) {
             threadCount = 4;
+        } else if (threadCount == 1) {
+            // default to 2 threads so that we don't go over 3 hours in a slow build machine with only two CPUs
+            threadCount = 2;
         }
+        // leaving <= instead of < in case we change back to only one thread in a two CPU environment.
         if (threadCount <= 1) {
             checkFeatures(featureName, new ArrayDeque<String>(featureSet), specialConflicts, errors);
         } else {


### PR DESCRIPTION
- The build systems are usually 2 CPU VMs.  When some starts take longer to get the error, one thread is not enough.  Force to run with 2 threads for a 2 CPU system instead of number of CPUs - 1.