### PR TITLE
Add optimized abort to purgePoolContents

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/mbean/ConnectionManagerMBean.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/mbean/ConnectionManagerMBean.java
@@ -89,10 +89,12 @@ public interface ConnectionManagerMBean {
      * this Connection Manager.
      *
      * @param doImmediately The priority to be used to purge the connection pool.
-     *                          Priority may be <code>"immediate"</code>, <code>"abort"</code> or <code>null</code>.
-     *                          Immediate sets the total connection count to 0 and purges the pool
+     *                          <p>Priority may be <code>"immediate"</code>, <code>"optimizedAbort"</code>, <code>"abort"</code> or <code>null</code>.
+     *                          <p>Immediate sets the total connection count to 0 and purges the pool
      *                          as quickly as possible but waits for transactions to complete.
-     *                          Abort purges the pool by aborting connections without waiting for transactions to complete.
+     *                          <p>OptimizedAbort purges the pool by aborting in use connections that may be unusable
+     *                          without waiting for transactions to complete.
+     *                          <p>Abort purges the pool by aborting connections without waiting for transactions to complete.
      *                          The default behavior if no value is specified is to purge the pool with normal priority.
      * @throws MBeanException
      */


### PR DESCRIPTION
Option purgePoolContents optimizedAbort attempts to avoid aborting working connections in comparison to the current option abort that removes all of the connections.  Avoiding to abort working connections should provide a faster recovery from errors or hung connection than aborting all connections.   If use either abort or optimizedAbort are used, unexpected error can occur, but with optimizedAbort fewer unexpected error should occur.