### PR TITLE
cleared context defaults to Transaction

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/ConcurrencyTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/ConcurrencyTestServlet.java
@@ -2584,12 +2584,9 @@ public class ConcurrencyTestServlet extends FATServlet {
                 assertEquals("[68]", ListContext.asString()); // unchanged
                 assertEquals(6, Thread.currentThread().getPriority()); // unchanged
                 try {
-                    // TODO need to determine how the absence of context-service.cleared in web.xml is distinguished from
-                    // clearing no context types. ContextServiceDefinition defaults cleared to Transaction, and this test
-                    // case assumed that context-service in web.xml would do the same, but currently it does not,
-                    //assertEquals(Status.STATUS_NO_TRANSACTION, tran.getStatus()); // cleared
+                    assertEquals(Status.STATUS_NO_TRANSACTION, tran.getStatus()); // cleared
                     assertNotNull(InitialContext.doLookup("java:comp/concurrent/dd/web/TZContextService")); // unchanged
-                } catch (NamingException /* | SystemException */ x) {
+                } catch (NamingException | SystemException x) {
                     throw new CompletionException(x);
                 }
             });

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ContextServiceType.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ContextServiceType.java
@@ -60,10 +60,11 @@ public class ContextServiceType extends JNDIEnvironmentRefType implements Contex
 
     @Override
     public String[] getCleared() {
-        if ( cleared != null ) {
-            return cleared.getArray();
+        if ( cleared == null ) {
+            // Per the xsd documentation, "Absent other configuration, cleared context defaults to Transaction."
+            return new String[] { "Transaction" };
         } else {
-            return StringType.ListType.getEmptyArray();
+            return cleared.getArray();
         }
     }
 


### PR DESCRIPTION
When cleared context is absent from a context-service definition in a deployment descriptor, it must default to clearing Transaction context, per the xsd documentation, which also aligns with the default from the ContextServiceDefinition annotation.