### PR TITLE
Update FAT bnd.bnd files to reference correct fat.minimum.java.level property

### DIFF
--- a/dev/build.example_fat/bnd.bnd
+++ b/dev/build.example_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -25,7 +25,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/build.featureStart.aToL_fat/bnd.bnd
+++ b/dev/build.featureStart.aToL_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/build.featureStart.mToZ_fat/bnd.bnd
+++ b/dev/build.featureStart.mToZ_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.concurrent_fat_policy/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent_fat_policy/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2020 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -16,8 +16,6 @@ src: \
 	test-applications/concurrentpolicyfat/src
 
 fat.project: true
-
-fat.minimum.java.level: 1.8
 
 -buildpath: \
 	com.ibm.ws.componenttest.2.0;version=latest,\

--- a/dev/com.ibm.ws.ejbcontainer.interceptor.v32_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.interceptor.v32_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2021 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -37,7 +37,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.grpc_fat/bnd.bnd
+++ b/dev/com.ibm.ws.grpc_fat/bnd.bnd
@@ -27,7 +27,6 @@ src: \
     test-applications/StoreApp.war/src
 
 fat.project: true
-fat.minimum.java.level: 1.8
 
 # Define additional tested features that are NOT present in any XML files in this bucket.
 tested.features:\

--- a/dev/com.ibm.ws.install.featureUtility_fat/bnd.bnd
+++ b/dev/com.ibm.ws.install.featureUtility_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.install.packaging_fat/bnd.bnd
+++ b/dev/com.ibm.ws.install.packaging_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/bnd.bnd
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018,2020 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -45,7 +45,7 @@ tested.features: connectors-2.1, xmlbinding-4.0
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (com.ibm.websphere.javaee.servlet.3.1)
 # or binaries from Artifactory (org.apache.derby:derbynet).

--- a/dev/com.ibm.ws.jaxws.clientcontainer_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.clientcontainer_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -36,7 +36,7 @@ tested.features: \
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.managedbeans_fat/bnd.bnd
+++ b/dev/com.ibm.ws.managedbeans_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2021 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -43,7 +43,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.messaging.open_comms_fat/bnd.bnd
+++ b/dev/com.ibm.ws.messaging.open_comms_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.messaging.open_fat/bnd.bnd
+++ b/dev/com.ibm.ws.messaging.open_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 2020 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@ tested.features: servlet-4.0, xmlBinding-3.0, messagingserver-3.0, servlet-5.0, 
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.messaging.open_jms20_fat/bnd.bnd
+++ b/dev/com.ibm.ws.messaging.open_jms20_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2021 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -48,7 +48,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (com.ibm.websphere.javaee.servlet.3.1)
 # or binaries from Artifactory (org.apache.derby:derbynet).

--- a/dev/com.ibm.ws.messaging.open_jms20context_fat/bnd.bnd
+++ b/dev/com.ibm.ws.messaging.open_jms20context_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2021 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -30,7 +30,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (com.ibm.websphere.javaee.servlet.3.1)
 # or binaries from Artifactory (org.apache.derby:derbynet).

--- a/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/bnd.bnd
+++ b/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2020 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -35,7 +35,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (com.ibm.websphere.javaee.servlet.3.1)
 # or binaries from Artifactory (org.apache.derby:derbynet).

--- a/dev/com.ibm.ws.microprofile.config.1.1_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -36,7 +36,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.config_git_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config_git_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -29,7 +29,7 @@ tested.features: mpConfig-1.0,\
                
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2020 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@ tested.features: mpmetrics-1.1, mpmetrics-2.0, mpFaultTolerance-1.1, mpfaulttole
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2020 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.faulttolerance_git_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_git_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -26,7 +26,7 @@ tested.features: concurrent-1.0,\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.health.1.0_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.health.1.0_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2020 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@ tested.features=cdi-1.2,servlet-3.1,cdi-2.0,servlet-4.0
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2020 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@ tested.features=cdi-1.2,servlet-3.1,cdi-2.0,servlet-4.0
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.health.2.1_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.health.2.1_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2020 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@ tested.features=cdi-1.2,servlet-3.1,cdi-2.0,servlet-4.0
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.health.2.2_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.health.2.2_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@ tested.features=cdi-1.2,servlet-3.1,cdi-2.0,servlet-4.0
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.metrics.1.1.noAuth_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1.noAuth_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.metrics.2.3_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics.2.3_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -25,7 +25,7 @@ tested.features:\
 	
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.metrics_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.metrics_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.openapi.1.1_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.openapi.1.1_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.openapi_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -21,8 +21,6 @@ src: \
     test-applications/simpleServlet/src
 
 fat.project: true
-
-fat.minimum.java.level: 1.8
 
 tested.features=mpOpenAPI-1.0,mpOpenAPI-1.1,mpOpenAPI-2.0,mpOpenAPI-3.0,jsonb-1.0,jsonb-2.0
 

