### PR TITLE
Issue 20058 and 20060: Remainder of required logout token validation

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
@@ -290,7 +290,7 @@ LOGOUT_TOKEN_CONTAINS_NONCE_CLAIM.explanation=A logout token must not contain a 
 LOGOUT_TOKEN_CONTAINS_NONCE_CLAIM.useraction=Ensure that the logout token does not contain a "nonce" claim.
 
 LOGOUT_TOKEN_EVENTS_MEMBER_VALUE_NOT_JSON=CWWKS1550E: The value for the "{0}" member in the "events" claim is not a JSON object.
-LOGOUT_TOKEN_EVENTS_MEMBER_VALUE_NOT_JSON.explanation=The value of the member that is specified in the message must be a JSON object. The value should be the empty JSON object.
+LOGOUT_TOKEN_EVENTS_MEMBER_VALUE_NOT_JSON.explanation=The corresponding member value must be a JSON object. The expected value is "{}", an empty JSON object.
 LOGOUT_TOKEN_EVENTS_MEMBER_VALUE_NOT_JSON.useraction=Ensure that the "events" claim in the logout token is formatted correctly.
 
 # STOP HERE, OIDC SERVER HAS RESERVED 1600 - 1649

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
@@ -272,18 +272,18 @@ LOGOUT_TOKEN_MISSING_CLAIMS.useraction=Ensure that the OpenID Connect provider i
 
 # Do not translate "sub" or "sid"
 LOGOUT_TOKEN_MISSING_SUB_AND_SID=CWWKS1546E: The logout token is not valid because it does not contain a "sub" or "sid" claim. The token must have at least one of those claims.
-LOGOUT_TOKEN_MISSING_SUB_AND_SID.explanation=The sub and sid claims identify the user and session that is associated with a token. At least one of those claims must be present to determine the user or session to log out.
+LOGOUT_TOKEN_MISSING_SUB_AND_SID.explanation=The "sub" and "sid" claims identify the user and session that is associated with a token. At least one of those claims must be present to determine the user or session to log out.
 LOGOUT_TOKEN_MISSING_SUB_AND_SID.useraction=Ensure that the OpenID Connect provider includes the missing claims in the logout token.
 
 # Do not translate "events"
 LOGOUT_TOKEN_EVENTS_CLAIM_WRONG_TYPE=CWWKS1547E: The logout token is not valid because the "events" claim is not a JSON object: {0}
-LOGOUT_TOKEN_EVENTS_CLAIM_WRONG_TYPE.explanation=The events claim in the logout token must be a JSON object.
-LOGOUT_TOKEN_EVENTS_CLAIM_WRONG_TYPE.useraction=Ensure that the OpenID Connect provider uses the correct data type for the events claim.
+LOGOUT_TOKEN_EVENTS_CLAIM_WRONG_TYPE.explanation=The "events" claim in the logout token must be a JSON object.
+LOGOUT_TOKEN_EVENTS_CLAIM_WRONG_TYPE.useraction=Ensure that the OpenID Connect provider uses the correct data type for the "events" claim.
 
 # Do not translate "events"
 LOGOUT_TOKEN_EVENTS_CLAIM_MISSING_EXPECTED_MEMBER=CWWKS1548E: The logout token is not valid because the "events" claim does not contain "{0}" as a member. The "events" claim value is {1}.
