### PR TITLE
Initial drop of componenttest public API and provider API source

### DIFF
--- a/dev/build.featureStart.aToL_fat/bnd.bnd
+++ b/dev/build.featureStart.aToL_fat/bnd.bnd
@@ -32,6 +32,4 @@ tested.features:\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	io.openliberty.org.apache.commons.logging;version=latest, \
     org.jboss.shrinkwrap:shrinkwrap-api;version=1.2.3, \
-    fattest.simplicity;version=latest, \
-    com.ibm.ws.componenttest:public.api;version=1.0.0, \
-    com.ibm.ws.componenttest;version=latest
+    fattest.simplicity;version=latest

--- a/dev/build.featureStart.mToZ_fat/bnd.bnd
+++ b/dev/build.featureStart.mToZ_fat/bnd.bnd
@@ -32,6 +32,4 @@ tested.features:\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	io.openliberty.org.apache.commons.logging;version=latest, \
     org.jboss.shrinkwrap:shrinkwrap-api;version=1.2.3, \
-    fattest.simplicity;version=latest, \
-    com.ibm.ws.componenttest:public.api;version=1.0.0, \
-    com.ibm.ws.componenttest;version=latest
+    fattest.simplicity;version=latest

--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -188,26 +188,6 @@
     </dependency>
     <dependency>
       <groupId>com.ibm.ws.componenttest</groupId>
-      <artifactId>com.ibm.componenttest.common</artifactId>
-      <version>1.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.ibm.ws.componenttest</groupId>
-      <artifactId>com.ibm.ws.topology.helper</artifactId>
-      <version>1.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.ibm.ws.componenttest</groupId>
-      <artifactId>fat.harness</artifactId>
-      <version>1.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.ibm.ws.componenttest</groupId>
-      <artifactId>fat.util</artifactId>
-      <version>1.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.ibm.ws.componenttest</groupId>
       <artifactId>mantis-collections</artifactId>
       <version>2.5.0</version>
     </dependency>
@@ -215,16 +195,6 @@
       <groupId>com.ibm.ws.componenttest</groupId>
       <artifactId>mantis-nls-standalone</artifactId>
       <version>2.5.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.ibm.ws.componenttest</groupId>
-      <artifactId>provider.api</artifactId>
-      <version>1.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.ibm.ws.componenttest</groupId>
-      <artifactId>public.api</artifactId>
-      <version>1.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.icegreen</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -33,14 +33,8 @@ com.graphql-java:graphql-java:16.2
 com.graphql-java:java-dataloader:2.2.3
 com.ibm.async:asyncutil:0.1.0
 com.ibm.db2:jcc:11.1.4.4
-com.ibm.ws.componenttest:com.ibm.componenttest.common:1.0.0
-com.ibm.ws.componenttest:com.ibm.ws.topology.helper:1.0.0
-com.ibm.ws.componenttest:fat.harness:1.0.0
-com.ibm.ws.componenttest:fat.util:1.0.0
 com.ibm.ws.componenttest:mantis-collections:2.5.0
 com.ibm.ws.componenttest:mantis-nls-standalone:2.5.0
-com.ibm.ws.componenttest:provider.api:1.0.0
-com.ibm.ws.componenttest:public.api:1.0.0
 com.icegreen:greenmail:1.5.10
 com.jcraft:jsch:0.1.54
 com.microsoft.sqlserver:mssql-jdbc:9.2.1.jre8

--- a/dev/cnf/resources/bnd/test.bnd
+++ b/dev/cnf/resources/bnd/test.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -30,7 +30,6 @@ mockito: \
   org.jboss.shrinkwrap:shrinkwrap-api\\;version=1.2.3, \
   fattest.simplicity\\;version=latest, \
   com.ibm.ws.org.slf4j.api\\;version=latest, \
