### PR TITLE
improve trace of context propagation

### DIFF
--- a/dev/com.ibm.ws.classloader.context/src/com/ibm/ws/classloader/context/internal/ClassloaderContextProviderImpl.java
+++ b/dev/com.ibm.ws.classloader.context/src/com/ibm/ws/classloader/context/internal/ClassloaderContextProviderImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.classloader.context.ClassLoaderThreadContextFactory;
 import com.ibm.ws.classloading.ClassLoaderIdentifierService;
 import com.ibm.wsspi.threadcontext.ThreadContext;
@@ -34,6 +35,7 @@ import com.ibm.wsspi.threadcontext.ThreadContextProvider;
  * Classloader thread context provider.
  */
 @Component(name = "com.ibm.ws.classloader.context.provider", configurationPolicy = ConfigurationPolicy.IGNORE)
+@SuppressWarnings("deprecation")
 public class ClassloaderContextProviderImpl implements ThreadContextProvider, ClassLoaderThreadContextFactory {
 
     /**
@@ -113,6 +115,7 @@ public class ClassloaderContextProviderImpl implements ThreadContextProvider, Cl
      * @see com.ibm.wsspi.threadcontext.ThreadContextProvider#getPrerequisites()
      */
     @Override
+    @Trivial
     public List<ThreadContextProvider> getPrerequisites() {
         return null;
     }

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
@@ -113,11 +113,14 @@ public class ContextServiceImpl implements ContextService, //
     /**
      * List of supported properties
      */
-    private static final List<String> SUPPORTED_PROPERTIES = Arrays.asList(BASE_CONTEXT_REF,
+    private static final List<String> SUPPORTED_PROPERTIES = Arrays.asList("application", // for app-defined resources
+                                                                           BASE_CONTEXT_REF,
+                                                                           "component", // for app-defined resources
                                                                            ResourceFactory.CREATES_OBJECT_CLASS,
                                                                            ID,
                                                                            "javaCompDefaultName", // for java:comp/DefaultContextService
                                                                            JNDI_NAME,
+                                                                           "module", // for app-defined resources
                                                                            Constants.OBJECTCLASS,
                                                                            OnErrorUtil.CFG_KEY_ON_ERROR);
 
@@ -491,6 +494,7 @@ public class ContextServiceImpl implements ContextService, //
     /**
      * @see javax.enterprise.concurrent.ContextService#createContextualProxy(java.lang.Object, java.util.Map, java.lang.Class<?>[])
      */
+    @SuppressWarnings("unchecked")
     @Override
     public Object createContextualProxy(final Object instance, Map<String, String> executionProperties, final Class<?>... interfaces) {
         if (instance instanceof ContextualAction)
@@ -504,7 +508,6 @@ public class ContextServiceImpl implements ContextService, //
                 throw new IllegalArgumentException(instance + ", " + (intf == null ? null : intf.getName()));
 
         Set<String> internalPropNames = executionProperties == null ? null : new HashSet<String>();
-        @SuppressWarnings("unchecked")
         ThreadContextDescriptor threadContextDescriptor = captureThreadContext(executionProperties, instance, internalPropNames);
 
         checkIfSerializable(threadContextDescriptor, interfaces);
@@ -701,6 +704,7 @@ public class ContextServiceImpl implements ContextService, //
     }
 
     @Override
+    @Trivial
     public ApplicationRecycleContext getContext() {
         return null;
     }

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedThreadFactoryService.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedThreadFactoryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013,2021 IBM Corporation and others.
+ * Copyright (c) 2013,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -77,16 +77,6 @@ public class ManagedThreadFactoryService implements ResourceFactory, Application
      * Names of applications using this ResourceFactory
      */
     private final Set<String> applications = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
-
-    /**
-     * Privileged action to lazily obtain the context service.
-     */
-    private final PrivilegedAction<WSContextService> contextSvcAccessor = new PrivilegedAction<WSContextService>() {
-        @Override
-        public WSContextService run() {
-            return contextSvcRef.getServiceWithException();
-        }
-    };
 
     /**
      * Reference to the context service for this managed thread factory service.
@@ -329,10 +319,11 @@ public class ManagedThreadFactoryService implements ResourceFactory, Application
          * @param serverAccessControlContext server access control context, which we can use to run certain privileged operations
          *                                       that aren't available to application threads.
          */
+        @SuppressWarnings("unchecked")
         ManagedThreadFactoryImpl(AccessControlContext serverAccessControlContext) {
             this.serverAccessControlContext = serverAccessControlContext;
 
-            WSContextService contextSvc = AccessController.doPrivileged(service.contextSvcAccessor);
+            WSContextService contextSvc = contextSvcRef.getServiceWithException();
             threadContextDescriptor = contextSvc.captureThreadContext(defaultExecutionProperties);
 
             ComponentMetaData cData = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();

--- a/dev/com.ibm.ws.context/bnd.bnd
+++ b/dev/com.ibm.ws.context/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2020 IBM Corporation and others.
+# Copyright (c) 2017,2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -42,4 +42,5 @@ instrument.classesExcludes: com/ibm/ws/context/service/resources/*.class
 	com.ibm.websphere.org.osgi.service.component,\
 	com.ibm.wsspi.org.osgi.service.component.annotations, \
 	com.ibm.ws.javaee.version;version=latest,\
+	com.ibm.ws.kernel.service;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest

--- a/dev/com.ibm.ws.context/src/com/ibm/ws/context/service/serializable/ContextualObject.java
+++ b/dev/com.ibm.ws.context/src/com/ibm/ws/context/service/serializable/ContextualObject.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2013 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,8 +18,6 @@ import java.io.ObjectInputStream.GetField;
 import java.io.ObjectOutputStream;
 import java.io.ObjectOutputStream.PutField;
 import java.io.ObjectStreamField;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -55,18 +53,6 @@ public abstract class ContextualObject<T> {
                                              new ObjectStreamField(INTERNAL_PROP_NAMES, Set.class),
                                              new ObjectStreamField(OBJECT, byte[].class)
                     };
-
-    /**
-     * Privileged action that gets the thread context class loader.
-     */
-    private static final GetThreadContextClassLoader getThreadContextClassLoader = new GetThreadContextClassLoader();
-
-    private static final class GetThreadContextClassLoader implements PrivilegedAction<ClassLoader> {
-        @Override
-        public ClassLoader run() {
-            return Thread.currentThread().getContextClassLoader();
-        }
-    }
 
     /**
      * Instance to wrap with context.
@@ -144,7 +130,7 @@ public abstract class ContextualObject<T> {
 
         DeserializationObjectInputStream doin = new DeserializationObjectInputStream(
                         new ByteArrayInputStream(bytes),
-                        AccessController.doPrivileged(getThreadContextClassLoader));
+                        ThreadContextManager.priv.getContextClassLoader());
         object = (T) doin.readObject();
         doin.close();
 

--- a/dev/com.ibm.ws.javaee.metadata.context/src/com/ibm/ws/javaee/metadata/context/internal/JEEMetadataContextProviderImpl.java
+++ b/dev/com.ibm.ws.javaee.metadata.context/src/com/ibm/ws/javaee/metadata/context/internal/JEEMetadataContextProviderImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2013 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.container.service.metadata.extended.MetaDataIdentifierService;
 import com.ibm.ws.javaee.metadata.context.ComponentMetaDataDecorator;
 import com.ibm.ws.javaee.metadata.context.JEEMetadataThreadContextFactory;
@@ -38,6 +39,7 @@ import com.ibm.wsspi.threadcontext.ThreadContextProvider;
  * Java EE application component context service provider.
  */
 @Component(name = "com.ibm.ws.javaee.metadata.context.provider", configurationPolicy = ConfigurationPolicy.IGNORE)
+@SuppressWarnings("deprecation")
 public class JEEMetadataContextProviderImpl implements ThreadContextProvider, JEEMetadataThreadContextFactory {
     final ConcurrentServiceReferenceMap<String, ComponentMetaDataDecorator> componentMetadataDecoratorRefs = new ConcurrentServiceReferenceMap<String, ComponentMetaDataDecorator>("componentMetadataDecorator");
 
@@ -102,6 +104,7 @@ public class JEEMetadataContextProviderImpl implements ThreadContextProvider, JE
      * @see com.ibm.wsspi.threadcontext.ThreadContextProvider#getPrerequisites()
      */
     @Override
+    @Trivial
     public List<ThreadContextProvider> getPrerequisites() {
         return null;
     }

--- a/dev/com.ibm.ws.security.context/src/com/ibm/ws/security/context/internal/SecurityContextProviderImpl.java
+++ b/dev/com.ibm.ws.security.context/src/com/ibm/ws/security/context/internal/SecurityContextProviderImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2016 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,6 +33,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferencePolicy;
 
 import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.SecurityService;
 import com.ibm.ws.security.authentication.UnauthenticatedSubjectService;
@@ -50,6 +51,7 @@ import com.ibm.wsspi.threadcontext.ThreadContextProvider;
            name = "com.ibm.ws.security.context.provider",
            configurationPolicy = ConfigurationPolicy.IGNORE,
            property = "service.vendor=IBM")
+@SuppressWarnings("deprecation")
 public class SecurityContextProviderImpl implements ThreadContextProvider {
 
     static final String KEY_CONFIGURATION_ADMIN = "configurationAdmin";
@@ -157,6 +159,7 @@ public class SecurityContextProviderImpl implements ThreadContextProvider {
      * @see com.ibm.wsspi.threadcontext.ThreadContextProvider#getPrerequisites()
      */
     @Override
+    @Trivial
     public List<ThreadContextProvider> getPrerequisites() {
         return null;
     }

--- a/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/TransactionContextProviderImpl.java
+++ b/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/TransactionContextProviderImpl.java
@@ -22,6 +22,7 @@ import javax.enterprise.concurrent.ManagedTask;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.Transaction.UOWCurrent;
 import com.ibm.ws.tx.embeddable.EmbeddableWebSphereTransactionManager;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
@@ -174,6 +175,7 @@ public class TransactionContextProviderImpl implements JCAContextProvider, Threa
      * @see com.ibm.wsspi.threadcontext.ThreadContextProvider#getPrerequisites()
      */
     @Override
+    @Trivial
     public List<ThreadContextProvider> getPrerequisites() {
         return null;
     }

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/context/ThirdPartyContextCoordinator.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/context/ThirdPartyContextCoordinator.java
@@ -170,6 +170,7 @@ public class ThirdPartyContextCoordinator implements ApplicationStateListener, /
     }
 
     @Override
+    @Trivial
     public List<com.ibm.wsspi.threadcontext.ThreadContextProvider> getPrerequisites() {
         return null;
     }

--- a/dev/io.openliberty.handlelist.context.internal/src/io/openliberty/handlelist/context/internal/EmptyHandleListContext.java
+++ b/dev/io.openliberty.handlelist.context.internal/src/io/openliberty/handlelist/context/internal/EmptyHandleListContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -52,6 +52,7 @@ public class EmptyHandleListContext implements ThreadContext {
 
     /** {@inheritDoc} */
     @Override
+    @Trivial
     public ThreadContext clone() {
         try {
             EmptyHandleListContext copy = (EmptyHandleListContext) super.clone();
@@ -78,29 +79,23 @@ public class EmptyHandleListContext implements ThreadContext {
      * Push a new HandleList onto the thread.
      */
     @Override
+    @Trivial // method name is misleading in trace
     public void taskStarting() {
-        final boolean trace = TraceComponent.isAnyTracingEnabled();
-        if (trace && tc.isEntryEnabled())
-            Tr.entry(this, tc, "taskStarting");
-
         com.ibm.ws.threadContext.ThreadContext<HandleListInterface> threadContext = //
                         ConnectionHandleAccessorImpl.getConnectionHandleAccessor().getThreadContext();
 
         HandleListInterface prevHandleList = threadContext.beginContext(new HandleList());
 
-        if (trace && tc.isEntryEnabled())
-            Tr.exit(this, tc, "taskStarting", prevHandleList + " --> " + threadContext.getContext());
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "clear     " + prevHandleList + " --> " + threadContext.getContext());
     }
 
     /**
      * Restore the HandleList (if any) that was previously on the thread.
      */
     @Override
+    @Trivial // method name is misleading in trace
     public void taskStopping() {
-        final boolean trace = TraceComponent.isAnyTracingEnabled();
-        if (trace && tc.isEntryEnabled())
-            Tr.entry(this, tc, "taskStopping");
-
         com.ibm.ws.threadContext.ThreadContext<HandleListInterface> threadContext = //
                         ConnectionHandleAccessorImpl.getConnectionHandleAccessor().getThreadContext();
 
@@ -108,8 +103,8 @@ public class EmptyHandleListContext implements ThreadContext {
         if (removedHandleList != null)
             removedHandleList.close();
 
-        if (trace && tc.isEntryEnabled())
-            Tr.exit(this, tc, "taskStopping", threadContext.getContext() + " <-- " + removedHandleList);
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "restore   " + threadContext.getContext() + " <-- " + removedHandleList);
     }
 
     @Override


### PR DESCRIPTION
It is difficult to debug trace of context being propagated to managed executor tasks and actions because of numerous misleading trace points for run, taskStarting, and taskStopping that don't actually indicate the running of the task.  Some of these come from PrivilegedAction classes, others from what is actually context being propagated or cleaned up some time before or after running the task.  There are also a lot of useless trace points that fill up the log and obscure the valuable information here.  This pull aims to suppress the useless information and improve on the beneficial trace points to provide a clearer and more concise picture of what is actually happening.