### PR TITLE
Removing the problematic pom file from built jar

### DIFF
--- a/dev/com.ibm.ws.net.sf.ehcache.core/bnd.bnd
+++ b/dev/com.ibm.ws.net.sf.ehcache.core/bnd.bnd
@@ -11,6 +11,6 @@
 -include= jar:${fileuri;${repo;net.sf.ehcache:ehcache-core;2.5.2}}!/META-INF/MANIFEST.MF,bnd.overrides
 
 -includeresource: \
-   @${repo;net.sf.ehcache:ehcache-core;2.5.2}
+   @${repo;net.sf.ehcache:ehcache-core;2.5.2}!/!META-INF/MANIFEST.MF|META-INF/maven/*
 
 -buildpath: net.sf.ehcache:ehcache-core;version=2.5.2


### PR DESCRIPTION
Making sure the Meta-Inf/maven directory isn't shipped in built bundle.   Not used in build.