-LOGOUT_TOKEN_EVENTS_CLAIM_MISSING_EXPECTED_MEMBER.explanation=The events claim must be a JSON object that contains a member with the name that is specified in the message.
-LOGOUT_TOKEN_EVENTS_CLAIM_MISSING_EXPECTED_MEMBER.useraction=Ensure that the events claim includes the required member.
+LOGOUT_TOKEN_EVENTS_CLAIM_MISSING_EXPECTED_MEMBER.explanation=The "events" claim must be a JSON object that contains a member with the name that is specified in the message.
+LOGOUT_TOKEN_EVENTS_CLAIM_MISSING_EXPECTED_MEMBER.useraction=Ensure that the "events" claim includes the required member.
 
 LOGOUT_TOKEN_CONTAINS_NONCE_CLAIM=CWWKS1549E: The logout token is not valid because it contains a "nonce" claim.
 LOGOUT_TOKEN_CONTAINS_NONCE_CLAIM.explanation=A logout token must not contain a "nonce" claim so that the token cannot be used in a forged authentication response in place of an ID token.

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
@@ -270,4 +270,23 @@ LOGOUT_TOKEN_MISSING_CLAIMS=CWWKS1545E: The logout token is not valid because it
 LOGOUT_TOKEN_MISSING_CLAIMS.explanation=The logout token must contain the claims that are specified in the message.
 LOGOUT_TOKEN_MISSING_CLAIMS.useraction=Ensure that the OpenID Connect provider includes the missing claims in the logout token.
 
+# Do not translate "sub" or "sid"
+LOGOUT_TOKEN_MISSING_SUB_AND_SID=CWWKS1546E: The logout token is not valid because it does not contain a "sub" or "sid" claim. The token must have at least one of those claims.
+LOGOUT_TOKEN_MISSING_SUB_AND_SID.explanation=The sub and sid claims identify the user and session that is associated with a token. At least one of those claims must be present to determine the user or session to log out.
+LOGOUT_TOKEN_MISSING_SUB_AND_SID.useraction=Ensure that the OpenID Connect provider includes the missing claims in the logout token.
+
+# Do not translate "events"
+LOGOUT_TOKEN_EVENTS_CLAIM_WRONG_TYPE=CWWKS1547E: The logout token is not valid because the "events" claim is not a JSON object: {0}
+LOGOUT_TOKEN_EVENTS_CLAIM_WRONG_TYPE.explanation=The events claim in the logout token must be a JSON object.
+LOGOUT_TOKEN_EVENTS_CLAIM_WRONG_TYPE.useraction=Ensure that the OpenID Connect provider uses the correct data type for the events claim.
+
+# Do not translate "events"
+LOGOUT_TOKEN_EVENTS_CLAIM_MISSING_EXPECTED_MEMBER=CWWKS1548E: The logout token is not valid because the "events" claim does not contain "{0}" as a member. The "events" claim value is {1}.
+LOGOUT_TOKEN_EVENTS_CLAIM_MISSING_EXPECTED_MEMBER.explanation=The events claim must be a JSON object that contains a member with the name that is specified in the message.
+LOGOUT_TOKEN_EVENTS_CLAIM_MISSING_EXPECTED_MEMBER.useraction=Ensure that the events claim includes the required member.
+
+LOGOUT_TOKEN_CONTAINS_NONCE_CLAIM=CWWKS1549E: The logout token is not valid because it contains a "nonce" claim.
+LOGOUT_TOKEN_CONTAINS_NONCE_CLAIM.explanation=A logout token must not contain a "nonce" claim so that the token cannot be used in a forged authentication response in place of an ID token.
+LOGOUT_TOKEN_CONTAINS_NONCE_CLAIM.useraction=Ensure that the logout token does not contain a "nonce" claim.
+
 # STOP HERE, OIDC SERVER HAS RESERVED 1600 - 1649

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
@@ -289,4 +289,8 @@ LOGOUT_TOKEN_CONTAINS_NONCE_CLAIM=CWWKS1549E: The logout token is not valid beca
 LOGOUT_TOKEN_CONTAINS_NONCE_CLAIM.explanation=A logout token must not contain a "nonce" claim so that the token cannot be used in a forged authentication response in place of an ID token.
 LOGOUT_TOKEN_CONTAINS_NONCE_CLAIM.useraction=Ensure that the logout token does not contain a "nonce" claim.
 
