### PR TITLE
Issue 20058 and 20060: Enhance logout token validation

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
@@ -266,4 +266,8 @@ BACKCHANNEL_LOGOUT_REQUEST_NO_MATCHING_CONFIG=CWWKS1544E: The back-channel logou
 BACKCHANNEL_LOGOUT_REQUEST_NO_MATCHING_CONFIG.explanation=The OpenID Connect feature expects the back-channel request URI to include an OpenID Connect client ID to determine which client to log out.
 BACKCHANNEL_LOGOUT_REQUEST_NO_MATCHING_CONFIG.useraction=Verify that the request URI includes the OpenID Connect client ID to use for logging out the user.
 
+LOGOUT_TOKEN_MISSING_CLAIMS=CWWKS1545E: The logout token is not valid because it is missing at least one claim that is required: {0}
+LOGOUT_TOKEN_MISSING_CLAIMS.explanation=The logout token must contain the claims that are specified in the message.
+LOGOUT_TOKEN_MISSING_CLAIMS.useraction=Ensure that the OpenID Connect provider includes the missing claims in the logout token.
+
 # STOP HERE, OIDC SERVER HAS RESERVED 1600 - 1649

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/common/internal/resources/OidcCommonMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/common/internal/resources/OidcCommonMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2013, 2020 IBM Corporation and others.
+# Copyright (c) 2013, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -187,3 +187,7 @@ PROPAGATION_TOKEN_ISS_CLAIM_NOT_REQUIRED_ERR.useraction=Either obtain a new toke
 DISALLOWED_FORWARD_AUTHZ_PARAMS_CONFIGURED=CWWKS1783W: The OpenID Connect client [{0}] includes {1} in the values that are specified by the [{2}] configuration attribute. The specified values will be ignored.
 DISALLOWED_FORWARD_AUTHZ_PARAMS_CONFIGURED.explanation=The OAuth 2.0 specification defines a set of reserved request parameters that must be provided by the client for authorization requests. Values for those reserved parameters cannot be supplied by the user.
 DISALLOWED_FORWARD_AUTHZ_PARAMS_CONFIGURED.useraction=Remove the specified values from the list of values defined in the OpenID Connect client configuration.
+
+JWT_MISSING_ISSUER=CWWKS1784E: The token is not valid because it does not contain an issuer claim.
+JWT_MISSING_ISSUER.explanation=The token must contain an issuer claim to identify who issued the token.
+JWT_MISSING_ISSUER.useraction=Obtain a new token that includes an issuer claim.

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidator.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidator.java
@@ -10,17 +10,25 @@
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.backchannellogout;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.MalformedClaimException;
+import org.jose4j.jwt.NumericDate;
 import org.jose4j.jwt.consumer.JwtContext;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.security.jwt.Claims;
 import com.ibm.websphere.security.jwt.JwtToken;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.openidconnect.client.jose4j.util.Jose4jUtil;
 import com.ibm.ws.security.openidconnect.clients.common.ConvergedClientConfig;
+import com.ibm.ws.security.openidconnect.clients.common.OIDCClientAuthenticatorUtil;
+import com.ibm.ws.security.openidconnect.jose4j.Jose4jValidator;
 import com.ibm.wsspi.ssl.SSLSupport;
 
 @Component(name = "com.ibm.ws.security.openidconnect.backchannellogout.LogoutTokenValidator", service = {}, property = { "service.vendor=IBM" })
