### PR TITLE
PR for 20358 and 20357: Bulk of logout token creation

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
@@ -433,12 +433,12 @@ public class Jose4jUtil {
      * token to ensure it is formatted correctly. If the token is a JWE, this decrypts and extracts the JWS payload from the
      * token.
      */
-    public JwtContext validateJwtStructureAndGetContext(String logoutTokenString, ConvergedClientConfig clientConfig) throws Exception {
-        checkJwtFormatAgainstConfigRequirements(logoutTokenString, clientConfig);
-        if (JweHelper.isJwe(logoutTokenString)) {
-            logoutTokenString = JweHelper.extractJwsFromJweToken(logoutTokenString, clientConfig, null);
+    public JwtContext validateJwtStructureAndGetContext(String jwtString, ConvergedClientConfig clientConfig) throws Exception {
+        checkJwtFormatAgainstConfigRequirements(jwtString, clientConfig);
+        if (JweHelper.isJwe(jwtString)) {
+            jwtString = JweHelper.extractJwsFromJweToken(jwtString, clientConfig, null);
         }
-        return Jose4jUtil.parseJwtWithoutValidation(logoutTokenString);
+        return Jose4jUtil.parseJwtWithoutValidation(jwtString);
     }
 
     public JwtClaims validateJwsSignature(JwtContext jwtContext, ConvergedClientConfig clientConfig) throws Exception {

--- a/dev/com.ibm.ws.security.openidconnect.server/bnd.bnd
+++ b/dev/com.ibm.ws.security.openidconnect.server/bnd.bnd
@@ -164,7 +164,8 @@ Include-Resource: \
 	com.ibm.ws.webcontainer;version=latest,\
 	com.ibm.ws.org.jose4j;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-	com.ibm.ws.kernel.boot.core;version=latest
+	com.ibm.ws.kernel.boot.core;version=latest,\
+	com.ibm.ws.security.jwt;version=latest
 	
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file,\

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/com/ibm/ws/security/openidconnect/server/internal/resources/OidcServerMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/com/ibm/ws/security/openidconnect/server/internal/resources/OidcServerMessages.nlsprops
@@ -195,3 +195,13 @@ LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN.useraction=Ensure the ID token i
 LOGOUT_TOKEN_ERROR_GETTING_CLIENTS_TO_LOG_OUT=CWWKS1644E: The OpenID Connect provider cannot determine the set of OpenID Connect clients to log out because of an error: {0}
 LOGOUT_TOKEN_ERROR_GETTING_CLIENTS_TO_LOG_OUT.explanation=The provider failed to retrieve the set of clients that are registered, or the ID token claims might be malformed.
 LOGOUT_TOKEN_ERROR_GETTING_CLIENTS_TO_LOG_OUT.useraction=See the error that is included in the message for more information.
+
+ID_TOKEN_ISSUER_NOT_THIS_OP=CWWKS1645E: The issuer claim "{0}" in the ID token does not match the expected issuer "{1}" for the OpenID Connect provider [{2}].
+ID_TOKEN_ISSUER_NOT_THIS_OP.explanation=The OpenID Connect provider did not issue the ID token, so the token should not be handled by this OpenID Connect provider.
+ID_TOKEN_ISSUER_NOT_THIS_OP.useraction=Send only ID tokens whose issuer claim matches the configuration for the OpenID Connect provider that is specified in the message.
+
+ID_TOKEN_MISSING_REQUIRED_CLAIMS=CWWKS1646E: The ID token is not valid because it is missing at least one claim that is required: {0}
+ID_TOKEN_MISSING_REQUIRED_CLAIMS.explanation=The OpenID Connect specification requires that the claim or claims that are listed in the error message must be present in the ID token.
+ID_TOKEN_MISSING_REQUIRED_CLAIMS.useraction=Ensure that the ID token contains all of the required claims.
+
+# NOTE: Stop at CWWKS1649

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/com/ibm/ws/security/openidconnect/server/internal/resources/OidcServerMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/com/ibm/ws/security/openidconnect/server/internal/resources/OidcServerMessages.nlsprops
@@ -196,11 +196,16 @@ LOGOUT_TOKEN_ERROR_GETTING_CLIENTS_TO_LOG_OUT=CWWKS1644E: The OpenID Connect pro
 LOGOUT_TOKEN_ERROR_GETTING_CLIENTS_TO_LOG_OUT.explanation=The provider failed to retrieve the set of clients that are registered, or the ID token claims might be malformed.
 LOGOUT_TOKEN_ERROR_GETTING_CLIENTS_TO_LOG_OUT.useraction=See the error that is included in the message for more information.
 
-ID_TOKEN_ISSUER_NOT_THIS_OP=CWWKS1645E: The [{0}] issuer claim in the ID token does not match the [{1}] expected issuer for the {2} OpenID Connect provider.
+# NOTE: THE CWWKS1645W MESSAGE IS NOT BEING USED IN THE PRODUCT AS OF 19.0.0.8
+IDT_MEDIATOR_SPI_REQUIRES_JDK=CWWKS1645W: The Java version used by this run time [{0}] is not supported by the ID token Mediator SPI. The supported Java version is 1.7 or higher.
+IDT_MEDIATOR_SPI_REQUIRES_JDK.explanation=The Java version in the message can not support the ID token Mediator SPI function. 
+IDT_MEDIATOR_SPI_REQUIRES_JDK.useraction=Install Java version 1.7 or higher.
+
+ID_TOKEN_ISSUER_NOT_THIS_OP=CWWKS1646E: The [{0}] issuer claim in the ID token does not match the [{1}] expected issuer for the {2} OpenID Connect provider.
 ID_TOKEN_ISSUER_NOT_THIS_OP.explanation=The OpenID Connect provider did not issue the ID token, so the token should not be handled by this OpenID Connect provider.
 ID_TOKEN_ISSUER_NOT_THIS_OP.useraction=Send only ID tokens whose issuer claim matches the configuration for the OpenID Connect provider that is specified in the message.
 
-ID_TOKEN_MISSING_REQUIRED_CLAIMS=CWWKS1646E: The ID token is not valid because it is missing at least one claim that is required: {0}
+ID_TOKEN_MISSING_REQUIRED_CLAIMS=CWWKS1647E: The ID token is not valid because it is missing at least one claim that is required: {0}
 ID_TOKEN_MISSING_REQUIRED_CLAIMS.explanation=The OpenID Connect specification requires that the claim or claims that are listed in the error message must be present in the ID token.
 ID_TOKEN_MISSING_REQUIRED_CLAIMS.useraction=Ensure that the ID token contains all of the required claims.
 

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/com/ibm/ws/security/openidconnect/server/internal/resources/OidcServerMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/com/ibm/ws/security/openidconnect/server/internal/resources/OidcServerMessages.nlsprops
@@ -184,7 +184,14 @@ OIDC_SERVER_THIRDPARTY_IDTOKEN_ERROR=CWWKS1641E: The claims from the third-party
 OIDC_SERVER_THIRDPARTY_IDTOKEN_ERROR.explanation=The claims from the third-party ID token cannot be extracted. View the error message for more information.
 OIDC_SERVER_THIRDPARTY_IDTOKEN_ERROR.useraction=Ensure that the third-party OpenID Connect provider is sending a valid ID token.
 
-IDT_MEDIATOR_SPI_REQUIRES_JDK=CWWKS1645W: The Java version used by this run time [{0}] is not supported by the ID token Mediator SPI. The supported Java version is 1.7 or higher.
-IDT_MEDIATOR_SPI_REQUIRES_JDK.explanation=The Java version in the message can not support the ID token Mediator SPI function. 
-IDT_MEDIATOR_SPI_REQUIRES_JDK.useraction=Install Java version 1.7 or higher.
+OIDC_SERVER_BACKCHANNEL_LOGOUT_REQUEST_ERROR=CWWKS1642E: The OpenID Connect provider [{0}] encountered an error while building logout tokens for back-channel logout requests: {1}
+OIDC_SERVER_BACKCHANNEL_LOGOUT_REQUEST_ERROR.explanation=The ID token string in the id_token_hint parameter, if one was provided, might be malformed. The provider might not be able to determine the set of clients to send back-channel logout requests. Or another error occurred while building a logout token.
+OIDC_SERVER_BACKCHANNEL_LOGOUT_REQUEST_ERROR.useraction=See the user action for the error that is included in the message.
 
+LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN=CWWKS1643E: The OpenID Connect provider cannot extract claims to reuse from the ID token. {0}
+LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN.explanation=The ID token might be malformed or in an unexpected format.
+LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN.useraction=Ensure the ID token is formatted correctly. See the error that is included in the message for more information.
+
+LOGOUT_TOKEN_ERROR_GETTING_CLIENTS_TO_LOG_OUT=CWWKS1644E: The OpenID Connect provider cannot determine the set of OpenID Connect clients to log out because of an error: {0}
+LOGOUT_TOKEN_ERROR_GETTING_CLIENTS_TO_LOG_OUT.explanation=The provider failed to retrieve the set of clients that are registered, or the ID token claims might be malformed.
+LOGOUT_TOKEN_ERROR_GETTING_CLIENTS_TO_LOG_OUT.useraction=See the error that is included in the message for more information.

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/com/ibm/ws/security/openidconnect/server/internal/resources/OidcServerMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/com/ibm/ws/security/openidconnect/server/internal/resources/OidcServerMessages.nlsprops
@@ -196,7 +196,7 @@ LOGOUT_TOKEN_ERROR_GETTING_CLIENTS_TO_LOG_OUT=CWWKS1644E: The OpenID Connect pro
 LOGOUT_TOKEN_ERROR_GETTING_CLIENTS_TO_LOG_OUT.explanation=The provider failed to retrieve the set of clients that are registered, or the ID token claims might be malformed.
 LOGOUT_TOKEN_ERROR_GETTING_CLIENTS_TO_LOG_OUT.useraction=See the error that is included in the message for more information.
 
-ID_TOKEN_ISSUER_NOT_THIS_OP=CWWKS1645E: The issuer claim "{0}" in the ID token does not match the expected issuer "{1}" for the OpenID Connect provider [{2}].
+ID_TOKEN_ISSUER_NOT_THIS_OP=CWWKS1645E: The [{0}] issuer claim in the ID token does not match the [{1}] expected issuer for the {2} OpenID Connect provider.
 ID_TOKEN_ISSUER_NOT_THIS_OP.explanation=The OpenID Connect provider did not issue the ID token, so the token should not be handled by this OpenID Connect provider.
 ID_TOKEN_ISSUER_NOT_THIS_OP.useraction=Send only ID tokens whose issuer claim matches the configuration for the OpenID Connect provider that is specified in the message.
 

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/com/ibm/ws/security/openidconnect/server/internal/resources/OidcServerMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/com/ibm/ws/security/openidconnect/server/internal/resources/OidcServerMessages.nlsprops
@@ -184,15 +184,15 @@ OIDC_SERVER_THIRDPARTY_IDTOKEN_ERROR=CWWKS1641E: The claims from the third-party
 OIDC_SERVER_THIRDPARTY_IDTOKEN_ERROR.explanation=The claims from the third-party ID token cannot be extracted. View the error message for more information.
 OIDC_SERVER_THIRDPARTY_IDTOKEN_ERROR.useraction=Ensure that the third-party OpenID Connect provider is sending a valid ID token.
 
-OIDC_SERVER_BACKCHANNEL_LOGOUT_REQUEST_ERROR=CWWKS1642E: The {0} OpenID Connect provider encountered an error while building logout tokens for back-channel logout requests: {1}
-OIDC_SERVER_BACKCHANNEL_LOGOUT_REQUEST_ERROR.explanation=The ID token string in the id_token_hint parameter, if one was provided, might be malformed. The provider might not be able to determine the set of clients to send back-channel logout requests. Or another error occurred while building a logout token.
+OIDC_SERVER_BACKCHANNEL_LOGOUT_REQUEST_ERROR=CWWKS1642E: The {0} OpenID Connect provider encountered the following error when it tried to build logout tokens for back-channel logout requests: {1}
+OIDC_SERVER_BACKCHANNEL_LOGOUT_REQUEST_ERROR.explanation=The ID token string in the id_token_hint parameter, if one was provided, might be malformed. The provider might not be able to determine the set of clients to send back-channel logout requests. If the id_token_hint parameter is not malformed, another error occurred when the provider tried to build a logout token.
 OIDC_SERVER_BACKCHANNEL_LOGOUT_REQUEST_ERROR.useraction=See the user action for the error that is included in the message.
 
-LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN=CWWKS1643E: The OpenID Connect provider cannot extract claims to reuse from the ID token. {0}
-LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN.explanation=The ID token might be malformed, or the token is formatted incorrectly.
+LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN=CWWKS1643E: The OpenID Connect provider cannot extract claims to reuse from the ID token. The error is: {0}
+LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN.explanation=The ID token might be malformed or a claim within the token might have a value that is an unexpected data type. Alternatively, the token might be missing claims that are required or the issuer of the token is not the issuer that is expected.
 LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN.useraction=Ensure the ID token is formatted correctly. See the error that is included in the message for more information.
 
-LOGOUT_TOKEN_ERROR_GETTING_CLIENTS_TO_LOG_OUT=CWWKS1644E: The OpenID Connect provider cannot determine the set of OpenID Connect clients to log out because of an error: {0}
+LOGOUT_TOKEN_ERROR_GETTING_CLIENTS_TO_LOG_OUT=CWWKS1644E: The OpenID Connect provider cannot determine the set of OpenID Connect clients to log out because of the following error: {0}
 LOGOUT_TOKEN_ERROR_GETTING_CLIENTS_TO_LOG_OUT.explanation=The provider failed to retrieve the set of clients that are registered, or the ID token claims might be malformed.
 LOGOUT_TOKEN_ERROR_GETTING_CLIENTS_TO_LOG_OUT.useraction=See the error that is included in the message for more information.
 
@@ -202,8 +202,8 @@ IDT_MEDIATOR_SPI_REQUIRES_JDK.explanation=The Java version in the message can no
 IDT_MEDIATOR_SPI_REQUIRES_JDK.useraction=Install Java version 1.7 or higher.
 
 ID_TOKEN_ISSUER_NOT_THIS_OP=CWWKS1646E: The [{0}] issuer claim in the ID token does not match the [{1}] expected issuer for the {2} OpenID Connect provider.
-ID_TOKEN_ISSUER_NOT_THIS_OP.explanation=The OpenID Connect provider did not issue the ID token, so the token should not be handled by this OpenID Connect provider.
-ID_TOKEN_ISSUER_NOT_THIS_OP.useraction=Send only ID tokens whose issuer claim matches the configuration for the OpenID Connect provider that is specified in the message.
+ID_TOKEN_ISSUER_NOT_THIS_OP.explanation=The OpenID Connect provider did not issue the ID token, so the token cannot be handled by this OpenID Connect provider.
+ID_TOKEN_ISSUER_NOT_THIS_OP.useraction=Send only ID tokens with an issuer claim that matches the configuration for the OpenID Connect provider that is specified in the message.
 
 ID_TOKEN_MISSING_REQUIRED_CLAIMS=CWWKS1647E: The ID token is not valid because it is missing at least one claim that is required: {0}
 ID_TOKEN_MISSING_REQUIRED_CLAIMS.explanation=The OpenID Connect specification requires that the claim or claims that are listed in the error message must be present in the ID token.

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/com/ibm/ws/security/openidconnect/server/internal/resources/OidcServerMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/com/ibm/ws/security/openidconnect/server/internal/resources/OidcServerMessages.nlsprops
@@ -184,12 +184,12 @@ OIDC_SERVER_THIRDPARTY_IDTOKEN_ERROR=CWWKS1641E: The claims from the third-party
 OIDC_SERVER_THIRDPARTY_IDTOKEN_ERROR.explanation=The claims from the third-party ID token cannot be extracted. View the error message for more information.
 OIDC_SERVER_THIRDPARTY_IDTOKEN_ERROR.useraction=Ensure that the third-party OpenID Connect provider is sending a valid ID token.
 
-OIDC_SERVER_BACKCHANNEL_LOGOUT_REQUEST_ERROR=CWWKS1642E: The OpenID Connect provider [{0}] encountered an error while building logout tokens for back-channel logout requests: {1}
+OIDC_SERVER_BACKCHANNEL_LOGOUT_REQUEST_ERROR=CWWKS1642E: The {0} OpenID Connect provider encountered an error while building logout tokens for back-channel logout requests: {1}
 OIDC_SERVER_BACKCHANNEL_LOGOUT_REQUEST_ERROR.explanation=The ID token string in the id_token_hint parameter, if one was provided, might be malformed. The provider might not be able to determine the set of clients to send back-channel logout requests. Or another error occurred while building a logout token.
 OIDC_SERVER_BACKCHANNEL_LOGOUT_REQUEST_ERROR.useraction=See the user action for the error that is included in the message.
 
 LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN=CWWKS1643E: The OpenID Connect provider cannot extract claims to reuse from the ID token. {0}
-LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN.explanation=The ID token might be malformed or in an unexpected format.
+LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN.explanation=The ID token might be malformed, or the token is formatted incorrectly.
 LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN.useraction=Ensure the ID token is formatted correctly. See the error that is included in the message for more information.
 
 LOGOUT_TOKEN_ERROR_GETTING_CLIENTS_TO_LOG_OUT=CWWKS1644E: The OpenID Connect provider cannot determine the set of OpenID Connect clients to log out because of an error: {0}

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/OidcEndpointServices.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/OidcEndpointServices.java
@@ -548,6 +548,12 @@ public class OidcEndpointServices extends OAuth20EndpointServices {
         if (!ProductInfo.getBetaEdition()) {
             return;
         }
+        if (idTokenString == null || idTokenString.isEmpty()) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "ID token string was not provided or was empty, so back-channel logout will not be performed.");
+            }
+            return;
+        }
         BackchannelLogoutRequestHelper bclRequestCreator = new BackchannelLogoutRequestHelper(request, oidcServerConfig);
         bclRequestCreator.sendBackchannelLogoutRequests(idTokenString);
     }

--- a/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutRequestHelper.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutRequestHelper.java
@@ -6,16 +6,18 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.security.openidconnect.backchannellogout;
 
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.security.oauth20.plugins.OidcBaseClient;
 import com.ibm.ws.webcontainer.security.openidconnect.OidcServerConfig;
 
 public class BackchannelLogoutRequestHelper {
@@ -36,14 +38,13 @@ public class BackchannelLogoutRequestHelper {
      * also created for all RPs that the OP is aware of having active or recently valid sessions.
      */
     public void sendBackchannelLogoutRequests(String idTokenString) {
-        Map<String, String> logoutTokens = null;
+        if (idTokenString == null || idTokenString.isEmpty()) {
+            return;
+        }
+        Map<OidcBaseClient, List<String>> logoutTokens = null;
         try {
             LogoutTokenBuilder tokenBuilder = new LogoutTokenBuilder(request, oidcServerConfig);
-            if (idTokenString != null) {
-                logoutTokens = tokenBuilder.buildLogoutTokensFromIdTokenString(idTokenString);
-            } else {
-                logoutTokens = tokenBuilder.buildLogoutTokens();
-            }
+            logoutTokens = tokenBuilder.buildLogoutTokensFromIdTokenString(idTokenString);
         } catch (LogoutTokenBuilderException e) {
             Tr.error(tc, "OIDC_SERVER_BACKCHANNEL_LOGOUT_REQUEST_ERROR", new Object[] { oidcServerConfig.getProviderId(), e.getMessage() });
             return;

--- a/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutRequestHelper.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutRequestHelper.java
@@ -10,64 +10,45 @@
  *******************************************************************************/
 package io.openliberty.security.openidconnect.backchannellogout;
 
+import java.util.Map;
+
 import javax.servlet.http.HttpServletRequest;
 
-import org.jose4j.jwt.consumer.JwtContext;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
-
-import com.ibm.ws.security.openidconnect.client.jose4j.util.Jose4jUtil;
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.webcontainer.security.openidconnect.OidcServerConfig;
-import com.ibm.wsspi.ssl.SSLSupport;
 
-@Component
 public class BackchannelLogoutRequestHelper {
 
-    private static SSLSupport SSL_SUPPORT = null;
+    private static TraceComponent tc = Tr.register(BackchannelLogoutRequestHelper.class);
 
-    private HttpServletRequest request;
-    private OidcServerConfig oidcServerConfig;
-
-    private Jose4jUtil jose4jUtil = null;
-
-    @Reference
-    protected void setSslSupport(SSLSupport sslSupport) {
-        SSL_SUPPORT = sslSupport;
-    }
-
-    protected void unsetSslSupport() {
-        SSL_SUPPORT = null;
-    }
-
-    /**
-     * Do not use; needed for this to be a valid @Component object.
-     */
-    public BackchannelLogoutRequestHelper() {
-    }
+    private final HttpServletRequest request;
+    private final OidcServerConfig oidcServerConfig;
 
     public BackchannelLogoutRequestHelper(HttpServletRequest request, OidcServerConfig oidcServerConfig) {
         this.request = request;
         this.oidcServerConfig = oidcServerConfig;
-        jose4jUtil = new Jose4jUtil(SSL_SUPPORT);
     }
 
     /**
-     * Uses the provided ID token string to build a Logout Token and sends that Logout Token in back-channel logout requests to
-     * all of the necessary RPs.
-     *
-     * @param idTokenString
+     * Uses the provided ID token string to build logout tokens and sends back-channel logout requests to all of the necessary
+     * RPs. If the ID token contains multiple audiences, logout tokens are created for each client audience. Logout tokens are
+     * also created for all RPs that the OP is aware of having active or recently valid sessions.
      */
     public void sendBackchannelLogoutRequests(String idTokenString) {
+        Map<String, String> logoutTokens = null;
         try {
-            JwtContext jwtContext = Jose4jUtil.parseJwtWithoutValidation(idTokenString);
-        } catch (Exception e) {
-            // TODO Auto-generated catch block
-            // Do you need FFDC here? Remember FFDC instrumentation and @FFDCIgnore
-            e.printStackTrace();
+            LogoutTokenBuilder tokenBuilder = new LogoutTokenBuilder(request, oidcServerConfig);
+            if (idTokenString != null) {
+                logoutTokens = tokenBuilder.buildLogoutTokensFromIdTokenString(idTokenString);
+            } else {
+                logoutTokens = tokenBuilder.buildLogoutTokens();
+            }
+        } catch (LogoutTokenBuilderException e) {
+            Tr.error(tc, "OIDC_SERVER_BACKCHANNEL_LOGOUT_REQUEST_ERROR", new Object[] { oidcServerConfig.getProviderId(), e.getMessage() });
+            return;
         }
         // TODO
-//        JwtContext jwtContext = jose4jUtil.validateJwtStructureAndGetContext(idTokenString, config);
-//        JwtClaims claims = jose4jUtil.validateJwsSignature(jwtContext, config);
     }
 
 }

--- a/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/IdTokenDifferentIssuerException.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/IdTokenDifferentIssuerException.java
@@ -10,20 +10,12 @@
  *******************************************************************************/
 package io.openliberty.security.openidconnect.backchannellogout;
 
-public class LogoutTokenBuilderException extends Exception {
+public class IdTokenDifferentIssuerException extends LogoutTokenBuilderException {
 
     private static final long serialVersionUID = 1L;
 
-    public LogoutTokenBuilderException(Exception e) {
-        super(e);
-    }
-
-    public LogoutTokenBuilderException(String errorMsg) {
+    public IdTokenDifferentIssuerException(String errorMsg) {
         super(errorMsg);
-    }
-
-    public LogoutTokenBuilderException(String errorMsg, Exception e) {
-        super(errorMsg, e);
     }
 
 }

--- a/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/LogoutTokenBuilder.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/LogoutTokenBuilder.java
@@ -1,0 +1,203 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.openidconnect.backchannellogout;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.MalformedClaimException;
+import org.jose4j.jwt.consumer.JwtContext;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.security.jwt.utils.JwsSigner;
+import com.ibm.ws.security.jwt.utils.JwtData;
+import com.ibm.ws.security.jwt.utils.JwtDataConfig;
+import com.ibm.ws.security.oauth20.ProvidersService;
+import com.ibm.ws.security.oauth20.api.OAuth20Provider;
+import com.ibm.ws.security.oauth20.api.OidcOAuth20ClientProvider;
+import com.ibm.ws.security.oauth20.plugins.OidcBaseClient;
+import com.ibm.ws.security.openidconnect.client.jose4j.util.Jose4jUtil;
+import com.ibm.ws.webcontainer.security.openidconnect.OidcServerConfig;
+
+public class LogoutTokenBuilder {
+
+    private static TraceComponent tc = Tr.register(LogoutTokenBuilder.class);
+
+    public static final String EVENTS_MEMBER_NAME = "http://schemas.openid.net/event/backchannel-logout";
+
+    private final HttpServletRequest request;
+    private final OidcServerConfig oidcServerConfig;
+    private final OAuth20Provider oauth20provider;
+
+    public LogoutTokenBuilder(HttpServletRequest request, OidcServerConfig oidcServerConfig) {
+        this.request = request;
+        this.oidcServerConfig = oidcServerConfig;
+        this.oauth20provider = getOAuth20Provider(oidcServerConfig);
+    }
+
+    OAuth20Provider getOAuth20Provider(OidcServerConfig oidcServerConfig) {
+        String oauthProviderName = oidcServerConfig.getOauthProviderName();
+        return ProvidersService.getOAuth20Provider(oauthProviderName);
+    }
+
+    public Map<String, String> buildLogoutTokens() throws LogoutTokenBuilderException {
+        return buildLogoutTokens(null);
+    }
+
+    public Map<String, String> buildLogoutTokensFromIdTokenString(String idTokenString) throws LogoutTokenBuilderException {
+        JwtClaims idTokenClaims = getClaimsFromIdTokenString(idTokenString);
+        return buildLogoutTokens(idTokenClaims);
+    }
+
+    @FFDCIgnore(Exception.class)
+    Map<String, String> buildLogoutTokens(JwtClaims idTokenClaims) throws LogoutTokenBuilderException {
+        Map<String, String> clientsAndLogoutTokens = new HashMap<String, String>();
+        try {
+            List<OidcBaseClient> clientsToLogOut = getClientsToLogOut(idTokenClaims);
+            if (clientsToLogOut == null || clientsToLogOut.isEmpty()) {
+                return new HashMap<String, String>();
+            }
+            for (OidcBaseClient client : clientsToLogOut) {
+                String logoutToken = createLogoutTokenForClient(client, idTokenClaims);
+                clientsAndLogoutTokens.put(client.getClientId(), logoutToken);
+            }
+        } catch (Exception e) {
+            throw new LogoutTokenBuilderException(e);
+        }
+        return clientsAndLogoutTokens;
+    }
+
+    @FFDCIgnore(Exception.class)
+    JwtClaims getClaimsFromIdTokenString(String idTokenString) throws LogoutTokenBuilderException {
+        try {
+            JwtContext jwtContext = Jose4jUtil.parseJwtWithoutValidation(idTokenString);
+            return jwtContext.getJwtClaims();
+        } catch (Exception e) {
+            String errorMsg = Tr.formatMessage(tc, "LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN", new Object[] { e });
+            throw new LogoutTokenBuilderException(errorMsg, e);
+        }
+    }
+
+    List<OidcBaseClient> getClientsToLogOut(JwtClaims idTokenClaims) throws LogoutTokenBuilderException {
+        List<OidcBaseClient> clientsUnderConsideration = getClientsToConsiderLoggingOut(idTokenClaims);
+        // TODO
+        // Find all RPs with active or recently active sessions with the OP
+        return clientsUnderConsideration;
+    }
+
+    /**
+     * Returns a list of all OAuth clients that should be considered for logging out. If there are no ID token claims provided,
+     * this returns all OAuth clients registered with the OP. If there are ID token claims, this returns only the client IDs
+     * listed in the audience claim. It is expected that list would be compared to some kind of cache of RPs that have active
+     * or recently active sessions with the OP.
+     */
+    @FFDCIgnore(Exception.class)
+    List<OidcBaseClient> getClientsToConsiderLoggingOut(JwtClaims idTokenClaims) throws LogoutTokenBuilderException {
+        List<OidcBaseClient> clientsToConsiderLoggingOut = new ArrayList<>();
+        try {
+            OidcOAuth20ClientProvider clientProvider = oauth20provider.getClientProvider();
+            Collection<OidcBaseClient> clients = clientProvider.getAll();
+            if (idTokenClaims == null) {
+                // All registered clients should be considered for logout
+                clientsToConsiderLoggingOut.addAll(clients);
+            } else {
+                // Only clients in the aud claim of the ID token should be considered for logout
+                for (OidcBaseClient client : clients) {
+                    List<String> idTokenAudiences = idTokenClaims.getAudience();
+                    if (idTokenAudiences.contains(client.getClientId())) {
+                        clientsToConsiderLoggingOut.add(client);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            String errorMsg = Tr.formatMessage(tc, "LOGOUT_TOKEN_ERROR_GETTING_CLIENTS_TO_LOG_OUT", new Object[] { e });
+            throw new LogoutTokenBuilderException(errorMsg, e);
+        }
+        return clientsToConsiderLoggingOut;
+    }
+
+    String createLogoutTokenForClient(OidcBaseClient client, JwtClaims idTokenClaims) throws Exception {
+        JwtClaims logoutTokenClaims = populateLogoutTokenClaims(client, idTokenClaims);
+
+        String sharedKey = client.getClientSecret();
+        JwtDataConfig jwtDataConfig = new JwtDataConfig(oidcServerConfig.getSignatureAlgorithm(), oidcServerConfig.getJSONWebKey(), sharedKey, oidcServerConfig.getPrivateKey(), oidcServerConfig.getKeyAliasName(), oidcServerConfig.getKeyStoreRef(), JwtData.TYPE_JWT_TOKEN, oidcServerConfig.isJwkEnabled());
+        JwtData jwtData = new JwtData(jwtDataConfig);
+
+        // When we add support for JWE ID tokens, this will need to be updated to create a JWE logout token as well
+        return JwsSigner.getSignedJwt(logoutTokenClaims, jwtData);
+    }
+
+    JwtClaims populateLogoutTokenClaims(OidcBaseClient client, JwtClaims idTokenClaims) throws MalformedClaimException {
+        JwtClaims logoutTokenClaims = new JwtClaims();
+        if (idTokenClaims != null) {
+            logoutTokenClaims = populateLogoutTokenClaimsFromIdToken(client, idTokenClaims);
+        } else {
+            logoutTokenClaims = populateLogoutTokenClaims(client);
+        }
+        return logoutTokenClaims;
+    }
+
+    JwtClaims populateLogoutTokenClaimsFromIdToken(OidcBaseClient client, JwtClaims idTokenClaims) throws MalformedClaimException {
+        JwtClaims logoutTokenClaims = populateLogoutTokenClaims(client);
+        // TODO - ensure we end up setting at least sub or sid
+        String sub = idTokenClaims.getSubject();
+        if (sub != null) {
+            logoutTokenClaims.setSubject(sub);
+        }
+        String sid = idTokenClaims.getStringClaimValue("sid");
+        if (sid != null && !sid.isEmpty()) {
+            logoutTokenClaims.setClaim("sid", sid);
+        }
+        return logoutTokenClaims;
+    }
+
+    JwtClaims populateLogoutTokenClaims(OidcBaseClient client) {
+        JwtClaims logoutTokenClaims = new JwtClaims();
+        logoutTokenClaims.setIssuer(getIssuer());
+        logoutTokenClaims.setAudience(client.getClientId());
+        logoutTokenClaims.setIssuedAtToNow();
+        logoutTokenClaims.setGeneratedJwtId();
+
+        Map<String, Object> eventsClaim = new HashMap<>();
+        eventsClaim.put(EVENTS_MEMBER_NAME, new HashMap<>());
+        logoutTokenClaims.setClaim("events", eventsClaim);
+
+        // TODO
+        // Set sid
+
+        return logoutTokenClaims;
+    }
+
+    String getIssuer() {
+        String issuerIdentifier = oidcServerConfig.getIssuerIdentifier();
+        if (issuerIdentifier != null && !issuerIdentifier.isEmpty()) {
+            return issuerIdentifier;
+        }
+        issuerIdentifier = request.getScheme() + "://" + request.getServerName();
+        int port = request.getServerPort();
+        if (port != 80 && port != 443) {
+            issuerIdentifier += ":" + port;
+        }
+        String requestUri = request.getRequestURI();
+        requestUri = requestUri.substring(0, requestUri.lastIndexOf("/"));
+        issuerIdentifier += requestUri;
+        return issuerIdentifier;
+    }
+
+}

--- a/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/LogoutTokenBuilder.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/LogoutTokenBuilder.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.security.openidconnect.backchannellogout;
 
@@ -22,17 +22,23 @@ import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.MalformedClaimException;
 import org.jose4j.jwt.consumer.JwtContext;
 
+import com.ibm.oauth.core.api.oauth20.token.OAuth20Token;
+import com.ibm.oauth.core.internal.oauth20.OAuth20Constants;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.security.jwt.Claims;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.jwt.utils.JwsSigner;
 import com.ibm.ws.security.jwt.utils.JwtData;
 import com.ibm.ws.security.jwt.utils.JwtDataConfig;
 import com.ibm.ws.security.oauth20.ProvidersService;
+import com.ibm.ws.security.oauth20.api.OAuth20EnhancedTokenCache;
 import com.ibm.ws.security.oauth20.api.OAuth20Provider;
 import com.ibm.ws.security.oauth20.api.OidcOAuth20ClientProvider;
 import com.ibm.ws.security.oauth20.plugins.OidcBaseClient;
+import com.ibm.ws.security.openidconnect.backchannellogout.BackchannelLogoutException;
 import com.ibm.ws.security.openidconnect.client.jose4j.util.Jose4jUtil;
+import com.ibm.ws.security.openidconnect.server.plugins.IDTokenImpl;
 import com.ibm.ws.webcontainer.security.openidconnect.OidcServerConfig;
 
 public class LogoutTokenBuilder {
@@ -56,26 +62,67 @@ public class LogoutTokenBuilder {
         return ProvidersService.getOAuth20Provider(oauthProviderName);
     }
 
-    public Map<String, String> buildLogoutTokens() throws LogoutTokenBuilderException {
-        return buildLogoutTokens(null);
-    }
-
-    public Map<String, String> buildLogoutTokensFromIdTokenString(String idTokenString) throws LogoutTokenBuilderException {
+    public Map<OidcBaseClient, List<String>> buildLogoutTokensFromIdTokenString(String idTokenString) throws LogoutTokenBuilderException {
         JwtClaims idTokenClaims = getClaimsFromIdTokenString(idTokenString);
         return buildLogoutTokens(idTokenClaims);
     }
 
     @FFDCIgnore(Exception.class)
-    Map<String, String> buildLogoutTokens(JwtClaims idTokenClaims) throws LogoutTokenBuilderException {
-        Map<String, String> clientsAndLogoutTokens = new HashMap<String, String>();
+    JwtClaims getClaimsFromIdTokenString(String idTokenString) throws LogoutTokenBuilderException {
         try {
-            List<OidcBaseClient> clientsToLogOut = getClientsToLogOut(idTokenClaims);
+            JwtContext jwtContext = Jose4jUtil.parseJwtWithoutValidation(idTokenString);
+            JwtClaims claims = jwtContext.getJwtClaims();
+            verifyIdTokenContainsRequiredClaims(claims);
+            verifyIssuer(claims);
+            return claims;
+        } catch (Exception e) {
+            String errorMsg = Tr.formatMessage(tc, "LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN", new Object[] { e });
+            throw new LogoutTokenBuilderException(errorMsg, e);
+        }
+    }
+
+    void verifyIdTokenContainsRequiredClaims(JwtClaims claims) throws Exception {
+        List<String> missingClaims = new ArrayList<>();
+        String iss = claims.getIssuer();
+        if (iss == null || iss.isEmpty()) {
+            missingClaims.add(Claims.ISSUER);
+        }
+        String sub = claims.getSubject();
+        if (sub == null || sub.isEmpty()) {
+            missingClaims.add(Claims.SUBJECT);
+        }
+        List<String> aud = claims.getAudience();
+        if (aud == null || aud.isEmpty()) {
+            missingClaims.add(Claims.AUDIENCE);
+        }
+        if (!missingClaims.isEmpty()) {
+            String errorMsg = Tr.formatMessage(tc, "ID_TOKEN_MISSING_REQUIRED_CLAIMS", new Object[] { missingClaims });
+            throw new BackchannelLogoutException(errorMsg);
+        }
+    }
+
+    void verifyIssuer(JwtClaims idTokenClaims) throws MalformedClaimException, IdTokenDifferentIssuerException {
+        String issuerClaim = idTokenClaims.getIssuer();
+        String expectedIssuer = getIssuer();
+        if (!expectedIssuer.equals(issuerClaim)) {
+            String errorMsg = Tr.formatMessage(tc, "ID_TOKEN_ISSUER_NOT_THIS_OP", new Object[] { issuerClaim, expectedIssuer, oidcServerConfig.getProviderId() });
+            throw new IdTokenDifferentIssuerException(errorMsg);
+        }
+    }
+
+    @FFDCIgnore(Exception.class)
+    Map<OidcBaseClient, List<String>> buildLogoutTokens(JwtClaims idTokenClaims) throws LogoutTokenBuilderException {
+        Map<OidcBaseClient, List<String>> clientsAndLogoutTokens = new HashMap<OidcBaseClient, List<String>>();
+        try {
+            Map<OidcBaseClient, List<IDTokenImpl>> clientsToLogOut = getClientsToLogOut(idTokenClaims);
             if (clientsToLogOut == null || clientsToLogOut.isEmpty()) {
-                return new HashMap<String, String>();
+                return new HashMap<OidcBaseClient, List<String>>();
             }
-            for (OidcBaseClient client : clientsToLogOut) {
-                String logoutToken = createLogoutTokenForClient(client, idTokenClaims);
-                clientsAndLogoutTokens.put(client.getClientId(), logoutToken);
+            for (OidcBaseClient client : clientsToLogOut.keySet()) {
+                List<IDTokenImpl> cachedIdTokens = clientsToLogOut.get(client);
+                for (IDTokenImpl cachedIdToken : cachedIdTokens) {
+                    createLogoutTokenForClientFromCachedIdToken(clientsAndLogoutTokens, client, cachedIdToken);
+                }
             }
         } catch (Exception e) {
             throw new LogoutTokenBuilderException(e);
@@ -83,28 +130,32 @@ public class LogoutTokenBuilder {
         return clientsAndLogoutTokens;
     }
 
-    @FFDCIgnore(Exception.class)
-    JwtClaims getClaimsFromIdTokenString(String idTokenString) throws LogoutTokenBuilderException {
-        try {
-            JwtContext jwtContext = Jose4jUtil.parseJwtWithoutValidation(idTokenString);
-            return jwtContext.getJwtClaims();
-        } catch (Exception e) {
-            String errorMsg = Tr.formatMessage(tc, "LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN", new Object[] { e });
-            throw new LogoutTokenBuilderException(errorMsg, e);
-        }
-    }
+    /**
+     * Returns a map of all OAuth clients that will be logged out. Each client to log out maps to a list of ID tokens found in the
+     * OP's token cache that were issued to that client. The ID token claims can be used to build the claims for the respective
+     * logout token(s).
+     */
+    Map<OidcBaseClient, List<IDTokenImpl>> getClientsToLogOut(JwtClaims idTokenClaims) throws LogoutTokenBuilderException, MalformedClaimException {
+        String user = idTokenClaims.getSubject();
 
-    List<OidcBaseClient> getClientsToLogOut(JwtClaims idTokenClaims) throws LogoutTokenBuilderException {
         List<OidcBaseClient> clientsUnderConsideration = getClientsToConsiderLoggingOut(idTokenClaims);
-        // TODO
-        // Find all RPs with active or recently active sessions with the OP
-        return clientsUnderConsideration;
+        if (clientsUnderConsideration == null || clientsUnderConsideration.isEmpty()) {
+            return new HashMap<>();
+        }
+        // Find all RPs with active or recently active sessions with the OP. Do this by looking for any ID tokens in the
+        // provider's token cache.
+        OAuth20EnhancedTokenCache tokenCache = oauth20provider.getTokenCache();
+        Collection<OAuth20Token> allCachedUserTokens = tokenCache.getAllUserTokens(user);
+        if (allCachedUserTokens == null || allCachedUserTokens.isEmpty()) {
+            return new HashMap<>();
+        }
+
+        return getClientToCachedIdTokensMap(clientsUnderConsideration, allCachedUserTokens, idTokenClaims);
     }
 
     /**
-     * Returns a list of all OAuth clients that should be considered for logging out. If there are no ID token claims provided,
-     * this returns all OAuth clients registered with the OP. If there are ID token claims, this returns only the client IDs
-     * listed in the audience claim. It is expected that list would be compared to some kind of cache of RPs that have active
+     * Returns a list of all OAuth clients that should be considered for logging out. This should be only the client IDs listed
+     * in the ID token's audience claim. It is expected that list would be compared to some kind of cache of RPs that have active
      * or recently active sessions with the OP.
      */
     @FFDCIgnore(Exception.class)
@@ -113,14 +164,13 @@ public class LogoutTokenBuilder {
         try {
             OidcOAuth20ClientProvider clientProvider = oauth20provider.getClientProvider();
             Collection<OidcBaseClient> clients = clientProvider.getAll();
-            if (idTokenClaims == null) {
-                // All registered clients should be considered for logout
-                clientsToConsiderLoggingOut.addAll(clients);
-            } else {
-                // Only clients in the aud claim of the ID token should be considered for logout
-                for (OidcBaseClient client : clients) {
-                    List<String> idTokenAudiences = idTokenClaims.getAudience();
-                    if (idTokenAudiences.contains(client.getClientId())) {
+            // Only clients in the aud claim of the ID token should be considered for logout
+            List<String> idTokenAudiences = idTokenClaims.getAudience();
+            for (OidcBaseClient client : clients) {
+                if (idTokenAudiences.contains(client.getClientId())) {
+                    // Only consider clients that have a backchannel_logout_uri configured
+                    String logoutUri = client.getBackchannelLogoutUri();
+                    if (logoutUri != null) {
                         clientsToConsiderLoggingOut.add(client);
                     }
                 }
@@ -132,8 +182,144 @@ public class LogoutTokenBuilder {
         return clientsToConsiderLoggingOut;
     }
 
+    /**
+     * Determines all clients and associated ID tokens for the user that should be logged out. Finds all ID tokens in the set of
+     * cached tokens for the user and compares them against the claims in the ID token hint. Any tokens with matching client IDs,
+     * sub claims, and sid claims (if present) will be added to the map to use later when the creating the logout token(s).
+     */
+    Map<OidcBaseClient, List<IDTokenImpl>> getClientToCachedIdTokensMap(List<OidcBaseClient> clientsUnderConsiderationForLogout, Collection<OAuth20Token> allCachedUserTokens,
+                                                                        JwtClaims idTokenClaims) throws MalformedClaimException, LogoutTokenBuilderException {
+        Map<OidcBaseClient, List<IDTokenImpl>> cachedIdTokensMap = new HashMap<>();
+        for (OAuth20Token cachedToken : allCachedUserTokens) {
+            if (OAuth20Constants.ID_TOKEN.equals(cachedToken.getType())) {
+                for (OidcBaseClient client : clientsUnderConsiderationForLogout) {
+                    if (isIdTokenWithMatchingClaims(idTokenClaims, cachedToken, client)) {
+                        addCachedIdTokenToMap(cachedIdTokensMap, client, (IDTokenImpl) cachedToken);
+                    }
+                }
+            }
+        }
+        return cachedIdTokensMap;
+    }
+
+    @FFDCIgnore(LogoutTokenBuilderException.class)
+    boolean isIdTokenWithMatchingClaims(JwtClaims idTokenClaims, OAuth20Token cachedToken, OidcBaseClient client) throws MalformedClaimException, LogoutTokenBuilderException {
+        if (!isSameClientId(cachedToken, client)) {
+            return false;
+        }
+        IDTokenImpl cachedIdToken = (IDTokenImpl) cachedToken;
+        JwtClaims cachedIdTokenClaims = null;
+        try {
+            cachedIdTokenClaims = getClaimsFromIdTokenString(cachedIdToken.getTokenString());
+        } catch (LogoutTokenBuilderException e) {
+            // Don't throw the exception if the issuer simply didn't match the expected issuer value; just return false instead
+            if (e.getCause() instanceof IdTokenDifferentIssuerException) {
+                return false;
+            } else {
+                throw e;
+            }
+        }
+        if (!isSameAud(client, cachedIdTokenClaims)) {
+            return false;
+        }
+        if (!isSameSub(idTokenClaims, cachedIdTokenClaims)) {
+            return false;
+        }
+        if (!isSameSid(idTokenClaims, cachedIdTokenClaims)) {
+            return false;
+        }
+        return true;
+    }
+
+    boolean isSameClientId(OAuth20Token cachedToken, OidcBaseClient client) {
+        if (!client.getClientId().equals(cachedToken.getClientId())) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Cached token client ID [" + cachedToken.getClientId() + "] did not match OAuth client ID [" + client.getClientId() + "]");
+            }
+            return false;
+        }
+        return true;
+    }
+
+    boolean isSameAud(OidcBaseClient client, JwtClaims cachedIdTokenClaims) throws MalformedClaimException {
+        List<String> cachedIdTokenAud = cachedIdTokenClaims.getAudience();
+        if (cachedIdTokenAud == null || cachedIdTokenAud.isEmpty()) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Cached token aud claim was null or empty");
+            }
+            return false;
+        }
+        String expectedAud = client.getClientId();
+        if (!cachedIdTokenAud.contains(expectedAud)) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Cached token aud claim [" + cachedIdTokenAud + "] did not contain client ID [" + expectedAud + "]");
+            }
+            return false;
+        }
+        return true;
+    }
+
+    boolean isSameSub(JwtClaims idTokenClaims, JwtClaims cachedIdTokenClaims) throws MalformedClaimException {
+        String sub = idTokenClaims.getSubject();
+        String cachedIdTokenSub = cachedIdTokenClaims.getSubject();
+        if (sub == null && cachedIdTokenSub == null) {
+            return true;
+        }
+        if (sub != null && cachedIdTokenSub != null && sub.equals(cachedIdTokenSub)) {
+            return true;
+        }
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "Cached token sub claim [" + cachedIdTokenSub + "] did not match sub claim in ID token hint [" + sub + "]");
+        }
+        return false;
+    }
+
+    boolean isSameSid(JwtClaims idTokenClaims, JwtClaims cachedIdTokenClaims) throws MalformedClaimException {
+        String sid = idTokenClaims.getStringClaimValue("sid");
+        String cachedIdTokenSid = cachedIdTokenClaims.getStringClaimValue("sid");
+        if (sid != null && !sid.isEmpty()) {
+            if (cachedIdTokenSid != null && sid.equals(cachedIdTokenSid)) {
+                return true;
+            }
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Cached token sid claim [" + cachedIdTokenSid + "] did not match sid claim in ID token hint [" + sid + "]");
+            }
+            return false;
+        } else {
+            // ID token hint didn't contain a "sid" claim; ensure the cached ID token doesn't either
+            if (cachedIdTokenSid != null && !cachedIdTokenSid.isEmpty()) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Cached token sid claim [" + cachedIdTokenSid + "] did not match sid claim in ID token hint [" + sid + "]");
+                }
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void addCachedIdTokenToMap(Map<OidcBaseClient, List<IDTokenImpl>> cachedIdTokensMap, OidcBaseClient client, IDTokenImpl cachedToken) {
+        List<IDTokenImpl> cachedIdTokens = new ArrayList<>();
+        if (cachedIdTokensMap.containsKey(client)) {
+            cachedIdTokens = cachedIdTokensMap.get(client);
+        }
+        cachedIdTokens.add(cachedToken);
+        cachedIdTokensMap.put(client, cachedIdTokens);
+    }
+
+    void createLogoutTokenForClientFromCachedIdToken(Map<OidcBaseClient, List<String>> clientsAndLogoutTokens, OidcBaseClient client, IDTokenImpl cachedIdToken) throws Exception {
+        JwtClaims cachedIdTokenClaims = getClaimsFromIdTokenString(cachedIdToken.getTokenString());
+        String logoutToken = createLogoutTokenForClient(client, cachedIdTokenClaims);
+
+        List<String> logoutTokensForClient = new ArrayList<>();
+        if (clientsAndLogoutTokens.containsKey(client)) {
+            logoutTokensForClient = clientsAndLogoutTokens.get(client);
+        }
+        logoutTokensForClient.add(logoutToken);
+        clientsAndLogoutTokens.put(client, logoutTokensForClient);
+    }
+
     String createLogoutTokenForClient(OidcBaseClient client, JwtClaims idTokenClaims) throws Exception {
-        JwtClaims logoutTokenClaims = populateLogoutTokenClaims(client, idTokenClaims);
+        JwtClaims logoutTokenClaims = populateLogoutTokenClaimsFromIdToken(client, idTokenClaims);
 
         String sharedKey = client.getClientSecret();
         JwtDataConfig jwtDataConfig = new JwtDataConfig(oidcServerConfig.getSignatureAlgorithm(), oidcServerConfig.getJSONWebKey(), sharedKey, oidcServerConfig.getPrivateKey(), oidcServerConfig.getKeyAliasName(), oidcServerConfig.getKeyStoreRef(), JwtData.TYPE_JWT_TOKEN, oidcServerConfig.isJwkEnabled());
@@ -143,23 +329,11 @@ public class LogoutTokenBuilder {
         return JwsSigner.getSignedJwt(logoutTokenClaims, jwtData);
     }
 
-    JwtClaims populateLogoutTokenClaims(OidcBaseClient client, JwtClaims idTokenClaims) throws MalformedClaimException {
-        JwtClaims logoutTokenClaims = new JwtClaims();
-        if (idTokenClaims != null) {
-            logoutTokenClaims = populateLogoutTokenClaimsFromIdToken(client, idTokenClaims);
-        } else {
-            logoutTokenClaims = populateLogoutTokenClaims(client);
-        }
-        return logoutTokenClaims;
-    }
-
-    JwtClaims populateLogoutTokenClaimsFromIdToken(OidcBaseClient client, JwtClaims idTokenClaims) throws MalformedClaimException {
+    JwtClaims populateLogoutTokenClaimsFromIdToken(OidcBaseClient client, JwtClaims idTokenClaims) throws MalformedClaimException, LogoutTokenBuilderException {
         JwtClaims logoutTokenClaims = populateLogoutTokenClaims(client);
-        // TODO - ensure we end up setting at least sub or sid
-        String sub = idTokenClaims.getSubject();
-        if (sub != null) {
-            logoutTokenClaims.setSubject(sub);
-        }
+
+        logoutTokenClaims.setSubject(idTokenClaims.getSubject());
+
         String sid = idTokenClaims.getStringClaimValue("sid");
         if (sid != null && !sid.isEmpty()) {
             logoutTokenClaims.setClaim("sid", sid);
@@ -177,9 +351,6 @@ public class LogoutTokenBuilder {
         Map<String, Object> eventsClaim = new HashMap<>();
         eventsClaim.put(EVENTS_MEMBER_NAME, new HashMap<>());
         logoutTokenClaims.setClaim("events", eventsClaim);
-
-        // TODO
-        // Set sid
 
         return logoutTokenClaims;
     }

--- a/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/LogoutTokenBuilderException.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/LogoutTokenBuilderException.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.openidconnect.backchannellogout;
+
+public class LogoutTokenBuilderException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public LogoutTokenBuilderException(Exception e) {
+        super(e);
+    }
+
+    public LogoutTokenBuilderException(String errorMsg, Exception e) {
+        super(errorMsg, e);
+    }
+
+}

--- a/dev/com.ibm.ws.security.openidconnect.server/test/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutRequestHelperTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/test/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutRequestHelperTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package io.openliberty.security.openidconnect.backchannellogout;
 
-import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -18,7 +18,6 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 import com.ibm.ws.security.test.common.CommonTestClass;
 import com.ibm.ws.webcontainer.security.openidconnect.OidcServerConfig;
@@ -55,12 +54,6 @@ public class BackchannelLogoutRequestHelperTest extends CommonTestClass {
     public static void tearDownAfterClass() throws Exception {
         outputMgr.dumpStreams();
         outputMgr.restoreStreams();
-    }
-
-    @Test
-    public void test_sendBackchannelLogoutRequests_nullToken() throws IOException {
-        String idTokenString = null;
-        helper.sendBackchannelLogoutRequests(idTokenString);
     }
 
 }

--- a/dev/com.ibm.ws.security.openidconnect.server/test/io/openliberty/security/openidconnect/backchannellogout/LogoutTokenBuilderTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/test/io/openliberty/security/openidconnect/backchannellogout/LogoutTokenBuilderTest.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.security.openidconnect.backchannellogout;
 
@@ -19,7 +19,7 @@ import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Base64;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,11 +37,20 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.ibm.json.java.JSONArray;
+import com.ibm.json.java.JSONObject;
+import com.ibm.oauth.core.api.error.OidcServerException;
+import com.ibm.oauth.core.api.oauth20.token.OAuth20Token;
+import com.ibm.oauth.core.internal.oauth20.OAuth20Constants;
+import com.ibm.websphere.security.jwt.Claims;
+import com.ibm.ws.security.oauth20.api.OAuth20EnhancedTokenCache;
 import com.ibm.ws.security.oauth20.api.OAuth20Provider;
 import com.ibm.ws.security.oauth20.api.OidcOAuth20ClientProvider;
 import com.ibm.ws.security.oauth20.plugins.OidcBaseClient;
 import com.ibm.ws.security.openidconnect.client.jose4j.util.Jose4jUtil;
+import com.ibm.ws.security.openidconnect.server.plugins.IDTokenImpl;
 import com.ibm.ws.security.test.common.CommonTestClass;
+import com.ibm.ws.security.test.common.jwt.utils.JwtUnitTestUtils;
 import com.ibm.ws.webcontainer.security.openidconnect.OidcServerConfig;
 
 import test.common.SharedOutputManager;
@@ -50,11 +59,16 @@ public class LogoutTokenBuilderTest extends CommonTestClass {
 
     private static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("OpenIdConnect*=all");
 
+    private static final String CWWKS1643E_LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN = "CWWKS1643E";
+    private static final String CWWKS1645E_ID_TOKEN_ISSUER_NOT_THIS_OP = "CWWKS1645E";
+    private static final String CWWKS1646E_ID_TOKEN_MISSING_REQUIRED_CLAIMS = "CWWKS1646E";
+
     private final String issuerIdentifier = "https://localhost/oidc/endpoint/OP";
     private final String client1Id = "client1";
     private final String client2Id = "client2";
     private final String client3Id = "client3";
     private final String client1Secret = "client1secret";
+    private final String client2Secret = "client2secret";
     private final String client3Secret = "client3secret";
     private final String subject = "testuser";
     private final String sid = "somesidvalue";
@@ -66,8 +80,18 @@ public class LogoutTokenBuilderTest extends CommonTestClass {
     private final OidcBaseClient client1 = mockery.mock(OidcBaseClient.class, "client1");
     private final OidcBaseClient client2 = mockery.mock(OidcBaseClient.class, "client2");
     private final OidcBaseClient client3 = mockery.mock(OidcBaseClient.class, "client3");
+    private final OAuth20EnhancedTokenCache tokenCache = mockery.mock(OAuth20EnhancedTokenCache.class);
+    private final OAuth20Token token = mockery.mock(OAuth20Token.class, "token");
+    private final OAuth20Token accessToken1 = mockery.mock(OAuth20Token.class, "accessToken1");
+    private final OAuth20Token accessToken2 = mockery.mock(OAuth20Token.class, "accessToken2");
+    private final IDTokenImpl idToken = mockery.mock(IDTokenImpl.class, "idToken");
+    private final IDTokenImpl idToken1 = mockery.mock(IDTokenImpl.class, "idToken1");
+    private final IDTokenImpl idToken2 = mockery.mock(IDTokenImpl.class, "idToken2");
+    private final IDTokenImpl idToken3 = mockery.mock(IDTokenImpl.class, "idToken3");
 
     private LogoutTokenBuilder builder;
+
+    private final JwtUnitTestUtils jwtUtils = new JwtUnitTestUtils();
 
     private class MockLogoutTokenBuilder extends LogoutTokenBuilder {
         public MockLogoutTokenBuilder(HttpServletRequest request, OidcServerConfig oidcServerConfig) {
@@ -89,6 +113,40 @@ public class LogoutTokenBuilderTest extends CommonTestClass {
     public void setUp() throws Exception {
         System.out.println("Entering test: " + testName.getMethodName());
         builder = new MockLogoutTokenBuilder(request, oidcServerConfig);
+        mockery.checking(new Expectations() {
+            {
+                allowing(oidcServerConfig).getProviderId();
+                will(returnValue("OP"));
+                allowing(client1).getClientId();
+                will(returnValue(client1Id));
+                allowing(client2).getClientId();
+                will(returnValue(client2Id));
+                allowing(client3).getClientId();
+                will(returnValue(client3Id));
+                allowing(accessToken1).getType();
+                will(returnValue(OAuth20Constants.ACCESS_TOKEN));
+                allowing(accessToken2).getType();
+                will(returnValue(OAuth20Constants.ACCESS_TOKEN));
+                allowing(idToken1).getType();
+                will(returnValue(OAuth20Constants.ID_TOKEN));
+                allowing(idToken1).getClientId();
+                will(returnValue(client1Id));
+                allowing(idToken1).getTokenString();
+                will(returnValue(getIdToken1String()));
+                allowing(idToken2).getType();
+                will(returnValue(OAuth20Constants.ID_TOKEN));
+                allowing(idToken2).getClientId();
+                will(returnValue(client2Id));
+                allowing(idToken2).getTokenString();
+                will(returnValue(getIdToken2String()));
+                allowing(idToken3).getType();
+                will(returnValue(OAuth20Constants.ID_TOKEN));
+                allowing(idToken3).getClientId();
+                will(returnValue(client3Id));
+                allowing(idToken3).getTokenString();
+                will(returnValue(getIdToken3String()));
+            }
+        });
     }
 
     @After
@@ -105,391 +163,1225 @@ public class LogoutTokenBuilderTest extends CommonTestClass {
 
     @Test
     public void test_buildLogoutTokens_noRegisteredClients() throws Exception {
-        List<OidcBaseClient> registeredClients = new ArrayList<>();
+        setRegisteredClients(new ArrayList<>());
 
-        JwtClaims idTokenClaims = null;
-        mockery.checking(new Expectations() {
-            {
-                one(oauth20provider).getClientProvider();
-                will(returnValue(clientProvider));
-                one(clientProvider).getAll();
-                will(returnValue(registeredClients));
-            }
-        });
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
 
-        Map<String, String> result = builder.buildLogoutTokens(idTokenClaims);
+        Map<OidcBaseClient, List<String>> result = builder.buildLogoutTokens(idTokenClaims);
         assertNotNull("Result should not have been null but was.", result);
         assertTrue("Result should have been empty but wasn't: " + result, result.isEmpty());
     }
 
     @Test
-    public void test_buildLogoutTokens_nullIdTokenClaims_oneClientRegistered() throws Exception {
-        List<OidcBaseClient> registeredClients = new ArrayList<>();
-        registeredClients.add(client1);
-
-        JwtClaims idTokenClaims = null;
-        mockery.checking(new Expectations() {
-            {
-                one(oauth20provider).getClientProvider();
-                will(returnValue(clientProvider));
-                one(clientProvider).getAll();
-                will(returnValue(registeredClients));
-                one(oidcServerConfig).getIssuerIdentifier();
-                will(returnValue(issuerIdentifier));
-                allowing(client1).getClientId();
-                will(returnValue(client1Id));
-            }
-        });
-        setJwtCreationExpectations(client1, client1Secret);
-
-        Map<String, String> result = builder.buildLogoutTokens(idTokenClaims);
-        assertNotNull("Result should not have been null but was.", result);
-        assertEquals("Result did not have the expected number of entries: " + result, 1, result.size());
-        assertTrue("Result did not contain an entry for the expected client \"" + client1Id + "\". Result was: " + result, result.containsKey(client1Id));
-
-        String clientLogoutToken = result.get(client1Id);
-        verifyLogoutToken(clientLogoutToken, Arrays.asList(client1Id), null, null);
-    }
-
-    @Test
     public void test_buildLogoutTokens_idTokenOneAudience_oneClientRegistered_doesNotMatch() throws Exception {
-        List<OidcBaseClient> registeredClients = new ArrayList<>();
-        registeredClients.add(client1);
+        setRegisteredClients(Arrays.asList(client1));
 
-        JwtClaims idTokenClaims = new JwtClaims();
-        idTokenClaims.setAudience(client3Id);
-        mockery.checking(new Expectations() {
-            {
-                one(oauth20provider).getClientProvider();
-                will(returnValue(clientProvider));
-                one(clientProvider).getAll();
-                will(returnValue(registeredClients));
-                one(client1).getClientId();
-                will(returnValue(client1Id));
-            }
-        });
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client3Id);
 
-        Map<String, String> result = builder.buildLogoutTokens(idTokenClaims);
+        Map<OidcBaseClient, List<String>> result = builder.buildLogoutTokens(idTokenClaims);
         assertNotNull("Result should not have been null but was.", result);
         assertTrue("Result should have been empty but wasn't: " + result, result.isEmpty());
     }
 
     @Test
     public void test_buildLogoutTokens_idTokenOneAudience_oneClientRegistered_matches() throws Exception {
-        List<OidcBaseClient> registeredClients = new ArrayList<>();
-        registeredClients.add(client1);
+        setRegisteredClients(Arrays.asList(client1));
 
-        JwtClaims idTokenClaims = new JwtClaims();
-        idTokenClaims.setAudience(client1Id);
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        setTokenCacheExpectations(subject, idToken1);
         mockery.checking(new Expectations() {
             {
-                one(oauth20provider).getClientProvider();
-                will(returnValue(clientProvider));
-                one(clientProvider).getAll();
-                will(returnValue(registeredClients));
-                one(oidcServerConfig).getIssuerIdentifier();
+                allowing(oidcServerConfig).getIssuerIdentifier();
                 will(returnValue(issuerIdentifier));
-                allowing(client1).getClientId();
-                will(returnValue(client1Id));
+                one(client1).getBackchannelLogoutUri();
+                will(returnValue("https://localhost/my/logout/uri/client1"));
             }
         });
         setJwtCreationExpectations(client1, client1Secret);
 
-        Map<String, String> result = builder.buildLogoutTokens(idTokenClaims);
+        Map<OidcBaseClient, List<String>> result = builder.buildLogoutTokens(idTokenClaims);
         assertNotNull("Result should not have been null but was.", result);
         assertEquals("Result did not have the expected number of entries: " + result, 1, result.size());
-        assertTrue("Result did not contain an entry for the expected client \"" + client1Id + "\". Result was: " + result, result.containsKey(client1Id));
+        assertTrue("Result did not contain an entry for the expected client \"" + client1Id + "\". Result was: " + result, result.containsKey(client1));
 
-        String clientLogoutToken = result.get(client1Id);
-        verifyLogoutToken(clientLogoutToken, Arrays.asList(client1Id), null, null);
+        String clientLogoutToken = result.get(client1).get(0);
+        verifyLogoutToken(clientLogoutToken, Arrays.asList(client1Id), subject, null);
     }
 
     @Test
-    public void test_buildLogoutTokens_idTokenMultipleAudiences_multipleClientsRegistered() throws Exception {
-        List<OidcBaseClient> registeredClients = new ArrayList<>();
-        registeredClients.add(client1);
-        registeredClients.add(client2);
-        registeredClients.add(client3);
+    public void test_buildLogoutTokens_idTokenContainsSid_oneMatchingCachedToken() throws Exception {
+        setRegisteredClients(Arrays.asList(client1));
 
-        JwtClaims idTokenClaims = new JwtClaims();
-        idTokenClaims.setAudience(client1Id, client3Id);
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+        idTokenClaims.setStringClaim("sid", sid);
+
+        // One cached ID token has a matching sid
+        JSONObject cachedTokenClaims = getIdTokenClaims(subject, issuerIdentifier, client1Id);
+        cachedTokenClaims.put("sid", sid);
+        String cachedIdTokenString = jwtUtils.getHS256Jws(cachedTokenClaims, client1Secret);
+
+        setTokenCacheExpectations(subject, idToken1, idToken, idToken2, idToken3);
+
         mockery.checking(new Expectations() {
             {
-                one(oauth20provider).getClientProvider();
-                will(returnValue(clientProvider));
-                one(clientProvider).getAll();
-                will(returnValue(registeredClients));
                 allowing(oidcServerConfig).getIssuerIdentifier();
                 will(returnValue(issuerIdentifier));
-                allowing(client1).getClientId();
+                one(client1).getBackchannelLogoutUri();
+                will(returnValue("https://localhost/my/logout/uri/client1"));
+                allowing(idToken).getType();
+                will(returnValue(OAuth20Constants.ID_TOKEN));
+                allowing(idToken).getClientId();
                 will(returnValue(client1Id));
-                one(client2).getClientId();
+                allowing(idToken).getTokenString();
+                will(returnValue(cachedIdTokenString));
+            }
+        });
+        setJwtCreationExpectations(client1, client1Secret);
+
+        Map<OidcBaseClient, List<String>> result = builder.buildLogoutTokens(idTokenClaims);
+        assertNotNull("Result should not have been null but was.", result);
+        assertEquals("Result did not have the expected number of entries: " + result, 1, result.size());
+        assertTrue("Result did not contain an entry for the expected client \"" + client1Id + "\". Result was: " + result, result.containsKey(client1));
+
+        String clientLogoutToken = result.get(client1).get(0);
+        verifyLogoutToken(clientLogoutToken, Arrays.asList(client1Id), subject, sid);
+    }
+
+    @Test
+    public void test_buildLogoutTokens_idTokenMultipleAudiences_multipleClientsRegistered_oneCachedTokenHasWrongIssuer() throws Exception {
+        setRegisteredClients(Arrays.asList(client1, client2, client3));
+
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id, client2Id, client3Id);
+
+        // One cached ID token has a different issuer
+        String cachedIdTokenString = jwtUtils.getHS256Jws(getIdTokenClaims(subject, "some other issuer", client2Id), client2Secret);
+
+        setTokenCacheExpectations(subject, idToken1, idToken, idToken3);
+
+        mockery.checking(new Expectations() {
+            {
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                allowing(idToken).getType();
+                will(returnValue(OAuth20Constants.ID_TOKEN));
+                allowing(idToken).getClientId();
                 will(returnValue(client2Id));
-                allowing(client3).getClientId();
-                will(returnValue(client3Id));
+                allowing(idToken).getTokenString();
+                will(returnValue(cachedIdTokenString));
+                one(client1).getBackchannelLogoutUri();
+                will(returnValue("https://localhost/my/logout/uri/client1"));
+                one(client2).getBackchannelLogoutUri();
+                will(returnValue("https://localhost/my/logout/uri/client2"));
+                one(client3).getBackchannelLogoutUri();
+                will(returnValue("https://localhost/my/logout/uri/client3"));
             }
         });
         setJwtCreationExpectations(client1, client1Secret);
         setJwtCreationExpectations(client3, client3Secret);
 
-        Map<String, String> result = builder.buildLogoutTokens(idTokenClaims);
+        Map<OidcBaseClient, List<String>> result = builder.buildLogoutTokens(idTokenClaims);
         assertNotNull("Result should not have been null but was.", result);
         assertEquals("Result did not have the expected number of entries: " + result, 2, result.size());
-        assertTrue("Result did not contain an entry for the expected client \"" + client1Id + "\". Result was: " + result, result.containsKey(client1Id));
-        assertTrue("Result did not contain an entry for the expected client \"" + client3Id + "\". Result was: " + result, result.containsKey(client3Id));
+        assertTrue("Result did not contain an entry for the expected client \"" + client1 + "\". Result was: " + result, result.containsKey(client1));
+        assertTrue("Result did not contain an entry for the expected client \"" + client3 + "\". Result was: " + result, result.containsKey(client3));
 
-        String client1LogoutToken = result.get(client1Id);
-        verifyLogoutToken(client1LogoutToken, Arrays.asList(client1Id), null, null);
-        String client3LogoutToken = result.get(client3Id);
-        verifyLogoutToken(client3LogoutToken, Arrays.asList(client3Id), null, null);
+        String client1LogoutToken = result.get(client1).get(0);
+        verifyLogoutToken(client1LogoutToken, Arrays.asList(client1Id), subject, null);
+        String client3LogoutToken = result.get(client3).get(0);
+        verifyLogoutToken(client3LogoutToken, Arrays.asList(client3Id), subject, null);
+    }
+
+    @Test
+    public void test_buildLogoutTokens_idTokenMultipleAudiences_multipleClientsRegistered() throws Exception {
+        setRegisteredClients(Arrays.asList(client1, client2, client3));
+
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id, client3Id);
+
+        setTokenCacheExpectations(subject, idToken1, idToken3);
+        mockery.checking(new Expectations() {
+            {
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                one(client1).getBackchannelLogoutUri();
+                will(returnValue("https://localhost/my/logout/uri/client1"));
+                one(client3).getBackchannelLogoutUri();
+                will(returnValue("https://localhost/my/logout/uri/client3"));
+            }
+        });
+        setJwtCreationExpectations(client1, client1Secret);
+        setJwtCreationExpectations(client3, client3Secret);
+
+        Map<OidcBaseClient, List<String>> result = builder.buildLogoutTokens(idTokenClaims);
+        assertNotNull("Result should not have been null but was.", result);
+        assertEquals("Result did not have the expected number of entries: " + result, 2, result.size());
+        assertTrue("Result did not contain an entry for the expected client \"" + client1 + "\". Result was: " + result, result.containsKey(client1));
+        assertTrue("Result did not contain an entry for the expected client \"" + client3 + "\". Result was: " + result, result.containsKey(client3));
+
+        String client1LogoutToken = result.get(client1).get(0);
+        verifyLogoutToken(client1LogoutToken, Arrays.asList(client1Id), subject, null);
+        String client3LogoutToken = result.get(client3).get(0);
+        verifyLogoutToken(client3LogoutToken, Arrays.asList(client3Id), subject, null);
     }
 
     @Test
     public void test_getClaimsFromIdTokenString_emptyClaims() throws Exception {
-        String idTokenString = "eyJhbGciOiJub25lIn0.e30.";
-        JwtClaims result = builder.getClaimsFromIdTokenString(idTokenString);
-        assertNotNull("Returned claims object should not have been null but was.", result);
-        Map<String, Object> claimsMap = result.getClaimsMap();
-        assertTrue("Claims should have been empty but were: " + claimsMap, claimsMap.isEmpty());
+        String idTokenString = jwtUtils.getHS256Jws(new JSONObject(), client1Secret);
+        try {
+            JwtClaims result = builder.getClaimsFromIdTokenString(idTokenString);
+            fail("Should have thrown an exception but got: " + result);
+        } catch (LogoutTokenBuilderException e) {
+            verifyException(e, CWWKS1643E_LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN + ".*" + CWWKS1646E_ID_TOKEN_MISSING_REQUIRED_CLAIMS);
+        }
     }
 
     @Test
     public void test_getClaimsFromIdTokenString_goldenPathClaims() throws Exception {
-        JwtClaims input = new JwtClaims();
-        input.setIssuer(issuerIdentifier);
-        input.setAudience(client1Id);
+        JwtClaims input = getClaims(subject, issuerIdentifier, client1Id);
         input.setIssuedAtToNow();
         input.setGeneratedJwtId();
-        input.setSubject(subject);
         input.setExpirationTimeMinutesInTheFuture(60);
         input.setNotBeforeMinutesInThePast(10);
 
-        String encodedClaims = new String(Base64.getEncoder().encode(input.toJson().getBytes()));
-        String idTokenString = "eyJhbGciOiJub25lIn0." + encodedClaims + ".";
+        String idTokenString = jwtUtils.getHS256Jws(JSONObject.parse(input.toJson()), client1Secret);
 
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+            }
+        });
         JwtClaims result = builder.getClaimsFromIdTokenString(idTokenString);
         assertNotNull("Returned claims object should not have been null but was.", result);
         assertEquals("Returned claims object did not match the input.", input.getClaimsMap(), result.getClaimsMap());
     }
 
-    //@Test
-    public void test_getClientsToLogOut_() throws Exception {
-        JwtClaims idTokenClaims = new JwtClaims();
-        mockery.checking(new Expectations() {
-            {
-                one(oauth20provider).getClientProvider();
-                will(returnValue(clientProvider));
-            }
-        });
-        List<OidcBaseClient> result = builder.getClientsToLogOut(idTokenClaims);
-    }
-
-    // TODO - continue getClientsToLogOut
-
     @Test
-    public void test_getClientsToConsiderLoggingOut_nullClaims_noConfiguredClients() throws Exception {
+    public void test_getClientsToLogOut_noCachedUserTokens() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        setRegisteredClients(Arrays.asList(client1, client2, client3));
+
         mockery.checking(new Expectations() {
             {
-                one(oauth20provider).getClientProvider();
-                will(returnValue(clientProvider));
-                one(clientProvider).getAll();
-                will(returnValue(new ArrayList<>()));
+                one(client1).getBackchannelLogoutUri();
+                will(returnValue("https://localhost/my/logout/uri/client1"));
             }
         });
-        JwtClaims claims = null;
-        try {
-            List<OidcBaseClient> clients = builder.getClientsToConsiderLoggingOut(claims);
-            assertNotNull("List of clients should not have been null but was.", clients);
-            assertTrue("List of clients should have been empty but wasn't: " + clients, clients.isEmpty());
-        } catch (LogoutTokenBuilderException e) {
-            fail("Should not have thrown an exception but did: " + e);
-        }
+
+        // No tokens cached for user
+        setTokenCacheExpectations(subject);
+
+        Map<OidcBaseClient, List<IDTokenImpl>> result = builder.getClientsToLogOut(idTokenClaims);
+        assertNotNull("Result should not have been null but was.", result);
+        assertTrue("Result should have been empty but was: " + result, result.isEmpty());
     }
 
     @Test
-    public void test_getClientsToConsiderLoggingOut_nullClaims_multipleClients() throws Exception {
-        List<OidcBaseClient> registeredClients = new ArrayList<>();
-        registeredClients.add(client1);
-        registeredClients.add(client2);
-        registeredClients.add(client3);
+    public void test_getClientsToLogOut_noCachedIdTokens() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        setRegisteredClients(Arrays.asList(client1, client2, client3));
+
         mockery.checking(new Expectations() {
             {
-                one(oauth20provider).getClientProvider();
-                will(returnValue(clientProvider));
-                one(clientProvider).getAll();
-                will(returnValue(registeredClients));
+                one(client1).getBackchannelLogoutUri();
+                will(returnValue("https://localhost/my/logout/uri/client1"));
             }
         });
-        JwtClaims claims = null;
-        try {
-            List<OidcBaseClient> clients = builder.getClientsToConsiderLoggingOut(claims);
-            assertNotNull("List of clients should not have been null but was.", clients);
-            assertFalse("List of clients should not have been empty but was.", clients.isEmpty());
-            for (OidcBaseClient expectedClient : registeredClients) {
-                assertTrue("List of clients did not contain expected client [" + expectedClient + "]. Clients were: " + clients, clients.contains(expectedClient));
-            }
-        } catch (LogoutTokenBuilderException e) {
-            fail("Should not have thrown an exception but did: " + e);
-        }
+
+        // No ID tokens cached for user
+        setTokenCacheExpectations(subject, accessToken1, accessToken2);
+
+        Map<OidcBaseClient, List<IDTokenImpl>> result = builder.getClientsToLogOut(idTokenClaims);
+        assertNotNull("Result should not have been null but was.", result);
+        assertTrue("Result should have been empty but was: " + result, result.isEmpty());
     }
 
     @Test
-    public void test_getClientsToConsiderLoggingOut_claimsMissingAud_multipleRegisteredClients() throws Exception {
-        List<OidcBaseClient> registeredClients = new ArrayList<>();
-        registeredClients.add(client1);
-        registeredClients.add(client2);
-        registeredClients.add(client3);
+    public void test_getClientsToLogOut_noRegisteredClients() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        // No registered clients
+        setRegisteredClients(new ArrayList<>());
+
+        Map<OidcBaseClient, List<IDTokenImpl>> result = builder.getClientsToLogOut(idTokenClaims);
+        assertNotNull("Result should not have been null but was.", result);
+        assertTrue("Result should have been empty but was: " + result, result.isEmpty());
+    }
+
+    @Test
+    public void test_getClientsToLogOut_idTokenAudDoesNotMatchAnyRegisteredClients() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        // client1 not among registered clients
+        setRegisteredClients(Arrays.asList(client2, client3));
+
+        Map<OidcBaseClient, List<IDTokenImpl>> result = builder.getClientsToLogOut(idTokenClaims);
+        assertNotNull("Result should not have been null but was.", result);
+        assertTrue("Result should have been empty but was: " + result, result.isEmpty());
+    }
+
+    @Test
+    public void test_getClientsToLogOut_idTokenAudDoesNotMatchAnyCachedIdTokenClients() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        setRegisteredClients(Arrays.asList(client1, client2, client3));
+
         mockery.checking(new Expectations() {
             {
-                one(oauth20provider).getClientProvider();
-                will(returnValue(clientProvider));
-                one(clientProvider).getAll();
-                will(returnValue(registeredClients));
-                one(client1).getClientId();
+                one(client1).getBackchannelLogoutUri();
+                will(returnValue("https://localhost/my/logout/uri/client1"));
+            }
+        });
+
+        // No ID tokens cached for client1
+        setTokenCacheExpectations(subject, idToken2, idToken3);
+
+        Map<OidcBaseClient, List<IDTokenImpl>> result = builder.getClientsToLogOut(idTokenClaims);
+        assertNotNull("Result should not have been null but was.", result);
+        assertTrue("Result should have been empty but was: " + result, result.isEmpty());
+    }
+
+    @Test
+    public void test_getClientsToLogOut_goldenPath_oneAud_oneCachedIdToken() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        // One ID token cached for client1
+        setTokenCacheExpectations(subject, idToken1, idToken2, idToken3);
+
+        setRegisteredClients(Arrays.asList(client1, client2, client3));
+
+        mockery.checking(new Expectations() {
+            {
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                one(client1).getBackchannelLogoutUri();
+                will(returnValue("https://localhost/my/logout/uri/client1"));
+            }
+        });
+
+        Map<OidcBaseClient, List<IDTokenImpl>> result = builder.getClientsToLogOut(idTokenClaims);
+        assertNotNull("Result should not have been null but was.", result);
+        assertEquals("Resulting map of clients to cached ID tokens did not match expected size. Result was: " + result, 1, result.size());
+        assertTrue("Resulting map of clients to cached ID tokens did not contain entry for [" + client1 + "]: " + result, result.containsKey(client1));
+
+        // Should find the ID token that matched
+        List<IDTokenImpl> cachedIdTokensForClient = result.get(client1);
+        assertEquals("List of cached ID tokens for [" + client1 + "] did not match expected size. Result was: " + cachedIdTokensForClient, 1, cachedIdTokensForClient.size());
+        assertTrue("List of cached ID tokens for [" + client1 + "] did not contain [" + idToken1 + "]: " + cachedIdTokensForClient, cachedIdTokensForClient.contains(idToken1));
+    }
+
+    @Test
+    public void test_getClientsToLogOut_goldenPath_oneAud_multipleCachedIdTokens() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        // Two ID tokens cached for client1
+        setTokenCacheExpectations(subject, idToken1, idToken, idToken2, idToken3);
+
+        setRegisteredClients(Arrays.asList(client1, client2, client3));
+
+        String cachedIdTokenString = jwtUtils.getHS256Jws(getIdTokenClaims(subject, issuerIdentifier, client1Id), client1Secret);
+
+        mockery.checking(new Expectations() {
+            {
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                allowing(idToken).getType();
+                will(returnValue(OAuth20Constants.ID_TOKEN));
+                allowing(idToken).getClientId();
                 will(returnValue(client1Id));
-                one(client2).getClientId();
-                will(returnValue(client2Id));
-                one(client3).getClientId();
-                will(returnValue(client3Id));
+                allowing(idToken).getTokenString();
+                will(returnValue(cachedIdTokenString));
+                one(client1).getBackchannelLogoutUri();
+                will(returnValue("https://localhost/my/logout/uri/client1"));
             }
         });
-        JwtClaims claims = new JwtClaims();
-        claims.setSubject(subject);
-        try {
-            List<OidcBaseClient> clients = builder.getClientsToConsiderLoggingOut(claims);
-            assertNotNull("List of clients should not have been null but was.", clients);
-            assertTrue("List of clients should have been empty but wasn't: " + clients, clients.isEmpty());
-        } catch (LogoutTokenBuilderException e) {
-            fail("Should not have thrown an exception but did: " + e);
-        }
+
+        Map<OidcBaseClient, List<IDTokenImpl>> result = builder.getClientsToLogOut(idTokenClaims);
+        assertNotNull("Result should not have been null but was.", result);
+        assertEquals("Resulting map of clients to cached ID tokens did not match expected size. Result was: " + result, 1, result.size());
+        assertTrue("Resulting map of clients to cached ID tokens did not contain entry for [" + client1 + "]: " + result, result.containsKey(client1));
+
+        // Should find the ID tokens that matched
+        List<IDTokenImpl> cachedIdTokensForClient = result.get(client1);
+        assertEquals("List of cached ID tokens for [" + client1 + "] did not match expected size. Result was: " + cachedIdTokensForClient, 2, cachedIdTokensForClient.size());
+        assertTrue("List of cached ID tokens for [" + client1 + "] did not contain [" + idToken + "]: " + cachedIdTokensForClient, cachedIdTokensForClient.contains(idToken));
+        assertTrue("List of cached ID tokens for [" + client1 + "] did not contain [" + idToken1 + "]: " + cachedIdTokensForClient, cachedIdTokensForClient.contains(idToken1));
+    }
+
+    @Test
+    public void test_getClientsToLogOut_goldenPath_multipleAud_multipleCachedIdTokens() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id, client2Id, client3Id);
+
+        // One ID token cached for each of client1, client2, and client3
+        setTokenCacheExpectations(subject, idToken1, idToken2, idToken3);
+
+        setRegisteredClients(Arrays.asList(client1, client2, client3));
+
+        mockery.checking(new Expectations() {
+            {
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                one(client1).getBackchannelLogoutUri();
+                will(returnValue("https://localhost/my/logout/uri/client1"));
+                one(client2).getBackchannelLogoutUri();
+                will(returnValue("https://localhost/my/logout/uri/client2"));
+                one(client3).getBackchannelLogoutUri();
+                will(returnValue("https://localhost/my/logout/uri/client3"));
+            }
+        });
+
+        Map<OidcBaseClient, List<IDTokenImpl>> result = builder.getClientsToLogOut(idTokenClaims);
+        assertNotNull("Result should not have been null but was.", result);
+        assertEquals("Resulting map of clients to cached ID tokens did not match expected size. Result was: " + result, 3, result.size());
+        assertTrue("Resulting map of clients to cached ID tokens did not contain entry for [" + client1 + "]: " + result, result.containsKey(client1));
+        assertTrue("Resulting map of clients to cached ID tokens did not contain entry for [" + client2 + "]: " + result, result.containsKey(client2));
+        assertTrue("Resulting map of clients to cached ID tokens did not contain entry for [" + client3 + "]: " + result, result.containsKey(client3));
+
+        // Should find the ID tokens that matched
+        List<IDTokenImpl> cachedIdTokensForClient = result.get(client1);
+        assertEquals("List of cached ID tokens for [" + client1 + "] did not match expected size. Result was: " + cachedIdTokensForClient, 1, cachedIdTokensForClient.size());
+        assertTrue("List of cached ID tokens for [" + client1 + "] did not contain [" + idToken1 + "]: " + cachedIdTokensForClient, cachedIdTokensForClient.contains(idToken1));
+
+        cachedIdTokensForClient = result.get(client2);
+        assertEquals("List of cached ID tokens for [" + client2 + "] did not match expected size. Result was: " + cachedIdTokensForClient, 1, cachedIdTokensForClient.size());
+        assertTrue("List of cached ID tokens for [" + client2 + "] did not contain [" + idToken2 + "]: " + cachedIdTokensForClient, cachedIdTokensForClient.contains(idToken2));
+
+        cachedIdTokensForClient = result.get(client3);
+        assertEquals("List of cached ID tokens for [" + client3 + "] did not match expected size. Result was: " + cachedIdTokensForClient, 1, cachedIdTokensForClient.size());
+        assertTrue("List of cached ID tokens for [" + client3 + "] did not contain [" + idToken3 + "]: " + cachedIdTokensForClient, cachedIdTokensForClient.contains(idToken3));
+    }
+
+    @Test
+    public void test_getClientsToConsiderLoggingOut_noConfiguredClients() throws Exception {
+        setRegisteredClients(new ArrayList<>());
+
+        JwtClaims claims = getClaims(subject, issuerIdentifier, client1Id);
+
+        List<OidcBaseClient> clients = builder.getClientsToConsiderLoggingOut(claims);
+
+        assertNotNull("List of clients should not have been null but was.", clients);
+        assertTrue("List of clients should have been empty but wasn't: " + clients, clients.isEmpty());
     }
 
     @Test
     public void test_getClientsToConsiderLoggingOut_audNotOneOfRegisteredClients() throws Exception {
-        List<OidcBaseClient> registeredClients = new ArrayList<>();
-        registeredClients.add(client1);
-        registeredClients.add(client2);
-        registeredClients.add(client3);
-        mockery.checking(new Expectations() {
-            {
-                one(oauth20provider).getClientProvider();
-                will(returnValue(clientProvider));
-                one(clientProvider).getAll();
-                will(returnValue(registeredClients));
-                one(client1).getClientId();
-                will(returnValue(client1Id));
-                one(client2).getClientId();
-                will(returnValue(client2Id));
-                one(client3).getClientId();
-                will(returnValue(client3Id));
-            }
-        });
-        JwtClaims claims = new JwtClaims();
-        claims.setSubject(subject);
-        claims.setAudience("client4");
-        try {
-            List<OidcBaseClient> clients = builder.getClientsToConsiderLoggingOut(claims);
-            assertNotNull("List of clients should not have been null but was.", clients);
-            assertTrue("List of clients should have been empty but wasn't: " + clients, clients.isEmpty());
-        } catch (LogoutTokenBuilderException e) {
-            fail("Should not have thrown an exception but did: " + e);
-        }
+        setRegisteredClients(Arrays.asList(client1, client2, client3));
+
+        JwtClaims claims = getClaims(subject, issuerIdentifier, "client4");
+
+        List<OidcBaseClient> clients = builder.getClientsToConsiderLoggingOut(claims);
+
+        assertNotNull("List of clients should not have been null but was.", clients);
+        assertTrue("List of clients should have been empty but wasn't: " + clients, clients.isEmpty());
     }
 
     @Test
     public void test_getClientsToConsiderLoggingOut_audMatchesOneRegisteredClient() throws Exception {
-        List<OidcBaseClient> registeredClients = new ArrayList<>();
-        registeredClients.add(client1);
-        registeredClients.add(client2);
-        registeredClients.add(client3);
+        setRegisteredClients(Arrays.asList(client1, client2, client3));
+
+        JwtClaims claims = getClaims(subject, issuerIdentifier, client1Id);
+
         mockery.checking(new Expectations() {
             {
-                one(oauth20provider).getClientProvider();
-                will(returnValue(clientProvider));
-                one(clientProvider).getAll();
-                will(returnValue(registeredClients));
-                one(client1).getClientId();
-                will(returnValue(client1Id));
-                one(client2).getClientId();
-                will(returnValue(client2Id));
-                one(client3).getClientId();
-                will(returnValue(client3Id));
+                one(client1).getBackchannelLogoutUri();
+                will(returnValue("https://localhost/my/logout/uri/client1"));
             }
         });
-        JwtClaims claims = new JwtClaims();
-        claims.setAudience(client1Id);
+
+        List<OidcBaseClient> clients = builder.getClientsToConsiderLoggingOut(claims);
+
+        assertNotNull("List of clients should not have been null but was.", clients);
+        assertFalse("List of clients should not have been empty but was.", clients.isEmpty());
+        assertEquals("Did not receive expected number of clients. Clients were: " + clients, 1, clients.size());
+        assertTrue("List of clients did not contain expected client [" + client1 + "]. Clients were: " + clients, clients.contains(client1));
+    }
+
+    @Test
+    public void test_getClientsToConsiderLoggingOut_audMatchesSubsetOfRegisteredClients_noneHaveLogoutUri() throws Exception {
+        setRegisteredClients(Arrays.asList(client1, client2, client3));
+
+        JwtClaims claims = getClaims(subject, issuerIdentifier, client2Id, client3Id);
+
+        mockery.checking(new Expectations() {
+            {
+                one(client2).getBackchannelLogoutUri();
+                will(returnValue(null));
+                one(client3).getBackchannelLogoutUri();
+                will(returnValue(null));
+            }
+        });
+
+        List<OidcBaseClient> clients = builder.getClientsToConsiderLoggingOut(claims);
+
+        assertNotNull("List of clients should not have been null but was.", clients);
+        assertTrue("List of clients should have been empty but wasn't: " + clients, clients.isEmpty());
+    }
+
+    @Test
+    public void test_getClientsToConsiderLoggingOut_audMatchesSubsetOfRegisteredClients_someHaveLogoutUri() throws Exception {
+        setRegisteredClients(Arrays.asList(client1, client2, client3));
+
+        JwtClaims claims = getClaims(subject, issuerIdentifier, client1Id, client2Id, client3Id);
+
+        mockery.checking(new Expectations() {
+            {
+                one(client1).getBackchannelLogoutUri();
+                will(returnValue("https://localhost/my/logout/uri/client1"));
+                one(client2).getBackchannelLogoutUri();
+                will(returnValue(null));
+                one(client3).getBackchannelLogoutUri();
+                will(returnValue("https://localhost/my/logout/uri/client3"));
+            }
+        });
+
+        List<OidcBaseClient> clients = builder.getClientsToConsiderLoggingOut(claims);
+
+        assertNotNull("List of clients should not have been null but was.", clients);
+        assertFalse("List of clients should not have been empty but was.", clients.isEmpty());
+        assertEquals("Did not receive expected number of clients. Clients were: " + clients, 2, clients.size());
+        assertTrue("List of clients did not contain expected client [" + client1 + "]. Clients were: " + clients, clients.contains(client1));
+        assertTrue("List of clients did not contain expected client [" + client3 + "]. Clients were: " + clients, clients.contains(client3));
+    }
+
+    @Test
+    public void test_getClientToCachedIdTokensMap_noCachedIdTokens() throws Exception {
+        List<OidcBaseClient> clientsUnderConsiderationForLogout = Arrays.asList(client1);
+
+        // No ID tokens are in the cache
+        Collection<OAuth20Token> allCachedUserTokens = Arrays.asList(accessToken1, accessToken2);
+
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        Map<OidcBaseClient, List<IDTokenImpl>> result = builder.getClientToCachedIdTokensMap(clientsUnderConsiderationForLogout, allCachedUserTokens, idTokenClaims);
+        assertNotNull("Resulting map of clients to cached ID tokens should not have been null but was.", result);
+        assertTrue("Resulting map of clients to cached ID tokens should have been empty but wasn't: " + result, result.isEmpty());
+    }
+
+    @Test
+    public void test_getClientToCachedIdTokensMap_multipleCachedIdTokens_noneMatchClientUnderConsideration() throws Exception {
+        List<OidcBaseClient> clientsUnderConsiderationForLogout = Arrays.asList(client1);
+
+        // No ID tokens for client1 are cached
+        Collection<OAuth20Token> allCachedUserTokens = Arrays.asList(accessToken1, idToken3, accessToken2, idToken2);
+
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        Map<OidcBaseClient, List<IDTokenImpl>> result = builder.getClientToCachedIdTokensMap(clientsUnderConsiderationForLogout, allCachedUserTokens, idTokenClaims);
+        assertNotNull("Resulting map of clients to cached ID tokens should not have been null but was.", result);
+        assertTrue("Resulting map of clients to cached ID tokens should have been empty but wasn't: " + result, result.isEmpty());
+    }
+
+    @Test
+    public void test_getClientToCachedIdTokensMap_oneCachedIdToken_matchesClientUnderConsideration_differentIss() throws Exception {
+        List<OidcBaseClient> clientsUnderConsiderationForLogout = Arrays.asList(client1);
+
+        Collection<OAuth20Token> allCachedUserTokens = Arrays.asList(idToken, accessToken1, accessToken2);
+
+        // The ID token hint has been verified to have the correct issuer at this point, so the cached token must be the one with a different issuer value
+        String cachedIdTokenString = jwtUtils.getHS256Jws(getIdTokenClaims(subject, "some other issuer", client1Id), client1Secret);
+
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        mockery.checking(new Expectations() {
+            {
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                allowing(idToken).getType();
+                will(returnValue(OAuth20Constants.ID_TOKEN));
+                allowing(idToken).getClientId();
+                will(returnValue(client1Id));
+                allowing(idToken).getTokenString();
+                will(returnValue(cachedIdTokenString));
+            }
+        });
+
+        Map<OidcBaseClient, List<IDTokenImpl>> result = builder.getClientToCachedIdTokensMap(clientsUnderConsiderationForLogout, allCachedUserTokens, idTokenClaims);
+        assertNotNull("Resulting map of clients to cached ID tokens should not have been null but was.", result);
+        assertTrue("Resulting map of clients to cached ID tokens should have been empty but wasn't: " + result, result.isEmpty());
+    }
+
+    @Test
+    public void test_getClientToCachedIdTokensMap_oneCachedIdToken_matchesClientUnderConsideration_differentSub() throws Exception {
+        List<OidcBaseClient> clientsUnderConsiderationForLogout = Arrays.asList(client1);
+
+        Collection<OAuth20Token> allCachedUserTokens = Arrays.asList(accessToken1, accessToken2, idToken1);
+
+        // ID token hint has a different sub claim
+        JwtClaims idTokenClaims = getClaims("some other subject", issuerIdentifier, client1Id);
+
+        mockery.checking(new Expectations() {
+            {
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+            }
+        });
+
+        Map<OidcBaseClient, List<IDTokenImpl>> result = builder.getClientToCachedIdTokensMap(clientsUnderConsiderationForLogout, allCachedUserTokens, idTokenClaims);
+        assertNotNull("Resulting map of clients to cached ID tokens should not have been null but was.", result);
+        assertTrue("Resulting map of clients to cached ID tokens should have been empty but wasn't: " + result, result.isEmpty());
+    }
+
+    @Test
+    public void test_getClientToCachedIdTokensMap_oneCachedIdToken_matchesClientUnderConsideration_allClaimsMatch() throws Exception {
+        List<OidcBaseClient> clientsUnderConsiderationForLogout = Arrays.asList(client1);
+
+        Collection<OAuth20Token> allCachedUserTokens = Arrays.asList(accessToken1, accessToken2, idToken1);
+
+        // All requisite claims in the ID token hint match the cached ID token
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        mockery.checking(new Expectations() {
+            {
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+            }
+        });
+
+        Map<OidcBaseClient, List<IDTokenImpl>> result = builder.getClientToCachedIdTokensMap(clientsUnderConsiderationForLogout, allCachedUserTokens, idTokenClaims);
+        assertNotNull("Resulting map of clients to cached ID tokens should not have been null but was.", result);
+        assertEquals("Resulting map of clients to cached ID tokens did not match expected size. Result was: " + result, 1, result.size());
+    }
+
+    @Test
+    public void test_getClientToCachedIdTokensMap_multipleCachedIdTokens_oneMatchesClientUnderConsideration_allClaimsMatch() throws Exception {
+        List<OidcBaseClient> clientsUnderConsiderationForLogout = Arrays.asList(client1);
+
+        // Multiple ID tokens in the cache, but only one for client1
+        Collection<OAuth20Token> allCachedUserTokens = Arrays.asList(accessToken1, idToken2, accessToken2, idToken1, idToken3);
+
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        mockery.checking(new Expectations() {
+            {
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+            }
+        });
+
+        Map<OidcBaseClient, List<IDTokenImpl>> result = builder.getClientToCachedIdTokensMap(clientsUnderConsiderationForLogout, allCachedUserTokens, idTokenClaims);
+        assertNotNull("Resulting map of clients to cached ID tokens should not have been null but was.", result);
+        assertEquals("Resulting map of clients to cached ID tokens did not match expected size. Result was: " + result, 1, result.size());
+    }
+
+    @Test
+    public void test_getClientToCachedIdTokensMap_multipleCachedIdTokens_multipleMatchClientUnderConsideration() throws Exception {
+        List<OidcBaseClient> clientsUnderConsiderationForLogout = Arrays.asList(client1);
+
+        // Multiple ID tokens in the cache, more than one are for client1
+        Collection<OAuth20Token> allCachedUserTokens = Arrays.asList(accessToken1, idToken, accessToken2, idToken1, idToken3);
+
+        // Set a "sid" claim for one of the ID tokens; this should prevent it from matching
+        JSONObject cachedTokenClaims = getIdTokenClaims(subject, issuerIdentifier, client1Id);
+        cachedTokenClaims.put("sid", sid);
+        String cachedIdTokenString = jwtUtils.getHS256Jws(cachedTokenClaims, client1Secret);
+
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        mockery.checking(new Expectations() {
+            {
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                allowing(idToken).getType();
+                will(returnValue(OAuth20Constants.ID_TOKEN));
+                allowing(idToken).getClientId();
+                will(returnValue(client1Id));
+                allowing(idToken).getTokenString();
+                will(returnValue(cachedIdTokenString));
+            }
+        });
+
+        // Should find an entry for client1
+        Map<OidcBaseClient, List<IDTokenImpl>> result = builder.getClientToCachedIdTokensMap(clientsUnderConsiderationForLogout, allCachedUserTokens, idTokenClaims);
+        assertNotNull("Resulting map of clients to cached ID tokens should not have been null but was.", result);
+        assertEquals("Resulting map of clients to cached ID tokens did not match expected size. Result was: " + result, 1, result.size());
+        assertTrue("Resulting map of clients to cached ID tokens did not contain entry for [" + client1 + "]: " + result, result.containsKey(client1));
+
+        // Should find the one ID token that matched
+        List<IDTokenImpl> cachedIdTokensForClient = result.get(client1);
+        assertEquals("List of cached ID tokens for [" + client1 + "] did not match expected size. Result was: " + cachedIdTokensForClient, 1, cachedIdTokensForClient.size());
+        assertTrue("List of cached ID tokens for [" + client1 + "] did not contain [" + idToken1 + "]: " + cachedIdTokensForClient, cachedIdTokensForClient.contains(idToken1));
+    }
+
+    @Test
+    public void test_getClientToCachedIdTokensMap_multipleClientsUnderConsideration_multipleCachedIdTokens_multipleMatchClientsUnderConsideration() throws Exception {
+        // Multiple clients are under consideration for logout
+        List<OidcBaseClient> clientsUnderConsiderationForLogout = Arrays.asList(client1, client2);
+
+        // A couple cached ID tokens are for client1, another ID token is for client2
+        Collection<OAuth20Token> allCachedUserTokens = Arrays.asList(accessToken1, idToken, accessToken2, idToken1, idToken2, idToken3);
+
+        String cachedIdTokenString = jwtUtils.getHS256Jws(getIdTokenClaims(subject, issuerIdentifier, client1Id), client1Secret);
+
+        // ID token hint aud claim lists multiple clients, two of which are under consideration for logout
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id, client2Id, client3Id);
+
+        mockery.checking(new Expectations() {
+            {
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                allowing(idToken).getType();
+                will(returnValue(OAuth20Constants.ID_TOKEN));
+                allowing(idToken).getClientId();
+                will(returnValue(client1Id));
+                allowing(idToken).getTokenString();
+                will(returnValue(cachedIdTokenString));
+            }
+        });
+
+        // Should find entries for all clients under consideration for logout that were also in the ID token hint's aud claim
+        Map<OidcBaseClient, List<IDTokenImpl>> result = builder.getClientToCachedIdTokensMap(clientsUnderConsiderationForLogout, allCachedUserTokens, idTokenClaims);
+        assertNotNull("Resulting map of clients to cached ID tokens should not have been null but was.", result);
+        assertEquals("Resulting map of clients to cached ID tokens did not match expected size. Result was: " + result, 2, result.size());
+        assertTrue("Resulting map of clients to cached ID tokens did not contain entry for [" + client1 + "]: " + result, result.containsKey(client1));
+        assertTrue("Resulting map of clients to cached ID tokens did not contain entry for [" + client2 + "]: " + result, result.containsKey(client2));
+
+        List<IDTokenImpl> cachedIdTokensForClient = result.get(client1);
+        assertEquals("List of cached ID tokens for [" + client1 + "] did not match expected size. Result was: " + cachedIdTokensForClient, 2, cachedIdTokensForClient.size());
+        assertTrue("List of cached ID tokens for [" + client1 + "] did not contain [" + idToken + "]: " + cachedIdTokensForClient, cachedIdTokensForClient.contains(idToken));
+        assertTrue("List of cached ID tokens for [" + client1 + "] did not contain [" + idToken1 + "]: " + cachedIdTokensForClient, cachedIdTokensForClient.contains(idToken1));
+
+        cachedIdTokensForClient = result.get(client2);
+        assertEquals("List of cached ID tokens for [" + client2 + "] did not match expected size. Result was: " + cachedIdTokensForClient, 1, cachedIdTokensForClient.size());
+        assertTrue("List of cached ID tokens for [" + client2 + "] did not contain [" + idToken2 + "]: " + cachedIdTokensForClient, cachedIdTokensForClient.contains(idToken2));
+    }
+
+    @Test
+    public void test_isIdTokenWithMatchingClaims_differentClientIds() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+        mockery.checking(new Expectations() {
+            {
+                allowing(token).getClientId();
+                will(returnValue(client2Id));
+            }
+        });
+        assertFalse("A cached token with a different client ID should not have matched " + client1 + ".", builder.isIdTokenWithMatchingClaims(idTokenClaims, token, client1));
+    }
+
+    @Test
+    public void test_isIdTokenWithMatchingClaims_cachedTokenMissingIss() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        String cachedTokenString = jwtUtils.getHS256Jws(getIdTokenClaims(subject, null, client1Id), client1Secret);
+        mockery.checking(new Expectations() {
+            {
+                one(idToken).getClientId();
+                will(returnValue(client1Id));
+                one(idToken).getTokenString();
+                will(returnValue(cachedTokenString));
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+            }
+        });
         try {
-            List<OidcBaseClient> clients = builder.getClientsToConsiderLoggingOut(claims);
-            assertNotNull("List of clients should not have been null but was.", clients);
-            assertFalse("List of clients should not have been empty but was.", clients.isEmpty());
-            assertEquals("Did not receive expected number of clients. Clients were: " + clients, 1, clients.size());
-            assertTrue("List of clients did not contain expected client [" + client1 + "]. Clients were: " + clients, clients.contains(client1));
+            boolean result = builder.isIdTokenWithMatchingClaims(idTokenClaims, idToken, client1);
+            fail("Should have thrown an exception but didn't. Was ID token considered a match? " + result + ".");
         } catch (LogoutTokenBuilderException e) {
-            fail("Should not have thrown an exception but did: " + e);
+            verifyException(e, CWWKS1643E_LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN + ".*" + CWWKS1646E_ID_TOKEN_MISSING_REQUIRED_CLAIMS + ".*" + "iss");
         }
     }
 
     @Test
-    public void test_getClientsToConsiderLoggingOut_audMatchesMultipleRegisteredClients() throws Exception {
-        List<OidcBaseClient> registeredClients = new ArrayList<>();
-        registeredClients.add(client1);
-        registeredClients.add(client2);
-        registeredClients.add(client3);
+    public void test_isIdTokenWithMatchingClaims_differentIssuer() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        JSONObject cachedTokenClaims = getIdTokenClaims(subject, "some other issuer", client1Id);
+        String cachedTokenString = jwtUtils.getHS256Jws(cachedTokenClaims, client1Secret);
         mockery.checking(new Expectations() {
             {
-                one(oauth20provider).getClientProvider();
-                will(returnValue(clientProvider));
-                one(clientProvider).getAll();
-                will(returnValue(registeredClients));
-                one(client1).getClientId();
+                one(idToken).getClientId();
                 will(returnValue(client1Id));
-                one(client2).getClientId();
-                will(returnValue(client2Id));
-                one(client3).getClientId();
-                will(returnValue(client3Id));
+                one(idToken).getTokenString();
+                will(returnValue(cachedTokenString));
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
             }
         });
-        JwtClaims claims = new JwtClaims();
-        claims.setAudience(client2Id, client3Id);
+        assertFalse("A cached token with a different \"iss\" claim should not have matched. ID token hint claims: " + idTokenClaims + ". Cached token claims: " + cachedTokenClaims
+                    + ".", builder.isIdTokenWithMatchingClaims(idTokenClaims, idToken, client1));
+    }
+
+    @Test
+    public void test_isIdTokenWithMatchingClaims_cachedTokenMissingAud() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        String cachedTokenString = jwtUtils.getHS256Jws(getIdTokenClaims(subject, issuerIdentifier), client1Secret);
+        mockery.checking(new Expectations() {
+            {
+                one(idToken).getClientId();
+                will(returnValue(client1Id));
+                one(idToken).getTokenString();
+                will(returnValue(cachedTokenString));
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+            }
+        });
         try {
-            List<OidcBaseClient> clients = builder.getClientsToConsiderLoggingOut(claims);
-            assertNotNull("List of clients should not have been null but was.", clients);
-            assertFalse("List of clients should not have been empty but was.", clients.isEmpty());
-            assertEquals("Did not receive expected number of clients. Clients were: " + clients, 2, clients.size());
-            assertTrue("List of clients did not contain expected client [" + client2 + "]. Clients were: " + clients, clients.contains(client2));
-            assertTrue("List of clients did not contain expected client [" + client3 + "]. Clients were: " + clients, clients.contains(client3));
+            boolean result = builder.isIdTokenWithMatchingClaims(idTokenClaims, idToken, client1);
+            fail("Should have thrown an exception but didn't. Was ID token considered a match? " + result + ".");
         } catch (LogoutTokenBuilderException e) {
-            fail("Should not have thrown an exception but did: " + e);
+            verifyException(e, CWWKS1643E_LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN + ".*" + CWWKS1646E_ID_TOKEN_MISSING_REQUIRED_CLAIMS + ".*" + "aud");
         }
     }
 
     @Test
-    public void test_createLogoutTokenForClient_nullIdTokenClaims() throws Exception {
-        JwtClaims idTokenClaims = null;
+    public void test_isIdTokenWithMatchingClaims_differentAud() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        JSONObject cachedTokenClaims = getIdTokenClaims(subject, issuerIdentifier, client2Id);
+        String cachedTokenString = jwtUtils.getHS256Jws(cachedTokenClaims, client1Secret);
         mockery.checking(new Expectations() {
             {
+                one(idToken).getClientId();
+                will(returnValue(client1Id));
+                one(idToken).getTokenString();
+                will(returnValue(cachedTokenString));
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+            }
+        });
+        assertFalse("A cached token with a different \"aud\" claim should not have matched. ID token hint claims: " + idTokenClaims + ". Cached token claims: " + cachedTokenClaims
+                    + ".", builder.isIdTokenWithMatchingClaims(idTokenClaims, idToken, client1));
+    }
+
+    @Test
+    public void test_isIdTokenWithMatchingClaims_cachedTokenMissingSub() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        String cachedTokenString = jwtUtils.getHS256Jws(getIdTokenClaims(null, issuerIdentifier, client1Id), client1Secret);
+        mockery.checking(new Expectations() {
+            {
+                one(idToken).getClientId();
+                will(returnValue(client1Id));
+                one(idToken).getTokenString();
+                will(returnValue(cachedTokenString));
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+            }
+        });
+        try {
+            boolean result = builder.isIdTokenWithMatchingClaims(idTokenClaims, idToken, client1);
+            fail("Should have thrown an exception but didn't. Was ID token considered a match? " + result + ".");
+        } catch (LogoutTokenBuilderException e) {
+            verifyException(e, CWWKS1643E_LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN + ".*" + CWWKS1646E_ID_TOKEN_MISSING_REQUIRED_CLAIMS + ".*" + "sub");
+        }
+    }
+
+    @Test
+    public void test_isIdTokenWithMatchingClaims_differentSub() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        JSONObject cachedTokenClaims = getIdTokenClaims("some other sub", issuerIdentifier, client1Id);
+        String cachedTokenString = jwtUtils.getHS256Jws(cachedTokenClaims, client1Secret);
+        mockery.checking(new Expectations() {
+            {
+                one(idToken).getClientId();
+                will(returnValue(client1Id));
+                one(idToken).getTokenString();
+                will(returnValue(cachedTokenString));
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+            }
+        });
+        assertFalse("A cached token with a different \"sub\" claim should not have matched. ID token hint claims: " + idTokenClaims + ". Cached token claims: " + cachedTokenClaims
+                    + ".", builder.isIdTokenWithMatchingClaims(idTokenClaims, idToken, client1));
+    }
+
+    @Test
+    public void test_isIdTokenWithMatchingClaims_idTokenMissingSid_cachedTokenContainsSid() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        JSONObject cachedTokenClaims = getIdTokenClaims("some other sub", issuerIdentifier, client1Id);
+        cachedTokenClaims.put("sid", sid);
+        String cachedTokenString = jwtUtils.getHS256Jws(cachedTokenClaims, client1Secret);
+        mockery.checking(new Expectations() {
+            {
+                one(idToken).getClientId();
+                will(returnValue(client1Id));
+                one(idToken).getTokenString();
+                will(returnValue(cachedTokenString));
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+            }
+        });
+        assertFalse("A cached token with a \"sid\" claim should not have matched an ID token hint with one. ID token hint claims: " + idTokenClaims + ". Cached token claims: "
+                    + cachedTokenClaims + ".", builder.isIdTokenWithMatchingClaims(idTokenClaims, idToken, client1));
+    }
+
+    @Test
+    public void test_isIdTokenWithMatchingClaims_idTokenContainsSid_cachedTokenMissingSid() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+        idTokenClaims.setStringClaim("sid", sid);
+
+        JSONObject cachedTokenClaims = getIdTokenClaims("some other sub", issuerIdentifier, client1Id);
+        String cachedTokenString = jwtUtils.getHS256Jws(cachedTokenClaims, client1Secret);
+        mockery.checking(new Expectations() {
+            {
+                one(idToken).getClientId();
+                will(returnValue(client1Id));
+                one(idToken).getTokenString();
+                will(returnValue(cachedTokenString));
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+            }
+        });
+        assertFalse("A cached token with missing a \"sid\" claim should not have matched. ID token hint claims: " + idTokenClaims + ". Cached token claims: " + cachedTokenClaims
+                    + ".", builder.isIdTokenWithMatchingClaims(idTokenClaims, idToken, client1));
+    }
+
+    @Test
+    public void test_isIdTokenWithMatchingClaims_differentSid() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+        idTokenClaims.setStringClaim("sid", sid);
+
+        JSONObject cachedTokenClaims = getIdTokenClaims("some other sub", issuerIdentifier, client1Id);
+        cachedTokenClaims.put("sid", "some other sid value");
+        String cachedTokenString = jwtUtils.getHS256Jws(cachedTokenClaims, client1Secret);
+        mockery.checking(new Expectations() {
+            {
+                one(idToken).getClientId();
+                will(returnValue(client1Id));
+                one(idToken).getTokenString();
+                will(returnValue(cachedTokenString));
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+            }
+        });
+        assertFalse("A cached token with a different \"sid\" claim should not have matched. ID token hint claims: " + idTokenClaims + ". Cached token claims: " + cachedTokenClaims
+                    + ".", builder.isIdTokenWithMatchingClaims(idTokenClaims, idToken, client1));
+    }
+
+    @Test
+    public void test_isIdTokenWithMatchingClaims_allNecessaryClaimsMatch_excludeSid() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+
+        JSONObject cachedTokenClaims = getIdTokenClaims(subject, issuerIdentifier, client1Id);
+        String cachedTokenString = jwtUtils.getHS256Jws(cachedTokenClaims, client1Secret);
+        mockery.checking(new Expectations() {
+            {
+                one(idToken).getClientId();
+                will(returnValue(client1Id));
+                one(idToken).getTokenString();
+                will(returnValue(cachedTokenString));
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+            }
+        });
+        assertTrue("A cached token with matching claims should have matched. ID token hint claims: " + idTokenClaims + ". Cached token claims: " + cachedTokenClaims + ".",
+                   builder.isIdTokenWithMatchingClaims(idTokenClaims, idToken, client1));
+    }
+
+    @Test
+    public void test_isIdTokenWithMatchingClaims_allNecessaryClaimsMatch_includeSid() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+        idTokenClaims.setStringClaim("sid", sid);
+
+        JSONObject cachedTokenClaims = getIdTokenClaims(subject, issuerIdentifier, client1Id);
+        cachedTokenClaims.put("sid", sid);
+        cachedTokenClaims.put(Claims.ISSUED_AT, 1);
+        cachedTokenClaims.put(Claims.EXPIRATION, 2);
+        cachedTokenClaims.put("nonce", "some nonce value");
+        String cachedTokenString = jwtUtils.getHS256Jws(cachedTokenClaims, client1Secret);
+        mockery.checking(new Expectations() {
+            {
+                one(idToken).getClientId();
+                will(returnValue(client1Id));
+                one(idToken).getTokenString();
+                will(returnValue(cachedTokenString));
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+            }
+        });
+        assertTrue("A cached token with matching claims should have matched. ID token hint claims: " + idTokenClaims + ". Cached token claims: " + cachedTokenClaims + ".",
+                   builder.isIdTokenWithMatchingClaims(idTokenClaims, idToken, client1));
+    }
+
+    @Test
+    public void test_isSameClientId_tokenMissingClientId() throws Exception {
+        mockery.checking(new Expectations() {
+            {
+                allowing(token).getClientId();
+                will(returnValue(null));
+            }
+        });
+        assertFalse("A cached token missing a client ID should not have matched " + client1 + ".", builder.isSameClientId(token, client1));
+    }
+
+    @Test
+    public void test_isSameClientId_tokenHasDifferentClientId() throws Exception {
+        mockery.checking(new Expectations() {
+            {
+                allowing(token).getClientId();
+                will(returnValue(client2Id));
+            }
+        });
+        assertFalse("A cached token with a different client ID should not have matched " + client1 + ".", builder.isSameClientId(token, client1));
+    }
+
+    @Test
+    public void test_isSameClientId_tokenHasSameClientId() throws Exception {
+        mockery.checking(new Expectations() {
+            {
+                allowing(token).getClientId();
+                will(returnValue(client1Id));
+            }
+        });
+        assertTrue("A cached token with the same client ID should have matched " + client1 + ".", builder.isSameClientId(token, client1));
+    }
+
+    @Test
+    public void test_isSameAud_emptyAud() throws Exception {
+        JwtClaims cachedIdTokenClaims = getClaims(subject, issuerIdentifier);
+        cachedIdTokenClaims.setAudience(new ArrayList<>());
+        assertFalse("A token with an empty \"aud\" claim should not have matched " + client1 + ".", builder.isSameAud(client1, cachedIdTokenClaims));
+    }
+
+    @Test
+    public void test_isSameAud_audSingleString_audDoesNotContainClient() throws Exception {
+        JwtClaims cachedIdTokenClaims = getClaims(subject, issuerIdentifier, client2Id);
+        assertFalse("A token with an \"aud\" claim that doesn't include the client ID should not have matched " + client1 + ".", builder.isSameAud(client1, cachedIdTokenClaims));
+    }
+
+    @Test
+    public void test_isSameAud_audSingleString_matchesClient() throws Exception {
+        JwtClaims cachedIdTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+        assertTrue("A token with an \"aud\" claim that matches the client ID should have matched " + client1 + ".", builder.isSameAud(client1, cachedIdTokenClaims));
+    }
+
+    @Test
+    public void test_isSameAud_audList_audDoesNotContainClient() throws Exception {
+        JwtClaims cachedIdTokenClaims = getClaims(subject, issuerIdentifier, client2Id, client3Id);
+        assertFalse("A token with an \"aud\" claim that doesn't include the client ID should not have matched " + client1 + ".", builder.isSameAud(client1, cachedIdTokenClaims));
+    }
+
+    @Test
+    public void test_isSameAud_audList_audContainsClient() throws Exception {
+        JwtClaims cachedIdTokenClaims = getClaims(subject, issuerIdentifier, client2Id, client1Id, client3Id);
+        assertTrue("A token with an \"aud\" claim that includes the client ID should have matched " + client1 + ".", builder.isSameAud(client1, cachedIdTokenClaims));
+    }
+
+    @Test
+    public void test_isSameSub_differentValues() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+        JwtClaims cachedIdTokenClaims = getClaims("some other subject", issuerIdentifier, client1Id);
+        assertFalse("Two sets of claims with different \"sub\" entries should not be considered to have the same sub.", builder.isSameSub(idTokenClaims, cachedIdTokenClaims));
+    }
+
+    @Test
+    public void test_isSameSub_sameValue() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+        JwtClaims cachedIdTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+        assertTrue("Two sets of claims with identical \"sub\" entries should be considered to have the same sub.", builder.isSameSub(idTokenClaims, cachedIdTokenClaims));
+    }
+
+    @Test
+    public void test_isSameSid_bothClaimsMissingSid() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+        JwtClaims cachedIdTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+        assertTrue("Two sets of claims both missing a \"sid\" entry should be considered to have the same sid.", builder.isSameSid(idTokenClaims, cachedIdTokenClaims));
+    }
+
+    @Test
+    public void test_isSameSid_idTokenHasSid_cachedTokenDoesNot() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+        idTokenClaims.setStringClaim("sid", sid);
+        JwtClaims cachedIdTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+        assertFalse("One set of claims with a \"sid\" entry and the other without should not be considered to have the same sid.",
+                    builder.isSameSid(idTokenClaims, cachedIdTokenClaims));
+    }
+
+    @Test
+    public void test_isSameSid_cachedTokenHasSid_idTokenDoesNot() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+        JwtClaims cachedIdTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+        cachedIdTokenClaims.setStringClaim("sid", sid);
+        assertFalse("One set of claims with a \"sid\" entry and the other without should not be considered to have the same sid.",
+                    builder.isSameSid(idTokenClaims, cachedIdTokenClaims));
+    }
+
+    @Test
+    public void test_isSameSid_bothHaveSid_differentValues() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+        idTokenClaims.setStringClaim("sid", sid);
+        JwtClaims cachedIdTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+        cachedIdTokenClaims.setStringClaim("sid", "some other sid");
+        assertFalse("Two sets of claims with different \"sid\" entries should not be considered to have the same sid.", builder.isSameSid(idTokenClaims, cachedIdTokenClaims));
+    }
+
+    @Test
+    public void test_isSameSid_bothHaveSid_sameValue() throws Exception {
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+        idTokenClaims.setStringClaim("sid", sid);
+        JwtClaims cachedIdTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
+        cachedIdTokenClaims.setStringClaim("sid", sid);
+        assertTrue("Two sets of claims with identical \"sid\" entries should be considered to have the same sid.", builder.isSameSid(idTokenClaims, cachedIdTokenClaims));
+    }
+
+    @Test
+    public void test_addCachedIdTokenToMap_noEntries() throws Exception {
+        Map<OidcBaseClient, List<IDTokenImpl>> cachedIdTokensMap = new HashMap<OidcBaseClient, List<IDTokenImpl>>();
+
+        builder.addCachedIdTokenToMap(cachedIdTokensMap, client1, idToken1);
+
+        assertEquals("Updated map did was not the expected size: " + cachedIdTokensMap, 1, cachedIdTokensMap.size());
+        assertTrue("Updated map did not contain entry for [" + client1 + "]: " + cachedIdTokensMap, cachedIdTokensMap.containsKey(client1));
+        List<IDTokenImpl> cachedIdTokensForClient = cachedIdTokensMap.get(client1);
+        assertEquals("List of cached ID tokens for client was not the expected size: " + cachedIdTokensForClient, 1, cachedIdTokensForClient.size());
+        assertEquals("Cached ID token did not match expected value.", idToken1, cachedIdTokensForClient.get(0));
+    }
+
+    @Test
+    public void test_addCachedIdTokenToMap_entriesForOtherClients() throws Exception {
+        Map<OidcBaseClient, List<IDTokenImpl>> cachedIdTokensMap = new HashMap<OidcBaseClient, List<IDTokenImpl>>();
+        cachedIdTokensMap.put(client2, new ArrayList<>());
+        cachedIdTokensMap.put(client3, new ArrayList<>());
+
+        builder.addCachedIdTokenToMap(cachedIdTokensMap, client1, idToken1);
+
+        assertEquals("Updated map did was not the expected size: " + cachedIdTokensMap, 3, cachedIdTokensMap.size());
+        assertTrue("Updated map did not contain entry for [" + client1 + "]: " + cachedIdTokensMap, cachedIdTokensMap.containsKey(client1));
+        List<IDTokenImpl> cachedIdTokensForClient = cachedIdTokensMap.get(client1);
+        assertEquals("List of cached ID tokens for client was not the expected size: " + cachedIdTokensForClient, 1, cachedIdTokensForClient.size());
+        assertEquals("Cached ID token did not match expected value.", idToken1, cachedIdTokensForClient.get(0));
+    }
+
+    @Test
+    public void test_addCachedIdTokenToMap_oneExistingEntryForClient() throws Exception {
+        Map<OidcBaseClient, List<IDTokenImpl>> cachedIdTokensMap = new HashMap<OidcBaseClient, List<IDTokenImpl>>();
+        List<IDTokenImpl> existingCachedTokens = new ArrayList<>();
+        existingCachedTokens.add(idToken1);
+        cachedIdTokensMap.put(client1, existingCachedTokens);
+        cachedIdTokensMap.put(client2, new ArrayList<>());
+
+        builder.addCachedIdTokenToMap(cachedIdTokensMap, client1, idToken2);
+
+        assertEquals("Updated map did was not the expected size: " + cachedIdTokensMap, 2, cachedIdTokensMap.size());
+        assertTrue("Updated map did not contain entry for [" + client1 + "]: " + cachedIdTokensMap, cachedIdTokensMap.containsKey(client1));
+        List<IDTokenImpl> cachedIdTokensForClient = cachedIdTokensMap.get(client1);
+        assertEquals("List of cached ID tokens for client was not the expected size: " + cachedIdTokensForClient, 2, cachedIdTokensForClient.size());
+        assertEquals("Cached ID token #1 did not match expected value. Cached tokens were: " + cachedIdTokensForClient, idToken1, cachedIdTokensForClient.get(0));
+        assertEquals("Cached ID token #2 did not match expected value. Cached tokens were: " + cachedIdTokensForClient, idToken2, cachedIdTokensForClient.get(1));
+    }
+
+    @Test
+    public void test_createLogoutTokenForClientFromCachedIdToken_idTokenDifferentIssuer() throws Exception {
+        Map<OidcBaseClient, List<String>> clientsAndLogoutTokens = new HashMap<OidcBaseClient, List<String>>();
+
+        JSONObject idTokenClaims = getIdTokenClaims("some subject", "some other issuer", "some audience");
+        final String idTokenString = jwtUtils.getHS256Jws(idTokenClaims, "some secret");
+        mockery.checking(new Expectations() {
+            {
+                one(idToken).getTokenString();
+                will(returnValue(idTokenString));
                 one(oidcServerConfig).getIssuerIdentifier();
                 will(returnValue(issuerIdentifier));
-                one(client1).getClientId();
-                will(returnValue(client1Id));
+            }
+        });
+        try {
+            builder.createLogoutTokenForClientFromCachedIdToken(clientsAndLogoutTokens, client1, idToken);
+            fail("Should have thrown an exception but didn't. Clients and logout tokens map was: " + clientsAndLogoutTokens);
+        } catch (LogoutTokenBuilderException e) {
+            verifyException(e, CWWKS1643E_LOGOUT_TOKEN_ERROR_GETTING_CLAIMS_FROM_ID_TOKEN + ".*" + CWWKS1645E_ID_TOKEN_ISSUER_NOT_THIS_OP);
+        }
+    }
+
+    @Test
+    public void test_createLogoutTokenForClientFromCachedIdToken_noExistingLogoutTokens() throws Exception {
+        Map<OidcBaseClient, List<String>> clientsAndLogoutTokens = new HashMap<OidcBaseClient, List<String>>();
+
+        JSONObject idTokenClaims = getIdTokenClaims(subject, issuerIdentifier, client1Id);
+        final String idTokenString = jwtUtils.getHS256Jws(idTokenClaims, "some secret");
+        mockery.checking(new Expectations() {
+            {
+                one(idToken).getTokenString();
+                will(returnValue(idTokenString));
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
             }
         });
         setJwtCreationExpectations(client1, client1Secret);
 
-        String result = builder.createLogoutTokenForClient(client1, idTokenClaims);
-        verifyLogoutToken(result, Arrays.asList(client1Id), null, null);
+        builder.createLogoutTokenForClientFromCachedIdToken(clientsAndLogoutTokens, client1, idToken);
+
+        assertEquals("Did not find expected number of entries in the logout tokens map: " + clientsAndLogoutTokens, 1, clientsAndLogoutTokens.size());
+        assertTrue("Logout tokens map did not contain entry for client [" + client1 + "]. Map was: " + clientsAndLogoutTokens, clientsAndLogoutTokens.containsKey(client1));
+    }
+
+    @Test
+    public void test_createLogoutTokenForClientFromCachedIdToken_someExistingLogoutTokensDifferentClient() throws Exception {
+        Map<OidcBaseClient, List<String>> clientsAndLogoutTokens = new HashMap<OidcBaseClient, List<String>>();
+        clientsAndLogoutTokens.put(client2, Arrays.asList("one", "two"));
+
+        JSONObject idTokenClaims = getIdTokenClaims(subject, issuerIdentifier, client1Id);
+        final String idTokenString = jwtUtils.getHS256Jws(idTokenClaims, "some secret");
+        mockery.checking(new Expectations() {
+            {
+                one(idToken).getTokenString();
+                will(returnValue(idTokenString));
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+            }
+        });
+        setJwtCreationExpectations(client1, client1Secret);
+
+        builder.createLogoutTokenForClientFromCachedIdToken(clientsAndLogoutTokens, client1, idToken);
+
+        assertEquals("Did not find expected number of entries in the logout tokens map: " + clientsAndLogoutTokens, 2, clientsAndLogoutTokens.size());
+        assertTrue("Logout tokens map did not contain entry for client [" + client1 + "]. Map was: " + clientsAndLogoutTokens, clientsAndLogoutTokens.containsKey(client1));
+
+        // Verify the new logout token that was created
+        List<String> clientLogoutTokens = clientsAndLogoutTokens.get(client1);
+        assertEquals("Did not find the expected number of logout tokens for client [" + client1 + "]: " + clientLogoutTokens, 1, clientLogoutTokens.size());
+        JwtClaims logoutTokenClaims = builder.getClaimsFromIdTokenString(clientLogoutTokens.get(0));
+        verifyLogoutTokenClaims(logoutTokenClaims, Arrays.asList(client1Id), subject, null);
+    }
+
+    @Test
+    public void test_createLogoutTokenForClientFromCachedIdToken_someExistingLogoutTokens() throws Exception {
+        Map<OidcBaseClient, List<String>> clientsAndLogoutTokens = new HashMap<OidcBaseClient, List<String>>();
+        // Client already contains entries for a couple logout tokens
+        List<String> client1Tokens = new ArrayList<>();
+        client1Tokens.add("1-one");
+        client1Tokens.add("1-two");
+        List<String> client2Tokens = new ArrayList<>();
+        client2Tokens.add("2-one");
+        client2Tokens.add("2-two");
+        clientsAndLogoutTokens.put(client1, client1Tokens);
+        clientsAndLogoutTokens.put(client2, client2Tokens);
+
+        JSONObject idTokenClaims = getIdTokenClaims(subject, issuerIdentifier, client1Id);
+        idTokenClaims.put("sid", sid);
+        final String idTokenString = jwtUtils.getHS256Jws(idTokenClaims, "some secret");
+        mockery.checking(new Expectations() {
+            {
+                one(idToken).getTokenString();
+                will(returnValue(idTokenString));
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+            }
+        });
+        setJwtCreationExpectations(client1, client1Secret);
+
+        builder.createLogoutTokenForClientFromCachedIdToken(clientsAndLogoutTokens, client1, idToken);
+
+        assertEquals("Did not find expected number of entries in the logout tokens map: " + clientsAndLogoutTokens, 2, clientsAndLogoutTokens.size());
+        assertTrue("Logout tokens map did not contain entry for client [" + client1 + "]. Map was: " + clientsAndLogoutTokens, clientsAndLogoutTokens.containsKey(client1));
+
+        // Verify the new logout token that was created
+        List<String> clientLogoutTokens = clientsAndLogoutTokens.get(client1);
+        assertEquals("Did not find the expected number of logout tokens for client [" + client1 + "]: " + clientLogoutTokens, 3, clientLogoutTokens.size());
+        JwtClaims logoutTokenClaims = builder.getClaimsFromIdTokenString(clientLogoutTokens.get(2));
+        verifyLogoutTokenClaims(logoutTokenClaims, Arrays.asList(client1Id), subject, sid);
     }
 
     @Test
     public void test_createLogoutTokenForClient_idTokenContainsSub() throws Exception {
-        JwtClaims idTokenClaims = new JwtClaims();
-        idTokenClaims.setSubject(subject);
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
         mockery.checking(new Expectations() {
             {
                 one(oidcServerConfig).getIssuerIdentifier();
                 will(returnValue(issuerIdentifier));
-                one(client1).getClientId();
-                will(returnValue(client1Id));
             }
         });
         setJwtCreationExpectations(client1, client1Secret);
@@ -499,34 +1391,13 @@ public class LogoutTokenBuilderTest extends CommonTestClass {
     }
 
     @Test
-    public void test_createLogoutTokenForClient_idTokenContainsSid() throws Exception {
-        JwtClaims idTokenClaims = new JwtClaims();
-        idTokenClaims.setStringClaim("sid", sid);
-        mockery.checking(new Expectations() {
-            {
-                one(oidcServerConfig).getIssuerIdentifier();
-                will(returnValue(issuerIdentifier));
-                one(client1).getClientId();
-                will(returnValue(client1Id));
-            }
-        });
-        setJwtCreationExpectations(client1, client1Secret);
-
-        String result = builder.createLogoutTokenForClient(client1, idTokenClaims);
-        verifyLogoutToken(result, Arrays.asList(client1Id), null, sid);
-    }
-
-    @Test
     public void test_createLogoutTokenForClient_idTokenContainsSubAndSid() throws Exception {
-        JwtClaims idTokenClaims = new JwtClaims();
-        idTokenClaims.setSubject(subject);
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
         idTokenClaims.setStringClaim("sid", sid);
         mockery.checking(new Expectations() {
             {
                 one(oidcServerConfig).getIssuerIdentifier();
                 will(returnValue(issuerIdentifier));
-                one(client1).getClientId();
-                will(returnValue(client1Id));
             }
         });
         setJwtCreationExpectations(client1, client1Secret);
@@ -536,30 +1407,12 @@ public class LogoutTokenBuilderTest extends CommonTestClass {
     }
 
     @Test
-    public void test_populateLogoutTokenClaimsFromIdToken_emptyIdTokenClaims() throws Exception {
-        JwtClaims idTokenClaims = new JwtClaims();
-        mockery.checking(new Expectations() {
-            {
-                one(oidcServerConfig).getIssuerIdentifier();
-                will(returnValue(issuerIdentifier));
-                one(client1).getClientId();
-                will(returnValue(client1Id));
-            }
-        });
-        // TODO - this should be an error scenario; that has yet to be fully implemented
-        JwtClaims result = builder.populateLogoutTokenClaimsFromIdToken(client1, idTokenClaims);
-    }
-
-    @Test
     public void test_populateLogoutTokenClaimsFromIdToken_subGoldenPath() throws Exception {
-        JwtClaims idTokenClaims = new JwtClaims();
-        idTokenClaims.setSubject(subject);
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
         mockery.checking(new Expectations() {
             {
                 one(oidcServerConfig).getIssuerIdentifier();
                 will(returnValue(issuerIdentifier));
-                one(client1).getClientId();
-                will(returnValue(client1Id));
             }
         });
         JwtClaims result = builder.populateLogoutTokenClaimsFromIdToken(client1, idTokenClaims);
@@ -568,32 +1421,13 @@ public class LogoutTokenBuilderTest extends CommonTestClass {
     }
 
     @Test
-    public void test_populateLogoutTokenClaimsFromIdToken_subEmpty_noSid() throws Exception {
-        JwtClaims idTokenClaims = new JwtClaims();
-        idTokenClaims.setSubject("");
-        mockery.checking(new Expectations() {
-            {
-                one(oidcServerConfig).getIssuerIdentifier();
-                will(returnValue(issuerIdentifier));
-                one(client1).getClientId();
-                will(returnValue(client1Id));
-            }
-        });
-        JwtClaims result = builder.populateLogoutTokenClaimsFromIdToken(client1, idTokenClaims);
-
-        verifyLogoutTokenClaims(result, Arrays.asList(client1Id), "", null);
-    }
-
-    @Test
     public void test_populateLogoutTokenClaimsFromIdToken_sidNotString() throws Exception {
-        JwtClaims idTokenClaims = new JwtClaims();
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
         idTokenClaims.setClaim("sid", 123);
         mockery.checking(new Expectations() {
             {
                 one(oidcServerConfig).getIssuerIdentifier();
                 will(returnValue(issuerIdentifier));
-                one(client1).getClientId();
-                will(returnValue(client1Id));
             }
         });
         try {
@@ -605,32 +1439,30 @@ public class LogoutTokenBuilderTest extends CommonTestClass {
     }
 
     @Test
-    public void test_populateLogoutTokenClaimsFromIdToken_sidEmpty_noSub() throws Exception {
-        JwtClaims idTokenClaims = new JwtClaims();
-        idTokenClaims.setClaim("sid", "");
-        mockery.checking(new Expectations() {
-            {
-                one(oidcServerConfig).getIssuerIdentifier();
-                will(returnValue(issuerIdentifier));
-                one(client1).getClientId();
-                will(returnValue(client1Id));
-            }
-        });
-        JwtClaims result = builder.populateLogoutTokenClaimsFromIdToken(client1, idTokenClaims);
-        // TODO - this should be an error scenario; that has yet to be fully implemented
-    }
-
-    @Test
     public void test_populateLogoutTokenClaimsFromIdToken_subAndSidGoldenPath() throws Exception {
-        JwtClaims idTokenClaims = new JwtClaims();
-        idTokenClaims.setSubject(subject);
+        JwtClaims idTokenClaims = getClaims(subject, issuerIdentifier, client1Id);
         idTokenClaims.setClaim("sid", sid);
         mockery.checking(new Expectations() {
             {
                 one(oidcServerConfig).getIssuerIdentifier();
                 will(returnValue(issuerIdentifier));
-                one(client1).getClientId();
-                will(returnValue(client1Id));
+            }
+        });
+        JwtClaims result = builder.populateLogoutTokenClaimsFromIdToken(client1, idTokenClaims);
+
+        verifyLogoutTokenClaims(result, Arrays.asList(client1Id), subject, sid);
+    }
+
+    @Test
+    public void test_populateLogoutTokenClaimsFromIdToken_idTokenIssuerDifferent() throws Exception {
+        // Ensure that the server config's issuer value is used in the logout token, not the ID token's issuer.
+        // These two values should never be different since this server issued the ID token, but we can still check.
+        JwtClaims idTokenClaims = getClaims(subject, "some other issuer", client1Id);
+        idTokenClaims.setClaim("sid", sid);
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
             }
         });
         JwtClaims result = builder.populateLogoutTokenClaimsFromIdToken(client1, idTokenClaims);
@@ -644,8 +1476,6 @@ public class LogoutTokenBuilderTest extends CommonTestClass {
             {
                 one(oidcServerConfig).getIssuerIdentifier();
                 will(returnValue(issuerIdentifier));
-                one(client1).getClientId();
-                will(returnValue(client1Id));
             }
         });
         JwtClaims result = builder.populateLogoutTokenClaims(client1);
@@ -750,7 +1580,6 @@ public class LogoutTokenBuilderTest extends CommonTestClass {
         assertEquals("JWT alg header did not match expected value.", "HS256", jsonWebStructure.getAlgorithmHeaderValue());
         assertEquals("JWT typ header did not match expected value.", "JWT", jsonWebStructure.getHeader("typ"));
 
-        // TODO sid claim should at least be there
         verifyLogoutTokenClaims(resultContext.getJwtClaims(), expectedAudiences, expectedSubject, expectedSid);
     }
 
@@ -762,28 +1591,51 @@ public class LogoutTokenBuilderTest extends CommonTestClass {
         long timeFrameStart = now - 5;
         long timeFrameEnd = now + 5;
 
-        assertEquals("Issuer did not match expected value.", issuerIdentifier, result.getIssuer());
-        assertEquals("Audience did not match expected value.", expectedAudiences, result.getAudience());
+        assertEquals("Issuer did not match expected value. Claims were: " + result, issuerIdentifier, result.getIssuer());
+        assertEquals("Audience did not match expected value. Claims were: " + result, expectedAudiences, result.getAudience());
         long issuedAt = result.getIssuedAt().getValue();
-        assertTrue("Issued at time (" + issuedAt + ") is not in an expected reasonable time frame (" + timeFrameStart + " to " + timeFrameEnd + ").",
+        assertTrue("Issued at time (" + issuedAt + ") is not in an expected reasonable time frame (" + timeFrameStart + " to " + timeFrameEnd + "). Claims were: " + result,
                    (timeFrameStart <= issuedAt) && (issuedAt <= timeFrameEnd));
-        assertNotNull("JTI claim should not have been null but was.", result.getJwtId());
+        assertNotNull("JTI claim should not have been null but was. Claims were: " + result, result.getJwtId());
         Map<String, Object> eventsClaim = (Map<String, Object>) result.getClaimValue("events");
-        assertNotNull("Events claim should not have been null but was.", eventsClaim);
-        assertTrue("Events claim did not contain the " + LogoutTokenBuilder.EVENTS_MEMBER_NAME + " member.", eventsClaim.containsKey(LogoutTokenBuilder.EVENTS_MEMBER_NAME));
-        assertEquals("Events claim entry did not match expected value.", new HashMap<>(), eventsClaim.get(LogoutTokenBuilder.EVENTS_MEMBER_NAME));
-        assertNull("A nonce claim was found but shouldn't have been: \"" + result + "\".", result.getClaimValue("nonce"));
+        assertNotNull("Events claim should not have been null but was. Claims were: " + result, eventsClaim);
+        assertTrue("Events claim did not contain the " + LogoutTokenBuilder.EVENTS_MEMBER_NAME + " member. Claims were: " + result,
+                   eventsClaim.containsKey(LogoutTokenBuilder.EVENTS_MEMBER_NAME));
+        assertEquals("Events claim entry did not match expected value. Claims were: " + result, new HashMap<>(), eventsClaim.get(LogoutTokenBuilder.EVENTS_MEMBER_NAME));
+        assertNull("A nonce claim was found but shouldn't have been. Claims were: " + result, result.getClaimValue("nonce"));
 
         if (expectedSubject == null) {
             assertNull("A sub claim was found but shouldn't have been: \"" + result + "\".", result.getSubject());
         } else {
-            assertEquals("Sub claim did not match expected value.", expectedSubject, result.getSubject());
+            assertEquals("Sub claim did not match expected value. Claims were: " + result, expectedSubject, result.getSubject());
         }
         if (expectedSid == null) {
             assertNull("A sid claim was found but shouldn't have been: \"" + result + "\".", result.getStringClaimValue("sid"));
         } else {
-            assertEquals("SID claim did not match expected value.", expectedSid, result.getStringClaimValue("sid"));
+            assertEquals("SID claim did not match expected value. Claims were: " + result, expectedSid, result.getStringClaimValue("sid"));
         }
+    }
+
+    private void setRegisteredClients(List<OidcBaseClient> registeredClients) throws OidcServerException {
+        mockery.checking(new Expectations() {
+            {
+                one(oauth20provider).getClientProvider();
+                will(returnValue(clientProvider));
+                one(clientProvider).getAll();
+                will(returnValue(registeredClients));
+            }
+        });
+    }
+
+    private void setTokenCacheExpectations(String user, OAuth20Token... tokens) {
+        mockery.checking(new Expectations() {
+            {
+                one(oauth20provider).getTokenCache();
+                will(returnValue(tokenCache));
+                one(tokenCache).getAllUserTokens(subject);
+                will(returnValue(Arrays.asList(tokens)));
+            }
+        });
     }
 
     private void setJwtCreationExpectations(OidcBaseClient client, String clientSecret) throws Exception {
@@ -806,4 +1658,50 @@ public class LogoutTokenBuilderTest extends CommonTestClass {
             }
         });
     }
+
+    private String getIdToken1String() throws Exception {
+        return jwtUtils.getHS256Jws(getIdTokenClaims(subject, issuerIdentifier, client1Id), client1Secret);
+    }
+
+    private String getIdToken2String() throws Exception {
+        return jwtUtils.getHS256Jws(getIdTokenClaims(subject, issuerIdentifier, client2Id), client2Secret);
+    }
+
+    private String getIdToken3String() throws Exception {
+        return jwtUtils.getHS256Jws(getIdTokenClaims(subject, issuerIdentifier, client3Id), client3Secret);
+    }
+
+    private JwtClaims getClaims(String subject, String issuer, String... audiences) {
+        JwtClaims claims = new JwtClaims();
+        claims.setSubject(subject);
+        claims.setIssuer(issuer);
+        claims.setAudience(audiences);
+        return claims;
+    }
+
+    private JSONObject getIdTokenClaims(String subject, String issuer, String... audiences) {
+        JSONArray audiencesArray = null;
+        if (audiences != null) {
+            audiencesArray = new JSONArray();
+            for (String aud : audiences) {
+                audiencesArray.add(aud);
+            }
+        }
+        return getIdTokenClaims(subject, issuer, audiencesArray);
+    }
+
+    private JSONObject getIdTokenClaims(String subject, String issuer, JSONArray audiences) {
+        JSONObject claims = new JSONObject();
+        if (subject != null) {
+            claims.put(Claims.SUBJECT, subject);
+        }
+        if (issuer != null) {
+            claims.put(Claims.ISSUER, issuer);
+        }
+        if (audiences != null) {
+            claims.put(Claims.AUDIENCE, audiences);
+        }
+        return claims;
+    }
+
 }

