### PR TITLE
add java.security.AllPermission to the Microprofile RestClient 2.0 TCk

### DIFF
--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/servers/FATServer/server.xml
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/servers/FATServer/server.xml
@@ -1,9 +1,9 @@
-<!--Copyright (c) 2020 IBM Corporation and others. All rights reserved.
-    This program and the accompanying materials are made available under the 
-    terms of the Eclipse Public License v1.0 which accompanies this distribution, 
-    and is available at 
-        http://www.eclipse.org/legal/epl-v10.html 
-    Contributors: 
+<!--Copyright (c) 2020, 2022 IBM Corporation and others. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v1.0 which accompanies this distribution,
+    and is available at
+        http://www.eclipse.org/legal/epl-v10.html
+    Contributors:
         IBM Corporation - initial API and implementation
 -->
 <server>
@@ -18,6 +18,9 @@
         <feature>arquillian-support-1.0</feature>
         <feature>ssl-1.0</feature>
     </featureManager>
+
+    <!--Java2 security-->
+    <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 
     <include location="../fatTestPorts.xml" />
 


### PR DESCRIPTION
Currently, the ```io.openliberty.microprofile.rest.client.2.0.internal_fat_tck``` can fail with the following error:

```
Access denied ("java.lang.RuntimePermission" "getClassLoader")


java.security.AccessControlException: Access denied ("java.lang.RuntimePermission" "getClassLoader")
at java.base/java.security.AccessController.throwACE(AccessController.java:176)
at java.base/java.security.AccessController.checkPermissionHelper(AccessController.java:238)
at java.base/java.security.AccessController.checkPermission(AccessController.java:385)
at java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:322)
at java.base/java.lang.Thread.getContextClassLoader(Thread.java:578)
at org.jboss.arquillian.protocol.servlet.runner.SecurityActions$GetTcclAction.run(SecurityActions.java:333)
at org.jboss.arquillian.protocol.servlet.runner.SecurityActions$GetTcclAction.run(SecurityActions.java:327)
at java.base/java.security.AccessController.doPrivileged(AccessController.java:682)
at org.jboss.arquillian.protocol.servlet.runner.SecurityActions.getThreadContextClassLoader(SecurityActions.java:58)
at org.jboss.arquillian.protocol.servlet.runner.ServletTestRunner.executeTest(ServletTestRunner.java:137)
at org.jboss.arquillian.protocol.servlet.runner.ServletTestRunner.execute(ServletTestRunner.java:117)
at org.jboss.arquillian.protocol.servlet.runner.ServletTestRunner.doGet(ServletTestRunner.java:86)
at javax.servlet.http.HttpServlet.service(HttpServlet.java:686)
at javax.servlet.http.HttpServlet.service(HttpServlet.java:791)
at com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1258)
at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:746)
at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:443)
at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1227)
at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1011)
at com.ibm.ws.webcontainer.servlet.CacheServletWrapper.handleRequest(CacheServletWrapper.java:75)
at com.ibm.ws.webcontainer40.servlet.CacheServletWrapper40.handleRequest(CacheServletWrapper40.java:85)
at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:938)
at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:281)
at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1184)
at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:453)
at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:412)
at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:566)
at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:500)
at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:360)
at com.ibm.ws.http.channel.internal.inbound.HttpICLReadCallback.complete(HttpICLReadCallback.java:70)
at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:514)
at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:584)
at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:968)
at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1057)
at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:245)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
at java.base/java.lang.Thread.run(Thread.java:866)
```

The solution is to add ```<javaPermission className="java.security.AllPermission"  name="*" actions="*" />``` to the ```server.xml``` of the the test server. This is what we do for other TCK FAT projects.