@@ -61,17 +69,60 @@ public class LogoutTokenValidator {
         try {
             JwtContext jwtContext = jose4jUtil.validateJwtStructureAndGetContext(logoutTokenString, config);
             JwtClaims claims = jose4jUtil.validateJwsSignature(jwtContext, config);
-            // TODO;
+
+            verifyAllRequiredClaimsArePresent(claims);
+
+            Jose4jValidator validator = getJose4jValidator();
             // 3. Validate the iss, aud, and iat Claims in the same way they are validated in ID Tokens
+            validator.verifyIssForIdToken(claims.getIssuer());
+            validator.verifyAudForIdToken(claims.getAudience());
+            validator.verifyIatAndExpClaims(claims);
+            // TODO;
             // 4. Verify that the Logout Token contains a sub Claim, a sid Claim, or both.
             // 5. Verify that the Logout Token contains an events Claim whose value is JSON object containing the member name http://schemas.openid.net/event/backchannel-logout.
             // 6. Verify that the Logout Token does not contain a nonce Claim.
+            // 7. Optionally verify that another Logout Token with the same jti value has not been recently received.
+            // 8. Optionally verify that the iss Logout Token Claim matches the iss Claim in an ID Token issued for the current session or a recent session of this RP with the OP.
+            // 9. Optionally verify that any sub Logout Token Claim matches the sub Claim in an ID Token issued for the current session or a recent session of this RP with the OP.
+            // 10. Optionally verify that any sid Logout Token Claim matches the sid Claim in an ID Token issued for the current session or a recent session of this RP with the OP.
 
         } catch (Exception e) {
             String errorMsg = Tr.formatMessage(tc, "BACKCHANNEL_LOGOUT_TOKEN_ERROR", new Object[] { e });
             throw new BackchannelLogoutException(errorMsg, e);
         }
         return null;
+    }
+
+    void verifyAllRequiredClaimsArePresent(JwtClaims claims) throws MalformedClaimException, BackchannelLogoutException {
+        List<String> missingClaims = new ArrayList<>();
+        String iss = claims.getIssuer();
+        if (iss == null) {
+            missingClaims.add(Claims.ISSUER);
+        }
+        List<String> aud = claims.getAudience();
+        if (aud == null || aud.isEmpty()) {
+            missingClaims.add(Claims.AUDIENCE);
+        }
+        NumericDate iat = claims.getIssuedAt();
+        if (iat == null) {
+            missingClaims.add(Claims.ISSUED_AT);
+        }
+        String jti = claims.getJwtId();
+        if (jti == null) {
+            missingClaims.add(Claims.ID);
+        }
+        Object events = claims.getClaimValue("events");
+        if (events == null) {
+            missingClaims.add("events");
+        }
+        if (!missingClaims.isEmpty()) {
+            String errorMsg = Tr.formatMessage(tc, "LOGOUT_TOKEN_MISSING_CLAIMS", new Object[] { missingClaims });
+            throw new BackchannelLogoutException(errorMsg);
+        }
+    }
+
+    Jose4jValidator getJose4jValidator() {
+        return new Jose4jValidator(null, config.getClockSkewInSeconds(), new OIDCClientAuthenticatorUtil().getIssuerIdentifier(config), config.getClientId(), config.getSignatureAlgorithm(), null);
     }
 
 }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/jose4j/Jose4jValidator.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/jose4j/Jose4jValidator.java
@@ -20,6 +20,7 @@ import java.util.StringTokenizer;
 import org.joda.time.Instant;
 import org.jose4j.jws.JsonWebSignature;
 import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.MalformedClaimException;
 import org.jose4j.jwt.NumericDate;
 import org.jose4j.jwt.consumer.InvalidJwtException;
 import org.jose4j.jwt.consumer.InvalidJwtSignatureException;
