### PR TITLE
Update concurrency TCK to run new signature tests

### DIFF
--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/README.md
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/README.md
@@ -99,7 +99,8 @@ cd io.openliberty.jakarta.concurrency.3.0_fat_tck/wlp
 -Denv.tck_username=arquillian \
 -Denv.tck_password=arquillianPassword \
 -Denv.tck_port=9080 \
--Denv.tck_port_secure=9443
+-Denv.tck_port_secure=9443 \
+-Djimage.dir=$PWD/usr/shared/jimage/output
 ```
 ### Run the TCK
 
@@ -122,12 +123,12 @@ mvn clean test -B \
 -Djava.util.logging.config.file=$PWD/usr/servers/ConcurrentTCKServer/resources/logging/logging.properties
 ```
 
-By default the TCK will run against a snapshot of the Jakarta API and TCK uploaded to the DHE repository.
+By default the TCK will run against a staged version of Jakarta API and TCK uploaded to sonatype.
 If you want to test against a local `3.0.0-SNAPSHOT` then set these properties on the command above: 
 
 ```txt
--Djakarta.concurrent.groupid=jakarta.enterprise.concurrent
--Djakarta.concurrent.version=3.0.0-SNAPSHOT
+-Djakarta.concurrent.tck.groupid=jakarta.enterprise.concurrent \
+-Djakarta.concurrent.tck.version=3.0.0-SNAPSHOT
 ```
 
 Finally, remember to stop the running server

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/build.gradle
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/build.gradle
@@ -11,22 +11,21 @@
 
 configurations {
   testNG { transitive = false; }
+  sigTest { transitive = false; } 
   arquillian
-  sigtest
   wlp
 }
 
 dependencies {
-	testNG 'org.testng:testng:6.14.3',
-	       'com.beust:jcommander:1.78',
-	       'org.apache-extras.beanshell:bsh:2.0b6'
+  testNG 'org.testng:testng:6.14.3',
+	     'com.beust:jcommander:1.78',
+	     'org.apache-extras.beanshell:bsh:2.0b6'
+  
+  sigTest 'org.netbeans.tools:sigtest-maven-plugin:1.6'
 
-  arquillian 'io.openliberty.arquillian:arquillian-liberty-support-jakarta:2.0.2'
+  arquillian 'io.openliberty.arquillian:arquillian-liberty-support-jakarta:2.0.1'
 
-  sigtest 'org.netbeans.tools:sigtest-maven-plugin:1.6'
-
-  //TODO configure WLP dependency, Examples (may not be valid):
-  //wlp 'io.openliberty.beta:openliberty-jakartaee10:22.0.0.3-beta@zip'
+  //TODO configure WLP dependency, Example below:
   //wlp 'io.openliberty.beta:openliberty-runtime:22.0.0.3-beta@zip'
 }
 
@@ -39,16 +38,17 @@ task copyTestNG(type: Copy) {
   rename 'bsh-.*.jar', 'bsh.jar'
 }
 
