### PR TITLE
Pre-initialize statics for ORB ValueHandler and other classes during applications checkpoint

### DIFF
--- a/dev/com.ibm.ws.transport.iiop/bnd.bnd
+++ b/dev/com.ibm.ws.transport.iiop/bnd.bnd
@@ -69,7 +69,8 @@ instrument.classesExcludes: com/ibm/ws/transport/iiop/resources/*.class
 	com.ibm.ws.org.apache.yoko.core.1.5;version=latest,\
 	com.ibm.ws.org.apache.yoko.rmi.impl.1.5;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest
+	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+	com.ibm.ws.kernel.boot.core;version=latest
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.transport.iiop/src/com/ibm/ws/transport/iiop/internal/ORBWrapperInternal.java
+++ b/dev/com.ibm.ws.transport.iiop/src/com/ibm/ws/transport/iiop/internal/ORBWrapperInternal.java
@@ -18,6 +18,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.rmi.CORBA.Util;
+
 import org.apache.felix.scr.ext.annotation.DSExt;
 import org.omg.CORBA.LocalObject;
 import org.omg.CORBA.ORB;
@@ -48,6 +50,8 @@ import com.ibm.ws.transport.iiop.spi.ServerPolicySource;
 import com.ibm.ws.transport.iiop.spi.SubsystemFactory;
 import com.ibm.wsspi.kernel.service.utils.ConcurrentServiceReferenceMap;
 
+import io.openliberty.checkpoint.spi.CheckpointPhase;
+
 /**
  * Provides access to the ORB.
  */
@@ -70,11 +74,23 @@ public class ORBWrapperInternal extends ServerPolicySourceImpl implements ORBRef
     private final Map<String, Object> extraConfig = new HashMap<>();
 
     private final transient ConcurrentServiceReferenceMap<String, AdapterActivatorOp> map = new ConcurrentServiceReferenceMap<>(KEY);
