### PR TITLE
merging for managed executor definitions

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/resources/WEB-INF/web.xml
@@ -55,10 +55,9 @@
     <propagated>ZipCode</propagated>
   </context-service>
 
-<!-- TODO enable to test merging
   <managed-executor>
-     <name>java:module/concurrent/merged/web/ZLExecutor</name>
-     <max-async>3</max-async>
+    <name>java:module/concurrent/merged/web/ZLExecutor</name>
+    <max-async>3</max-async>
   </managed-executor>
 
   <managed-executor>
@@ -87,6 +86,5 @@
     <name>java:app/concurrent/merged/web/LTThreadFactory</name>
     <priority>8</priority>
   </managed-thread-factory>
--->
 
 </web-app>

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/ConcurrencyTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/ConcurrencyTestServlet.java
@@ -146,32 +146,31 @@ import test.jakarta.concurrency.ejb.MTFDBean;
                           propagated = { ListContext.CONTEXT_NAME, Timestamp.CONTEXT_NAME }, // web.xml replaces with ZipCode
                           unchanged = ALL_REMAINING)
 
-//TODO enable in web.xml and update the following,
 @ManagedExecutorDefinition(name = "java:module/concurrent/merged/web/ZLExecutor",
                            context = "java:module/concurrent/ZLContextSvc",
-                           maxAsync = 3, // TODO 6, // web.xml replaces with 3
+                           maxAsync = 6, // web.xml replaces with 3
                            hungTaskThreshold = 360000)
 
 @ManagedExecutorDefinition(name = "java:comp/concurrent/merged/web/ZPExecutor",
-                           context = "java:app/concurrent/dd/ZPContextService", // TODO "java:comp/concurrent/dd/web/TZContextService", // web.xml replaces with ZPContextService
+                           context = "java:comp/concurrent/dd/web/TZContextService", // web.xml replaces with ZPContextService
                            maxAsync = 2)
 
 @ManagedScheduledExecutorDefinition(name = "java:module/concurrent/merged/web/ZLScheduledExecutor",
                                     context = "java:module/concurrent/ZLContextSvc",
-                                    maxAsync = 1, // TODO 7, // web.xml replaces with 1
+                                    maxAsync = 7, // web.xml replaces with 1
                                     hungTaskThreshold = 170000)
 
 @ManagedScheduledExecutorDefinition(name = "java:app/concurrent/merged/web/LPScheduledExecutor",
-                                    context = "java:global/concurrent/anno/ejb/LPContextService", // TODO "java:app/concurrent/dd/ZPContextService", // web.xml replaces with LPContextService
+                                    context = "java:app/concurrent/dd/ZPContextService", // web.xml replaces with LPContextService
                                     maxAsync = 4)
 
 @ManagedThreadFactoryDefinition(name = "java:comp/concurrent/merged/web/TZThreadFactory",
-                                context = "java:comp/concurrent/dd/web/TZContextService", // TODO "java:module/concurrent/ZLContextSvc", // web.xml replaces with TZContextService
+                                context = "java:module/concurrent/ZLContextSvc", // web.xml replaces with TZContextService
                                 priority = 3)
 
 @ManagedThreadFactoryDefinition(name = "java:app/concurrent/merged/web/LTThreadFactory",
                                 context = "java:app/concurrent/merged/web/LTContextService",
-                                priority = 8) // TODO priority = 4) // web.xml replaces with 8
+                                priority = 4) // web.xml replaces with 8
 
 @SuppressWarnings("serial")
 @WebServlet("/*")

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedExecutorType.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedExecutorType.java
@@ -54,7 +54,7 @@ public class ManagedExecutorType extends JNDIEnvironmentRefType implements Manag
     
     @Override
     public String getContextServiceRef() {
-        return contextServiceRef.getValue();
+        return contextServiceRef == null ? null : contextServiceRef.getValue();
     }
 
     @Override

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedScheduledExecutorType.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedScheduledExecutorType.java
@@ -54,7 +54,7 @@ public class ManagedScheduledExecutorType extends JNDIEnvironmentRefType impleme
     
     @Override
     public String getContextServiceRef() {
-        return contextServiceRef.getValue();
+        return contextServiceRef == null ? null : contextServiceRef.getValue();
     }
 
     @Override

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedThreadFactoryType.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedThreadFactoryType.java
@@ -53,7 +53,7 @@ public class ManagedThreadFactoryType extends JNDIEnvironmentRefType implements 
     
     @Override
     public String getContextServiceRef() {
-        return contextServiceRef.getValue();
+        return contextServiceRef == null ? null : contextServiceRef.getValue();
     }
 
     @Override

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/AppDefinedResourceFactory.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/AppDefinedResourceFactory.java
@@ -23,6 +23,7 @@ import org.osgi.util.tracker.ServiceTracker;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.resource.ResourceFactoryBuilder;
 import com.ibm.ws.resource.ResourceRefInfo;
