### PR TITLE
Schemagen - Improve command line options parsing

### DIFF
--- a/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/Generator.java
+++ b/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/Generator.java
@@ -14,15 +14,10 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.text.MessageFormat;
 import java.util.ArrayList;
-import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
-import java.util.Set;
-import java.util.TreeSet;
-
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamWriter;
 
@@ -223,31 +218,19 @@ public class Generator {
         final String odpfx = "option-desc.";
 
         // Kernel feature list tools and schema tools for some reason share the same configuration options file.
-        // Create an exclusion set to prevent the schema generator tool help from displaying undesired information.
-        Set<String> exclusionSet = new HashSet<String>();
-        exclusionSet.add("option-key.productExtension");
-        
-        Enumeration<String> keys = options.getKeys();
-        Set<String> optionKeys = new TreeSet<String>();
+        // Hard-code the ones that apply to the schema generator tool to prevent --help from displaying undesired information.
 
-        while (keys.hasMoreElements()) {
-            String key = keys.nextElement();
-            if (key.startsWith(okpfx) && !exclusionSet.contains(key)) {
-                optionKeys.add(key);
-            }
-        }
+        String[] optionKeys = new String[] { "option-key.compactoutput", "option-key.encoding", "option-key.ignorePids", "option-key.locale", "option-key.schemaVersion", "option-key.outputVersion" };
 
-        if (optionKeys.size() > 0) {
-            System.out.println(options.getString("use.options"));
+        System.out.println(options.getString("use.options"));
+        System.out.println();
+
+        // Print each option and it's associated descriptive text
+        for (String optionKey : optionKeys) {
+            String option = optionKey.substring(okpfx.length());
+            System.out.println(options.getString(optionKey));
+            System.out.println(options.getString(odpfx + option));
             System.out.println();
-
-            // Print each option and it's associated descriptive text
-            for (String optionKey : optionKeys) {
-                String option = optionKey.substring(okpfx.length());
-                System.out.println(options.getString(optionKey));
-                System.out.println(options.getString(odpfx + option));
-                System.out.println();
-            }
         }
     }
 }

