### PR TITLE
Admin Center changes to support Windows high contrast mode

### DIFF
--- a/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/cssShared/breadcrumb.css
+++ b/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/cssShared/breadcrumb.css
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -344,6 +344,10 @@
   margin: 8%;
 }
 
+#breadcrumbController-mainDashboard_label {
+    display: none; /* new accessibility rule fix */
+}
+
 @media screen and (max-device-width : 480px) {
 
     .breadcrumbPane {
@@ -439,3 +443,60 @@
 	padding-bottom:0px;
 }
 
+/* high contrast mode css */
+.dj_a11y .dijitIcon {
+    display: none !important;
+}
+
+.dj_a11y .dijitButtonNode {
+    text-overflow: ellipsis;
+    overflow-x: hidden;
+    display: inline-block;
+}
+
+.dj_a11y .dijitButtonContents {
+    display: inline;
+}
+
+.dj_a11y .dijitButtonContents .dijitButtonText {
+    display: inline !important;
+}
+
+.dj_a11y .breadcrumbPane {
+    left: 8px !important
+}
+
+.dj_a11y #breadcrumbStackContainer-id {
+    border-bottom: 2px solid;
+}
+
+.dj_a11y #breadcrumbContainer-id {
+    top: 46px;
+}
+
+.dj_a11y .breadcrumbController {
+    border: 0;
+}
+/*
+.dj_a11y .breadcrumbTextOnly .dijitButtonContents {
+    padding: 0px !important;
+} */
+
+.dj_a11y #searchDiv {
+    right: 8px;
+}
+
+.dj_a11y .breadcrumbSeparatorButton {
+    display: none;
+}
+
+.dj_a11y .breadcrumb .dijitButtonContents:focus {
+  outline: 1px solid !important;
+  cursor: pointer;
+}
+
+.d1_ally .breadcrumbTextOnlyFocused .dijitButtonNode, .d1_ally .breadcrumbTextOnlyHover .dijitButtonNode,
+.d1_ally .breadcrumbTextOnlyFocused .dijitButtonContents, .d1_ally .breadcrumbTextOnlyHover .dijitButtonContents,
+.d1_ally .breadcrumbTextOnlyFocused .dijitButtonText, .d1_ally .breadcrumbTextOnlyHover .dijitButtonText {
+    cursor: text;
+}

--- a/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/cssShared/dialog.css
+++ b/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/cssShared/dialog.css
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -384,4 +384,14 @@ svg.yesNoDescriptionIcon {
     font-size: 14px;
     display: inline-block;
   }
+}
+
+/* high contrast mode css */
+.dj_a11y .acDialog, .dj_a11y .dijitDialog, .dj_a11y .yesNoButton,
+.dj_a11y .confirmOkButton, .dj_a11y .messageDialog, .dj_a11y .messageOKButton {
+  border: 1px solid !important;
+}
+
+.dj_a11y .dijitDialog .closeText {
+  display: none !important;
 }

--- a/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/cssShared/search.css
+++ b/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/cssShared/search.css
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -101,6 +101,10 @@
 	width: 22px;
 	height: 22px;
 	background-size: 100%;
+}
+
+#search-searchBoxClear-button_label, #search-searchBoxSearch-button_label, #search-searchBoxAddPill-button_label {
+	display: none; /* not to show the button labels added for high contrast mode */
 }
 
 .searchPillPane{
@@ -504,8 +508,33 @@
 	border-bottom-right-radius: 3.9px;
 }
 
+.searchPillDeleteButton span {
+	display: none; /* not to show the delete text added for high contrast mode */
+}
+
 .searchPillDeleteButton:focus,
 .searchPillDeleteButton:hover {
 	border: none;
 	background-color: #E3E4E6;
+}
+
+/* high contrast mode css */
+.dj_a11y .searchPill .dijitButtonNode {
+	border: none !important;
+	height: 22px;
+	padding-top: 0 !important;
+	padding-bottom: 0 !important;
+}
+
+.dj_a11y .searchPill .dijitArrowButtonChar {
+	display: inline !important;
+}
+
+.dj_a11y .searchPillDeleteButton span {
+	display: inline !important;
+}
+
+.dj_a11y .searchInputDropDownButtonFocused,
+.dj_a11y .searchByDropDownButtonFocused{
+	border: 1px solid;
 }

