### PR TITLE
Update to lazily get expensive audit data

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/internal/jacc/EJBJaccAuthorizationHelper.java
+++ b/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/internal/jacc/EJBJaccAuthorizationHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@ package com.ibm.ws.ejbcontainer.security.internal.jacc;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.ejb.EnterpriseBean;
 import javax.security.auth.Subject;
@@ -47,11 +48,9 @@ public class EJBJaccAuthorizationHelper implements EJBAuthorizationHelper {
         this.jaccServiceRef = jaccServiceRef;
     }
 
-    public HashMap<String, Object> ejbAuditHashMap = new HashMap<String, Object>();
-
     protected AuditManager auditManager;
 
-    public void populateAuditEJBHashMap(EJBRequestData request) {
+    public void populateAuditEJBHashMap(EJBRequestData request, Map<String, Object> ejbAuditHashMap) {
         EJBMethodMetaData methodMetaData = request.getEJBMethodMetaData();
         Object[] methodArguments = request.getMethodArguments();
         String applicationName = methodMetaData.getEJBComponentMetaData().getJ2EEName().getApplication();
@@ -85,7 +84,7 @@ public class EJBJaccAuthorizationHelper implements EJBAuthorizationHelper {
      * <li>is the subject authorized to any of the required roles</li>
      *
      * @param methodMetaData the info on the EJB method to call
-     * @param subject the subject authorize
+     * @param subject        the subject authorize
      * @throws EJBAccessDeniedException when the subject is not authorized to the EJB
      */
     @Override
@@ -104,7 +103,9 @@ public class EJBJaccAuthorizationHelper implements EJBAuthorizationHelper {
         String beanName = methodMetaData.getEJBComponentMetaData().getJ2EEName().getComponent();
         List<Object> methodParameters = null;
 
-        populateAuditEJBHashMap(request);
+        HashMap<String, Object> ejbAuditHashMap = new HashMap<String, Object>();
+
+        populateAuditEJBHashMap(request, ejbAuditHashMap);
 
         Object bean = request.getBeanInstance();
         EnterpriseBean ejb = null;

--- a/dev/com.ibm.ws.request.probe.audit.servlet/src/com/ibm/ws/request/probe/audit/servlet/AuditPE.java
+++ b/dev/com.ibm.ws.request.probe.audit.servlet/src/com/ibm/ws/request/probe/audit/servlet/AuditPE.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 IBM Corporation and others.
+ * Copyright (c) 2016, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 
 import javax.management.NotificationFilter;
 import javax.management.ObjectName;
@@ -374,13 +373,12 @@ public class AuditPE implements ProbeExtension {
 
 	private void auditEventAuthnDelegation01(Object[] methodParams) {
 		Object[] varargs = (Object[]) methodParams[1];
+		HashMap<String, Object> extraAuditData = (HashMap) varargs[0];
 		String auditOutcome = (String) varargs[1];
+		Integer statusCode = (Integer) varargs[2];
 		if (auditServiceRef.getService() != null && auditServiceRef.getService()
 				.isAuditRequired(AuditConstants.SECURITY_AUTHN_DELEGATION, auditOutcome)) {
-			Supplier<HashMap<String, Object>> extraAuditSupplier = (Supplier<HashMap<String, Object>>) varargs[0];
-			HashMap<String, Object> extraAuditData = extraAuditSupplier.get();
 			if (extraAuditData.get("HTTP_SERVLET_REQUEST") != null) {
-				Integer statusCode = (Integer) varargs[2];
 				AuthenticationDelegationEvent av = new AuthenticationDelegationEvent(extraAuditData, statusCode);
 				auditServiceRef.getService().sendEvent(av);
 			}

--- a/dev/com.ibm.ws.request.probe.audit.servlet/src/com/ibm/ws/request/probe/audit/servlet/AuditPE.java
+++ b/dev/com.ibm.ws.request.probe.audit.servlet/src/com/ibm/ws/request/probe/audit/servlet/AuditPE.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 IBM Corporation and others.
+ * Copyright (c) 2016, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import javax.management.NotificationFilter;
 import javax.management.ObjectName;
@@ -373,12 +374,13 @@ public class AuditPE implements ProbeExtension {
 
 	private void auditEventAuthnDelegation01(Object[] methodParams) {
 		Object[] varargs = (Object[]) methodParams[1];
-		HashMap<String, Object> extraAuditData = (HashMap) varargs[0];
 		String auditOutcome = (String) varargs[1];
-		Integer statusCode = (Integer) varargs[2];
 		if (auditServiceRef.getService() != null && auditServiceRef.getService()
 				.isAuditRequired(AuditConstants.SECURITY_AUTHN_DELEGATION, auditOutcome)) {
+			Supplier<HashMap<String, Object>> extraAuditSupplier = (Supplier<HashMap<String, Object>>) varargs[0];
+			HashMap<String, Object> extraAuditData = extraAuditSupplier.get();
 			if (extraAuditData.get("HTTP_SERVLET_REQUEST") != null) {
+				Integer statusCode = (Integer) varargs[2];
 				AuthenticationDelegationEvent av = new AuthenticationDelegationEvent(extraAuditData, statusCode);
 				auditServiceRef.getService().sendEvent(av);
 			}

--- a/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/source/AuditServiceImpl.java
+++ b/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/source/AuditServiceImpl.java
@@ -380,26 +380,11 @@ public class AuditServiceImpl implements AuditService, Source {
                     }
                     return true;
                 } else {
-                    boolean foundMatchingEvent = false;
-                    boolean foundAnOutcome = false;
-                    boolean foundMatchingEventAndOutcome = false;
-                    for (Entry<String, Object> entry : handlerEvents.entrySet()) {
-                        if (entry.getKey().equals(AuditConstants.EVENT_NAME) && entry.getValue().equals(eventType)) {
-                            foundMatchingEvent = true;
-                        } else {
-                            if (entry.getKey().equals(AuditConstants.OUTCOME)) {
-                                foundAnOutcome = true;
-                                if (entry.getValue().toString().equalsIgnoreCase(outcome)) {
-                                    if (foundMatchingEvent) {
-                                        foundMatchingEventAndOutcome = true;
-                                    }
-                                }
-                            }
+                    if (eventType.equals(handlerEvents.get(AuditConstants.EVENT_NAME))) {
+                        Object eventOutcome = handlerEvents.get(AuditConstants.OUTCOME);
+                        if (eventOutcome == null || eventOutcome.toString().equalsIgnoreCase(outcome)) {
+                            return true;
                         }
-
-                    }
-                    if (foundMatchingEventAndOutcome || (foundMatchingEvent && !foundAnOutcome)) {
-                        return true;
                     }
                 }
             }

--- a/dev/com.ibm.ws.security/src/com/ibm/ws/security/audit/Audit.java
+++ b/dev/com.ibm.ws.security/src/com/ibm/ws/security/audit/Audit.java
@@ -11,6 +11,9 @@
 package com.ibm.ws.security.audit;
 
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.websphere.security.audit.AuditConstants;
+import com.ibm.ws.security.utils.SecurityUtils;
+import com.ibm.wsspi.security.audit.AuditService;
 
 /**
  * This class provides an audit probe point method and constants.
@@ -19,33 +22,55 @@ import com.ibm.websphere.ras.annotation.Trivial;
 public class Audit {
     @Trivial
     public static enum EventID {
-        SECURITY_AUTHN_01,
-        SECURITY_AUTHZ_01, // web
-        SECURITY_AUTHZ_02, // jacc web
-        SECURITY_AUTHZ_03, // jacc ejb
-        SECURITY_AUTHZ_04, // ejb
-        SECURITY_AUDIT_MGMT_01,
-        SECURITY_AUDIT_MGMT_02,
-        SECURITY_AUTHN_DELEGATION_01,
-        SECURITY_AUTHZ_DELEGATION_01,
-        SECURITY_API_AUTHN_01,
-        SECURITY_API_AUTHN_TERMINATE_01,
-        SECURITY_AUTHN_TERMINATE_01,
-        SECURITY_AUTHN_FAILOVER_01,
-        SECURITY_MEMBER_MGMT_01,
-        SECURITY_JMS_AUTHN_01,
-        SECURITY_JMS_AUTHZ_01,
-        SECURITY_JMS_AUTHN_TERMINATE_01,
-        SECURITY_JMS_CLOSED_CONNECTION_01,
-        SECURITY_REST_HANDLER_AUTHZ,
-        SECURITY_SAF_AUTHZ,
-        SECURITY_SAF_AUTHZ_DETAILS,
-        JMX_NOTIFICATION_01,
-        JMX_MBEAN_01,
-        JMX_MBEAN_ATTRIBUTES_01,
-        JMX_MBEAN_REGISTER_01,
-        APPLICATION_PASSWORD_TOKEN_01
+        SECURITY_AUTHN_01(AuditConstants.SECURITY_AUTHN),
+        SECURITY_AUTHZ_01(AuditConstants.SECURITY_AUTHZ), // web
+        SECURITY_AUTHZ_02(AuditConstants.SECURITY_AUTHZ), // jacc web
+        SECURITY_AUTHZ_03(AuditConstants.SECURITY_AUTHZ), // jacc ejb
+        SECURITY_AUTHZ_04(AuditConstants.SECURITY_AUTHZ), // ejb
+        SECURITY_AUDIT_MGMT_01(AuditConstants.SECURITY_AUDIT_MGMT),
+        SECURITY_AUDIT_MGMT_02(AuditConstants.SECURITY_AUDIT_MGMT),
+        SECURITY_AUTHN_DELEGATION_01(AuditConstants.SECURITY_AUTHN_DELEGATION),
+        SECURITY_AUTHZ_DELEGATION_01(AuditConstants.SECURITY_AUTHZ_DELEGATION),
+        SECURITY_API_AUTHN_01(AuditConstants.SECURITY_API_AUTHN),
+        SECURITY_API_AUTHN_TERMINATE_01(AuditConstants.SECURITY_API_AUTHN_TERMINATE),
+        SECURITY_AUTHN_TERMINATE_01(AuditConstants.SECURITY_AUTHN_TERMINATE),
+        SECURITY_AUTHN_FAILOVER_01(AuditConstants.SECURITY_AUTHN_FAILOVER),
+        SECURITY_MEMBER_MGMT_01(AuditConstants.SECURITY_MEMBER_MGMT),
+        SECURITY_JMS_AUTHN_01(AuditConstants.SECURITY_JMS_AUTHN),
+        SECURITY_JMS_AUTHZ_01(AuditConstants.SECURITY_JMS_AUTHZ),
+        SECURITY_JMS_AUTHN_TERMINATE_01(AuditConstants.SECURITY_JMS_AUTHN_TERMINATE),
+        SECURITY_JMS_CLOSED_CONNECTION_01(AuditConstants.SECURITY_JMS_CLOSED_CONNECTION),
+        SECURITY_REST_HANDLER_AUTHZ(AuditConstants.SECURITY_REST_HANDLER_AUTHZ),
+        SECURITY_SAF_AUTHZ(AuditConstants.SECURITY_SAF_AUTHZ),
+        SECURITY_SAF_AUTHZ_DETAILS(AuditConstants.SECURITY_SAF_AUTHZ_DETAILS),
+        JMX_NOTIFICATION_01(AuditConstants.JMX_NOTIFICATION),
+        JMX_MBEAN_01(AuditConstants.JMX_MBEAN),
+        JMX_MBEAN_ATTRIBUTES_01(AuditConstants.JMX_MBEAN_ATTRIBUTES),
+        JMX_MBEAN_REGISTER_01(AuditConstants.JMX_MBEAN_REGISTER),
+        APPLICATION_PASSWORD_TOKEN_01(AuditConstants.APPLICATION_TOKEN_MANAGEMENT);
 
+        final String eventType;
+
+        EventID(String eventType) {
+            this.eventType = eventType;
+        }
+
+        public String getEventType() {
+            return eventType;
+        }
+
+    }
+
+    public static boolean isAuditServiceEnabled() {
+        return SecurityUtils.getAuditService() != null;
+    }
+
+    public static boolean isAuditRequired(EventID eventID, String outcome) {
+        AuditService auditService = SecurityUtils.getAuditService();
+        if (auditService == null) {
+            return false;
+        }
+        return auditService.isAuditRequired(eventID.getEventType(), outcome);
     }
 
     /**

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
@@ -16,9 +16,11 @@ import java.security.Principal;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import javax.security.auth.Subject;
 import javax.security.auth.login.CredentialExpiredException;
@@ -156,7 +158,6 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
     protected HTTPSRedirectHandler httpsRedirectHandler;
 
     protected AuditManager auditManager;
-    public HashMap<String, Object> extraAuditData = new HashMap<String, Object>();
 
     protected WebAuthenticatorProxy authenticatorProxy;
     protected WebProviderAuthenticatorProxy providerAuthenticatorProxy;
@@ -617,12 +618,9 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
                 performSecurityChecks(req, resp, receivedSubject, webSecurityContext);
             }
 
-            if (req != null) {
-                extraAuditData.put("HTTP_SERVLET_REQUEST", req);
-            }
             //auditManager.setHttpServletRequest(req);
 
-            performDelegation(servletName);
+            performDelegation(req, servletName);
 
             syncToOSThread(webSecurityContext);
         }
@@ -881,105 +879,100 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
         return authResult;
     }
 
-    private void performDelegation(String servletName) {
+    private void performDelegationAudit(HttpServletRequest req, Subject callerSubject, String roleName, Subject delegationSubject, boolean success,
+                                        AuthenticationService authService) {
+        String outcome = success ? AuditConstants.SUCCESS : AuditConstants.FAILURE;
 
-        Subject delegationSubject = subjectManager.getCallerSubject();
-        if (delegationSubject != null && delegationSubject.getPublicCredentials(WSCredential.class) != null
-            && delegationSubject.getPublicCredentials(WSCredential.class).iterator() != null &&
-            delegationSubject.getPublicCredentials(WSCredential.class).iterator().hasNext()) {
-            WSCredential credential = delegationSubject.getPublicCredentials(WSCredential.class).iterator().next();
-            try {
-                extraAuditData.put("REALM", credential.getRealmName());
-            } catch (CredentialExpiredException e) {
-            } catch (CredentialDestroyedException e) {
-            }
-        }
-        ArrayList<String> delUsers = new ArrayList<String>();
-        if (delegationSubject != null) {
-            String buff = getSubjectToString(delegationSubject);
-            if (buff != null) {
-                int a = buff.indexOf("accessId");
-                if (a != -1) {
-                    buff = buff.substring(a + 9);
-                    a = buff.indexOf(",");
-                    if (a != -1) {
-                        buff = buff.substring(0, a);
-                        delUsers.add(buff);
+        Supplier<HashMap<String, Object>> extraAuditSupplier = new Supplier<HashMap<String, Object>>() {
+
+            @Override
+            public HashMap<String, Object> get() {
+                HashMap<String, Object> extraAuditData = new HashMap<String, Object>();
+
+                if (req != null) {
+                    extraAuditData.put("HTTP_SERVLET_REQUEST", req);
+                }
+
+                Set<WSCredential> publicCredentials = (callerSubject == null ? null : callerSubject.getPublicCredentials(WSCredential.class));
+                Iterator<WSCredential> it = null;
+                if (publicCredentials != null && (it = publicCredentials.iterator()) != null && it.hasNext()) {
+                    WSCredential credential = it.next();
+                    try {
+                        extraAuditData.put("REALM", credential.getRealmName());
+                    } catch (CredentialExpiredException e) {
+                    } catch (CredentialDestroyedException e) {
                     }
                 }
 
-            }
-        }
-        SecurityMetadata secMetadata = getSecurityMetadata();
-        if (secMetadata != null) {
-            String roleName = secMetadata.getRunAsRoleForServlet(servletName);
-            String invalidUser = "";
-            if (roleName != null) {
+                ArrayList<String> delUsers = new ArrayList<String>();
+                if (callerSubject != null) {
+                    String buff = getSubjectToString(callerSubject);
+                    if (buff != null) {
+                        int a = buff.indexOf("accessId");
+                        if (a != -1) {
+                            buff = buff.substring(a + 9);
+                            a = buff.indexOf(",");
+                            if (a != -1) {
+                                buff = buff.substring(0, a);
+                                delUsers.add(buff);
+                            }
+                        }
+
+                    }
+                }
+
                 extraAuditData.put("RUN_AS_ROLE", roleName);
-
-                try {
-                    SecurityService securityService = securityServiceRef.getService();
-                    AuthenticationService authService = securityService.getAuthenticationService();
-                    delegationSubject = authService.delegate(roleName, getApplicationName());
-                    if (delegationSubject != null) {
-                        String buff = getSubjectToString(delegationSubject);
-                        if (buff != null) {
-                            int a = buff.indexOf("accessId");
+                if (delegationSubject == null) {
+                    String invalidUser = authService.getInvalidDelegationUser();
+                    delUsers.add(invalidUser);
+                } else if (delegationSubject != callerSubject) {
+                    String buff = getSubjectToString(delegationSubject);
+                    if (buff != null) {
+                        int a = buff.indexOf("accessId");
+                        if (a != -1) {
+                            buff = buff.substring(a + 9);
+                            a = buff.indexOf(",");
                             if (a != -1) {
-                                buff = buff.substring(a + 9);
-                                a = buff.indexOf(",");
-                                if (a != -1) {
-                                    buff = buff.substring(0, a);
-                                    delUsers.add(buff);
-                                }
+                                buff = buff.substring(0, a);
+                                delUsers.add(buff);
                             }
-
                         }
-                    } else {
-                        invalidUser = authService.getInvalidDelegationUser();
-                        delUsers.add(invalidUser);
-                    }
 
-                    extraAuditData.put("DELEGATION_USERS_LIST", delUsers);
-                    //auditManager.setDelegatedUsers(delUsers);
-                    //Audit.audit(Audit.EventID.SECURITY_AUTHN_DELEGATION_01, auditManager, AuditConstants.SUCCESS, Integer.valueOf(200));
-                    if (delegationSubject != null) {
-                        Audit.audit(Audit.EventID.SECURITY_AUTHN_DELEGATION_01, extraAuditData, AuditConstants.SUCCESS, Integer.valueOf(200));
-                    } else {
-                        Audit.audit(Audit.EventID.SECURITY_AUTHN_DELEGATION_01, extraAuditData, AuditConstants.FAILURE, Integer.valueOf(401));
-
-                    }
-
-                } catch (IllegalArgumentException e) {
-                    if (delegationSubject != null) {
-                        String buff = getSubjectToString(delegationSubject);
-                        if (buff != null) {
-                            int a = buff.indexOf("accessId");
-                            if (a != -1) {
-                                buff = buff.substring(a + 9);
-                                a = buff.indexOf(",");
-                                if (a != -1) {
-                                    buff = buff.substring(0, a);
-                                    delUsers.add(buff);
-                                }
-                            }
-
-                        }
-                    } else {
-                        SecurityService securityService = securityServiceRef.getService();
-                        AuthenticationService authService = securityService.getAuthenticationService();
-                        invalidUser = authService.getInvalidDelegationUser();
-                        delUsers.add(invalidUser);
-                        extraAuditData.put(DELEGATION_USERS_LIST, delUsers);
-                    }
-
-                    //Audit.audit(Audit.EventID.SECURITY_AUTHN_DELEGATION_01, auditManager, AuditConstants.FAILURE, Integer.valueOf(401));
-                    Audit.audit(Audit.EventID.SECURITY_AUTHN_DELEGATION_01, extraAuditData, AuditConstants.FAILURE, Integer.valueOf(401));
-
-                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                        Tr.debug(tc, "Exception performing delegation.", e);
                     }
                 }
+
+                extraAuditData.put("DELEGATION_USERS_LIST", delUsers);
+                return extraAuditData;
+            }
+
+        };
+        Audit.audit(Audit.EventID.SECURITY_AUTHN_DELEGATION_01, extraAuditSupplier, outcome, success ? Integer.valueOf(200) : Integer.valueOf(401));
+    }
+
+    private void performDelegation(HttpServletRequest req, String servletName) {
+
+        Subject callerSubject = subjectManager.getCallerSubject();
+
+        SecurityMetadata secMetadata = getSecurityMetadata();
+        String roleName = secMetadata == null ? null : secMetadata.getRunAsRoleForServlet(servletName);
+
+        Subject delegationSubject = callerSubject;
+        if (roleName != null) {
+            SecurityService securityService = securityServiceRef.getService();
+            AuthenticationService authService = securityService.getAuthenticationService();
+            boolean success;
+            try {
+                delegationSubject = authService.delegate(roleName, getApplicationName());
+                success = delegationSubject != null;
+            } catch (IllegalArgumentException e) {
+                success = false;
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Exception performing delegation.", e);
+                }
+            }
+            // if HttpRequest is null, the audit does nothing, so don't call it if null
+            if (req != null) {
+                performDelegationAudit(req, callerSubject, roleName, delegationSubject, success, authService);
             }
         }
         if (delegationSubject != null) {

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAuthenticatorProxy.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAuthenticatorProxy.java
@@ -48,7 +48,6 @@ public class WebAuthenticatorProxy implements WebAuthenticator {
     protected volatile WebAppSecurityConfig webAppSecurityConfig;
     private volatile PostParameterHelper postParameterHelper;
     private final WebProviderAuthenticatorProxy providerAuthenticatorProxy;
-    public HashMap<String, Object> extraAuditData = new HashMap<String, Object>();
 
     public WebAuthenticatorProxy(WebAppSecurityConfig webAppSecurityConfig,
                                  PostParameterHelper postParameterHelper,
@@ -89,6 +88,7 @@ public class WebAuthenticatorProxy implements WebAuthenticator {
             if (authenticator instanceof CertificateLoginAuthenticator &&
                 authResult != null && authResult.getStatus() != AuthResult.SUCCESS &&
                 webAppSecurityConfig.allowFailOver() && !webRequest.isDisableClientCertFailOver()) {
+                HashMap<String, Object> extraAuditData = new HashMap<String, Object>();
                 extraAuditData.put(AuditConstants.ORIGINAL_AUTH_TYPE, authType);
                 authType = getFailOverToAuthType(webRequest);
                 extraAuditData.put(AuditConstants.FAILOVER_AUTH_TYPE, authType);


### PR DESCRIPTION
- For authentication, process the Subjects used for audit only if audit is enabled.
- Update HashMaps used for audit to be method scoped instead of class scoped

Fixes #20171