### PR TITLE
Move grpc API bundles to be jars instead of bundles in the feature files.

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpc1.0.internal.ee-8.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpc1.0.internal.ee-8.0.feature
@@ -6,7 +6,6 @@ Subsystem-Name: gRPC internal 1.0
   com.ibm.websphere.appserver.servlet-4.0
 -bundles=\
   io.openliberty.grpc.1.0.internal.common, \
-  io.openliberty.io.grpc.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="io.grpc:grpc-api:1.43.2", \
   io.openliberty.grpc.1.0.internal, \
   com.ibm.ws.security.authorization.util
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpc1.0.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpc1.0.internal.ee-9.0.feature
@@ -6,7 +6,6 @@ Subsystem-Name: Jakarta gRPC internal 1.0
   com.ibm.websphere.appserver.servlet-5.0; ibm.tolerates:="6.0"
 -bundles=\
   io.openliberty.grpc.1.0.internal.common.jakarta, \
-  io.openliberty.io.grpc.1.0.jakarta; location:="dev/api/stable/,lib/"; mavenCoordinates="io.grpc:grpc-api:1.43.2", \
   io.openliberty.grpc.1.0.internal.jakarta, \
   com.ibm.ws.security.authorization.util.jakarta
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpcClient1.0.internal.ee-8.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpcClient1.0.internal.ee-8.0.feature
@@ -8,9 +8,7 @@ Subsystem-Name: gRPC Client 1.0
   com.ibm.websphere.appserver.servlet-4.0
 -bundles=\
   io.openliberty.grpc.1.0.internal.common, \
-  io.openliberty.grpc.1.0.internal.client, \
-  io.openliberty.io.grpc.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="io.grpc:grpc-api:1.43.2", \
-  io.openliberty.grpc.client.1.0.thirdparty; location:="dev/api/third-party/,lib/"
+  io.openliberty.grpc.1.0.internal.client
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpcClient1.0.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpcClient1.0.internal.ee-9.0.feature
@@ -8,9 +8,7 @@ Subsystem-Name: Jakarta gRPC Client 1.0
   com.ibm.websphere.appserver.servlet-5.0; ibm.tolerates:="6.0"
 -bundles=\
   io.openliberty.grpc.1.0.internal.common.jakarta, \
-  io.openliberty.grpc.1.0.internal.client.jakarta, \
-  io.openliberty.io.grpc.1.0.jakarta; location:="dev/api/stable/,lib/"; mavenCoordinates="io.grpc:grpc-api:1.43.2", \
-  io.openliberty.grpc.client.1.0.jakarta.thirdparty; location:="dev/api/third-party/,lib/"
+  io.openliberty.grpc.1.0.internal.client.jakarta
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/grpc-1.0/io.openliberty.grpc-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/grpc-1.0/io.openliberty.grpc-1.0.feature
@@ -15,7 +15,9 @@ Subsystem-Name: gRPC 1.0
   io.openliberty.internal.grpc-1.0
 -files=dev/api/ibm/javadoc/io.openliberty.grpc.1.0_1.0-javadoc.zip
 -jars=\
-  io.openliberty.grpc.1.0; location:="dev/api/ibm/,lib/"
+  io.openliberty.grpc.1.0; location:="dev/api/ibm/,lib/", \
+  io.openliberty.io.grpc.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="io.grpc:grpc-api:1.43.2", \
+  io.openliberty.io.grpc.1.0.jakarta; location:="dev/api/stable/,lib/"; mavenCoordinates="io.grpc:grpc-api:1.43.2"
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/grpcClient-1.0/io.openliberty.grpcClient-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/grpcClient-1.0/io.openliberty.grpcClient-1.0.feature
@@ -16,6 +16,11 @@ Subsystem-Name: gRPC Client 1.0
   io.openliberty.grpcClient1.0.internal.ee-8.0; ibm.tolerates:="9.0", \
   com.ibm.websphere.appserver.internal.slf4j-1.7.7, \
   io.openliberty.internal.grpc-1.0
+-jars=\
+  io.openliberty.io.grpc.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="io.grpc:grpc-api:1.43.2", \
+  io.openliberty.io.grpc.1.0.jakarta; location:="dev/api/stable/,lib/"; mavenCoordinates="io.grpc:grpc-api:1.43.2", \
+  io.openliberty.grpc.client.1.0.thirdparty; location:="dev/api/third-party/,lib/", \
+  io.openliberty.grpc.client.1.0.jakarta.thirdparty; location:="dev/api/third-party/,lib/"
 -bundles=\
   io.openliberty.org.apache.commons.logging
 kind=ga

--- a/dev/io.openliberty.grpc.1.0.internal.client.security/bnd.bnd
+++ b/dev/io.openliberty.grpc.1.0.internal.client.security/bnd.bnd
@@ -18,7 +18,9 @@ Bundle-Name: gRPC Client security
 Bundle-SymbolicName: io.openliberty.grpc.1.0.internal.client.security
 Bundle-Description: Liberty gRPC Client security, version ${bVersion}
 
-Import-Package: *
+Import-Package: \
+  io.grpc.netty; version="[1.43.0, 11)",\
+  *
  
 Export-Package: \
   io.openliberty.grpc.internal.client.security.*

--- a/dev/io.openliberty.grpc.1.0.internal.client/bnd.bnd
+++ b/dev/io.openliberty.grpc.1.0.internal.client/bnd.bnd
@@ -10,6 +10,7 @@
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
+grpcVersion=1.43.2
 nettyVersion=4.1.72.Final
 
 Bundle-Name: gRPC Client
@@ -43,7 +44,7 @@ Import-Package: \
   *
 
 Export-Package: \
-  !io.netty.handler.ssl,\
+  io.grpc.netty;version=${grpcVersion}, \
   io.netty.*;version=${nettyVersion},\
   io.openliberty.grpc.internal.client.*,\
   io.openliberty.grpc.client.monitor
@@ -86,7 +87,7 @@ instrument.disabled: true
   io.netty:netty-handler-proxy;version=${nettyVersion},\
   io.netty:netty-resolver;version=${nettyVersion},\
   io.netty:netty-transport;version=${nettyVersion},\
-  io.openliberty.grpc.client.1.0.thirdparty;version=latest,\
+  io.grpc:grpc-netty;version=${grpcVersion},\
   io.openliberty.grpc.1.0.internal.common;version=latest,\
   io.openliberty.io.grpc.1.0;version=latest,\
   org.osgi.service.component.annotations;version=latest


### PR DESCRIPTION
- Move grpc API bundles to the main feature file instead of in the private tolerate features.  With them being in the tolerate features only the preferred internal feature gets picked up as containing API jars in it.
- Update io.openliberty.grpc.1.0.internal.client bundle to contain the classes that are in the thirdparty jars so that the needed classes are found.

#build