@@ -160,6 +161,7 @@ public class AppDefinedResourceFactory implements com.ibm.ws.resource.ResourceFa
      * @see com.ibm.ws.resource.ResourceFactory#createResource(com.ibm.ws.resource.ResourceRefInfo)
      */
     @Override
+    @Trivial
     public Object createResource(ResourceRefInfo ref) throws Exception {
         return createResource((ResourceInfo) ref);
     }

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceDefinitionBinding.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceDefinitionBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -81,10 +81,10 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
     public void merge(ContextServiceDefinition annotation, Class<?> instanceClass, Member member) throws InjectionException {
         final boolean trace = TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled();
         if (trace)
-            Tr.entry(this, tc, "merge", annotation, instanceClass, member, annotation.name(),
-                     (XMLcleared ? "(xml)" : "") + "cleared   : " + toString(cleared) + " << " + toString(annotation.cleared()),
-                     (XMLpropagated ? "(xml)" : "") + "propagated: " + toString(propagated) + " << " + toString(annotation.propagated()),
-                     (XMLunchanged ? "(xml)" : "") + "unchanged : " + toString(unchanged) + " << " + toString(annotation.unchanged()));
+            Tr.entry(this, tc, "merge", toString(annotation), instanceClass, member,
+                     (XMLcleared ? "   (xml)" : "        ") + "cleared: " + toString(cleared) + " << " + toString(annotation.cleared()),
+                     (XMLpropagated ? "(xml)" : "     ") + "propagated: " + toString(propagated) + " << " + toString(annotation.propagated()),
+                     (XMLunchanged ? " (xml)" : "      ") + "unchanged: " + toString(unchanged) + " << " + toString(annotation.unchanged()));
 
         if (member != null) {
             // ContextServiceDefinition is a class-level annotation only.
@@ -105,9 +105,9 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
 
         if (trace)
             Tr.exit(this, tc, "merge", new String[] {
-                                                      (XMLcleared ? "(xml)" : "") + "cleared   = " + toString(cleared),
-                                                      (XMLpropagated ? "(xml)" : "") + "propagated= " + toString(propagated),
-                                                      (XMLunchanged ? "(xml)" : "") + "unchanged = " + toString(unchanged)
+                                                      (XMLcleared ? "   (xml)" : "        ") + "cleared= " + toString(cleared),
+                                                      (XMLpropagated ? "(xml)" : "     ") + "propagated= " + toString(propagated),
+                                                      (XMLunchanged ? " (xml)" : "      ") + "unchanged= " + toString(unchanged)
             });
     }
 
@@ -115,9 +115,9 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
         final boolean trace = TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled();
         if (trace)
             Tr.entry(this, tc, "mergeXML", csd, csd.getName(),
-                     (XMLcleared ? "(xml)" : "") + "cleared   : " + toString(cleared) + " << " + toString(csd.getCleared()),
-                     (XMLpropagated ? "(xml)" : "") + "propagated: " + toString(propagated) + " << " + toString(csd.getPropagated()),
-                     (XMLunchanged ? "(xml)" : "") + "unchanged : " + toString(unchanged) + " << " + toString(csd.getUnchanged()));
+                     (XMLcleared ? "   (xml)" : "        ") + "cleared: " + toString(cleared) + " << " + toString(csd.getCleared()),
+                     (XMLpropagated ? "(xml)" : "     ") + "propagated: " + toString(propagated) + " << " + toString(csd.getPropagated()),
+                     (XMLunchanged ? " (xml)" : "      ") + "unchanged: " + toString(unchanged) + " << " + toString(csd.getUnchanged()));
 
         List<Description> descriptionList = csd.getDescriptions();
 
@@ -155,9 +155,9 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
 
         if (trace)
             Tr.exit(this, tc, "mergeXML", new String[] {
-                                                         (XMLcleared ? "(xml)" : "") + "cleared   = " + toString(cleared),
-                                                         (XMLpropagated ? "(xml)" : "") + "propagated= " + toString(propagated),
-                                                         (XMLunchanged ? "(xml)" : "") + "unchanged = " + toString(unchanged)
+                                                         (XMLcleared ? "   (xml)" : "        ") + "cleared= " + toString(cleared),
+                                                         (XMLpropagated ? "(xml)" : "     ") + "propagated= " + toString(propagated),
+                                                         (XMLunchanged ? " (xml)" : "      ") + "unchanged= " + toString(unchanged)
             });
     }
 
