### PR TITLE
Fix duplicate messages and missing messages

### DIFF
--- a/dev/com.ibm.ws.jaxb.tools.2.3/resources/com/ibm/ws/jaxb/tools/internal/resources/JaxbToolsMessages.nlsprops
+++ b/dev/com.ibm.ws.jaxb.tools.2.3/resources/com/ibm/ws/jaxb/tools/internal/resources/JaxbToolsMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -13,11 +13,13 @@
 #ISMESSAGEFILE TRUE
 #COMPONENTPREFIX CWWKW
 #COMPONENTNAMEFOR CWWKW WebSphere JAXB Tools Code
-#RANGE 0700 - 0799
+#RANGE 1400 - 1499
+#Message range shared with com.ibm.ws.jaxb.tools and io.openliberty.xmlbinding.3.0.internal.tools
+
 #
 #NLS_MESSAGEFORMAT_VAR
 #NLS_ENCODING=UNICODE
 
-error.parameter.target.missed=CWWKW0700E: The required parameter target was not specified.
+error.parameter.target.missed=CWWKW1401E: The required -target parameter was not specified. The valid values are 2.0, 2.1, 2.2, or 2.3.
 error.parameter.target.missed.explanation=If the target parameter is specified, existing applications can be re-generated without changing their behavior when the JAXB specification level supported by the Liberty Profile is updated.
-error.parameter.target.missed.useraction=Specify the JAXB specification level to which the generated code conforms. The valid value is 2.0, 2.1, 2.2, or 2.3.
+error.parameter.target.missed.useraction=Specify the JAXB specification level to which the generated code conforms. The valid values are 2.0, 2.1, 2.2, or 2.3.

--- a/dev/com.ibm.ws.jaxb.tools/resources/com/ibm/ws/jaxb/tools/internal/resources/JaxbToolsMessages.nlsprops
+++ b/dev/com.ibm.ws.jaxb.tools/resources/com/ibm/ws/jaxb/tools/internal/resources/JaxbToolsMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011 IBM Corporation and others.
+# Copyright (c) 2011, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -9,15 +9,17 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 
-#CMVCPATHNAME com.ibm.ws.jaxws.ejb/resources/com/ibm/ws/jaxb/tools/internal/resources/JaxbToolsMessages.nlsprops
+#CMVCPATHNAME com.ibm.ws.jaxb.tools/resources/com/ibm/ws/jaxb/tools/internal/resources/JaxbToolsMessages.nlsprops
 #ISMESSAGEFILE TRUE
 #COMPONENTPREFIX CWWKW
 #COMPONENTNAMEFOR CWWKW WebSphere JAXB Tools Code
-#RANGE 0700 - 0799
+#RANGE 1400 - 1499
+#Message range shared with com.ibm.ws.jaxb.tools.2.3 and io.openliberty.xmlbinding.3.0.internal.tools
+
 #
 #NLS_MESSAGEFORMAT_VAR
 #NLS_ENCODING=UNICODE
 
-error.parameter.target.missed=CWWKW0700E: The required parameter target was not specified.
+error.parameter.target.missed=CWWKW1400E: The required -target parameter was not specified. The valid values are 2.0, 2.1, or 2.2.
 error.parameter.target.missed.explanation=If the target parameter is specified, existing applications can be re-generated without changing their behavior when the JAXB specification level supported by the Liberty Profile is updated.
-error.parameter.target.missed.useraction=Specify the JAXB specification level to which the generated code conforms. The valid value is 2.0, 2.1, or 2.2.
+error.parameter.target.missed.useraction=Specify the JAXB specification level to which the generated code conforms. The valid values are 2.0, 2.1, or 2.2.

