### PR TITLE
Update JAXRS test case to work with Java 18

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientLtpaTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientLtpaTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -119,7 +119,7 @@ public class JAXRSClientLtpaTest extends AbstractTest {
     @Test
     public void testClientLtpaHandler_ClientWithToken() throws Exception {
         String result = setCookie(true);
-        Assert.assertTrue("Expect access resource with sso successfully: ", result.equals("Hello LTPA Resource"));
+        Assert.assertEquals("Expect access resource with sso successfully: ", "Hello LTPA Resource", result);
     }
 
     @Test
@@ -164,8 +164,17 @@ public class JAXRSClientLtpaTest extends AbstractTest {
         HttpURLConnection resumeConnection = (HttpURLConnection) url
                         .openConnection();
         if (cookieVal != null) {
-            String newCookie = cookieVal.toString().substring(cookieVal.toString().indexOf("HttpOnly,"), cookieVal.toString().indexOf("]"));
-            newCookie = newCookie.replace("Path=/;", "");
+            StringBuilder newCookieBuilder = new StringBuilder();
+            for (String cookie : cookieVal) {
+                if (cookie.indexOf("Expires=") != -1) {
+                    continue;
+                }
+                if (newCookieBuilder.length() != 0) {
+                    newCookieBuilder.append(", ");
+                }
+                newCookieBuilder.append(cookie.replace("Path=/;", ""));
+            }
+            String newCookie = newCookieBuilder.toString();
             Log.info(c, "setCookie", "newCookie: " + newCookie);
 
             if (setCookie) {


### PR DESCRIPTION
- Don't use unreliable substring to get the LtpaToken2 attribute we want.   If the cookie attribute order is different, the cookie includes a WASReqURL with an Expires attribute that we don't want.

#build