+LOGOUT_TOKEN_EVENTS_MEMBER_VALUE_NOT_JSON=CWWKS1550E: The value for the "{0}" member in the "events" claim is not a JSON object.
+LOGOUT_TOKEN_EVENTS_MEMBER_VALUE_NOT_JSON.explanation=The value of the member that is specified in the message must be a JSON object. The value should be the empty JSON object.
+LOGOUT_TOKEN_EVENTS_MEMBER_VALUE_NOT_JSON.useraction=Ensure that the "events" claim in the logout token is formatted correctly.
+
 # STOP HERE, OIDC SERVER HAS RESERVED 1600 - 1649

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidator.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidator.java
@@ -12,6 +12,7 @@ package com.ibm.ws.security.openidconnect.backchannellogout;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.MalformedClaimException;
@@ -29,12 +30,16 @@ import com.ibm.ws.security.openidconnect.client.jose4j.util.Jose4jUtil;
 import com.ibm.ws.security.openidconnect.clients.common.ConvergedClientConfig;
 import com.ibm.ws.security.openidconnect.clients.common.OIDCClientAuthenticatorUtil;
 import com.ibm.ws.security.openidconnect.jose4j.Jose4jValidator;
+import com.ibm.ws.security.openidconnect.token.IDTokenValidationFailedException;
+import com.ibm.ws.security.openidconnect.token.JWTTokenValidationFailedException;
 import com.ibm.wsspi.ssl.SSLSupport;
 
 @Component(name = "com.ibm.ws.security.openidconnect.backchannellogout.LogoutTokenValidator", service = {}, property = { "service.vendor=IBM" })
 public class LogoutTokenValidator {
 
     private static TraceComponent tc = Tr.register(LogoutTokenValidator.class);
+
+    public static final String EVENTS_MEMBER_NAME = "http://schemas.openid.net/event/backchannel-logout";
 
     private static SSLSupport SSL_SUPPORT = null;
 
@@ -71,20 +76,11 @@ public class LogoutTokenValidator {
             JwtClaims claims = jose4jUtil.validateJwsSignature(jwtContext, config);
 
             verifyAllRequiredClaimsArePresent(claims);
-
-            Jose4jValidator validator = getJose4jValidator();
-            // 3. Validate the iss, aud, and iat Claims in the same way they are validated in ID Tokens
-            validator.verifyIssForIdToken(claims.getIssuer());
-            validator.verifyAudForIdToken(claims.getAudience());
-            validator.verifyIatAndExpClaims(claims);
-            // TODO;
-            // 4. Verify that the Logout Token contains a sub Claim, a sid Claim, or both.
-            // 5. Verify that the Logout Token contains an events Claim whose value is JSON object containing the member name http://schemas.openid.net/event/backchannel-logout.
-            // 6. Verify that the Logout Token does not contain a nonce Claim.
-            // 7. Optionally verify that another Logout Token with the same jti value has not been recently received.
-            // 8. Optionally verify that the iss Logout Token Claim matches the iss Claim in an ID Token issued for the current session or a recent session of this RP with the OP.
-            // 9. Optionally verify that any sub Logout Token Claim matches the sub Claim in an ID Token issued for the current session or a recent session of this RP with the OP.
-            // 10. Optionally verify that any sid Logout Token Claim matches the sid Claim in an ID Token issued for the current session or a recent session of this RP with the OP.
+            verifyIssAudIatExpClaims(claims);
+            verifySubAndOrSidPresent(claims);
+            verifyEventsClaim(claims);
+            verifyNonceClaimNotPresent(claims);
+            doOptionalVerificationChecks();
 
         } catch (Exception e) {
             String errorMsg = Tr.formatMessage(tc, "BACKCHANNEL_LOGOUT_TOKEN_ERROR", new Object[] { e });
@@ -121,8 +117,68 @@ public class LogoutTokenValidator {
         }
     }
 
+    /**
+     * Validate the iss, aud, and iat (and exp) Claims in the same way they are validated in ID Tokens.
+     */
+    void verifyIssAudIatExpClaims(JwtClaims claims) throws IDTokenValidationFailedException, Exception, MalformedClaimException, JWTTokenValidationFailedException {
+        Jose4jValidator validator = getJose4jValidator();
+        validator.verifyIssForIdToken(claims.getIssuer());
+        validator.verifyAudForIdToken(claims.getAudience());
+        validator.verifyIatAndExpClaims(claims);
+    }
+
     Jose4jValidator getJose4jValidator() {
         return new Jose4jValidator(null, config.getClockSkewInSeconds(), new OIDCClientAuthenticatorUtil().getIssuerIdentifier(config), config.getClientId(), config.getSignatureAlgorithm(), null);
+    }
+
+    /**
+     * Verifies that the Logout Token contains a sub Claim, a sid Claim, or both.
+     */
+    void verifySubAndOrSidPresent(JwtClaims claims) throws MalformedClaimException, BackchannelLogoutException {
+        String sub = claims.getSubject();
+        String sid = claims.getClaimValue("sid", String.class);
+        if (sub == null && sid == null) {
+            String errorMsg = Tr.formatMessage(tc, "LOGOUT_TOKEN_MISSING_SUB_AND_SID");
+            throw new BackchannelLogoutException(errorMsg);
+        }
+    }
+
+    /**
+     * Verify that the Logout Token contains an events Claim whose value is JSON object containing the member name
+     * http://schemas.openid.net/event/backchannel-logout.
+     */
+    @SuppressWarnings("unchecked")
+    @FFDCIgnore(MalformedClaimException.class)
+    void verifyEventsClaim(JwtClaims claims) throws BackchannelLogoutException {
+        try {
+            Map<String, Object> events = claims.getClaimValue("events", Map.class);
+            if (!events.containsKey(EVENTS_MEMBER_NAME)) {
+                String errorMsg = Tr.formatMessage(tc, "LOGOUT_TOKEN_EVENTS_CLAIM_MISSING_EXPECTED_MEMBER", new Object[] { EVENTS_MEMBER_NAME, events });
+                throw new BackchannelLogoutException(errorMsg);
+            }
+        } catch (MalformedClaimException e) {
+            String errorMsg = Tr.formatMessage(tc, "LOGOUT_TOKEN_EVENTS_CLAIM_WRONG_TYPE", new Object[] { e.getMessage() });
+            throw new BackchannelLogoutException(errorMsg, e);
+        }
+    }
+
+    /**
+     * Verify that the Logout Token does not contain a nonce Claim.
+     */
+    void verifyNonceClaimNotPresent(JwtClaims claims) throws BackchannelLogoutException {
+        Object nonce = claims.getClaimValue("nonce");
+        if (nonce != null) {
+            String errorMsg = Tr.formatMessage(tc, "LOGOUT_TOKEN_CONTAINS_NONCE_CLAIM");
+            throw new BackchannelLogoutException(errorMsg);
+        }
+    }
+
+    void doOptionalVerificationChecks() {
+        // TODO;
+        // 7. Optionally verify that another Logout Token with the same jti value has not been recently received.
+        // 8. Optionally verify that the iss Logout Token Claim matches the iss Claim in an ID Token issued for the current session or a recent session of this RP with the OP.
+        // 9. Optionally verify that any sub Logout Token Claim matches the sub Claim in an ID Token issued for the current session or a recent session of this RP with the OP.
+        // 10. Optionally verify that any sid Logout Token Claim matches the sid Claim in an ID Token issued for the current session or a recent session of this RP with the OP.
     }
 
 }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidator.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidator.java
