### PR TITLE
update com.ibm.ws.jaxrs.2.1_fat's tested features

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat/bnd.bnd
@@ -21,7 +21,15 @@ src: \
 
 fat.project: true
 
-tested.features: mpconfig-1.4, restfulWS-3.0, restfulWSClient-3.0, appsecurity-2.0, appsecurity-3.0
+tested.features: \
+  mpconfig-1.4,\
+  restfulWS-3.0,\
+  restfulWSClient-3.0,\
+  appsecurity-2.0,\
+  appsecurity-3.0,\
+  appsecurity-4.0,\
+  expressionlanguage-4.0,\
+  xmlbinding-3.0
 
 -buildpath: \
   com.ibm.websphere.javaee.annotation.1.2,\
@@ -35,4 +43,4 @@ tested.features: mpconfig-1.4, restfulWS-3.0, restfulWSClient-3.0, appsecurity-2
   com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2,\
   com.ibm.ws.org.apache.cxf.cxf.rt.rs.client.3.2,\
   com.ibm.ws.org.apache.httpcomponents;version=latest
-  
+


### PR DESCRIPTION
Fixes the following error in the project's `output.txt`:
```
[02/27/2022 20:58:23:023 PST] 001 FeatureDependencyProcessor     validateTestedFeatures         S null
java.lang.Exception: Installed feature(s) [appsecurity-4.0, expressionlanguage-4.0, xmlbinding-3.0] were not defined in the autoFVT/fat-metadata.json file! To correct this, add [appsecurity-4.0, expressionlanguage-4.0, xmlbinding-3.0] to the 'tested.features' property in the bnd.bnd or build-test.xml file for this FAT so that an accurate test depdendency graph can be generated in the future.
	at componenttest.depchain.FeatureDependencyProcessor.validateTestedFeatures(FeatureDependencyProcessor.java:84)
	at componenttest.topology.impl.LibertyServer.validateServerStarted(LibertyServer.java:2544)
	at componenttest.topology.impl.LibertyServer.startServerWithArgs(LibertyServer.java:1683)
	at componenttest.topology.impl.LibertyServer.startServerAndValidate(LibertyServer.java:1260)
	at componenttest.topology.impl.LibertyServer.startServerAndValidate(LibertyServer.java:1242)
	at componenttest.topology.impl.LibertyServer.startServerAndValidate(LibertyServer.java:1229)
	at componenttest.topology.impl.LibertyServer.startServer(LibertyServer.java:994)
	at com.ibm.ws.jaxrs21.fat.JAXRS21SecurityAnnotationsTestRolesAsGroups.setupClass(JAXRS21SecurityAnnotationsTestRolesAsGroups.java:56)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:45)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:15)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:42)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:27)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:30)
	at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:320)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:300)
	at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:173)
	at org.junit.runners.Suite.runChild(Suite.java:12
	at org.junit.runners.Suite.runChild(Suite.java:24)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:231)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:60)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:50)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:222)
	at componenttest.rules.repeater.RepeatTests$CompositeRepeatTestActionStatement.evaluate(RepeatTests.java:143)
	at org.junit.rules.RunRules.evaluate(RunRules.java:18)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:300)
	at junit.framework.JUnit4TestAdapter.run(JUnit4TestAdapter.java:39)
	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.run(JUnitTestRunner.java:520)
	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.launch(JUnitTestRunner.java:1060)
	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.main(JUnitTestRunner.java:911)
```

This exception doesn't affect any tests, but I noticed it so I thought I'd clean it up.