--- a/dev/com.ibm.ws.security.openidconnect.server/test/io/openliberty/security/openidconnect/backchannellogout/LogoutTokenBuilderTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/test/io/openliberty/security/openidconnect/backchannellogout/LogoutTokenBuilderTest.java
@@ -1,0 +1,809 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.openidconnect.backchannellogout;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.jmock.Expectations;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.MalformedClaimException;
+import org.jose4j.jwt.consumer.JwtContext;
+import org.jose4j.jwx.JsonWebStructure;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.ws.security.oauth20.api.OAuth20Provider;
+import com.ibm.ws.security.oauth20.api.OidcOAuth20ClientProvider;
+import com.ibm.ws.security.oauth20.plugins.OidcBaseClient;
+import com.ibm.ws.security.openidconnect.client.jose4j.util.Jose4jUtil;
+import com.ibm.ws.security.test.common.CommonTestClass;
+import com.ibm.ws.webcontainer.security.openidconnect.OidcServerConfig;
+
+import test.common.SharedOutputManager;
+
+public class LogoutTokenBuilderTest extends CommonTestClass {
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("OpenIdConnect*=all");
+
+    private final String issuerIdentifier = "https://localhost/oidc/endpoint/OP";
+    private final String client1Id = "client1";
+    private final String client2Id = "client2";
+    private final String client3Id = "client3";
+    private final String client1Secret = "client1secret";
+    private final String client3Secret = "client3secret";
+    private final String subject = "testuser";
+    private final String sid = "somesidvalue";
+
+    private final HttpServletRequest request = mockery.mock(HttpServletRequest.class);
+    private final OidcServerConfig oidcServerConfig = mockery.mock(OidcServerConfig.class);
+    private final OAuth20Provider oauth20provider = mockery.mock(OAuth20Provider.class);
+    private final OidcOAuth20ClientProvider clientProvider = mockery.mock(OidcOAuth20ClientProvider.class);
+    private final OidcBaseClient client1 = mockery.mock(OidcBaseClient.class, "client1");
+    private final OidcBaseClient client2 = mockery.mock(OidcBaseClient.class, "client2");
+    private final OidcBaseClient client3 = mockery.mock(OidcBaseClient.class, "client3");
+
+    private LogoutTokenBuilder builder;
+
+    private class MockLogoutTokenBuilder extends LogoutTokenBuilder {
+        public MockLogoutTokenBuilder(HttpServletRequest request, OidcServerConfig oidcServerConfig) {
+            super(request, oidcServerConfig);
+        }
+
+        @Override
+        OAuth20Provider getOAuth20Provider(OidcServerConfig oidcServerConfig) {
+            return oauth20provider;
+        }
+    }
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        System.out.println("Entering test: " + testName.getMethodName());
+        builder = new MockLogoutTokenBuilder(request, oidcServerConfig);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.out.println("Exiting test: " + testName.getMethodName());
+        mockery.assertIsSatisfied();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    @Test
+    public void test_buildLogoutTokens_noRegisteredClients() throws Exception {
+        List<OidcBaseClient> registeredClients = new ArrayList<>();
+
+        JwtClaims idTokenClaims = null;
+        mockery.checking(new Expectations() {
+            {
+                one(oauth20provider).getClientProvider();
+                will(returnValue(clientProvider));
+                one(clientProvider).getAll();
+                will(returnValue(registeredClients));
+            }
+        });
+
+        Map<String, String> result = builder.buildLogoutTokens(idTokenClaims);
+        assertNotNull("Result should not have been null but was.", result);
+        assertTrue("Result should have been empty but wasn't: " + result, result.isEmpty());
+    }
+
+    @Test
+    public void test_buildLogoutTokens_nullIdTokenClaims_oneClientRegistered() throws Exception {
+        List<OidcBaseClient> registeredClients = new ArrayList<>();
+        registeredClients.add(client1);
+
+        JwtClaims idTokenClaims = null;
+        mockery.checking(new Expectations() {
+            {
+                one(oauth20provider).getClientProvider();
+                will(returnValue(clientProvider));
+                one(clientProvider).getAll();
+                will(returnValue(registeredClients));
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                allowing(client1).getClientId();
+                will(returnValue(client1Id));
+            }
+        });
+        setJwtCreationExpectations(client1, client1Secret);
+
+        Map<String, String> result = builder.buildLogoutTokens(idTokenClaims);
+        assertNotNull("Result should not have been null but was.", result);
+        assertEquals("Result did not have the expected number of entries: " + result, 1, result.size());
+        assertTrue("Result did not contain an entry for the expected client \"" + client1Id + "\". Result was: " + result, result.containsKey(client1Id));
+
+        String clientLogoutToken = result.get(client1Id);
+        verifyLogoutToken(clientLogoutToken, Arrays.asList(client1Id), null, null);
+    }
+
+    @Test
+    public void test_buildLogoutTokens_idTokenOneAudience_oneClientRegistered_doesNotMatch() throws Exception {
+        List<OidcBaseClient> registeredClients = new ArrayList<>();
+        registeredClients.add(client1);
+
+        JwtClaims idTokenClaims = new JwtClaims();
+        idTokenClaims.setAudience(client3Id);
+        mockery.checking(new Expectations() {
+            {
+                one(oauth20provider).getClientProvider();
+                will(returnValue(clientProvider));
+                one(clientProvider).getAll();
+                will(returnValue(registeredClients));
+                one(client1).getClientId();
+                will(returnValue(client1Id));
+            }
+        });
+
+        Map<String, String> result = builder.buildLogoutTokens(idTokenClaims);
+        assertNotNull("Result should not have been null but was.", result);
+        assertTrue("Result should have been empty but wasn't: " + result, result.isEmpty());
+    }
+
+    @Test
+    public void test_buildLogoutTokens_idTokenOneAudience_oneClientRegistered_matches() throws Exception {
+        List<OidcBaseClient> registeredClients = new ArrayList<>();
+        registeredClients.add(client1);
+
+        JwtClaims idTokenClaims = new JwtClaims();
+        idTokenClaims.setAudience(client1Id);
+        mockery.checking(new Expectations() {
+            {
+                one(oauth20provider).getClientProvider();
+                will(returnValue(clientProvider));
+                one(clientProvider).getAll();
+                will(returnValue(registeredClients));
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                allowing(client1).getClientId();
+                will(returnValue(client1Id));
+            }
+        });
+        setJwtCreationExpectations(client1, client1Secret);
+
+        Map<String, String> result = builder.buildLogoutTokens(idTokenClaims);
+        assertNotNull("Result should not have been null but was.", result);
+        assertEquals("Result did not have the expected number of entries: " + result, 1, result.size());
+        assertTrue("Result did not contain an entry for the expected client \"" + client1Id + "\". Result was: " + result, result.containsKey(client1Id));
+
+        String clientLogoutToken = result.get(client1Id);
+        verifyLogoutToken(clientLogoutToken, Arrays.asList(client1Id), null, null);
+    }
+
+    @Test
+    public void test_buildLogoutTokens_idTokenMultipleAudiences_multipleClientsRegistered() throws Exception {
+        List<OidcBaseClient> registeredClients = new ArrayList<>();
+        registeredClients.add(client1);
+        registeredClients.add(client2);
+        registeredClients.add(client3);
+
+        JwtClaims idTokenClaims = new JwtClaims();
+        idTokenClaims.setAudience(client1Id, client3Id);
+        mockery.checking(new Expectations() {
+            {
+                one(oauth20provider).getClientProvider();
+                will(returnValue(clientProvider));
+                one(clientProvider).getAll();
+                will(returnValue(registeredClients));
+                allowing(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                allowing(client1).getClientId();
+                will(returnValue(client1Id));
+                one(client2).getClientId();
+                will(returnValue(client2Id));
+                allowing(client3).getClientId();
+                will(returnValue(client3Id));
+            }
+        });
+        setJwtCreationExpectations(client1, client1Secret);
+        setJwtCreationExpectations(client3, client3Secret);
+
+        Map<String, String> result = builder.buildLogoutTokens(idTokenClaims);
+        assertNotNull("Result should not have been null but was.", result);
+        assertEquals("Result did not have the expected number of entries: " + result, 2, result.size());
+        assertTrue("Result did not contain an entry for the expected client \"" + client1Id + "\". Result was: " + result, result.containsKey(client1Id));
+        assertTrue("Result did not contain an entry for the expected client \"" + client3Id + "\". Result was: " + result, result.containsKey(client3Id));
+
+        String client1LogoutToken = result.get(client1Id);
+        verifyLogoutToken(client1LogoutToken, Arrays.asList(client1Id), null, null);
+        String client3LogoutToken = result.get(client3Id);
+        verifyLogoutToken(client3LogoutToken, Arrays.asList(client3Id), null, null);
+    }
+
+    @Test
+    public void test_getClaimsFromIdTokenString_emptyClaims() throws Exception {
+        String idTokenString = "eyJhbGciOiJub25lIn0.e30.";
+        JwtClaims result = builder.getClaimsFromIdTokenString(idTokenString);
+        assertNotNull("Returned claims object should not have been null but was.", result);
+        Map<String, Object> claimsMap = result.getClaimsMap();
+        assertTrue("Claims should have been empty but were: " + claimsMap, claimsMap.isEmpty());
+    }
+
+    @Test
+    public void test_getClaimsFromIdTokenString_goldenPathClaims() throws Exception {
+        JwtClaims input = new JwtClaims();
+        input.setIssuer(issuerIdentifier);
+        input.setAudience(client1Id);
+        input.setIssuedAtToNow();
+        input.setGeneratedJwtId();
+        input.setSubject(subject);
+        input.setExpirationTimeMinutesInTheFuture(60);
+        input.setNotBeforeMinutesInThePast(10);
+
+        String encodedClaims = new String(Base64.getEncoder().encode(input.toJson().getBytes()));
+        String idTokenString = "eyJhbGciOiJub25lIn0." + encodedClaims + ".";
+
+        JwtClaims result = builder.getClaimsFromIdTokenString(idTokenString);
+        assertNotNull("Returned claims object should not have been null but was.", result);
+        assertEquals("Returned claims object did not match the input.", input.getClaimsMap(), result.getClaimsMap());
+    }
+
+    //@Test
+    public void test_getClientsToLogOut_() throws Exception {
+        JwtClaims idTokenClaims = new JwtClaims();
+        mockery.checking(new Expectations() {
+            {
+                one(oauth20provider).getClientProvider();
+                will(returnValue(clientProvider));
+            }
+        });
+        List<OidcBaseClient> result = builder.getClientsToLogOut(idTokenClaims);
+    }
+
+    // TODO - continue getClientsToLogOut
+
+    @Test
+    public void test_getClientsToConsiderLoggingOut_nullClaims_noConfiguredClients() throws Exception {
+        mockery.checking(new Expectations() {
+            {
+                one(oauth20provider).getClientProvider();
+                will(returnValue(clientProvider));
+                one(clientProvider).getAll();
+                will(returnValue(new ArrayList<>()));
+            }
+        });
+        JwtClaims claims = null;
+        try {
+            List<OidcBaseClient> clients = builder.getClientsToConsiderLoggingOut(claims);
+            assertNotNull("List of clients should not have been null but was.", clients);
+            assertTrue("List of clients should have been empty but wasn't: " + clients, clients.isEmpty());
+        } catch (LogoutTokenBuilderException e) {
+            fail("Should not have thrown an exception but did: " + e);
+        }
+    }
+
+    @Test
+    public void test_getClientsToConsiderLoggingOut_nullClaims_multipleClients() throws Exception {
+        List<OidcBaseClient> registeredClients = new ArrayList<>();
+        registeredClients.add(client1);
+        registeredClients.add(client2);
+        registeredClients.add(client3);
+        mockery.checking(new Expectations() {
+            {
+                one(oauth20provider).getClientProvider();
+                will(returnValue(clientProvider));
+                one(clientProvider).getAll();
+                will(returnValue(registeredClients));
+            }
+        });
+        JwtClaims claims = null;
+        try {
+            List<OidcBaseClient> clients = builder.getClientsToConsiderLoggingOut(claims);
+            assertNotNull("List of clients should not have been null but was.", clients);
+            assertFalse("List of clients should not have been empty but was.", clients.isEmpty());
+            for (OidcBaseClient expectedClient : registeredClients) {
+                assertTrue("List of clients did not contain expected client [" + expectedClient + "]. Clients were: " + clients, clients.contains(expectedClient));
+            }
+        } catch (LogoutTokenBuilderException e) {
+            fail("Should not have thrown an exception but did: " + e);
+        }
+    }
+
+    @Test
+    public void test_getClientsToConsiderLoggingOut_claimsMissingAud_multipleRegisteredClients() throws Exception {
+        List<OidcBaseClient> registeredClients = new ArrayList<>();
+        registeredClients.add(client1);
+        registeredClients.add(client2);
+        registeredClients.add(client3);
+        mockery.checking(new Expectations() {
+            {
+                one(oauth20provider).getClientProvider();
+                will(returnValue(clientProvider));
+                one(clientProvider).getAll();
+                will(returnValue(registeredClients));
+                one(client1).getClientId();
+                will(returnValue(client1Id));
+                one(client2).getClientId();
+                will(returnValue(client2Id));
+                one(client3).getClientId();
+                will(returnValue(client3Id));
+            }
+        });
+        JwtClaims claims = new JwtClaims();
+        claims.setSubject(subject);
+        try {
+            List<OidcBaseClient> clients = builder.getClientsToConsiderLoggingOut(claims);
+            assertNotNull("List of clients should not have been null but was.", clients);
+            assertTrue("List of clients should have been empty but wasn't: " + clients, clients.isEmpty());
+        } catch (LogoutTokenBuilderException e) {
+            fail("Should not have thrown an exception but did: " + e);
+        }
+    }
+
+    @Test
+    public void test_getClientsToConsiderLoggingOut_audNotOneOfRegisteredClients() throws Exception {
+        List<OidcBaseClient> registeredClients = new ArrayList<>();
+        registeredClients.add(client1);
+        registeredClients.add(client2);
+        registeredClients.add(client3);
+        mockery.checking(new Expectations() {
+            {
+                one(oauth20provider).getClientProvider();
+                will(returnValue(clientProvider));
+                one(clientProvider).getAll();
+                will(returnValue(registeredClients));
+                one(client1).getClientId();
+                will(returnValue(client1Id));
+                one(client2).getClientId();
+                will(returnValue(client2Id));
+                one(client3).getClientId();
+                will(returnValue(client3Id));
+            }
+        });
+        JwtClaims claims = new JwtClaims();
+        claims.setSubject(subject);
+        claims.setAudience("client4");
+        try {
+            List<OidcBaseClient> clients = builder.getClientsToConsiderLoggingOut(claims);
+            assertNotNull("List of clients should not have been null but was.", clients);
+            assertTrue("List of clients should have been empty but wasn't: " + clients, clients.isEmpty());
+        } catch (LogoutTokenBuilderException e) {
+            fail("Should not have thrown an exception but did: " + e);
+        }
+    }
+
+    @Test
+    public void test_getClientsToConsiderLoggingOut_audMatchesOneRegisteredClient() throws Exception {
+        List<OidcBaseClient> registeredClients = new ArrayList<>();
+        registeredClients.add(client1);
+        registeredClients.add(client2);
+        registeredClients.add(client3);
+        mockery.checking(new Expectations() {
+            {
+                one(oauth20provider).getClientProvider();
+                will(returnValue(clientProvider));
+                one(clientProvider).getAll();
+                will(returnValue(registeredClients));
+                one(client1).getClientId();
+                will(returnValue(client1Id));
+                one(client2).getClientId();
+                will(returnValue(client2Id));
+                one(client3).getClientId();
+                will(returnValue(client3Id));
+            }
+        });
+        JwtClaims claims = new JwtClaims();
+        claims.setAudience(client1Id);
+        try {
+            List<OidcBaseClient> clients = builder.getClientsToConsiderLoggingOut(claims);
+            assertNotNull("List of clients should not have been null but was.", clients);
+            assertFalse("List of clients should not have been empty but was.", clients.isEmpty());
+            assertEquals("Did not receive expected number of clients. Clients were: " + clients, 1, clients.size());
+            assertTrue("List of clients did not contain expected client [" + client1 + "]. Clients were: " + clients, clients.contains(client1));
+        } catch (LogoutTokenBuilderException e) {
+            fail("Should not have thrown an exception but did: " + e);
+        }
+    }
+
+    @Test
+    public void test_getClientsToConsiderLoggingOut_audMatchesMultipleRegisteredClients() throws Exception {
+        List<OidcBaseClient> registeredClients = new ArrayList<>();
+        registeredClients.add(client1);
+        registeredClients.add(client2);
+        registeredClients.add(client3);
+        mockery.checking(new Expectations() {
+            {
+                one(oauth20provider).getClientProvider();
+                will(returnValue(clientProvider));
+                one(clientProvider).getAll();
+                will(returnValue(registeredClients));
+                one(client1).getClientId();
+                will(returnValue(client1Id));
+                one(client2).getClientId();
+                will(returnValue(client2Id));
+                one(client3).getClientId();
+                will(returnValue(client3Id));
+            }
+        });
+        JwtClaims claims = new JwtClaims();
+        claims.setAudience(client2Id, client3Id);
+        try {
+            List<OidcBaseClient> clients = builder.getClientsToConsiderLoggingOut(claims);
+            assertNotNull("List of clients should not have been null but was.", clients);
+            assertFalse("List of clients should not have been empty but was.", clients.isEmpty());
+            assertEquals("Did not receive expected number of clients. Clients were: " + clients, 2, clients.size());
+            assertTrue("List of clients did not contain expected client [" + client2 + "]. Clients were: " + clients, clients.contains(client2));
+            assertTrue("List of clients did not contain expected client [" + client3 + "]. Clients were: " + clients, clients.contains(client3));
+        } catch (LogoutTokenBuilderException e) {
+            fail("Should not have thrown an exception but did: " + e);
+        }
+    }
+
+    @Test
+    public void test_createLogoutTokenForClient_nullIdTokenClaims() throws Exception {
+        JwtClaims idTokenClaims = null;
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                one(client1).getClientId();
+                will(returnValue(client1Id));
+            }
+        });
+        setJwtCreationExpectations(client1, client1Secret);
+
+        String result = builder.createLogoutTokenForClient(client1, idTokenClaims);
+        verifyLogoutToken(result, Arrays.asList(client1Id), null, null);
+    }
+
+    @Test
+    public void test_createLogoutTokenForClient_idTokenContainsSub() throws Exception {
+        JwtClaims idTokenClaims = new JwtClaims();
+        idTokenClaims.setSubject(subject);
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                one(client1).getClientId();
+                will(returnValue(client1Id));
+            }
+        });
+        setJwtCreationExpectations(client1, client1Secret);
+
+        String result = builder.createLogoutTokenForClient(client1, idTokenClaims);
+        verifyLogoutToken(result, Arrays.asList(client1Id), subject, null);
+    }
+
+    @Test
+    public void test_createLogoutTokenForClient_idTokenContainsSid() throws Exception {
+        JwtClaims idTokenClaims = new JwtClaims();
+        idTokenClaims.setStringClaim("sid", sid);
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                one(client1).getClientId();
+                will(returnValue(client1Id));
+            }
+        });
+        setJwtCreationExpectations(client1, client1Secret);
+
+        String result = builder.createLogoutTokenForClient(client1, idTokenClaims);
+        verifyLogoutToken(result, Arrays.asList(client1Id), null, sid);
+    }
+
+    @Test
+    public void test_createLogoutTokenForClient_idTokenContainsSubAndSid() throws Exception {
+        JwtClaims idTokenClaims = new JwtClaims();
+        idTokenClaims.setSubject(subject);
+        idTokenClaims.setStringClaim("sid", sid);
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                one(client1).getClientId();
+                will(returnValue(client1Id));
+            }
+        });
+        setJwtCreationExpectations(client1, client1Secret);
+
+        String result = builder.createLogoutTokenForClient(client1, idTokenClaims);
+        verifyLogoutToken(result, Arrays.asList(client1Id), subject, sid);
+    }
+
+    @Test
+    public void test_populateLogoutTokenClaimsFromIdToken_emptyIdTokenClaims() throws Exception {
+        JwtClaims idTokenClaims = new JwtClaims();
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                one(client1).getClientId();
+                will(returnValue(client1Id));
+            }
+        });
+        // TODO - this should be an error scenario; that has yet to be fully implemented
+        JwtClaims result = builder.populateLogoutTokenClaimsFromIdToken(client1, idTokenClaims);
+    }
+
+    @Test
+    public void test_populateLogoutTokenClaimsFromIdToken_subGoldenPath() throws Exception {
+        JwtClaims idTokenClaims = new JwtClaims();
+        idTokenClaims.setSubject(subject);
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                one(client1).getClientId();
+                will(returnValue(client1Id));
+            }
+        });
+        JwtClaims result = builder.populateLogoutTokenClaimsFromIdToken(client1, idTokenClaims);
+
+        verifyLogoutTokenClaims(result, Arrays.asList(client1Id), subject, null);
+    }
+
+    @Test
+    public void test_populateLogoutTokenClaimsFromIdToken_subEmpty_noSid() throws Exception {
+        JwtClaims idTokenClaims = new JwtClaims();
+        idTokenClaims.setSubject("");
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                one(client1).getClientId();
+                will(returnValue(client1Id));
+            }
+        });
+        JwtClaims result = builder.populateLogoutTokenClaimsFromIdToken(client1, idTokenClaims);
+
+        verifyLogoutTokenClaims(result, Arrays.asList(client1Id), "", null);
+    }
+
+    @Test
+    public void test_populateLogoutTokenClaimsFromIdToken_sidNotString() throws Exception {
+        JwtClaims idTokenClaims = new JwtClaims();
+        idTokenClaims.setClaim("sid", 123);
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                one(client1).getClientId();
+                will(returnValue(client1Id));
+            }
+        });
+        try {
+            JwtClaims result = builder.populateLogoutTokenClaimsFromIdToken(client1, idTokenClaims);
+            fail("Should have thrown an exception but didn't. Got: " + result);
+        } catch (MalformedClaimException e) {
+            verifyException(e, "sid");
+        }
+    }
+
+    @Test
+    public void test_populateLogoutTokenClaimsFromIdToken_sidEmpty_noSub() throws Exception {
+        JwtClaims idTokenClaims = new JwtClaims();
+        idTokenClaims.setClaim("sid", "");
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                one(client1).getClientId();
+                will(returnValue(client1Id));
+            }
+        });
+        JwtClaims result = builder.populateLogoutTokenClaimsFromIdToken(client1, idTokenClaims);
+        // TODO - this should be an error scenario; that has yet to be fully implemented
+    }
+
+    @Test
+    public void test_populateLogoutTokenClaimsFromIdToken_subAndSidGoldenPath() throws Exception {
+        JwtClaims idTokenClaims = new JwtClaims();
+        idTokenClaims.setSubject(subject);
+        idTokenClaims.setClaim("sid", sid);
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                one(client1).getClientId();
+                will(returnValue(client1Id));
+            }
+        });
+        JwtClaims result = builder.populateLogoutTokenClaimsFromIdToken(client1, idTokenClaims);
+
+        verifyLogoutTokenClaims(result, Arrays.asList(client1Id), subject, sid);
+    }
+
+    @Test
+    public void test_populateLogoutTokenClaims() throws Exception {
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+                one(client1).getClientId();
+                will(returnValue(client1Id));
+            }
+        });
+        JwtClaims result = builder.populateLogoutTokenClaims(client1);
+
+        verifyLogoutTokenClaims(result, Arrays.asList(client1Id), null, null);
+    }
+
+    @Test
+    public void test_getIssuer_configIncludesIssuerIdentifier() throws Exception {
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(issuerIdentifier));
+            }
+        });
+        String result = builder.getIssuer();
+        assertEquals("Issuer value did not match expected value.", issuerIdentifier, result);
+    }
+
+    @Test
+    public void test_getIssuer_configMissingIssuerIdentifier_standardHttpPort() throws Exception {
+        final String scheme = "http";
+        final String serverName = "myserver";
+        final String expectedIssuerPath = "/some/path/to/the/OP";
+        final String requestUri = expectedIssuerPath + "/end_session";
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(null));
+                one(request).getScheme();
+                will(returnValue(scheme));
+                one(request).getServerName();
+                will(returnValue(serverName));
+                one(request).getServerPort();
+                will(returnValue(80));
+                one(request).getRequestURI();
+                will(returnValue(requestUri));
+            }
+        });
+        String expectedIssuer = scheme + "://" + serverName + expectedIssuerPath;
+        String result = builder.getIssuer();
+        assertEquals("Issuer value did not match expected value.", expectedIssuer, result);
+    }
+
+    @Test
+    public void test_getIssuer_configMissingIssuerIdentifier_standardHttpsPort() throws Exception {
+        final String scheme = "https";
+        final String serverName = "myserver";
+        final String expectedIssuerPath = "/some/path/to/the/OP";
+        final String requestUri = expectedIssuerPath + "/end_session";
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(null));
+                one(request).getScheme();
+                will(returnValue(scheme));
+                one(request).getServerName();
+                will(returnValue(serverName));
+                one(request).getServerPort();
+                will(returnValue(443));
+                one(request).getRequestURI();
+                will(returnValue(requestUri));
+            }
+        });
+        String expectedIssuer = scheme + "://" + serverName + expectedIssuerPath;
+        String result = builder.getIssuer();
+        assertEquals("Issuer value did not match expected value.", expectedIssuer, result);
+    }
+
+    @Test
+    public void test_getIssuer_configMissingIssuerIdentifier_nonStandardPort() throws Exception {
+        final String scheme = "https";
+        final String serverName = "myserver";
+        final int port = 98765;
+        final String expectedIssuerPath = "/some/path/to/the/OP";
+        final String requestUri = expectedIssuerPath + "/end_session";
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(null));
+                one(request).getScheme();
+                will(returnValue(scheme));
+                one(request).getServerName();
+                will(returnValue(serverName));
+                one(request).getServerPort();
+                will(returnValue(port));
+                one(request).getRequestURI();
+                will(returnValue(requestUri));
+            }
+        });
+        String expectedIssuer = scheme + "://" + serverName + ":" + port + expectedIssuerPath;
+        String result = builder.getIssuer();
+        assertEquals("Issuer value did not match expected value.", expectedIssuer, result);
+    }
+
+    void verifyLogoutToken(String logoutTokenString, List<String> expectedAudiences, String expectedSubject, String expectedSid) throws Exception {
+        assertNotNull("Logout token string should not have been null but was.", logoutTokenString);
+
+        // Verify token header values
+        JwtContext resultContext = Jose4jUtil.parseJwtWithoutValidation(logoutTokenString);
+        JsonWebStructure jsonWebStructure = resultContext.getJoseObjects().get(0);
+        assertEquals("JWT alg header did not match expected value.", "HS256", jsonWebStructure.getAlgorithmHeaderValue());
+        assertEquals("JWT typ header did not match expected value.", "JWT", jsonWebStructure.getHeader("typ"));
+
+        // TODO sid claim should at least be there
+        verifyLogoutTokenClaims(resultContext.getJwtClaims(), expectedAudiences, expectedSubject, expectedSid);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void verifyLogoutTokenClaims(JwtClaims result, List<String> expectedAudiences, String expectedSubject, String expectedSid) throws MalformedClaimException {
+        assertNotNull("Result should not have been null but was.", result);
+
+        long now = System.currentTimeMillis() / 1000;
+        long timeFrameStart = now - 5;
+        long timeFrameEnd = now + 5;
+
+        assertEquals("Issuer did not match expected value.", issuerIdentifier, result.getIssuer());
+        assertEquals("Audience did not match expected value.", expectedAudiences, result.getAudience());
+        long issuedAt = result.getIssuedAt().getValue();
+        assertTrue("Issued at time (" + issuedAt + ") is not in an expected reasonable time frame (" + timeFrameStart + " to " + timeFrameEnd + ").",
+                   (timeFrameStart <= issuedAt) && (issuedAt <= timeFrameEnd));
+        assertNotNull("JTI claim should not have been null but was.", result.getJwtId());
+        Map<String, Object> eventsClaim = (Map<String, Object>) result.getClaimValue("events");
+        assertNotNull("Events claim should not have been null but was.", eventsClaim);
+        assertTrue("Events claim did not contain the " + LogoutTokenBuilder.EVENTS_MEMBER_NAME + " member.", eventsClaim.containsKey(LogoutTokenBuilder.EVENTS_MEMBER_NAME));
+        assertEquals("Events claim entry did not match expected value.", new HashMap<>(), eventsClaim.get(LogoutTokenBuilder.EVENTS_MEMBER_NAME));
+        assertNull("A nonce claim was found but shouldn't have been: \"" + result + "\".", result.getClaimValue("nonce"));
+
+        if (expectedSubject == null) {
+            assertNull("A sub claim was found but shouldn't have been: \"" + result + "\".", result.getSubject());
+        } else {
+            assertEquals("Sub claim did not match expected value.", expectedSubject, result.getSubject());
+        }
+        if (expectedSid == null) {
+            assertNull("A sid claim was found but shouldn't have been: \"" + result + "\".", result.getStringClaimValue("sid"));
+        } else {
+            assertEquals("SID claim did not match expected value.", expectedSid, result.getStringClaimValue("sid"));
+        }
+    }
+
+    private void setJwtCreationExpectations(OidcBaseClient client, String clientSecret) throws Exception {
+        mockery.checking(new Expectations() {
+            {
+                one(client).getClientSecret();
+                will(returnValue(clientSecret));
+                one(oidcServerConfig).getSignatureAlgorithm();
+                will(returnValue("HS256"));
+                one(oidcServerConfig).getJSONWebKey();
+                will(returnValue(null));
+                one(oidcServerConfig).getPrivateKey();
+                will(returnValue(null));
+                one(oidcServerConfig).getKeyAliasName();
+                will(returnValue(null));
+                one(oidcServerConfig).getKeyStoreRef();
+                will(returnValue(null));
+                one(oidcServerConfig).isJwkEnabled();
+                will(returnValue(false));
+            }
+        });
+    }
+}

