### PR TITLE
merging for context service definition

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/resources/WEB-INF/web.xml
@@ -37,7 +37,6 @@
     <priority>10</priority>
   </managed-thread-factory>
 
-<!-- TODO enable to test merging
   <context-service>
     <name>java:app/concurrent/merged/web/LTContextService</name>
     <cleared></cleared>
@@ -50,6 +49,13 @@
     <propagated>Timestamp</propagated>
   </context-service>
 
+  <context-service>
+    <name>java:module/concurrent/merged/web/ZContextService</name>
+    <cleared>Transaction</cleared>
+    <propagated>ZipCode</propagated>
+  </context-service>
+
+<!-- TODO enable to test merging
   <managed-executor>
      <name>java:module/concurrent/merged/web/ZLExecutor</name>
      <max-async>3</max-async>

--- a/dev/com.ibm.ws.injection.core/src/com/ibm/wsspi/injectionengine/InjectionBinding.java
+++ b/dev/com.ibm.ws.injection.core/src/com/ibm/wsspi/injectionengine/InjectionBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2015 IBM Corporation and others.
+ * Copyright (c) 2006, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -815,6 +815,12 @@ implements Formattable
         String module = ivNameSpaceConfig.getModuleName();
         String application = ivNameSpaceConfig.getApplicationName();
         String jndiName = getJndiName();
