### PR TITLE
enable Concurrency TCK to run with other EE 10 features

### DIFF
--- a/dev/fattest.simplicity/build.gradle
+++ b/dev/fattest.simplicity/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2021 IBM Corporation and others.
+ * Copyright (c) 2017,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -49,7 +49,7 @@ configurations {
 
 dependencies {
     arquillianFeature 'io.openliberty.arquillian:arquillian-liberty-support:1.0.5:feature@zip'
-    arquillianJakartaFeature 'io.openliberty.arquillian:arquillian-liberty-support-jakarta:2.0.0:feature@zip'
+    arquillianJakartaFeature 'io.openliberty.arquillian:arquillian-liberty-support-jakarta:2.0.2:feature@zip'
 }
 
 task extractArquillianSupportFeature(type:Sync) {

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/bnd.bnd
@@ -16,8 +16,7 @@ src: \
 
 fat.project: true
 
-tested.features:\
-	concurrent-3.0
+tested.features: appsecurity-4.0, cdi-3.0, concurrent-3.0, pages-3.0
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/build.gradle
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/build.gradle
@@ -12,6 +12,7 @@
 configurations {
   testNG { transitive = false; }
   arquillian
+  sigtest
   wlp
 }
 
@@ -21,6 +22,8 @@ dependencies {
 	       'org.apache-extras.beanshell:bsh:2.0b6'
 
   arquillian 'io.openliberty.arquillian:arquillian-liberty-support-jakarta:2.0.2'
+
+  sigtest 'org.netbeans.tools:sigtest-maven-plugin:1.6'
 
   //TODO configure WLP dependency, Examples (may not be valid):
   //wlp 'io.openliberty.beta:openliberty-jakartaee10:22.0.0.3-beta@zip'
@@ -36,9 +39,16 @@ task copyTestNG(type: Copy) {
   rename 'bsh-.*.jar', 'bsh.jar'
 }
 
+task copySigtest(type: Copy) {
+  mustRunAfter jar
+  from configurations.sigtest
+  into new File(autoFvtDir, 'publish/shared/resources/sigtest')
+  rename 'sigtest-maven-plugin-.*.jar', 'sigtest-maven-plugin.jar'
+}
+
 addRequiredLibraries.dependsOn addDerby
 addRequiredLibraries.dependsOn copyTestNG
-
+addRequiredLibraries.dependsOn copySigtest
 
 // These tasks are used only for external users who do not want to build all of liberty to run TCK
 task getWLP(type: Copy) {

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/build.gradle
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 	       'com.beust:jcommander:1.78',
 	       'org.apache-extras.beanshell:bsh:2.0b6'
 
-  arquillian 'io.openliberty.arquillian:arquillian-liberty-support-jakarta:2.0.1'
+  arquillian 'io.openliberty.arquillian:arquillian-liberty-support-jakarta:2.0.2'
 
   //TODO configure WLP dependency, Examples (may not be valid):
   //wlp 'io.openliberty.beta:openliberty-jakartaee10:22.0.0.3-beta@zip'

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/servers/ConcurrentTCKServer/jvm.options
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/servers/ConcurrentTCKServer/jvm.options
@@ -1,1 +1,4 @@
 -Dcom.ibm.tools.attach.enable=yes
+-Djimage.dir=sigtest
+--add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED
+--add-opens=java.base/jdk.internal.vm.annotation=ALL-UNNAMED

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/servers/ConcurrentTCKServer/server.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/servers/ConcurrentTCKServer/server.xml
@@ -52,11 +52,13 @@
     <library id="global">
                <fileset dir="${shared.resource.dir}/derby" includes="*.jar"/>
                <fileset dir="${shared.resource.dir}/testng/6.14.3" includes="*.jar"/>
+               <fileset dir="${shared.resource.dir}/sigtest" includes="sigtest-maven-plugin.jar"/>
     </library>
 
     <!--Java2 security-->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
-    <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/sigtest/sigtest-maven-plugin.jar" className="java.security.AllPermission"/>
 
     <!-- Ensure JSP can handle lamdas -->
     <jspEngine jdkSourceLevel="18"/>

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/servers/ConcurrentTCKServer/server.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/servers/ConcurrentTCKServer/server.xml
@@ -9,70 +9,70 @@
         IBM Corporation - initial API and implementation
  -->
 <server>
-	<featureManager>
-		<!-- Features being tested -->
-		<!--TODO enable <feature>jakartaee-10.0</feature> -->
-		<feature>concurrent-3.0</feature>
-		<feature>jdbc-4.2</feature>
-		<feature>enterpriseBeans-4.0</feature>
-		<feature>cdi-3.0</feature>
-		<feature>pages-3.0</feature>
-	    <!-- Supporting features -->
-	    <feature>jndi-1.0</feature> 
-	    <feature>appSecurity-4.0</feature>
-	    <!-- Features needed for arquillan support -->
-	    <feature>localConnector-1.0</feature>
-	    <feature>restConnector-2.0</feature>
-	</featureManager>
+    <featureManager>
+        <!-- Features being tested -->
+        <!--TODO one all of EE 10 is beta, could enable <feature>jakartaee-10.0</feature> or leave the individual features -->
+        <feature>concurrent-3.0</feature>
+        <feature>jdbc-4.2</feature>
+        <feature>enterpriseBeans-4.0</feature>
+        <feature>cdi-3.0</feature> <!-- TODO once EE 10 feature is beta: <feature>cdi-4.0</feature> -->
+        <feature>pages-3.0</feature> <!-- TODO once EE 10 feature is beta: <feature>pages-3.1</feature> -->
+        <!-- Supporting features -->
+        <feature>jndi-1.0</feature>
+        <feature>appSecurity-4.0</feature> <!-- TODO once EE 10 feature is beta: <feature>appSecurity-5.0</feature> -->
+        <!-- Features needed for arquillan support -->
+        <feature>localConnector-1.0</feature>
+        <feature>restConnector-2.0</feature>
+    </featureManager>
 
-	<!-- Use logging instead of bootstrap for standalone WLP case -->
-	<logging traceSpecification="*=info:concurrent=all:concurrencyPolicy=all:context=all" /> 
-   
-	<!-- Allow Arquillian to monitor application -->
-	<applicationMonitor updateTrigger="mbean"/>
-   
-	<!-- Allow Arquillian remote access to server -->
-	<quickStartSecurity userName="${env.tck_username}" userPassword="${env.tck_password}" />
-	
-	<!-- Allow Arquillian to participate in TLS handshake with server -->
-	<ssl id="defaultSSLConfig" trustDefaultCerts="true" />
-	<keyStore id="defaultKeyStore" password="libertyPassword"/>
-	
-	<!-- Allow Arquillian to create a secure connection -->
+    <!-- Use logging instead of bootstrap for standalone WLP case -->
+    <logging traceSpecification="*=info:concurrent=all:concurrencyPolicy=all:context=all" />
+
+    <!-- Allow Arquillian to monitor application -->
+    <applicationMonitor updateTrigger="mbean"/>
+
+    <!-- Allow Arquillian remote access to server -->
+    <quickStartSecurity userName="${env.tck_username}" userPassword="${env.tck_password}" />
+
+    <!-- Allow Arquillian to participate in TLS handshake with server -->
+    <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
+    <keyStore id="defaultKeyStore" password="libertyPassword"/>
+
+    <!-- Allow Arquillian to create a secure connection -->
     <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${env.tck_port}" httpsPort="${env.tck_port_secure}">
-    	<sslOptions sslRef="defaultKeyStore"/>
+        <sslOptions sslRef="defaultKeyStore"/>
     </httpEndpoint>
-	
-	<!-- Allow Arquillian access to dropins directory for application installation -->
-	<remoteFileAccess>
-		<writeDir>${server.config.dir}/dropins</writeDir>
-	</remoteFileAccess>
-   
-	<!-- Include derby in gloabl library to make it available to all dropin apps -->
-	<library id="global">
-   	    	<fileset dir="${shared.resource.dir}/derby" includes="*.jar"/>
-   	    	<fileset dir="${shared.resource.dir}/testng/6.14.3" includes="*.jar"/>
-	</library>
 
-	<!--Java2 security-->
-	<javaPermission className="java.security.AllPermission"  name="*" actions="*" />   
-	<javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
-	
-	<!-- Ensure JSP can handle lamdas -->
-	<jspEngine jdkSourceLevel="18"/>
-	
-	<!-- Security role(s) needed for TCK tests -->
-	<orb id="defaultOrb" orbSSLInitTimeout="60"/>
-		
-	<basicRegistry id="basic" realm="default">       
-	    <user name="javajoe" password="javajoe"/>
-	    <group name="Manager">
-	      <member name="javajoe"/>
-	    </group>
-	</basicRegistry>
-	
-	<security-role-mapping> 
-	  <role-name>Manager</role-name>
-	  <principal-name>javajoe</principal-name>
-	</security-role-mapping>
+    <!-- Allow Arquillian access to dropins directory for application installation -->
+    <remoteFileAccess>
+        <writeDir>${server.config.dir}/dropins</writeDir>
+    </remoteFileAccess>
+
+    <!-- Include derby in gloabl library to make it available to all dropin apps -->
+    <library id="global">
+               <fileset dir="${shared.resource.dir}/derby" includes="*.jar"/>
+               <fileset dir="${shared.resource.dir}/testng/6.14.3" includes="*.jar"/>
+    </library>
+
+    <!--Java2 security-->
+    <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
+    <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+
+    <!-- Ensure JSP can handle lamdas -->
+    <jspEngine jdkSourceLevel="18"/>
+
+    <!-- Security role(s) needed for TCK tests -->
+    <orb id="defaultOrb" orbSSLInitTimeout="60"/>
+
+    <basicRegistry id="basic" realm="default">
+        <user name="javajoe" password="javajoe"/>
+        <group name="Manager">
+          <member name="javajoe"/>
+        </group>
+    </basicRegistry>
+
+    <security-role-mapping>
+      <role-name>Manager</role-name>
+      <principal-name>javajoe</principal-name>
+    </security-role-mapping>
 </server>

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -23,7 +23,7 @@
         <!-- TODO: Update this once TCK is GAed -->
         <jakarta.concurrent.tck.version>3.0.0.20220126</jakarta.concurrent.tck.version>
         
-        <arquillian.version>1.6.0.Final</arquillian.version>
+        <arquillian.version>1.7.0.Alpha10</arquillian.version>
         <arquillian-wlp.version>2.0.2</arquillian-wlp.version>
         
         <testng.version>6.14.3</testng.version>

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -117,6 +117,11 @@
             <artifactId>jcommander</artifactId>
             <version>1.78</version>
         </dependency>
+        <dependency>
+            <groupId>org.netbeans.tools</groupId>
+            <artifactId>sigtest-maven-plugin</artifactId>
+            <version>1.6</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/standalone.pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/standalone.pom.xml
@@ -97,6 +97,11 @@
             <artifactId>jcommander</artifactId>
             <version>1.78</version>
         </dependency>
+        <dependency>
+            <groupId>org.netbeans.tools</groupId>
+            <artifactId>sigtest-maven-plugin</artifactId>
+            <version>1.6</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/standalone.pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/standalone.pom.xml
@@ -23,7 +23,7 @@
         <jakarta.concurrent.groupid>io.openliberty.jakarta.enterprise.concurrent</jakarta.concurrent.groupid>
         <jakarta.concurrent.version>3.0.0.20220126</jakarta.concurrent.version>
         
-        <arquillian.version>1.6.0.Final</arquillian.version>
+        <arquillian.version>1.7.0.Alpha10</arquillian.version>
         <arquillian-wlp.version>2.0.2</arquillian-wlp.version>
         
         <testng.version>6.14.3</testng.version>


### PR DESCRIPTION
The Concurrency TCK temporarily runs with concurrent-3.0 (EE 10 level) but other features (like servlet) at the EE 9 level, because those features are available as beta or ga.  This pull makes it possible to run with all EE 10 features, although we will not switch to that yet because those features are non-ship and we should be using at least beta to collect official TCK results.