--- a/dev/com.ibm.ws.security.test.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.test.common/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@ Bundle-Description: Common code for security test bundles; version=${bVersion}
 WS-TraceGroup: SecurityTestCommon
 
 Export-Package: \
-    com.ibm.ws.security.test.common
+    com.ibm.ws.security.test.common*
 
 Import-Package: \
     !*.internal.*, \
@@ -40,7 +40,8 @@ generate.replacement: true
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \
     com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-    com.ibm.ws.kernel.boot;version=latest
+    com.ibm.ws.kernel.boot;version=latest, \
+    com.ibm.json4j;version=latest
 
 -testpath: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.security.test.common/src/com/ibm/ws/security/test/common/jwt/utils/JwtUnitTestUtils.java
+++ b/dev/com.ibm.ws.security.test.common/src/com/ibm/ws/security/test/common/jwt/utils/JwtUnitTestUtils.java
@@ -1,0 +1,43 @@
+package com.ibm.ws.security.test.common.jwt.utils;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Base64;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import com.ibm.json.java.JSONObject;
+
+public class JwtUnitTestUtils {
+
+    public JSONObject getJwsHeader(String alg) {
+        JSONObject header = new JSONObject();
+        header.put("typ", "JWT");
+        header.put("alg", alg);
+        return header;
+    }
+
+    public JSONObject getHS256Header() {
+        return getJwsHeader("HS256");
+    }
+
+    public String getHS256Jws(JSONObject claims, String secret) throws Exception {
+        String headerAndPayload = encode(getHS256Header()) + "." + encode(claims);
+        String signature = getHS256Signature(headerAndPayload, secret);
+        return headerAndPayload + "." + signature;
+    }
+
+    public String getHS256Signature(String input, String secret) throws Exception {
+        byte[] secretBytes = secret.getBytes("UTF-8");
+        Mac hs256Mac = Mac.getInstance("HmacSHA256");
+        SecretKeySpec keySpec = new SecretKeySpec(secretBytes, "HmacSHA256");
+        hs256Mac.init(keySpec);
+        byte[] hashBytes = hs256Mac.doFinal(input.getBytes("UTF-8"));
+        return Base64.getEncoder().encodeToString(hashBytes);
+    }
+
+    public String encode(Object input) throws UnsupportedEncodingException {
+        return Base64.getEncoder().encodeToString(input.toString().getBytes("UTF-8"));
+    }
+
+}

