### PR TITLE
Update to bnd 6.2.0

### DIFF
--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -376,10 +376,10 @@ task ('index', type: Index) {
     description 'Index the release repository. (Does not depend on releaseNeeded)'
     group 'release'
     repositoryName = "OpenLiberty ${version}"
-    destinationDir = releaserepo
+    destinationDirectory = releaserepo
     gzip = true
     /* Bundles to index. */
-    bundles fileTree(destinationDir) {
+    bundles fileTree(destinationDirectory) {
         include '**/*.jar'
         exclude '**/*-latest.jar'
         exclude '**/*-sources.jar'

--- a/dev/gradle.properties
+++ b/dev/gradle.properties
@@ -13,7 +13,7 @@ bnd_cnf=cnf
 
 # bnd_plugin is the dependency declaration for the bnd gradle plugin
 #bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:+
-bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:5.3.0
+bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:6.2.0
 
 # The URL to the bnd build repo.
 bnd_repourl=https://repo1.maven.org/maven2


### PR DESCRIPTION
- Identify sizing of needed remediations for bnd behavior changes.
  - https://github.com/bndtools/bnd/wiki/Changes-in-6.2.0
  - https://github.com/bndtools/bnd/wiki/Changes-in-6.1.0
  - https://github.com/bndtools/bnd/wiki/Changes-in-6.0.0

- Changes to address `The Bnd Gradle plugins and tasks now support Gradle 7.`

```
> Task :com.ibm.ws.classloading_test.jarB:compileJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':com.ibm.ws.classloading_test.jarB:compileJava'.
> Cannot specify --release via `CompileOptions.compilerArgs` when using `JavaCompile.release`.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.8.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 12m 13s
1312 actionable tasks: 1013 executed, 299 up-to-date
```