-
+    
+    private CheckpointPhase checkpointPhase = null;
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL)
+    protected void setCheckpoint(CheckpointPhase checkpointPhase) {
+    	this.checkpointPhase = checkpointPhase;
+    }
+    
     @Activate
     protected void activate(Map<String, Object> properties, ComponentContext cc) throws Exception {
         map.activate(cc);
         super.activate(properties, cc.getBundleContext());
+        try {
+        	if (checkpointPhase == CheckpointPhase.APPLICATIONS) {
+        		Util.createValueHandler().getRunTimeCodeBase();
+        	}
+        } catch (Exception e) {
+        }
         try {
             if (endpoints.isEmpty()) {
                 this.orb = configAdapter.createClientORB(properties, subsystemFactories);

--- a/dev/io.openliberty.checkpoint_fat/.classpath
+++ b/dev/io.openliberty.checkpoint_fat/.classpath
@@ -4,6 +4,7 @@
 	<classpathentry kind="src" path="test-applications/app1/src"/>
 	<classpathentry kind="src" path="test-applications/app2/src"/>
 	<classpathentry kind="src" path="test-applications/mpapp1/src"/>
+	<classpathentry kind="src" path="test-applications/ejbapp1/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>

--- a/dev/io.openliberty.checkpoint_fat/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat/bnd.bnd
@@ -15,7 +15,8 @@ src: \
 	fat/src,\
 	test-applications/app1/src,\
 	test-applications/app2/src,\
-	test-applications/mpapp1/src
+	test-applications/mpapp1/src,\
+	test-applications/ejbapp1/src
 
 
 fat.project: true

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FATSuite.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FATSuite.java
@@ -27,6 +27,7 @@ import componenttest.topology.impl.LibertyServer;
                 TestWithFATServlet2.class,
                 LogsVerificationTest.class,
                 OSGiConsoleTest.class,
+                RemoteEJBTest.class,
                 TestMPConfigServlet.class
 })
 public class FATSuite {

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/RemoteEJBTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/RemoteEJBTest.java
@@ -1,0 +1,169 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.checkpoint.fat;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.io.File;
+import java.util.Iterator;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.FileAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.websphere.simplicity.config.Variable;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfCheckpointNotSupported;
+import componenttest.annotation.TestServlet;
+import componenttest.annotation.TestServlets;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import componenttest.topology.utils.HttpUtils;
+import ejbapp1.EJBEvent;
+import ejbapp1.RemoteEJBServlet;
+import ejbapp1.RemoteInterface;
+import ejbapp1.TestObserver;
+import io.openliberty.checkpoint.fat.TestMPConfigServlet.TestMethod;
+import io.openliberty.checkpoint.spi.CheckpointPhase;
+
+@RunWith(FATRunner.class)
+@SkipIfCheckpointNotSupported
+public class RemoteEJBTest extends FATServletClient {
+
+    public static final String SERVER_NAME = "checkpointEJB";
+    public static final String REMOTE_EJB_APP_NAME = "ejbapp1";
+
+    @Server(SERVER_NAME)
+    @TestServlets({
+                    @TestServlet(servlet = ejbapp1.RemoteEJBServlet.class, contextRoot = REMOTE_EJB_APP_NAME)
+    })
+    public static LibertyServer server;
+
+    @Before
+    public void setUp() throws Exception {
+        System.out.println("***JTD: setUp ");
+        WebArchive ejbMisc = ShrinkWrap.create(WebArchive.class, REMOTE_EJB_APP_NAME + ".war")
+                        .addClass(RemoteEJBServlet.class)
+                        .addClass(TestObserver.class)
+                        .addClass(RemoteInterface.class)
+                        .addClass(EJBEvent.class)
+                        .addPackages(true, RemoteEJBServlet.class.getPackage())
+                        .add(new FileAsset(new File("test-applications/" + REMOTE_EJB_APP_NAME + "/resources/META-INF/permissions.xml")),
+                             "/META-INF/permissions.xml")
+                        .add(new FileAsset(new File("test-applications/" + REMOTE_EJB_APP_NAME + "/resources/WEB-INF/beans.xml")), "/WEB-INF/beans.xml");
+        ShrinkHelper.exportDropinAppToServer(server, ejbMisc, DeployOptions.SERVER_ONLY);
+        TestMethod testMethod = this.getTestMethod();
+        server.setCheckpoint(CheckpointPhase.APPLICATIONS, true,
+                             server -> {
+
+                                 assertNotNull("'SRVE0169I: Loading Web Module: " + REMOTE_EJB_APP_NAME + "' message not found in log before restore",
+                                               server.waitForStringInLogUsingMark("SRVE0169I: .*" + REMOTE_EJB_APP_NAME, 0));
+                                 assertNotNull("'CWWKZ0001I: Application " + REMOTE_EJB_APP_NAME + " started' message not found in log.",
+                                               server.waitForStringInLogUsingMark("CWWKZ0001I: .*" + REMOTE_EJB_APP_NAME, 0));
+                                 configureBeforeRestore(testMethod);
+
+                             });
+        server.startServer();
+
+    }
+
+    public TestMethod getTestMethod() {
+        String testMethodSimpleName = getTestMethodSimpleName();
+        int dot = testMethodSimpleName.indexOf('.');
+        if (dot != -1) {
+            testMethodSimpleName = testMethodSimpleName.substring(dot + 1);
+        }
+        try {
+            return TestMethod.valueOf(testMethodSimpleName);
+        } catch (IllegalArgumentException e) {
+            Log.info(getClass(), testName.getMethodName(), "No configuration enum: " + testMethodSimpleName);
+            return TestMethod.unknown;
+        }
+    }
+
+    private void configureBeforeRestore(TestMethod testMethod) {
+        try {
+            server.saveServerConfiguration();
+            Log.info(getClass(), testName.getMethodName(), "Configuring: " + testMethod);
+            switch (testMethod) {
+                case envValueTest:
+                    // environment value overrides defaultValue in restore
+                    server.copyFileToLibertyServerRoot("envValueTest/server.env");
+                    break;
+                case serverValueTest:
+                    // change config of variable for restore
+                    ServerConfiguration config = removeTestKeyVar(server.getServerConfiguration());
+                    config.getVariables().add(new Variable("test_key", "serverValue"));
+                    server.updateServerConfiguration(config);
+                    break;
+                case annoValueTest:
+                    // remove variable for restore, fall back to default value on annotation
+                    server.updateServerConfiguration(removeTestKeyVar(server.getServerConfiguration()));
+                    break;
+                case envValueChangeTest:
+                    server.copyFileToLibertyServerRoot("envValueChangeTest/server.env");
+                    break;
+                case defaultValueTest:
+                    // Just fall through and do the default (no configuration change)
+                    // should use the defaultValue from server.xml
+                default:
+                    Log.info(getClass(), testName.getMethodName(), "No configuration required: " + testMethod);
+                    break;
+            }
+
+        } catch (Exception e) {
+            throw new AssertionError("Unexpected error configuring test.", e);
+        }
+    }
+
+    private ServerConfiguration removeTestKeyVar(ServerConfiguration config) {
+        for (Iterator<Variable> iVars = config.getVariables().iterator(); iVars.hasNext();) {
+            Variable var = iVars.next();
+            if (var.getName().equals("test_key")) {
+                iVars.remove();
+            }
+        }
+        return config;
+    }
+
+    @Test
+    public void testAtApplicationsMultiRestore() throws Exception {
+        server.setCheckpoint(CheckpointPhase.APPLICATIONS, false, null);
+        HttpUtils.findStringInUrl(server, REMOTE_EJB_APP_NAME, "Got RemoteEJBServlet");
+
+        server.stopServer(false, "");
+        server.checkpointRestore();
+        HttpUtils.findStringInUrl(server, REMOTE_EJB_APP_NAME, "Got RemoteEJBServlet");
+
+        server.stopServer(false, "");
+        server.checkpointRestore();
+        HttpUtils.findStringInUrl(server, REMOTE_EJB_APP_NAME, "Got RemoteEJBServlet");
+    }
+
+    @AfterClass
+    public static void shutdown() throws Exception {
+        if (server != null) {
+            server.stopServer();
+            server.deleteFileFromLibertyServerRoot("server.env");
+        }
+    }
+
+}

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointEJB/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointEJB/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:criu=all

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointEJB/jvm.options
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointEJB/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointEJB/server.xml
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointEJB/server.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+    <featureManager>
+        <feature>cdi-2.0</feature>
+        <feature>ejb-3.2</feature>
+        <feature>servlet-4.0</feature>
+        <feature>componenttest-1.0</feature>
+        <feature>checkpoint-1.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    
+    <variable name="VARIABLE_SOURCE_DIRS" defaultValue="defaultSrcDir" />
+</server>

--- a/dev/io.openliberty.checkpoint_fat/test-applications/ejbapp1/resources/META-INF/permissions.xml
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/ejbapp1/resources/META-INF/permissions.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+    version="7">
+    <permission>
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>getClassLoader</name>
+    </permission>
+
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>*</name>
+        <actions>read,write</actions>
+    </permission>
+</permissions>
+
+

--- a/dev/io.openliberty.checkpoint_fat/test-applications/ejbapp1/resources/WEB-INF/beans.xml
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/ejbapp1/resources/WEB-INF/beans.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd"/>

--- a/dev/io.openliberty.checkpoint_fat/test-applications/ejbapp1/src/ejbapp1/EJBEvent.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/ejbapp1/src/ejbapp1/EJBEvent.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package ejbapp1;
+
+import java.io.Serializable;
+
+@SuppressWarnings("serial")
+public class EJBEvent implements Serializable {
+
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/ejbapp1/src/ejbapp1/RemoteEJBServlet.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/ejbapp1/src/ejbapp1/RemoteEJBServlet.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package ejbapp1;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import javax.ejb.EJB;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import componenttest.app.FATServlet;
+
+@WebServlet("/")
+public class RemoteEJBServlet extends FATServlet {
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    RemoteInterface test;
+
+    @Inject
+    Event<EJBEvent> anEvent;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        anEvent.fire(new EJBEvent());
+        assertTrue(test.observed());
+
+        response.getOutputStream().println("Got RemoteEJBServlet");
+    }
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/ejbapp1/src/ejbapp1/RemoteInterface.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/ejbapp1/src/ejbapp1/RemoteInterface.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package ejbapp1;
+
+import javax.ejb.Remote;
+
+@Remote
+public interface RemoteInterface {
+
+    public boolean observed();
+
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/ejbapp1/src/ejbapp1/TestObserver.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/ejbapp1/src/ejbapp1/TestObserver.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package ejbapp1;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.ejb.Stateful;
+import javax.enterprise.event.Observes;
+
+@Stateful
+public class TestObserver implements RemoteInterface {
+
+    static AtomicBoolean observed = new AtomicBoolean(false);
+
+    public static void observeRemote(@Observes EJBEvent e) {
+        observed.set(true);
+    }
+
+    @Override
+    public boolean observed() {
+        return observed.get();
+    }
+
+}


### PR DESCRIPTION
I'm doing criu testing with the daytrader7 application (specifically the ejb3/PingServlet2Session/Remote servlet), trying to reduce restore times by moving work into the checkpoint phase. Profiles show javax/rmi/CORBA/Util.createValueHandler() and org/apache/yoko/rmi/impl/ValueHandlerImpl.getRunTimeCodeBase() calling static initializers during the first request to the application. We can move those static initializers into the checkpoint time by adding the following call to ORBWrapperInternal.activate:  _Util.createValueHandler().getRunTimeCodeBase()_. This simple change give us a 5-10% reduction in restore time. We will only do this when doing an APPLICATIONS checkpoint, as that is the only phase that shows the gain.