### PR TITLE
Spruce up command-line help for schemaGen command

### DIFF
--- a/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/Generator.java
+++ b/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/Generator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012,2021 IBM Corporation and others.
+ * Copyright (c) 2012,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -56,6 +56,7 @@ public class Generator {
         // Jump a few numbers for error return codes
         BAD_ARGUMENT(20),
         RUNTIME_EXCEPTION(21),
+        NO_ARGUMENT(22),
 
         // All "actions" should be < 0, these are not returned externally
         HELP_ACTION(-1),
@@ -141,13 +142,18 @@ public class Generator {
                     generate(smtp.getMetatypeInformation());
                     break;
                 case HELP_ACTION:
-                    // Only show command-line-style brief usage -help or --help invoked from command line
-                    System.out.println(MessageFormat.format(options.getString("briefUsageScript"), SCRIPT_NAME));
-                    System.out.println();
+
+                    showPurpose();                    
+                    showBriefUsage();
                     showUsageInfo();
 
                     rc = ReturnCode.OK;
                     break;
+                case NO_ARGUMENT:
+
+                    showPurpose();                    
+                    showBriefUsage();
+                    
                 default:
                     rc = ReturnCode.BAD_ARGUMENT;
                     break;
@@ -201,9 +207,17 @@ public class Generator {
         }
     }
 
-    /**
-     * @param b
-     */
+    private void showPurpose() {
+        System.out.println();
+        System.out.println(MessageFormat.format(options.getString("purpose"), SCRIPT_NAME));
+        System.out.println();
+    }
+    
+    private void showBriefUsage() {
+        System.out.println(MessageFormat.format(options.getString("briefUsageScript"), SCRIPT_NAME));
+        System.out.println();
+    }
+
     private void showUsageInfo() {
         final String okpfx = "option-key.";
         final String odpfx = "option-desc.";

--- a/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/GeneratorOptions.java
+++ b/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/GeneratorOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -78,6 +78,10 @@ public class GeneratorOptions {
      */
     public ReturnCode processArgs(String[] args) {
         ReturnCode rc = ReturnCode.OK;
+        
+        if ((args.length == 0)) {
+            return ReturnCode.NO_ARGUMENT;
+        }
 
         for (int i = 0; i < args.length; i++) {
             String arg = args[i];
@@ -92,7 +96,7 @@ public class GeneratorOptions {
                     } catch (IOException ex) {
                         System.out.println(MessageFormat.format(messages.getString("error.fileNotFound"), args[i]));
                         System.out.println();
-                        rc = ReturnCode.BAD_ARGUMENT;
+                        return(ReturnCode.BAD_ARGUMENT);
                     }
                 } else if (argToLower.contains("-encoding")) {
                     setEncoding(getArgumentValue(args[i]));
@@ -107,7 +111,7 @@ public class GeneratorOptions {
                 }  else {
                     System.out.println(MessageFormat.format(messages.getString("error.unknownArgument"), arg));
                     System.out.println();
-                    rc = ReturnCode.BAD_ARGUMENT;
+                    return(ReturnCode.BAD_ARGUMENT);
                 }
             } else {
                 if (outputFile != null) {

--- a/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
+++ b/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
@@ -480,6 +480,13 @@ error.bad.variable.file=CWWKG0106E: The {0} file can not be read.
 error.bad.variable.file.explanation=The file can not be loaded as a variable because it can not be read. 
 error.bad.variable.file.useraction=Verify that the file contains text content and check the operating system permissions for the file.
 
+error.unknownOutputVersion=CWWKG0107E: The output version, {0}, is not supported.
+error.unknownOutputVersion.explanation=The value supplied with the "--ouputVersion" option is not valid.
+error.unknownOutputVersion.useraction=To see valid options enter the "./schemaGen --help" command.
+
+error.unknownSchemaVersion=CWWKG0108E: The schema version, {0}, is not supported.
+error.unknownSchemaVersion.explanation=The value supplied with the "--schemaVersion" option is not valid.
+error.unknownSchemaVersion.useraction=To see valid options enter the "./schemaGen --help" command.
 
 # Non-TR message
 error.invalidOCDRef=ERROR: Metatype PID [{0}] specifies non-existent object class definition ID [{1}]

--- a/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigOptions.nlsprops
+++ b/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigOptions.nlsprops
@@ -14,11 +14,16 @@
 # NLS_MESSAGEFORMAT_VAR
 
 #------------------------------\n at 72 chars -- leading tab-----------\n\#
+purpose=\
+The {0} command generates the XML schema for the                       \n\
+Liberty core configuration and other installed products                \n\
+extensions in a single output file.
+
 briefUsage=\
-Usage: java [JVM options] -jar {0} [options] outputFile  
+Usage: java [JVM options] -jar {0} [options] outputFile
+  
 briefUsageScript=\
 Usage: ./{0} [options] outputFile
-
 
 use.options=Options:
 # -------- OPTIONS ----------------------------------------------------#
@@ -27,13 +32,18 @@ use.options=Options:
 # whitespace, and begin descriptions with \t 
 #------------------------------\n at 72 chars -- leading tab-----------\n\#
 option-key.ignorePids=--ignorePidsFile
-option-desc.ignorePids=A file name containing a list of pids to ignore
+option-desc.ignorePids=A file name containing a list of pids to ignore.
 option-key.encoding=--encoding
-option-desc.encoding=The character encoding to use for the output
+option-desc.encoding=The character encoding to use for the output.
 option-key.locale=--locale
-option-desc.locale=The locale to use for the output
+option-desc.locale=The language to use when you are creating the output\n\
+file. This string consists of the ISO-639 two-letter lowercase language\n\
+code, optionally followed by and underscores and the ISO-3166 uppercase\n\
+two-letter country code.
+
 option-key.compactoutput=--compactOutput
-option-desc.compactoutput=The output schema will not contain indenting spaces, new line feeds, or XML comments
+option-desc.compactoutput=The output schema will not contain indenting \n\
+spaces, new line feeds, or XML comments.
 option-key.productExtension=--productExtension
 option-desc.productExtension=\
 The product extension name to be processed.                            \n\
@@ -45,13 +55,13 @@ option-key.schemaVersion=--schemaVersion
 
 # "schemaVersion=1.1" is not translated.  "xsd:any" is not translated
 option-desc.schemaVersion=\
-If schemaVersion=1.1 is specified, then both explicitly named child \n\
+If schemaVersion=1.1 is specified, then both explicitly named child    \n\
 elements and the xsd:any element are written to the output file.
 
 option-key.outputVersion=--outputVersion
 
 # "outputVersion=2.0" is not translated.  "xsd:any" is not translated
 option-desc.outputVersion=\
-If outputVersion=2.0 is specified, only the xsd:any element is used \n\
-in the output file, so that unknown elements pass XSD validation at \n\
+If outputVersion=2.0 is specified, only the xsd:any element is used    \n\
+in the output file, so that unknown elements pass XSD validation at    \n\
 the expense of losing validation for known elements.


### PR DESCRIPTION
-------------
What's new?
-------------

Fixes  #20508

When no arguments are entered, display a blurb about what the command does.
Display basic syntax.

When -help or --help is in the argument list, display full help info for the command.

-    Added consistency in use of periods
-    locale option now matches what is documented online

When an invalid argument is entered, display an error message, and stop processing.

-----------------------------------------------------------------
  No parameters
-----------------------------------------------------------------
~/libertyGit/open-liberty/dev/build.image/wlp/bin >>> ./schemaGen

The schemaGen command generates the XML schema for the                       
Liberty core configuration and other installed products                
extensions in a single output file.

Usage: ./schemaGen [options] outputFile


-----------------------------------------------------------------------
   -help or --help option
-----------------------------------------------------------------------
~/libertyGit/open-liberty/dev/build.image/wlp/bin >>> ./schemaGen -help

The schemaGen command generates the XML schema for the                       
Liberty core configuration and other installed products                
extensions in a single output file.

Usage: ./schemaGen [options] outputFile

Options:

--compactOutput
The output schema will not contain indenting 
spaces, new line feeds, or XML comments.

--encoding
The character encoding to use for the output.

--ignorePidsFile
A file name containing a list of pids to ignore.

--locale
The language to use when you are creating the output
file. This string consists of the ISO-639 two-letter lowercase language
code, optionally followed by and underscores and the ISO-3166 uppercase
two-letter country code.

--outputVersion
If outputVersion=2.0 is specified, only the xsd:any element is used    
in the output file, so that unknown elements pass XSD validation at    
the expense of losing validation for known elements.

--schemaVersion
If schemaVersion=1.1 is specified, then both explicitly named child    
elements and the xsd:any element are written to the output file.

-----------------------------------------------------------------------
 Invalid option case
-----------------------------------------------------------------------
~/libertyGit/open-liberty/dev/build.image/wlp/bin >>> ./schemaGen -fred
CWWKG0035E: Unknown option: -fred

