### PR TITLE
work-around the failure loading jaxb service provider impl in wss4j-stax/xmlsec init

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/bus/LibertyApplicationBusFactory.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/bus/LibertyApplicationBusFactory.java
@@ -71,7 +71,13 @@ public class LibertyApplicationBusFactory extends CXFBusFactory {
         extensions.put(LibertyApplicationBus.Type.class, LibertyApplicationBus.Type.SERVER);
 
         final ClassLoader moduleClassLoader = moduleInfo.getClassLoader();
-        return createBus(extensions, properties, moduleClassLoader);
+        Object origTccl = THREAD_CONTEXT_ACCESSOR.pushContextClassLoaderForUnprivileged(moduleClassLoader);
+        try {
+            return createBus(extensions, properties, moduleClassLoader);
+        } finally {
+            THREAD_CONTEXT_ACCESSOR.popContextClassLoaderForUnprivileged(origTccl);
+        }
+        //return createBus(extensions, properties, moduleClassLoader);
     }
 
     public LibertyApplicationBus createClientScopedBus(JaxWsModuleMetaData moduleMetaData) {
@@ -85,7 +91,13 @@ public class LibertyApplicationBusFactory extends CXFBusFactory {
         extensions.put(LibertyApplicationBus.Type.class, LibertyApplicationBus.Type.CLIENT);
 
         final ClassLoader moduleClassLoader = moduleInfo.getClassLoader();
-        return createBus(extensions, properties, moduleClassLoader);
+        Object origTccl = THREAD_CONTEXT_ACCESSOR.pushContextClassLoaderForUnprivileged(moduleClassLoader);
+        try {
+            return createBus(extensions, properties, moduleClassLoader);
+        } finally {
+            THREAD_CONTEXT_ACCESSOR.popContextClassLoaderForUnprivileged(origTccl);
+        }
+        //return createBus(extensions, properties, moduleClassLoader);
     }
 
     @Override

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.stax.2.3.0/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.stax.2.3.0/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -16,8 +16,9 @@
   
 instrument.classesExcludes: org/apache/wss4j/stax/setup/*.class
 -buildpath: \
-	org.apache.wss4j:wss4j-ws-security-stax;version='2.3.0',\
+	org.apache.wss4j:wss4j-ws-security-stax;version=2.3.0,\
 	com.ibm.ws.org.apache.wss4j.ws.security.common.2.3.0;version=latest,\
 	com.ibm.ws.org.slf4j.api.1.7.7;version=latest,\
 	com.ibm.ws.org.apache.wss4j.bindings.2.3.0;version=latest,\
-	com.ibm.ws.org.apache.santuario.xmlsec.2.2.0;version=latest
+	com.ibm.ws.org.apache.santuario.xmlsec.2.2.0;version=latest,\
+	io.openliberty.xmlBinding.3.0.internal.tools

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.stax.2.3.0/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.stax.2.3.0/bnd.overrides
@@ -21,6 +21,7 @@ Export-Package: \
  org.apache.wss4j.stax.*
 
 Import-Package: \
+ org.glassfish.jaxb.runtime.v2;resolution:=optional,\
  *
 
 DynamicImport-Package: \


### PR DESCRIPTION
revert the change (to the libertyapplicationbusfactory)that I made to address the issue of where wss4j/xmlsec initialization fails due to the cnfe of the jaxb gf service provide implementation.
reason to revert the libertyapplicationbusfactory change - this may potentially cause problems with loading the external policy attachments.
