### PR TITLE
Update Oracle jdbc driver to ojdbc11

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -248,28 +248,28 @@
     </dependency>
     <dependency>
       <groupId>com.oracle.database.jdbc.debug</groupId>
-      <artifactId>ojdbc8_g</artifactId>
-      <version>21.1.0.0</version>
+      <artifactId>ojdbc11_g</artifactId>
+      <version>21.5.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.database.jdbc</groupId>
       <artifactId>ucp</artifactId>
-      <version>21.1.0.0</version>
+      <version>21.5.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.database.security</groupId>
       <artifactId>oraclepki</artifactId>
-      <version>21.1.0.0</version>
+      <version>21.5.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.database.security</groupId>
       <artifactId>osdt_cert</artifactId>
-      <version>21.1.0.0</version>
+      <version>21.5.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.database.security</groupId>
       <artifactId>osdt_core</artifactId>
-      <version>21.1.0.0</version>
+      <version>21.5.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.sebastian-daschner</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -45,11 +45,11 @@ com.icegreen:greenmail:1.5.10
 com.jcraft:jsch:0.1.54
 com.microsoft.sqlserver:mssql-jdbc:9.2.1.jre8
 com.nimbusds:nimbus-jose-jwt:4.23
-com.oracle.database.jdbc.debug:ojdbc8_g:21.1.0.0
-com.oracle.database.jdbc:ucp:21.1.0.0
-com.oracle.database.security:oraclepki:21.1.0.0
-com.oracle.database.security:osdt_cert:21.1.0.0
-com.oracle.database.security:osdt_core:21.1.0.0
+com.oracle.database.jdbc.debug:ojdbc11_g:21.5.0.0
+com.oracle.database.jdbc:ucp:21.5.0.0
+com.oracle.database.security:oraclepki:21.5.0.0
+com.oracle.database.security:osdt_cert:21.5.0.0
+com.oracle.database.security:osdt_core:21.5.0.0
 com.sebastian-daschner:jaxrs-analyzer:0.9
 com.sun.activation:jakarta.activation:2.0.0
 com.sun.faces:jsf-api:2.2.14

--- a/dev/com.ibm.ws.jdbc_fat/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat/build.gradle
@@ -26,7 +26,7 @@ task copyAnonymousDrivers(type: Copy) {
   rename 'jcc.*.jar', 'driver0.jar'
   rename 'derby-.*.jar', 'driver1.jar'
   rename 'derbyclient-.*.jar', 'driver2.jar'
-  rename 'ojdbc8_g.*.jar', 'driver3.jar'
+  rename 'ojdbc11_g.*.jar', 'driver3.jar'
   rename 'postgresql.*.jar', 'driver4.jar'
   rename 'mssql-jdbc.*.jar', 'driver5.jar'
 }

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/OracleKerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/OracleKerberosTest.java
@@ -32,7 +32,6 @@ import com.ibm.ws.jdbc.fat.krb5.containers.KerberosPlatformRule;
 import com.ibm.ws.jdbc.fat.krb5.containers.OracleKerberosContainer;
 
 import componenttest.annotation.AllowedFFDC;
