### PR TITLE
Create server logs directory if it does not exist

### DIFF
--- a/dev/com.ibm.ws.config.server.schemagen/src/com/ibm/ws/config/server/schemagen/ServerSchemaGenCommand.java
+++ b/dev/com.ibm.ws.config.server.schemagen/src/com/ibm/ws/config/server/schemagen/ServerSchemaGenCommand.java
@@ -172,8 +172,15 @@ public class ServerSchemaGenCommand extends UtilityTemplate {
         // Check the output dir.. If the value isn't the same as the value the server is using we won't find the logs directory
         File logsDir = new File(getOutputDir(serverName) + serverName + File.separator + "logs");
         if (!logsDir.exists()) {
-            stderr.println(getMessage("server.output.logs.dir.not.found", serverName, logsDir.getAbsolutePath()));
-            return RC_SERVER_OUTPUT_NOT_FOUND;
+            // If the logs dir isn't there, then that probably means the server isn't running.  When the
+            // server is created, the logs directory will not exist until the server is run for the first time.
+            // In that case, it is better to make the logs dir here, which will avoid the message about the
+            // logs dir and eventually give the more important message that the server isn't running.
+            boolean logsDirCreated = logsDir.mkdir();
+            if (!logsDirCreated) {
+                stderr.println(getMessage("server.output.logs.dir.not.found", serverName, logsDir.getAbsolutePath()));
+                return RC_SERVER_OUTPUT_NOT_FOUND;
+            }
         }
 
         // The file containing the local connector URL is always in the


### PR DESCRIPTION
Fixes #20207 
Adds code to **server**SchemaGen to create the server/**logs** directory, if it does not already exist.   If the logs directory doesn't exist it probably means the server has never been run, since when the server runs for the first time, it creates the logs directory.   By doing this, it avoids the message about the missing logs directory and then gives the more important message that the server is not running.   The server needs to be running in order for the **server**SchemaGen command to work.

### Before:  
[>>>] **./server create**

Server defaultServer created.
[>>>] **./serverSchemaGen defaultServer**
_CWWKG3011E: **The logs directory for the server named defaultServer was not found**. It was expected to be at the following location: /Users/jimblye/downloads/openliberty-21.0.0.12/wlp/usr/servers/defaultServer/logs. The value of the logs directory is computed using the WLP_OUTPUT_DIR variable._

### After:

[>>>] **./server create**

Server defaultServer created.
[>>>] **./serverSchemaGen defaultServer**
_CWWKG3002E: **The server named defaultServer is not configured to accept local JMX requests. Ensure that the server configuration includes the localConnector feature, and that the server is started.**_
~/libertyGit/open-liberty/dev/build.image/wlp/bin >>>