--- a/dev/com.ibm.ws.jaxb_fat/fat/src/com/ibm/ws/jaxb/fat/JAXBToolsTest.java
+++ b/dev/com.ibm.ws.jaxb_fat/fat/src/com/ibm/ws/jaxb/fat/JAXBToolsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -117,8 +117,8 @@ public class JAXBToolsTest extends FATServletClient {
         commandBuilder.append(" ").append(xjcArgs);
 
         String output = execute(commandBuilder.toString());
-        assertTrue("The output should contain the error id 'CWWKW0700E', but does not.\nActual output:\n" + output,
-                   output.indexOf("CWWKW0700E") >= 0);
+        assertTrue("The output should contain the error id 'CWWKW1400E', 'CWWKW1401E', or 'CWWKW1402E', but does not.\nActual output:\n" + output,
+                   ((output.indexOf("CWWKW1400E") >= 0) || (output.indexOf("CWWKW1401E") >= 0) || (output.indexOf("CWWKW1402E") >= 0)));
     }
 
     @Test

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/TimeoutClientTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/TimeoutClientTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -54,7 +54,7 @@ public class TimeoutClientTest extends AbstractTest {
     @AfterClass
     public static void tearDown() throws Exception {
         if (server != null) {
-            server.stopServer("CWWKW0700E", "CWWKW1302W");
+            server.stopServer("CWWKW0700E", "CWWKW1306W");
         }
     }
 

--- a/dev/io.openliberty.org.jboss.resteasy.common/resources/io/openliberty/org/jboss/resteasy/common/nls/RESTfulWSServer.nlsprops
+++ b/dev/io.openliberty.org.jboss.resteasy.common/resources/io/openliberty/org/jboss/resteasy/common/nls/RESTfulWSServer.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -38,6 +38,8 @@
 #ISMESSAGEFILE TRUE
 #NLS_MESSAGEFORMAT_VAR
 #NLS_ENCODING=UNICODE
+#RANGE 1300 - 1399 
+#Message range shared with io.openliberty.org.jboss.resteasy.server
 #
 #   Strings in this file which contain replacement variables are processed by the MessageFormat
 #   class (single quote must be coded as 2 consecutive single quotes ''). Strings in this file
@@ -52,18 +54,6 @@
 #
 #-------------------------------------------------------------------------------
 
-MULTIPLE_REST_SERVLETS_CWWKW1300W=CWWKW1300W: Multiple REST servlets are defined for the web module, {0}. Only zero or one REST servlet is allowed per web module.
-MULTIPLE_REST_SERVLETS_CWWKW1300W.explanation=Only one REST servlet is allowed to be defined per web module. A REST servlet is any servlet that uses one of the following class names: com.ibm.websphere.jaxrs.server.IBMRestServlet, org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher, or org.jboss.resteasy.plugins.server.servlet.HttpServlet30Dispatcher. This message indicates that more than one servlet is specified either in the web.xml or configured dynamically. 
-MULTIPLE_REST_SERVLETS_CWWKW1300W.useraction=Review the web.xml for these servlets and remove all or all but one.
-
-MULTIPLE_REST_SERVLET_MAPPINGS_CWWKW1301W=CWWKW1301W: Multiple REST servlet mappings are defined for the web module, {0}. A REST servlet can be associated only with a single path mapping.
-MULTIPLE_REST_SERVLET_MAPPINGS_CWWKW1301W.explanation=A REST servlet is only allowed to be configured with zero or one path mapping. A REST servlet is any servlet that uses one of the following class names: com.ibm.websphere.jaxrs.server.IBMRestServlet, org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher, or org.jboss.resteasy.plugins.server.servlet.HttpServlet30Dispatcher. This message indicates that more than one mapping is associated with a REST servlet in the web.xml. 
-MULTIPLE_REST_SERVLET_MAPPINGS_CWWKW1301W.useraction=Review the web.xml for the servlet-mappings that are associated with the REST servlet and remove all or all but one.
-
-INVALID_LONG_PROPERTY_CWWKW1302W=CWWKW1302W: The {0} client property must be a long integer, but was configured incorrectly with {1}. This setting will be ignored.
-INVALID_LONG_PROPERTY_CWWKW1302W.explanation=Client properties, such as timeout settings, must be configured as a positive long integer or a string that can be converted to a long integer. This message indicates that a client property was configured with an invalid value. This property will be ignored.
-INVALID_LONG_PROPERTY_CWWKW1302W.useraction=Review the application code and server configuration to determine where this property was set incorrectly and either remove the property or change it to a valid long integer value.
-
 INVALID_INT_PROPERTY_CWWKW1303W=CWWKW1303W: The {0} client property must be an integer, but was configured incorrectly with {1}. This setting will be ignored.
 INVALID_INT_PROPERTY_CWWKW1303W.explanation=Client properties, such as proxy port settings, must be configured as a positive integer or a string that can be converted to an integer. This message indicates that a client property was configured with an invalid value. This property will be ignored.
 INVALID_INT_PROPERTY_CWWKW1303W.useraction=Review the application code and server configuration to determine where this property was set incorrectly and either remove the property or change it to a valid integer value.
@@ -76,8 +66,30 @@ INVALID_PROVIDER_CWWKW1305W=CWWKW1305W: The server is ignoring the {0} provider 
 INVALID_PROVIDER_CWWKW1305W.explanation=The specified provider class likely does not contain a valid public constructor or does not implement a Jakarta REST provider interface. The requirements for a valid provider implementation are documented in section 4 of the Jakarta RESTful Web Services specification.
 INVALID_PROVIDER_CWWKW1305W.useraction=Review the application code to ensure that the specified provider properly implements the provider interface and contains a valid public constructor per the specification requirements.
 
+INVALID_LONG_PROPERTY_CWWKW1306W=CWWKW1306W: The {0} client property must be a long integer, but was configured incorrectly with {1}. This setting is ignored.
+INVALID_LONG_PROPERTY_CWWKW1306W.explanation=Client properties, such as timeout settings, must be configured as a positive long integer or a string that can be converted to a long integer. This message indicates that a client property was configured with an invalid value. As a result, this property is ignored.
+INVALID_LONG_PROPERTY_CWWKW1306W.useraction=Review the application code and server configuration to determine where this property was set incorrectly and either remove the property or change it to a valid long integer value.
 
-# Same message as in /com.ibm.ws.jaxrs.2.0.client/resources/com/ibm/ws/jaxrs20/client/internal/resources/JAXRSClientMessages.nlsprops
+# Same message as in /com.ibm.ws.jaxrs.2.0.common/resources/com/ibm/ws/jaxrs20/common/internal/resources/JaxRsCommonMessages.nlsprops
+
+warn.invalid.authorization.token.type=CWWKW0061W: The  {0} authorization token type specified in the server configuration is invalid and will be ignored.
+warn.invalid.authorization.token.type.explanation=The authorization token type specified in the server configuration is invalid.
+warn.invalid.authorization.token.type.useraction=Specify a valid authorization token type.
+
+# Same messages as in /com.ibm.ws.jaxrs.2.0.client/resources/com/ibm/ws/jaxrs20/client/internal/resources/JAXRSClientMessages.nlsprops
+
+failed_to_extract_saml_token_from_subject=CWWKW0705W: An exception occurred while attempting to use the SAML PropagationHelper API. The exception was: [{0}]
+failed_to_extract_saml_token_from_subject.explanation=An exception occurred while invoking the PropagationHelper API to retrieve the SAML token from the subject.
+failed_to_extract_saml_token_from_subject.useraction=Ensure that the server.xml has the samlWeb-2.0 feature specified. Also, check the server logs for additional information regarding the exception. 
+
+failed_run_as_subject=CWWKW0706E: An exception occurred while attempting to get the RunAsSubject. The exception was: [{0}].
+failed_run_as_subject.explanation=An exception occurred while getting the RunAsSubject.
+failed_run_as_subject.useraction=Make sure the server is configured and started properly.
+
 warn_missing_mpjwt_token=CWWKW0707W: The [{0}] attribute in the [{1}] configuration is set to [{2}], but the MicroProfile JSON Web Token (JWT) is not available. The request does not contain an Authorization header with the token.
 warn_missing_mpjwt_token.explanation=The runtime failed to find the MicroProfile JWT in the runAs subject. This error usually indicates a problem with the authentication. Make sure that no errors are encountered while the MicroProfile JWT feature authenticates a user.
 warn_missing_mpjwt_token.useraction=Check the user action for any prior errors that the server logged.
+
+warn_mpjwt_prop_service_notavail=CWWKW0708W: The MicroProfile JWT Propagation service is not available. The runtime cannot access the token to include it in the Authorization header.
+warn_mpjwt_prop_service_notavail.explanation=The MicroProfile JWT Propagation service requires the mpJwt-1.0 feature. 
+warn_mpjwt_prop_service_notavail.useraction=Make sure that the server is running with the required feature.

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/client/LibertyClientWebTarget.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/client/LibertyClientWebTarget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -108,7 +108,7 @@ public class LibertyClientWebTarget extends ClientWebTarget {
             }
             return (Long) o;
         } catch (ClassCastException | NumberFormatException ex) {
-            Tr.warning(tc, "INVALID_LONG_PROPERTY_CWWKW1302W", key, o);
+            Tr.warning(tc, "INVALID_LONG_PROPERTY_CWWKW1306W", key, o);
         }
         return null;
     }

