### PR TITLE
Handle delay in example.com response

### DIFF
--- a/dev/com.ibm.ws.security.saml.sso_fat.logout/fat/src/com/ibm/ws/security/saml/fat/logout/common/SAMLLogoutCommonTest.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout/fat/src/com/ibm/ws/security/saml/fat/logout/common/SAMLLogoutCommonTest.java
@@ -518,7 +518,6 @@ public abstract class SAMLLogoutCommonTest extends SAMLCommonTest {
             logoutStep = SAMLConstants.PERFORM_SP_LOGOUT;
             settings.setSpLogoutURL(setIBMSecurityLogoutURL(testSAMLServer));
         }
-        
 
         Log.info(thisClass, thisMethod, "loginPart: " + StringUtils.join(loginPart, ", "));
         Log.info(thisClass, thisMethod, "logoutFlow: " + StringUtils.join(logoutFlow, ", "));
@@ -779,6 +778,10 @@ public abstract class SAMLLogoutCommonTest extends SAMLCommonTest {
             break;
         case IBMSECURITYREMOTE:
         case HTTPSERVLETREMOTE:
+            // overwrite the expectations to remove the 200 status code on the last step - sometimes the call to example.com returns the valid page, but with a 404 status code - looks like it may take too long - allow the other checks to validate we got where we expect
+            if (postLogoutPage.equals(PostLogoutPage.EXTERNALPOSTLOGOUTPAGE)) {
+                expectations = vData.addSuccessStatusCodes(null, lastStep);
+            }
             //        case SPINITIATED:
             expectations = vData.addExpectation(expectations, logoutStep, SAMLConstants.RESPONSE_URL, SAMLConstants.STRING_CONTAINS, "Did not get to the Logout submit page", null, settings.getSpLogoutURL());
             //                        expectations = vData.addExpectation(expectations, SAMLConstants.PROCESS_LOGOUT_REQUEST, SAMLConstants.RESPONSE_TITLE, SAMLConstants.STRING_CONTAINS, "Did not get to the Successful Logout page", null, SAMLConstants.SAML_SHIBBOLETH_LOGIN_HEADER);


### PR DESCRIPTION
Allow for a 404 response after hitting the example.com page - validate page content only to avoid build breaks due to a rare 404 return status code from a site that we do not control.
