### PR TITLE
Create a unit test for schemaGen script

### DIFF
--- a/dev/com.ibm.ws.config.schemagen/test/com/ibm/ws/config/schemagen/internal/SchemaGenTest.java
+++ b/dev/com.ibm.ws.config.schemagen/test/com/ibm/ws/config/schemagen/internal/SchemaGenTest.java
@@ -27,12 +27,13 @@ import org.junit.Test;
  */
 public class SchemaGenTest {
 
-    public static String WLP_BIN_DIR = "../build.image/wlp/bin";
-    public static String OUTPUT_FILE = "schemaGenOutput.xsd";
-    public static String HELP_OPTION = "-help";
-    public static String SCHEMAGEN_BAT = "./schemaGen.bat";
-    public static String SCHEMAGEN_LINUX_SCRIPT = "./schemaGen";
-    public static long TIMEOUT = 30_000_000_000L;  // 30-second timeout
+    public static final String WLP_BIN_DIR = "../build.image/wlp/bin";
+    public static final String OUTPUT_FILE = "schemaGenOutput.xsd";
+    public static final String HELP_OPTION = "-help";
+    public static final String SCHEMAGEN_BAT = "./schemaGen.bat";
+    public static final String SCHEMAGEN_LINUX_SCRIPT = "./schemaGen";
+    public static final long TIMEOUT = 30_000_000_000L;  // 30-second timeout
+    public static final int MAX_OUTPUT_LINES = 500;      // Reasonable limit to output to standard output by schemaGen
     public static final boolean IS_WINDOWS = isWindows();
 
     public static boolean isWindows() {
@@ -86,8 +87,12 @@ public class SchemaGenTest {
                     encodingAppears = true;
                 }
 
-                if ((lineCounter++ > 500) 
-                        || (System.nanoTime() - startTime >  TIMEOUT)) {
+                // Exit loop if we are getting hung
+                if (lineCounter++ > MAX_OUTPUT_LINES) {
+                    System.out.println("schemaGen usage info exceeded [ " + MAX_OUTPUT_LINES + " ] lines");
+                    break;
+                } else if (System.nanoTime() - startTime >  TIMEOUT) {
+                    System.out.println("SchemaGen exceeded [ " + TIMEOUT + " ] ns  when displaying usage Info");
                     break;
                 }
             }
@@ -145,8 +150,12 @@ public class SchemaGenTest {
                     encodingAppears = true;
                 }
 
-                if ((lineCounter++ > 500) 
-                        || (System.nanoTime() - startTime >  TIMEOUT)) {
+                // Exit loop if we are getting hung
+                if (lineCounter++ > MAX_OUTPUT_LINES) {
+                    System.out.println("schemaGen help exceeded [ " + MAX_OUTPUT_LINES + " ] lines");
+                    break;
+                } else if (System.nanoTime() - startTime >  TIMEOUT) {
+                    System.out.println("schemaGen exceeded [ " + TIMEOUT + " ] ns when displaying help");
                     break;
                 }
             }

--- a/dev/com.ibm.ws.config.schemagen/test/com/ibm/ws/config/schemagen/internal/SchemaGenTest.java
+++ b/dev/com.ibm.ws.config.schemagen/test/com/ibm/ws/config/schemagen/internal/SchemaGenTest.java
@@ -39,8 +39,11 @@ public class SchemaGenTest {
     public void testSchemaGenNoParms() {
         System.out.println("==================== testSchemaGenNoParms ...");
 
+        ProcessBuilder pb;
+        Process p = null;
+        
         try {
-            ProcessBuilder pb;
+            
             if (isWindows()) {
                 pb = new ProcessBuilder("cmd", "/c", SCHEMAGEN_BAT);
             } else {
@@ -49,7 +52,7 @@ public class SchemaGenTest {
 
             File dir = new File(WLP_BIN_DIR);
             pb.directory(dir);
-            Process p = pb.start();
+            p = pb.start();
 
             BufferedReader br = new BufferedReader(new InputStreamReader(p.getInputStream()));
             String line;
@@ -57,15 +60,27 @@ public class SchemaGenTest {
             boolean usageAppears = false;     
             boolean encodingAppears = false;
                     
-            if (p.isAlive()) {
-                while ((line = br.readLine()) != null) {
-                    System.out.println(line);
-                    if (line.indexOf("Usage") != -1) {
-                        usageAppears = true;
-                    }
-                    if (line.indexOf("--encoding") != -1) {
-                        encodingAppears = true;
-                    }
+            long startTime = System.nanoTime();
+            long currentTime;
+            long elapsedTime;
+            int lineCounter = 0;
+
+            while ((line = br.readLine()) != null) {
+                System.out.println(line);
+                if (line.indexOf("Usage") != -1) {
+                    usageAppears = true;
+                }
+                if (line.indexOf("--encoding") != -1) {
+                    encodingAppears = true;
+                }
+
+                currentTime = System.nanoTime();
+                elapsedTime = currentTime - startTime;
+                if (elapsedTime >  3_000_000_000L) {   // 3 second timeout
+                    break;
+                }
+                if (lineCounter++ > 500) {
+                    break;
                 }
             }
             
@@ -76,6 +91,10 @@ public class SchemaGenTest {
         } catch (IOException ioe) {
             System.out.println("Caught exception [" + ioe.getMessage() + "]");
             ioe.printStackTrace();
+        } finally {
+            if ( p!= null) {
+                p.destroy();
+            }
         }
     }
     
@@ -83,8 +102,10 @@ public class SchemaGenTest {
     public void testSchemaGenHelp() {
         System.out.println("==================== testSchemaGenHelp ...");
 
+        ProcessBuilder pb;
+        Process p = null;
         try {
-            ProcessBuilder pb;
+
             if (isWindows()) {
                 pb = new ProcessBuilder("cmd", "/c", SCHEMAGEN_BAT, HELP_OPTION);
             } else {
@@ -93,7 +114,7 @@ public class SchemaGenTest {
 
             File dir = new File(WLP_BIN_DIR);
             pb.directory(dir);
-            Process p = pb.start();
+            p = pb.start();
 
             BufferedReader br = new BufferedReader(new InputStreamReader(p.getInputStream()));
             String line;
@@ -101,15 +122,14 @@ public class SchemaGenTest {
             boolean usageAppears = false;     
             boolean encodingAppears = false;
 
-            if (p.isAlive()) {
-                while ((line = br.readLine()) != null) {
-                    System.out.println(line);
-                    if (line.indexOf("Usage") != -1) {
-                        usageAppears = true;
-                    }
-                    if (line.indexOf("--encoding") != -1) {
-                        encodingAppears = true;
-                    }
+
+            while ((line = br.readLine()) != null) {
+                System.out.println(line);
+                if (line.indexOf("Usage") != -1) {
+                    usageAppears = true;
+                }
+                if (line.indexOf("--encoding") != -1) {
+                    encodingAppears = true;
                 }
             }
             
@@ -120,6 +140,10 @@ public class SchemaGenTest {
         } catch (IOException ioe) {
             System.out.println("Caught exception [" + ioe.getMessage() + "]");
             ioe.printStackTrace();
+        } finally {
+            if ( p!= null) {
+                p.destroy();
+            }
         }
     }
     
@@ -127,8 +151,9 @@ public class SchemaGenTest {
     public void testSchemaGenOutput() {
         System.out.println("==================== testSchemaGenOutput ...");
 
+        ProcessBuilder pb;
+        Process p = null;
         try {
-            ProcessBuilder pb;
             if (isWindows()) {
                 pb = new ProcessBuilder("cmd", "/c", SCHEMAGEN_BAT,  OUTPUT_FILE);
             } else {
@@ -137,14 +162,13 @@ public class SchemaGenTest {
 
             File dir = new File(WLP_BIN_DIR);
             pb.directory(dir);
-            Process p = pb.start();
+            p = pb.start();
 
             BufferedReader br = new BufferedReader(new InputStreamReader(p.getInputStream()));
             
             // The command should not generate any output to stdio or stderr
-            if (p.isAlive()) {
-                assertNull("Stream should be null", br.readLine());
-            }
+
+            assertNull("Stream should be null", br.readLine());
             
             File outputFile = new File(WLP_BIN_DIR + "/" + OUTPUT_FILE);        
             assertTrue("File [" + outputFile.getName() + "] should exist.", outputFile.exists());
@@ -162,6 +186,10 @@ public class SchemaGenTest {
         } catch (IOException ioe) {
             System.out.println("Caught exception [" + ioe.getMessage() + "]");
             ioe.printStackTrace();
+        } finally {
+            if ( p!= null) {
+                p.destroy();
+            }
         }
     }
 

--- a/dev/com.ibm.ws.config.schemagen/test/com/ibm/ws/config/schemagen/internal/SchemaGenTest.java
+++ b/dev/com.ibm.ws.config.schemagen/test/com/ibm/ws/config/schemagen/internal/SchemaGenTest.java
@@ -1,0 +1,176 @@
+package com.ibm.ws.config.schemagen.internal;
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import org.junit.Test;
+
+import test.common.SharedOutputManager;
+
+/**
+ *
+ */
+public class SchemaGenTest {
+
+    public static String WLP_BIN_DIR = "../build.image/wlp/bin";
+    public static String OUTPUT_FILE = "schemaGenOutput.xsd";
+    public static String HELP_OPTION = "-help";
+    public static String SCHEMAGEN_BAT = "./schemaGen.bat";
+    public static String SCHEMAGEN_LINUX_SCRIPT = "./schemaGen";
+
+    @Test
+    public void testSchemaGenNoParms() {
+        System.out.println("==================== testSchemaGenNoParms ...");
+
+        try {
+            ProcessBuilder pb;
+            if (isWindows()) {
+                pb = new ProcessBuilder("cmd", "/c", SCHEMAGEN_BAT);
+            } else {
+                pb = new ProcessBuilder(SCHEMAGEN_LINUX_SCRIPT);
+            }
+
+            File dir = new File(WLP_BIN_DIR);
+            pb.directory(dir);
+            Process p = pb.start();
+
+            BufferedReader br = new BufferedReader(new InputStreamReader(p.getInputStream()));
+            String line;
+            
+            boolean usageAppears = false;     
+            boolean encodingAppears = false;
+                    
+            if (p.isAlive()) {
+                while ((line = br.readLine()) != null) {
+                    System.out.println(line);
+                    if (line.indexOf("Usage") != -1) {
+                        usageAppears = true;
+                    }
+                    if (line.indexOf("--encoding") != -1) {
+                        encodingAppears = true;
+                    }
+                }
+            }
+            
+            assertTrue("'Usage' should appear in command output", usageAppears);
+            assertFalse("'--encoding' should NOT appear in command output when no arguments passed.", encodingAppears);
+            System.out.println("PASSED");
+            
+        } catch (IOException ioe) {
+            System.out.println("Caught exception [" + ioe.getMessage() + "]");
+            ioe.printStackTrace();
+        }
+    }
+    
+    @Test
+    public void testSchemaGenHelp() {
+        System.out.println("==================== testSchemaGenHelp ...");
+
+        try {
+            ProcessBuilder pb;
+            if (isWindows()) {
+                pb = new ProcessBuilder("cmd", "/c", SCHEMAGEN_BAT, HELP_OPTION);
+            } else {
+                pb = new ProcessBuilder(SCHEMAGEN_LINUX_SCRIPT, HELP_OPTION);
+            }
+
+            File dir = new File(WLP_BIN_DIR);
+            pb.directory(dir);
+            Process p = pb.start();
+
+            BufferedReader br = new BufferedReader(new InputStreamReader(p.getInputStream()));
+            String line;
+            
+            boolean usageAppears = false;     
+            boolean encodingAppears = false;
+
+            if (p.isAlive()) {
+                while ((line = br.readLine()) != null) {
+                    System.out.println(line);
+                    if (line.indexOf("Usage") != -1) {
+                        usageAppears = true;
+                    }
+                    if (line.indexOf("--encoding") != -1) {
+                        encodingAppears = true;
+                    }
+                }
+            }
+            
+            assertTrue("'Usage' should appear in command output", usageAppears);
+            assertTrue("'--encoding' should appear in command output when " + HELP_OPTION + " is passed.", encodingAppears);
+            System.out.println("PASSED");
+                    
+        } catch (IOException ioe) {
+            System.out.println("Caught exception [" + ioe.getMessage() + "]");
+            ioe.printStackTrace();
+        }
+    }
+    
+    @Test
+    public void testSchemaGenOutput() {
+        System.out.println("==================== testSchemaGenOutput ...");
+
+        try {
+            ProcessBuilder pb;
+            if (isWindows()) {
+                pb = new ProcessBuilder("cmd", "/c", SCHEMAGEN_BAT,  OUTPUT_FILE);
+            } else {
+                pb = new ProcessBuilder(SCHEMAGEN_LINUX_SCRIPT,  OUTPUT_FILE);
+            }
+
+            File dir = new File(WLP_BIN_DIR);
+            pb.directory(dir);
+            Process p = pb.start();
+
+            BufferedReader br = new BufferedReader(new InputStreamReader(p.getInputStream()));
+            
+            // The command should not generate any output to stdio or stderr
+            if (p.isAlive()) {
+                assertNull("Stream should be null", br.readLine());
+            }
+            
+            File outputFile = new File(WLP_BIN_DIR + "/" + OUTPUT_FILE);        
+            assertTrue("File [" + outputFile.getName() + "] should exist.", outputFile.exists());
+            outputFile.delete();
+            System.out.println("PASSED");
+            
+            //        // Display WLP_BIN_DIR directory listing
+            //        File f = new File(WLP_BIN_DIR);
+            //        String[] files = f.list();
+            //        Arrays.sort(files);
+            //        for (String s : files) {
+            //            System.out.println("   " + s);
+            //        }
+
+        } catch (IOException ioe) {
+            System.out.println("Caught exception [" + ioe.getMessage() + "]");
+            ioe.printStackTrace();
+        }
+    }
+
+    public boolean isWindows() {
+        String os = System.getProperty("os.name");
+        if (os.startsWith("Win")) {
+            return true;
+        }
+        return false;
+    }
+
+}


### PR DESCRIPTION
I added 3 tests for the wlp/bin/schemaGen script which was added by issue #18191 .

This is the output from the tests when they run successfully on Linux.  I still need to try it on Windows.

==================== testSchemaGenNoParms ...

The schemaGen command generates the XML schema for the                       
Liberty core configuration and other installed products                
extensions in a single output file.

Usage: ./schemaGen [options] outputFile

PASSED
==================== testSchemaGenHelp ...

The schemaGen command generates the XML schema for the                       
Liberty core configuration and other installed products                
extensions in a single output file.

Usage: ./schemaGen [options] outputFile

Options:

--compactOutput
The output schema will not contain indenting 
spaces, new line feeds, or XML comments.

--encoding
The character encoding to use for the output.

--ignorePidsFile
A file name containing a list of pids to ignore.

--locale
The language to use when you are creating the output
file. This string consists of the ISO-639 two-letter lowercase language
code, optionally followed by and underscores and the ISO-3166 uppercase
two-letter country code.

--outputVersion
If outputVersion=2.0 is specified, only the xsd:any element is used    
in the output file, so that unknown elements pass XSD validation at    
the expense of losing validation for known elements.

--schemaVersion
If schemaVersion=1.1 is specified, then both explicitly named child    
elements and the xsd:any element are written to the output file.

PASSED
==================== testSchemaGenOutput ...
PASSED