--- a/dev/io.openliberty.org.jboss.resteasy.server/resources/io/openliberty/org/jboss/resteasy/server/nls/RESTfulWSServer.nlsprops
+++ b/dev/io.openliberty.org.jboss.resteasy.server/resources/io/openliberty/org/jboss/resteasy/server/nls/RESTfulWSServer.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -38,6 +38,8 @@
 #ISMESSAGEFILE TRUE
 #NLS_MESSAGEFORMAT_VAR
 #NLS_ENCODING=UNICODE
+#RANGE 1300 - 1399 
+#Message range shared with io.openliberty.org.jboss.resteasy.common
 #
 #   Strings in this file which contain replacement variables are processed by the MessageFormat
 #   class (single quote must be coded as 2 consecutive single quotes ''). Strings in this file

--- a/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/server/component/package-info.java
+++ b/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/server/component/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 @org.osgi.annotation.versioning.Version("1.0")
-@TraceOptions(traceGroup = "RESTfulWS", messageBundle="io.openliberty.org.jboss.resteasy.common.nls.RESTfulWSServer")
+@TraceOptions(traceGroup = "RESTfulWS", messageBundle="io.openliberty.org.jboss.resteasy.server.nls.RESTfulWSServer")
 package io.openliberty.org.jboss.resteasy.server.component;
 
 import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/io.openliberty.xmlBinding.3.0.internal.tools/resources/io/openliberty/xmlbinding/tools/internal/resources/JaxbToolsMessages.nlsprops