@@ -78,7 +79,6 @@ public class Jose4jValidator {
 
         // for audiences checking
         List<String> audiences = jwtClaims.getAudience();
-        boolean emptyAudienceClaim = audiences.isEmpty();
         String okAudience = clientId; // default audience
         if (oidcClientRequest.getTokenType().equalsIgnoreCase(OidcClientRequest.TYPE_JWT_TOKEN)) {
             // check issuer
@@ -94,7 +94,7 @@ public class Jose4jValidator {
 
             // do JWT specific checking
             List<String> allowedAudiences = oidcClientRequest.getAudiences();
-            if (!emptyAudienceClaim) {
+            if (!audiences.isEmpty()) {
                 String strOkAudience = oidcClientRequest.allowedAllAudiences() ? audiences.get(0) //any audiences is accepted
                         : jwtAudienceElementCheck(allowedAudiences, audiences);
                 if (strOkAudience == null) { // no ok audience was found
@@ -124,20 +124,8 @@ public class Jose4jValidator {
                         new Object[] { clientId });
             }
 
-            if (!JWT.checkIssuer(clientId, issuers, issuer)) {
-                // issuer verification failed
-                // Let's make it behave the same the old IDToken though why it failed
-                // 221386
-                String errMsg = OidcClientRequest.TYPE_ID_TOKEN.equals(oidcClientRequest.getTokenType()) ? "ID token validation Error[issuer]" : "Json Web Token validation Error[issuer]";
-                throw new Exception(errMsg);
-            }
-            // So far, we only have JWT and IDToken in this code path
-            // Do some specific ID Token checking
-            if (!emptyAudienceClaim && !multipleAudienceElementCheck(clientId, audiences)) {
-                String aud = array2String(audiences);
-                throw IDTokenValidationFailedException.format("OIDC_IDTOKEN_VERIFY_AUD_ERR", // 219214
-                        new Object[] { aud, clientId }); // 219214
-            }
+            verifyIssForIdToken(issuer);
+            verifyAudForIdToken(audiences);
 
             // azp is offer in JWT while the audience and the requesting client is not the same
             // And it should not be checked as the client ID of the audience in JWT.
@@ -150,38 +138,7 @@ public class Jose4jValidator {
             }
         }
 
-        // checking
-        NumericDate issueAtClaim = jwtClaims.getIssuedAt();
-        NumericDate expirationClaim = jwtClaims.getExpirationTime();
-
-        Instant issuedAt = null;
-        Instant expiration = null;
-        if (issueAtClaim == null) {
-            if (expirationClaim != null) {
-                issuedAt = new Instant(0);
-                expiration = new Instant(expirationClaim.getValueInMillis());
-            } // no issueAt and no expiration, no checking
-        } else {
-            issuedAt = new Instant(issueAtClaim.getValueInMillis());
-            if (expirationClaim == null) {
-                expiration = new Instant(Long.MAX_VALUE);
-            } else {
-                expiration = new Instant(expirationClaim.getValueInMillis());
-            }
-        }
-
-        if (issuedAt != null) {
-            if (issuedAt.isAfter(expiration) ||
-                    !JsonTokenUtil.isCurrentTimeInInterval(clockSkewInSeconds, issuedAt.getMillis(), expiration.getMillis())) {
-
-                Object[] objects = new Object[] { this.clientId, jwtClaims.getSubject(), new Instant(System.currentTimeMillis()), expiration, issuedAt };
-
-                String failMsg = Tr.formatMessage(tc, "OIDC_JWT_VERIFY_STATE_ERR", objects);
-                oidcClientRequest.setRsFailMsg(OidcCommonClientRequest.EXPIRED_TOKEN, failMsg);
-
-                throw oidcClientRequest.errorCommon(true, tc, "OIDC_JWT_VERIFY_STATE_ERR", objects); // 219214
-            }
-        }
+        verifyIatAndExpClaims(jwtClaims);
 
         // check nbf
         NumericDate nbf = jwtClaims.getNotBefore();
@@ -211,7 +168,7 @@ public class Jose4jValidator {
         if (!oidcClientRequest.getTokenType().equalsIgnoreCase(OidcClientRequest.TYPE_JWT_TOKEN)) {
             builder.setRequireSubject();
         }
-        if (emptyAudienceClaim) { // no audience claim in jwtClaims
+        if (audiences.isEmpty()) { // no audience claim in jwtClaims
             builder.setSkipDefaultAudienceValidation();
         }
         if (!rpSpecifiedSigningAlgorithm) { // allow signatureAlgorithme as none
@@ -263,6 +220,65 @@ public class Jose4jValidator {
         }
 
         return jwtClaims;
+    }
+
+    public void verifyIssForIdToken(String issuer) throws IDTokenValidationFailedException, Exception {
+        if (!JWT.checkIssuer(clientId, issuers, issuer)) {
+            // issuer verification failed
+            // Let's make it behave the same the old IDToken though why it failed
+            // 221386
+            String errMsg = Tr.formatMessage(tc, "JWT_MISSING_ISSUER");
+            throw new Exception(errMsg);
+        }
+    }
+
+    public void verifyAudForIdToken(List<String> audiences) throws IDTokenValidationFailedException {
+        // So far, we only have JWT and IDToken in this code path
+        // Do some specific ID Token checking
+        if (audiences != null && !audiences.isEmpty() && !multipleAudienceElementCheck(clientId, audiences)) {
+            String aud = array2String(audiences);
+            throw IDTokenValidationFailedException.format("OIDC_IDTOKEN_VERIFY_AUD_ERR", // 219214
+                    new Object[] { aud, clientId }); // 219214
+        }
+    }
+
+    public void verifyIatAndExpClaims(JwtClaims jwtClaims) throws MalformedClaimException, JWTTokenValidationFailedException {
+        NumericDate issueAtClaim = jwtClaims.getIssuedAt();
+        NumericDate expirationClaim = jwtClaims.getExpirationTime();
+
+        Instant issuedAt = null;
+        Instant expiration = null;
+        if (issueAtClaim == null) {
+            if (expirationClaim != null) {
+                issuedAt = new Instant(0);
+                expiration = new Instant(expirationClaim.getValueInMillis());
+            } // no issueAt and no expiration, no checking
+        } else {
+            issuedAt = new Instant(issueAtClaim.getValueInMillis());
+            if (expirationClaim == null) {
+                expiration = new Instant(Long.MAX_VALUE);
+            } else {
+                expiration = new Instant(expirationClaim.getValueInMillis());
+            }
+        }
+
+        if (issuedAt != null) {
+            if (issuedAt.isAfter(expiration) ||
+                    !JsonTokenUtil.isCurrentTimeInInterval(clockSkewInSeconds, issuedAt.getMillis(), expiration.getMillis())) {
+
+                Object[] objects = new Object[] { this.clientId, jwtClaims.getSubject(), new Instant(System.currentTimeMillis()), expiration, issuedAt };
+                String msgCode = "OIDC_JWT_VERIFY_STATE_ERR";
+
+                if (oidcClientRequest != null) {
+                    String failMsg = Tr.formatMessage(tc, msgCode, objects);
+                    oidcClientRequest.setRsFailMsg(OidcCommonClientRequest.EXPIRED_TOKEN, failMsg);
+                    throw oidcClientRequest.errorCommon(true, tc, msgCode, objects); // 219214
+                } else {
+                    Tr.error(tc, msgCode, objects);
+                    throw JWTTokenValidationFailedException.format(tc, msgCode, objects);
+                }
+            }
+        }
     }
 
     public JwtClaims validateJwsSignature(JsonWebSignature signature, String jwtString) throws JWTTokenValidationFailedException, InvalidJwtException {

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidatorTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidatorTest.java
@@ -12,13 +12,21 @@ package com.ibm.ws.security.openidconnect.backchannellogout;
 
 import static org.junit.Assert.fail;
 
+import java.io.UnsupportedEncodingException;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
 import org.jmock.Expectations;
+import org.jose4j.base64url.Base64;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.google.gson.JsonObject;
+import com.ibm.websphere.security.jwt.Claims;
 import com.ibm.ws.security.jwt.config.ConsumerUtils;
 import com.ibm.ws.security.openidconnect.clients.common.ConvergedClientConfig;
 import com.ibm.ws.security.test.common.CommonTestClass;
@@ -32,10 +40,20 @@ public class LogoutTokenValidatorTest extends CommonTestClass {
     final String CWWKS1536E_OIDC_CLIENT_JWS_REQUIRED_BUT_TOKEN_NOT_JWS = "CWWKS1536E";
     final String CWWKS1537E_OIDC_CLIENT_JWE_REQUIRED_BUT_TOKEN_NOT_JWE = "CWWKS1537E";
     final String CWWKS1543E_BACKCHANNEL_LOGOUT_TOKEN_ERROR = "CWWKS1543E";
+    final String CWWKS1545E_LOGOUT_TOKEN_MISSING_CLAIMS = "CWWKS1545E";
+    final String CWWKS1751E_OIDC_IDTOKEN_VERIFY_ISSUER_ERR = "CWWKS1751E";
+    final String CWWKS1754E_OIDC_IDTOKEN_VERIFY_AUD_ERR = "CWWKS1754E";
     final String CWWKS1778E_OIDC_JWT_SIGNATURE_VERIFY_MISSING_SIGNATURE_ERR = "CWWKS1778E";
+    final String CWWKS1784E_JWT_MISSING_ISSUER = "CWWKS1784E";
 
     final String CONFIG_ID = "myConfigId";
     final String CLIENT_ID = "client01";
+    final String SHARED_SECRET = "secret";
+    final String ISSUER = "https://localhost/oidc/provider/OP";
+    final String TOKEN_ENDPOINT = ISSUER + "/token";
+    final String SUBJECT = "testuser";
+    final String JTI_VALID_NO_SID = "valid-noSid";
+    final String EVENTS_MEMBER_KEY = "http://schemas.openid.net/event/backchannel-logout";
 
     final ConvergedClientConfig clientConfig = mockery.mock(ConvergedClientConfig.class);
     final ConsumerUtils consumerUtils = mockery.mock(ConsumerUtils.class);
@@ -163,20 +181,10 @@ public class LogoutTokenValidatorTest extends CommonTestClass {
 
     @Test
     public void test_validateToken_jwsUnsigned_configAlgHs256() throws Exception {
-        String logoutTokenString = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.e30.";
+        String logoutTokenString = encode(getJwsHeader("none")) + "." + encode("{}") + ".";
         try {
-            mockery.checking(new Expectations() {
-                {
-                    allowing(clientConfig).getKeyManagementKeyAlias();
-                    will(returnValue(null));
-                    allowing(clientConfig).getSignatureAlgorithm();
-                    will(returnValue("HS256"));
-                    one(clientConfig).getSharedKey();
-                    will(returnValue("secret"));
-                    one(clientConfig).getClientId();
-                    will(returnValue(CLIENT_ID));
-                }
-            });
+            setConfigExpectations("HS256", SHARED_SECRET, 300L, ISSUER);
+
             validator.validateToken(logoutTokenString);
             fail("Should have thrown an exception but didn't.");
         } catch (BackchannelLogoutException e) {
@@ -185,42 +193,37 @@ public class LogoutTokenValidatorTest extends CommonTestClass {
     }
 
     @Test
-    public void test_validateToken_jwsUnsigned_configAlgNone() throws Exception {
-        String logoutTokenString = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.e30.";
+    public void test_validateToken_jwsUnsigned_configAlgNone_emptyClaims() throws Exception {
+        String logoutTokenString = encode(getJwsHeader("none")) + "." + encode("{}") + ".";
         try {
-            mockery.checking(new Expectations() {
-                {
-                    allowing(clientConfig).getKeyManagementKeyAlias();
-                    will(returnValue(null));
-                    allowing(clientConfig).getSignatureAlgorithm();
-                    will(returnValue("none"));
-                    one(clientConfig).getClientId();
-                    will(returnValue(CLIENT_ID));
-                }
-            });
+            setConfigExpectations("none", null, 300L, ISSUER);
+
+            validator.validateToken(logoutTokenString);
+            fail("Should have thrown an exception but didn't.");
+        } catch (BackchannelLogoutException e) {
+            verifyException(e, CWWKS1543E_BACKCHANNEL_LOGOUT_TOKEN_ERROR + ".*" + CWWKS1545E_LOGOUT_TOKEN_MISSING_CLAIMS + ".*" + "iss, aud, iat, jti, events");
+        }
+    }
+
+    @Test
+    public void test_validateToken_jwsUnsigned_minimumClaims() throws Exception {
+        String logoutTokenString = encode(getJwsHeader("none")) + "." + encode(getMinimumClaimsNoSid()) + ".";
+        try {
+            setConfigExpectations("none", null, 300L, ISSUER);
+
             validator.validateToken(logoutTokenString);
         } catch (BackchannelLogoutException e) {
-            fail("Caught an exception but shouldn't have: " + e);
+            fail("Should not have thrown an exception but did: " + e);
         }
     }
 
     @Test
     public void test_validateToken_hs256_keyMismatch() throws Exception {
-        // Signed using "secret2" as the key
-        String logoutTokenString = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.e30.Uj2QmdsSiazCsMcLY2bZifMmTOVmvxNmh3j3GnslIbA";
+        JsonObject claims = new JsonObject();
+        String logoutTokenString = getHS256Jws(claims, "secret2");
         try {
-            mockery.checking(new Expectations() {
-                {
-                    allowing(clientConfig).getKeyManagementKeyAlias();
-                    will(returnValue(null));
-                    allowing(clientConfig).getSignatureAlgorithm();
-                    will(returnValue("HS256"));
-                    one(clientConfig).getSharedKey();
-                    will(returnValue("secret"));
-                    one(clientConfig).getClientId();
-                    will(returnValue(CLIENT_ID));
-                }
-            });
+            setConfigExpectations("HS256", SHARED_SECRET, 300L, ISSUER);
+
             validator.validateToken(logoutTokenString);
             fail("Should have thrown an exception but didn't.");
         } catch (BackchannelLogoutException e) {
@@ -230,25 +233,212 @@ public class LogoutTokenValidatorTest extends CommonTestClass {
 
     @Test
     public void test_validateToken_hs256_emptyClaims() throws Exception {
-        String logoutTokenString = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.e30.DMCAvRgzrcf5w0Z879BsqzcrnDFKBY_GN6c3qKOUFtQ";
+        JsonObject claims = new JsonObject();
+        String logoutTokenString = getHS256Jws(claims, SHARED_SECRET);
         try {
+            setConfigExpectations("HS256", SHARED_SECRET, 300L, ISSUER);
+
+            validator.validateToken(logoutTokenString);
+            fail("Should have thrown an exception but didn't.");
+        } catch (BackchannelLogoutException e) {
+            verifyException(e, CWWKS1543E_BACKCHANNEL_LOGOUT_TOKEN_ERROR + ".*" + CWWKS1545E_LOGOUT_TOKEN_MISSING_CLAIMS + ".*" + "iss, aud, iat, jti, events");
+        }
+    }
+
+    @Test
+    public void test_validateToken_hs256_missingIss() throws Exception {
+        JsonObject claims = getMinimumClaimsNoSid();
+        String claimToRemove = Claims.ISSUER;
+        claims.remove(claimToRemove);
+        String logoutTokenString = getHS256Jws(claims, SHARED_SECRET);
+        try {
+            setConfigExpectations("HS256", SHARED_SECRET, 300L, ISSUER);
+
+            validator.validateToken(logoutTokenString);
+            fail("Should have thrown an exception but didn't.");
+        } catch (BackchannelLogoutException e) {
+            verifyException(e, CWWKS1543E_BACKCHANNEL_LOGOUT_TOKEN_ERROR + ".*" + CWWKS1545E_LOGOUT_TOKEN_MISSING_CLAIMS + ".*" + claimToRemove + "[^,]");
+        }
+    }
+
+    @Test
+    public void test_validateToken_hs256_missingAud() throws Exception {
+        JsonObject claims = getMinimumClaimsNoSid();
+        String claimToRemove = Claims.AUDIENCE;
+        claims.remove(claimToRemove);
+        String logoutTokenString = getHS256Jws(claims, SHARED_SECRET);
+        try {
+            setConfigExpectations("HS256", SHARED_SECRET, 300L, ISSUER);
+
+            validator.validateToken(logoutTokenString);
+            fail("Should have thrown an exception but didn't.");
+        } catch (BackchannelLogoutException e) {
+            verifyException(e, CWWKS1543E_BACKCHANNEL_LOGOUT_TOKEN_ERROR + ".*" + CWWKS1545E_LOGOUT_TOKEN_MISSING_CLAIMS + ".*" + claimToRemove + "[^,]");
+        }
+    }
+
+    @Test
+    public void test_validateToken_hs256_missingIat() throws Exception {
+        JsonObject claims = getMinimumClaimsNoSid();
+        String claimToRemove = Claims.ISSUED_AT;
+        claims.remove(claimToRemove);
+        String logoutTokenString = getHS256Jws(claims, SHARED_SECRET);
+        try {
+            setConfigExpectations("HS256", SHARED_SECRET, 300L, ISSUER);
+
+            validator.validateToken(logoutTokenString);
+            fail("Should have thrown an exception but didn't.");
+        } catch (BackchannelLogoutException e) {
+            verifyException(e, CWWKS1543E_BACKCHANNEL_LOGOUT_TOKEN_ERROR + ".*" + CWWKS1545E_LOGOUT_TOKEN_MISSING_CLAIMS + ".*" + claimToRemove + "[^,]");
+        }
+    }
+
+    @Test
+    public void test_validateToken_hs256_missingJti() throws Exception {
+        JsonObject claims = getMinimumClaimsNoSid();
+        String claimToRemove = Claims.ID;
+        claims.remove(claimToRemove);
+        String logoutTokenString = getHS256Jws(claims, SHARED_SECRET);
+        try {
+            setConfigExpectations("HS256", SHARED_SECRET, 300L, ISSUER);
+
+            validator.validateToken(logoutTokenString);
+            fail("Should have thrown an exception but didn't.");
+        } catch (BackchannelLogoutException e) {
+            verifyException(e, CWWKS1543E_BACKCHANNEL_LOGOUT_TOKEN_ERROR + ".*" + CWWKS1545E_LOGOUT_TOKEN_MISSING_CLAIMS + ".*" + claimToRemove + "[^,]");
+        }
+    }
+
+    @Test
+    public void test_validateToken_hs256_missingEvents() throws Exception {
+        JsonObject claims = getMinimumClaimsNoSid();
+        String claimToRemove = "events";
+        claims.remove(claimToRemove);
+        String logoutTokenString = getHS256Jws(claims, SHARED_SECRET);
+        try {
+            setConfigExpectations("HS256", SHARED_SECRET, 300L, ISSUER);
+
+            validator.validateToken(logoutTokenString);
+            fail("Should have thrown an exception but didn't.");
+        } catch (BackchannelLogoutException e) {
+            verifyException(e, CWWKS1543E_BACKCHANNEL_LOGOUT_TOKEN_ERROR + ".*" + CWWKS1545E_LOGOUT_TOKEN_MISSING_CLAIMS + ".*" + claimToRemove + "[^,]");
+        }
+    }
+
+    @Test
+    public void test_validateToken_hs256_badIss() throws Exception {
+        JsonObject claims = getMinimumClaimsNoSid();
+        claims.addProperty(Claims.ISSUER, "https://localhost/oidc/provider/NOPE");
+        String logoutTokenString = getHS256Jws(claims, SHARED_SECRET);
+        try {
+            setConfigExpectations("HS256", SHARED_SECRET, 300L, ISSUER);
+
+            validator.validateToken(logoutTokenString);
+            fail("Should have thrown an exception but didn't.");
+        } catch (BackchannelLogoutException e) {
+            verifyException(e, CWWKS1543E_BACKCHANNEL_LOGOUT_TOKEN_ERROR + ".*" + CWWKS1751E_OIDC_IDTOKEN_VERIFY_ISSUER_ERR);
+        }
+    }
+
+    @Test
+    public void test_validateToken_hs256_badAud() throws Exception {
+        JsonObject claims = getMinimumClaimsNoSid();
+        claims.addProperty(Claims.AUDIENCE, "client02");
+        String logoutTokenString = getHS256Jws(claims, SHARED_SECRET);
+        try {
+            setConfigExpectations("HS256", SHARED_SECRET, 300L, ISSUER);
+
+            validator.validateToken(logoutTokenString);
+            fail("Should have thrown an exception but didn't.");
+        } catch (BackchannelLogoutException e) {
+            verifyException(e, CWWKS1543E_BACKCHANNEL_LOGOUT_TOKEN_ERROR + ".*" + CWWKS1754E_OIDC_IDTOKEN_VERIFY_AUD_ERR);
+        }
+    }
+
+    // TODO
+
+    @Test
+    public void test_validateToken_hs256_minimumClaims() throws Exception {
+        JsonObject claims = getMinimumClaimsNoSid();
+        String logoutTokenString = getHS256Jws(claims, SHARED_SECRET);
+        try {
+            setConfigExpectations("HS256", SHARED_SECRET, 300L, ISSUER);
+
+            validator.validateToken(logoutTokenString);
+        } catch (BackchannelLogoutException e) {
+            fail("Should not have thrown an exception but did: " + e);
+        }
+    }
+
+    private JsonObject getJwsHeader(String alg) {
+        JsonObject header = new JsonObject();
+        header.addProperty("typ", "JWT");
+        header.addProperty("alg", alg);
+        return header;
+    }
+
+    private JsonObject getHS256Header() {
+        return getJwsHeader("HS256");
+    }
+
+    private JsonObject getMinimumClaimsNoSid() {
+        JsonObject claims = new JsonObject();
+        claims.addProperty(Claims.ISSUER, ISSUER);
+        claims.addProperty(Claims.AUDIENCE, CLIENT_ID);
+        claims.addProperty(Claims.ISSUED_AT, System.currentTimeMillis() / 1000);
+        claims.addProperty(Claims.ID, JTI_VALID_NO_SID);
+        claims.add("events", getValidEventsEntry());
+        claims.addProperty(Claims.SUBJECT, SUBJECT);
+        return claims;
+    }
+
+    private JsonObject getValidEventsEntry() {
+        JsonObject events = new JsonObject();
+        events.add(EVENTS_MEMBER_KEY, new JsonObject());
+        return events;
+    }
+
+    private String getHS256Jws(JsonObject claims, String secret) throws Exception {
+        String headerAndPayload = encode(getHS256Header()) + "." + encode(claims);
+        String signature = getHS256Signature(headerAndPayload, secret);
+        return headerAndPayload + "." + signature;
+    }
+
+    private String getHS256Signature(String input, String secret) throws Exception {
+        byte[] secretBytes = secret.getBytes("UTF-8");
+        Mac hs256Mac = Mac.getInstance("HmacSHA256");
+        SecretKeySpec keySpec = new SecretKeySpec(secretBytes, "HmacSHA256");
+        hs256Mac.init(keySpec);
+        byte[] hashBytes = hs256Mac.doFinal(input.getBytes("UTF-8"));
+        return Base64.encode(hashBytes);
+    }
+
+    private String encode(Object input) throws UnsupportedEncodingException {
+        return Base64.encode(input.toString().getBytes("UTF-8"));
+    }
+
+    private void setConfigExpectations(String signatureAlgorithm, String sharedKey, long clockSkew, String issuerIdentifier) {
+        mockery.checking(new Expectations() {
+            {
+                allowing(clientConfig).getKeyManagementKeyAlias();
+                will(returnValue(null));
+                allowing(clientConfig).getSignatureAlgorithm();
+                will(returnValue(signatureAlgorithm));
+                allowing(clientConfig).getClientId();
+                will(returnValue(CLIENT_ID));
+                allowing(clientConfig).getClockSkewInSeconds();
+                will(returnValue(clockSkew));
+                allowing(clientConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+            }
+        });
+        if (sharedKey != null) {
             mockery.checking(new Expectations() {
                 {
-                    allowing(clientConfig).getKeyManagementKeyAlias();
-                    will(returnValue(null));
-                    allowing(clientConfig).getSignatureAlgorithm();
-                    will(returnValue("HS256"));
                     one(clientConfig).getSharedKey();
-                    will(returnValue("secret"));
-                    one(clientConfig).getClientId();
-                    will(returnValue(CLIENT_ID));
+                    will(returnValue(sharedKey));
                 }
             });
-            validator.validateToken(logoutTokenString);
-            // TODO
-            //            fail("Should have thrown an exception but didn't.");
-        } catch (BackchannelLogoutException e) {
-            //            verifyException(e, CWWKS1543E_BACKCHANNEL_LOGOUT_TOKEN_ERROR + ".*" + "Invalid JWS Signature");
         }
     }
 


### PR DESCRIPTION
Adds the following validation to the logout token:
- Validates that all required claims (`iss`, `aud`, `iat`, `jti`, `events`) are present
- Validates the `iss` claim
- Validates the `aud` claim
- Validates the `iat` and `exp` claims

For #20058
For #20060