### PR TITLE
Fix keystore file names (replace jks.jks with jks)

### DIFF
--- a/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/BasicRegistry_ssl_user_missing_in_trust.xml
+++ b/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/BasicRegistry_ssl_user_missing_in_trust.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/BasicRegistry_ssl_user_missing_in_trust.xml
+++ b/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/BasicRegistry_ssl_user_missing_in_trust.xml
@@ -46,7 +46,7 @@
 		id="myTrustStore"
 		password="Liberty"
 		type="jks"
-		location="${server.config.dir}/commonTrustStore.jks.jks" />
+		location="${server.config.dir}/commonTrustStore.jks" />
 
 	<authorization-roles id="com.ibm.ws.security.oidc10">
 		<security-role name="authenticated">

--- a/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/BasicRegistry_ssl_user_missing_in_trust_required.xml
+++ b/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/BasicRegistry_ssl_user_missing_in_trust_required.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -36,7 +36,8 @@
 		id="DefaultSSLSettings"
 		keyStoreRef="myKeyStore"
 		trustStoreRef="myTrustStore"
-		clientAuthentication="true" />
+		clientAuthentication="true"
+		sslProtocol="TLSv1.2" /> <!-- we need the server to pass the "hint" back to the client for the test using this config TLSv1.3 no longer sends the hint -->
 	<keyStore
 		id="myKeyStore"
 		password="Liberty"

--- a/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/BasicRegistry_ssl_user_missing_in_trust_required.xml
+++ b/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/BasicRegistry_ssl_user_missing_in_trust_required.xml
@@ -46,7 +46,7 @@
 		id="myTrustStore"
 		password="Liberty"
 		type="jks"
-		location="${server.config.dir}/commonTrustStore.jks.jks" />
+		location="${server.config.dir}/commonTrustStore.jks" />
 
 	<authorization-roles id="com.ibm.ws.security.oidc10">
 		<security-role name="authenticated">

--- a/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/certRequiredJavaPermissions.xml
+++ b/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/certRequiredJavaPermissions.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -29,7 +29,7 @@
 		actions="POST:"/>
 	<javaPermission
 		className="java.net.URLPermission"
-		name="https://localhost:*/oidc/provider/OidcConfigSample/token" 
+		name="https://localhost:*/oidc/providers/OidcConfigSample/token" 
 		actions="POST:"/>
 
 </server>

--- a/dev/com.ibm.ws.security.oidc.server_fat/publish/servers/com.ibm.ws.security.openidconnect.server-1.0_fat.cert_required/jvm.options
+++ b/dev/com.ibm.ws.security.oidc.server_fat/publish/servers/com.ibm.ws.security.openidconnect.server-1.0_fat.cert_required/jvm.options
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -9,5 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 
--Djavax.net.debug=ssl
-
+#-Djavax.net.debug=all


### PR DESCRIPTION
Fix the keystore file names in a couple config files - replace commonTrustStore.jks.jks with commonTrustStore.jks.
With Java 17 on AIX, we're seeing failures trying to load the files - I don't know why it was working up until now...