--- a/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/jsShared/nls/sharedMessages.js
+++ b/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/jsShared/nls/sharedMessages.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,9 @@ define({
       SEARCH_BUTTON_ADD : "Add Search Criteria",
       SEARCH_BUTTON_CLEAR : "Clear Search Field",
       SEARCH_BUTTON_SEARCH : "Search",
+      SEARCH_BUTTON_ADD_TEXT : "Add",
+      SEARCH_BUTTON_CLEAR_TEXT : "Clear",
+      SEARCH_BUTTON_SEARCH_TEXT : "Search",
       SEARCH_RESOURCE_TYPE_ALL: "All", // Search all resource types
       GRID_COLUMN_SELECTION_BUTTON_LABEL: "Column Selection",
       GRID_COLUMN_SELECTION_MENU_LABEL: "Column Selection for {0}",    // Grid Identifier 

--- a/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/jsShared/search/SearchBox.html
+++ b/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/jsShared/search/SearchBox.html
@@ -1,6 +1,6 @@
 <div data-dojo-type="dijit/layout/ContentPane" class="searchBox" data-dojo-attach-event="" id="search-box">
 <!--
-    Copyright (c) 2016 IBM Corporation and others.
+    Copyright (c) 2016, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -22,17 +22,17 @@
    			 data-dojo-attach-event="keypress:checkKeyCode" />
      	
 	<div id="searchBoxButtonsDiv" >
-       <button  title="${addButtonLabel}" value="${addButtonLabel}" aria-label="${addButtonLabel}" id="search-searchBoxAddPill-button"  data-dojo-type="dijit/form/Button" type="button"  tabindex="0" 
+       <button  title="${addButtonLabel}" value="${addButtonLabel}" aria-label="${addButtonLabel}" label="${addButtonLabelText}" id="search-searchBoxAddPill-button"  data-dojo-type="dijit/form/Button" type="button"  tabindex="0"
 	   			data-dojo-props="iconClass:'searchBoxAddPillButtonIcon', baseClass:'searchBoxButton'" 
 	   			data-dojo-attach-point="searchPaneAddButton" 
 	   			data-dojo-attach-event="click:addNewSearchPill">
 	   </button>
-	   <button 	title="${searchButtonLabel}" value="${searchButtonLabel}" aria-label="${searchButtonLabel}" id="search-searchBoxSearch-button"  data-dojo-type="dijit/form/Button" type="button"   tabindex="0"
+	   <button 	title="${searchButtonLabel}" value="${searchButtonLabel}" aria-label="${searchButtonLabel}" label="${searchButtonLabelText}" id="search-searchBoxSearch-button"  data-dojo-type="dijit/form/Button" type="button"   tabindex="0"
 	   			data-dojo-props="iconClass:'searchBoxSearchButtonIcon', baseClass:'searchBoxButton'" 
 	   			data-dojo-attach-point="searchPaneSearchButton" 
 	   			data-dojo-attach-event="click:performSearch">
 	   </button>
-	   <button 	title="${clearButtonLabel}" value="${clearButtonLabel}" aria-label="${clearButtonLabel}" id="search-searchBoxClear-button"  data-dojo-type="dijit/form/Button" type="button" tabindex="0"  
+	   <button 	title="${clearButtonLabel}" value="${clearButtonLabel}" aria-label="${clearButtonLabel}" label="${clearButtonLabelText}" id="search-searchBoxClear-button"  data-dojo-type="dijit/form/Button" type="button" tabindex="0"
 	   			data-dojo-props="iconClass:'searchBoxClearButtonIcon', baseClass:'searchBoxButton'" 
 	   			data-dojo-attach-point="searchPaneClearButton" 
 	   			data-dojo-attach-event="click:resetSearchBox">

--- a/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/jsShared/search/SearchBox.js
+++ b/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/jsShared/search/SearchBox.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,6 +47,9 @@ define([
         addButtonLabel : i18n.SEARCH_BUTTON_ADD,
         clearButtonLabel : i18n.SEARCH_BUTTON_CLEAR,
         searchButtonLabel : i18n.SEARCH_BUTTON_SEARCH,
+        addButtonLabelText : i18n.SEARCH_BUTTON_ADD_TEXT,
+        clearButtonLabelText : i18n.SEARCH_BUTTON_CLEAR_TEXT,
+        searchButtonLabelText : i18n.SEARCH_BUTTON_SEARCH_TEXT,
         totalNumSearchPillsCreated : 0, /*for searchpill ID*/
         origSearchPaneHeight : 75, /*hard code the value to match what we currently use. can update later to dynamically pull the height*/
         keepSearchAreaExpanded : false, /*the on (mouse in/out, focus, blur, keypress, etc.) have very specific behaviors that will need to know if the expanded search box is expected to remain open or not*/

--- a/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/jsShared/search/SearchPill.html
+++ b/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/jsShared/search/SearchPill.html
@@ -1,7 +1,7 @@
 <div class="searchPill searchPillNotSelected"  tabindex="0"
 	 data-dojo-attach-event="click:showPillAsSelected,focus:showPillAsSelected,blur:showPillAsNotSelected,keypress:checkKeyCode">
 <!--
-    Copyright (c) 2016 IBM Corporation and others.
+    Copyright (c) 2016, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -27,5 +27,6 @@
 	 </div>
 
  	 <button id="${id}_deleteButton" data-dojo-attach-point="searchPillDeleteButton" role="button" aria-label="" title="" tab-index="0" class="searchPillDeleteIcon searchPillDeleteButton">
+			<span>x</span>
 	 </button>
 </div>

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/card.css
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/card.css
@@ -8,6 +8,8 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+ @import url("cardExcludeValidator.css");
+
 /* @media only screen and (min-device-width: 767px) {  */
 .tableContainerDropDownActionButton {
     border: 0;

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/card.css
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/card.css
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -809,4 +809,80 @@ input.checkboxToggleButton:checked+label:after {
         overflow: hidden;
         text-overflow: ellipsis;
     }
+}
+
+/* High contrast mode css */
+.dj_a11y .actionMenu .dijitTooltipContainer .dijitButtonNode {
+    border: 0 !important;
+}
+
+.dj_a11y .dropDownActionButtonsDisabled {
+    opacity: 0.5;
+}
+
+.dj_a11y .dropDownButton, .dj_a11y .dropDownButton .dijitButtonNode {
+    border: 0 !important;
+    height: 32px;
+}
+
+/* show both the drop down image and the arrow button char on each card for maxiumum contrast
+   as the down arrow in the image doesn't show well in the white on black theme */
+.dj_a11y .dropDownButton .dijitButtonNode img {
+    height: 24px;
+    width: 24px;
+}
+
+/* .dj_a11y .dropDownButton .dijitArrowButtonChar {
+    display: none !important;
+} */
+
+.dj_a11y .dropDownActionButtons:not(.dropDownActionButtonsDisabled):hover,
+.dj_a11y .dropDownButtonFocused,
+.dj_a11y .dropDownActionButtonsFocused {
+    outline: 1px solid !important;
+}
+
+.dj_a11y .actionMenu {
+    padding: 9px 0 5px 0;
+    margin-left: 0;
+}
+
+.dj_a11y .actionMenu-start-Icon-SVG, .dj_a11y .actionMenu-restart-Icon-SVG, .dj_a11y .actionMenu-stop-Icon-SVG,
+.dj_a11y .actionMenu-start-disabled-Icon-SVG, .dj_a11y .actionMenu-restart-disabled-Icon-SVG,
+.dj_a11y .actionMenu-stop-disabled-Icon-SVG {
+    display: none;
+}
+
+.dj_a11y .actionMenuPopup {
+    border: 1px solid;
+}
+
+.dj_a11y .cardInner:focus, .dj_a11y .cardInner:hover {
+    outline: 3px solid !important;
+}
+
+.dj_a11y .expandButton svg {
+    display: none;
+}
+
+.dj_a11y .expandButton:hover, .dj_a11y .expandButton:focus, .dj_a11y .expandButtonFocused {
+    outline: 1px solid;
+}
+
+.dj_a11y input.checkboxToggleButton:checked+label {
+    opacity: 1 !important;
+}
+
+.dj_a11y input.checkboxToggleButton+label,
+.dj_a11y input.checkboxToggleButton:checked+label:before  {
+    height: 24px;
+}
+
+.dj_a11y input.checkboxToggleButton+label:before,
+.dj_a11y input.checkboxToggleButton+label:after {
+    height: 20px;
+}
+
+.dj_a11y input.checkboxToggleButton+label:hover, .dj_a11y input.checkboxToggleButton:focus+label {
+    outline: 2px dashed;
 }

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/cardExcludeValidator.css
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/cardExcludeValidator.css
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+.dj_a11y input.checkboxToggleButton+label {
+  border: 1px solid;
+  background-color: canvasText; /* canvasText means using text color as the background color */
+  opacity: 0.5;
+}
+
+.dj_a11y input.checkboxToggleButton:checked+label:before {
+  background-color: canvasText;
+}

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/desktop.css
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/desktop.css
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -78,4 +78,16 @@
 .dropDownActionButtonIcon {
     height: 14px;
     width: 14px;
+}
+
+/* high contrast css */
+.dj_a11y .breadcrumbDashboard .dijitButtonNode, .dj_a11y .searchDiv .dijitButtonNode,
+.dj_a11y .breadcrumb .dijitButtonNode {
+    margin-top: 8px;  /* verifically center the breadcrumb button in the breadcrumb dashboard */
+}
+
+.dj_a11y .breadcrumbTextOnly .dijitButtonNode {
+    border: none !important;
+    height: 44px;
+    margin-top: 8px;
 }

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/explore.css
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/explore.css
@@ -18,8 +18,6 @@
 
 @import url("card.css");
 
-@import url("cardExcludeValidator.css");
-
 @import url("dashboard.css");
 
 @import url("desktop.css");

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/explore.css
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/explore.css
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corporation and others.
+ * Copyright (c) 2016, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,8 @@
 @import url("../../../../com.ibm.ws.ui.shared/resources/WEB-CONTENT/cssShared/breadcrumb.css");
 
 @import url("card.css");
+
+@import url("cardExcludeValidator.css");
 
 @import url("dashboard.css");
 
@@ -63,6 +65,6 @@
     font-family: 'HelvNeueRoman', Helvetica, Arial, sans-serif;
 }
 
-.dijitHidden {
+.dijitHidden, input.dijitOffScreen { /* latest accessibility checker fix for input.dijitOffScreen */
     display: none;
 }

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/filterBar.css
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/filterBar.css
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -668,4 +668,22 @@
     .actionDisabledIconDropDownMenu {
         background-color: #e4e5e6;
     }
+}
+
+/* High contrast mode css */
+.dj_a11y .actionBarSelectAllIcon, dj_a11y .actionBarSelectAllIconDisabled,
+.dj_a11y .actionBarSelectNoneIcon, dj_a11y .actionBarSelectNoneIconDisabled {
+    display: inline-block !important;
+}
+
+.dj_a11y .editButtons .dijitButtonNode {
+    border: 0 !important;
+}
+
+.dj_a11y .editButtons .dijitArrowButtonChar {
+    display: none !important; /* since button text is an icon, no need to show the down arrow */
+}
+
+.dj_a11y .editButtonsFocused, .dj_a11y .editButtonsHover {
+    border: 1px solid !important;
 }

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/graphs.css
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/graphs.css
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -549,4 +549,70 @@
     width: 22px;
     float: left;
     padding-right: 10px;
+}
+
+/* High contrast mode css */
+.dj_a11y .statusGraphActionButton, .dj_a11y .statusGraphActionButton .dijitButtonNode {
+    border: 0 !important;
+}
+
+.dj_a11y .statusGraphActionMenu .statusGraphActionMenuItems .dijitMenuArrowCell .dijitMenuExpandA11y {
+    display: none;
+}
+
+.dj_a11y .showGraphsButton .dijitButtonNode {
+    border: 0 !important;
+}
+
+.dj_a11y .showGraphsButton:hover, .dj_a11y .showGraphsButton.dijitButtonFocused {
+    border: black outset medium !important;
+}
+
+.dj_a11y .showGraphsButton .dijitIcon {
+    display: inline-block !important; /* show the edit graphs icon */
+}
+
+.dj_a11y .showGraphsOptionButton .dijitButtonNode {
+    border: 0 !important;
+}
+
+.dj_a11y .showGraphsOptionButton .dijitIcon {
+    display: inline-block !important;
+}
+
+.dj_a11y .statusGraphDeleteButton, .dj_a11y .statusGraphDeleteButton .dijitButtonNode {
+    border: 0 !important;
+}
+
+.dj_a11y .statusGraphDeleteButton:hover, .dj_a11y .statusGraphDeleteButton:focus {
+    border: 2px solid transparent !important;
+}
+
+.dj_a11y .statusGraphActionButtonFocused {
+    outline: 1px solid !important;
+}
+
+.dj_a11y .hoverEnableGraphButtonIcon {
+    background-image: url(../images/monitoring-added-check-DT.png);
+    background-repeat: no-repeat;
+    background-color: transparent;
+    width: 15px;
+    height: 15px;
+}
+
+.dj_a11y .showGraphsDialogButton .dijitIcon {
+    display: inline-block !important;
+}
+
+.dj_a11y .showGraphsDialogButton .dijitButtonText {
+    display: none !important;
+}
+
+.dj_a11y .showGraphs_openButton:hover, .dj_a11y .showGraphs_openButton.dijitButtonFocused,
+.dj_a11y .showGraphs_closeButton:hover, .dj_a11y .showGraphs_closeButton.dijitButtonFocused {
+   outline: 1px solid;
+}
+
+.dj_a11y .showGraphsDialogContainer {
+    border: 1px solid;
 }

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/graphs.css
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/graphs.css
@@ -8,6 +8,8 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+ @import url("graphsExcludeValidator.css");
+
 .statusGraph {
     display: none;
     position: relative;

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/graphsExcludeValidator.css
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/graphsExcludeValidator.css
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+.a11y_blackOnWhite .showGraphsDialogButton .dijitIcon {
+  background-color: canvasText;
+}

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/listView.css
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/listView.css
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -230,7 +230,7 @@
     width: 26px;
 }
 
-.listViewSettings:hover {
+.listViewSettings:hover, .listViewSettings:focus, .listViewSettingsFocused {
     cursor: pointer;
     box-shadow: #7CC7FF 0 0 2px 1px;
     background-color: #C0E6FF;
@@ -324,3 +324,84 @@
     background-color: #ddf2f9
 }
 */
+
+/* high contrast mode css */
+.dj_a11y .listViewActionDropDown {
+    border: 0;
+}
+
+.dj_a11y .listViewActionDropDown .dijitButtonNode {
+    border: 0 !important;
+}
+
+/* show both the drop down image and the arrow button char for actions column in each row for maxiumum contrast
+   as the down arrow in the image doesn't show well in the white on black theme */
+.dj_a11y .listViewActionDropDown .dijitButtonText img {
+    height: 18px;
+    width: 18px;
+}
+
+/* .dj_a11y .listViewActionDropDown .dijitArrowButtonChar {
+    display: none !important;
+} */
+
+.dj_a11y .searchViewMetaDataButton {
+    border: 0;
+}
+
+.dj_a11y .listViewHeaderMenuItem_checked, .dj_a11y .listViewHeaderMenuItem_unchecked {
+    display: inline-block !important;
+    width: 12px;
+    height: 12px;
+}
+
+.dj_a11y .listViewHeaderMenuItem_checked {
+    background-image: url(../images/monitoring-added-check-DT.png);
+}
+
+.dj_a11y .listViewMultiSelect .dijitButtonNode {
+    border: 0 !important;
+}
+
+.dj_a11y .listViewMultiSelectChecked, .dj_a11y .listViewMultiSelectUnchecked {
+    display: inline-block !important;
+}
+
+.dj_a11y .dijitMenuItemSelected .dijitMenuItemIconCell {
+    border: 1px solid !important;
+    border-right: none !important;
+}
+
+.dj_a11y .dijitMenuItemSelected .dijitMenuItemLabel {
+    border: 1px solid !important;
+    border-left: none !important;
+}
+
+.dj_a11y .listViewSettings .dijitButtonNode {
+    border: none !important;
+}
+
+.dj_a11y .listViewSettings .dijitIcon {
+    display: inline-block !important;
+}
+
+.dj_a11y .listViewSettings .dijitButtonText, .dj_a11y .listViewSettings .dijitArrowButtonChar,
+.dj_a11y .listViewMultiSelect .dijitToggleButtonIconChar {
+    display: none !important;
+}
+
+.dj_a11y .listViewSettings:hover, .dj_a11y .listViewSettingsFocused {
+    outline: 1px solid;
+}
+
+.dj_a11y .listViewRowSelect .dijitButtonNode {
+    border: 0 !important;
+}
+
+.dj_a11y .listViewRowSelect  .dijitIcon {
+    display: inline-block !important;
+}
+
+.dj_a11y .listViewRowSelect  .dijitToggleButtonIconChar, .dj_a11y .listViewRowSelect .dijitButtonText {
+    display: none !important;
+}

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/setAttributesDialog.css
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/setAttributesDialog.css
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -333,4 +333,13 @@
 
 .fieldError {
     border: 1px solid #a91024 !important;
+}
+
+/* high contrast mode css */
+.dj_a11y .setAttrsDlg, .dj_a11y .attrsSaveButton {
+    border: 1px solid !important;
+}
+
+.dj_a11y .circleNew {
+    outline: 1px solid;
 }

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/singleResource.css
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/css/singleResource.css
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -678,4 +678,28 @@ table.dojoxCheckedMultiSelectButton .dijitArrowButtonInner {
    .sideTabConfigSelected {
         background: url('../images/triangle-connector-leftward-white.png') no-repeat 68px 29px;
     }
+}
+
+/* High contrast mode css */
+.dj_a11y .sideTabButton .dijitButtonNode {
+    border: 0 !important;
+}
+
+.dj_a11y .sideTabButtonLabel {
+    padding-bottom: 0 !important;
+}
+
+.dj_a11y .sideTabSelectedLabel .dijitButtonNode, .dj_a11y .sideTabButton .dijitButtonNode:hover, .dj_a11y .sideTabButton .dijitButtonNode:focus,
+.dj_a11y .sideTabButtonFocused .dijitButtonNode {
+    outline: 1px solid;
+    outline-offset: -1px
+}
+
+.dj_a11y .sideTabSelectedLabel.sideTabButtonFocused .dijitButtonNode{
+    outline: 2px solid;
+}
+
+.dj_a11y .topResourceContentPane .sideTab {
+    width: 86px; /* 77px; */
+    border-right: 2px solid;
 }

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/views/searchView.js
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/views/searchView.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corporation and others.
+ * Copyright (c) 2016, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -643,6 +643,7 @@ function(declare, lang, window, on, Memory, Observable, ToggleButton, dom, domCl
             baseClass : 'listViewHeaderMenuItem',
             iconClass : grid.structure[grid.hideableColumns[i]].display ? 'listViewHeaderMenuItem_checked' : 'listViewHeaderMenuItem_unchecked', 
             selected : grid.structure[grid.hideableColumns[i]].display,
+            showTitle: true,
             onClick : function(){              
               self.__headerMenuItemClick(this, self);
             }

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/ExploreBreadcrumbPane.js
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/ExploreBreadcrumbPane.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -75,9 +75,9 @@ define([ "js/common/platform", 'dojo/_base/lang', "dojo/_base/declare", 'dijit/r
       if (!utils.isStandalone()) {
         this.resource = registry.byId('mainDashboard');
         if(onSearchPane)
-          this.dashboardButton = new ExploreBreadcrumbButton([ this.resource, "mainDashboard-search" ]);
+          this.dashboardButton = new ExploreBreadcrumbButton([ this.resource, "mainDashboard-search", i18n.DASHBOARD ]);
         else
-          this.dashboardButton = new ExploreBreadcrumbButton([ this.resource, "mainDashboard" ]);
+          this.dashboardButton = new ExploreBreadcrumbButton([ this.resource, "mainDashboard", i18n.DASHBOARD ]);
         this.dashboardButton.set("displayed", true);
         this.dashboardButton.pane = this; // GRAPH_REDRAW_CHANGE Bind the pane into the dashboardButton button //<prhodes> confirm
         // this is

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/ObjectViewHeaderPane.js
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/ObjectViewHeaderPane.js
@@ -727,7 +727,7 @@ define(['dojo/_base/declare', 'dojo/_base/lang', 'dojo/dom', 'dojo/has', 'jsExpl
     if (resource.tags) {
       var tags = resource.tags;
       if (tags.length > 0) {
-        tagIcon.set('content', imgUtils.getSVGSmall('metadata-tag'));
+        tagIcon.set('content', imgUtils.getSVGSmall('metadata-tag', null, i18n.TAGS, true));
       }
       for (var i=0; i < tags.length; i++) {
         tagPane.addChild(TagButton.createTagButton(['objectView', resource.type, resource.id, 'tag', tags[i]]));
@@ -735,13 +735,13 @@ define(['dojo/_base/declare', 'dojo/_base/lang', 'dojo/dom', 'dojo/has', 'jsExpl
       tagPane.addChild(TagButton.createTagButton(['objectView', resource.type, resource.id, 'expand-tag', 'more']));
     }
     if (resource.owner) {
-      ownerIcon.set('content', imgUtils.getSVGSmall('metadata-user'));
+      ownerIcon.set('content', imgUtils.getSVGSmall('metadata-user', null, i18n.OWNER, true));
       ownerTagPane.addChild(TagButton.createTagButton(['objectView', resource.type, resource.id, 'owner', resource.owner]));
     }
     if (resource.contacts) {
       var contactTags = resource.contacts;
       if (contactTags.length > 0) {
-        contactIcon.set('content', imgUtils.getSVGSmall('metadata-contacts'));
+        contactIcon.set('content', imgUtils.getSVGSmall('metadata-contacts', null, i18n.CONTACTS, true));
       }
       for (var i=0; i < contactTags.length; i++) {
         contactTagPane.addChild(TagButton.createTagButton(['objectView', resource.type, resource.id, 'contact', contactTags[i]]));
@@ -750,7 +750,7 @@ define(['dojo/_base/declare', 'dojo/_base/lang', 'dojo/dom', 'dojo/has', 'jsExpl
     }
     if (resource.ports) {
       var ports = resource.ports;
-        portIcon.set('content', imgUtils.getSVGSmall('metadata-port'));
+        portIcon.set('content', imgUtils.getSVGSmall('metadata-port', null, i18n.PORTS, true));
         var list = formatPorts(resource, ports);
         serverPortsPane.set('content', list);
         serverPortsPane.set('aria-label', lang.replace(i18n.PORTS, [ports]));
@@ -758,7 +758,7 @@ define(['dojo/_base/declare', 'dojo/_base/lang', 'dojo/dom', 'dojo/has', 'jsExpl
     if (resource.note) {
       var exp = /(\bhttps?:\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/i;
       var note = resource.note;
-      notesIcon.set('content', imgUtils.getSVGSmall('metadata-notes'));
+      notesIcon.set('content', imgUtils.getSVGSmall('metadata-notes', null, i18n.NOTES, true));
       resourceNotePane.set('content', "<span dir='" + utils.getStringTextDirection(note) + "'>" + note.replace(exp,"<a href='$1' target=_blank' rel='noreferrer'>$1</a>") + "</span>");
       resourceNotePane.set('aria-label', lang.replace(i18n.NOTE_LABEL, [note]));
       resourceNotePane.domNode.style.display = 'inline-block';

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/graphs/GraphContainer.js
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/graphs/GraphContainer.js
@@ -293,7 +293,6 @@ define([
          * which has a white arrow png.
          */
         __handleHighContrastBackgroundColor: function() {
-          console.log("----- lavena: handling black on white contrast for graphs button");
           if (document.body.classList.contains('dj_a11y')) {
             // determine whether it is black on white
             const testDiv = document.createElement('div');

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/graphs/GraphContainer.js
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/graphs/GraphContainer.js
@@ -242,6 +242,12 @@ define([
             // already existed so make sure it is expanded
             showHideDialog.show();
           }
+
+          // instead of making this call someewhere else and calling once only, the handling of high contrast mode
+          // black on white theme is called every time the edit graph button is clicked so as to make expand/collapse
+          // button more resposnsive to the contrast mode change.
+          this.__handleHighContrastBackgroundColor();
+
           return showHideDialog;
         },
 
@@ -279,7 +285,31 @@ define([
               cancelButton.resetEditPanes();
             }
           }
-        }
+        },
+
+        /**
+         * Add a class to indicate that it is high contrast black on white theme.
+         * This is to change the background color of the expand/collase graph dialog button
+         * which has a white arrow png.
+         */
+        __handleHighContrastBackgroundColor: function() {
+          console.log("----- lavena: handling black on white contrast for graphs button");
+          if (document.body.classList.contains('dj_a11y')) {
+            // determine whether it is black on white
+            const testDiv = document.createElement('div');
+            testDiv.style.color = 'rgb(50, 50, 50)';
+            document.body.appendChild(testDiv);
+            var color = document.defaultView ? document.defaultView.getComputedStyle(testDiv, null).color : testDiv.currentStyle.color;
+            color = color.replace(/ /g, '');
+            if (color === 'rgb(0,0,0)') {
+              document.body.classList.add("a11y_blackOnWhite");
+            } else {
+              document.body.classList.remove("a11y_blackOnWhite");
+            }
+          } else {
+            document.body.classList.remove("a11y_blackOnWhite");
+          }
+        },
     });
 
     return GraphContainer;

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/graphs/ShowGraphsDialog.js
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/graphs/ShowGraphsDialog.js
@@ -799,31 +799,6 @@ define(["jsShared/utils/toolData",
 
         );
       }));
-
-      this.__handleHighContrastBackgroundColor();
-    },
-
-    /**
-     * Add a class to indicate that it is high contrast black on white theme.
-     * This is to change the background color of the expand/collase graph dialog button
-     * which has a white arrow png.
-     */
-    __handleHighContrastBackgroundColor: function() {
-      if (document.body.classList.contains('dj_a11y')) {
-        // determine whether it is black on white
-        const testDiv = document.createElement('div');
-        testDiv.style.color = 'rgb(50, 50, 50)';
-        document.body.appendChild(testDiv);
-        var color = document.defaultView ? document.defaultView.getComputedStyle(testDiv, null).color : testDiv.currentStyle.color;
-        color = color.replace(/ /g, '');
-        if (color === 'rgb(0,0,0)') {
-          document.body.classList.add("a11y_blackOnWhite");
-        } else {
-          document.body.classList.remove("a11y_blackOnWhite");
-        }
-      } else {
-        document.body.classList.remove("a11y_blackOnWhite");
-      }
     },
 
     /**

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/graphs/ShowGraphsDialog.js
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/graphs/ShowGraphsDialog.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corporation and others.
+ * Copyright (c) 2016, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -799,6 +799,31 @@ define(["jsShared/utils/toolData",
 
         );
       }));
+
+      this.__handleHighContrastBackgroundColor();
+    },
+
+    /**
+     * Add a class to indicate that it is high contrast black on white theme.
+     * This is to change the background color of the expand/collase graph dialog button
+     * which has a white arrow png.
+     */
+    __handleHighContrastBackgroundColor: function() {
+      if (document.body.classList.contains('dj_a11y')) {
+        // determine whether it is black on white
+        const testDiv = document.createElement('div');
+        testDiv.style.color = 'rgb(50, 50, 50)';
+        document.body.appendChild(testDiv);
+        var color = document.defaultView ? document.defaultView.getComputedStyle(testDiv, null).color : testDiv.currentStyle.color;
+        color = color.replace(/ /g, '');
+        if (color === 'rgb(0,0,0)') {
+          document.body.classList.add("a11y_blackOnWhite");
+        } else {
+          document.body.classList.remove("a11y_blackOnWhite");
+        }
+      } else {
+        document.body.classList.remove("a11y_blackOnWhite");
+      }
     },
 
     /**

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/shared/ActionButtons.js
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/shared/ActionButtons.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -67,7 +67,8 @@ define([ 'dojo/_base/lang', 'dojo/_base/window', 'dojo/aspect', 'dojo/dom-geomet
   var startCleanActionIcon = __createImgTag("actionMenu-start", startCleanLabel);
   var startCleanActionDisabledIcon = __createImgTag("actionMenu-start-disabled", startCleanLabel);
   
-  var ellipsisIcon = __createImgTag("actionMenu-expandEllipsis", "");
+  // use ... as the label of the expand/collapse button for high contrast mode
+  var ellipsisIcon = __createImgTag("actionMenu-expandEllipsis", "...");
   
   function __createImgTag(icon, label) {
     var className = "dropDownActionButtonIcon";

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/shared/SetAttributesDialog.js
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/shared/SetAttributesDialog.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -402,7 +402,7 @@ define([
         icon = icon + "-selected";
       }
 
-      return imgUtils.getSVGSmall(icon);
+      return imgUtils.getSVGWithAriaLabelledBy(icon, 'small', this.id + "_name");
     },
 
     /** 
@@ -418,7 +418,7 @@ define([
       // Add the new tag field
       this.tagNewEditBox = this._createEditField(this.TYPE_TAG);
       this.tagAttrsPane.addChild(this.tagNewEditBox);
-      this.attributeTagsIcon.innerHTML = imgUtils.getSVGSmall('metadata-tag');
+      this.attributeTagsIcon.innerHTML = imgUtils.getSVGSmall('metadata-tag', null, i18n.TAGS, true);
             
       // After completing editing in the new Tag Edit field,
       // create a pill for the new value.
@@ -467,6 +467,12 @@ define([
         // Reset the pillSelection
         this.pillSelection.widget = null;
       }));
+
+      var newTagComboxBoxWidget = dom.byId("widget_newTagEditField");
+      if (newTagComboxBoxWidget) {
+        newTagComboxBoxWidget.setAttribute('aria-label', i18n.TAGS_LABEL);
+        newTagComboxBoxWidget.setAttribute('aria-expanded', 'false');
+      }
       
 
       // *****************
@@ -475,7 +481,7 @@ define([
       // Add the new owner field.
       this.ownerNewEditBox = this._createEditField(this.TYPE_OWNER); 
       this.ownerAttrsPane.addChild(this.ownerNewEditBox);
-      this.attributeOwnerIcon.innerHTML = imgUtils.getSVGSmall('metadata-user');
+      this.attributeOwnerIcon.innerHTML = imgUtils.getSVGSmall('metadata-user', null, i18n.OWNER, true);
 
       // After completing editing in the new Owner Edit field, 
       // create a pill for the new value.
@@ -532,7 +538,7 @@ define([
       // Add the new contact field
       this.contactNewEditBox = this._createEditField(this.TYPE_CONTACT);
       this.contactAttrsPane.addChild(this.contactNewEditBox);
-      this.attributeContactsIcon.innerHTML = imgUtils.getSVGSmall('metadata-contacts');
+      this.attributeContactsIcon.innerHTML = imgUtils.getSVGSmall('metadata-contacts', null, i18n.CONTACTS, true);
       
       // After completing editing in the new Contact Edit field, 
       // create a pill for the new value.
@@ -581,11 +587,18 @@ define([
         // Reset the pillSelection
         this.pillSelection.widget = null;
       }));
+
+      // new accessibility requirement
+      var newContactComboxBoxWidget = dom.byId("widget_newContactEditField");
+      if (newContactComboxBoxWidget) {
+        newContactComboxBoxWidget.setAttribute('aria-label', i18n.CONTACTS);
+        newContactComboxBoxWidget.setAttribute('aria-expanded', 'false');
+      }
       
       // *****************
       // Notes section
       // *****************
-      this.attributeNotesIcon.innerHTML = imgUtils.getSVGSmall('metadata-notes');
+      this.attributeNotesIcon.innerHTML = imgUtils.getSVGSmall('metadata-notes', null, i18n.NOTES, true);
       on(this.notesAttrsPane, "click", lang.hitch(this, function(e) {
         // Remove any 'selected' indication on pills
         query(".selectedAttribute").forEach(function(selectedPillNode) {
@@ -723,7 +736,6 @@ define([
            }
          }
       );
-            
       return newEditBox;
     }, 
     

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/templates/SetAttributesDialog.html
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/widgets/templates/SetAttributesDialog.html
@@ -1,6 +1,6 @@
 <div title="${title}" class="setAttrsDlg" role="dialog" aria-labelledby="${id}_title">
   <!--
-    Copyright (c) 2016 IBM Corporation and others.
+    Copyright (c) 2016, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -11,7 +11,7 @@
  	-->
 	<div data-dojo-attach-point="titleBar" class="dijitDialogTitleBar">
 		<span data-dojo-attach-point="titleNode" class="dijitDialogTitle" id="${id}_title"
-				role="heading"></span>
+				role="heading" aria-level="1"></span>
 		<span data-dojo-attach-point="closeButtonNode" class="dijitDialogCloseIcon"  id="${id}_close"
 		        data-dojo-attach-event="ondijitclick: onCancel" title="${buttonCancel}" role="button">
 		</span>
@@ -23,7 +23,7 @@
   		<div class="attrsWrapper">  
   		  <span data-dojo-attach-point="resourceIconNode" class="setAttResourceIcon"></span>
   		  <span data-dojo-attach-point="resourceNameNode" class="setAttrResourceLabel ${resourceNameClass}" id=${id}_name
-  		         role="heading" >${!name}</span>
+  		         role="heading" aria-level="2">${!name}</span>
   		</div>
 	    <div id="clusteredMetadataMsgContainer" class="attrsWrapper noteAttrArea"></div>
   

--- a/dev/com.ibm.ws.ui/resources/WEB-CONTENT/css/desktop.css
+++ b/dev/com.ibm.ws.ui/resources/WEB-CONTENT/css/desktop.css
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -224,4 +224,77 @@
 svg.confirmDescriptionIcon {
     height: 32px;
     width: 32px;
+}
+
+input.dijitOffScreen {
+    display: none; /* latest accessibility checker fix */
+}
+
+.dj_a11y .dijitIcon {
+    display: none !important;
+}
+
+.dj_a11y .idxHeaderSecondaryTrailing .dijitArrowButtonChar,
+.dj_a11y .leftSecondaryHeader .dijitArrowButtonChar {  /* not showing the arrow for menu expansion in the header */
+    display: none !important;
+}
+
+.dj_a11y .dijitButtonNode {
+    text-overflow: ellipsis;
+    overflow-x: hidden;
+    display: inline-block;
+}
+
+.dj_a11y .dijitButtonContents  {
+    display: inline;
+}
+
+.dj_a11y .dijitButtonContents .dijitButtonText {
+    display: inline !important;
+}
+
+.dj_a11y .idxHeaderContainer .idxHeaderSecondaryTrailing {
+    margin-right: 8px;
+}
+
+.dj_a11y .idxHeaderContainer #editHeaderWidgetRightTrailingDiv {
+    width: 310px !important;  /* to accomodate more text */
+}
+
+.dj_a11y .idxHeaderSecondary .idxHeaderSecondaryTitleContainer .idxHeaderSecondaryTitle {
+    display: inline !important; /* to fix the broken border */
+}
+
+.dj_a11y .idxHeaderSecondary .dijitButtonNode {
+    padding-top: 16px !important;
+    height: 38px; /* to compensate for the padding-top */
+    width: 80px;
+    margin-right: 8px;
+}
+
+.dj_a11y .idxHeaderContainer .leftSecondaryHeader .dijitButtonNode {
+    margin-left: 8px;
+}
+
+.dj_a11y #modifyButtonWidgetDiv .dijitButtonText {
+    padding-right: 8px; /* to override the 30px causing unnecessary text overflow */
+}
+
+.dj_a11y #bgTaskButtonDiv .dijitButtonNode .dijitButtonContents .dijitButtonText,
+.dj_a11y #profileButtonWidgetDiv_toolboxContainer .dijitButtonNode .dijitButtonContents .dijitButtonText {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    padding-right: 8px;
+}
+
+.dj_a11y .profileMenuPopup:after {
+    right: 125px;
+}
+
+.dj_a11y .profileMenuPopup:before {
+    right: 125px;
+}
+
+.dj_a11y .toolContentContainerDiv {
+    top: 55px; /* to show the header border-bottom */
 }

--- a/dev/com.ibm.ws.ui/resources/WEB-CONTENT/css/preferences.css
+++ b/dev/com.ibm.ws.ui/resources/WEB-CONTENT/css/preferences.css
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -96,4 +96,19 @@
     font-weight: normal;
     margin: 0;
     color: #babdbe
+}
+
+/* High contrast mode css */
+.dj_a11y .profile-container .profile-right-panel .section .group-radius .dijitReset .dijitCheckBoxInput {
+    width: 18px !important;
+    height: 18px !important;
+}
+
+.dj_a11y .profile-container .profile-right-panel .section h3 .right-button:focus,
+.dj_a11y .profile-container .profile-right-panel .section h3 .right-button:hover  {
+    outline: 1px dashed;
+}
+
+.dj_a11y .right-buttonChecked {
+    opacity: 1 !important;
 }

--- a/dev/com.ibm.ws.ui/resources/WEB-CONTENT/css/preferencesExcludeValidator.css
+++ b/dev/com.ibm.ws.ui/resources/WEB-CONTENT/css/preferencesExcludeValidator.css
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+.dj_a11y .right-button {
+  opacity: 0.5;
+  background-color: canvasText;
+}

--- a/dev/com.ibm.ws.ui/resources/WEB-CONTENT/css/tablet.css
+++ b/dev/com.ibm.ws.ui/resources/WEB-CONTENT/css/tablet.css
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -829,4 +829,79 @@ noscript {
         top: 70px;
         bottom: 0px;
     }
+}
+
+/* high contrast mode css */
+.dj_a11y #editButtonWidgetDiv .dijitButtonFocused .dijitButtonContents, .dj_a11y #filterButtonWidgetDiv .dijitButtonFocused .dijitButtonContents,
+.dj_a11y #modifyButtonWidgetDiv .dijitDropDownButtonFocused .dijitButtonContents, .dj_a11y #doneButtonWidgetDiv .dijitButtonFocused .dijitButtonContents,
+.dj_a11y #homeButtonDivcatalogContainer .dijitButtonFocused .dijitButtonContents, .dj_a11y #homeButtonDivtoolContainer .dijitButtonFocused .dijitButtonContents,
+.dj_a11y #homeButtonDivprefsContainer .dijitButtonFocused .dijitButtonContents, .dj_a11y #homeButtonDivbgTasksContainer .dijitButtonFocused .dijitButtonContents,
+.dj_a11y #profileButtonWidgetDiv_toolboxContainer .dijitDropDownButtonFocused .dijitButtonContents, .dj_a11y #profileButtonWidgetDiv_catalogContainer .dijitDropDownButtonFocused .dijitButtonContents,
+.dj_a11y #profileButtonWidgetDiv_toolContainer .dijitDropDownButtonFocused .dijitButtonContents, .dj_a11y #profileButtonWidgetDiv_bgTasksContainer .dijitDropDownButtonFocused .dijitButtonContents,
+.dj_a11y #bgTaskButtonDiv .dijitDropDownButtonFocused .dijitButtonNode, .dj_a11y #catalogBgTaskButtonDiv .dijitDropDownButtonFocused .dijitButtonNode,
+.dj_a11y #toolBgTaskButtonDiv .dijitDropDownButtonFocused .dijitButtonNode, .dj_a11y #prefsBgTaskButtonDiv .dijitDropDownButtonFocused .dijitButtonNode,
+.dj_a11y #bgTasksDetailsbgTaskButtonDiv .dijitDropDownButtonFocused .dijitButtonNode {
+    border: 1px solid !important;
+}
+
+/* .dj_a11y .idxHeaderSecondaryTrailing .dijitDropDownButtonHover .dijitButtonContents,
+.dj_a11y .idxHeaderSecondaryTrailing .dijitButtonHover .dijitButtonContents,
+.dj_a11y .leftSecondaryHeader .dijitDropDownButtonHover .dijitButtonContents,
+.dj_a11y .leftSecondaryHeader .dijitButtonHover .dijitButtonContents,
+.dj_a11y #homeButtonDivcatalogContainer .dijitButtonHover .dijitButtonContents,
+.dj_a11y #homeButtonDivprefsContainer .dijitButtonHover .dijitButtonContents,
+.dj_a11y #homeButtonDivtoolContainer .dijitButtonHover .dijitButtonContents,
+.dj_a11y #homeButtonDivbgTasksContainer .dijitButtonHover .dijitButtonContents { */
+.dj_a11y #editButtonWidgetDiv .dijitButtonHover .dijitButtonContents, .dj_a11y #filterButtonWidgetDiv .dijitButtonHover .dijitButtonContents,
+.dj_a11y #modifyButtonWidgetDiv .dijitDropDownButtonHover .dijitButtonContents, .dj_a11y #doneButtonWidgetDiv .dijitButtonHover .dijitButtonContents,
+.dj_a11y #homeButtonDivcatalogContainer .dijitButtonHover .dijitButtonContents, .dj_a11y #homeButtonDivtoolContainer .dijitButtonHover .dijitButtonContents,
+.dj_a11y #homeButtonDivprefsContainer .dijitButtonHover .dijitButtonContents, .dj_a11y #homeButtonDivbgTasksContainer .dijitButtonHover .dijitButtonContents,
+.dj_a11y #profileButtonWidgetDiv_toolboxContainer .dijitDropDownButtonHover .dijitButtonContents, .dj_a11y #profileButtonWidgetDiv_catalogContainer .dijitDropDownButtonHover .dijitButtonContents,
+.dj_a11y #profileButtonWidgetDiv_toolContainer .dijitDropDownButtonHover .dijitButtonContents, .dj_a11y #profileButtonWidgetDiv_bgTasksContainer .dijitDropDownButtonHover .dijitButtonContents,
+.dj_a11y #bgTaskButtonDiv .dijitDropDownButtonHover .dijitButtonNode, .dj_a11y #catalogBgTaskButtonDiv .dijitDropDownButtonHover .dijitButtonNode,
+.dj_a11y #toolBgTaskButtonDiv .dijitDropDownButtonHover .dijitButtonNode, .dj_a11y #prefsBgTaskButtonDiv .dijitDropDownButtonHover .dijitButtonNode,
+.dj_a11y #bgTasksDetailsbgTaskButtonDiv .dijitDropDownButtonHover .dijitButtonNode {
+    border: 1px solid !important;
+}
+
+.dj_a11y .searchBoxInput {
+    border: 2px solid !important;
+}
+
+.dj_a11y  .cancelFilterImg {
+    right: 16px;
+    top: 14px;
+}
+
+.dj_a11y  .mblImageIcon:focus, .dj_a11y  .mblImageIcon:hover {
+    border: 6px solid;
+}
+
+.dj_a11y .profileMenuPopup:after, .dj_a11y .profileMenuPopup:before,
+.dj_a11y .backgroundTaskPopupDialog:after, .dj_a11y .backgroundTaskPopupDialog:before {
+    border: 0;
+}
+
+.dj_a11y #addBookmarkDialogId .dijitButtonNode {
+    border: 1px solid !important;
+}
+
+.dj_a11y #addBookmarkDialogId .dijitButtonContents {
+    display: block;
+    height: 34px;
+    width: 356px;
+}
+
+.dj_a11y #addBookmarkButtonId:focus, .dj_a11y #addBookmarkButtonId:hover {
+    border: 1px solid !important;
+    outline: 0 !important;
+    height: 32px;
+}
+
+.dj_a11y #addBookmarkDialogId, .dj_a11y #catalogAddToolId, .dj_a11y #toolboxRemoveToolId, .dj_a11y .messageDialog {
+    border: 1px solid !important;
+}
+
+.dj_a11y .addDropDownPopup:after, .dj_a11y .addDropDownPopup:before {
+    display: none !important;
 }

--- a/dev/com.ibm.ws.ui/resources/WEB-CONTENT/css/toolbox.css
+++ b/dev/com.ibm.ws.ui/resources/WEB-CONTENT/css/toolbox.css
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,8 @@
 @import url("mobile.css");
 
 @import url("preferences.css");
+
+@import url("preferencesExcludeValidator.css");
 
 @import url("tablet.css");
 
@@ -76,4 +78,9 @@
 
 .skipToContent:visited {
     color: #FFFFFF;
+}
+
+/* high contrast css */
+.a11yHighContrastMode .skipToContent:focus {
+    outline: 2px solid;
 }

--- a/dev/com.ibm.ws.ui/resources/WEB-CONTENT/js/widgets/LibertyToolbox.js
+++ b/dev/com.ibm.ws.ui/resources/WEB-CONTENT/js/widgets/LibertyToolbox.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corporation and others.
+ * Copyright (c) 2016, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -429,6 +429,14 @@ define(["js/toolbox/toolbox",
         // need to take care of the small box created by the widget domNode
         console.log("filterIconButtonWidget: ", filterIconButtonWidget);
         filterIconButtonWidget.domNode.style.display = filterIconDisplayStyle;
+      }
+
+      // if in high contrast mode, use delete-D.png instead for cancel
+      if (this._isUsingHighContrastMode()) {
+       var cancelFilterDom = dom.byId("cancelFiltering");
+       if (cancelFilterDom !== undefined) {
+         cancelFilterDom.src = "images/delete-D.png";
+       }
       }
     },
 
@@ -873,6 +881,10 @@ define(["js/toolbox/toolbox",
         toolbox.getToolbox().updateToolEntries(this.buildOrderedToolEntries());
       }
 
+    },
+
+    _isUsingHighContrastMode: function() {
+      return document.body.classList.contains('dj_a11y');
     }
 
   });

--- a/dev/com.ibm.ws.ui/resources/WEB-CONTENT/login/login.css
+++ b/dev/com.ibm.ws.ui/resources/WEB-CONTENT/login/login.css
@@ -126,7 +126,7 @@ noscript {
 
 #login {
     position: absolute;
-    width: 380px;
+    width: 400px; /* make it wider to remove the horizontal scrollbar */
     top: 40%;
     left: 50%;
     margin-top: -200px;


### PR DESCRIPTION
When Windows high contrast mode is on, dojo native behavior is to enable button with text label and disable button with icon. If the icon button is able to be displayed in both white on black and black on white themes, then we will keep the icon button. Otherwise button with text label will be used. This PR addresses the changes in admin center + the explore tool.

Some screen shots with the changes:

![image](https://user-images.githubusercontent.com/25039033/160706731-ab39b799-4629-4ae6-89c1-7da6344d1c45.png)

![image](https://user-images.githubusercontent.com/25039033/160706850-19384b13-46d2-40e5-8b1f-86e70ee3a11b.png)

![image](https://user-images.githubusercontent.com/25039033/160706990-fc6a13ae-67ba-4a34-985a-3338cda7c75e.png)

![image](https://user-images.githubusercontent.com/25039033/160707041-a3cd9328-c28d-429e-af75-baf0fa626e5b.png)

![image](https://user-images.githubusercontent.com/25039033/160707215-1c9fd4e2-be16-4c53-b13b-b0f74e6b63fd.png)

![image](https://user-images.githubusercontent.com/25039033/160709113-0e3389ea-a388-42a5-9274-d14f88ddfd1d.png)

![image](https://user-images.githubusercontent.com/25039033/160709231-ead90815-545b-4e77-ba51-b7e85b45b100.png)

