### PR TITLE
Preload classes for all checkpoint types

### DIFF
--- a/dev/com.ibm.ws.transport.iiop/src/com/ibm/ws/transport/iiop/internal/ORBWrapperInternal.java
+++ b/dev/com.ibm.ws.transport.iiop/src/com/ibm/ws/transport/iiop/internal/ORBWrapperInternal.java
@@ -86,7 +86,7 @@ public class ORBWrapperInternal extends ServerPolicySourceImpl implements ORBRef
         map.activate(cc);
         super.activate(properties, cc.getBundleContext());
         try {
-        	if (checkpointPhase == CheckpointPhase.APPLICATIONS) {
+        	if (checkpointPhase != null) {
         		Util.createValueHandler().getRunTimeCodeBase();
         	}
         } catch (Exception e) {


### PR DESCRIPTION
Previous PR 20471 should have done the class preload for all checkpoint types, as the ORBWrapperInternal.activate happens during checkpoint for all checkpoint types. 
