### PR TITLE
Reduce to 1 sleep for Custom Repo on UserEnumTest

### DIFF
--- a/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/UserEnumerationTest.java
+++ b/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/UserEnumerationTest.java
@@ -167,7 +167,7 @@ public class UserEnumerationTest {
 
         FederatedRepository federatedRepository = clone.getFederatedRepository();
         federatedRepository.setFailedLoginDelayMax("7s");
-        federatedRepository.setFailedLoginDelayMin("2s");
+        federatedRepository.setFailedLoginDelayMin("2ms");
 
         LDAPFatUtils.updateConfigDynamically(libertyServer, clone);
 
@@ -175,7 +175,7 @@ public class UserEnumerationTest {
          * This message appears in trace only and depends on what you provide in the setFailedLoginDelayMax/Min above.
          */
         assertFalse("Should have logged custom config",
-                    libertyServer.findStringsInLogsAndTrace("2000 and 7000").isEmpty());
+                    libertyServer.findStringsInLogsAndTrace("2 and 7000").isEmpty());
 
         runLoginTestCommon(true);
     }

--- a/dev/com.ibm.ws.security.wim.repository_test.custom.delay/src/com/myorg/SampleCustomRepositoryDelay.java
+++ b/dev/com.ibm.ws.security.wim.repository_test.custom.delay/src/com/myorg/SampleCustomRepositoryDelay.java
@@ -129,13 +129,6 @@ public class SampleCustomRepositoryDelay implements CustomRepository {
      */
     @Override
     public Root login(Root inRoot) throws WIMException {
-        System.out.println(CLASS_NAME + " <login> entry, sleep for test purposes");
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            System.out.println(CLASS_NAME + " Sleep was interrupted");
-        }
-
         System.out.println(CLASS_NAME + " <login> entry, inRoot: \n" + inRoot.toString());
         Root outRoot = new Root();
 


### PR DESCRIPTION
Adjust the sleep time in the Custom test repo for the `UserEnumerationTest` -- we really only need a sleep between the search and login to create an exaggerated difference in the login (originally tested out with 2 sleeps). Also adjusted the `testUserEnumerationCustomConfig` so the window hopefully provides more consistent results on assorted test environments.

RTC 289674