--- a/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/Generator.java
+++ b/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/Generator.java
@@ -220,7 +220,7 @@ public class Generator {
         // Kernel feature list tools and schema tools for some reason share the same configuration options file.
         // Hard-code the ones that apply to the schema generator tool to prevent --help from displaying undesired information.
 
-        String[] optionKeys = new String[] { "option-key.compactoutput", "option-key.encoding", "option-key.ignorePids", "option-key.locale", "option-key.schemaVersion", "option-key.outputVersion" };
+        String[] optionKeys = new String[] { "option-key.encoding", "option-key.ignorePids", "option-key.locale", "option-key.schemaVersion", "option-key.outputVersion" };
 
         System.out.println(options.getString("use.options"));
         System.out.println();

--- a/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/Generator.java
+++ b/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/Generator.java
@@ -148,7 +148,9 @@ public class Generator {
 
                     showPurpose();                    
                     showBriefUsage();
-                    
+
+                    rc = ReturnCode.OK;
+                    break;
                 default:
                     rc = ReturnCode.BAD_ARGUMENT;
                     break;

--- a/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/Generator.java
+++ b/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/Generator.java
@@ -177,14 +177,6 @@ public class Generator {
         XMLOutputFactory factory = XMLOutputFactory.newInstance();
         try {
             String outputFileName = generatorOptions.getOutputFile();
-            File outputFile = new File(outputFileName);
-            if ( outputFile.exists()) {
-                if ( !generatorOptions.getOverwriteExistingFile())  {
-                    System.out.println(MessageFormat.format(messages.getString("schemagen.error.output.file.exists"), outputFileName));
-                    return;
-                }                   
-            }
-            
             PrintWriter writer = new PrintWriter(outputFileName, generatorOptions.getEncoding());
             XMLStreamWriter xmlWriter = null;
             if (generatorOptions.getCompactOutput()) {
@@ -230,7 +222,7 @@ public class Generator {
         // Kernel feature list tools and schema tools for some reason share the same configuration options file.
         // Hard-code the ones that apply to the schema generator tool to prevent --help from displaying undesired information.
 
-        String[] optionKeys = new String[] { "option-key.compactoutput", "option-key.encoding", "option-key.ignorePids", "option-key.locale", "option-key.schemaVersion", "option-key.outputVersion", "option-key.overwriteExistingFile" };
+        String[] optionKeys = new String[] { "option-key.compactoutput", "option-key.encoding", "option-key.ignorePids", "option-key.locale", "option-key.schemaVersion", "option-key.outputVersion" };
 
         System.out.println(options.getString("use.options"));
         System.out.println();

--- a/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/Generator.java
+++ b/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/Generator.java
@@ -176,7 +176,16 @@ public class Generator {
     private void generate(List<MetaTypeInformationSpecification> metatype) {
         XMLOutputFactory factory = XMLOutputFactory.newInstance();
         try {
-            PrintWriter writer = new PrintWriter(generatorOptions.getOutputFile(), generatorOptions.getEncoding());
+            String outputFileName = generatorOptions.getOutputFile();
+            File outputFile = new File(outputFileName);
+            if ( outputFile.exists()) {
+                if ( !generatorOptions.getOverwriteExistingFile())  {
+                    System.out.println(MessageFormat.format(messages.getString("schemagen.error.output.file.exists"), outputFileName));
+                    return;
+                }                   
+            }
+            
+            PrintWriter writer = new PrintWriter(outputFileName, generatorOptions.getEncoding());
             XMLStreamWriter xmlWriter = null;
             if (generatorOptions.getCompactOutput()) {
             	 xmlWriter = new CompactOutputXMLStreamWriter(factory.createXMLStreamWriter(writer));
@@ -195,6 +204,7 @@ public class Generator {
                 schemaWriter.add(item);
             }
             schemaWriter.generate(true);
+            System.out.println(MessageFormat.format(messages.getString("schemagen.info.schema.file.created"), outputFileName));           
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
@@ -220,7 +230,7 @@ public class Generator {
         // Kernel feature list tools and schema tools for some reason share the same configuration options file.
         // Hard-code the ones that apply to the schema generator tool to prevent --help from displaying undesired information.
 
-        String[] optionKeys = new String[] { "option-key.encoding", "option-key.ignorePids", "option-key.locale", "option-key.schemaVersion", "option-key.outputVersion" };
+        String[] optionKeys = new String[] { "option-key.compactoutput", "option-key.encoding", "option-key.ignorePids", "option-key.locale", "option-key.schemaVersion", "option-key.outputVersion", "option-key.overwriteExistingFile" };
 
         System.out.println(options.getString("use.options"));
         System.out.println();

--- a/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/GeneratorOptions.java
+++ b/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/GeneratorOptions.java
@@ -45,8 +45,8 @@ public class GeneratorOptions {
     private String outputFile;
     private String encoding = "UTF-8";
     private Locale locale = Locale.getDefault();
-    private SchemaVersion schemaVersion = SchemaVersion.getEnum("");
-    private OutputVersion outputVersion = OutputVersion.getEnum("");
+    private SchemaVersion schemaVersion = SchemaVersion.v1_0;
+    private OutputVersion outputVersion = OutputVersion.v1;
     private boolean compactOutput = false;
 
     /**
@@ -90,32 +90,53 @@ public class GeneratorOptions {
             if (arg.startsWith("-")) {
                 if (argToLower.contains("-help")) {
                     return ReturnCode.HELP_ACTION;
+                    
                 } else if (argToLower.contains("-ignorepidsfile")) {
                     try {
-                        addExcludeFile(new PidFileArgument(args[i]));
+                        addExcludeFile(new PidFileArgument(arg));
                     } catch (IOException ex) {
                         System.out.println(MessageFormat.format(messages.getString("error.fileNotFound"), args[i]));
                         System.out.println();
                         return(ReturnCode.BAD_ARGUMENT);
                     }
+                    
                 } else if (argToLower.contains("-encoding")) {
-                    setEncoding(getArgumentValue(args[i]));
+                    setEncoding(getArgumentValue(arg));
+                    
                 } else if (argToLower.contains("-locale")) {
                     setLocale(new LocaleArgument(args[i]).getLocale());
+                    
                 } else if (argToLower.contains("-schemaversion")) {
-                    setSchemaVersion(SchemaVersion.getEnum(getArgumentValue(argToLower)));
+                    String argValue = getArgumentValue(argToLower);
+                    if (SchemaVersion.isValid(argValue)) {
+                        schemaVersion = SchemaVersion.getEnum(argValue);
+                    } else {
+                        System.out.println(MessageFormat.format(messages.getString("error.unknownSchemaVersion"), argValue));
+                        return(ReturnCode.BAD_ARGUMENT);
+                    }
+                    
                 } else if (argToLower.contains("-outputversion")) {
-                    setOutputVersion(OutputVersion.getEnum(getArgumentValue(argToLower)));
-                } else if (argToLower.contains("-compactoutput")) {
-                	setCompactOutput(Boolean.parseBoolean(getArgumentValue(args[i])));
+                    String argValue = getArgumentValue(argToLower);
+                    if (OutputVersion.isValid(argValue)) {
+                        outputVersion = OutputVersion.getEnum(argValue);
+                    } else {
+                        System.out.println(MessageFormat.format(messages.getString("error.unknownOutputVersion"), argValue));
+                        return(ReturnCode.BAD_ARGUMENT);
+                    }
+                	
                 }  else {
                     System.out.println(MessageFormat.format(messages.getString("error.unknownArgument"), arg));
-                    System.out.println();
                     return(ReturnCode.BAD_ARGUMENT);
                 }
             } else {
+                // The online help doesn't indicate this, but the output file can be placed anywhere on the command line.
+                // It is indicated by not starting with a hyphen "-".  If we encounter a second non-hyphenated argument,
+                // flag the first one.  Reasoning:  the help says that the outputFile should be the final argument.  So
+                // if there are multipled non-hypenated args, the first should be considered as the invalid one; not the
+                // current arg that we are processing.
                 if (outputFile != null) {
-                    System.out.println(MessageFormat.format(messages.getString("error.unknownArgument"), arg));
+                    System.out.println(MessageFormat.format(messages.getString("error.unknownArgument"), outputFile));
+                    return(ReturnCode.BAD_ARGUMENT);
                 } else {
                     outputFile = arg;
                     rc = ReturnCode.GENERATE_ACTION;

--- a/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/GeneratorOptions.java
+++ b/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/GeneratorOptions.java
@@ -48,6 +48,15 @@ public class GeneratorOptions {
     private SchemaVersion schemaVersion = SchemaVersion.v1_0;
     private OutputVersion outputVersion = OutputVersion.v1;
     private boolean compactOutput = false;
+    private boolean overwriteExistingFile = false;
+
+    public boolean getOverwriteExistingFile() {
+        return overwriteExistingFile;
+    }
+
+    public void setOverwriteExistingFile(boolean overwriteExistinFile) {
+        this.overwriteExistingFile = overwriteExistinFile;
+    }
 
     /**
      * @return
@@ -91,6 +100,9 @@ public class GeneratorOptions {
                 if (argToLower.contains("-help")) {
                     return ReturnCode.HELP_ACTION;
                     
+                } else if (argToLower.contains("-compactoutput")) {
+                    compactOutput = processBooleanArg(argToLower);
+                                      
                 } else if (argToLower.contains("-ignorepidsfile")) {
                     try {
                         addExcludeFile(new PidFileArgument(arg));
@@ -123,6 +135,9 @@ public class GeneratorOptions {
                         System.out.println(MessageFormat.format(messages.getString("error.unknownOutputVersion"), argValue));
                         return(ReturnCode.BAD_ARGUMENT);
                     }
+                    
+                } else if (argToLower.contains("-overwrite")) {
+                    overwriteExistingFile = processBooleanArg(argToLower);
                 	
                 }  else {
                     System.out.println(MessageFormat.format(messages.getString("error.unknownArgument"), arg));
@@ -152,6 +167,36 @@ public class GeneratorOptions {
         return rc;
     }
 
+    /**
+     * Boolean args are expected to be unary and are true if specified as unary.
+     * However, allow them to be specified as an assignment.
+     * Expected: 
+     *    --compactoutput    meaning: compactOutput=true
+     *    --overwrite        meaning: overwriteExistingFile=true
+     * Acceptable:
+     *    --compactoutput=true  (any value other than true is false)
+     *    --overwrite=true
+     * @param arg
+     * @return
+     */
+    private boolean processBooleanArg(String arg) {
+        String argValue;
+        try {
+            argValue= getArgumentValue(arg);
+            if (Boolean.parseBoolean(argValue)) {
+                return true;
+            } else {
+                return false;
+            }
+            
+        // If no "assignment" is specified, then it means compactOutput = true.
+        // This is actually the normal, documented, expected case, but code this 
+        // way to allow -compactOutput=true
+        } catch (SchemaGeneratorException sge) {
+            return true;
+        }
+    }
+    
     /**
      * @return
      */

--- a/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/GeneratorOptions.java
+++ b/dev/com.ibm.ws.config.schemagen/src/com/ibm/ws/config/schemagen/internal/GeneratorOptions.java
@@ -48,15 +48,6 @@ public class GeneratorOptions {
     private SchemaVersion schemaVersion = SchemaVersion.v1_0;
     private OutputVersion outputVersion = OutputVersion.v1;
     private boolean compactOutput = false;
-    private boolean overwriteExistingFile = false;
-
-    public boolean getOverwriteExistingFile() {
-        return overwriteExistingFile;
-    }
-
-    public void setOverwriteExistingFile(boolean overwriteExistinFile) {
-        this.overwriteExistingFile = overwriteExistinFile;
-    }
 
     /**
      * @return
@@ -135,9 +126,6 @@ public class GeneratorOptions {
                         System.out.println(MessageFormat.format(messages.getString("error.unknownOutputVersion"), argValue));
                         return(ReturnCode.BAD_ARGUMENT);
                     }
-                    
-                } else if (argToLower.contains("-overwrite")) {
-                    overwriteExistingFile = processBooleanArg(argToLower);
                 	
                 }  else {
                     System.out.println(MessageFormat.format(messages.getString("error.unknownArgument"), arg));
@@ -169,13 +157,13 @@ public class GeneratorOptions {
 
     /**
      * Boolean args are expected to be unary and are true if specified as unary.
-     * However, allow them to be specified as an assignment.
+     * However, allow them to be specified as an assignment.  For example:
      * Expected: 
      *    --compactoutput    meaning: compactOutput=true
-     *    --overwrite        meaning: overwriteExistingFile=true
+     *
      * Acceptable:
      *    --compactoutput=true  (any value other than true is false)
-     *    --overwrite=true
+     *
      * @param arg
      * @return
      */
@@ -189,9 +177,9 @@ public class GeneratorOptions {
                 return false;
             }
             
-        // If no "assignment" is specified, then it means compactOutput = true.
+        // If no "assignment" is specified, then it means the unary option is "true".
         // This is actually the normal, documented, expected case, but code this 
-        // way to allow -compactOutput=true
+        // way to allow -unaryOption=true
         } catch (SchemaGeneratorException sge) {
             return true;
         }

--- a/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
+++ b/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
@@ -488,5 +488,13 @@ error.unknownSchemaVersion=CWWKG0108E: The schema version, {0}, is not supported
 error.unknownSchemaVersion.explanation=The value supplied with the "--schemaVersion" option is not valid.
 error.unknownSchemaVersion.useraction=To see valid options enter the "./schemaGen --help" command.
 
+schemagen.info.schema.file.created=CWWKG0109I: The schema was created in file [{0}].
+schemagen.info.schema.file.created.explanation=The command completed successfully.
+schemagen.info.schema.file.created.useraction=No action is required.
+
+schemagen.error.output.file.exists=CWWKG0110E: The output file [{0}] already exists.
+schemagen.error.output.file.exists.explanation=The file could not be written, because another file with the same name already exists.
+schemagen.error.output.file.exists.useraction=Specify a different output file name or use the {0} option.
+
 # Non-TR message
 error.invalidOCDRef=ERROR: Metatype PID [{0}] specifies non-existent object class definition ID [{1}]

--- a/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
+++ b/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
@@ -492,9 +492,5 @@ schemagen.info.schema.file.created=CWWKG0109I: The schema was created in file [{
 schemagen.info.schema.file.created.explanation=The command completed successfully.
 schemagen.info.schema.file.created.useraction=No action is required.
 
-schemagen.error.output.file.exists=CWWKG0110E: The output file [{0}] already exists.
-schemagen.error.output.file.exists.explanation=The file could not be written, because another file with the same name already exists.
-schemagen.error.output.file.exists.useraction=Specify a different output file name or use the {0} option.
-
 # Non-TR message
 error.invalidOCDRef=ERROR: Metatype PID [{0}] specifies non-existent object class definition ID [{1}]

--- a/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
+++ b/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
@@ -488,7 +488,7 @@ error.unknownSchemaVersion=CWWKG0108E: The schema version, {0}, is not supported
 error.unknownSchemaVersion.explanation=The value supplied with the "--schemaVersion" option is not valid.
 error.unknownSchemaVersion.useraction=To see valid options enter the "./schemaGen --help" command.
 
-schemagen.info.schema.file.created=CWWKG0109I: The schema was created in file [{0}].
+schemagen.info.schema.file.created=CWWKG0109I: The schema was created in [{0}] file.
 schemagen.info.schema.file.created.explanation=The command completed successfully.
 schemagen.info.schema.file.created.useraction=No action is required.
 

--- a/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
+++ b/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
@@ -488,7 +488,7 @@ error.unknownSchemaVersion=CWWKG0108E: The schema version, {0}, is not supported
 error.unknownSchemaVersion.explanation=The value supplied with the "--schemaVersion" option is not valid.
 error.unknownSchemaVersion.useraction=To see valid options enter the "./schemaGen --help" command.
 
-schemagen.info.schema.file.created=CWWKG0109I: The schema was created in [{0}] file.
+schemagen.info.schema.file.created=CWWKG0109I: The schema was created in the [{0}] file.
 schemagen.info.schema.file.created.explanation=The command completed successfully.
 schemagen.info.schema.file.created.useraction=No action is required.
 

--- a/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigOptions.nlsprops
+++ b/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigOptions.nlsprops
@@ -34,7 +34,7 @@ use.options=Options:
 option-key.ignorePids=--ignorePidsFile
 option-desc.ignorePids=A file name containing a list of pids to ignore.
 option-key.encoding=--encoding
-option-desc.encoding=The character encoding to use for the output.     \n
+option-desc.encoding=The character encoding to use for the output.     \n\
 The default encoding is "UTF-8".
 option-key.locale=--locale
 option-desc.locale=The language to use when you are creating the output\n\

--- a/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigOptions.nlsprops
+++ b/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigOptions.nlsprops
@@ -66,7 +66,3 @@ option-desc.outputVersion=\
 If outputVersion=2.0 is specified, only the xsd:any element is used    \n\
 in the output file, so that unknown elements pass XSD validation at    \n\
 the expense of losing validation for known elements.
-
-option-key.overwriteExistingFile=--overwrite
-option-desc.overwriteExistingFile=                                     \n\
-Overwrite output schema file if it already exists.

--- a/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigOptions.nlsprops
+++ b/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigOptions.nlsprops
@@ -66,3 +66,7 @@ option-desc.outputVersion=\
 If outputVersion=2.0 is specified, only the xsd:any element is used    \n\
 in the output file, so that unknown elements pass XSD validation at    \n\
 the expense of losing validation for known elements.
+
+option-key.overwriteExistingFile=--overwrite
+option-desc.overwriteExistingFile=                                     \n\
+Overwrite output schema file if it already exists.

--- a/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigOptions.nlsprops
+++ b/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigOptions.nlsprops
@@ -34,7 +34,8 @@ use.options=Options:
 option-key.ignorePids=--ignorePidsFile
 option-desc.ignorePids=A file name containing a list of pids to ignore.
 option-key.encoding=--encoding
-option-desc.encoding=The character encoding to use for the output.
+option-desc.encoding=The character encoding to use for the output.     \n
+The default encoding is "UTF-8".
 option-key.locale=--locale
 option-desc.locale=The language to use when you are creating the output\n\
 file. This string consists of the ISO-639 two-letter lowercase language\n\

--- a/dev/com.ibm.ws.config/src/com/ibm/websphere/metatype/OutputVersion.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/websphere/metatype/OutputVersion.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,8 +18,8 @@ public enum OutputVersion {
 
     private String value;
 
-    private OutputVersion(String val) {
-        value = val;
+    private OutputVersion(String version) {
+        value = getNormalizedVersion(version);
     }
 
     @Override
@@ -27,17 +27,47 @@ public enum OutputVersion {
         return value;
     }
 
-    public static OutputVersion getEnum(String value) {
-        if (value == null || value.length() == 0) {
-            return v1; //default to v1 if not specified
-        }
+    public static OutputVersion getEnum(String version) {
+
+        String normalizedVersion = getNormalizedVersion(version);
 
         for (OutputVersion v : values()) {
-            if (v.value.equals(value)) {
+            if (v.value.equals(normalizedVersion)) {
                 return v;
             }
         }
 
-        throw new IllegalArgumentException(value);
+        throw new IllegalArgumentException(version);
+    }
+
+    public static boolean isValid(String version) {
+
+        try {
+            getEnum(version);
+        } catch (IllegalArgumentException iae) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Strips spaces and ".0" from version parameter.
+     * Default to version "1" if version parameter is null or "";
+     */
+    public static String getNormalizedVersion(String version) {
+
+        if (version == null) {
+            version = "1";
+        } else {
+            version = version.trim();
+            if (version.length() == 0) {
+                version = "1";
+            }
+        }
+
+        if (version.endsWith(".0")) {
+            return version.substring(0, version.length() - 2);
+        }
+        return version;
     }
 }

--- a/dev/com.ibm.ws.config/src/com/ibm/websphere/metatype/SchemaGeneratorOptions.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/websphere/metatype/SchemaGeneratorOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,8 +29,8 @@ public class SchemaGeneratorOptions {
     private Set<String> ignoredPids;
     private boolean isRuntime = false;
 
-    private String schemaVersion;
-    private String outputVersion;
+    private SchemaVersion schemaVersion;
+    private OutputVersion outputVersion;
 
     public Bundle[] getBundles() {
         return bundles;
@@ -72,20 +72,31 @@ public class SchemaGeneratorOptions {
         this.isRuntime = value;
     }
 
+    @Deprecated
     public String getSchemaVersion() {
+        return schemaVersion.toString();
+    }
+
+    @Deprecated
+    public String getOutputVersion() {
+        return outputVersion.toString();
+    }
+
+    // New getter
+    public SchemaVersion schemaVersion() {
         return schemaVersion;
     }
 
-    public String getOutputVersion() {
+    // New getter
+    public OutputVersion outputVersion() {
         return outputVersion;
     }
 
     public void setSchemaVersion(String v) {
-        schemaVersion = v;
+        schemaVersion = SchemaVersion.getEnum(v);
     }
 
     public void setOutputVersion(String v) {
-        outputVersion = v;
+        outputVersion = OutputVersion.getEnum(v);
     }
-
 }

--- a/dev/com.ibm.ws.config/src/com/ibm/websphere/metatype/SchemaVersion.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/websphere/metatype/SchemaVersion.java
@@ -14,7 +14,12 @@ package com.ibm.websphere.metatype;
  *
  */
 public enum SchemaVersion {
-    v1_0("1"), v1_1("1.1");
+
+    // If new versions are added, for example V2, be consistent and make it V2_0("2.0").  The version
+    // representation here is, unfortunately, not consistent with the "OutputVersion", but we can't do
+    // anything about that now.  Note getNormalizedVersion() adds ".0" when the version does not
+    // contain a ".".  This is to make, for example, v1 = v1_0, or "1" = "1.0".
+    v1_0("1.0"), v1_1("1.1");
 
     private String value;
 
@@ -57,16 +62,16 @@ public enum SchemaVersion {
     public static String getNormalizedVersion(String version) {
 
         if (version == null) {
-            version = "1";
+            version = "1.0";
         } else {
             version = version.trim();
             if (version.length() == 0) {
-                version = "1";
+                version = "1.0";
             }
         }
 
-        if (version.endsWith(".0")) {
-            return version.substring(0, version.length() - 2);
+        if (!version.contains(".")) {
+            return version.concat(".0");
         }
         return version;
     }

--- a/dev/com.ibm.ws.config/src/com/ibm/websphere/metatype/SchemaVersion.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/websphere/metatype/SchemaVersion.java
@@ -14,12 +14,12 @@ package com.ibm.websphere.metatype;
  *
  */
 public enum SchemaVersion {
-    v1_0("1.0"), v1_1("1.1");
+    v1_0("1"), v1_1("1.1");
 
     private String value;
 
-    private SchemaVersion(String val) {
-        value = val;
+    private SchemaVersion(String version) {
+        value = getNormalizedVersion(version);
     }
 
     @Override
@@ -27,17 +27,47 @@ public enum SchemaVersion {
         return value;
     }
 
-    public static SchemaVersion getEnum(String value) {
-        if (value == null || value.length() == 0) {
-            return v1_0; //default to v1 if not specified
-        }
+    public static SchemaVersion getEnum(String version) {
+
+        String normalizedVersion = getNormalizedVersion(version);
 
         for (SchemaVersion v : values()) {
-            if (v.value.equals(value)) {
+            if (v.value.equals(normalizedVersion)) {
                 return v;
             }
         }
 
-        throw new IllegalArgumentException(value);
+        throw new IllegalArgumentException(version);
+    }
+
+    public static boolean isValid(String version) {
+
+        try {
+            getEnum(version);
+        } catch (IllegalArgumentException iae) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Strips spaces and ".0" from version parameter.
+     * Default to version "1" if version parameter is null or "";
+     */
+    public static String getNormalizedVersion(String version) {
+
+        if (version == null) {
+            version = "1";
+        } else {
+            version = version.trim();
+            if (version.length() == 0) {
+                version = "1";
+            }
+        }
+
+        if (version.endsWith(".0")) {
+            return version.substring(0, version.length() - 2);
+        }
+        return version;
     }
 }

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/schemagen/internal/SchemaGeneratorImpl.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/schemagen/internal/SchemaGeneratorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,7 +28,7 @@ import com.ibm.websphere.metatype.SchemaGenerator;
 import com.ibm.websphere.metatype.SchemaGeneratorOptions;
 
 /**
- * 
+ *
  */
 public class SchemaGeneratorImpl implements SchemaGenerator {
 
@@ -65,6 +65,8 @@ public class SchemaGeneratorImpl implements SchemaGenerator {
         schemaWriter.setLocale(options.getLocale());
         schemaWriter.setIgnoredPids(options.getIgnoredPids());
         schemaWriter.setIsRuntime(options.isRuntime());
+        schemaWriter.setOutputVersion(options.outputVersion());
+        schemaWriter.setSchemaVersion(options.schemaVersion());
 
         for (Bundle bundle : options.getBundles()) {
             MetaTypeInformation info = metaTypeService.getMetaTypeInformation(bundle);


### PR DESCRIPTION
Fixes issue #20627

##                                                      **Changes**

### Generator.java:

  - Updated **showUsageInfo()**:  The feature list tools and the schema list tools share the same messages file, ConfigOptions.nlsprops.  The code was using an exclusion set to exclude options that did not apply to the schemaGen tools.  I replaced the exclusion set with an explicit set of command line options (basically an inclusion set.  **Server**SchemaGen also explicity specifies the options to include.) 
     - Problem with exclusion set.  If someone adds a message, unrelated to schemaGen, it won't be excluded.   
     
     - Added message to tell what the command did -- success case.
     
### GeneratorOptions.java:
 - Explicitly set default values when instantiating SchemaVersion and OutputVersion.  Previously, it passed in "", which got defaulted to v1.

 - Validate options entered for schemaVersion and outputVersion.  Invalid options previously caused an IllegalArgumentException which displayed a stack dump in the terminal window.

```
java -jar ws-schemagen.jar -schemaVersion=2.5 fred
CWWKG0036E: Error generating schema: 2.5
java.lang.IllegalArgumentException: 2.5
	at com.ibm.websphere.metatype.SchemaVersion.getEnum(SchemaVersion.java:41)
	at com.ibm.ws.config.schemagen.internal.GeneratorOptions.processArgs(GeneratorOptions.java:102)
	at com.ibm.ws.config.schemagen.internal.Generator.createSchema(Generator.java:102)
	at com.ibm.ws.config.schemagen.internal.Generator.main(Generator.java:84)
```
-  Add --compactoutput option.  This was previously listed in the help, but was not parsed as a valid option.  This option needs to be added to web documentation.
 
- Immediately stop parsing when an invalid option found.
- If two non-hyphenated options are entered, the first is simply ignored.   I changed this to flag the first non-hyphenated option as a bad argument.  There should only be one non-hyphenated argument, which is the output file name.

### ConfigMessages.nlsprops

  - Add message for successful case

### ConfigOptions.nlsprops

- Updated **encoding** option description to include default encoding which is UTF-8.

### OutputVersion.java & SchemaVersion.java

   - **Problem**: User must enter the version exactly as expected.  For OutputVersion, that means they need to enter OutputVersion=1, while for SchemaVersion they must enter  SchemaVersion=1.0.  Not only is it inconsistent, but 1 should be acceptable for meaning 1.0 and vice versa.
   - **Solution**:  I added a getNormalizedVersion methods. Unfortunately, they have to be implemented differently beacuse of the inconsistency between the enum values in OutputVersion.java and SchemaVersion.java.   So in one case getNormalizedVersion strips spaces and removes ".0", while in the other case it strips spaces and adds ".0" (meaning if there is no ".", the code is going to assume ".0") 
   -    The documentation is a little weird when it comes to these options.  It only lists --schemaVersion=1.1 and --outputVersion=2.0 as options.   The default values, which are not documented ,are --schemaVersion=1.0 and --outputVersion=1.0. The default should be documented, though I'm not exactly sure how to describe what the default options do.  They seem to be the opposite of the "v2" options.  So maybe a proper description could be derived from the new version descriptions?

### SchemaGeneratorOptions.java
   - This class was using the internal representation of the OutputVersion and SchemaVersion enum values; i.e. it was using String instead of OutputVersion and SchemaVersion.

I added new getters, to retrieve OutputVersion and SchemaVersion instead of getting the String form of the version.   It would have been better to replace the APIs, rather than add new ones, but I wasn't sure I was allowed to do that.
  I could not find anywhere else in Liberty code where schemaVersion from package com.ibm.websphere.metatype is used outside of the schemaGen code.

### SchemaGeneratorImpl.java

  - Now passes OutputVersion and SchemaVersion command line options to the SchemaWriter.  Previously, the SchemaWriter had no awareness of the values entered on the command line. So these options had previously had no effect.
  
### Other considerations
The _ignorePids_ option is not well documented and will confuse most people.  I thought it meant Process ID, but apparently has something to do with metatypes, which I am not sure is documented anywhere either.   So I'm not exactly sure how this option affects the output.  Note that **server**SchemaGen does not have _ignorePids_ as an option.   Though we cannot remove _ignorePids_ as an option for schemaGen, since it is in the documentation and is implemented.
     