### PR TITLE
Support enableLoggingInOutInterceptor property in xmlws-3.0

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/EndpointPropertiesTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/EndpointPropertiesTest.java
@@ -226,6 +226,31 @@ public class EndpointPropertiesTest {
 
     }
 
+    @Test
+    @SkipForRepeat({ SkipForRepeat.NO_MODIFICATION })
+    public void testDefaultLoggingInOutInterceptorPropertyCXFFeature() throws Exception {
+        TestUtils.publishFileToServer(server,
+                                      "EndpointPropertiesTest", "ibm-ws-bnd_testDefaultLoggingInOutInterceptorProperty.xml",
+                                      "dropins/testEndpointPropertiesWeb.war/WEB-INF", "ibm-ws-bnd.xml");
+
+        server.startServer();
+        server.waitForStringInLog("CWWKZ0001I.*testEndpointPropertiesWeb");
+        String wsdl = getBaseUrl() + "/testEndpointPropertiesWeb/HelloNoWSDLService?wsdl";
+        URL url = new URL(wsdl);
+
+        HelloNoWSDLService service = new HelloNoWSDLService(url);
+        // QName serviceQName = new QName("http://server.properties.endpoint.test.jaxws.ws.ibm.com/", "HelloNoWSDLService");
+        //Service service = null;
+        //service = Service.create(url, serviceQName);
+        String result = service.getPort(HelloNoWSDLInterface.class).sayHello("Hello");
+        assertTrue("Can not get expected result, the return result is: " + result,
+                   result.equalsIgnoreCase("Hello Hello"));
+        List<String> dumpInMessages = server.findStringsInLogs("REQ_IN");
+        List<String> dumpOutMessages = server.findStringsInLogs("RESP_OUT");
+        assertTrue("Can't find inBoundMessage, the return inboundmessage is: " + dumpInMessages.toString(), !dumpInMessages.isEmpty());
+        assertTrue("Can't find outBoundMessage, the return outboundmessage is: " + dumpOutMessages.toString(), !dumpOutMessages.isEmpty());
+    }
+
     //override properties tests
     /**
      * TestDescription:
@@ -313,6 +338,44 @@ public class EndpointPropertiesTest {
                    result.equalsIgnoreCase("Hello HelloOverride"));
         List<String> dumpInMessages = server.findStringsInLogs("Inbound Message");
         List<String> dumpOutMessages = server.findStringsInLogs("Outbound Message");
+        assertTrue("Can't find inBoundMessage, the return inboundmessage is: " + dumpInMessages.toString(), !dumpInMessages.isEmpty());
+        assertTrue("Can't find outBoundMessage, the return outboundmessage is: " + dumpOutMessages.toString(), !dumpOutMessages.isEmpty());
+
+    }
+
+    /**
+     * TestDescription:
+     * - Test the user defined property - enableLoggingInOutInterceptor
+     * - Use webservice-endpoint-properties and webservice-endpoint/properties elements in binding file to config this property
+     * - webservice-endpoint.properties should override webservice-endpoint-properties
+     * Condition:
+     * - A testEndpointPropertiesWeb.war publishes HelloService
+     * - Config the enableLoggingInOutInterceptor="true" in binding file: WEB-INF/ibm-ws-bnd.xml
+     * Result:
+     * - incoming/outcoming messages will be dumped into message.log. Caution: if user enabled this setting for
+     * their applicaion, any credential in the messages will be output in the log files.
+     * - LoggingInOutInterceptors are replaced by LoggingFeature for jaxws-2.3 and xmlWS-3.0. This test will be skipped
+     */
+    @Test
+    @SkipForRepeat({ SkipForRepeat.NO_MODIFICATION })
+    public void testOverrideLogginInOutInterceptorPropertyCXFFeature() throws Exception {
+        TestUtils.publishFileToServer(server,
+                                      "EndpointPropertiesTest", "ibm-ws-bnd_testOverrideLogginInOutInterceptorProperty.xml",
+                                      "dropins/testEndpointPropertiesWeb.war/WEB-INF", "ibm-ws-bnd.xml");
+
+        server.startServer();
+        server.waitForStringInLog("CWWKZ0001I.*testEndpointPropertiesWeb");
+        String wsdl = getBaseUrl() + "/testEndpointPropertiesWeb/HelloNoWSDLService?wsdl";
+        URL url = new URL(wsdl);
+        HelloNoWSDLService service = new HelloNoWSDLService(url);
+        //QName serviceQName = new QName("http://server.properties.endpoint.test.jaxws.ws.ibm.com/", "HelloNoWSDLService");
+        //Service service = null;
+        //service = Service.create(url, serviceQName);
+        String result = service.getPort(HelloNoWSDLInterface.class).sayHello("HelloOverride");
+        assertTrue("Can not get expected result, the return result is: " + result,
+                   result.equalsIgnoreCase("Hello HelloOverride"));
+        List<String> dumpInMessages = server.findStringsInLogs("REQ_IN");
+        List<String> dumpOutMessages = server.findStringsInLogs("RESP_OUT");
         assertTrue("Can't find inBoundMessage, the return inboundmessage is: " + dumpInMessages.toString(), !dumpInMessages.isEmpty());
         assertTrue("Can't find outBoundMessage, the return outboundmessage is: " + dumpOutMessages.toString(), !dumpOutMessages.isEmpty());
 

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/WsBndServiceRefOverrideTest_Lite.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/WsBndServiceRefOverrideTest_Lite.java
@@ -192,6 +192,24 @@ public class WsBndServiceRefOverrideTest_Lite {
 
     }
 
+    @Test
+    @SkipForRepeat({ SkipForRepeat.NO_MODIFICATION })
+    public void testOverrideLogginInOutInterceptorPropertyCXFFeature() throws Exception {
+        TestUtils.publishFileToServer(server,
+                                      "WsBndServiceRefOverrideTest", "ibm-ws-bnd_testLoggingInOutInterceptorProp.xml",
+                                      "dropins/wsBndServiceRefOverride.war/WEB-INF/", "ibm-ws-bnd.xml");
+        String wsdlAddr = getDefaultEndpointAddr() + "?wsdl";
+        TestUtils.replaceServerFileString(server, "dropins/wsBndServiceRefOverride.war/WEB-INF/ibm-ws-bnd.xml", "#WSDL_LOCATION#", wsdlAddr);
+        server.startServer();
+        server.waitForStringInLog("CWWKZ0001I.*wsBndServiceRefOverride");
+        getServletResponse(getServletAddr());
+        List<String> dumpInMessages = server.findStringsInLogs("REQ_OUT");
+        List<String> dumpOutMessages = server.findStringsInLogs("RESP_IN");
+        assertTrue("Can't find inBoundMessage, the return inboundmessage is: " + dumpInMessages.toString(), !dumpInMessages.isEmpty());
+        assertTrue("Can't find outBoundMessage, the return outboundmessage is: " + dumpOutMessages.toString(), !dumpOutMessages.isEmpty());
+
+    }
+
     protected String getServletResponse(String servletUrl) throws Exception {
         URL url = new URL(servletUrl);
         HttpURLConnection con = HttpUtils.getHttpConnection(url, HttpURLConnection.HTTP_OK, CONN_TIMEOUT);

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/LibertyServiceImpl.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/LibertyServiceImpl.java
@@ -12,6 +12,7 @@ package com.ibm.ws.jaxws.client;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -36,6 +37,9 @@ import org.apache.cxf.jaxws.ServiceImpl;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.ws.addressing.EndpointReferenceType;
 
+import org.apache.cxf.ext.logging.LoggingFeature;
+import org.apache.cxf.feature.Feature;
+
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.jaxws.JaxWsConstants;
@@ -44,6 +48,8 @@ import com.ibm.ws.jaxws.metadata.PortComponentRefInfo;
 import com.ibm.ws.jaxws.metadata.WebServiceFeatureInfo;
 import com.ibm.ws.jaxws.metadata.WebServiceRefInfo;
 import com.ibm.ws.jaxws.security.JaxWsSecurityConfigurationService;
+import com.ibm.ws.jaxws.support.LibertyLoggingInInterceptor;
+import com.ibm.ws.jaxws.support.LibertyLoggingOutInterceptor;
 import com.ibm.ws.jaxws23.client.security.LibertyJaxWsClientSecurityOutInterceptor;
 
 /**
@@ -145,6 +151,30 @@ public class LibertyServiceImpl extends ServiceImpl {
 
             if (null != portProps) {
                 requestContext.putAll(portProps);
+            }
+            
+            if (null != wsrProps && Boolean.valueOf(wsrProps.get(JaxWsConstants.ENABLE_lOGGINGINOUTINTERCEPTOR))) {
+
+                Bus bus = this.getBus();
+                if(bus != null) {               
+                    
+                    // Get all the Features enabled on the CXF BUS
+                    Collection<Feature> featureList = bus.getFeatures();
+                    
+                    if( !featureList.contains(LoggingFeature.class)) {
+                        // Create a new LogginFeature instance
+                        LoggingFeature loggingFeature = new LoggingFeature();
+
+                        // Add new LoggingFeature instance to Feature list and set it back on the Bus
+                        if (!featureList.contains(loggingFeature)) {
+                            loggingFeature.setPrettyLogging(true);
+                            loggingFeature.initialize(bus);
+                            featureList.add(loggingFeature);
+                            bus.setFeatures(featureList);
+                        }
+                    }
+                }
+
             }
         }
 


### PR DESCRIPTION
This pull request adds support of logging of inbound and outbound SOAP Messages in xmlws-3.0 via the `enableLoggingInOutInteceptor` property that is supported by jaxws-2.2. 