### PR TITLE
Split JWT builder/consumer trustStoreRef metatype description for clarification

### DIFF
--- a/dev/com.ibm.ws.security.jwt/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.jwt/resources/OSGI-INF/l10n/metatype.properties
@@ -47,8 +47,8 @@ keyAliasName.desc=A key alias name that is used to locate the private key for si
 trustedAliasName=Trusted alias name
 trustedAliasName.desc=A trusted key alias for using the public key to verify the signature of the token
 trustStoreRef=Trust keystore
-trustStoreRef.consumer.desc=A keystore containing the public key necessary for verifying a signature of the JWT token.
-trustStoreRef.builder.desc=A keystore containing the key management key that is used to encrypt the Content Encryption Key of a JWE.
+trustStoreRef.consumer.desc=A keystore that contains the public key that can verify a signature of the JWT token.
+trustStoreRef.builder.desc=A keystore that contains the key management key that is used to encrypt the Content Encryption Key of a JWE.
 
 jwkRotationTime=JWK rotation time
 jwkRotationTime.desc=Amount of time after which a new JWK will be generated.

--- a/dev/com.ibm.ws.security.jwt/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.jwt/resources/OSGI-INF/l10n/metatype.properties
@@ -47,7 +47,8 @@ keyAliasName.desc=A key alias name that is used to locate the private key for si
 trustedAliasName=Trusted alias name
 trustedAliasName.desc=A trusted key alias for using the public key to verify the signature of the token
 trustStoreRef=Trust keystore
-trustStoreRef.desc=A keystore containing the public key necessary for verifying a signature of the JWT token. The keystore should also contain the key management key that is used to encrypt the Content Encryption Key of a JWE.
+trustStoreRef.consumer.desc=A keystore containing the public key necessary for verifying a signature of the JWT token.
+trustStoreRef.builder.desc=A keystore containing the key management key that is used to encrypt the Content Encryption Key of a JWE.
 
 jwkRotationTime=JWK rotation time
 jwkRotationTime.desc=Amount of time after which a new JWK will be generated.

--- a/dev/com.ibm.ws.security.jwt/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.jwt/resources/OSGI-INF/metatype/metatype.xml
@@ -40,7 +40,7 @@
 		 <AD id="jti" name="%jti" description="%jti.desc" required="false" type="Boolean" default="false"/>
          <AD id="keyStoreRef" name="%keyStoreRef" description="%keyStoreRef.desc" required="false" type="String" ibmui:uiReference="com.ibm.ws.ssl.keystore" />
          <AD id="keyAlias" name="%keyAliasName" description="%keyAliasName.desc" required="false" type="String" />
-         <AD id="trustStoreRef" name="%trustStoreRef" description="%trustStoreRef.desc" required="false" type="String" ibmui:uiReference="com.ibm.ws.ssl.keystore" />
+         <AD id="trustStoreRef" name="%trustStoreRef" description="%trustStoreRef.builder.desc" required="false" type="String" ibmui:uiReference="com.ibm.ws.ssl.keystore" />
          <AD id="jwkRotationTime" name="internal" description="internal use only" required="false" type="String" ibm:type="duration(m)" default="720m" min="60m"/>
          <AD id="jwkSigningKeySize" name="internal" description="internal use only" required="false" type="Long" default="2048">
             <Option label="%jwkSigningKeySize.1024" value="1024"/>
@@ -79,7 +79,7 @@
             <Option label="%tokenSignAlgorithm.ES384" value="ES384" />
             <Option label="%tokenSignAlgorithm.ES512" value="ES512" />
         </AD>
-        <AD id="trustStoreRef" name="%trustStoreRef" description="%trustStoreRef.desc" required="false" type="String" ibmui:uiReference="com.ibm.ws.ssl.keystore" />
+        <AD id="trustStoreRef" name="%trustStoreRef" description="%trustStoreRef.consumer.desc" required="false" type="String" ibmui:uiReference="com.ibm.ws.ssl.keystore" />
         <AD id="trustedAlias" name="%trustedAliasName" description="%trustedAliasName.desc" required="false" type="String" />
         <AD id="clockSkew" name="%clockSkew" description="%clockSkew.desc" required="false" type="String" default="5m" ibm:type="duration" />
         <AD id="validationRequired" name="internal" description="internal use only"  required="false" type="Boolean" default="true"/>


### PR DESCRIPTION
The `trustStoreRef` metatype description in the JWT bundle is overloaded and used by both the builder and consumer. However only one part of the description applies to the builder and the other part applies to the consumer. This splits the description so the builder and consumer can have accurate descriptions reflecting their own functionality.