### PR TITLE
update AnnotationScanTest to provide more diagnostic info

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/AnnotationScanTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/AnnotationScanTest.java
@@ -439,7 +439,7 @@ public class AnnotationScanTest {
         } else {
             messageCount = server.findStringsInLogs("CWWKW0102W.*annotationscan.*NotAnAppIBMRestServlet.*com.ibm.ws.jaxrs.fat.annotation.multipleapp.MyResource3").size();
         }
-        assertEquals("Did not find expected warning indicating servlet contains invalid Application class", 1,
+        assertEquals("Did not find expected warning indicating servlet contains invalid Application class; jakarta=" + JakartaEE9Action.isActive(), 1,
                      messageCount);
     }
 }


### PR DESCRIPTION
Modifying the assert method to indicate which check was done, javax or jakarta.

This is to help debug an intermittently failing test where the ```server.findStringsInLogs()``` call isn't finding the matching message in the logs, but I am able to manually match the method.

I suspect that maybe we may be trying to match the javax message when running EE9.