--- a/dev/com.ibm.ws.microprofile.openapi_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.openapi_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_git_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_git_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.repository_fat/bnd.bnd
+++ b/dev/com.ibm.ws.repository_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.security.jwt_fat.builder/bnd.bnd
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2020 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -32,7 +32,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/bnd.bnd
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2020 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -33,7 +33,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2021 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -27,7 +27,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.transaction.cloud_fat.dualFS/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.dualFS/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2021 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -27,7 +27,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.transaction.cloud_fat.peerlocking/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.peerlocking/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2021 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -27,7 +27,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.transaction.cloud_fat.simpleFS/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.simpleFS/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2021 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -27,7 +27,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.transaction.core_fat.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.1/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2021 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -36,7 +36,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.transaction.core_fat.10/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.10/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2021 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -45,7 +45,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.transaction.core_fat.2/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.2/bnd.bnd
@@ -44,7 +44,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.transaction.core_fat.3/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.3/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2021 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -44,7 +44,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.transaction.core_fat.4/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.4/bnd.bnd
@@ -44,7 +44,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.transaction.core_fat.5/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.5/bnd.bnd
@@ -44,7 +44,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.transaction.core_fat.6/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.6/bnd.bnd
@@ -44,7 +44,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.transaction.core_fat.7/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.7/bnd.bnd
@@ -35,7 +35,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.transaction.core_fat.8/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.8/bnd.bnd
@@ -44,7 +44,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.transaction.core_fat.9/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.9/bnd.bnd
@@ -44,7 +44,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.transaction.core_fat.startMultiEJB/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat.startMultiEJB/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2021 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -32,7 +32,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.transaction.recovery_fat.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.recovery_fat.1/bnd.bnd
@@ -39,7 +39,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.transaction.recovery_fat.2/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.recovery_fat.2/bnd.bnd
@@ -47,7 +47,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.transaction.recovery_fat.3/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.recovery_fat.3/bnd.bnd
@@ -38,7 +38,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.transport.http.remoteip_fat/bnd.bnd
+++ b/dev/com.ibm.ws.transport.http.remoteip_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.tx.jta_fat/bnd.bnd
+++ b/dev/com.ibm.ws.tx.jta_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -27,7 +27,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.tx.jta_fat_hibernate/bnd.bnd
+++ b/dev/com.ibm.ws.tx.jta_fat_hibernate/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2020 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -16,7 +16,6 @@ src: \
 	test-applications/hibernateApp/src
 
 fat.project: true
-fat.minimum.java.level: 1.8
 
 tested.features:\
    servlet-4.0,\

--- a/dev/io.openliberty.cdi.3.0.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.cdi.3.0.internal_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/io.openliberty.checkpoint_fat/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat/bnd.bnd
@@ -29,7 +29,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.4.0)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/.classpath
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/.classpath
@@ -9,6 +9,10 @@
     -->
     <classpathentry kind="src" path="fat/src"/>
     <classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+        <attributes>
+            <attribute name="module" value="true"/>
+        </attributes>
+    </classpathentry>
     <classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/bnd.bnd
@@ -20,7 +20,7 @@ tested.features: appsecurity-4.0, cdi-3.0, concurrent-3.0, pages-3.0
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 11
+fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2020 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/io.openliberty.microprofile.faulttolerance.4.0.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.faulttolerance.4.0.internal_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2021 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/io.openliberty.microprofile.graphql.2.0.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.graphql.2.0.internal_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/io.openliberty.microprofile.health.3.0.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.health.3.0.internal_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@ tested.features=cdi-2.0,mpConfig-1.4,mpConfig-2.0
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@ tested.features=cdi-2.0,mpConfig-2.0
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/io.openliberty.microprofile.health.4.0.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.health.4.0.internal_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@ tested.features=cdi-3.0,mpConfig-3.0
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@ tested.features:\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/io.openliberty.microprofile.lra.1.0.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.lra.1.0.internal_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/io.openliberty.microprofile.metrics.internal.3.0_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -26,7 +26,7 @@ tested.features:\
 	
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/io.openliberty.microprofile.metrics.internal.4.0_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.0_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -26,7 +26,7 @@ tested.features:\
 	
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -17,8 +17,6 @@ src: \
     test-applications/complete-flow/src
 
 fat.project: true
-
-fat.minimum.java.level: 1.8
 
 tested.features=mpOpenAPI-2.0,restfulwsclient-3.0, transportsecurity-1.0, mpconfig-3.0, servlet-5.0, concurrent-2.0, mpopenapi-3.0, jndi-1.0, restfulws-3.0, jsonp-2.0, cdi-3.0
 

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/io.openliberty.microprofile.openapi.3.0.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.openapi.3.0.internal_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,5 +20,5 @@ fat.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-runtime.minimum.java.level: 1.8
+# fat.minimum.java.level: 11
 


### PR DESCRIPTION
Many FAT projects reference an outdated `runtime.minimum.java.level` property in their bnd.bnd files. That property should be `fat.minimum.java.level`. FATs also run, by default, on a minimum of Java 8, so any uses of that property to specify a minimum of Java 8 have either been removed (if the property wasn't commented out) or updated to reference Java 11 (if the property was commented out). Now if people need a reference to see how to require a minimum Java level they'll see a valid sample using Java 11 as the example.