@@ -186,6 +186,18 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
         addOrRemoveProperty(props, KEY_UNCHANGED, unchanged);
 
         setObjects(null, createDefinitionReference(null, jakarta.enterprise.concurrent.ContextService.class.getName(), props));
+    }
+
+    @Trivial
+    static final String toString(ContextServiceDefinition anno) {
+        StringBuilder b = new StringBuilder();
+        b.append("ContextServiceDefinition@").append(Integer.toHexString(anno.hashCode())) //
+                        .append("(name=").append(anno.name()) //
+                        .append(", cleared=").append(Arrays.toString(anno.cleared())) //
+                        .append(", propagated=").append(Arrays.toString(anno.propagated())) //
+                        .append(", unchanged=").append(Arrays.toString(anno.unchanged())) //
+                        .append(")");
+        return b.toString();
     }
 
     @Trivial

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceDefinitionProvider.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceDefinitionProvider.java
@@ -17,6 +17,8 @@ import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.javaee.dd.common.ContextService;
 import com.ibm.ws.javaee.dd.common.JNDIEnvironmentRef;
@@ -35,6 +37,8 @@ import jakarta.enterprise.concurrent.ContextServiceDefinition;
 public class ContextServiceDefinitionProvider extends InjectionProcessorProvider<ContextServiceDefinition, ContextServiceDefinition.List> {
 
     static final SecureAction priv = AccessController.doPrivileged(SecureAction.get());
+
+    private static final TraceComponent tc = Tr.register(ContextServiceDefinitionProvider.class);
 
     private static final List<Class<? extends JNDIEnvironmentRef>> REF_CLASSES = //
                     Collections.<Class<? extends JNDIEnvironmentRef>> singletonList(ContextService.class);
@@ -72,18 +76,37 @@ public class ContextServiceDefinitionProvider extends InjectionProcessorProvider
         public InjectionBinding<ContextServiceDefinition> createInjectionBinding(ContextServiceDefinition annotation,
                                                                                  Class<?> instanceClass, Member member,
                                                                                  String jndiName) throws InjectionException {
+            final boolean trace = TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled();
+            if (trace)
+                Tr.entry(this, tc, "createInjectionBinding", ContextServiceDefinitionBinding.toString(annotation), instanceClass, member, jndiName);
+
             InjectionBinding<ContextServiceDefinition> injectionBinding = //
                             new ContextServiceDefinitionBinding(jndiName, ivNameSpaceConfig);
             injectionBinding.merge(annotation, instanceClass, null);
+
+            if (trace)
+                Tr.exit(this, tc, "createInjectionBinding", injectionBinding);
             return injectionBinding;
         }
 
         @Override
+        @Trivial
         public ContextServiceDefinition[] getAnnotations(ContextServiceDefinition.List pluralAnnotation) {
-            return pluralAnnotation.value();
+            ContextServiceDefinition[] annos = pluralAnnotation.value();
+
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Object[] a = new String[annos.length];
+                for (int i = 0; i < annos.length; i++)
+                    a[i] = new StringBuilder().append("ContextServiceDefinition@").append(Integer.toHexString(annos[i].hashCode())) //
+                                    .append(' ').append(annos[i].name()) //
+                                    .toString();
+                Tr.debug(this, tc, "getAnnotations", a);
+            }
+            return annos;
         }
 
         @Override
+        @Trivial
         public String getJndiName(ContextServiceDefinition annotation) {
             return annotation.name();
         }

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedScheduledExecutorDefinitionBinding.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedScheduledExecutorDefinitionBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.javaee.dd.common.Description;
 import com.ibm.ws.javaee.dd.common.ManagedScheduledExecutor;
 import com.ibm.ws.javaee.dd.common.Property;
