### PR TITLE
Update Equinox Framework to 3.17.200

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -3959,7 +3959,7 @@
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.osgi</artifactId>
-      <version>3.17.100</version>
+      <version>3.17.200</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse</groupId>

--- a/dev/cnf/oss_source_dependencies.maven
+++ b/dev/cnf/oss_source_dependencies.maven
@@ -105,7 +105,7 @@ org.eclipse.platform:org.eclipse.equinox.console:1.4.300
 org.eclipse.platform:org.eclipse.equinox.coordinator:1.4.0
 org.eclipse.platform:org.eclipse.equinox.metatype:1.6.0
 org.eclipse.platform:org.eclipse.equinox.region:1.5.100
-org.eclipse.platform:org.eclipse.osgi:3.17.100
+org.eclipse.platform:org.eclipse.osgi:3.17.200
 org.eclipse:yasson:1.0.8
 org.jboss.classfilewriter:jboss-classfilewriter:1.2.5.Final
 org.jboss.jdeparser:jdeparser:1.0.0.Final

--- a/dev/org.eclipse.osgi/bnd.bnd
+++ b/dev/org.eclipse.osgi/bnd.bnd
@@ -8,12 +8,12 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
--include= jar:${fileuri;${repo;org.eclipse.platform:org.eclipse.osgi;3.17.100}}!/META-INF/MANIFEST.MF,bnd.overrides
+-include= jar:${fileuri;${repo;org.eclipse.platform:org.eclipse.osgi;3.17.200}}!/META-INF/MANIFEST.MF,bnd.overrides
 -nouses: true
 -nodefaultversion: true
 
 -includeresource: \
-   @${repo;org.eclipse.platform:org.eclipse.osgi;3.17.100}
+   @${repo;org.eclipse.platform:org.eclipse.osgi;3.17.200}
 
 -buildpath: \
-	org.eclipse.platform:org.eclipse.osgi;version=3.17.100
+	org.eclipse.platform:org.eclipse.osgi;version=3.17.200

--- a/dev/org.eclipse.osgi/bnd.overrides
+++ b/dev/org.eclipse.osgi/bnd.overrides
@@ -1,6 +1,6 @@
 -include= ~../cnf/resources/bnd/rejar.props
 bVersion=3.17.0
-bFullVersion=3.17.100
+bFullVersion=3.17.200
 
 Bundle-SymbolicName: org.eclipse.osgi; singleton:=true
 


### PR DESCRIPTION
This cannot be verified until the org.eclipse.osgi 3.17.200 artifact is published to maven central.