### PR TITLE
require-java to support range

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
+++ b/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
@@ -563,8 +563,8 @@ public class FeatureList {
 
                 APIType apiType = APIType.getAPIType(fr);
                 Map<String,String> attrs = new HashMap<String,String>(1);
-                if (fr.getRequireJava() != null)
-                    attrs.put("require-java", fr.getRequireJava().toString());
+                if (fr.getJavaRange() != null)
+                    attrs.put("require-java", fr.getJavaRange().toString());
                 if (apiType == APIType.API) {
                     if (apiJars != null) {
                         apiJars.put(f, attrs);

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/BundleList.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/BundleList.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -281,8 +281,8 @@ public class BundleList {
         }
 
         @Override
-        public Integer getRequireJava() {
-            return fr.getRequireJava();
+        public VersionRange getJavaRange() {
+            return fr.getJavaRange();
         }
 
         @Override
@@ -442,7 +442,7 @@ public class BundleList {
         }
 
         @Override
-        public Integer getRequireJava() {
+        public VersionRange getJavaRange() {
             return null;
         }
 
@@ -602,7 +602,8 @@ public class BundleList {
         for (FeatureResource fr : fdefinition.getConstituents(SubsystemContentType.BUNDLE_TYPE)) {
             RuntimeFeatureResource rfr = (RuntimeFeatureResource) ((fr instanceof RuntimeFeatureResource) ? fr : new RuntimeFeatureResource(fr));
             // only add bundles that match the current osgi.ee capability
-            if (!featureManager.missingRequiredJava(rfr)) {
+            // OLGH20563: Adds bundle only if the runtime is within the bundle's specified range
+            if (featureManager.withinJavaRange(rfr)) {
                 resources.add(rfr);
             }
         }

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
@@ -55,6 +55,8 @@ import org.osgi.framework.Constants;
 import org.osgi.framework.Filter;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 import org.osgi.framework.namespace.ExecutionEnvironmentNamespace;
 import org.osgi.framework.startlevel.FrameworkStartLevel;
 import org.osgi.framework.wiring.BundleCapability;
@@ -88,6 +90,7 @@ import com.ibm.ws.kernel.feature.ServerReadyStatus;
 import com.ibm.ws.kernel.feature.ServerStarted;
 import com.ibm.ws.kernel.feature.ServerStartedPhase2;
 import com.ibm.ws.kernel.feature.Visibility;
+import com.ibm.ws.kernel.feature.internal.BundleList.RuntimeFeatureResource;
 import com.ibm.ws.kernel.feature.internal.subsystem.FeatureDefinitionUtils;
 import com.ibm.ws.kernel.feature.internal.subsystem.FeatureRepository;
 import com.ibm.ws.kernel.feature.internal.subsystem.KernelFeatureDefinitionImpl;
@@ -2491,9 +2494,9 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
         refreshFeatures();
     }
 
-    boolean missingRequiredJava(FeatureResource fr) {
-        Integer requiredJava = fr.getRequireJava();
-        return requiredJava == null ? false : JavaInfo.majorVersion() < requiredJava;
+    public boolean withinJavaRange(FeatureResource fr) {
+        VersionRange range = fr.getJavaRange();
+        return range == null ? true : range.includes(new Version(Integer.toString(JavaInfo.majorVersion())));
     }
 
 }

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
@@ -90,7 +90,6 @@ import com.ibm.ws.kernel.feature.ServerReadyStatus;
 import com.ibm.ws.kernel.feature.ServerStarted;
 import com.ibm.ws.kernel.feature.ServerStartedPhase2;
 import com.ibm.ws.kernel.feature.Visibility;
-import com.ibm.ws.kernel.feature.internal.BundleList.RuntimeFeatureResource;
 import com.ibm.ws.kernel.feature.internal.subsystem.FeatureDefinitionUtils;
 import com.ibm.ws.kernel.feature.internal.subsystem.FeatureRepository;
 import com.ibm.ws.kernel.feature.internal.subsystem.KernelFeatureDefinitionImpl;
@@ -171,6 +170,8 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
     final static String FEATURE_PRODUCT_EXTENSIONS_FILE_EXTENSION = ".properties";
     final static String PRODUCT_INFO_STRING_OPEN_LIBERTY = "Open Liberty";
     final static FeatureResolver featureResolver = new FeatureResolverImpl();
+
+    private static Version JAVA_MAJOR_VERSION =  new Version(JavaInfo.majorVersion(), 0, 0);
 
     final static Collection<String> ALLOWED_ON_ALL_FEATURES = Arrays.asList("com.ibm.websphere.appserver.timedexit-1.0", "com.ibm.websphere.appserver.osgiConsole-1.0");
     final static Collection<String> ALL_ALLOWED_ON_CLIENT_FEATURES;
@@ -2494,9 +2495,9 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
         refreshFeatures();
     }
 
-    public boolean withinJavaRange(FeatureResource fr) {
-        VersionRange range = fr.getJavaRange();
-        return range == null ? true : range.includes(new Version(Integer.toString(JavaInfo.majorVersion())));
+    boolean withinJavaRange(FeatureResource fr) {
+        VersionRange range =  fr.getJavaRange();
+        return range == null ? true :  range.includes(JAVA_MAJOR_VERSION);
     }
 
 }

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureResourceImpl.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureResourceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.osgi.framework.VersionRange;
+import org.osgi.framework.Version;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -290,7 +291,7 @@ public class FeatureResourceImpl implements FeatureResource {
                && Objects.equals(getLocation(), other.getLocation())
                && Objects.equals(getOsList(), other.getOsList())
                && Objects.equals(getTolerates(), other.getTolerates())
-               && Objects.equals(getRequireJava(), other.getRequireJava());
+               && Objects.equals(getJavaRange(), other.getJavaRange());
     }
 
     /** {@inheritDoc} */
@@ -334,10 +335,10 @@ public class FeatureResourceImpl implements FeatureResource {
     }
 
     @Override
-    public Integer getRequireJava() {
+    public VersionRange getJavaRange() {
         // Directive names are in the attributes map, but end with a colon
-        String requireJava = _rawAttributes.get("require-java:");
-        return requireJava == null ? null : Integer.valueOf(requireJava);
+        String javaRange = _rawAttributes.get("require-java:");
+        return javaRange == null ? null : new VersionRange(javaRange);
     }
 
     @Override

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/provisioning/FeatureResource.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/provisioning/FeatureResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -52,7 +52,7 @@ public interface FeatureResource extends HeaderElementDefinition {
 
     public List<String> getTolerates();
 
-    public Integer getRequireJava();
+    public VersionRange getJavaRange();
 
     /**
      * @return the activation type for the resource

--- a/dev/com.ibm.ws.kernel.feature/test/com/ibm/ws/kernel/feature/internal/FeatureResolverInterfacesTest.java
+++ b/dev/com.ibm.ws.kernel.feature/test/com/ibm/ws/kernel/feature/internal/FeatureResolverInterfacesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -574,7 +574,7 @@ public class FeatureResolverInterfacesTest {
         }
 
         @Override
-        public Integer getRequireJava() {
+        public VersionRange getJavaRange() {
             throw new UnsupportedOperationException();
         }
 

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRequirement.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRequirement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -124,7 +124,7 @@ public class KernelResolverRequirement implements FeatureResource {
     }
 
     @Override
-    public Integer getRequireJava() {
+    public VersionRange getJavaRange() {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
fixes #20563

Example use case: 
```
-bundles=\
 com.ibm.ws.org.eclipse.jdt.core; require-java:="[8,11)", \
 com.ibm.ws.org.eclipse.jdt.core.java11; require-java:="[11,17)", \
 com.ibm.ws.org.eclipse.jdt.core.java17; require-java:=17, \
 ```