### PR TITLE
Ensure JSONB TCK compatibility with Windows and Semaru

### DIFF
--- a/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/fat/src/io/openliberty/jakarta/jsonb/tck/JsonbTckLauncher.java
+++ b/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/fat/src/io/openliberty/jakarta/jsonb/tck/JsonbTckLauncher.java
@@ -13,12 +13,14 @@ package io.openliberty.jakarta.jsonb.tck;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Collections;
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.BeforeClass;
+
+import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.MinimumJavaLevel;
@@ -47,10 +49,19 @@ public class JsonbTckLauncher {
     @BeforeClass
     public static void setUp() throws Exception {
         int javaSpecVersion = Integer.parseInt(System.getProperty("java.specification.version"));
-        //To work around the issue described in issue:
-        //https://github.com/eclipse-ee4j/jsonb-api/issues/272
-        if(javaSpecVersion >= 13) {
+        // To work around the issue described in issue:
+        // https://github.com/eclipse-ee4j/jsonb-api/issues/272
+        if (javaSpecVersion >= 13) {
             additionalProps.put("java.locale.providers", "COMPAT");
+        }
+
+        // Skip signature testing on Windows and Semeru JDK.
+        // So far as I can tell the signature test plugin is not supported on this configuration
+        //Opened an issue against jsonb tck https://github.com/eclipse-ee4j/jsonb-api/issues/327
+        if (System.getProperty("os.name").contains("Windows") &&
+            System.getProperty("java.runtime.name").contains("Semeru")) {
+            Log.info(JsonbTckLauncher.class, "setUp", "Skipping JSONB Signature Test on Windows and Semeru JDK");
+            additionalProps.put("exclude.tests", "ee.jakarta.tck.json.bind.signaturetest.jsonb.JSONBSigTest.java");
         }
     }
 
@@ -60,6 +71,7 @@ public class JsonbTckLauncher {
     @Test
     @AllowedFFDC // The tested exceptions cause FFDC so we have to allow for this.
     public void launchJsonbTCK() throws Exception {
+
         Map<String, String> resultInfo = MvnUtils.getResultInfo(DONOTSTART);
 
         /**

--- a/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -54,6 +54,13 @@
 			<artifactId>jakarta.json.bind-tck</artifactId>
 			<version>${jakarta.jsonb.tck.version}</version>
 			<scope>test</scope>
+			<!-- Try to force TCK to  use version 1.6 instead of 1.4 -->
+		    <exclusions>
+		        <exclusion>
+		            <groupId>org.netbeans.tools</groupId>
+		            <artifactId>sigtest-maven-plugin</artifactId>
+		        </exclusion>
+		    </exclusions>
 		</dependency>
 		<!-- api - jsonb - internal bundle -->
 		<!-- TODO revert to jakarta.json.bind when GA version is in GHE -->
@@ -104,6 +111,13 @@
 			<version>1.7.0.Alpha10</version>
 			<scope>test</scope>
 		</dependency>
+		
+		<!-- Try to force TCK to  use version 1.6 instead of 1.4 -->
+		<dependency>
+            <groupId>org.netbeans.tools</groupId>
+            <artifactId>sigtest-maven-plugin</artifactId>
+            <version>1.6</version>
+        </dependency>
 	</dependencies>
 
 	<build>
@@ -180,6 +194,9 @@
 						<jimage.dir>${project.build.directory}/jdk11-bundle</jimage.dir>
 						<signature.sigTestClasspath>${project.build.directory}/signaturedirectory/jakarta.json.bind-api.jar:${project.build.directory}/jdk11-bundle/java.base:${project.build.directory}/jdk11-bundle/java.rmi:${project.build.directory}/jdk11-bundle/java.sql:${project.build.directory}/jdk11-bundle/java.naming</signature.sigTestClasspath>
 					</systemPropertyVariables>
+					<excludes>
+						<exclude>${exclude.tests}</exclude>
+					</excludes>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
The JSONB TCK is currently failing when running on Windows (any version) with Semaru (any version).
The failure is due to the Signature Test plugin failing to run in static mode because it does not recognize or thinks that a certain argument is missing.  This leads it to just output the "Help" message instead of running.

Example output: 
```txt
Calling:  com.sun.tdk.signaturetest.SignatureTest() with following args:
   testArguments[0] = -Static
   testArguments[1] = -CheckValue
   testArguments[2] = -mode
   testArguments[3] = src
   testArguments[4] = -Verbose
   testArguments[5] = -FileName
   testArguments[6] = C:\Users\JAZZ_B~1.EBC\AppData\Local\Temp\jakarta.json.bind.sig_3.0.0
   testArguments[7] = -Classpath
   testArguments[8] = C:\Users\jazz_build\Build\jazz-build-engines\wasrtc\EBCPROD\build\dev\io.openliberty.jakarta.jsonb.3.0_fat_tck\autoFVT\results\tck_defaultServer/signaturedirectory/jakarta.json.bind-api.jar:C:\Users\jazz_build\Build\jazz-build-engines\wasrtc\EBCPROD\build\dev\io.openliberty.jakarta.jsonb.3.0_fat_tck\autoFVT\results\tck_defaultServer/jdk11-bundle/java.base:C:\Users\jazz_build\Build\jazz-build-engines\wasrtc\EBCPROD\build\dev\io.openliberty.jakarta.jsonb.3.0_fat_tck\autoFVT\results\tck_defaultServer/jdk11-bundle/java.rmi:C:\Users\jazz_build\Build\jazz-build-engines\wasrtc\EBCPROD\build\dev\io.openliberty.jakarta.jsonb.3.0_fat_tck\autoFVT\results\tck_defaultServer/jdk11-bundle/java.sql:C:\Users\jazz_build\Build\jazz-build-engines\wasrtc\EBCPROD\build\dev\io.openliberty.jakarta.jsonb.3.0_fat_tck\autoFVT\results\tck_defaultServer/jdk11-bundle/java.naming
   testArguments[9] = -Package
   testArguments[10] = jakarta.json.bind
   testArguments[11] = -Exclude
   testArguments[12] = jakarta.json.bind.adapter
   testArguments[13] = -Exclude
   testArguments[14] = jakarta.json.bind.annotation
   testArguments[15] = -Exclude
   testArguments[16] = jakarta.json.bind.config
   testArguments[17] = -Exclude
   testArguments[18] = jakarta.json.bind.serializer
   testArguments[19] = -Exclude
   testArguments[20] = jakarta.json.bind.spi
   testArguments[21] = -IgnoreJDKClass
   testArguments[22] = java.util.Map
   testArguments[23] = -IgnoreJDKClass
   testArguments[24] = java.lang.Object
   testArguments[25] = -IgnoreJDKClass
   testArguments[26] = java.io.ByteArrayInputStream
   testArguments[27] = -IgnoreJDKClass
   testArguments[28] = java.io.InputStream
   testArguments[29] = -IgnoreJDKClass
   testArguments[30] = java.lang.Deprecated
   testArguments[31] = -IgnoreJDKClass
   testArguments[32] = java.io.Writer
   testArguments[33] = -IgnoreJDKClass
   testArguments[34] = java.io.OutputStream
   testArguments[35] = -IgnoreJDKClass
   testArguments[36] = java.util.List
   testArguments[37] = -IgnoreJDKClass
   testArguments[38] = java.util.Collection
   testArguments[39] = -IgnoreJDKClass
   testArguments[40] = java.lang.instrument.IllegalClassFormatException
   testArguments[41] = -IgnoreJDKClass
   testArguments[42] = javax.transaction.xa.XAException
   testArguments[43] = -IgnoreJDKClass
   testArguments[44] = java.lang.annotation.Repeatable
   testArguments[45] = -IgnoreJDKClass
   testArguments[46] = java.lang.InterruptedException
   testArguments[47] = -IgnoreJDKClass
   testArguments[48] = java.lang.CloneNotSupportedException
   testArguments[49] = -IgnoreJDKClass
   testArguments[50] = java.lang.Throwable
   testArguments[51] = -IgnoreJDKClass
   testArguments[52] = java.lang.Thread
   testArguments[53] = -IgnoreJDKClass
   testArguments[54] = java.lang.Enum
   testArguments[55] = -ApiVersion
   testArguments[56] = 3.0.0
Test - SignatureTest version 2.2
Available options are:
------------------
-Static           Run SignatureTest in static mode (default: reflection)
-Mode [src|bin]   Select checking mode - source code or binary (default: source)
-Backward | -B    Backward compatibility checking (default: mutual compatibility)
-Classpath <path> Specify search path for tested classes in static mode
-FileName <file>  Specify signature file name
or
-Files <filelist> Specify list of signature files. Use ; to separate files.
-Package <name>   Specify package to be tested along with subpackages
-FormatHuman | -H Human readable error output
-Out <file>       Specify report file name
------------------
-TestURL <url>    Specify URL of signature file
-PackageWithoutSubpackages <name> Specify package to be tested excluding subpackages
-Exclude <name>   Specify package or class, which is not required to be tested
-NoMerge          Cancels default merging according to the JSR 68 rules (see User's Guide)
-Update <file>    Specify update file
-IgnoreJDKClass <name>   Specify JDK package or class, which is not required to be tested
-ApiVersion <str> Set API version for report
-CheckValue       Check values of primitive constants (static mode only)
-FormatPlain      Do not sort error messages
-ExtensibleInterfaces Allow extensible interfaces for backward compatibility checking 
------------------
-ClassCacheSize <numb>  Specify size of class cache (default value is 1,024). Actual in static mode only.
-Verbose          Enable error diagnostics for inherited class members
-Debug            Enable debug mode (prints stack trace)
-ErrorAll         Specifies to make the test more strict by upgrading certain warnings to errors
------------------
-Version          Print version information
-Help             Print this text
------------------
All options are case-insensitive.
********** Status Report 'jakarta.json.bind' **********
********** Package 'jakarta.json.bind' - FAILED (STATIC MODE) **********
```

In the end all the static test fail, while all the reflective tests run and pass:

```txt
Some signatures failed.
	Failed packages listed below: 
		jakarta.json.bind(static mode)
		jakarta.json.bind.adapter(static mode)
		jakarta.json.bind.annotation(static mode)
		jakarta.json.bind.config(static mode)
		jakarta.json.bind.serializer(static mode)
		jakarta.json.bind.spi(static mode)
	Passed packages listed below: 
		jakarta.json.bind(reflection mode)
		jakarta.json.bind.adapter(reflection mode)
		jakarta.json.bind.annotation(reflection mode)
		jakarta.json.bind.config(reflection mode)
		jakarta.json.bind.serializer(reflection mode)
		jakarta.json.bind.spi(reflection mode)
```

Attempting to force the TCK to use the updated 1.6 plugin instead of 1.4