### PR TITLE
Removing Jakarta from restfulWS name and path

### DIFF
--- a/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -151,10 +151,10 @@
          </dependency>
          <dependency>
             <groupId>io.openliberty</groupId>
-            <artifactId>io.openliberty.restfulWS30.jsonb20provider.jakarta</artifactId>
+            <artifactId>io.openliberty.restfulWS30.jsonb20provider</artifactId>
             <version>1</version>
             <scope>system</scope>
-            <systemPath>${io.openliberty.restfulWS30.jsonb20provider.jakarta_}</systemPath>
+            <systemPath>${io.openliberty.restfulWS30.jsonb20provider_}</systemPath>
          </dependency>
          <dependency>
             <groupId>org.glassfish</groupId>


### PR DESCRIPTION
Fixes #20510 

io.openliberty.restfulWS30.jsonb20provider.jakarta was changed to no longer transform to Jakarta and now uses the Jakarta API by default, so a name change is required in the TCK pom.xml.