-task copySigtest(type: Copy) {
+task copySigTest(type: Copy) {
   mustRunAfter jar
-  from configurations.sigtest
-  into new File(autoFvtDir, 'publish/shared/resources/sigtest')
-  rename 'sigtest-maven-plugin-.*.jar', 'sigtest-maven-plugin.jar'
+  from configurations.sigTest
+  into new File(autoFvtDir, 'publish/shared/resources/sigtest/1.6')
+  rename 'sigtest-maven-plugin-.*.jar', 'sigtest.jar'
 }
 
 addRequiredLibraries.dependsOn addDerby
 addRequiredLibraries.dependsOn copyTestNG
-addRequiredLibraries.dependsOn copySigtest
+addRequiredLibraries.dependsOn copySigTest
+
 
 // These tasks are used only for external users who do not want to build all of liberty to run TCK
 task getWLP(type: Copy) {
@@ -84,6 +84,13 @@ task copyDerbyWLP(type: Copy) {
   rename 'derby-.*.jar', 'derby.jar'
 }
 
+task copySigTestWLP(type: Copy) {
+  mustRunAfter createServer
+  from configurations.sigTest
+  into new File(project.projectDir, 'wlp/usr/shared/resources/sigtest/1.6')
+  rename 'sigtest-maven-plugin-.*.jar', 'sigtest.jar'
+}
+
 task copyConfigWLP(type: Copy) {
   mustRunAfter createServer
   from new File(project.projectDir, 'publish/servers/ConcurrentTCKServer')
@@ -108,4 +115,5 @@ task buildWLP {
   dependsOn 'copyDerbyWLP'
   dependsOn 'copyConfigWLP'
   dependsOn 'copyRunnerWLP'
+  dependsOn 'copySigTestWLP'
 }

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncher.java
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncher.java
@@ -15,9 +15,6 @@ import static org.junit.Assert.assertEquals;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -34,9 +31,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.TestModeFilter;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.utils.MvnUtils;
-
 
 /**
  * This is a test class that runs the whole Jakarta Concurrency TCK. The TCK results
@@ -56,6 +51,10 @@ public class ConcurrentTckLauncher {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        //UNCOMMENT - To test against a local snapshot of TCK
+        //additionalProps.put("jakarta.concurrent.tck.groupid", "jakarta.enterprise.concurrent");
+        //additionalProps.put("jakarta.concurrent.tck.version", "3.0.0-SNAPSHOT");
+
         //username and password for Arquillian to authenticate to restConnect
         additionalProps.put("tck_username", "arquillian");
         additionalProps.put("tck_password", "arquillianPassword");
@@ -70,6 +69,11 @@ public class ConcurrentTckLauncher {
         //Ports liberty should be using for testing
         server.addEnvVar("tck_port", "" + server.getPort(PortType.WC_defaulthost));
         server.addEnvVar("tck_port_secure", "" + server.getPort(PortType.WC_defaulthost_secure));
+
+        Map<String, String> opts = server.getJvmOptionsAsMap();
+        //Path that jimage will output modules for signature testing
+        opts.put("-Djimage.dir", server.getServerSharedPath() + "jimage/output/");
+        server.setJvmOptions(opts);
 
         //Finally start the server
         server.startServer();
@@ -98,6 +102,10 @@ public class ConcurrentTckLauncher {
             Log.info(getClass(), "launchConcurrentTCK", "Running lite tests");
             suiteXmlFile = "tck-suite-lite.xml";
         }
+
+        //UNCOMMENT - To perform signature testing only
+        //suiteXmlFile = "tck-suite-signature.xml";
+
         Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
 
         /**
@@ -112,8 +120,8 @@ public class ConcurrentTckLauncher {
                                            suiteXmlFile, //tck suite
                                            additionalProps, //additional props
                                            Collections.emptySet() //additional jars
-        );  
-        
+        );
+
         resultInfo.put("results_type", "Jakarta");
         resultInfo.put("feature_name", "Concurrency");
         resultInfo.put("feature_version", "3.0");

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/servers/ConcurrentTCKServer/jvm.options
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/servers/ConcurrentTCKServer/jvm.options
@@ -1,4 +1,3 @@
 -Dcom.ibm.tools.attach.enable=yes
--Djimage.dir=sigtest
 --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED
 --add-opens=java.base/jdk.internal.vm.annotation=ALL-UNNAMED

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/servers/ConcurrentTCKServer/server.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/servers/ConcurrentTCKServer/server.xml
@@ -52,13 +52,24 @@
     <library id="global">
                <fileset dir="${shared.resource.dir}/derby" includes="*.jar"/>
                <fileset dir="${shared.resource.dir}/testng/6.14.3" includes="*.jar"/>
-               <fileset dir="${shared.resource.dir}/sigtest" includes="sigtest-maven-plugin.jar"/>
+               <fileset dir="${shared.resource.dir}/sigtest/1.6" includes="*.jar"/>
     </library>
 
     <!--Java2 security-->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
-    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}/sigtest/sigtest-maven-plugin.jar" className="java.security.AllPermission"/>
+
+    <!-- Derby Permissions -->
+    <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+    <javaPermission codeBase="${shared.resource.dir}/sigtest/sigtest-maven-plugin.jar" className="java.security.AllPermission"/>
+
+    <!-- Signature test application permissions -->
+    <javaPermission codeBase="${server.config.dir}/dropins/signatureTest.war" className="java.security.AllPermission"/>
+	
+    <!-- Signature test plugin permissions -->
+    <javaPermission codeBase="${shared.resource.dir}/sigtest/1.6/sigtest.jar" className="java.security.AllPermission" />
+    <javaPermission codeBase="${shared.resource.dir}/sigtest/1.6/sigtest.jar" className="java.lang.RuntimePermission"  name="accessClassInPackage.jdk.internal" />
+    <javaPermission codeBase="${shared.resource.dir}/sigtest/1.6/sigtest.jar" className="java.lang.RuntimePermission"  name="accessClassInPackage.jdk.internal.reflect" />
+    <javaPermission codeBase="${shared.resource.dir}/sigtest/1.6/sigtest.jar" className="java.lang.RuntimePermission"  name="accessClassInPackage.jdk.internal.vm.annotation" />
 
     <!-- Ensure JSP can handle lamdas -->
     <jspEngine jdkSourceLevel="18"/>

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,10 +18,11 @@
     <name>Jakarta Concurrency TCK Runner TCK Module</name>
 
     <properties>
-        <jakarta.concurrent.version>3.0.0</jakarta.concurrent.version>
+    	<!-- These properties can be overwritten by users if they want to test against a snapshot version-->
+        <jakarta.concurrent.tck.groupid>jakarta.enterprise.concurrent</jakarta.concurrent.tck.groupid>
+        <jakarta.concurrent.tck.version>3.0.0</jakarta.concurrent.tck.version>
         
-        <!-- TODO: Update this once TCK is GAed -->
-        <jakarta.concurrent.tck.version>3.0.0.20220126</jakarta.concurrent.tck.version>
+        <jakarta.concurrent.version>3.0.0</jakarta.concurrent.version>
         
         <arquillian.version>1.7.0.Alpha10</arquillian.version>
         <arquillian-wlp.version>2.0.2</arquillian-wlp.version>
@@ -38,21 +39,19 @@
         <targetDirectory>${project.basedir}/target</targetDirectory>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>ibmdhe</id>
-            <name>IBM_DHE File Server</name>
-            <url>https://public.dhe.ibm.com/ibmdl/export/pub/software/olrepo</url>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </snapshots>
-        </repository>
-    </repositories>
+	<repositories> <!-- For artifacts not yet in Maven Central -->
+		<repository>
+			<id>sonatype-nexus-staging</id>
+			<name>Sonatype Nexus Staging</name>
+			<url>https://jakarta.oss.sonatype.org/content/repositories/staging/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
 
     <dependencyManagement>
         <dependencies>
@@ -77,8 +76,7 @@
         </dependency>
         <!-- TCK Dependency -->
         <dependency>
-            <!-- TODO: Update this once TCK is available on maven -->
-		    <groupId>io.openliberty.jakarta.enterprise.concurrent</groupId>
+		    <groupId>${jakarta.concurrent.tck.groupid}</groupId>
 		    <artifactId>jakarta.enterprise.concurrent-tck</artifactId>
 		    <version>${jakarta.concurrent.tck.version}</version>
         </dependency>

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/standalone.pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/standalone.pom.xml
@@ -18,10 +18,11 @@
     <name>Jakarta Concurrency TCK Runner TCK Module</name>
 
     <properties>
-        <!-- TODO remove once spec is GAed -->
-        <!-- These properties can be overwritten by users -->
-        <jakarta.concurrent.groupid>io.openliberty.jakarta.enterprise.concurrent</jakarta.concurrent.groupid>
-        <jakarta.concurrent.version>3.0.0.20220126</jakarta.concurrent.version>
+    	<!-- These properties can be overwritten by users if they want to test against a snapshot version-->
+        <jakarta.concurrent.tck.groupid>jakarta.enterprise.concurrent</jakarta.concurrent.tck.groupid>
+        <jakarta.concurrent.tck.version>3.0.0</jakarta.concurrent.tck.version>
+        
+        <jakarta.concurrent.version>3.0.0</jakarta.concurrent.version>
         
         <arquillian.version>1.7.0.Alpha10</arquillian.version>
         <arquillian-wlp.version>2.0.2</arquillian-wlp.version>
@@ -38,13 +39,19 @@
         <targetDirectory>${project.basedir}/target</targetDirectory>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>ibmdhe</id>
-            <name>IBM_DHE File Server</name>
-            <url>https://public.dhe.ibm.com/ibmdl/export/pub/software/olrepo</url>
-        </repository>
-    </repositories>
+	<repositories> <!-- For artifacts not yet in Maven Central -->
+		<repository>
+			<id>sonatype-nexus-staging</id>
+			<name>Sonatype Nexus Staging</name>
+			<url>https://jakarta.oss.sonatype.org/content/repositories/staging/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
 
     <dependencyManagement>
         <dependencies>
@@ -61,10 +68,9 @@
     <dependencies>
         <!-- TCK Dependency -->
         <dependency>
-            <!-- TODO: Update this once TCK is available on maven -->
-		    <groupId>${jakarta.concurrent.groupid}</groupId>
+		    <groupId>${jakarta.concurrent.tck.groupid}</groupId>
 		    <artifactId>jakarta.enterprise.concurrent-tck</artifactId>
-		    <version>${jakarta.concurrent.version}</version>
+		    <version>${jakarta.concurrent.tck.version}</version>
         </dependency>
         <!-- API Dependency -->
         <dependency>

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/tck-suite-signature.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/tck-suite-signature.xml
@@ -1,0 +1,17 @@
+<!--Copyright (c) 2022 IBM Corporation and others. All rights reserved.
+    This program and the accompanying materials are made available under the 
+    terms of the Eclipse Public License v1.0 which accompanies this distribution, 
+    and is available at 
+        http://www.eclipse.org/legal/epl-v10.html 
+    Contributors: 
+        IBM Corporation - initial API and implementation
+-->
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="jakarta-concurrency" verbose="2" configfailurepolicy="continue">
+	<test name="jakarta-concurrency.tck.sig">
+		<packages>
+    		<package name="ee.jakarta.tck.concurrent.spec.signature"/>
+        </packages> 
+	</test>
+</suite>


### PR DESCRIPTION
This change will allow the updated TCK tests from PR https://github.com/eclipse-ee4j/concurrency-api/pull/185 to run on Open Liberty.