@@ -34,6 +37,8 @@ import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
  * and managed-scheduled-executor deployment descriptor element.
  */
 public class ManagedScheduledExecutorDefinitionBinding extends InjectionBinding<ManagedScheduledExecutorDefinition> {
+    private static final TraceComponent tc = Tr.register(ManagedScheduledExecutorDefinitionBinding.class);
+
     private static final String KEY_CONTEXT = "context";
     private static final String KEY_DESCRIPTION = "description";
     private static final String KEY_HUNG_TASK_THRESHOLD = "hungTaskThreshold";
@@ -71,6 +76,13 @@ public class ManagedScheduledExecutorDefinitionBinding extends InjectionBinding<
 
     @Override
     public void merge(ManagedScheduledExecutorDefinition annotation, Class<?> instanceClass, Member member) throws InjectionException {
+        final boolean trace = TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled();
+        if (trace)
+            Tr.entry(this, tc, "merge", toString(annotation), instanceClass, member,
+                     (XMLContextServiceRef ? "(xml)" : "     ") + "contextServiceRef: " + contextServiceJndiName + " << " + annotation.context(),
+                     (XMLHungTaskThreshold ? "(xml)" : "     ") + "hungTaskThreshold: " + hungTaskThreshold + " << " + annotation.hungTaskThreshold(),
+                     (XMLMaxAsync ? "         (xml)" : "              ") + "maxAsync: " + maxAsync + " << " + annotation.maxAsync());
+
         if (member != null) {
             // ManagedScheduledExecutorDefinition is a class-level annotation only.
             throw new IllegalArgumentException(member.toString());
@@ -81,9 +93,23 @@ public class ManagedScheduledExecutorDefinitionBinding extends InjectionBinding<
         hungTaskThreshold = mergeAnnotationValue(hungTaskThreshold, XMLHungTaskThreshold, annotation.hungTaskThreshold(), KEY_HUNG_TASK_THRESHOLD, -1L);
         maxAsync = mergeAnnotationValue(maxAsync, XMLMaxAsync, annotation.maxAsync(), KEY_MAX_ASYNC, -1);
         properties = mergeAnnotationProperties(properties, XMLProperties, new String[] {}); // ManagedScheduledExecutorDefinition has no properties attribute
+
+        if (trace)
+            Tr.exit(this, tc, "merge", new String[] {
+                                                      (XMLContextServiceRef ? "(xml)" : "     ") + "contextServiceRef= " + contextServiceJndiName,
+                                                      (XMLHungTaskThreshold ? "(xml)" : "     ") + "hungTaskThreshold= " + hungTaskThreshold,
+                                                      (XMLMaxAsync ? "         (xml)" : "              ") + "maxAsync= " + maxAsync
+            });
     }
 
     void mergeXML(ManagedScheduledExecutor mxd) throws InjectionConfigurationException {
+        final boolean trace = TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled();
+        if (trace)
+            Tr.entry(this, tc, "mergeXML", mxd, mxd.getName(),
+                     (XMLContextServiceRef ? "(xml)" : "     ") + "contextServiceRef: " + contextServiceJndiName + " << " + mxd.getContextServiceRef(),
+                     (XMLHungTaskThreshold ? "(xml)" : "     ") + "hungTaskThreshold: " + hungTaskThreshold + " << " + mxd.getHungTaskThreshold(),
+                     (XMLMaxAsync ? "         (xml)" : "              ") + "maxAsync: " + maxAsync + " << " + mxd.getMaxAsync());
+
         List<Description> descriptionList = mxd.getDescriptions();
 
         String contextServiceRefValue = mxd.getContextServiceRef();
@@ -109,6 +135,13 @@ public class ManagedScheduledExecutorDefinitionBinding extends InjectionBinding<
 
         List<Property> mxdProps = mxd.getProperties();
         properties = mergeXMLProperties(properties, XMLProperties, mxdProps);
+
+        if (trace)
+            Tr.exit(this, tc, "mergeXML", new String[] {
+                                                         (XMLContextServiceRef ? "(xml)" : "     ") + "contextServiceRef= " + contextServiceJndiName,
+                                                         (XMLHungTaskThreshold ? "(xml)" : "     ") + "hungTaskThreshold= " + hungTaskThreshold,
+                                                         (XMLMaxAsync ? "         (xml)" : "              ") + "maxAsync= " + maxAsync
+            });
     }
 
     @Override
@@ -136,5 +169,17 @@ public class ManagedScheduledExecutorDefinitionBinding extends InjectionBinding<
         addOrRemoveProperty(props, KEY_MAX_ASYNC, maxAsync);
 
         setObjects(null, createDefinitionReference(null, ManagedScheduledExecutorService.class.getName(), props));
+    }
+
+    @Trivial
+    static final String toString(ManagedScheduledExecutorDefinition anno) {
+        StringBuilder b = new StringBuilder();
+        b.append("ManagedScheduledExecutorDefinition@").append(Integer.toHexString(anno.hashCode())) //
+                        .append("(name=").append(anno.name()) //
+                        .append(", context=").append(anno.context()) //
+                        .append(", hungTaskThreshold=").append(anno.hungTaskThreshold()) //
+                        .append(", maxAsync=").append(anno.maxAsync()) //
+                        .append(")");
+        return b.toString();
     }
 }


### PR DESCRIPTION
Implementation and test coverage of merging managed executor definitions from deployment descriptors with managed executor definition annotations.  Also for managed scheduled executor definitions and managed thread factory definitions.