+
+        if (oldValue instanceof String[])
+            oldValue = Arrays.toString((String[]) oldValue);
+
+        if (newValue instanceof String[])
+            newValue = Arrays.toString((String[]) newValue);
 
         if (xml) {
             Tr.error(tc, "CONFLICTING_XML_VALUES_CWNEN0052E",

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ContextServiceType.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ContextServiceType.java
@@ -62,7 +62,9 @@ public class ContextServiceType extends JNDIEnvironmentRefType implements Contex
     public String[] getCleared() {
         if ( cleared == null ) {
             // Per the xsd documentation, "Absent other configuration, cleared context defaults to Transaction."
-            return new String[] { "Transaction" };
+            // However, we cannot default it here because we need to represent the state of unspecified
+            // so that merging with annotations can be performed correctly.
+            return StringType.ListType.getEmptyArray();
         } else {
             return cleared.getArray();
         }

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceDefinitionBinding.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceDefinitionBinding.java
@@ -11,12 +11,16 @@
 package io.openliberty.concurrent.internal.processor;
 
 import java.lang.reflect.Member;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.javaee.dd.common.ContextService;
 import com.ibm.ws.javaee.dd.common.Description;
 import com.ibm.ws.javaee.dd.common.Property;
@@ -33,10 +37,15 @@ import jakarta.enterprise.concurrent.ContextServiceDefinition;
  * and context-service deployment descriptor element.
  */
 public class ContextServiceDefinitionBinding extends InjectionBinding<ContextServiceDefinition> {
+    private static final TraceComponent tc = Tr.register(ContextServiceDefinitionBinding.class);
+
     private static final String KEY_CLEARED = "cleared";
     private static final String KEY_DESCRIPTION = "description";
     private static final String KEY_PROPAGATED = "propagated";
     private static final String KEY_UNCHANGED = "unchanged";
+
+    private static final String[] DEFAULT_CLEARED = new String[] { ContextServiceDefinition.TRANSACTION };
+    private static final String[] DEFAULT_PROPAGATED = new String[] { ContextServiceDefinition.ALL_REMAINING };
 
     private String[] cleared;
     private boolean XMLcleared;
@@ -70,23 +79,53 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
 
     @Override
     public void merge(ContextServiceDefinition annotation, Class<?> instanceClass, Member member) throws InjectionException {
+        final boolean trace = TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled();
+        if (trace)
+            Tr.entry(this, tc, "merge", annotation, instanceClass, member, annotation.name(),
+                     (XMLcleared ? "(xml)" : "") + "cleared   : " + toString(cleared) + " << " + toString(annotation.cleared()),
+                     (XMLpropagated ? "(xml)" : "") + "propagated: " + toString(propagated) + " << " + toString(annotation.propagated()),
+                     (XMLunchanged ? "(xml)" : "") + "unchanged : " + toString(unchanged) + " << " + toString(annotation.unchanged()));
+
         if (member != null) {
             // ContextServiceDefinition is a class-level annotation only.
             throw new IllegalArgumentException(member.toString());
         }
 
-        cleared = mergeAnnotationValue(cleared, XMLcleared, annotation.cleared(), KEY_CLEARED, new String[] { ContextServiceDefinition.TRANSACTION });
+        cleared = mergeAnnotationValue(cleared == DEFAULT_CLEARED ? null : cleared,
+                                       XMLcleared, annotation.cleared(), KEY_CLEARED, DEFAULT_CLEARED);
+
         description = mergeAnnotationValue(description, XMLDescription, "", KEY_DESCRIPTION, ""); // ContextServiceDefinition has no description attribute
-        propagated = mergeAnnotationValue(propagated, XMLpropagated, annotation.propagated(), KEY_PROPAGATED, new String[] { ContextServiceDefinition.ALL_REMAINING });
+
+        propagated = mergeAnnotationValue(propagated == DEFAULT_PROPAGATED ? null : propagated,
+                                          XMLpropagated, annotation.propagated(), KEY_PROPAGATED, DEFAULT_PROPAGATED);
+
         properties = mergeAnnotationProperties(properties, XMLProperties, new String[] {}); // ContextServiceDefinition has no properties attribute
+
         unchanged = mergeAnnotationValue(unchanged, XMLunchanged, annotation.unchanged(), KEY_UNCHANGED, new String[0]);
+
+        if (trace)
+            Tr.exit(this, tc, "merge", new String[] {
+                                                      (XMLcleared ? "(xml)" : "") + "cleared   = " + toString(cleared),
+                                                      (XMLpropagated ? "(xml)" : "") + "propagated= " + toString(propagated),
+                                                      (XMLunchanged ? "(xml)" : "") + "unchanged = " + toString(unchanged)
+            });
     }
 
     void mergeXML(ContextService csd) throws InjectionConfigurationException {
+        final boolean trace = TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled();
+        if (trace)
+            Tr.entry(this, tc, "mergeXML", csd, csd.getName(),
+                     (XMLcleared ? "(xml)" : "") + "cleared   : " + toString(cleared) + " << " + toString(csd.getCleared()),
+                     (XMLpropagated ? "(xml)" : "") + "propagated: " + toString(propagated) + " << " + toString(csd.getPropagated()),
+                     (XMLunchanged ? "(xml)" : "") + "unchanged : " + toString(unchanged) + " << " + toString(csd.getUnchanged()));
+
         List<Description> descriptionList = csd.getDescriptions();
 
         String[] clearedValues = csd.getCleared();
-        if (clearedValues != null) {
+        if (clearedValues == null || clearedValues.length == 0) {
+            if (cleared == null)
+                cleared = DEFAULT_CLEARED;
+        } else {
             cleared = mergeXMLValue(cleared, clearedValues, "cleared", KEY_CLEARED, null);
             XMLcleared = true;
         }
@@ -97,7 +136,10 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
         }
 
         String[] propagatedValues = csd.getPropagated();
-        if (propagatedValues != null) {
+        if (propagatedValues == null || propagatedValues.length == 0) {
+            if (propagated == null)
+                propagated = DEFAULT_PROPAGATED;
+        } else {
             propagated = mergeXMLValue(propagated, propagatedValues, "propagated", KEY_PROPAGATED, null);
             XMLpropagated = true;
         }
@@ -106,10 +148,17 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
         properties = mergeXMLProperties(properties, XMLProperties, csdProps);
 
         String[] unchangedValues = csd.getUnchanged();
-        if (unchangedValues != null) {
+        if (unchangedValues != null && unchangedValues.length > 0) {
             unchanged = mergeXMLValue(unchanged, unchangedValues, "unchanged", KEY_UNCHANGED, null);
-            XMLunchanged = true;
+            XMLunchanged |= true;
         }
+
+        if (trace)
+            Tr.exit(this, tc, "mergeXML", new String[] {
+                                                         (XMLcleared ? "(xml)" : "") + "cleared   = " + toString(cleared),
+                                                         (XMLpropagated ? "(xml)" : "") + "propagated= " + toString(propagated),
+                                                         (XMLunchanged ? "(xml)" : "") + "unchanged = " + toString(unchanged)
+            });
     }
 
     @Override
@@ -137,5 +186,15 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
         addOrRemoveProperty(props, KEY_UNCHANGED, unchanged);
 
         setObjects(null, createDefinitionReference(null, jakarta.enterprise.concurrent.ContextService.class.getName(), props));
+    }
+
+    @Trivial
+    private static final String toString(String[] list) {
+        if (list == null || list.length == 0)
+            return "Unspecified";
+        boolean none = true;
+        for (int i = 0; none && i < list.length; i++)
+            none &= list[i] == null || list[i].length() == 0;
+        return none ? "None" : Arrays.toString(list);
     }
 }

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceDefinitionProvider.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceDefinitionProvider.java
@@ -63,6 +63,7 @@ public class ContextServiceDefinitionProvider extends InjectionProcessorProvider
     }
 
     class Processor extends InjectionProcessor<ContextServiceDefinition, ContextServiceDefinition.List> {
+        @Trivial
         public Processor() {
             super(ContextServiceDefinition.class, ContextServiceDefinition.List.class);
         }


### PR DESCRIPTION
Implement merging of the context type lists of context service definition between the context-service in web.xml and the ContextServiceDefinition annotation in the web module.  For each category (propagated, cleared, unchanged), the deployment descriptor should override the entire context list if configured there.   Ensure that we can distinguish unspecified from the default value.