-import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
@@ -46,7 +45,6 @@ import jdbc.krb5.oracle.web.OracleKerberosTestServlet;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-@MaximumJavaLevel(javaLevel = 15) // TODO The current Oracle JDBC driver (ojdbc8_g.jar v21.1.0.0) only supports Java 8-15, modify/remove this line once it supports 16+
 public class OracleKerberosTest extends FATServletClient {
 
     private static final Class<?> c = OracleKerberosTest.class;

--- a/dev/com.ibm.ws.jdbc_fat_krb5/publish/servers/com.ibm.ws.jdbc.fat.krb5.oracle/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/publish/servers/com.ibm.ws.jdbc.fat.krb5.oracle/server.xml
@@ -8,7 +8,7 @@
   <include location="../fatTestPorts.xml"/>
 
   <library id="OracleLib">
-    <file name="${shared.resource.dir}/jdbc/ojdbc8_g.jar"/>
+    <file name="${shared.resource.dir}/jdbc/ojdbc11_g.jar"/>
   </library>
   
   <kerberos keytab="${server.config.dir}security/oracle_client.keytab" configFile="${KRB5_CONF}"/>

--- a/dev/com.ibm.ws.jdbc_fat_oracle/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/bnd.bnd
@@ -29,5 +29,5 @@ fat.project: true
     com.ibm.websphere.javaee.servlet.3.1;version=latest,\
     com.ibm.websphere.javaee.transaction.1.1;version=latest,\
     io.openliberty.org.testcontainers;version=latest,\
-    com.oracle.database.jdbc.debug:ojdbc8_g;version=21.1.0.0,\
-    com.oracle.database.jdbc:ucp;version=21.1.0.0
+    com.oracle.database.jdbc.debug:ojdbc11_g;version=21.5.0.0,\
+    com.oracle.database.jdbc:ucp;version=21.5.0.0

--- a/dev/com.ibm.ws.jdbc_fat_oracle/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/build.gradle
@@ -10,7 +10,7 @@
  *******************************************************************************/
 apply from: "../wlp-gradle/subprojects/maven-central-mirror.gradle"
 
-ext.oracleVersion = '21.1.0.0'
+ext.oracleVersion = '21.5.0.0'
 
 configurations {
   oracle	{transitive = false}
@@ -19,8 +19,8 @@ configurations {
 }
 
 dependencies {
-  oracle        "com.oracle.database.jdbc.debug:ojdbc8_g:${oracleVersion}"
-  oraclessl     "com.oracle.database.jdbc.debug:ojdbc8_g:${oracleVersion}",
+  oracle        "com.oracle.database.jdbc.debug:ojdbc11_g:${oracleVersion}"
+  oraclessl     "com.oracle.database.jdbc.debug:ojdbc11_g:${oracleVersion}",
                	"com.oracle.database.security:oraclepki:${oracleVersion}",
                	"com.oracle.database.security:osdt_core:${oracleVersion}",
                	"com.oracle.database.security:osdt_cert:${oracleVersion}"				
@@ -31,14 +31,14 @@ task copyAnonymousOracle(type: Copy) {
   shouldRunAfter jar
   from configurations.oracle
   into new File(autoFvtDir, "publish/shared/resources/oracle/")
-  rename "ojdbc8_g-.*.", "oracleunknown.jar"
+  rename "ojdbc11_g-.*.", "oracleunknown.jar"
 }
 
 task copySharedOracle(type: Copy) {
   shouldRunAfter jar
   from configurations.oracle
   into new File(autoFvtDir, "publish/shared/resources/ucp/")
-  rename "ojdbc8_g-.*.", "ojdbc8_g.jar"
+  rename "ojdbc11_g-.*.", "ojdbc11_g.jar"
 }
 
 task copySharedUCP(type: Copy) {
@@ -52,7 +52,7 @@ task copySharedOracleSSL(type: Copy) {
   shouldRunAfter jar
   from configurations.oraclessl
   into new File(autoFvtDir, "publish/shared/resources/ssl/")
-  rename "ojdbc8_g-.*.", "ojdbc8_g.jar"
+  rename "ojdbc11_g-.*.", "ojdbc11_g.jar"
   rename "oraclepki.*.", "oraclepki.jar"
   rename "osdt_core.*.", "osdt_core.jar"
   rename "osdt_cert.*.", "osdt_cert.jar"

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ssl/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ssl/server.xml
@@ -59,7 +59,7 @@
     	<properties.oracle URL="${env.SSL_URL}" connectionProperties="${oracle.conn.props.jks}" />
     </dataSource>
      -->
-    <javaPermission codebase="${shared.resource.dir}/ssl/ojdbc8_g.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/ssl/ojdbc11_g.jar" className="java.security.AllPermission"/>
     <javaPermission codebase="${server.config.dir}/apps/oraclesslfat.war" className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
 
     <variable name="onError" value="FAIL"/>

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ucp/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ucp/server.xml
@@ -78,7 +78,7 @@
     	<properties.oracle URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}"/>
     </dataSource>
     
-    <javaPermission codebase="${shared.resource.dir}/ucp/ojdbc8_g.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/ucp/ojdbc11_g.jar" className="java.security.AllPermission"/>
     <javaPermission codebase="${shared.resource.dir}/ucp/ucp.jar" className="java.security.AllPermission"/>
     <javaPermission codebase="${server.config.dir}/apps/oracleucpfat.war" className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
     <javaPermission codebase="${server.config.dir}/apps/oracleucpfat.war" className="javax.management.MBeanServerPermission" name="createMBeanServer"/>    

--- a/dev/com.ibm.ws.transaction.hadb_fat.oracle.1/build.gradle
+++ b/dev/com.ibm.ws.transaction.hadb_fat.oracle.1/build.gradle
@@ -60,7 +60,7 @@ task copyTxJdbcDrivers(type: Copy) {
   mustRunAfter jar
   from configurations.jdbcDrivers
   into new File(autoFvtDir, 'publish/shared/resources/ifx')
-  rename 'ojdbc8_g.*.jar', 'anomyous.jar'
+  rename 'ojdbc11_g.*.jar', 'anomyous.jar'
 }
 
 jar.dependsOn copyCommonFiles

--- a/dev/com.ibm.ws.transaction.hadb_fat.oracle.2/build.gradle
+++ b/dev/com.ibm.ws.transaction.hadb_fat.oracle.2/build.gradle
@@ -65,7 +65,7 @@ task copyTxJdbcDrivers(type: Copy) {
   mustRunAfter jar
   from configurations.jdbcDrivers
   into new File(autoFvtDir, 'publish/shared/resources/ifx')
-  rename 'ojdbc8_g.*.jar', 'anomyous.jar'
+  rename 'ojdbc11_g.*.jar', 'anomyous.jar'
 }
 
 jar.dependsOn copyCommonFiles

--- a/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerType.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerType.java
@@ -37,7 +37,7 @@ public enum DatabaseContainerType {
         DockerImageName.parse("kyleaure/db2:1.0").asCompatibleSubstituteFor("ibmcom/db2")),
     Derby("derby.jar", DerbyNoopContainer.class.getCanonicalName(), Properties_derby_embedded.class, DockerImageName.parse("")),
     DerbyClient("derbyclient.jar", DerbyClientContainer.class.getCanonicalName(), Properties_derby_client.class, DockerImageName.parse("")),
-    Oracle("ojdbc8_g.jar", OracleContainer.class.getCanonicalName(), Properties_oracle.class, //
+    Oracle("ojdbc11_g.jar", OracleContainer.class.getCanonicalName(), Properties_oracle.class, //
            DockerImageName.parse("kyleaure/oracle-18.4.0-expanded:1.0.slim").asCompatibleSubstituteFor("gvenzl/oracle-xe")),
     Postgres("postgresql.jar", PostgreSQLContainer.class.getCanonicalName(), Properties_postgresql.class, //
              DockerImageName.parse("postgres:14.1-alpine")),
@@ -68,7 +68,7 @@ public enum DatabaseContainerType {
 
     /**
      * Returns the common JDBC Driver name for this testcontainer type.
-     * Example: 'ojdbc8_g.jar'
+     * Example: 'ojdbc11_g.jar'
      *
      * @return String - JDBC Driver Name
      */

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -54,7 +54,7 @@ dependencies {
 		'com.microsoft.sqlserver:mssql-jdbc:9.2.1.jre8',
 		'org.apache.derby:derbyclient:10.11.1.1',
 		'org.apache.derby:derby:10.11.1.1',
-		'com.oracle.database.jdbc.debug:ojdbc8_g:21.1.0.0'
+		'com.oracle.database.jdbc.debug:ojdbc11_g:21.5.0.0'
 
   jakartaTransformer 'biz.aQute.bnd:biz.aQute.bnd.transform:5.3.0',
        'commons-cli:commons-cli:1.4',
@@ -107,7 +107,7 @@ task copyJdbcDrivers(type: Copy) {
   rename 'jcc.*.jar', 'jcc.jar'
   rename 'derby-.*.jar', 'derby.jar'
   rename 'derbyclient-.*.jar', 'derbyclient.jar'
-  rename 'ojdbc8_g.*.jar', 'ojdbc8_g.jar'
+  rename 'ojdbc11_g.*.jar', 'ojdbc11_g.jar'
   rename 'postgresql.*.jar', 'postgresql.jar'
   rename 'mssql-jdbc.*.jar', 'mssql-jdbc.jar'
 }


### PR DESCRIPTION
Update to use Oracle JDBC 11. 
The previous Oracle JDBC 8 driver did not support JDK 16+.
Fixes #18341
Currently testing if we can upgrade to ojdbc11 without breaking builds that still use Java 8. 