### PR TITLE
add concurrencyPolicy trace to help debug intermittent test failure

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta/publish/servers/com.ibm.ws.concurrent.fat.jakarta/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/publish/servers/com.ibm.ws.concurrent.fat.jakarta/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021,2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -9,4 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:concurrent=all:context=all
+com.ibm.ws.logging.trace.specification=*=info:concurrent=all:context=all:concurrencyPolicy=all


### PR DESCRIPTION
Enabling trace in an automated test bucket to help debug an intermittent failure that has currently been seen just once in automated test but never reproduced locally.