### PR TITLE
Generate io.openliberty.microprofile.graphql.2.0.internal_fat_tck results adoc

### DIFF
--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/fat/src/org/eclipse/microprofile/graphql/tck/GraphQLTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/fat/src/org/eclipse/microprofile/graphql/tck/GraphQLTckPackageTest.java
@@ -55,11 +55,11 @@ public class GraphQLTckPackageTest {
 
     @Test
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
-    public void testRestClientTck() throws Exception {
+    public void testGraphQLTck() throws Exception {
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.graphql_fat_tck", this.getClass() + ":testGraphQLTck");
         Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
         resultInfo.put("results_type", "MicroProfile");
-        resultInfo.put("feature_name", "Graph QL");
+        resultInfo.put("feature_name", "GraphQL");
         resultInfo.put("feature_version", "1.0");
         MvnUtils.preparePublicationFile(resultInfo);
     }

--- a/dev/io.openliberty.microprofile.graphql.2.0.internal_fat_tck/fat/src/org/eclipse/microprofile/graphql/tck/GraphQLTckPackageTest.java
+++ b/dev/io.openliberty.microprofile.graphql.2.0.internal_fat_tck/fat/src/org/eclipse/microprofile/graphql/tck/GraphQLTckPackageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.microprofile.graphql.tck;
 
+import java.util.Map;
+
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,7 +20,6 @@ import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.utils.MvnUtils;
 
 /**
@@ -40,7 +41,12 @@ public class GraphQLTckPackageTest {
 
     @Test
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
-    public void testRestClientTck() throws Exception {
-        MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.graphql_fat_tck", this.getClass() + ":testGraphQLTck");
+    public void testGraphQLTck() throws Exception {
+        MvnUtils.runTCKMvnCmd(server, "io.openliberty.microprofile.graphql.2.0.internal_fat_tck", this.getClass() + ":testGraphQLTck");
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(server);
+        resultInfo.put("results_type", "MicroProfile");
+        resultInfo.put("feature_name", "GraphQL");
+        resultInfo.put("feature_version", "2.0");
+        MvnUtils.preparePublicationFile(resultInfo);
     }
 }


### PR DESCRIPTION
io.openliberty.microprofile.graphql.2.0.internal_fat_tck doesn't currently generate an adoc file in the results folder