+++ b/dev/io.openliberty.xmlBinding.3.0.internal.tools/resources/io/openliberty/xmlbinding/tools/internal/resources/JaxbToolsMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -15,11 +15,13 @@
 #ISMESSAGEFILE TRUE
 #COMPONENTPREFIX CWWKW
 #COMPONENTNAMEFOR CWWKW WebSphere XML Binding Tools Code
-#RANGE 0700 - 0799
+#RANGE 1400 - 1499
+#Message range shared with com.ibm.ws.jaxb.tools and com.ibm.ws.jaxb.tools.2.3
+
 #
 #NLS_MESSAGEFORMAT_VAR
 #NLS_ENCODING=UNICODE
 
-error.parameter.target.missed=CWWKW0700E: The required parameter target was not specified.
+error.parameter.target.missed=CWWKW1402E: The required -target parameter was not specified. The valid value is 3.0.
 error.parameter.target.missed.explanation=If the target parameter is specified, existing applications can be re-generated without changing their behavior when the XML Binding specification level supported by the Liberty Profile is updated.
-error.parameter.target.missed.useraction=Specify the XML Binding specification level to which the generated code conforms. The valid value is 3.0
+error.parameter.target.missed.useraction=Specify the XML Binding specification level to which the generated code conforms. The valid value is 3.0.


### PR DESCRIPTION
Fixes #20283 
This PR addresses the duplicate messages posted in the corresponding issue #20283.   Beyond that it also removes some messages not used in the bundles where they reside.

Note:  Messages CWWKW1400E, CWWKW1401E, and CWWKW1402E are essentially the same message with slightly different text due to the versions they apply to.  Normally we would use replacement text, but in these cases the class that post these errors are intended to be IBM wrappers for the XJC tool and do not use the normal Liberty Tr.error().  Instead they create a PrintStream and post that to System.err.  So separate messages for the separate bundles seemed appropriate.
