### PR TITLE
Build changes for swagger-ui 4.6.0

### DIFF
--- a/dev/com.ibm.ws.openapi.ui/swagger-ui/package.json
+++ b/dev/com.ibm.ws.openapi.ui/swagger-ui/package.json
@@ -31,8 +31,10 @@
     "webpack-dev-server": "^4.7.4"
   },
   "dependencies": {
+    "buffer": "^6.0.3",
     "core-js": "^3.21.0",
     "regenerator-runtime": "^0.13.9",
+    "stream-browserify": "^3.0.0",
     "swagger-ui": "^4.5.0"
   },
   "browserslist": [

--- a/dev/com.ibm.ws.openapi.ui/swagger-ui/webpack.config.js
+++ b/dev/com.ibm.ws.openapi.ui/swagger-ui/webpack.config.js
@@ -15,6 +15,10 @@ module.exports = {
   },
   resolve: {
     extensions: ['.ts', '.js'],
+    fallback: {
+      "stream": require.resolve("stream-browserify"),
+      "buffer": require.resolve("buffer/"),
+    }
   },
   devtool: "hidden-source-map",
   performance : {
@@ -105,7 +109,7 @@ module.exports = {
         {
           // Copy the Swagger OAuth2 redirect file to the project root;
           // that file handles the OAuth2 redirect after authenticating the end-user.
-          from: require.resolve('swagger-ui/dist/oauth2-redirect.html'),
+          from: 'node_modules/swagger-ui/dist/oauth2-redirect.html',
           to: './'
         },
         {
@@ -142,5 +146,6 @@ module.exports = {
     path: outputPath,
     library: 'SwaggerUI',
     publicPath: '' // Needed for IE
-  }
+  },
+  ignoreWarnings: [/Failed to parse source map/],
 };


### PR DESCRIPTION
Swagger-ui made some changes to their packaging for webpack 5 in 4.6.0 which requires some changes to our webpack config

This PR does not update or rebuild the OpenAPI UI. That will be done as a separate PR when #20388 is merged.

The changes included here are:
* manually include polyfills for buffer and stream-browserify which are no longer automatically brought in
* change how we include oauth2-redirect.html
* the source maps for some modules can't be loaded. We're not really worried about this so suppress the warnings.

Fixes #20390 