--- a/dev/com.ibm.ws.security.test.common/src/com/ibm/ws/security/test/common/jwt/utils/package-info.java
+++ b/dev/com.ibm.ws.security.test.common/src/com/ibm/ws/security/test/common/jwt/utils/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+package com.ibm.ws.security.test.common.jwt.utils;


### PR DESCRIPTION
Adds the bulk of the logic for creating logout tokens in the OP. A request to the OP's `/end_session` endpoint will now build logout tokens for RPs with the following logic:
- If an `id_token_hint` parameter is not included in the `/end_session` request, we will **not** send any back-channel logout requests.
- If an `id_token_hint` parameter is provided to the `/end_session` endpoint (and it can be successfully parsed as a JWS):
    - The `aud` claim of the ID token is used to decide what RPs will be logged out; each audience listed in the `aud` claim will have a unique logout token created for it
    - The OP's token cache is queried to find any cached ID tokens that correspond to the same client and user (and `sid`, if one is in the ID token hint)
        - Cached ID tokens with matching claims will have corresponding logout tokens created for them
    - The `sub` claim of the ID token (if present) is used as the `sub` claim value for the logout token
    - The `sid` claim of the ID token (if present) is used as the `sid` claim value for the logout token

The remaining logout token claims are set like so:
- `iss`: Set to the OP's `issuerIdentifier` config attribute, if configured. Otherwise this is set using the request URI as the base (i.e. if the request came into `https://<server>:<port>/oidc/endpoint/OP/end_session` then `iss` will be set to `https://<server>:<port>/oidc/endpoint/OP`)
- `aud`: Every RP to log out will have a unique logout token created for it, so this is set to the ID of the OAuth client the token is being created for
- `iat`: Set to the current time
- `jti`: Generated at runtime
- `events`: Set to the minimum JSON object required by the spec

For #20358
For #20357