-  com.ibm.ws.componenttest:public.api\\;version=1.0.0, \
   com.ibm.ws.componenttest\\;version=latest}
 
 -dependson: ${if;${matches;${project};.*_fat.*}; \

--- a/dev/com.ibm.ws.com.unboundid/bnd.bnd
+++ b/dev/com.ibm.ws.com.unboundid/bnd.bnd
@@ -24,6 +24,6 @@ Include-Resource: \
   
 -buildpath: \
 	com.unboundid:unboundid-ldapsdk;version=5.1.0,\
-	com.ibm.ws.componenttest:public.api;version=1.0.0,\
+	fattest.simplicity;version=latest,\
 	org.apache.commons.io
     

--- a/dev/com.ibm.ws.componenttest.2.0/bnd.bnd
+++ b/dev/com.ibm.ws.componenttest.2.0/bnd.bnd
@@ -56,16 +56,11 @@ test.project: true
     org.hamcrest:hamcrest-all;version=1.3, \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file,\
     commons-httpclient:commons-httpclient;version=3.1,\
-    com.ibm.ws.componenttest:com.ibm.componenttest.common;version=1.0.0,\
-    com.ibm.ws.componenttest:com.ibm.ws.topology.helper;version=1.0.0,\
     httpunit:httpunit;version=1.5.4,\
     net.sf.jtidy:jtidy;version=9.3.8,\
-    com.ibm.ws.componenttest:provider.api;version=1.0.0,\
-    com.ibm.ws.componenttest:public.api;version=1.0.0,\
     org.jboss.shrinkwrap:shrinkwrap-api;version=1.2.3,\
     org.jboss.shrinkwrap:shrinkwrap-impl-base;version=1.2.3,\
     org.jboss.shrinkwrap:shrinkwrap-spi;version=1.2.3,\
-    com.ibm.ws.componenttest:fat.util;version=1.0.0,\
     org.jmock:jmock;strategy=exact;version=2.5.1,\
     io.openliberty.jakarta.servlet.5.0;version=latest,\
     com.ibm.websphere.org.osgi.core;version=latest,\

--- a/dev/com.ibm.ws.componenttest/bnd.bnd
+++ b/dev/com.ibm.ws.componenttest/bnd.bnd
@@ -56,16 +56,11 @@ test.project: true
     org.hamcrest:hamcrest-all;version=1.3, \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file,\
     commons-httpclient:commons-httpclient;version=3.1,\
-    com.ibm.ws.componenttest:com.ibm.componenttest.common;version=1.0.0,\
-    com.ibm.ws.componenttest:com.ibm.ws.topology.helper;version=1.0.0,\
     httpunit:httpunit;version=1.5.4,\
     net.sf.jtidy:jtidy;version=9.3.8,\
-    com.ibm.ws.componenttest:provider.api;version=1.0.0,\
-    com.ibm.ws.componenttest:public.api;version=1.0.0,\
     org.jboss.shrinkwrap:shrinkwrap-api;version=1.2.3,\
     org.jboss.shrinkwrap:shrinkwrap-impl-base;version=1.2.3,\
     org.jboss.shrinkwrap:shrinkwrap-spi;version=1.2.3,\
-    com.ibm.ws.componenttest:fat.util;version=1.0.0,\
     org.jmock:jmock;strategy=exact;version=2.5.1,\
     com.ibm.websphere.javaee.servlet.3.0;version=latest,\
     com.ibm.websphere.org.osgi.core;version=latest,\

--- a/dev/com.ibm.ws.jaxrs.2.x.webcontainer_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.x.webcontainer_fat/bnd.bnd
@@ -39,7 +39,6 @@ tested.features: \
   com.ibm.websphere.javaee.servlet.3.1,\
   com.ibm.websphere.javaee.validation.1.1,\
   com.ibm.ws.cdi.interfaces;version=latest,\
-  com.ibm.ws.componenttest:provider.api;version=1.0.0,\
   com.ibm.ws.jaxrs.2.0.common;version=latest,\
   javax.activation:activation;version=1.1,\
   javax.jws:jsr181-api;version=latest,\

--- a/dev/com.ibm.ws.jbatch.fat.common/bnd.bnd
+++ b/dev/com.ibm.ws.jbatch.fat.common/bnd.bnd
@@ -35,7 +35,6 @@ generate.replacement: true
 	com.ibm.websphere.javaee.cdi.1.2;version=latest,\
 	com.ibm.websphere.javaee.jsonp.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
-	com.ibm.ws.componenttest:public.api;version=latest,\
 	com.ibm.ws.kernel.service;version=latest,\
 	com.ibm.ws.logging.core;version=latest,\
 	fattest.simplicity;version=latest,\

--- a/dev/com.ibm.ws.jbatch.fat.common/src/com/ibm/ws/jbatch/test/BatchRestUtils.java
+++ b/dev/com.ibm.ws.jbatch.fat.common/src/com/ibm/ws/jbatch/test/BatchRestUtils.java
@@ -46,7 +46,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonNumber;

--- a/dev/com.ibm.ws.junit.extensions/bnd.bnd
+++ b/dev/com.ibm.ws.junit.extensions/bnd.bnd
@@ -24,9 +24,9 @@ instrument.disabled: true
 -buildpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	com.ibm.ws.logging;version=latest,\
-	com.ibm.ws.componenttest:public.api;version=1.0.0,\
 	com.ibm.ws.org.apache.ant;version=latest,\
 	com.ibm.ws.org.apache.ant-junit;version=latest,\
 	org.jmock:jmock;version=2.5.1,\
 	org.osgi:osgi.core;version=8.0.0,\
-	org.osgi:org.osgi.service.component;version=1.4.0
+	org.osgi:org.osgi.service.component;version=1.4.0,\
+        com.ibm.ws.logging.core;version=latest

--- a/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/CommonTasks.java
+++ b/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/CommonTasks.java
@@ -8,45 +8,21 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-//%Z% %I% %W% %G% %U% [%H% %T%]
-/*
- * Change History:
- *
- * Reason  		  Version 	 Date       User id     Description
- * ----------------------------------------------------------------------------
- * F017049-28712	8.0		06/29/2010	shighbar	Updates for SSFAT test cases and new useful methods in prep for z/OS support.
- * F17049-32205		8.0		10/04/2010	shighbar	Generalize common methods to support additional ServerTypes.
- * 681388			8.0		12/07/2010  shighbar	Add method to start server with non-standard mBean timeout.
- * 689639.fvt       8.0     02/09/2011  spaungam    sensitive filtering needs to be enabled earlier
- * 695538			8.0		03/08/2011	shighbar	testMergedRepositories failures on z/OS.
- * 707366			8.0		06/01/2011	shighbar	Hpel Internal Trace failures / test case expansion
- * PM41930			8.0		08/23/2011	spaungam	FFDC loggers to be asynchronous
- * 721541           8.0     10/26/2011  spaungam    Ensure exceptions appear with logging
- */
 package com.ibm.ws.logging.hpel.fat;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.util.Properties;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.xml.sax.SAXException;
 
-import com.ibm.websphere.simplicity.Cell;
-import com.ibm.websphere.simplicity.Node;
 import com.ibm.websphere.simplicity.PortType;
 import com.ibm.websphere.simplicity.RemoteFile;
-import com.ibm.websphere.simplicity.Server;
-import com.ibm.websphere.simplicity.ServerType;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
-import com.ibm.websphere.simplicity.runtime.ProcessStatus;
-import com.ibm.ws.fat.util.StopWatch;
 import com.meterware.httpunit.WebConversation;
 import com.meterware.httpunit.WebResponse;
 
@@ -59,79 +35,10 @@ import componenttest.topology.impl.LibertyServer;
 public class CommonTasks {
 
     public static final String HPEL_APP_CONTEXT_ROOT = "HpelFat";
-    public static final String HPEL_APP_GENLOG_JSP = "ivtLogSleep.jsp";
     public static final String HPEL_APP_CREATE_LOG_JSP = "LogCreator.jsp";
-    public static final String RAS_ZIPPER_UTIL_JSP = "RasZipper.jsp";
     public static final String LOGS = "Logs";
     public static final String TRACE = "Trace";
     public static final String LOGS_TRACE = "LogsAndTrace";
-
-    public static enum zOSProcessType {
-        Control, Adjunct, Servant
-    }
-
-    private static final int SERVER_START_MBEAN_TIMEOUT = 240;
-
-//    private static final String JYTHON_RAS_RAWTRACE_SWITCH = "RasConfigEnableRawTrace.jy";
-
-    /**
-     * Makes use of the ivtLogSleep.jsp in the sample application to drive creation of log records.
-     *
-     * @param numCycles
-     *                       How many iterations to run (each iteration generates multiple log records, one of each level). Must be
-     *                       a positive integer, or else only onecycle will be ran
-     *
-     * @param cycleDelay
-     *                       The delay you want between each cycle in seconds. Useful for having steady stream of log entries
-     *                       created. If not a positive number, zero will be used.
-     * @throws Exception
-     * @throws SAXException
-     * @throws IOException
-     * @throws MalformedURLException
-     */
-//    @Deprecated
-//    public static void genLogEntries(int numCycles, int cycleDelay) throws MalformedURLException, IOException, SAXException, Exception {
-//        if (numCycles <= 0) {
-//            numCycles = 1;
-//        }
-//        if (cycleDelay <= 0) {
-//            cycleDelay = 0;
-//        }
-//
-//        String jsp = "/" + HPEL_APP_CONTEXT_ROOT + "/" + HPEL_APP_GENLOG_JSP;
-//        String jspParams = "?ActionParm=trace&NumberOfIterations=" + Integer.toString(numCycles) + "&CycleDelay="
-//                           + Integer.toString(cycleDelay);
-//
-//        WebConversation wc = new WebConversation();
-//        writeLogMsg(Level.INFO, "    Getting URL: " + CommonActions.getUrl(HpelSetup.getServerUnderTest(), jsp + jspParams, false));
-//        WebResponse response = wc.getResponse(CommonActions.getUrl(HpelSetup.getServerUnderTest(), jsp + jspParams, false));
-//
-//        int rc = response.getResponseCode();
-//        writeLogMsg(Level.INFO, "      Response Code for jsp is: " + Integer.toString(rc));
-//
-//    }
-
-    /**
-     * @Deprecated A shortcut to createLogEntries(LibertyServer appServer, String loggerName, String message, Level
-     *             level, int iterations, String repository, int sleepTime) with no sleep time and assuming executing
-     *             against the default application server for the test bucket.
-     */
-//    @Deprecated
-//    public static WebResponse createLogEntries(String loggerName, String message, Level level, int iterations, String repository)
-//                    throws MalformedURLException, IOException, SAXException, Exception {
-//        return createLogEntries(loggerName, message, level, iterations, repository, -1);
-//    }
-
-    /**
-     * @Deprecated A shortcut to createLogEntries(LibertyServer appServer, String loggerName, String message, Level
-     *             level, int iterations, String repository, int sleepTime) without the requirement to pass in
-     *             application server.
-     */
-//    @Deprecated
-//    public static WebResponse createLogEntries(String loggerName, String message, Level level, int iterations, String repository,
-//                                               int sleepTime) throws MalformedURLException, IOException, SAXException, Exception {
-//        return createLogEntries(HpelSetup.getServerUnderTest(), loggerName, message, level, iterations, repository, sleepTime);
-//    }
 
     /**
      * Makes use of the LogCreator.jsp in the RAS sample application to drive creation of log records.
@@ -285,95 +192,6 @@ public class CommonTasks {
         return createLogEntries(appServer, loggerName, message, level, iterations, repository, sleepTime, false);
     }
 
-    /**
-     * Returns a ConfigObject representing the RAS Logging Service configuration in the model.
-     *
-     * @param aServer
-     *                    aServer The server you want the RAS Logging Service ConfigObject for
-     *
-     * @return ulsConfigObj
-     */
-//    public static ConfigObject getLegacyLoggingService(Server aServer) throws Exception {
-//        ConfigObject ulsConfigObj = ConfigObject.getConfigObject(aServer, aServer.getConfigId(), "RASLoggingService");
-//        return ulsConfigObj;
-//    }
-
-    /**
-     * Returns a ConfigObject representing the HPEL configuration in the model.
-     *
-     * @param aServer
-     *                    aServer The server you want the HPEL ConfigObject for
-     *
-     * @return ulsConfigObj
-     */
-//    public static ConfigObject getUnifiedLoggingService(Server aServer) throws Exception {
-//        ConfigObject ulsConfigObj = ConfigObject.getConfigObject(aServer, aServer.getConfigId(), "HighPerformanceExtensibleLogging");
-//        return ulsConfigObj;
-//    }
-
-    /**
-     * Returns a ConfigObject representing the child HPEL configuration in the model.
-     *
-     * @param aServer
-     *                      The server you want the child HPEL ConfigObject for.
-     * @param childName
-     *                      The name of the child configuration object you want to retrieve.
-     *
-     * @return ulsConfigObj
-     */
-//    private static ConfigObject getUnifiedLoggingServiceChild(Server aServer, String childName) throws Exception {
-//        // this fails due to bug in Simplicity.
-//        // return ConfigObject.getConfigObject(HpelSetup.getServerUnderTest(),
-//        // getUnifiedLoggingService().getConfigIdentifier(), childName);
-//
-//        List<ConfigObject> binChild1 = getUnifiedLoggingService(aServer).getChildObjectListByName(childName);
-//        if (binChild1.iterator().hasNext())
-//            return binChild1.iterator().next(); // We should only get one child back.
-//        else
-//            return null;
-//    }
-
-    /**
-     * Returns a ConfigObject representing the HPEL Binary Log configuration in the model.
-     *
-     * @param aServer
-     *                    The server you want the HPEL Binary Log ConfigObject for.
-     *
-     * @return The ConfigObject for the HPEL Binary Log.
-     */
-//    public static ConfigObject getBinaryLogChild(Server aServer) throws Exception {
-//        return getUnifiedLoggingServiceChild(aServer, "HPELLog");
-//    }
-
-    /**
-     * Returns a ConfigObject representing the HPEL Binary Trace configuration in the model.
-     *
-     * @param aServer
-     *                    The server you want the HPEL Binary Trace ConfigObject for.
-     *
-     * @return The ConfigObject for the HPEL Binary Trace.
-     */
-//    public static ConfigObject getBinaryTraceChild(Server aServer) throws Exception {
-//        return getUnifiedLoggingServiceChild(aServer, "HPELTrace");
-//    }
-
-    /**
-     * Returns a ConfigObject representing the HPEL Text Log configuration in the model.
-     *
-     * @param aServer
-     *                    The server you want the HPEL Text Log ConfigObject for.
-     *
-     * @return The ConfigObject for the HPEL Text Log.
-     */
-//    public static ConfigObject getTextLogChild(Server aServer) throws Exception {
-//        return getUnifiedLoggingServiceChild(aServer, "HPELTextLog");
-//    }
-
-//    @Deprecated
-//    public static boolean isHpelEnabled() throws Exception {
-//        return isHpelEnabled(HpelSetup.getServerUnderTest());
-//    }
-
     public static boolean isHpelEnabled(LibertyServer aServer) throws Exception {
         LibertyServer server = aServer;
         RemoteFile bootstrapFile = server.getServerBootstrapPropertiesFile();
@@ -386,79 +204,6 @@ public class CommonTasks {
         is.close();
         String logProvider = bootstrapProps.getProperty("websphere.log.provider");
         return logProvider != null && logProvider.startsWith("binaryLogging-");
-//        if (getUnifiedLoggingService(aServer) == null) {
-//            // For backward compatibility - we assume if HPEL config object is null then server.xml is not updated and
-//            // therefore HPEL must not be enabled since the ConfigObject is returning null.
-//            writeLogMsg(Level.SEVERE, "isHpelEnabled method got null back from UnifiedLoggingService");
-//            if (aServer == null) {
-//                writeLogMsg(Level.SEVERE, "The application server passed to isHpelEnabled is null");
-//            }
-//            return false;
-//        }
-//        boolean tempresult = (getUnifiedLoggingService(aServer).getAttributeByName("enable").getValueAsBoolean() && !getLegacyLoggingService(
-//                                                                                                                                             aServer).getAttributeByName("enable").getValueAsBoolean());
-//        return tempresult;
-    }
-
-    public static boolean isHpelSensitiveTraceEnabled(LibertyServer aServer) throws Exception {
-        //if in hpel mode, get HighPerformanceExtensibleLogging
-//        ConfigObject configObj = getUnifiedLoggingService(aServer).getAttributeByName("rawTraceFilterEnabled");
-//
-//        if (configObj != null) {
-//            return configObj.getValueAsBoolean();
-//        }
-//
-//        writeLogMsg(Level.INFO, "isHpelSensitiveTraceEnabled configObj is null");
-        return false;
-    }
-
-    public static boolean setHpelSensitiveTraceEnabled(LibertyServer aServer, boolean enable) throws Exception {
-        if (enable == isHpelSensitiveTraceEnabled(aServer)) {
-            // the server is already set to the value we are trying to set. So do nothing.
-            return false;
-        }
-
-        throw new UnsupportedOperationException("SensitiveTrace is not supported yet");
-//        Workspace tempWorkSpace = HpelSetup.getCellUnderTest().getWorkspace();
-//        getUnifiedLoggingService(aServer).getAttributeByName("rawTraceFilterEnabled").setValue(enable);
-//        tempWorkSpace.saveAndSync();
-//        return true;
-    }
-
-    public static boolean isRasSensitiveTraceEnabled() throws Exception {
-        throw new UnsupportedOperationException("SensitiveTrace is not supported yet");
-//              String[] scriptArgs = null;
-//              scriptArgs = new String[3];
-//              scriptArgs[0] = HpelSetup.getCellUnderTest().getName();
-//              scriptArgs[1] = HpelSetup.getNodeUnderTest().getName();
-//              scriptArgs[2] = HpelSetup.getServerUnderTest().getName();
-
-//		String result = RASWsadminScripts.exeJythonScript(JYTHON_RAS_RAWTRACE_SWITCH, scriptArgs);
-//		writeLogMsg(Level.INFO, "isRasSensitiveTraceEnabled result of wsadmin: " +  result);
-//
-//		return "true".equalsIgnoreCase(result);
-    }
-
-    public static boolean setRasSensitiveTraceEnabled(boolean enable) throws Exception {
-        if (enable == isRasSensitiveTraceEnabled()) {
-            // the server is already set to the value we are trying to set. So do nothing.
-            return false;
-        }
-
-        throw new UnsupportedOperationException("SensitiveTrace is not supported yet");
-//        String[] scriptArgs = null;
-//        scriptArgs = new String[5];
-//        scriptArgs[0] = HpelSetup.getCellUnderTest().getName();
-//        scriptArgs[1] = HpelSetup.getNodeUnderTest().getName();
-//        scriptArgs[2] = HpelSetup.getServerUnderTest().getName();
-//        scriptArgs[3] = "set";
-//        scriptArgs[4] = Boolean.toString(enable);
-//
-//        String result = RASWsadminScripts.exeJythonScript(JYTHON_RAS_RAWTRACE_SWITCH, scriptArgs);
-//        writeLogMsg(Level.INFO, "setRasSensitiveTraceEnabled result of wsadmin: " + result);
-//
-//        return true;
-
     }
 
     /**
@@ -485,72 +230,16 @@ public class CommonTasks {
         bootstrapProps.store(os, null);
         os.close();
         return true;
-//        Workspace tempWorkSpace = HpelSetup.getCellUnderTest().getWorkspace();
-//        getUnifiedLoggingService(aServer).getAttributeByName("enable").setValue(enable);
-//        getLegacyLoggingService(aServer).getAttributeByName("enable").setValue(!enable);
-//        tempWorkSpace.saveAndSync();
-//        return true;
 
         // TODO Enabling or disabling HPEL requires us to bounce the server - don't know if we should do that here or
         // not though? for now that is the caller's responsibility as they may not want it restarted and or have other
         // changes they are making before the restart.
     }
 
-    /**
-     * Sets if HPEL is enabled or not in the configuration, and bounces the application server if needed.
-     *
-     * @param aServer
-     *                    The server you want to enable or disable HPEL on. The server will only be bounced if the configuration does not already match what was requested.
-     *
-     * @return True if changes were needed/made, and the server was bounced. False - no changes were required, as in the configuration already matched what was requested.
-     */
-    public static boolean setHpelEnabledAndBounce(LibertyServer aServer, boolean enable) throws Exception {
-        if (setHpelEnabled(aServer, enable)) {
-            aServer.stopServer();
-            aServer.startServer();
-            return true;
-        }
-        return false;
-    }
-
-    public static boolean isTextLogEnabled(LibertyServer aServer) throws Exception {
-        LibertyServer server = aServer;
-        BufferedReader config = new BufferedReader(new InputStreamReader(server.getServerConfigurationFile().openForReading()));
-        String line;
-        boolean result = false;
-        boolean inLogging = false;
-        while ((line = config.readLine()) != null) {
-            int index = 0;
-            if (!inLogging) {
-                int index1 = line.indexOf("<logging");
-                if (index1 >= 0) {
-                    inLogging = true;
-                    index = index1;
-                }
-            }
-            if (inLogging) {
-                if (!result) {
-                    int index2 = line.indexOf("<textLog", index);
-                    if (index2 >= 0) {
-                        result = true;
-                        index = index2;
-                    }
-                }
-                int index2 = line.indexOf("</logging>", index);
-                if (index2 >= 0) {
-                    inLogging = false;
-                }
-            }
-        }
-        return result;
-//        return (getTextLogChild(aServer).getAttributeByName("enabled").getValueAsBoolean());
-    }
-
     public static String getHpelTraceSpec(LibertyServer aServer) throws Exception {
         LibertyServer server = aServer;
         String traceSpec = server.getServerConfiguration().getLogging().getTraceSpecification();
         return traceSpec == null ? "" : traceSpec;
-//        return (getUnifiedLoggingService(aServer).getAttributeByName("startupTraceSpec").getValueAsString());
     }
 
     /**
@@ -580,10 +269,6 @@ public class CommonTasks {
             ServerConfiguration config = server.getServerConfiguration();
             config.getLogging().setTraceSpecification(newTraceSpec);
             server.updateServerConfiguration(config);
-//            writeLogMsg(Level.FINE, "Setting the HPEL Trace Spec to " + newTraceSpec);
-//            Workspace tmpWS = HpelSetup.getCellUnderTest().getWorkspace();
-//            getUnifiedLoggingService(aServer).getAttributeByName("startupTraceSpec").setValue(newTraceSpec);
-//            tmpWS.saveAndSync();
         }
 
     }
@@ -591,172 +276,16 @@ public class CommonTasks {
     public static RemoteFile getBinaryLogDir(LibertyServer aServer) throws Exception {
         String logDir = aServer.getServerConfiguration().getLogging().getLogDirectory();
         return logDir == null ? aServer.getFileFromLibertyServerRoot("logs") : new RemoteFile(aServer.getMachine(), logDir);
-//        return new RemoteFile(HpelSetup.getNodeUnderTest().getMachine(), aServer.expandString(getBinaryLogChild(aServer)
-//                        .getAttributeByName("dataDirectory").getValueAsString()));
     }
 
     public static RemoteFile getBinaryTraceDir(LibertyServer aServer) throws Exception {
         String logDir = aServer.getServerConfiguration().getLogging().getLogDirectory();
         return logDir == null ? aServer.getFileFromLibertyServerRoot("logs") : new RemoteFile(aServer.getMachine(), logDir);
-//        return new RemoteFile(aServer.getNode().getMachine(), aServer.expandString(getBinaryTraceChild(aServer)
-//                        .getAttributeByName("dataDirectory").getValueAsString()));
     }
 
     public static RemoteFile getTextLogDir(LibertyServer aServer) throws Exception {
         String logDir = aServer.getServerConfiguration().getLogging().getLogDirectory();
         return logDir == null ? aServer.getFileFromLibertyServerRoot("logs") : new RemoteFile(aServer.getMachine(), logDir);
-//        return new RemoteFile(aServer.getNode().getMachine(), aServer.expandString(getTextLogChild(aServer).getAttributeByName(
-//                                                                                                                               "dataDirectory").getValueAsString()));
-    }
-
-    /**
-     * A utility method to get log repository from a remote application server. The entire log repository will be copied
-     * to the location specified.
-     *
-     * @param aServer
-     *                           The Application Server from which to retrieve the log repository from.
-     *
-     * @param destinationDir
-     *                           A RemoteFile handle to the directory where you want the log repository copied to.
-     *
-     * @return true if the copy was successful.
-     */
-    public static boolean getLogRepositoryFromServer(LibertyServer aServer, RemoteFile destinationDir) throws Exception {
-        RemoteFile remoteLogsDir = CommonTasks.getBinaryLogDir(aServer);
-        RemoteFile remoteLogRepository = new RemoteFile(remoteLogsDir.getMachine(), remoteLogsDir, "logdata");
-
-        return destinationDir.copyFromSource(remoteLogRepository, true, true);
-    }
-
-    /**
-     * A utility method to get a compressed log repository from a remote application server. The entire log repository
-     * will be copied to the location specified.
-     *
-     * @param aServer
-     *                               The Application Server from which to retrieve the log repository from.
-     *
-     * @param destinationZipFile
-     *                               A RemoteFile handle to the zip file where you want the zipped log repository copied to to. Note if the
-     *                               file already exists it will be overwritten.
-     *
-     * @return true if the copy was successful.
-     */
-//    public static boolean getZippedLogRepositoryFromServer(LibertyServer aServer, RemoteFile destinationZipFile) throws Exception {
-//        return zipAndCopyARepositoryFromServer(aServer, destinationZipFile, CommonTasks.LOGS);
-//    }
-
-    /**
-     * A utility method to get trace repository from a remote application server. The entire trace repository will be
-     * copied to the location specified.
-     *
-     * @param aServer
-     *                           The Application Server from which to retrieve the trace repository from.
-     *
-     * @param destinationDir
-     *                           A RemoteFile handle to the directory where you want the trace repository copied to.
-     *
-     * @return true if the copy was successful.
-     */
-//    public static boolean getTraceRepositoryFromServer(LibertyServer aServer, RemoteFile destinationDir) throws Exception {
-//        RemoteFile remoteTraceDir = CommonTasks.getBinaryTraceDir(aServer);
-//        RemoteFile remoteTraceRepository = new RemoteFile(remoteTraceDir.getMachine(), remoteTraceDir, "tracedata");
-//
-//        return destinationDir.copyFromSource(remoteTraceRepository, true, true);
-//    }
-
-    /**
-     * A utility method to get a compressed trace repository from a remote application server. The entire trace repository
-     * will be copied to the location specified.
-     *
-     * @param aServer
-     *                               The Application Server from which to retrieve the log repository from.
-     *
-     * @param destinationZipFile
-     *                               A RemoteFile handle to the zip file where you want the zipped log repository copied to to. Note if the
-     *                               file already exists it will be overwritten.
-     *
-     * @return true if the copy was successful.
-     */
-//    public static boolean getZippedTraceRepositoryFromServer(LibertyServer aServer, RemoteFile destinationZipFile) throws Exception {
-//        return zipAndCopyARepositoryFromServer(aServer, destinationZipFile, CommonTasks.TRACE);
-//    }
-
-//    private static boolean zipAndCopyARepositoryFromServer(LibertyServer aServer, RemoteFile destinationZipFile, String repositoryType) throws Exception {
-//        RemoteFile remoteRepositoryDir = null;
-//        String repositorySubDirName = "logdata"; // default is logs
-//        if (repositoryType.equals(CommonTasks.TRACE)) {
-//            remoteRepositoryDir = CommonTasks.getBinaryTraceDir(aServer);
-//            repositorySubDirName = "tracedata";
-//        } else
-//            remoteRepositoryDir = CommonTasks.getBinaryLogDir(aServer);
-//
-//        Machine rMachine = remoteRepositoryDir.getMachine();
-//        RemoteFile remoteRepository = new RemoteFile(rMachine, remoteRepositoryDir, repositorySubDirName);
-//
-//        String tmpZipFileName = ".tmp_" + Thread.currentThread().getId() + "_" + System.currentTimeMillis() + ".zip";
-//        RemoteFile rProfileLogsDir = new RemoteFile(rMachine, aServer.getNode().getProfileDir() + rMachine.getOperatingSystem().getFileSeparator() + "logs");
-//        RemoteFile tmpZipFile = new RemoteFile(rMachine, rProfileLogsDir, tmpZipFileName);
-//
-//        // 1. Have the files zipped up on the server.
-//        // Build the URL to this test case
-//        String URLsuffix = "/" + HPEL_APP_CONTEXT_ROOT + "/" + RAS_ZIPPER_UTIL_JSP;
-//        String URL = CommonActions.getUrl(aServer, URLsuffix, false);
-//
-//        writeLogMsg(Level.FINE, "Calling RazZipper to compress remote files");
-//        writeLogMsg(Level.FINE, "URL: " + URL);
-//        writeLogMsg(Level.FINE, "inputFile: " + remoteRepository.getAbsolutePath());
-//        writeLogMsg(Level.FINE, "outputZipArchive: " + tmpZipFile.getAbsolutePath());
-//
-//        WebRequest request = new PostMethodWebRequest(URL);
-//        request.setParameter("inputFile", remoteRepository.getAbsolutePath());
-//        request.setParameter("outputZipArchive", tmpZipFile.getAbsolutePath());
-//        // request.setParameter("archiveComment", "" );
-//
-//        WebConversation wc = new WebConversation();
-//        WebResponse response = null;
-//        response = wc.getResponse(request);
-//        if (response == null)
-//            writeLogMsg(Level.WARNING, "The response from RasZipper is null");
-//        if (response.getResponseCode() != 200)
-//            writeLogMsg(Level.WARNING, "Unxpected response code from RasZipper. Received response code of: "
-//                                       + response.getResponseCode());
-//
-//        // 2. Copy the zip file to the destination
-//        boolean returneCode = destinationZipFile.copyFromSource(tmpZipFile, true, true);
-//        if (!tmpZipFile.delete()) // clean up our tmp file.
-//            writeLogMsg(Level.WARNING, "Could not delete tmp zip file " + tmpZipFile.getAbsolutePath());
-//        return returneCode;
-//    }
-
-    /**
-     * A utility method to get log and trace repository from a remote application server. The entire repository will be
-     * copied to the location specified.
-     *
-     * @param aServer
-     *                           The Application Server from which to retrieve the repository from.
-     *
-     * @param destinationDir
-     *                           A RemoteFile handle to the directory where you want the repository copied to.
-     *
-     * @return true if the copy was successful.
-     */
-    public static boolean getRepositoryFromServer(LibertyServer aServer, RemoteFile destinationDir) throws Exception {
-        RemoteFile rRepLogDataDir = new RemoteFile(aServer.getMachine(), CommonTasks.getBinaryLogDir(aServer), "logdata");
-        RemoteFile rRepTraceDataDir = new RemoteFile(aServer.getMachine(), CommonTasks.getBinaryTraceDir(aServer), "tracedata");
-        boolean logCopyResult = false;
-        boolean traceCopyResult = false;
-        if (rRepLogDataDir.exists()) {
-            // copy the logdata dir
-            RemoteFile destLogDataDir = new RemoteFile(destinationDir.getMachine(), destinationDir, "logdata");
-            logCopyResult = destLogDataDir.copyFromSource(rRepLogDataDir, true, true);
-        }
-        if (rRepTraceDataDir.exists()) {
-            // copy the logdata dir
-            RemoteFile destTraceDataDir = new RemoteFile(destinationDir.getMachine(), destinationDir, "tracedata");
-            traceCopyResult = destTraceDataDir.copyFromSource(rRepTraceDataDir, true, true);
-        }
-
-        return (logCopyResult && traceCopyResult);
     }
 
     /**
@@ -777,121 +306,6 @@ public class CommonTasks {
         StackTraceElement element = stackTraceElements[3]; // get the latest entry after the calls to get stracktrace
         Logger bucketLogger = Logger.getLogger(element.getClassName());
         bucketLogger.logp(logLevel, element.getClassName(), element.getMethodName(), msg);
-    }
-
-    /**
-     * A simple method used to log messages to the output.txt log
-     *
-     * @param logLevel
-     *                     The level you want the message written as. If null will default to INFO
-     *
-     * @param msg
-     *                     The message to log.
-     * @param thrown
-     *                     Throwable to be logged
-     */
-    public static void writeLogMsg(Level logLevel, String msg, Throwable thrown) {
-        // default to INFO if level is null
-        if (logLevel == null)
-            logLevel = Level.INFO;
-        // determine who called me
-        StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
-        StackTraceElement element = stackTraceElements[3]; // get the latest entry after the calls to get stracktrace
-        Logger bucketLogger = Logger.getLogger(element.getClassName());
-        bucketLogger.logp(logLevel, element.getClassName(), element.getMethodName(), msg, thrown);
-    }
-
-    /**
-     * Stops and removes all Application Servers, Web Servers, and Proxy Servers in the specified cell, except for those
-     * specified in the excludes set
-     *
-     * @param cell
-     *                            The cell where you want to remove servers.
-     * @param excludedServers
-     *                            The Set of servers you want to keep.
-     * @throws Exception
-     *                       Thrown if any server can't be removed
-     */
-    public static void removeUnusedServers(Cell cell, Set<Server> excludedServers) throws Exception {
-        if (cell == null) {
-            return;
-        }
-        try {
-            Set<Server> allServers = cell.getServers();
-            for (Server server : allServers) {
-                ServerType type = server.getServerType();
-                if (ServerType.PROXY_SERVER.equals(type) || ServerType.WEB_SERVER.equals(type)
-                    || ServerType.APPLICATION_SERVER.equals(type)) {
-                    if (!excludedServers.contains(server)) {
-                        writeLogMsg(Level.INFO, "Removing the server " + server.getName());
-                        remove(server);
-                    }
-                }
-            }
-        } catch (Exception e) {
-            throw new Exception("Unable to remove unused Servers in the Cell named " + cell.getName(), e);
-        }
-    }
-
-    /**
-     * Removes a Server from the WebSphere configuration (and Simplicity object model) using Simplicity. If the server
-     * is currently running, it will be stopped before it's removed.
-     *
-     * @param server
-     *                   The Server you wish to remove.
-     * @throws Exception
-     *                       If Simplicity fails to remove the server.
-     */
-    public static void remove(Server server) throws Exception {
-        if (server == null) {
-            return; // nothing to do
-        }
-        Level logAtlevel = Level.INFO;
-        writeLogMsg(logAtlevel, "Removing a Server...");
-        ProcessStatus status = server.getServerStatus();
-        String serverName = server.getName();
-
-        writeLogMsg(logAtlevel, "  Type: " + server.getServerType().toString());
-        writeLogMsg(logAtlevel, "  Name: " + serverName);
-        Node node = server.getNode();
-        if (node == null) {
-            writeLogMsg(logAtlevel, "  Node: null");
-        } else {
-            writeLogMsg(logAtlevel, "  Node: " + node.getName());
-            Cell cell = node.getCell();
-            if (cell == null) {
-                writeLogMsg(logAtlevel, "  Cell: null");
-            } else {
-                writeLogMsg(logAtlevel, "  Cell: " + cell.getName());
-            }
-        }
-        writeLogMsg(logAtlevel, "  Status: " + server.getName());
-
-        StopWatch timer = new StopWatch();
-        timer.start();
-        if (ProcessStatus.RUNNING.equals(status)) {
-            writeLogMsg(logAtlevel, "Since the server is currently running, it will be stopped and then removed.");
-            server.stop();
-        }
-        server.getNode().deleteServer(serverName);
-        timer.stop();
-
-        writeLogMsg(logAtlevel, "The Server was removed after: " + timer.getTimeElapsedAsString());
-
-    }
-
-    /**
-     * Starts a server and explicitly sets the timeout value for the mBean start operation. On slower systems,
-     * especially z/OS where the server startup takes longer use of this start method may be needed. Using this method
-     * uses a higher timeout value when starting the application server.
-     *
-     * @param serverToStart
-     *                          The Server you wish to start.
-     * @throws Exception
-     *                       If Simplicity fails to start the server.
-     */
-    public static void startServer(Server serverToStart) throws Exception {
-        serverToStart.start(SERVER_START_MBEAN_TIMEOUT);
     }
 
     /**
@@ -936,171 +350,4 @@ public class CommonTasks {
         os.close();
 
     }
-
-    /**
-     * Returns a ConfigObject representing the JVMEntries for an Application Server. The JVMEntries is a child object of
-     * processDefinition. It's useful for getting at the systemProperties / customProperties configured for an
-     * application server.
-     *
-     * @param appServ
-     *                     The Server you want the JVMEntries ConfigObject for.
-     * @param procType
-     *                     Optional. Specifies which zOSProcessType type for this server you want to get the JVMEntries for. If
-     *                     the value is null, then Servant is used as a default. This parameter is ignored on non z/OS platforms.
-     *
-     * @throws Exception
-     */
-//    public static ConfigObject getJVMEntries(Server appServ, zOSProcessType procType) throws Exception {
-//        if (procType == null)
-//            procType = zOSProcessType.Servant;
-//
-//        ConfigObject jvmProcessDefCfgObj = null;
-//        if (appServ.getNode().getMachine().getOperatingSystem().equals(OperatingSystem.ZOS)) {
-//            // We are on z/OS. Need to get the process def for the procType.
-//            CommonTasks.writeLogMsg(Level.INFO, "z/OS detected. Getting the Process Definition ConfigObject for " + procType.toString());
-//            List<ConfigObject> jvmProcessDefCfgObjList = ConfigObject.getConfigObjectList(appServ, appServ.getConfigId(),
-//                                                                                          "JavaProcessDef");
-//            for (ConfigObject cfgObj : jvmProcessDefCfgObjList) {
-//                if (cfgObj.getAttributeByName("processType").getValueAsString().equals(procType.toString())) {
-//                    // We have the zOSProcessType process def.
-//                    CommonTasks.writeLogMsg(Level.INFO, "Found the " + procType + " Process Definition.");
-//                    jvmProcessDefCfgObj = cfgObj;
-//                    break; // no need to complete the for loop
-//                } else {
-//                    CommonTasks.writeLogMsg(Level.INFO, "Found the Process Definition for "
-//                                                        + cfgObj.getAttributeByName("processType").getValueAsString());
-//                }
-//            }
-//        } else {
-//            // distributed systems have only one JavaProcessDef configObject
-//            CommonTasks.writeLogMsg(Level.INFO, "Getting the Process Definition ConfigObject");
-//            jvmProcessDefCfgObj = ConfigObject.getConfigObject(appServ, appServ.getConfigId(), "JavaProcessDef");
-//        }
-//        if (jvmProcessDefCfgObj == null)
-//            CommonTasks.writeLogMsg(Level.WARNING, "Warning Process Definition ConfigObject is null.");
-//        ConfigObject jvmEntriesCfgObj = ConfigObject.getConfigObject(appServ, jvmProcessDefCfgObj.getConfigIdentifier(),
-//                                                                     "JavaVirtualMachine");
-//        return jvmEntriesCfgObj;
-//    }
-
-    /**
-     * Sets JVM system property / custom JVM property.
-     *
-     * @param theServer
-     *                          The application server on which to set the JVM system property.
-     * @param zProcType
-     *                          The zOSProcessType to use if on z/OS platform. Determine which process type updated on z/OS.
-     * @param propertyName
-     *                          The property name.
-     * @param propertyValue
-     *                          The value to set the property to. If the value passed in is null, and a property already exists in the
-     *                          config, the property will be removed from the config.
-     * @param requiredProp
-     *                          A boolean representing if the property is required or not.
-     * @return boolean Boolean value of true if changes to the configuration were required, false if no changes were
-     *         needed.
-     */
-//    public static boolean setCustomJVMPropertyInConfig(LibertyServer theServer, CommonTasks.zOSProcessType zProcType,
-//                                                       String propertyName, String propertyValue, boolean requiredProp) throws Exception {
-//        CommonTasks.writeLogMsg(Level.INFO, "Setting custom property " + propertyName + " with a value of " + propertyValue);
-//        Workspace tmpWS = theServer.getNode().getCell().getWorkspace();
-//        ConfigObject jvmEntriesCfgObj = CommonTasks.getJVMEntries(theServer, zProcType);
-//        if (null == jvmEntriesCfgObj)
-//            throw new Exception("Could not obtain Process JVMEntries");
-//
-//        // Check if and entry for propertyName already exists
-//        ConfigObject aProperty = null;
-//        List<ConfigObject> jvmCustomProps = jvmEntriesCfgObj.getChildObjects();
-//        if (null == jvmCustomProps)
-//            throw new Exception("Could not obtain JVM Properties");
-//
-//        for (ConfigObject i : jvmCustomProps) {
-//            // check if we have an existing matching property.
-//            if ((i.getName().equals("systemProperties"))
-//                    && i.getAttributeByName("name").getValueAsString().equalsIgnoreCase(propertyName)) {
-//                CommonTasks.writeLogMsg(Level.INFO, "Found system Propery " + propertyName + " in config with a value of "
-//                                                    + i.getAttributeByName("value").getValueAsString());
-//                aProperty = i;
-//                break;
-//            }
-//        }
-//
-//        if (aProperty != null) {
-//            // The property already exists in the configuration.
-//            if (null == propertyValue) { // remove the property since the value passed in was null.
-//                CommonTasks.writeLogMsg(Level.FINE, "Removing the systemPropery " + propertyName + " since set value is null.");
-//                jvmCustomProps.remove(aProperty);
-//            } else {
-//                if ((propertyValue.equals(aProperty.getAttributeByName("value").getValueAsString()))
-//                        && (requiredProp == aProperty.getAttributeByName("required").getValueAsBoolean())) {
-//                    // The property is already set to what we want. Do nothing.
-//                    CommonTasks.writeLogMsg(Level.INFO, "The property " + propertyName + " already set to " + propertyValue
-//                                                        + ". No changes were made.");
-//                    return false; // return that no changes were needed.
-//                } else {
-//                    // The property is not set to what we want. Change the value.
-//                    aProperty.getAttributeByName("value").setValue(propertyValue);
-//                    aProperty.getAttributeByName("required").setValue(requiredProp);
-//                    CommonTasks.writeLogMsg(Level.INFO, "Updated JVM custom property " + propertyName + " with a value of "
-//                                                        + propertyValue);
-//                }
-//            }
-//        } else {
-//            if (null != propertyValue) { // don't create if propertyValue was null
-//                // The property does not already exist.
-//                CommonTasks.writeLogMsg(Level.FINE, "The property " + propertyName + " does not exists.");
-//
-//                // we need to create the property and set it's value.
-//                CommonTasks.writeLogMsg(Level.INFO, "Creating the new JVM custom / System property " + propertyName);
-//                ConfigObject newJvmProperty = ConfigObject.createConfigObject(theServer, "Property", jvmEntriesCfgObj);
-//                CommonTasks.writeLogMsg(Level.FINE, "Setting attributes / name and value for new JVM custom property");
-//                newJvmProperty.getAttributeByName("name").setValue(propertyName);
-//                newJvmProperty.getAttributeByName("value").setValue(propertyValue);
-//                newJvmProperty.getAttributeByName("required").setValue("false");
-//            }
-//        }
-//
-//        // if we have not already returned false, then we changed something and need to save & sync before we return
-//        // true that we have changed the configuration.
-//        CommonTasks.writeLogMsg(Level.FINE, "Calling saveAndSync() on the workspace to persist changes.");
-//        tmpWS.saveAndSync();
-//        return true;
-//    }
-
-    /**
-     * Gets the value as a String of a JVM system property / custom JVM property. If the property does not exist a value
-     * of null is returned.
-     *
-     * @param theServer
-     *                         The application server on which to set the JVM system property.
-     * @param zProcType
-     *                         The zOSProcessType to use if on z/OS platform. Determine which process type updated on z/OS.
-     * @param propertyName
-     *                         The property name.
-     * @return propertyValue The value to set the property to. Returns null if property is not found.
-     */
-//    public String getCustomJVMPropertyInConfig(LibertyServer theServer, CommonTasks.zOSProcessType zProcType, String propertyName)
-//                    throws Exception {
-//        CommonTasks.writeLogMsg(Level.INFO, "Getting custom property " + propertyName);
-//        ConfigObject jvmEntriesCfgObj = CommonTasks.getJVMEntries(theServer, zProcType);
-//        if (null == jvmEntriesCfgObj)
-//            throw new Exception("Could not obtain Process JVMEntries");
-//
-//        // Check if and entry for propertyName already exists
-//        List<ConfigObject> jvmCustomProps = jvmEntriesCfgObj.getChildObjects();
-//        if (null == jvmCustomProps)
-//            throw new Exception("Could not obtain JVM Properties"); // there may not be any child props but there should
-//        // be child objects still.
-//
-//        for (ConfigObject i : jvmCustomProps) {
-//            // check if we have an existing property.
-//            if ((i.getName().equals("systemProperties"))
-//                    && i.getAttributeByName("name").getValueAsString().equalsIgnoreCase(propertyName)) {
-//                CommonTasks.writeLogMsg(Level.INFO, "Found system Propery " + propertyName + " in config with a value of "
-//                                                    + i.getAttributeByName("value").getValueAsString());
-//                return i.getAttributeByName("value").getValueAsString();
-//            }
-//        }
-//        return null;
-//    }
 }

--- a/dev/com.ibm.ws.org.apache.directory.server/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.directory.server/bnd.bnd
@@ -25,5 +25,5 @@ generate.replacement: true
 # The latest version is governed by cnf/oss_dependencies.maven.
 #
 -buildpath: \
-	org.apache.directory.server:apacheds-service;version=latest, \
-    com.ibm.ws.componenttest:public.api;version=1.0.0
+	org.apache.directory.server:apacheds-service;version=latest,\
+	fattest.simplicity;version=latest

--- a/dev/com.ibm.ws.persistence_fat/bnd.bnd
+++ b/dev/com.ibm.ws.persistence_fat/bnd.bnd
@@ -37,5 +37,4 @@ tested.features: xmlBinding-3.0, servlet-5.0, jpacontainer-3.0, persistence-3.0,
 	com.ibm.ws.resource;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.org.apache.commons.io;version=latest,\
-	com.ibm.ws.componenttest:provider.api;version=1.0.0,\
 	org.apache.derby:derby;version=10.11.1.1

--- a/dev/com.ibm.ws.security.fat.common.jwt/bnd.bnd
+++ b/dev/com.ibm.ws.security.fat.common.jwt/bnd.bnd
@@ -66,7 +66,6 @@ generate.replacement: true
 	io.openliberty.org.apache.commons.logging;version=latest,\
 	io.openliberty.org.apache.commons.codec;version=latest,\
 	com.ibm.websphere.security;version=latest,\
-	com.ibm.ws.componenttest:public.api;version=latest,\
 	com.ibm.ws.org.jose4j;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.json4j;version=latest,\

--- a/dev/com.ibm.ws.security.fat.common.mp.jwt/bnd.bnd
+++ b/dev/com.ibm.ws.security.fat.common.mp.jwt/bnd.bnd
@@ -64,7 +64,6 @@ com.ibm.websphere.security;version=latest,\
 com.ibm.ws.cdi.interfaces;version=latest,\
 com.ibm.ws.com.meterware.httpunit.1.7;version=latest,\
 com.ibm.ws.common.encoder,\
-com.ibm.ws.componenttest:public.api;version=latest,\
 com.ibm.ws.kernel.service;version=latest,\
 com.ibm.ws.logging.core;version=latest,\
 com.ibm.ws.logging;version=latest,\

--- a/dev/com.ibm.ws.security.fat.common.social/bnd.bnd
+++ b/dev/com.ibm.ws.security.fat.common.social/bnd.bnd
@@ -39,7 +39,6 @@ generate.replacement: true
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest, \
     io.openliberty.org.apache.commons.codec;version=latest, \
     com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
-    com.ibm.ws.componenttest:public.api;version=latest, \
     com.ibm.websphere.javaee.servlet.3.1;version=latest, \
     fattest.simplicity;version=latest, \
     com.ibm.ws.org.apache.httpcomponents;version=latest,\

--- a/dev/com.ibm.ws.security.fat.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.fat.common/bnd.bnd
@@ -44,7 +44,6 @@ generate.replacement: true
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	io.openliberty.org.apache.commons.codec;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-	com.ibm.ws.componenttest:public.api;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	org.jboss.shrinkwrap:shrinkwrap-api;version=1.2.3,\
 	fattest.simplicity;version=latest,\

--- a/dev/com.ibm.ws.security.javaeesec_fat.2/bnd.bnd
+++ b/dev/com.ibm.ws.security.javaeesec_fat.2/bnd.bnd
@@ -49,7 +49,6 @@ src: \
 	org.apache.httpcomponents:httpclient;strategy=exact;version=4.1.2,\
 	org.apache.httpcomponents:httpcore;strategy=exact;version=4.1.2,\
 	fattest.simplicity;version=latest,\
-	com.ibm.ws.componenttest:public.api;version=1.0.0,\
 	com.ibm.websphere.javaee.annotation.1.2;version=latest,\
 	com.ibm.websphere.javaee.cdi.1.2;version=latest,\
 	com.ibm.websphere.javaee.el.3.0;version=latest,\

--- a/dev/com.ibm.ws.security.javaeesec_fat.3/bnd.bnd
+++ b/dev/com.ibm.ws.security.javaeesec_fat.3/bnd.bnd
@@ -49,7 +49,6 @@ src: \
 	org.apache.httpcomponents:httpclient;strategy=exact;version=4.1.2,\
 	org.apache.httpcomponents:httpcore;strategy=exact;version=4.1.2,\
 	fattest.simplicity;version=latest,\
-	com.ibm.ws.componenttest:public.api;version=1.0.0,\
 	com.ibm.websphere.javaee.annotation.1.2;version=latest,\
 	com.ibm.websphere.javaee.cdi.1.2;version=latest,\
 	com.ibm.websphere.javaee.el.3.0;version=latest,\

--- a/dev/com.ibm.ws.security.registry.basic_fat/build.gradle
+++ b/dev/com.ibm.ws.security.registry.basic_fat/build.gradle
@@ -15,8 +15,7 @@
 def appBuildDir = "${buildDir}/test-application"
 
 dependencies { 
-  requiredLibs 'com.ibm.ws.componenttest:public.api:1.0.0',
-    project(':io.openliberty.org.apache.commons.logging'),
+  requiredLibs project(':io.openliberty.org.apache.commons.logging'),
     project(':io.openliberty.org.apache.commons.codec'),
     'org.apache.httpcomponents:httpclient:4.1.2',
     'org.apache.httpcomponents:httpcore:4.1.2',

--- a/dev/com.ibm.ws.security.spnego.fat.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.spnego.fat.common/bnd.bnd
@@ -25,7 +25,6 @@ test.project: true
     com.ibm.ws.org.slf4j.jdk14;version=latest, \
     com.ibm.websphere.javaee.servlet.3.1;version=latest,\
     com.ibm.websphere.security;version=latest,\
-    com.ibm.ws.componenttest:public.api;version=latest,\
     com.ibm.ws.kernel.service;version=latest,\
     com.ibm.ws.logging;version=latest,\
     com.ibm.ws.security;version=latest,\

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/bnd.bnd
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/bnd.bnd
@@ -68,5 +68,5 @@ instrument.classesExcludes: com/ibm/ws/security/wim/adapter/ldap/resources/*.cla
 	com.ibm.ws.security;version=latest,\
 	com.ibm.ws.org.apache.directory.server;version=latest,\
 	org.apache.directory.server:apacheds-service;version=latest,\
-	com.ibm.ws.crypto.passwordutil;version=latest, \
-	com.ibm.ws.componenttest:public.api;version=1.0.0
+	com.ibm.ws.crypto.passwordutil;version=latest,\
+	fattest.simplicity;version=latest

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/build.gradle
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/build.gradle
@@ -15,8 +15,7 @@
 def appBuildDir = "${buildDir}/test-application"
 
 dependencies { 
-  requiredLibs 'com.ibm.ws.componenttest:public.api:1.0.0',
-    project(':io.openliberty.org.apache.commons.logging'),
+  requiredLibs project(':io.openliberty.org.apache.commons.logging'),
     project(':io.openliberty.org.apache.commons.codec'),
     'org.apache.httpcomponents:httpclient:4.1.2',
     'org.apache.httpcomponents:httpcore:4.1.2',

--- a/dev/com.ibm.ws.ssl_fat_pkcs12/build.gradle
+++ b/dev/com.ibm.ws.ssl_fat_pkcs12/build.gradle
@@ -18,8 +18,7 @@ addRequiredLibraries {
 }
 
 dependencies { 
-  requiredLibs 'com.ibm.ws.componenttest:public.api:1.0.0',
-    project(':io.openliberty.org.apache.commons.logging'),
+  requiredLibs project(':io.openliberty.org.apache.commons.logging'),
     project(':io.openliberty.org.apache.commons.codec'),
     'org.apache.httpcomponents:httpclient:4.1.2',
     'org.apache.httpcomponents:httpcore:4.1.2',

--- a/dev/com.ibm.ws.transaction.fat.util/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.fat.util/bnd.bnd
@@ -30,5 +30,4 @@ Export-Package: com.ibm.ws.transaction.fat.util
 	com.ibm.websphere.org.osgi.service.component;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-	com.ibm.ws.componenttest:public.api;version=1.0.0,\
 	fattest.simplicity;version=latest

--- a/dev/com.ibm.ws.webcontainer.security_test.servlets/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.security_test.servlets/bnd.bnd
@@ -50,7 +50,6 @@ test.project: true
 	com.ibm.ws.security.jaas.common;version=latest, \
 	com.ibm.ws.security.token;version=latest, \
 	com.ibm.ws.webcontainer;version=latest, \
-	com.ibm.ws.componenttest:public.api;version=latest, \
 	fattest.simplicity;version=latest, \
 	org.apache.httpcomponents:httpclient;version=4.1.2, \
 	org.apache.httpcomponents:httpcore;version=4.1.2, \

--- a/dev/com.ibm.ws.wsat_fat.assertion/bnd.bnd
+++ b/dev/com.ibm.ws.wsat_fat.assertion/bnd.bnd
@@ -44,7 +44,6 @@ tested.features: \
   com.ibm.ws.transaction.fat.util;version=latest,\
   com.ibm.ws.tx.embeddable;version=latest,\
   com.ibm.wsspi.org.osgi.service.component.annotations,\
-  com.ibm.ws.componenttest:public.api;version=1.0.0,\
   com.ibm.ws.wsat_fat.db;version=latest
 
 -testpath: \

--- a/dev/com.ibm.ws.wssecurity.fat.utils.common/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity.fat.utils.common/bnd.bnd
@@ -26,6 +26,5 @@ test.project: true
 -buildpath: \
     com.ibm.ws.security.fat.common;version=latest,\
     httpunit:httpunit;version=1.5.4,\
-    fattest.simplicity;version=latest,\
-    com.ibm.ws.componenttest:public.api;version=latest
+    fattest.simplicity;version=latest
     

--- a/dev/fattest.simplicity/bnd.bnd
+++ b/dev/fattest.simplicity/bnd.bnd
@@ -9,48 +9,50 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
-bVersion=1.0
+bVersion=2.0
 
 Bundle-Name: FAT infrastructure
 Bundle-SymbolicName: fattest.simplicity
 Bundle-Description: FAT infrastructure; version=${bVersion}
 
 Export-Package: \
-	com.ibm.websphere.simplicity;version=1.0.16,\
-	com.ibm.websphere.simplicity.application;version=1.0.16,\
-	com.ibm.websphere.simplicity.beansxml;version=1.0.16,\
-	com.ibm.websphere.simplicity.config;version=1.0.16,\
-	com.ibm.websphere.simplicity.config.context;version=1.0.16,\
-	com.ibm.websphere.simplicity.config.dsprops;version=1.0.16,\
-	com.ibm.websphere.simplicity.config.dsprops.testrules;version=1.0.16,\
-	com.ibm.websphere.simplicity.config.wim;version=1.0.16,\
-	com.ibm.websphere.soe_reporting;version=1.0.16,\
-	com.ibm.ws.fat.util;version=1.0.16,\
-	com.ibm.ws.fat.util.browser;version=1.0.16,\
-	com.ibm.ws.fat.util.jmx;version=1.0.16,\
-	com.ibm.ws.fat.util.jmx.mbeans;version=1.0.16,\
-	com.ibm.ws.fat.util.tck;version=1.0.16,\
-	componenttest.annotation;version=1.0.16,\
-	componenttest.common.apiservices;version=1.0.16,\
-	componenttest.common.apiservices.cmdline;version=1.0.16,\
-	componenttest.containers;version=1.0.16,\
-	componenttest.custom.junit.runner;version=1.0.16,\
-	componenttest.exception;version=1.0.16,\
-	componenttest.logging.ffdc;version=1.0.16,\
-	componenttest.rules;version=1.0.16,\
-	componenttest.rules.repeater;version=1.0.16,\
-	componenttest.topology.database;version=1.0.16,\
-	componenttest.topology.database.container;version=1.0.16,\
-	componenttest.topology.impl;version=1.0.16,\
-	componenttest.topology.ldap;version=1.0.16,\
-	componenttest.topology.utils;version=1.0.16,\
-	componenttest.vulnerability;version=1.0.16,\
-	io.openliberty.checkpoint.spi
+        com.ibm.websphere.simplicity;version=2.0,\
+        com.ibm.websphere.simplicity.application;version=2.0,\
+        com.ibm.websphere.simplicity.beansxml;version=2.0,\
+        com.ibm.websphere.simplicity.config;version=2.0,\
+        com.ibm.websphere.simplicity.config.context;version=2.0,\
+        com.ibm.websphere.simplicity.config.dsprops;version=2.0,\
+        com.ibm.websphere.simplicity.config.dsprops.testrules;version=2.0,\
+        com.ibm.websphere.simplicity.config.wim;version=2.0,\
+        com.ibm.websphere.simplicity.log;version=2.0,\
+        com.ibm.websphere.soe_reporting;version=2.0,\
+        com.ibm.ws.fat.util;version=2.0,\
+        com.ibm.ws.fat.util.browser;version=2.0,\
+        com.ibm.ws.fat.util.jmx;version=2.0,\
+        com.ibm.ws.fat.util.jmx.mbeans;version=2.0,\
+        com.ibm.ws.fat.util.tck;version=2.0,\
+        componenttest.annotation;version=2.0,\
+        componenttest.common.apiservices;version=2.0,\
+        componenttest.common.apiservices.cmdline;version=2.0,\
+        componenttest.containers;version=2.0,\
+        componenttest.custom.junit.runner;version=2.0,\
+        componenttest.exception;version=2.0,\
+        componenttest.logging.ffdc;version=2.0,\
+        componenttest.rules;version=2.0,\
+        componenttest.rules.repeater;version=2.0,\
+        componenttest.topology.database;version=2.0,\
+        componenttest.topology.database.container;version=2.0,\
+        componenttest.topology.impl;version=2.0,\
+        componenttest.topology.ldap;version=2.0,\
+        componenttest.topology.utils;version=2.0,\
+        componenttest.vulnerability;version=2.0,\
+        io.openliberty.checkpoint.spi
 	
 Private-Package: \
 	componenttest.annotation.processor,\
 	componenttest.depchain,\
-	componenttest.topology.impl.probe
+	componenttest.topology.impl.probe,\
+	com.ibm.websphere.simplicity.configuration
 
 Include-Resource: \
     resources/init-sqlserver.sql=resources/init-sqlserver.sql, \
@@ -72,11 +74,6 @@ test.project: true
 	org.eclipse.transformer:org.eclipse.transformer;version=0.3.0.20211005,\
 	com.ibm.ws.common.encoder;version=latest,\
 	com.ibm.ws.componenttest;version=latest,\
-	com.ibm.ws.componenttest:com.ibm.componenttest.common;version=1.0.0,\
-	com.ibm.ws.componenttest:com.ibm.ws.topology.helper;version=1.0.0,\
-	com.ibm.ws.componenttest:provider.api;version=1.0.0,\
-	com.ibm.ws.componenttest:public.api;version=1.0.0,\
-	com.ibm.ws.componenttest:fat.util;version=1.0.0,\
 	com.ibm.ws.timedexit.internal;version=latest,\
 	com.sun.xml.bind:jaxb-core;version=2.2.10,\
 	com.sun.xml.bind:jaxb-impl;version=2.2.10,\

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/ConnectionInfo.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/ConnectionInfo.java
@@ -1,0 +1,242 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.websphere.simplicity;
+
+import java.io.File;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+/**
+ * This is a general container class to hold connection information. This information can be used to
+ * connect to entities suchs as a WebSphere cell or a remote machine.
+ */
+public class ConnectionInfo implements Cloneable {
+
+    private static Class c = ConnectionInfo.class;
+
+    protected String profileDir;
+    protected String host;
+    protected Integer port;
+    protected String user;
+    protected String password;
+    protected File keystore;
+
+    /**
+     * No argument constructor. If used, connection data must be set using the availabe setter
+     * methods.
+     */
+    public ConnectionInfo() {
+        Log.entering(c, "<clinit>");
+        Log.exiting(c, "<clinit>");
+    }
+
+    /**
+     * Constructor which takes in the minimal arguments needed to connect to a machine.
+     *
+     * @param host     The hostname of the machine
+     * @param user     The administrator username of the machine
+     * @param password The administartor password of the machine
+     */
+    public ConnectionInfo(String host, String user, String password) {
+        Log.entering(c, "<clinit>", new Object[] { host, user, password });
+        this.user = user;
+        this.password = password;
+        this.host = host;
+        Log.exiting(c, "<clinit>");
+    }
+
+    /**
+     * Constructor which takes in the minimal arguments needed to connect to a machine
+     * using an SSH keystore and passphrase.
+     *
+     * @param host     The hostname of the machine
+     * @param keystore The SSH keystore file
+     * @param user     The username of the machine
+     * @param password The password for the keystore file
+     */
+    public ConnectionInfo(String host, File keystore, String user, String password) {
+        Log.entering(c, "<construct>", new Object[] { host, keystore, user, password });
+        this.host = host;
+        this.keystore = keystore;
+        this.user = user;
+        this.password = password;
+        Log.exiting(c, "<construct>");
+    }
+
+    public String getProfileDir() {
+        return profileDir;
+    }
+
+    public void setProfileDir(String dir) {
+        this.profileDir = dir;
+    }
+
+    /**
+     * Get the hostname of the machine to connect to
+     *
+     * @return The hostname of the machine to connect to
+     */
+    public String getHost() {
+        return host;
+    }
+
+    /**
+     * Set the hostname of the machine to connect to
+     *
+     * @param host The hostname of the machine to connect to
+     */
+    void setHost(String host) {
+        this.host = host;
+    }
+
+    /**
+     * Get the password that is to be used during the connection.
+     *
+     * @return The password that is to be used during the connection.
+     */
+    public String getPassword() {
+        return password;
+    }
+
+    /**
+     * Set the password that is to be used during the connection.
+     *
+     * @param password The password that is to be used during the connection.
+     */
+    void setPassword(String password) {
+        this.password = password;
+    }
+
+    /**
+     * Get the port number that is to be used during the connection.
+     *
+     * @return The port number that is to be used during the connection.
+     */
+    public Integer getPort() {
+        return port;
+    }
+
+    /**
+     * Set the port number that is to be used during the connection.
+     *
+     * @param port The port number that is to be used during the connection.
+     */
+    void setPort(Integer port) {
+        this.port = port;
+    }
+
+    /**
+     * Get the username that is to be used during the connection.
+     *
+     * @return The username that is to be used during the connection.
+     */
+    public String getUser() {
+        return user;
+    }
+
+    /**
+     * Set the username that is to be used during the connection.
+     *
+     * @param user The username that is to be used during the connection.
+     */
+    void setUser(String user) {
+        this.user = user;
+    }
+
+    /**
+     * Get the SSH keystore file to be used during the connection
+     *
+     * @return The SSH keystore that will be used to make a connection
+     */
+    public File getKeystore() {
+        return keystore;
+    }
+
+    /**
+     * Set the SSH keystore file to be used during the connection
+     *
+     * @param keystore The SSH keystore to use to make a connection
+     */
+    void setKeystore(File keystore) {
+        this.keystore = keystore;
+    }
+
+    /**
+     * Two ConnectionInfo Objects are equal if all their member data is equal.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) {
+            return false;
+        }
+        if (!(o instanceof ConnectionInfo)) {
+            return false;
+        }
+
+        ConnectionInfo other = (ConnectionInfo) o;
+        if (((this.host == null) && (other.host != null)) || ((this.host != null) && (!this.host.equalsIgnoreCase(other.host)))
+            || ((this.password == null) && (other.password != null)) || ((this.password != null) && (!this.password.equals(other.password)))
+            || ((this.port == null) && (other.port != null)) || ((this.port != null) && (!this.port.equals(other.port)))
+            || ((this.user == null) && (other.user != null)) || ((this.user != null) && (!this.user.equals(other.user)))
+            || ((this.keystore == null) && (other.keystore != null)) || ((this.keystore != null) && (!this.keystore.equals(other.keystore)))
+            || ((this.profileDir == null) && (other.profileDir != null)) || (this.profileDir != null) && (!this.profileDir.equals(other.profileDir))) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Clone this ConnectionInfo
+     */
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+        final String method = "clone";
+        Log.entering(c, method);
+        ConnectionInfo clone = (ConnectionInfo) super.clone();
+
+        // make copies of mutable data
+        if (this.keystore != null) {
+            clone.setKeystore(new File(this.keystore.getAbsolutePath()));
+        } else {
+            clone.setKeystore(null);
+        }
+        if (this.port != null) {
+            clone.setPort(new Integer(this.port.intValue()));
+        } else {
+            clone.setPort(null);
+        }
+        Log.exiting(c, method, clone);
+        return clone;
+    }
+
+    /**
+     * Custom clone method to clone all values except those specified in the method header
+     *
+     * @param  port                       The port to connect to
+     * @param  user                       The user name to use when connecting
+     * @param  password                   The password to use when connecting
+     * @return                            Cloned ConnectionInfo
+     * @throws CloneNotSupportedException
+     */
+    public Object clone(int port, String user, String password) throws CloneNotSupportedException {
+        ConnectionInfo nci = (ConnectionInfo) this.clone();
+        if (port != 0)
+            nci.setPort(port);
+        if (user != null)
+            nci.setUser(user);
+        if (password != null)
+            nci.setPassword(password);
+        return nci;
+    }
+
+}

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/LocalFile.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/LocalFile.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2011 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.websphere.simplicity;
+
+import java.io.File;
+
+/**
+ * Represents a file or directory on the local {@link Machine}. This file or directory may or may not
+ * actually exist on the local {@link Machine}
+ */
+public class LocalFile extends RemoteFile {
+
+	/**
+	 * Construct an instance based on the fully qualified path of the remote file.
+	 * 
+	 * @param filePath The fully qualified (absolute) path of the file
+	 * @throws Exception
+	 */
+	public LocalFile(String filePath) throws Exception {
+		super(Machine.getLocalMachine(), new File(filePath).getAbsolutePath());
+	}
+
+	/**
+	 * Construct an instance based on the parent of the local file.
+	 * Behavior of LocalFile is undefined if the parent does not
+	 * reside on the local machine. 
+	 * 
+	 * @param parent The remote file's parent directory
+	 * @param name The name of the file
+	 */
+	public LocalFile(RemoteFile parent, String name) throws Exception {
+		super(Machine.getLocalMachine(), parent, name);
+	}
+
+	/**
+	 * Construct an instance based on the parent of the local file.
+	 * 
+	 * @param parent The local file's parent directory
+	 * @param name The name of the file
+	 */
+	public LocalFile(LocalFile parent, String name) throws Exception {
+		super(Machine.getLocalMachine(), parent, name);
+	}
+
+}

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/Machine.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/Machine.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,9 +19,7 @@ import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 
 import com.ibm.websphere.simplicity.log.Log;
-import com.ibm.websphere.simplicity.provider.commandline.CommandLineProvider;
-import com.ibm.websphere.simplicity.provider.commandline.RemoteCommandFactory;
-import com.ibm.websphere.simplicity.provider.commandline.local.LocalCommandLineProvider;
+
 import componenttest.common.apiservices.Bootstrap;
 import componenttest.common.apiservices.LocalMachine;
 import componenttest.common.apiservices.cmdline.LocalProvider;
@@ -51,11 +49,11 @@ public class Machine {
 
     /**
      * {@link ConnectionInfo} constructor
-     * 
-     * @param connInfo The {@link ConnectionInfo} contains the information needed to make a
-     *            connection to the machine. This includes the hostname, administrative username and
-     *            password.
-     * 
+     *
+     * @param  connInfo  The {@link ConnectionInfo} contains the information needed to make a
+     *                       connection to the machine. This includes the hostname, administrative username and
+     *                       password.
+     *
      * @throws Exception
      */
     protected Machine(ConnectionInfo connInfo) throws Exception {
@@ -66,11 +64,11 @@ public class Machine {
      * Factory method to get a Machine using a {@link ConnectionInfo} Object. This method
      * should be used by so that there is only one instance of a Machine per physical machine
      * existing at any one time.
-     * 
-     * @param connInfo The {@link ConnectionInfo} contains the information needed to make a
-     *            connection to the machine. This includes the hostname, administrative username and
-     *            password.
-     * @return A Machine Object corresponding to the {@link ConnectionInfo}
+     *
+     * @param  connInfo  The {@link ConnectionInfo} contains the information needed to make a
+     *                       connection to the machine. This includes the hostname, administrative username and
+     *                       password.
+     * @return           A Machine Object corresponding to the {@link ConnectionInfo}
      * @throws Exception
      */
     public static Machine getMachine(String hostname) throws Exception {
@@ -85,11 +83,11 @@ public class Machine {
      * Factory method to get a Machine using a {@link ConnectionInfo} Object. This method
      * should be used by so that there is only one instance of a Machine per physical machine
      * existing at any one time.
-     * 
-     * @param connInfo The {@link ConnectionInfo} contains the information needed to make a
-     *            connection to the machine. This includes the hostname, administrative username and
-     *            password.
-     * @return A Machine Object corresponding to the {@link ConnectionInfo}
+     *
+     * @param  connInfo  The {@link ConnectionInfo} contains the information needed to make a
+     *                       connection to the machine. This includes the hostname, administrative username and
+     *                       password.
+     * @return           A Machine Object corresponding to the {@link ConnectionInfo}
      * @throws Exception
      */
     public static Machine getMachine(ConnectionInfo connInfo) throws Exception {
@@ -114,8 +112,8 @@ public class Machine {
      * be made using "localhost" as the hostname. If the second attempt fails, a Machine instance
      * will be returned using the hostname localhost with no security information. Note that without
      * security credentials, remote command line operations may not be possible.
-     * 
-     * @return A Machine representation for the local physical machine.
+     *
+     * @return           A Machine representation for the local physical machine.
      * @throws Exception
      */
     public static Machine getLocalMachine() throws Exception {
@@ -128,9 +126,9 @@ public class Machine {
 
     /**
      * Get a Machine instance that represents the local physical machine.
-     * 
-     * @param connInfo The {@link ConnectionInfo} Object which contains connection information for the local machine
-     * @return A Machine representation for the local physical machine.
+     *
+     * @param  connInfo  The {@link ConnectionInfo} Object which contains connection information for the local machine
+     * @return           A Machine representation for the local physical machine.
      * @throws Exception
      */
     public static Machine getLocalMachine(ConnectionInfo connInfo) throws Exception {
@@ -140,7 +138,7 @@ public class Machine {
     /**
      * Get the {@link ConnectionInfo} Object that contains the information used to make a connection
      * to this Machine.
-     * 
+     *
      * @return The {@link ConnectionInfo} for this Machine
      */
     public ConnectionInfo getConnInfo() {
@@ -150,7 +148,7 @@ public class Machine {
     /**
      * Get the bootstrapping file key used to cache this Machine. If the caching is not enabled,
      * this returns null
-     * 
+     *
      * @return The key used to cache the machine in the bootstrapping file
      */
     public String getBootstrapFileKey() {
@@ -159,7 +157,7 @@ public class Machine {
 
     /**
      * Set the boostrapping file key
-     * 
+     *
      * @param bootstrapFileKey The boostrapping file key
      */
     protected void setBootstrapFileKey(String bootstrapFileKey) {
@@ -169,7 +167,7 @@ public class Machine {
     /**
      * Get the hostname or ip address of the Machine. The hostname can be used to communicate with
      * the Machine.
-     * 
+     *
      * @return The hostname of the Machine
      */
     public String getHostname() {
@@ -186,7 +184,7 @@ public class Machine {
     /**
      * Get the administrative username of the Machine. The username is used to establish a remote
      * connection to the machine.
-     * 
+     *
      * @return The administrative username of the Machine
      */
     public String getUsername() {
@@ -196,7 +194,7 @@ public class Machine {
     /**
      * Get the administrative password of the Machine. The password is used to establish a remote
      * connection to the machine.
-     * 
+     *
      * @return The administrative password of the Machine
      */
     public String getPassword() {
@@ -207,9 +205,9 @@ public class Machine {
      * Constructs a RemoteFile object that represents the path to the remote file indicated by the
      * input path. Note that the actual file is not guaranteed to exist. The input path may
      * represent either a file or a directory.
-     * 
-     * @param path The absolute path to a file on the remote device.
-     * @return A RemoteFile representing the input abstract path name
+     *
+     * @param  path The absolute path to a file on the remote device.
+     * @return      A RemoteFile representing the input abstract path name
      */
     public RemoteFile getFile(String path) {
         return new RemoteFile(this, path);
@@ -219,10 +217,10 @@ public class Machine {
      * Constructs a RemoteFile object that represents the path to the remote file indicated by the
      * input path. Note that the actual file is not guaranteed to exist. The input path may
      * represent either a file or a directory.
-     * 
-     * @param parent The parent directory of the target file
-     * @param name The name of the file
-     * @return A RemoteFile representing the input abstract path name
+     *
+     * @param  parent The parent directory of the target file
+     * @param  name   The name of the file
+     * @return        A RemoteFile representing the input abstract path name
      */
     public RemoteFile getFile(RemoteFile parent, String name) {
         return new RemoteFile(this, parent, name);
@@ -230,7 +228,7 @@ public class Machine {
 
     /**
      * Get the {@link OperatingSystem} that this Machine is running
-     * 
+     *
      * @return A representation of the operating system of the remote machine
      */
     public OperatingSystem getOperatingSystem() throws Exception {
@@ -246,8 +244,8 @@ public class Machine {
 
     /**
      * Get the version of the OperatingSystem that this Machine is running
-     * 
-     * @return A String value of the operating system returned by the operating system itself
+     *
+     * @return           A String value of the operating system returned by the operating system itself
      * @throws Exception
      */
     public String getOSVersion() throws Exception {
@@ -272,7 +270,7 @@ public class Machine {
 
     /**
      * Set the OS version for this Machine
-     * 
+     *
      * @param version The OS version to set
      */
     protected void setOSVersion(String version) {
@@ -282,8 +280,8 @@ public class Machine {
     /**
      * Get a String representation of the raw name of operating system that this Machine is running
      * (as opposed to the {@link OperatingSystem} enum).
-     * 
-     * @return A String representation of the raw name of the operating system
+     *
+     * @return           A String representation of the raw name of the operating system
      * @throws Exception
      */
     public String getRawOSName() throws Exception {
@@ -295,7 +293,7 @@ public class Machine {
 
     /**
      * Set the raw OS name for this Machine
-     * 
+     *
      * @param name The raw OS name to set
      */
     protected void setRawOSName(String name) {
@@ -306,9 +304,9 @@ public class Machine {
      * Execute the specified command line command.
      * If you have parameters you should use the version of execute where you
      * give the parameters in an Array.
-     * 
-     * @param cmd The command to execute.
-     * @return The result of the command
+     *
+     * @param  cmd                The command to execute.
+     * @return                    The result of the command
      * @throws ExecutionException
      */
     public ProgramOutput execute(String cmd) throws Exception {
@@ -319,11 +317,11 @@ public class Machine {
      * Execute the specified command line command.
      * If you have parameters you should use the version of execute where you
      * give the parameters in an Array.
-     * 
-     * @param cmd The command to execute.
-     * @param timeout Execute the command with timeout
-     * @param workDir The directory to execute the command from
-     * @return The result of the command
+     *
+     * @param  cmd                The command to execute.
+     * @param  timeout            Execute the command with timeout
+     * @param  workDir            The directory to execute the command from
+     * @return                    The result of the command
      * @throws ExecutionException
      */
     public ProgramOutput execute(String cmd, int timeout) throws Exception {
@@ -334,10 +332,10 @@ public class Machine {
      * Execute the specified command line command.
      * If you have parameters you should use the version of execute where you
      * give the parameters in an Array.
-     * 
-     * @param cmd The command to execute.
-     * @param workDir The directory to execute the command from
-     * @return The result of the command
+     *
+     * @param  cmd                The command to execute.
+     * @param  workDir            The directory to execute the command from
+     * @return                    The result of the command
      * @throws ExecutionException
      */
     public ProgramOutput execute(String cmd, String workDir) throws Exception {
@@ -348,11 +346,11 @@ public class Machine {
      * Execute the specified command line command.
      * If you have parameters you should use the version of execute where you
      * give the parameters in an Array.
-     * 
-     * @param cmd The command to execute.
-     * @param workDir The directory to execute the command from
-     * @param envVars Environment variables to modify the default environment
-     * @return The result of the command
+     *
+     * @param  cmd                The command to execute.
+     * @param  workDir            The directory to execute the command from
+     * @param  envVars            Environment variables to modify the default environment
+     * @return                    The result of the command
      * @throws ExecutionException
      */
     public ProgramOutput execute(String cmd, String workDir, Properties envVars) throws Exception {
@@ -361,12 +359,12 @@ public class Machine {
 
     /**
      * Execute the specified command line command.
-     * 
-     * @param cmd The command to execute.
-     * @param parameters The parameters to pass to the command. Spaces are allowed within arguments
-     *            and path names. DO NOT use quotation marks around paths, they will be inserted
-     *            automatically when needed.
-     * @return The result of the command
+     *
+     * @param  cmd                The command to execute.
+     * @param  parameters         The parameters to pass to the command. Spaces are allowed within arguments
+     *                                and path names. DO NOT use quotation marks around paths, they will be inserted
+     *                                automatically when needed.
+     * @return                    The result of the command
      * @throws ExecutionException
      */
     public ProgramOutput execute(String cmd, String[] parameters) throws Exception {
@@ -375,13 +373,13 @@ public class Machine {
 
     /**
      * Execute the specified command line command.
-     * 
-     * @param cmd The command to execute.
-     * @param parameters The parameters to pass to the command. Spaces are allowed within arguments
-     *            and path names. DO NOT use quotation marks around paths, they will be inserted
-     *            automatically when needed.
-     * @param envVars Environment variables to modify the default environment
-     * @return The result of the command
+     *
+     * @param  cmd                The command to execute.
+     * @param  parameters         The parameters to pass to the command. Spaces are allowed within arguments
+     *                                and path names. DO NOT use quotation marks around paths, they will be inserted
+     *                                automatically when needed.
+     * @param  envVars            Environment variables to modify the default environment
+     * @return                    The result of the command
      * @throws ExecutionException
      */
     public ProgramOutput execute(String cmd, String[] parameters, Properties envVars) throws Exception {
@@ -390,13 +388,13 @@ public class Machine {
 
     /**
      * Execute the specified command line command.
-     * 
-     * @param cmd The command to execute.
-     * @param parameters The parameters to pass to the command. Spaces are allowed within arguments
-     *            and path names. DO NOT use quotation marks around paths, they will be inserted
-     *            automatically when needed.
-     * @param workDir The directory to execute the command from
-     * @return The result of the command
+     *
+     * @param  cmd                The command to execute.
+     * @param  parameters         The parameters to pass to the command. Spaces are allowed within arguments
+     *                                and path names. DO NOT use quotation marks around paths, they will be inserted
+     *                                automatically when needed.
+     * @param  workDir            The directory to execute the command from
+     * @return                    The result of the command
      * @throws ExecutionException
      */
     public ProgramOutput execute(String cmd, String[] parameters, String workDir) throws Exception {
@@ -405,15 +403,15 @@ public class Machine {
 
     /**
      * Execute the specified command line command
-     * 
-     * @param cmd The command to execute
-     * @param parameters The parameters to pass to the command. Spaces are allowed within arguments
-     *            and path names. DO NOT use quotation marks around paths, they will be inserted
-     *            automatically when needed.
-     * @param workDir The directory to execute the command from
-     * @param envVars A Properties Object which contain name/value pairs for environment variables
-     *            needed to execute the command
-     * @return The result of the command
+     *
+     * @param  cmd        The command to execute
+     * @param  parameters The parameters to pass to the command. Spaces are allowed within arguments
+     *                        and path names. DO NOT use quotation marks around paths, they will be inserted
+     *                        automatically when needed.
+     * @param  workDir    The directory to execute the command from
+     * @param  envVars    A Properties Object which contain name/value pairs for environment variables
+     *                        needed to execute the command
+     * @return            The result of the command
      * @throws Exception
      */
     public ProgramOutput execute(String cmd, String[] parameters, String workDir, Properties envVars) throws Exception {
@@ -422,16 +420,16 @@ public class Machine {
 
     /**
      * Execute the specified command line command
-     * 
-     * @param cmd The command to execute
-     * @param parameters The parameters to pass to the command. Spaces are allowed within arguments
-     *            and path names. DO NOT use quotation marks around paths, they will be inserted
-     *            automatically when needed.
-     * @param workDir The directory to execute the command from
-     * @param envVars A Properties Object which contain name/value pairs for environment variables
-     *            needed to execute the command
-     * @param timeout Execute the command with timeout
-     * @return The result of the command
+     *
+     * @param  cmd        The command to execute
+     * @param  parameters The parameters to pass to the command. Spaces are allowed within arguments
+     *                        and path names. DO NOT use quotation marks around paths, they will be inserted
+     *                        automatically when needed.
+     * @param  workDir    The directory to execute the command from
+     * @param  envVars    A Properties Object which contain name/value pairs for environment variables
+     *                        needed to execute the command
+     * @param  timeout    Execute the command with timeout
+     * @return            The result of the command
      * @throws Exception
      */
     public ProgramOutput execute(String cmd, String[] parameters, String workDir, Properties envVars, int timeout) throws Exception {
@@ -448,9 +446,9 @@ public class Machine {
      * Asynchronously execute the specified command line command.
      * If you have parameters you should use the version of execute where you
      * give the parameters in an Array.
-     * 
-     * @param cmd The command to execute.
-     * @return The result of the command
+     *
+     * @param  cmd                The command to execute.
+     * @return                    The result of the command
      * @throws ExecutionException
      */
     public void executeAsync(String cmd) throws Exception {
@@ -459,13 +457,13 @@ public class Machine {
 
     /**
      * Asynchronously execute the specified command line command.
-     * 
-     * 
-     * @param cmd The command to execute.
-     * @param parameters The parameters to pass to the command. Spaces are allowed within arguments
-     *            and path names. DO NOT use quotation marks around paths, they will be inserted
-     *            automatically when needed.
-     * @return The result of the command
+     *
+     *
+     * @param  cmd                The command to execute.
+     * @param  parameters         The parameters to pass to the command. Spaces are allowed within arguments
+     *                                and path names. DO NOT use quotation marks around paths, they will be inserted
+     *                                automatically when needed.
+     * @return                    The result of the command
      * @throws ExecutionException
      */
     public AsyncProgramOutput executeAsync(String cmd, String[] parameters) throws Exception {
@@ -473,31 +471,9 @@ public class Machine {
     }
 
     /**
-     * Execute a command line command asynchronously. This method creates a {@link RemoteCommand} Object and starts the command execution in a separate thread. The
-     * {@link RemoteCommand} is
-     * returned for querying.
-     * 
-     * @param cmd The command to execute
-     * @param parameters The parameters to pass to the command. Spaces are allowed within arguments
-     *            and path names. DO NOT use quotation marks around paths, they will be inserted
-     *            automatically when needed.
-     * @param workDir The directory to execute the command from
-     * @param envVars A Properties Object which contain name/value pairs for environment variables
-     *            needed to execute the command
-     * @return The {@link RemoteCommand} Object
-     * @throws Exception
-     */
-    public RemoteCommand executeAsync(String cmd, String[] parameters, String workDir, Properties envVars) throws Exception {
-        RemoteCommand remoteCommand = RemoteCommandFactory.getInstance(cmd, parameters, workDir, envVars, this);
-        remoteCommand.setDaemon(true);
-        remoteCommand.start();
-        return remoteCommand;
-    }
-
-    /**
      * Get the temporary directory for the Machine defined by the Machines operating system.
-     * 
-     * @return A {@link RemoteFile} representation of the temporary directory
+     *
+     * @return           A {@link RemoteFile} representation of the temporary directory
      * @throws Exception
      */
     public RemoteFile getTempDir() throws Exception {
@@ -513,7 +489,7 @@ public class Machine {
 
     /**
      * Establish a remote connection if needed by the {@link CommandLineProvider} implementation.
-     * 
+     *
      * @throws Exception
      */
     public void connect() throws Exception {
@@ -522,7 +498,7 @@ public class Machine {
 
     /**
      * Close a remote connection to this Machine if there is one established
-     * 
+     *
      * @throws Exception
      */
     public void disconnect() throws Exception {
@@ -533,8 +509,8 @@ public class Machine {
      * Return true if a remote connection is currently established to the machine. The return value
      * is specific to the {@link CommandLineProvider} implementation. For example, the {@link LocalCommandLineProvider} will always return true since no connection is needed to
      * interact with the local machine.
-     * 
-     * @return true if a connection to the machine is currently established
+     *
+     * @return           true if a connection to the machine is currently established
      * @throws Exception
      */
     public boolean isConnected() throws Exception {
@@ -544,7 +520,7 @@ public class Machine {
     /**
      * Kill the process specified by the process id. The process is not killed "gracefully."
      * It is immediately stopped.
-     * 
+     *
      * @param processId The id of the process to kill
      */
     public void killProcess(int processId) throws Exception {
@@ -568,8 +544,8 @@ public class Machine {
 
     /**
      * Get a java.util.Date representation of the current time on the Machine
-     * 
-     * @return A Date repesentation of the current time on the Machine
+     *
+     * @return           A Date repesentation of the current time on the Machine
      * @throws Exception
      */
     public Date getDate() throws Exception {
@@ -678,10 +654,10 @@ public class Machine {
 
     /**
      * Returns whether the given processID is running on the system or not
-     * 
-     * @param processID The process ID to check for
-     * @return true - it is running
-     *         false - it is not running
+     *
+     * @param  processID The process ID to check for
+     * @return           true - it is running
+     *                   false - it is not running
      * @throws Exception
      */
     public boolean processStillRunning(int processID) throws Exception {

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/ProgramOutput.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/ProgramOutput.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2011 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.websphere.simplicity;
+
+/**
+ * This class is a container to hold output information for command line command results
+ */
+public class ProgramOutput {
+
+	private String command = "";
+    private String stdout = "";
+    private String stderr = "";
+    private int returnCode;
+    
+    public ProgramOutput(String command, int returnCode, String stdout, String stderr) {
+    	this.command = command;
+    	this.returnCode = returnCode;
+    	this.stdout = stdout;
+    	this.stderr = stderr;
+    }
+
+    /**
+     * @return The shell command executed on the target machine.
+     */
+    public String getCommand() {
+    	return command;
+    }
+    
+    /**
+     * Returns the command line return code
+     * 
+     * @return The command line return code
+     */
+    public int getReturnCode() {
+        return returnCode;
+    }
+
+    /**
+     * Get the output written to stderr
+     * 
+     * @return stderr
+     */
+    public String getStderr() {
+        return stderr;
+    }
+
+    /**
+     * Get the output written to stdout
+     * 
+     * @return stdout
+     */
+    public String getStdout() {
+        return stdout;
+    }
+    
+}

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/RemoteFile.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/RemoteFile.java
@@ -27,7 +27,6 @@ import java.util.regex.Pattern;
 
 import com.ibm.websphere.simplicity.log.Log;
 
-//open-liberty uses 'LocalProvider', where-as WS-CD-Open uses 'RXAProvider'.
 import componenttest.common.apiservices.cmdline.LocalProvider;
 import componenttest.topology.impl.LibertyServer;
 
@@ -51,9 +50,9 @@ public class RemoteFile {
      * Thread.sleep() is repeated until System.nanoTime() shows that the thread
      * has waited at least the specified time in milliseconds.
      *
-     * @param  requestedNs          The requested sleep time, in nano-seconds.
+     * @param requestedNs The requested sleep time, in nano-seconds.
      *
-     * @return                      The time slept, in nano-seconds.
+     * @return The time slept, in nano-seconds.
      *
      * @throws InterruptedException Thrown if if the sleep is
      *                                  interrupted.
@@ -102,10 +101,10 @@ public class RemoteFile {
      * Attempt an operation. Retry the operation, possibly several times,
      * across a specified retry interval.
      *
-     * @param  op          The operation which is being performed.
-     * @param  fullRetryNs The full retry duration.
+     * @param op          The operation which is being performed.
+     * @param fullRetryNs The full retry duration.
      *
-     * @return             True or false telling if the operation was successful.
+     * @return True or false telling if the operation was successful.
      *
      * @throws Exception
      */
@@ -280,7 +279,7 @@ public class RemoteFile {
      * Returns a RemoteFile representation of the parent directory of this file
      * or null if this pathname does not name a parent directory.
      *
-     * @return           A RemoteFile representation of the parent directory.
+     * @return A RemoteFile representation of the parent directory.
      * @throws Exception
      */
     public RemoteFile getParentFile() throws Exception {
@@ -314,15 +313,15 @@ public class RemoteFile {
      * This method is not thread-safe.
      * </p>
      *
-     * @param  prefix
-     *                                      an optional String that proceeds ordering information. All
-     *                                      characters must match: [a-zA-Z_0-9\\.]
-     * @param  digits
-     *                                      the number of digits to use for generated identifiers
-     * @param  suffix
-     *                                      the optional name of the desired file, without any numeric identifier.
-     *                                      All characters must match: [a-zA-Z_0-9\\.]
-     * @return                          a new RemoteFile representing a unique child of the parent. The file must be created before use.
+     * @param prefix
+     *                   an optional String that proceeds ordering information. All
+     *                   characters must match: [a-zA-Z_0-9\\.]
+     * @param digits
+     *                   the number of digits to use for generated identifiers
+     * @param suffix
+     *                   the optional name of the desired file, without any numeric identifier.
+     *                   All characters must match: [a-zA-Z_0-9\\.]
+     * @return a new RemoteFile representing a unique child of the parent. The file must be created before use.
      * @throws IllegalArgumentException
      *                                      if this instance does not denote a directory,
      *                                      if input arguments are invalid,
@@ -387,15 +386,15 @@ public class RemoteFile {
      * number is a total of <code>width</code> digits. Truncates the input
      * number if it has more than <code>width</code> digits.
      *
-     * @param  number
-     *                    a positive integer (negative integers cause problems with odd
-     *                    widths)
-     * @param  width
-     *                    the number of characters that you want in a String
-     *                    representation of <code>number</code>; must be a positive
-     *                    integer smaller than 18 (larger numbers cause an overflow
-     *                    issue)
-     * @return        a zero-padded String representation of the input number
+     * @param number
+     *                   a positive integer (negative integers cause problems with odd
+     *                   widths)
+     * @param width
+     *                   the number of characters that you want in a String
+     *                   representation of <code>number</code>; must be a positive
+     *                   integer smaller than 18 (larger numbers cause an overflow
+     *                   issue)
+     * @return a zero-padded String representation of the input number
      */
     private String zeroPad(long number, int width) {
         long n = Math.abs(number);
@@ -413,18 +412,18 @@ public class RemoteFile {
      * Copies the file or directory represented by this instance to a remote
      * machine.
      *
-     * @param  destFile
-     *                       The location on the remote device where you want to place this
-     *                       file
-     * @param  recursive
-     *                       If this instance represents a directory, whether or not to
-     *                       recursively transfer all files and directories within this
-     *                       directory
-     * @param  overwrite
-     *                       true if files should be overwritten durin the copy. If this is
-     *                       false and a file is encountered in the destination of the
-     *                       copy, an Exception is thrown.
-     * @return           true if the copy was successful
+     * @param destFile
+     *                      The location on the remote device where you want to place this
+     *                      file
+     * @param recursive
+     *                      If this instance represents a directory, whether or not to
+     *                      recursively transfer all files and directories within this
+     *                      directory
+     * @param overwrite
+     *                      true if files should be overwritten durin the copy. If this is
+     *                      false and a file is encountered in the destination of the
+     *                      copy, an Exception is thrown.
+     * @return true if the copy was successful
      */
     public boolean copyToDest(RemoteFile destFile, boolean recursive,
                               boolean overwrite) throws Exception {
@@ -435,18 +434,18 @@ public class RemoteFile {
      * Copies the file or directory represented by this instance to a remote
      * machine.
      *
-     * @param  destFile
-     *                       The location on the remote device where you want to place this
-     *                       file
-     * @param  recursive
-     *                       If this instance represents a directory, whether or not to
-     *                       recursively transfer all files and directories within this
-     *                       directory
-     * @param  overwrite
-     *                       true if files should be overwritten durin the copy. If this is
-     *                       false and a file is encountered in the destination of the
-     *                       copy, an Exception is thrown.
-     * @return           true if the copy was successful
+     * @param destFile
+     *                      The location on the remote device where you want to place this
+     *                      file
+     * @param recursive
+     *                      If this instance represents a directory, whether or not to
+     *                      recursively transfer all files and directories within this
+     *                      directory
+     * @param overwrite
+     *                      true if files should be overwritten durin the copy. If this is
+     *                      false and a file is encountered in the destination of the
+     *                      copy, an Exception is thrown.
+     * @return true if the copy was successful
      */
     public boolean copyToDestText(RemoteFile destFile, boolean recursive,
                                   boolean overwrite) throws Exception {
@@ -458,10 +457,10 @@ public class RemoteFile {
      * machine. If this is a directory the copy is not done recursively. Files
      * are overwritten during the copy.
      *
-     * @param  destFile
-     *                       The location on the remote device where you want to place this
-     *                       file
-     * @return           true if the copy was successful
+     * @param destFile
+     *                     The location on the remote device where you want to place this
+     *                     file
+     * @return true if the copy was successful
      * @throws Exception
      */
     public boolean copyToDest(RemoteFile destFile) throws Exception {
@@ -473,10 +472,10 @@ public class RemoteFile {
      * machine. If this is a directory the copy is not done recursively. Files
      * are overwritten during the copy.
      *
-     * @param  destFile
-     *                       The location on the remote device where you want to place this
-     *                       file
-     * @return           true if the copy was successful
+     * @param destFile
+     *                     The location on the remote device where you want to place this
+     *                     file
+     * @return true if the copy was successful
      * @throws Exception
      */
     public boolean copyToDestText(RemoteFile destFile) throws Exception {
@@ -487,18 +486,18 @@ public class RemoteFile {
      * Copies the file or directory from a RemoteMachine to the path specified
      * by this instance
      *
-     * @param  srcFile
-     *                       The location on the remote device where you want to get this
-     *                       file
-     * @param  recursive
-     *                       If this srcFile represents a directory, whether or not to
-     *                       recursively transfer all files and directories within the
-     *                       source directory
-     * @param  overwrite
-     *                       true if files should be overwritten durin the copy. If this is
-     *                       false and a file is encountered in the destination of the
-     *                       copy, an Exception is thrown.
-     * @return           true if the copy was successful
+     * @param srcFile
+     *                      The location on the remote device where you want to get this
+     *                      file
+     * @param recursive
+     *                      If this srcFile represents a directory, whether or not to
+     *                      recursively transfer all files and directories within the
+     *                      source directory
+     * @param overwrite
+     *                      true if files should be overwritten durin the copy. If this is
+     *                      false and a file is encountered in the destination of the
+     *                      copy, an Exception is thrown.
+     * @return true if the copy was successful
      */
     public boolean copyFromSource(RemoteFile srcFile, boolean recursive,
                                   boolean overwrite) throws Exception {
@@ -509,18 +508,18 @@ public class RemoteFile {
      * Copies the file or directory from a RemoteMachine to the path specified
      * by this instance
      *
-     * @param  srcFile
-     *                       The location on the remote device where you want to get this
-     *                       file
-     * @param  recursive
-     *                       If this srcFile represents a directory, whether or not to
-     *                       recursively transfer all files and directories within the
-     *                       source directory
-     * @param  overwrite
-     *                       true if files should be overwritten durin the copy. If this is
-     *                       false and a file is encountered in the destination of the
-     *                       copy, an Exception is thrown.
-     * @return           true if the copy was successful
+     * @param srcFile
+     *                      The location on the remote device where you want to get this
+     *                      file
+     * @param recursive
+     *                      If this srcFile represents a directory, whether or not to
+     *                      recursively transfer all files and directories within the
+     *                      source directory
+     * @param overwrite
+     *                      true if files should be overwritten durin the copy. If this is
+     *                      false and a file is encountered in the destination of the
+     *                      copy, an Exception is thrown.
+     * @return true if the copy was successful
      */
     public boolean copyFromSourceText(RemoteFile srcFile, boolean recursive,
                                       boolean overwrite) throws Exception {
@@ -532,10 +531,10 @@ public class RemoteFile {
      * by this instance. If the source is a directory the copy is not done
      * recursively. Files are overwritten during the copy.
      *
-     * @param  srcFile
-     *                       The location on the remote device where you want to get this
-     *                       file
-     * @return           true if the copy was successful
+     * @param srcFile
+     *                    The location on the remote device where you want to get this
+     *                    file
+     * @return true if the copy was successful
      * @throws Exception
      */
     public boolean copyFromSource(RemoteFile srcFile) throws Exception {
@@ -547,12 +546,12 @@ public class RemoteFile {
      * by this instance. If the source is a directory the copy is not done
      * recursively. Files are overwritten during the copy.
      *
-     * @param  srcFile
-     *                       The location on the remote device where you want to get this
-     *                       file
-     * @param  binary
-     *                       true if you want the file transfered in binary, ascii if false
-     * @return           true if the copy was successful
+     * @param srcFile
+     *                    The location on the remote device where you want to get this
+     *                    file
+     * @param binary
+     *                    true if you want the file transfered in binary, ascii if false
+     * @return true if the copy was successful
      * @throws Exception
      */
     public boolean copyFromSource(RemoteFile srcFile, boolean binary) throws Exception {
@@ -713,14 +712,14 @@ public class RemoteFile {
      * Returns an array of RemoteFiles denoting the files in the directory
      * denoted by this RemoteFile.
      *
-     * @param  recursive
-     *                       If this instance represents a directory, whether or not to
-     *                       recursively list all files and directories
+     * @param recursive
+     *                      If this instance represents a directory, whether or not to
+     *                      recursively list all files and directories
      *
-     * @return           An array of RemoteFiles denoting the files and directories in the
-     *                   directory denoted by this RemoteFile. The array will be empty if
-     *                   the directory is empty. Returns null if this abstract pathname
-     *                   does not denote a directory
+     * @return An array of RemoteFiles denoting the files and directories in the
+     *         directory denoted by this RemoteFile. The array will be empty if
+     *         the directory is empty. Returns null if this abstract pathname
+     *         does not denote a directory
      */
     public RemoteFile[] list(boolean recursive) throws Exception {
         final String method = "list";
@@ -736,8 +735,7 @@ public class RemoteFile {
         if (host.isLocal()) {
             File[] list = localFile.listFiles();
             for (int i = 0; i < list.length; ++i) {
-                RemoteFile remoteFile = new RemoteFile(host, list[i]
-                                .getCanonicalPath());
+                RemoteFile remoteFile = new RemoteFile(host, list[i].getCanonicalPath());
                 remoteFilesList.add(remoteFile);
 
                 // If needed recurse
@@ -821,7 +819,7 @@ public class RemoteFile {
     /**
      * Returns the name of the file or directory denoted by this RemoteFile
      *
-     * @return           The name of the file
+     * @return The name of the file
      * @throws Exception
      */
     public String getName() throws Exception {
@@ -860,15 +858,15 @@ public class RemoteFile {
     /**
      * Copy a RemoteFile
      *
-     * @param  srcFile
-     *                       The source RemoteFile
-     * @param  destFile
-     *                       The destination RemoteFile
-     * @param  recursive
-     *                       true if this a recursive copy
-     * @param  overwrite
-     *                       true if files should be overwritten during the copy
-     * @return           true if the copy was successful
+     * @param srcFile
+     *                      The source RemoteFile
+     * @param destFile
+     *                      The destination RemoteFile
+     * @param recursive
+     *                      true if this a recursive copy
+     * @param overwrite
+     *                      true if files should be overwritten during the copy
+     * @return true if the copy was successful
      * @throws Exception
      */
     private static boolean copy(RemoteFile srcFile, RemoteFile destFile,
@@ -938,9 +936,9 @@ public class RemoteFile {
     /**
      * Get the parent path of a file
      *
-     * @param  path
-     *                  The path of the file
-     * @return      The parent path of the file
+     * @param path
+     *                 The path of the file
+     * @return The parent path of the file
      */
     private String getParentPath(String path) {
         if (path.equals("/")) { // root

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/dsprops/testrules/DataSourcePropertiesOnlyRule.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/dsprops/testrules/DataSourcePropertiesOnlyRule.java
@@ -21,8 +21,6 @@ import com.ibm.websphere.simplicity.config.DataSource;
 import com.ibm.websphere.simplicity.config.DataSourceProperties;
 import com.ibm.websphere.simplicity.log.Log;
 
-import componenttest.topology.utils.FATServletClient;
-
 /**
  * This class can be used as a @Rule to process a @OnlyIfDataSourceProperties annotation
  * specified on one or more @Test.

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/configuration/ConfigurationProvider.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/configuration/ConfigurationProvider.java
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.websphere.simplicity.configuration;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * The <code>ConfigurationProvider</code> provides methods to read and set properties within
+ * configuration files. A configuration file in this context is an abstraction for any file used to
+ * feed user defined data to the project such as the bootstrapping properties file. When a
+ * configuration file is loaded, the properties are loaded into memory and any
+ * {@link #getProperty(String)}, {@link #setProperty(String, String)}, and other related method
+ * calls are read and loaded into memory. Any property value changes are not reflected in the
+ * configuration file itself until a call to {@link #writeProperties()} is made.
+ */
+public abstract class ConfigurationProvider {
+
+    protected static Class c = ConfigurationProvider.class;
+
+    private final File configFile;
+
+    /**
+     * Constructor
+     *
+     * @param configFile The configuration file to interact with
+     */
+    protected ConfigurationProvider(File configFile) {
+        this.configFile = configFile;
+    }
+
+    /**
+     * Check if a property exists in memory
+     *
+     * @param  property The property name
+     * @return          true if the property exists
+     */
+    public abstract boolean hasProperty(String property);
+
+    /**
+     * Get a property value from memory
+     *
+     * @param  property The name of the property to get
+     * @return          The property value
+     */
+    public abstract String getProperty(String property);
+
+    /**
+     * Retrieves all properties prefixed by a particular key.
+     *
+     * @param  key The prefix for the properties to get
+     * @return     All properties prefixed by the key
+     */
+    public abstract Properties getProperties(String key);
+
+    /**
+     * Set a property in memory
+     *
+     * @param property The name of the property to set
+     * @param value    The value of the property to set
+     */
+    public abstract void setProperty(String property, String value);
+
+    /**
+     * Set multiple properties in memory
+     *
+     * @param props A <code>Map</code> containing the property names and values to set
+     */
+    public abstract void setProperties(Map<String, String> props);
+
+    /**
+     * Remove a property in memory
+     *
+     * @param property The name of the property to remove
+     */
+    public abstract void removeProperty(String property);
+
+    /**
+     * Get an <code>Enumeration</code> instance containing the names of the available properties
+     *
+     * @return An <code>Enumeration</code> instance containg the property names
+     */
+    public abstract Enumeration<?> getPropertyNames();
+
+    /**
+     * Write the property names and values currently in memory to the configuration file.
+     *
+     * @throws Exception
+     */
+    public abstract void writeProperties() throws Exception;
+
+    /**
+     * This method clears all property values in memory and reloads the configuration file.
+     *
+     * @throws Exception
+     */
+    public abstract void reloadProperties() throws Exception;
+
+    /**
+     * Get the configuration file
+     *
+     * @return A <code>File</code> representing the configuration file for this instance
+     */
+    public File getConfigFile() {
+        return this.configFile;
+    }
+
+    /**
+     * Get a <code>FileInputStream</code> for direct read access to the configuration file. Note
+     * that the properties in the file may not reflect uncommitted changes.
+     *
+     * @return           A <code>FileInputStream</code> instance
+     * @throws Exception
+     */
+    public InputStream getInputStream() throws Exception {
+        return new FileInputStream(this.configFile);
+    }
+
+    /**
+     * Get a <code>FileOutputStream</code> for write read access to the configuration file. Note
+     * that the properties in the file may not reflect uncommitted changes.
+     *
+     * @param  append    True if writes should be appended to the existing file
+     * @return           A <code>FileOutputStream</code> instance
+     * @throws Exception
+     */
+    public OutputStream getOutputStream(boolean append) throws Exception {
+        return new FileOutputStream(this.configFile, append);
+    }
+
+}

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/configuration/FormattedProperties.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/configuration/FormattedProperties.java
@@ -1,0 +1,194 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.websphere.simplicity.configuration;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * This class extends the <code>java.util.Properties</code> Object overwriting the store method to
+ * store the properties in a format suitable for the project
+ */
+public class FormattedProperties extends Properties implements Comparator<String> {
+
+    private static final long serialVersionUID = 6615492615448326924L;
+
+    Map<String, String> userProps;
+    Map<String, String> generatedProps;
+
+    /**
+     * No argument constructor
+     */
+    public FormattedProperties() {
+        super();
+    }
+
+    /**
+     * Properties Constructor
+     *
+     * @param defaults The default properties to initialize the Object
+     */
+    public FormattedProperties(Properties defaults) {
+        super(defaults);
+    }
+
+    /**
+     * Write the properties to the specified <code>OutputStream</code>. User specified properties
+     * (those which do not contain {@link BootStrappingProperty#DATA}) are written first followed
+     * by generated data.
+     *
+     * @param out      The <code>OutputStream</code> to write to
+     * @param comments Comments to write to the stream
+     * @see            java.util.Properties
+     */
+    @Override
+    public void store(OutputStream out, String comments) throws IOException {
+        // write comments
+        if (comments != null) {
+            out.write('#');
+            out.write(comments.getBytes());
+            out.write(System.getProperty("line.separator").getBytes());
+        }
+        // write date
+        out.write('#');
+        out.write(new Date().toString().getBytes());
+        out.write(System.getProperty("line.separator").getBytes());
+
+        userProps = new HashMap<String, String>();
+        generatedProps = new HashMap<String, String>();
+
+        Set<Object> props = super.keySet();
+        String property = null;
+        for (Object prop : props) {
+            property = (String) prop;
+            if (getProperty(property) != null) {
+                if (property.indexOf("data") == -1) {
+                    userProps.put(property, getProperty(property));
+                } else {
+                    generatedProps.put(property, getProperty(property));
+                }
+            }
+        }
+
+        String[] userPropsArray = userProps.keySet().toArray(new String[0]);
+        Arrays.sort(userPropsArray, this);
+        String[] generatedPropsArray = generatedProps.keySet().toArray(new String[0]);
+        Arrays.sort(generatedPropsArray, this);
+
+        // first write the user properties
+        String next;
+        out.write(("# User Data" + System.getProperty("line.separator")).getBytes());
+        for (int i = 0; i < userPropsArray.length; ++i) {
+            next = userPropsArray[i];
+            write(out, next, true);
+            out.write('=');
+            write(out, userProps.get(next), false);
+            out.write(System.getProperty("line.separator").getBytes());
+        }
+
+        // write a couple of newlines
+        out.write(System.getProperty("line.separator").getBytes());
+        out.write(System.getProperty("line.separator").getBytes());
+
+        // next write the generated data
+        out.write(("# Generated Data" + System.getProperty("line.separator")).getBytes());
+        for (int i = 0; i < generatedPropsArray.length; ++i) {
+            next = generatedPropsArray[i];
+            write(out, next, true);
+            out.write('=');
+            write(out, generatedProps.get(next), false);
+            out.write(System.getProperty("line.separator").getBytes());
+        }
+    }
+
+    /**
+     * Write a value to the <code>OutputStream</code>
+     *
+     * @param  out         The <code>OutputStream</code> to write to
+     * @param  next        The next value to write
+     * @param  isKey       true if the next value is a property; false if it is a property value
+     * @throws IOException
+     */
+    private void write(OutputStream out, String next, boolean isKey) throws IOException {
+        for (int j = 0; j < next.length(); ++j) {
+            char ch = next.charAt(j);
+            byte[] bytes;
+            switch (ch) {
+                case '\\':
+                    bytes = "\\\\".getBytes();
+                    break;
+                case '\t':
+                    bytes = "\\t".getBytes();
+                    break;
+                case '\f':
+                    bytes = "\\f".getBytes();
+                    break;
+                case '\n':
+                    bytes = "\\n".getBytes();
+                    break;
+                case '\r':
+                    bytes = "\\r".getBytes();
+                    break;
+                case '#':
+                case '!':
+                case '=':
+                case ':':
+                case ' ':
+                    bytes = ("\\" + ch).getBytes();
+                    break;
+                default:
+                    bytes = ("" + ch).getBytes();
+                    break;
+            }
+            out.write(bytes);
+        }
+    }
+
+    /**
+     * Compare two Strings
+     *
+     * @param object1 The first String to compare
+     * @param object2 The second String to compare
+     */
+    @Override
+    public int compare(String object1, String object2) {
+        if (object1.equals(object2)) {
+            return 0;
+        }
+        if (object1.length() > object2.length()) {
+            for (int i = 0; i < object2.length(); ++i) {
+                if (object1.charAt(i) < object2.charAt(i)) {
+                    return -1;
+                } else if (object1.charAt(i) > object2.charAt(i)) {
+                    return 1;
+                }
+            }
+        } else {
+            for (int i = 0; i < object1.length(); ++i) {
+                if (object1.charAt(i) < object2.charAt(i)) {
+                    return -1;
+                } else if (object1.charAt(i) > object2.charAt(i)) {
+                    return 1;
+                }
+            }
+        }
+        return 0;
+    }
+
+}

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/configuration/PropertiesConfigurationProvider.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/configuration/PropertiesConfigurationProvider.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2011 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.websphere.simplicity.configuration;
+
+import java.io.File;
+import java.io.OutputStream;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * A {@link ConfigurationProvider} for a properties configuration file. This provider uses the
+ * {@link FormattedProperties} Object to manage and write properties.
+ */
+public class PropertiesConfigurationProvider extends ConfigurationProvider {
+    
+    FormattedProperties props;
+
+    /**
+     * Constructor
+     * 
+     * @param configFile The properties configuration file to load
+     * @throws Exception
+     */
+	public PropertiesConfigurationProvider(File configFile) throws Exception {
+		super(configFile);
+        props = new FormattedProperties();
+        props.load(getInputStream());
+	}
+	
+	@Override
+	public boolean hasProperty(String property) {
+        return props.containsKey(property);
+	}
+
+	@Override
+	public String getProperty(String property) {
+		return props.getProperty(property);
+	}
+
+	@Override
+	public Properties getProperties(String key) {
+		Properties p = new Properties();
+		for (Map.Entry<Object, Object> e : props.entrySet()) {
+			String ekey = (String)e.getKey();
+			if (ekey.startsWith(key)) {
+				p.put(e.getKey(), e.getValue());
+			}
+		}
+		return p;
+	}
+
+	@Override
+	public void setProperty(String property, String value) {
+		props.setProperty(property, value);	
+	}
+
+    @Override
+    public Enumeration<?> getPropertyNames() {
+        return props.propertyNames();
+    }
+
+    @Override
+    public void writeProperties() throws Exception {
+        OutputStream os = getOutputStream(false);
+        props.store(os, null);
+        os.close();
+    }
+
+    @Override
+    public void setProperties(Map<String, String> properties) {
+        for(String prop : properties.keySet()) {
+            props.setProperty(prop, properties.get(prop));
+        }
+    }
+
+    @Override
+    public void removeProperty(String property) {
+        props.remove(property);
+    }
+
+    @Override
+    public void reloadProperties() throws Exception {
+        props.clear();
+        props.load(getInputStream());
+    }
+
+}

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/log/Log.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/log/Log.java
@@ -1,0 +1,421 @@
+/*******************************************************************************
+ * Copyright (c) 2011 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.websphere.simplicity.log;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.text.DateFormat;
+import java.text.FieldPosition;
+import java.text.MessageFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map.Entry;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+public class Log {
+
+	private static LogManager manager = LogManager.getLogManager();
+	private static HashMap<Class, Logger> logCache = new HashMap<Class, Logger>();
+	private static Handler handler = null;
+	private static Formatter formatter = null;
+	private static HashMap<String, String> levelTranslations = new HashMap<String, String>();
+	
+	private Log() { }
+    
+    static {
+        initLevelTranslations();
+    }
+	
+	public static LogManager getManager() {
+		return manager;
+	}
+	
+	public static void setSpec(String s) {
+		setSpecInternal(s);
+	}
+	
+	public static Handler getHandler() {
+		return handler;
+	}
+	
+    /**
+     * Use this method to set the logging Handler
+     * 
+     * @param newHandler The Handler to log with
+     */
+	public static synchronized void setHandler(Handler newHandler) {
+		for (Entry<Class, Logger> entry : logCache.entrySet()) {
+			for (Handler handler : entry.getValue().getHandlers())
+				entry.getValue().removeHandler(handler);
+			entry.getValue().addHandler(newHandler);
+		}
+		handler = newHandler;
+	}
+    
+	public static Formatter getFormatter() {
+		return formatter;
+	}
+	
+	public static void setFormatter(Formatter newFormatter) {
+		handler.setFormatter(newFormatter);
+		formatter = newFormatter;
+	}
+	
+	public static void debug(Class c, String data) {
+		getLogger(c).log(Level.FINEST, data);
+	}
+	
+	public static void entering(Class c, String method) {
+		getLogger(c).entering(c.getCanonicalName(), method);
+	}
+	
+	public static void entering(Class c, String method, Object value) {
+		getLogger(c).entering(c.getCanonicalName(), method, value);
+	}
+	
+	public static void entering(Class c, String method, Object[] values) {
+		getLogger(c).entering(c.getCanonicalName(), method, values);
+	}
+	
+	public static void error(Class c, String method, Throwable e) {
+		getLogger(c).logp(Level.SEVERE, c.getCanonicalName(), method, null, e);
+	}
+	
+    public static void error(Class c, String method, Throwable e, String mesg) {
+        getLogger(c).logp(Level.SEVERE, c.getCanonicalName(), method, mesg, e);
+    }
+    
+    public static void info(Class c, String method, String data) {
+        getLogger(c).logp(Level.INFO, c.getCanonicalName(), method, data);
+    }
+    
+    public static void info(Class c, String method, String data, Object value) {
+        getLogger(c).logp(Level.INFO, c.getCanonicalName(), method, data, value);
+    }
+    
+    public static void info(Class c, String method, String data, Object[] values) {
+        getLogger(c).logp(Level.INFO, c.getCanonicalName(), method, data, values);
+    }
+	
+    public static void finer(Class c, String method, String data) {
+        getLogger(c).logp(Level.FINER, c.getCanonicalName(), method, data);
+    }
+    
+    public static void finer(Class c, String method, String data, Object value) {
+        getLogger(c).logp(Level.FINER, c.getCanonicalName(), method, data, value);
+    }
+	
+    public static void finer(Class c, String method, String data, Object[] values) {
+        getLogger(c).logp(Level.FINER, c.getCanonicalName(), method, data, values);
+    }
+	
+    public static void finest(Class c, String method, String data) {
+        getLogger(c).logp(Level.FINEST, c.getCanonicalName(), method, data);
+    }
+    
+    public static void finest(Class c, String method, String data, Object value) {
+        getLogger(c).logp(Level.FINEST, c.getCanonicalName(), method, data, value);
+    }
+    
+    public static void finest(Class c, String method, String data, Object[] values) {
+        getLogger(c).logp(Level.FINEST, c.getCanonicalName(), method, data, values);
+    }
+	
+	public static void exiting(Class c, String method) {
+		getLogger(c).exiting(c.getCanonicalName(), method);
+	}
+	
+	public static void exiting(Class c, String method, Object value) {
+		getLogger(c).exiting(c.getCanonicalName(), method, value);
+	}
+	
+	public static void exiting(Class c, String method, Object[] values) {
+		getLogger(c).exiting(c.getCanonicalName(), method, values);
+	}
+	
+	public static void warning(Class c, String message) {
+		getLogger(c).warning(message);
+	}
+	
+	private static Logger getLogger(Class c) {
+		Logger logger = logCache.get(c);
+		if (logger == null) {
+			logger = Logger.getLogger(c.getCanonicalName());
+			if (logger != null) {
+				logCache.put(c, logger);
+                if(handler != null)
+                    logger.addHandler(handler);
+			}
+		}
+		return logger;
+	}
+	
+	private static void setSpecInternal(String fullSpecification) {
+		String[] specs = fullSpecification.split(":");
+		String property = "";
+		for (String spec : specs) {
+			// Split at "=", results in parts[0]=spec, parts[1]=level
+			String[] parts = spec.split("=");
+			// Format the string properly
+			parts[0] = parts[0].replace("*", "");
+			if (!parts[0].endsWith(".level")) {
+				if (!parts[0].endsWith("."))
+					parts[0] += ".";
+				parts[0] += "level";
+			}
+			
+			// Translate WAS to Java levels
+			if (levelTranslations.containsKey(parts[1].toLowerCase()))
+				parts[1] = levelTranslations.get(parts[1].toLowerCase());
+			parts[1] = parts[1].toUpperCase();
+			
+			// Add it to property-style string
+			property += parts[0]+"="+parts[1]+"\n";
+		}
+
+		ByteArrayInputStream is = new ByteArrayInputStream(property.getBytes());
+		try {
+			manager.readConfiguration(is);
+		}
+		catch(IOException ioe) {
+			// ignore
+		}
+	}
+	
+	private static void initLevelTranslations() {
+		/*
+		 * In order of decreasing detail, these are the WebSphere levels:
+		 * 	all, dump, finest, debug, finer, entryExit, fine, event, detail, config, info, audit,
+		 *  warning, severe, error, fatal, off
+		 * 
+		 * In order of decreasing detail, these are the Java levels:
+		 *  all, finest, finer, fine, config, info, warning, severe, off
+		 *  
+		 */
+		levelTranslations.put("all", "ALL");
+		levelTranslations.put("dump", "FINEST");
+		levelTranslations.put("audit", "FINEST");
+		levelTranslations.put("debug", "FINEST");
+		levelTranslations.put("entryexit", "FINER");
+		levelTranslations.put("event", "FINE");
+		levelTranslations.put("detail", "FINE");
+		levelTranslations.put("audit", "INFO");
+		levelTranslations.put("error", "SEVERE");
+		levelTranslations.put("fatal", "SEVERE");
+	}
+
+	public static class DefaultHandler extends Handler {
+		
+		private PrintStream out;
+		
+		public DefaultHandler(PrintStream out) {
+			this.out = out;
+		}
+	
+		@Override
+		public void close() {
+			if (this.out != null)
+				this.out.close();
+		}
+	
+		@Override
+		public void flush() {
+			if (this.out != null)
+				this.out.flush();
+		}
+	
+		@Override
+		public void publish(LogRecord record) {
+			if (!this.isLoggable(record))
+				return;
+
+			Formatter f = null;
+			synchronized(this) {
+				f = this.getFormatter();
+				if (f == null) {
+					f = new DefaultFormatter();
+					this.setFormatter(f);
+				}
+			}
+			String output = f.format(record);
+			if (this.out != null)
+				this.out.println(output);
+			else
+				System.out.println(output);
+		}
+		
+	}
+	
+	public static class DefaultFormatter extends Formatter {
+		
+		private static final int classNameLength = 13;
+		private static final DateFormat dateFormatter = getBasicDateFormatter();
+		private static final FieldPosition fieldPosition = new FieldPosition(0);
+		private static final String lineSeparator = System.getProperty("line.separator");
+		private static final String indent = "                                 ";
+		private static final String lineSeparatorPlusIndent = lineSeparator+indent;
+		
+		@Override
+		public String format(LogRecord logRecord) {
+			StringBuffer buffer = new StringBuffer();
+			writeHeader(logRecord, buffer);
+			writeFormattedMessage(logRecord, buffer);
+			writeStackTrace(logRecord, buffer);
+			return new String(buffer);
+		}
+		
+		private void writeHeader(LogRecord logRecord, StringBuffer buffer) {
+			// Clear buffer
+			buffer.setLength(0);
+			// Add date & time
+			writeDateAndTime(logRecord, buffer);
+			// Append class name
+			writeClassName(logRecord, buffer);
+			writeEntryChar(logRecord, buffer);
+		}
+		
+		private void writeDateAndTime(LogRecord logRecord, StringBuffer buffer) {
+			buffer.append("[");
+			Date date = new Date(logRecord.getMillis());
+			dateFormatter.format(date, buffer, fieldPosition);
+			buffer.append("] ");
+			buffer.append(getThreadId(logRecord));
+			buffer.append(' ');
+		}
+		
+		private void writeClassName(LogRecord logRecord, StringBuffer buffer) {
+			String name = logRecord.getLoggerName();
+			int dot = name.lastIndexOf('.')+1;
+			if (dot > 0)
+				name = name.substring(dot);
+			
+			if (name.length() > classNameLength)
+				name = name.substring(0, classNameLength);
+			else {
+				while (name.length() < classNameLength)
+					name += " ";
+			}
+			buffer.append(name);
+			buffer.append(" ");
+		}
+		
+		private void writeEntryChar(LogRecord logRecord, StringBuffer buffer) {
+			char c = 'Z';
+			Level level = logRecord.getLevel();
+			if (level == Level.SEVERE)
+				c = 'E';
+			else if (level == Level.INFO)
+				c = 'I';
+			else if (level == Level.WARNING)
+				c = 'W';
+			else if (level == Level.FINE)
+				c = '1';
+			else if (level == Level.FINER) {
+				String msg = logRecord.getMessage();
+				if (msg.contains("Entry") || msg.contains("ENTRY"))
+					c = '>';
+				else if (msg.contains("Exit") || msg.contains("RETURN"))
+					c = '<';
+				else
+					c = '2';
+			} else if (level == Level.FINEST)
+				c = '3';
+			
+			buffer.append(" ");
+			buffer.append(c);
+			buffer.append(" ");
+		}
+		
+		private void writeFormattedMessage(LogRecord record, StringBuffer buffer) {
+			String msg = record.getMessage();
+			Object[] params = record.getParameters();
+	
+			try {
+				msg = msg.replace("ENTRY", record.getSourceMethodName()+" Entry");
+				msg = msg.replace("RETURN", record.getSourceMethodName()+" Exit");
+			}
+			catch(Exception e) { }
+	
+			if (params == null || params.length == 0) {
+				buffer.append(msg);
+				return;
+			} else
+				// Do NOT modify the original array
+				params = params.clone();
+	
+			// Ensure the placeholders are there for the param list
+			if (!msg.contains("{0}")) {
+				for (int i=0; i < params.length; i++)
+					msg += " {"+i+"}";
+			}
+			
+			// Put each param on a separate line
+			msg = msg.replace("{", lineSeparatorPlusIndent+"{");
+			
+			// Replace empty strings with double-quotes
+			for (int i=0; i < params.length; i++) {
+				Object o = params[i];
+				if (o instanceof String && ((String)o).length() == 0)
+					params[i] = "\"\"";
+			}
+			
+			// Format it
+			try {
+				msg = MessageFormat.format(msg, params);
+			}
+			catch(IllegalArgumentException e) {
+				// Ignore
+			}
+			buffer.append(msg);
+		}
+		
+		private void writeStackTrace(LogRecord record, StringBuffer buffer) {
+			Throwable t = record.getThrown();
+			if (t == null)
+				return;
+	
+			buffer.append(lineSeparatorPlusIndent);
+			buffer.append(getStackTrace(t));
+		}
+		
+		private String getThreadId(LogRecord logRecord) {
+			String tid = Integer.toHexString(logRecord.getThreadID());
+			while (tid.length() < 8)
+				tid = "0"+tid;
+			return tid;
+		}
+		
+		private String getStackTrace(Throwable t) {
+			StringWriter s = new StringWriter();
+			PrintWriter p = new PrintWriter(s);
+			t.printStackTrace(p);
+			return s.toString();
+		}
+		
+		private static DateFormat getBasicDateFormatter() {
+			// If this proves a mismatch, review FormatSet.getBasicDateFormatter
+			// "MM/dd/yyyy kk:mm:ss:SSS zzz"
+			return new SimpleDateFormat("yy.MM.dd HH:mm:ss:SSS z");
+		}
+		
+	}
+	
+}

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/log/package.html
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/log/package.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<!--
+/*******************************************************************************
+ * Copyright (c) 2011 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<html>
+<head>
+</head>
+<body bgcolor="white">
+
+The log package contains the Simplicity Log class used to log Simplicity trace
+
+</body>
+</html>

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/package.html
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/package.html
@@ -1,0 +1,26 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<!--
+/*******************************************************************************
+ * Copyright (c) 2011 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<html>
+<head>
+</head>
+<body bgcolor="white">
+
+This is the core Simplicity package. The core topology API resides in this package along 
+with classes, such as ConnectionInfo and WsadminConnectionOptions, which are used to support
+connectivity and bootstrap the topology.<br/>
+Additionally this package contains classes such as Machine and RemoteFile which can be used 
+to connect to remote machines.
+
+</body>
+</html>

--- a/dev/fattest.simplicity/src/com/ibm/ws/fat/util/GenericFormatter.java
+++ b/dev/fattest.simplicity/src/com/ibm/ws/fat/util/GenericFormatter.java
@@ -1,0 +1,356 @@
+/*******************************************************************************
+ * Copyright (c) 1997, 2009 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.fat.util;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+
+/**
+ * Provides a java.util.logging.Formatter implementation similar to WebSphere's SystemOut.log format.
+ * The following properties can be set in logging.properties to configure this Formatter:<br>
+ * <br>
+ * <ul>
+ * <li><code>com.ibm.ws.fat.util.GenericFormatter.class.full</code> - controls whether or not to log the full class name (default is false)</li>
+ * <li><code>com.ibm.ws.fat.util.GenericFormatter.class.length</code> - controls the length of the class name logged (default is 8)</li>
+ * <li><code>com.ibm.ws.fat.util.GenericFormatter.class.log</code> - controls whether or not to log the class name (default is false)</li>
+ * <li><code>com.ibm.ws.fat.util.GenericFormatter.level.log</code> - controls whether or not to log the first character of the message level (default is false)</li>
+ * <li><code>com.ibm.ws.fat.util.GenericFormatter.method.length</code> - controls the length of the method name logged (default is 8)</li>
+ * <li><code>com.ibm.ws.fat.util.GenericFormatter.method.log</code> - controls whether or not to log the method Name (default is false)</li>
+ * <li><code>com.ibm.ws.fat.util.GenericFormatter.thread.length</code> - controls the length of the thread ID logged (default is 8)</li>
+ * <li><code>com.ibm.ws.fat.util.GenericFormatter.thread.log</code> - controls whether or not to log the thread ID (default is false)</li>
+ * <li><code>com.ibm.ws.fat.util.GenericFormatter.time.format</code> - controls whether or not to log the timestamp (default is false)</li>
+ * <li><code>com.ibm.ws.fat.util.GenericFormatter.time.log</code> - controls the SimpleDateFormat of the timestamp (default is [MM/dd/yyyy HH:mm:ss:SSS z])</li>
+ * </ul>
+ *
+ * @author Tim Burns
+ *
+ */
+public class GenericFormatter extends Formatter {
+
+    protected static final String PROP_CLASS_FULL = GenericFormatter.class.getName() + ".class.full";
+    protected static final String PROP_CLASS_LENGTH = GenericFormatter.class.getName() + ".class.length";
+    protected static final String PROP_CLASS_LOG = GenericFormatter.class.getName() + ".class.log";
+    protected static final String PROP_LEVEL_LOG = GenericFormatter.class.getName() + ".level.log";
+    protected static final String PROP_METHOD_LENGTH = GenericFormatter.class.getName() + ".method.length";
+    protected static final String PROP_METHOD_LOG = GenericFormatter.class.getName() + ".method.log";
+    protected static final String PROP_THREAD_LENGTH = GenericFormatter.class.getName() + ".thread.length";
+    protected static final String PROP_THREAD_LOG = GenericFormatter.class.getName() + ".thread.log";
+    protected static final String PROP_TIME_FORMAT = GenericFormatter.class.getName() + ".time.format";
+    protected static final String PROP_TIME_LOG = GenericFormatter.class.getName() + ".time.log";
+
+    protected static final SimpleDateFormat DEFAULT_DATE_FORMAT = new SimpleDateFormat("[MM/dd/yyyy HH:mm:ss:SSS z]");
+    protected static final int DEFAULT_LENGTH = 8;
+    protected static final String LINE_SEPARATOR = System.getProperty("line.separator");
+//	protected static final String COLON = ": ";
+//	protected static final String CAUSED_BY = "Caused by ";
+    protected static final char SPACE = ' ';
+    protected static final char ZERO = '0';
+    protected static final char DOT = '.';
+//	protected static final String AT = "    at ";
+
+    protected boolean logClassName;
+    protected int classLength;
+    protected boolean logFullClass;
+    protected int methodLength;
+    protected boolean logLevel;
+    protected boolean logMethodName;
+    protected boolean logThreadId;
+    protected boolean logTimeStamp;
+    protected SimpleDateFormat timeFormat;
+    protected int threadIdLength;
+
+    /**
+     * The primary constructor sets state based on JVM system properties.
+     */
+    public GenericFormatter() {
+        LogManager manager = LogManager.getLogManager();
+        this.logFullClass = Boolean.valueOf(manager.getProperty(PROP_CLASS_FULL)).booleanValue();
+        this.logClassName = Boolean.valueOf(manager.getProperty(PROP_CLASS_LOG)).booleanValue();
+        try {
+            this.classLength = Integer.parseInt(manager.getProperty(PROP_CLASS_LENGTH));
+        } catch (NumberFormatException e) {
+            this.classLength = DEFAULT_LENGTH;
+        }
+        this.logLevel = Boolean.valueOf(manager.getProperty(PROP_LEVEL_LOG)).booleanValue();
+        this.logMethodName = Boolean.valueOf(manager.getProperty(PROP_METHOD_LOG)).booleanValue();
+        try {
+            this.methodLength = Integer.parseInt(manager.getProperty(PROP_METHOD_LENGTH));
+        } catch (NumberFormatException e) {
+            this.methodLength = DEFAULT_LENGTH;
+        }
+        this.logThreadId = Boolean.valueOf(manager.getProperty(PROP_THREAD_LOG)).booleanValue();
+        try {
+            this.threadIdLength = Integer.parseInt(manager.getProperty(PROP_THREAD_LENGTH));
+        } catch (NumberFormatException e) {
+            this.threadIdLength = DEFAULT_LENGTH;
+        }
+        this.logTimeStamp = Boolean.valueOf(manager.getProperty(PROP_TIME_LOG)).booleanValue();
+        try {
+            this.timeFormat = new SimpleDateFormat(manager.getProperty(PROP_TIME_FORMAT));
+        } catch (Exception e) {
+            this.timeFormat = DEFAULT_DATE_FORMAT;
+        }
+    }
+
+    @Override
+    public String format(LogRecord record) {
+        if (record == null) {
+            return "A null LogRecord was formatted";
+        }
+        StringBuffer buffer = new StringBuffer();
+        if (this.logTimeStamp) {
+            this.appendTimestamp(buffer, record.getMillis());
+            buffer.append(SPACE);
+        }
+        if (this.logThreadId) {
+            this.appendThreadId(buffer, record.getThreadID());
+            buffer.append(SPACE);
+        }
+        if (this.logClassName) {
+            this.appendClassName(buffer, record.getSourceClassName());
+            buffer.append(SPACE);
+        }
+        if (this.logMethodName) {
+            this.appendMethodName(buffer, record.getSourceMethodName());
+            buffer.append(SPACE);
+        }
+        if (this.logLevel) {
+            this.appendLogLevel(buffer, record.getLevel());
+            buffer.append(SPACE);
+        }
+        buffer.append(formatMessage(record));
+        buffer.append(LINE_SEPARATOR);
+
+        this.appendThrowable(buffer, record.getThrown());
+
+        return buffer.toString();
+    }
+
+    /**
+     * Controls whether or not to log the source class name.
+     * 
+     * @param log true if you want to log the source class name
+     */
+    public void setLogClassName(boolean log) {
+        this.logClassName = log;
+    }
+
+    /**
+     * Controls whether or not to log the source log level.
+     * 
+     * @param log true if you want to log the source log level
+     */
+    public void setLogLevel(boolean log) {
+        this.logLevel = log;
+    }
+
+    /**
+     * Controls whether or not to log the source method name.
+     * 
+     * @param log true if you want to log the source method name
+     */
+    public void setLogMethodName(boolean log) {
+        this.logMethodName = log;
+    }
+
+    /**
+     * Controls whether or not to log the source thread ID.
+     * 
+     * @param log true if you want to log the source thread ID
+     */
+    public void setLogThreadId(boolean log) {
+        this.logThreadId = log;
+    }
+
+    /**
+     * Controls whether or not to log the time stamp.
+     * 
+     * @param log true if you want to log the time stamp
+     */
+    public void setLogTimeStamp(boolean log) {
+        this.logTimeStamp = log;
+    }
+
+    /**
+     * Sets the classLength associated with this instance. If an invalid length
+     * is specified, the default length is used.
+     * 
+     * @param classLength the classLength to set
+     */
+    public void setClassLength(int classLength) {
+        if (classLength > 0) {
+            this.classLength = classLength;
+        } else {
+            this.classLength = DEFAULT_LENGTH;
+        }
+    }
+
+    /**
+     * Sets the logFullClass associated with this instance
+     * 
+     * @param logFullClass the logFullClass to set
+     */
+    public void setLogFullClass(boolean logFullClass) {
+        this.logFullClass = logFullClass;
+    }
+
+    /**
+     * Sets the methodLength associated with this instance. If an invalid length
+     * is specified, the default length is used.
+     * 
+     * @param methodLength
+     *                         the methodLength to set
+     */
+    public void setMethodLength(int methodLength) {
+        if (methodLength > 0) {
+            this.methodLength = methodLength;
+        } else {
+            this.methodLength = DEFAULT_LENGTH;
+        }
+    }
+
+    /**
+     * Sets the timeFormat associated with this instance
+     * 
+     * @param timeFormat the timeFormat to set
+     */
+    public void setTimeFormat(SimpleDateFormat timeFormat) {
+        if (timeFormat != null) {
+            this.timeFormat = timeFormat;
+        }
+    }
+
+    /**
+     * Sets the threadIdLength associated with this instance. If an invalid length
+     * is specified, the default length is used.
+     * 
+     * @param threadIdLength the threadIdLength to set
+     */
+    public void setThreadIdLength(int threadIdLength) {
+        if (threadIdLength > 0) {
+            this.threadIdLength = threadIdLength;
+        } else {
+            this.threadIdLength = DEFAULT_LENGTH;
+        }
+    }
+
+    protected void appendThrowable(StringBuffer buffer, Throwable thrown) {
+        if (thrown == null) {
+            return;
+        }
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(stringWriter);
+        thrown.printStackTrace(writer);
+        buffer.append(stringWriter.toString());
+//		buffer.append(thrown.getClass().getName());
+//		buffer.append(COLON);
+//		buffer.append(thrown.getMessage());
+//		buffer.append(LINE_SEPARATOR);
+//		StackTraceElement[] stack = thrown.getStackTrace();
+//		for(int i=0; i<stack.length; i++) {
+//			buffer.append(AT);
+//			buffer.append(stack[i].toString());
+//			buffer.append(LINE_SEPARATOR);
+//		}
+//		Throwable cause = thrown.getCause();
+//		if(cause!=null) {
+//			buffer.append(CAUSED_BY);
+//			this.appendThrowable(buffer, cause);
+//		}
+    }
+
+    protected void appendLogLevel(StringBuffer buffer, Level level) {
+        char c = (level == null) ? 'U' : level.toString().charAt(0);
+        buffer.append(c);
+    }
+
+    protected void appendMethodName(StringBuffer buffer, String methodName) {
+        appendString(buffer, methodName, this.methodLength, false, SPACE, false);
+    }
+
+    protected void appendClassName(StringBuffer buffer, String fullClassName) {
+        String className = fullClassName;
+        if (fullClassName != null && !this.logFullClass) {
+            int lastDotIndex = fullClassName.lastIndexOf(DOT);
+            lastDotIndex++;
+            if (0 < lastDotIndex && lastDotIndex < fullClassName.length()) {
+                className = fullClassName.substring(lastDotIndex);
+            }
+        }
+        appendString(buffer, className, this.classLength, false, SPACE, false);
+    }
+
+    protected void appendTimestamp(StringBuffer buffer, long millis) {
+        buffer.append(this.timeFormat.format(new Date(millis)));
+    }
+
+    protected void appendThreadId(StringBuffer buffer, int threadId) {
+        String decimal = Integer.toString(threadId);
+        appendString(buffer, decimal, this.threadIdLength, true, ZERO, true);
+    }
+
+    /**
+     * Appends a String 's' to a buffer 'buffer'.
+     * 
+     * @param buffer
+     *                            The buffer you want the String appended to
+     * @param s
+     *                            The String to append to the buffer
+     * @param length
+     *                            See the usage for 'allowLonger', and 'prependFiller'
+     * @param allowLonger
+     *                            If the length of 's' is less than 'length' and 'allowLonger'
+     *                            is false, then <code>s.substring(0, length)</code> is
+     *                            appended to 'buffer' (else 's' is appended)
+     * @param fillChar
+     *                            The character you want prepended to Strings that
+     *                            do not match the target length
+     * @param prependFillChar
+     *                            true if you want to prepend the fillChar,<br>
+     *                            false if you want to append the fillChar
+     */
+    protected static void appendString(StringBuffer buffer, String string, int length, boolean allowLonger, char fillChar, boolean prependFillChar) {
+        String s = (string == null) ? "(null)" : string;
+        int difference = length - s.length();
+        if (difference == 0) {
+            buffer.append(s);
+        } else {
+            if (difference < 0) {
+                if (allowLonger) {
+                    buffer.append(s);
+                } else {
+                    buffer.append(s.substring(0, length));
+                }
+            } else {
+                if (prependFillChar) {
+                    appendFillChar(buffer, fillChar, difference);
+                    buffer.append(s);
+                } else {
+                    buffer.append(s);
+                    appendFillChar(buffer, fillChar, difference);
+                }
+            }
+        }
+    }
+
+    protected static void appendFillChar(StringBuffer buffer, char fillChar, int length) {
+        for (int i = 0; i < length; i++) {
+            buffer.append(fillChar);
+        }
+    }
+
+}

--- a/dev/fattest.simplicity/src/com/ibm/ws/fat/util/GenericHandler.java
+++ b/dev/fattest.simplicity/src/com/ibm/ws/fat/util/GenericHandler.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.fat.util;
+
+import java.util.logging.Formatter;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+import java.util.logging.StreamHandler;
+
+/**
+ * Provides a java.util.logging.StreamHandler extension that outputs to sys out instead of sys err.
+ * The following properties can be set in logging.properties to configure this Handler:<br>
+ * <br>
+ * <ul>
+ * <li><code>com.ibm.ws.fat.util.GenericHandler.level</code> - specifies the default level for the Handler (defaults to Level.INFO).</li>
+ * <li><code>com.ibm.ws.fat.util.GenericHandler.formatter</code> - specifies the name of a Formatter class to use (defaults to com.ibm.ws.fvt.logging.GenericFormatter).</li>
+ * <li><code>com.ibm.ws.fat.util.GenericHandler.stream</code> - specifies the output stream to use (valid values are: System.err and System.out. defaults to System.out).</li>
+ * <li><code>com.ibm.ws.fat.util.GenericHandler.flush</code> - controls whether to flush the wrapped OutputStream whenever a LogRecord is published (defaults to false).</li>
+ * </ul>
+ *
+ * @author Tim Burns
+ *
+ */
+public class GenericHandler extends StreamHandler {
+
+    protected static final String PROP_FORMATTER = GenericHandler.class.getName() + ".formatter";
+    protected static final String PROP_STREAM = GenericHandler.class.getName() + ".stream";
+    protected static final String PROP_FLUSH = GenericHandler.class.getName() + ".flush";
+    protected static final String SYSTEM_ERR = "system.err";
+
+    protected boolean flush;
+
+    /**
+     * The primary constructor sets state based on JVM system properties.
+     */
+    public GenericHandler() {
+        super();
+        LogManager manager = LogManager.getLogManager();
+        this.flush = new Boolean(manager.getProperty(PROP_FLUSH)).booleanValue();
+        String formatter = manager.getProperty(PROP_FORMATTER);
+        Formatter formatterInstance;
+        try {
+            formatterInstance = (Formatter) Class.forName(formatter).newInstance();
+        } catch (Exception e) {
+            formatterInstance = new GenericFormatter();
+        }
+        this.setFormatter(formatterInstance);
+        String stream = manager.getProperty(PROP_STREAM);
+        if (stream != null && SYSTEM_ERR.equals(stream.toLowerCase())) {
+            this.setOutputStream(System.err);
+        } else {
+            this.setOutputStream(System.out);
+        }
+    }
+
+    @Override
+    public void publish(LogRecord record) {
+        super.publish(record);
+        if (this.flush) {
+            this.flush();
+        }
+    }
+
+}

--- a/dev/fattest.simplicity/src/com/ibm/ws/fat/util/Props.java
+++ b/dev/fattest.simplicity/src/com/ibm/ws/fat/util/Props.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,8 +17,6 @@ import java.net.UnknownHostException;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import com.ibm.websphere.simplicity.Topology;
 
 /**
  * <p>
@@ -168,7 +166,7 @@ public class Props {
 
     /**
      * Configures the global properties instance. Subclasses should call this method before any properties are read.
-     * 
+     *
      * @param props the global properties instance to use
      */
     public static void setInstance(Props props) {
@@ -226,37 +224,37 @@ public class Props {
 
     /**
      * Retrieves a list of useful system properties that describe a JRE
-     * 
+     *
      * @return a list of interesting Java property keys
      */
     protected String[] getJavaPropertyKeys() {
         return new String[] {
-                             "os.name",
-                             "os.version",
-                             "os.arch",
-                             "user.name",
-                             "user.home",
-                             "user.dir",
-                             "java.home",
-                             "java.version",
-                             "java.fullversion",
-                             "java.jcl.version",
-                             "java.vendor",
-                             "java.runtime.name",
-                             "java.runtime.version",
-                             "java.vm.name",
-                             "java.vm.home",
-                             "java.vm.version",
-                             "java.vm.vendor",
-                             "java.class.version",
-                             "java.compiler",
-                             "java.io.tmpdir" };
+                              "os.name",
+                              "os.version",
+                              "os.arch",
+                              "user.name",
+                              "user.home",
+                              "user.dir",
+                              "java.home",
+                              "java.version",
+                              "java.fullversion",
+                              "java.jcl.version",
+                              "java.vendor",
+                              "java.runtime.name",
+                              "java.runtime.version",
+                              "java.vm.name",
+                              "java.vm.home",
+                              "java.vm.version",
+                              "java.vm.vendor",
+                              "java.class.version",
+                              "java.compiler",
+                              "java.io.tmpdir" };
     }
 
     /**
      * Collects information about the current version of Java and other
      * dependencies.
-     * 
+     *
      * @return a map of key/value pairs that describe the current environment
      */
     public PropertyMap collectVersionInformation() {
@@ -264,7 +262,7 @@ public class Props {
         for (String prop : this.getJavaPropertyKeys()) {
             properties.put(prop, System.getProperty(prop));
         }
-        properties.put("simplicity.version", Topology.SIMPLICITY_VERSION);
+        properties.put("simplicity.version", "2.0.0");
         //        properties.put("jiiws.version", SessionManager.getVersion());
         try {
             properties.put("host.address", InetAddress.getLocalHost().getHostAddress());
@@ -278,10 +276,10 @@ public class Props {
 
     /**
      * Determines whether or not a property is set.
-     * 
-     * @param prop
-     *            The key of the property you want to check for the existence of
-     * @return true if the input property is set
+     *
+     * @param  prop
+     *                  The key of the property you want to check for the existence of
+     * @return      true if the input property is set
      */
     public boolean isSet(String prop) {
         if (prop == null) {
@@ -294,11 +292,11 @@ public class Props {
     /**
      * Determines whether a property is set to a String composed of white-space
      * characters.
-     * 
-     * @param prop
-     *            The key of the property you want to check
-     * @return true if the input property is set, but either contains spaces or
-     *         is the empty String
+     *
+     * @param  prop
+     *                  The key of the property you want to check
+     * @return      true if the input property is set, but either contains spaces or
+     *              is the empty String
      */
     public boolean isSetToBlank(String prop) {
         if (prop == null) {
@@ -314,10 +312,10 @@ public class Props {
     /**
      * Determines whether a property is set to a String composed of
      * non-white-space characters.
-     * 
-     * @param prop
-     *            The key of the property you want to check
-     * @return true if the input property is set and is not blank
+     *
+     * @param  prop
+     *                  The key of the property you want to check
+     * @return      true if the input property is set and is not blank
      */
     public boolean isSetToText(String prop) {
         if (prop == null) {
@@ -332,10 +330,10 @@ public class Props {
 
     /**
      * Determine the value of a property as a String
-     * 
-     * @param prop
-     *            The key of the property you want to check
-     * @return The value of the input property
+     *
+     * @param  prop
+     *                  The key of the property you want to check
+     * @return      The value of the input property
      */
     public String getProperty(String prop) {
         if (prop == null) {
@@ -346,11 +344,11 @@ public class Props {
 
     /**
      * Determine the value of a property as an int.
-     * 
-     * @param prop
-     *            The key of the property you want to check
-     * @return The value of the input property, or zero if the value of the
-     *         property could not be parsed
+     *
+     * @param  prop
+     *                  The key of the property you want to check
+     * @return      The value of the input property, or zero if the value of the
+     *              property could not be parsed
      */
     public int getIntProperty(String prop) {
         String value = getProperty(prop);
@@ -372,10 +370,10 @@ public class Props {
      * <br>
      * Example: <tt>Boolean.valueOf("True")</tt> returns <tt>true</tt>.<br>
      * Example: <tt>Boolean.valueOf("yes")</tt> returns <tt>false</tt>.
-     * 
-     * @param prop
-     *            The key of the property you want to check
-     * @return The value of the input property as a boolean
+     *
+     * @param  prop
+     *                  The key of the property you want to check
+     * @return      The value of the input property as a boolean
      */
     public boolean getBooleanProperty(String prop) {
         return Boolean.valueOf(getProperty(prop)).booleanValue();
@@ -386,10 +384,10 @@ public class Props {
      * <code>File</code> instance by converting the value specified by the
      * property key into an abstract pathname. If the given string is the empty
      * string, then the result is the empty abstract pathname.
-     * 
-     * @param prop
-     *            The key of the property you want to check
-     * @return The value of the input property as a File
+     *
+     * @param  prop
+     *                  The key of the property you want to check
+     * @return      The value of the input property as a File
      */
     public File getFileProperty(String prop) {
         return new File(getProperty(prop));
@@ -398,11 +396,11 @@ public class Props {
     /**
      * Sets a property if the input key and value are not null. If either
      * parameter is null, no property is set.
-     * 
+     *
      * @param prop
-     *            The key of the property you want to set
+     *                  The key of the property you want to set
      * @param value
-     *            The value of the property you want to set
+     *                  The value of the property you want to set
      */
     public void setProperty(String prop, String value) {
         if (prop != null && value != null) {
@@ -413,11 +411,11 @@ public class Props {
     /**
      * Sets an int property if the input key is not null. If the key is null, no
      * property is set.
-     * 
+     *
      * @param prop
-     *            The key of the property you want to set
+     *                  The key of the property you want to set
      * @param value
-     *            The value of the property you want to set
+     *                  The value of the property you want to set
      */
     public void setIntProperty(String prop, int value) {
         setProperty(prop, new Integer(value).toString());
@@ -426,11 +424,11 @@ public class Props {
     /**
      * Sets a boolean property if the input key is not null. If the key is null,
      * no property is set.
-     * 
+     *
      * @param prop
-     *            The key of the property you want to set
+     *                  The key of the property you want to set
      * @param value
-     *            The value of the property you want to set
+     *                  The value of the property you want to set
      */
     public void setBooleanProperty(String prop, boolean value) {
         setProperty(prop, new Boolean(value).toString());
@@ -439,11 +437,11 @@ public class Props {
     /**
      * Sets a File property if the input key and value are not null. If either
      * parameter is null, no property is set.
-     * 
+     *
      * @param prop
-     *            The key of the property you want to set
+     *                 The key of the property you want to set
      * @param file
-     *            The value of the property you want to set
+     *                 The value of the property you want to set
      */
     public void setFileProperty(String prop, File file) {
         if (file != null) {

--- a/dev/fattest.simplicity/src/com/ibm/ws/fat/util/StopWatch.java
+++ b/dev/fattest.simplicity/src/com/ibm/ws/fat/util/StopWatch.java
@@ -1,0 +1,358 @@
+/*******************************************************************************
+ * Copyright (c) 1997, 2009 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.fat.util;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+/**
+ * Helps you track the amount of time that passes between significant events.
+ *
+ * @author Tim Burns
+ *
+ */
+public class StopWatch {
+
+    /**
+     * The default DateFormat used to format Dates as Strings
+     */
+    public static final SimpleDateFormat DEFAULT_DATE_FORMAT = new SimpleDateFormat("[MM/dd/yyyy HH:mm:ss:SSS z]");
+
+    protected static final String SPACE = " ";
+    protected static final String S = "s";
+    protected static final String DAY = "day";
+    protected static final String HOUR = "hour";
+    protected static final String MINUTE = "minute";
+    protected static final String SECOND = "second";
+    protected static final String MILLISECOND = "millisecond";
+    protected static final String TINY = "Less than 1 millisecond";
+
+    protected long start;
+    protected long stop;
+    protected boolean started;
+    protected boolean stopped;
+
+    /**
+     * Primary constructor.
+     */
+    public StopWatch() {
+        this.start = 0;
+        this.stop = 0;
+        this.started = false;
+        this.stopped = false;
+    }
+
+    /**
+     * Capture the current system time, and store it as the internal start time.
+     */
+    public void start() {
+        this.start = getCurrentTimeInMilliseconds();
+        this.started = true;
+        this.stopped = false;
+    }
+
+    /**
+     * Determines if this instance has been started, but not stopped
+     * 
+     * @return true if this instance has been started, but not stopped
+     */
+    public boolean hasStarted() {
+        return this.started;
+    }
+
+    /**
+     * Determines the time that this instance was started, in milliseconds
+     * 
+     * @return the difference, measured in milliseconds, between the time that
+     *         this instance was started and midnight, January 1, 1970 UTC.
+     */
+    public long getStartTimeInMilliseconds() {
+        return this.start;
+    }
+
+    /**
+     * Determines the time that this instance was started
+     * 
+     * @return A GregorianCalendar that represents the time that this instance
+     *         was started.
+     */
+    public GregorianCalendar getStartTimeAsCalendar() {
+        return getTimeAsCalendar(this.start);
+    }
+
+    /**
+     * Capture the current system time, and store it as the internal stop time.
+     */
+    public void stop() {
+        this.stop = getCurrentTimeInMilliseconds();
+        this.started = false;
+        this.stopped = true;
+    }
+
+    /**
+     * Determines if this instance has been stopped, after being started at
+     * least once
+     * 
+     * @return true if this instance has been stopped, after being started at
+     *         least once
+     */
+    public boolean hasStopped() {
+        return this.stopped;
+    }
+
+    /**
+     * Determines the time that this instance was stopped, in milliseconds
+     * 
+     * @return the difference, measured in milliseconds, between the time that
+     *         this instance was stopped and midnight, January 1, 1970 UTC.
+     */
+    public long getStopTimeInMilliseconds() {
+        return this.stop;
+    }
+
+    /**
+     * Determines the time that this instance was stopped
+     * 
+     * @return A GregorianCalendar that represents the time that this instance
+     *         was stopped.
+     */
+    public GregorianCalendar getStopTimeAsCalendar() {
+        return getTimeAsCalendar(this.stop);
+    }
+
+    /**
+     * Calculate the time elapsed between starting and stopping this instance,
+     * as a human-readable String
+     * 
+     * @return the number of milliseconds that elapsed between the start time
+     *         and the stop time
+     */
+    public String getTimeElapsedAsString() {
+        return getTimeElapsedAsString(this.start, this.stop);
+    }
+
+    /**
+     * Calculate the time elapsed between starting and stopping this instance.
+     * 
+     * @return the number of milliseconds that elapsed between the start time
+     *         and the stop time
+     */
+    public long getTimeElapsedAsLong() {
+        return getTimeElapsedAsLong(this.start, this.stop);
+    }
+
+    /**
+     * Causes the current Thread to sleep for the specified number of minutes.
+     * If the current Thread is interrupted while it's sleeping, this method
+     * will return immediately.
+     * 
+     * @param minutes The number of minutes you want the current Thread to sleep
+     */
+    public static void sleepMinutes(long minutes) {
+        sleepMilliseconds(minutes * 60 * 1000);
+    }
+
+    /**
+     * Causes the current Thread to sleep for the specified number of seconds.
+     * If the current Thread is interrupted while it's sleeping, this method
+     * will return immediately.
+     * 
+     * @param seconds The number of seconds you want the current Thread to sleep
+     */
+    public static void sleepSeconds(long seconds) {
+        sleepMilliseconds(seconds * 1000);
+    }
+
+    /**
+     * Causes the current Thread to sleep for the specified number of
+     * milliseconds. If the current Thread is interrupted while it's sleeping,
+     * this method will return immediately.
+     * 
+     * @param milliseconds
+     *                         The number of milliseconds you want the current Thread to
+     *                         sleep
+     */
+    public static void sleepMilliseconds(long milliseconds) {
+        try {
+            Thread.sleep(milliseconds);
+        } catch (InterruptedException e) {
+            return;
+        }
+    }
+
+    /**
+     * Calculate the time elapsed between the input start and stop times,
+     * as a human-readable String
+     * 
+     * @param  start
+     *                   the start time
+     * @param  stop
+     *                   the stop time
+     * @return       the number of milliseconds that elapsed between the start time
+     *               and the stop time
+     */
+    public static String getTimeElapsedAsString(long start, long stop) {
+        return convertMillisecondsToString(stop - start);
+    }
+
+    /**
+     * Calculate the time elapsed between the input start and stop times.
+     * 
+     * @param  start
+     *                   the start time
+     * @param  stop
+     *                   the stop time
+     * @return       the number of milliseconds that elapsed between the start time
+     *               and the stop time
+     */
+    public static long getTimeElapsedAsLong(long start, long stop) {
+        return stop - start;
+    }
+
+    protected static long getCurrentTimeInMilliseconds() {
+        return System.currentTimeMillis();
+    }
+
+    /**
+     * Determines the current time
+     * 
+     * @return A GregorianCalendar that represents the current time
+     */
+    public static GregorianCalendar getCurrentTimeAsCalendar() {
+        return getTimeAsCalendar(getCurrentTimeInMilliseconds());
+    }
+
+    /**
+     * Converts the specified time in milliseconds to the same time as a
+     * GregorianCalendar
+     * 
+     * @param  millisecondsSinceEpoch
+     *                                    the time you want to convert
+     * @return                        A GregorianCalendar that represents the input time
+     */
+    public static GregorianCalendar getTimeAsCalendar(long millisecondsSinceEpoch) {
+        GregorianCalendar timestamp = new GregorianCalendar();
+        timestamp.setTimeInMillis(millisecondsSinceEpoch);
+        return timestamp;
+    }
+
+    /**
+     * Produces a human-readable String representation of elapsed time, in
+     * milliseconds
+     * 
+     * @param  milliseconds
+     *                          the amount of time elapsed, in milliseconds
+     * @return              A human-readable representation of the elapsed time
+     */
+    public static String convertMillisecondsToString(long milliseconds) {
+        return UnitConverter.millisecondsAsString(milliseconds);
+    }
+
+    /**
+     * Format the input Date as a String using the default date format.
+     * 
+     * @param  date
+     *                  The date you want to convert
+     * @return      A String description of the input date, or null if the input Date
+     *              is null
+     */
+    public static String formatTime(Date date) {
+        return formatTime(null, date);
+    }
+
+    /**
+     * Format the input Date as a String using the input date format.
+     * 
+     * @param  format
+     *                    the format you want to use to format the Date, or null if you
+     *                    want to use the default date format
+     * @param  date
+     *                    The date you want to convert
+     * @return        A String description of the input date, or null if the input Date
+     *                is null
+     */
+    public static String formatTime(SimpleDateFormat format, Date date) {
+        if (date == null) {
+            return null;
+        }
+        return formatTime(format, date.getTime());
+    }
+
+    /**
+     * Format the input Date as a String using the default date format.
+     * 
+     * @param  millisecondsSinceEpoch
+     *                                    The date you want to convert, in milliseconds since midnight,
+     *                                    January 1, 1970 UTC
+     * @return                        A String description of the input date
+     */
+    public static String formatTime(long millisecondsSinceEpoch) {
+        return formatTime(null, millisecondsSinceEpoch);
+    }
+
+    /**
+     * Format the input Date as a String using the input date format.
+     * 
+     * @param  format
+     *                                    the format you want to use to format the Date, or null if you
+     *                                    want to use the default date format
+     * @param  millisecondsSinceEpoch
+     *                                    The date you want to convert, in milliseconds since midnight,
+     *                                    January 1, 1970 UTC
+     * @return                        A String description of the input date, or null if the input Date
+     *                                is null
+     */
+    public static String formatTime(SimpleDateFormat format, long millisecondsSinceEpoch) {
+        GregorianCalendar calendar = new GregorianCalendar();
+        calendar.setTimeInMillis(millisecondsSinceEpoch);
+        if (format == null) {
+            return DEFAULT_DATE_FORMAT.format(calendar.getTime());
+        }
+        return format.format(calendar.getTime());
+    }
+
+    /**
+     * Convert the input String to a Date using the default date format.
+     * 
+     * @param  time
+     *                  The time you want to convert to a Date
+     * @return      A Date representation of the input time, or null if the input
+     *              String is invalid
+     */
+    public static Date parseTime(String time) {
+        return parseTime(null, time);
+    }
+
+    /**
+     * Convert the input String to a Date using the input date format.
+     * 
+     * @param  format
+     *                    the format you want to use to parse the Date, or null if you
+     *                    want to use the default date format
+     * @param  time
+     *                    The time you want to convert to a Date
+     * @return        A Date representation of the input time, or null if the input
+     *                String is invalid
+     */
+    public static Date parseTime(SimpleDateFormat format, String time) {
+        try {
+            if (format == null) {
+                return DEFAULT_DATE_FORMAT.parse(time);
+            }
+            return format.parse(time);
+        } catch (ParseException e) {
+            return null;
+        }
+    }
+
+}

--- a/dev/fattest.simplicity/src/com/ibm/ws/fat/util/UnitConverter.java
+++ b/dev/fattest.simplicity/src/com/ibm/ws/fat/util/UnitConverter.java
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ * Copyright (c) 1997, 2009 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.fat.util;
+
+/**
+ * Convenience class for converting measurements into human-readable
+ * strings
+ *
+ * @author Tim Burns
+ *
+ */
+public class UnitConverter {
+
+    protected final String unit;
+    protected long value;
+    protected final UnitConverter parent;
+
+    /**
+     * Encapsulates single value, and associates the value with a unit.
+     * 
+     * @param value
+     *                  The value to encapsulate
+     * @param unit
+     *                  The unit of the value
+     */
+    public UnitConverter(long value, String unit) {
+        this.value = value;
+        this.unit = unit;
+        this.parent = null;
+    }
+
+    /**
+     * Encapsulates a value that's derived from a parent value in terms of a
+     * size factor
+     * 
+     * @param factor
+     *                   The number of parents that can fit in one instance of this
+     * @param parent
+     *                   The more granular value size
+     * @param unit
+     *                   The unit of the value
+     */
+    public UnitConverter(long factor, UnitConverter parent, String unit) {
+        this.unit = unit;
+        this.parent = parent;
+        this.value = this.parent.value / factor;
+        this.parent.value = this.parent.value % factor;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder buffer = new StringBuilder();
+        this.appendValue(buffer, false);
+        return buffer.toString();
+    }
+
+    protected void appendValue(final StringBuilder buffer, final boolean alwaysAppend) {
+        boolean nextAlwaysAppend = false;
+        if (this.value > 0 || alwaysAppend) {
+            if (alwaysAppend) {
+                buffer.append(" ");
+            }
+            buffer.append(this.value).append(" ").append(this.unit);
+            if (this.value != 1) {
+                buffer.append("s");
+            }
+            nextAlwaysAppend = true;
+        }
+        if (this.parent == null) {
+            if (!nextAlwaysAppend) {
+                buffer.append("Less than 1 ").append(this.unit);
+            }
+        } else {
+            this.parent.appendValue(buffer, nextAlwaysAppend);
+        }
+    }
+
+    /**
+     * Converts a raw number of bytes into a human-readable String. For
+     * example:<br>
+     * <code>UnitConverter.bytesAsString(423466398)</code><br>
+     * returns:<br>
+     * <code>403 megabytes 869 kilobytes 414 bytes</code><br>
+     * 
+     * @param  bytes
+     *                   the raw number of bytes to convert
+     * @return       a human-readable String representation of the input number of
+     *               bytes
+     */
+    public static String bytesAsString(long bytes) {
+        UnitConverter B = new UnitConverter(bytes, "byte");
+        UnitConverter KB = new UnitConverter(1024, B, "kilobyte"); // 1024 B per KB
+        UnitConverter MB = new UnitConverter(1024, KB, "megabyte"); // 1024 KB per MB
+        UnitConverter GB = new UnitConverter(1024, MB, "gigabyte"); // 1024 MB per GB
+        UnitConverter TB = new UnitConverter(1024, GB, "terabyte"); // 1024 GB per TB
+        UnitConverter PB = new UnitConverter(1024, TB, "petabyte"); // 1024 TB per PB
+        return PB.toString();
+    }
+
+    /**
+     * Converts a raw number of milliseconds into a human-readable String.
+     * For example:<br>
+     * <code>UnitConverter.millisecondsAsString(System.currentTimeMillis())</code>
+     * <br>
+     * returns something like:<br>
+     * <code>40 years 98 days 14 hours 14 minutes 21 seconds 453 milliseconds</code>
+     * <br>
+     * 
+     * @param  milliseconds
+     *                          the raw number of milliseconds to convert
+     * @return              a human-readable String representation of the input number of
+     *                      milliseconds
+     */
+    public static String millisecondsAsString(long milliseconds) {
+        UnitConverter ms = new UnitConverter(milliseconds, "millisecond");
+        UnitConverter s = new UnitConverter(1000, ms, "second"); // 1000 ms per s
+        UnitConverter m = new UnitConverter(60, s, "minute"); // 60 s per m
+        UnitConverter h = new UnitConverter(60, m, "hour"); // 60 m per h
+        UnitConverter d = new UnitConverter(24, h, "day"); // 24 h per d
+        UnitConverter y = new UnitConverter(365, d, "year"); // 365 d per y
+        return y.toString();
+    }
+
+    /**
+     * Print a few example conversions to standard out
+     * 
+     * @param args
+     *                 no arguments needed
+     */
+    public static void main(String[] args) {
+        System.out.println(UnitConverter.bytesAsString(423466398));
+        System.out.println(UnitConverter.bytesAsString(0));
+        System.out.println(UnitConverter.bytesAsString(-1));
+        System.out.println(UnitConverter.bytesAsString(1));
+        System.out.println(UnitConverter.millisecondsAsString(System.currentTimeMillis()));
+        System.out.println(UnitConverter.millisecondsAsString(0));
+    }
+
+}

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -855,7 +855,6 @@ public class LibertyServer implements LogMonitorClient {
 
     /**
      * Copies the server.xml to the server.
-     *
      * @throws Exception
      */
     public void refreshServerXMLFromPublish() throws Exception {


### PR DESCRIPTION
I am removing the binary dependency on a number of `com.ibm.ws.componenttest` artifacts by checking in the source for some and stripping out what we are not using. This is just the first step of what I want to do. Once the OL side is using just source it will be easier to refactor and make the code common with what is used in the WL side. There are a lot of APIs here that are clearly just from tWAS and I don’t think there is any benefit to keeping them for use in Liberty.

Converted to source (merged into fattest.simplicity)
- public.api
- fat.util

Completely removed
- provider.api
- com.ibm.componenttest.common
- com.ibm.ws.topology.helper
- fat.harness