@@ -147,14 +147,21 @@ public class LogoutTokenValidator {
      * Verify that the Logout Token contains an events Claim whose value is JSON object containing the member name
      * http://schemas.openid.net/event/backchannel-logout.
      */
-    @SuppressWarnings("unchecked")
-    @FFDCIgnore(MalformedClaimException.class)
+    @SuppressWarnings({ "unchecked", "unused" })
+    @FFDCIgnore({ MalformedClaimException.class, ClassCastException.class })
     void verifyEventsClaim(JwtClaims claims) throws BackchannelLogoutException {
         try {
             Map<String, Object> events = claims.getClaimValue("events", Map.class);
             if (!events.containsKey(EVENTS_MEMBER_NAME)) {
                 String errorMsg = Tr.formatMessage(tc, "LOGOUT_TOKEN_EVENTS_CLAIM_MISSING_EXPECTED_MEMBER", new Object[] { EVENTS_MEMBER_NAME, events });
                 throw new BackchannelLogoutException(errorMsg);
+            }
+            try {
+                // Verify that the value is a JSON object
+                Map<String, Object> eventsEntry = (Map<String, Object>) events.get(EVENTS_MEMBER_NAME);
+            } catch (ClassCastException e) {
+                String errorMsg = Tr.formatMessage(tc, "LOGOUT_TOKEN_EVENTS_MEMBER_VALUE_NOT_JSON", new Object[] { EVENTS_MEMBER_NAME });
+                throw new BackchannelLogoutException(errorMsg, e);
             }
         } catch (MalformedClaimException e) {
             String errorMsg = Tr.formatMessage(tc, "LOGOUT_TOKEN_EVENTS_CLAIM_WRONG_TYPE", new Object[] { e.getMessage() });

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidatorTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidatorTest.java
@@ -47,6 +47,7 @@ public class LogoutTokenValidatorTest extends CommonTestClass {
     final String CWWKS1547E_LOGOUT_TOKEN_EVENTS_CLAIM_WRONG_TYPE = "CWWKS1547E";
     final String CWWKS1548E_LOGOUT_TOKEN_EVENTS_CLAIM_MISSING_EXPECTED_MEMBER = "CWWKS1548E";
     final String CWWKS1549E_LOGOUT_TOKEN_CONTAINS_NONCE_CLAIM = "CWWKS1549E";
+    final String CWWKS1550E_LOGOUT_TOKEN_EVENTS_MEMBER_VALUE_NOT_JSON = "CWWKS1550E";
 
     final String CWWKS1751E_OIDC_IDTOKEN_VERIFY_ISSUER_ERR = "CWWKS1751E";
     final String CWWKS1754E_OIDC_IDTOKEN_VERIFY_AUD_ERR = "CWWKS1754E";
@@ -441,6 +442,21 @@ public class LogoutTokenValidatorTest extends CommonTestClass {
             fail("Should have thrown an exception but didn't.");
         } catch (BackchannelLogoutException e) {
             verifyException(e, CWWKS1548E_LOGOUT_TOKEN_EVENTS_CLAIM_MISSING_EXPECTED_MEMBER);
+        }
+    }
+
+    @Test
+    public void test_verifyEventsClaim_memberValueWrongType() throws Exception {
+        JsonObject jsonClaims = getMinimumClaimsNoSid();
+        JsonObject eventsValue = new JsonObject();
+        eventsValue.addProperty(EVENTS_MEMBER_KEY, "string");
+        jsonClaims.add("events", eventsValue);
+        JwtClaims claims = JwtClaims.parse(jsonClaims.toString());
+        try {
+            validator.verifyEventsClaim(claims);
+            fail("Should have thrown an exception but didn't.");
+        } catch (BackchannelLogoutException e) {
+            verifyException(e, CWWKS1550E_LOGOUT_TOKEN_EVENTS_MEMBER_VALUE_NOT_JSON);
         }
     }
 


### PR DESCRIPTION
Adds validation to ensure the logout token:
- Includes a `sid` and/or `sub` claim.
- Contains an `events` claim of the expected type and with the expected member entry
- Does not contain a `nonce` claim

For #20058
For #20060