### PR TITLE
Allow artifactory substitution override

### DIFF
--- a/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/FATSuite.java
+++ b/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/FATSuite.java
@@ -25,6 +25,7 @@ import componenttest.rules.repeater.RepeatTests;
                 DatabaseRotationTest.class, //LITE
                 DockerfileTest.class, //FULL
                 ProgrammaticImageTest.class, //FULL
+                SyntheticImageTest.class //FULL
 })
 /**
  * Example FATSuite class to show how to setup suite level testcontainers and properties

--- a/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/SyntheticImageTest.java
+++ b/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/SyntheticImageTest.java
@@ -1,0 +1,188 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.testcontainers.example;
+
+import static componenttest.custom.junit.runner.Mode.TestMode.FULL;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testcontainers.utility.DockerImageName;
+
+import componenttest.containers.ArtifactoryImageNameSubstitutor;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+
+/**
+ * !!!!! DO NOT COPY, RUN, OR USE THIS CLASS !!!!!
+ *
+ * This test class is used to test hypothetical synthetic images to ensure that
+ * our test infrastructure will correctly handle Synthetic Images and throw the
+ * correct warning if one was created.
+ *
+ * Synthetic images have poor performance, and will do not allow us to use our
+ * Artifactory image cache
+ *
+ * If you need the level of customization that a synthetic image would provide
+ * then you should follow the DockerfileTest or ProgrammaticImageTest
+ *
+ * Most of this test is commented out on purpose so we don't actually run a
+ * synthetic container on our build systems.
+ *
+ * @see DockerfileTest
+ * @see ProgrammaticImageTest
+ */
+@Mode(FULL)
+@RunWith(FATRunner.class)
+public class SyntheticImageTest {
+
+//    public static final String APP_NAME = "containerApp";
+//
+//    @Server("build.example.testcontainers")
+//    @TestServlet(servlet = ContainersTestServlet.class, contextRoot = APP_NAME)
+//    public static LibertyServer server;
+//
+//    public static final String POSTGRES_DB = "test";
+//    public static final String POSTGRES_USER = "test";
+//    public static final String POSTGRES_PASSWORD = "test";
+//    public static final int POSTGRE_PORT = 5432;
+//
+//
+//    public static ImageFromDockerfile synteticImage = new ImageFromDockerfile()
+//                    .withDockerfile(Paths.get("lib/LibertyFATTestFiles/postgres/Dockerfile"));
+//
+//    @ClassRule
+//    public static GenericContainer<?> container = new GenericContainer<>(synteticImage) //
+//                    .withExposedPorts(POSTGRE_PORT)
+//                    .withEnv("POSTGRES_DB", POSTGRES_DB)
+//                    .withEnv("POSTGRES_USER", POSTGRES_USER)
+//                    .withEnv("POSTGRES_PASSWORD", POSTGRES_PASSWORD)
+//                    .withLogConsumer(new SimpleLogConsumer(ContainersTest.class, "postgres"))
+//                    .waitingFor(new LogMessageWaitStrategy()
+//                                    .withRegEx(".*database system is ready to accept connections.*\\s")
+//                                    .withTimes(2)
+//                                    .withStartupTimeout(Duration.ofSeconds(60)));
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+//        ShrinkHelper.defaultApp(server, APP_NAME, "web.generic");
+//
+//        //Execute a command within container after it has started
+//        container.execInContainer("echo \"This is executed after container has started\"");
+//
+//        server.addEnvVar("PS_URL", "jdbc:postgresql://" + container.getContainerIpAddress() //
+//                                   + ":" + container.getMappedPort(POSTGRE_PORT)
+//                                   + "/" + POSTGRES_DB);
+//        server.addEnvVar("PS_USER", POSTGRES_USER);
+//        server.addEnvVar("PS_PASSWORD", POSTGRES_PASSWORD);
+//
+//        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+//        server.stopServer();
+    }
+
+    /**
+     * If testcontainers ever changes the way that it names synthetic images we need
+     * to change the way we determine an image is synthetic in the ArtifactoryImageNameSubstitutor
+     *
+     * NOTE: this test was written due to a BUG: https://github.com/testcontainers/testcontainers-java/issues/5194
+     * Expect this to be fixed in later versions
+     *
+     * @see ArtifactoryImageNameSubstitutor#isSynthetic()
+     */
+//    @Test
+//    public void ensureSyntheticImageNameWithRealContainer() {
+//        DockerImageName name = DockerImageName.parse(container.getDockerImageName());
+//
+//        Log.info(SyntheticImageTest.class, "ensureSyntheticImageName", name.asCanonicalNameString());
+//
+//        //Example: localhost/testcontainers/jxbqdhfgsomphxr5:latest
+//        assertEquals("localhost", name.getRegistry()); //localhost
+//        assertEquals("testcontainers", name.getRepository().split("/")[0]); //testcontainers/jxbqdhfgsomphxr5
+//        assertEquals("latest", name.getVersionPart()); //latest
+//    }
+
+    /**
+     * If docker-java ever changes the way that it names committed images we need
+     * to change the way we determine an image is committed in the ArtifactoryImageNameSubstitutor
+     *
+     * NOTE: This model of committing a container to an image, just to turn around and start it as a container
+     * will result in VERY poor test performance. Please consider using a DockerFile or Programmatic image instead!
+     */
+//    @Test
+//    public void ensureCommittedImageWithRealContainer() {
+//
+//        GenericContainer duplicateContainer = null;
+//        try {
+//            String commitedImage = container.getDockerClient().commitCmd(container.getContainerId()).exec();
+//            duplicateContainer = new GenericContainer(commitedImage);
+//            duplicateContainer.start();
+//            DockerImageName name = DockerImageName.parse(duplicateContainer.getDockerImageName());
+//
+//            Log.info(SyntheticImageTest.class, "ensureCommittedImage", name.asCanonicalNameString());
+//
+//            //Example: sha256:5103a25d3efd8c0cbdbc80d358c5b1da91329c53e1fa99c43a8561a87eb61d3b
+//            assertEquals("", name.getRegistry());
+//            assertEquals("sha256", name.getRepository()); //sha256
+//            assertNotNull(name.getRepository()); //5103a25d3efd8c0cbdbc80d358c5b1da91329c53e1fa99c43a8561a87eb61d3b
+//        } catch (Exception e) {
+//            fail(e.toString());
+//        } finally {
+//            if (duplicateContainer != null) {
+//                duplicateContainer.close();
+//            }
+//        }
+//    }
+
+    /**
+     * If testcontainers ever changes the way that it names synthetic images we need
+     * to change the way we determine an image is synthetic in the ArtifactoryImageNameSubstitutor
+     *
+     * NOTE: this test was written due to a BUG: https://github.com/testcontainers/testcontainers-java/issues/5194
+     * Expect this to be fixed in later versions
+     *
+     * @see ArtifactoryImageNameSubstitutor#isSynthetic()
+     */
+    @Test
+    public void ensureSyntheticImageName() {
+        DockerImageName name = DockerImageName.parse("localhost/testcontainers/jxbqdhfgsomphxr5:latest");
+
+        //Example: localhost/testcontainers/jxbqdhfgsomphxr5:latest
+        assertEquals("localhost", name.getRegistry()); //localhost
+        assertEquals("testcontainers", name.getRepository().split("/")[0]); //testcontainers/jxbqdhfgsomphxr5
+        assertEquals("latest", name.getVersionPart()); //latest
+    }
+
+    /**
+     * If docker-java ever changes the way that it names committed images we need
+     * to change the way we determine an image is committed in the ArtifactoryImageNameSubstitutor
+     *
+     * NOTE: This model of committing a container to an image, just to turn around and start it as a container
+     * will result in VERY poor test performance. Please consider using a DockerFile or Programmatic image instead!
+     */
+    @Test
+    public void ensureCommittedImage() {
+
+        DockerImageName name = DockerImageName.parse("sha256:5103a25d3efd8c0cbdbc80d358c5b1da91329c53e1fa99c43a8561a87eb61d3b");
+
+        //Example: sha256:5103a25d3efd8c0cbdbc80d358c5b1da91329c53e1fa99c43a8561a87eb61d3b
+        assertEquals("", name.getRegistry());
+        assertEquals("sha256", name.getRepository()); //sha256
+        assertNotNull(name.getRepository()); //5103a25d3efd8c0cbdbc80d358c5b1da91329c53e1fa99c43a8561a87eb61d3b
+
+    }
+}


### PR DESCRIPTION
Fixes #20679 

# Manual Testing Results

* Ensure that local runs without fat.test.use.artifactory.substitution set we still use DockerHub

```
$ ./gradlew build.example.testcontainers_fat:buildandrun 
[04/01/2022 13:21:03:079 CDT] 001 ExternalTestServiceDockerClien useRemoteDocker                I Running against local docker host. Reason: fat.test.localrun set to true
[04/01/2022 13:21:03:080 CDT] 001 ExternalTestServiceDockerClien useArtifactorySubstitutor      I Using Docker default repository for docker images. Reason: USE_REMOTE_DOCKER_HOST set to false
```

* Ensure that local runs can set fat.test.use.artifactory.substitution=true and the image names are substituted

```
$ ./gradlew build.example.testcontainers_fat:buildandrun -Dfat.test.use.artifactory.substitution=true
[04/01/2022 13:25:50:912 CDT] 001 ExternalTestServiceDockerClien useRemoteDocker                I Running against local docker host. Reason: fat.test.localrun set to true
[04/01/2022 13:25:50:913 CDT] 001 ExternalTestServiceDockerClien useArtifactorySubstitutor      I Using Artifactory Substitution for docker images. Reason: fat.test.use.artifactory.substitution set to true
[04/01/2022 13:25:52:295 CDT] 001 ArtifactoryImageNameSubstituto getPrivateRegistryAuthToken    I Got auth token starting with: Y29u....
[04/01/2022 13:25:54:858 CDT] 001 ArtifactoryImageNameSubstituto apply                          I Swapping docker image name from testcontainers/ryuk:0.3.3 --> wasliberty-docker-remote.artifactory.swg-devops.com/testcontainers/ryuk:0.3.3
[04/01/2022 13:25:56:457 CDT] 001 ArtifactoryImageNameSubstituto apply                          I Swapping docker image name from postgres:14.1-alpine --> wasliberty-docker-remote.artifactory.swg-devops.com/postgres:14.1-alpine
```

* Ensure that local runs can set fat.test.use.artifactory.substitution=false and we still use Dockerhub

```
$ ./gradlew build.example.testcontainers_fat:buildandrun -Dfat.test.use.artifactory.substitution=false
[04/01/2022 13:27:49:238 CDT] 001 ExternalTestServiceDockerClien useRemoteDocker                I Running against local docker host. Reason: fat.test.localrun set to true
[04/01/2022 13:27:49:238 CDT] 001 ExternalTestServiceDockerClien useArtifactorySubstitutor      I Using Docker default repository for docker images. Reason: fat.test.use.artifactory.substitution set to false
```

* Ensure that remote runs without fat.test.use.artifactory.substitution set will still use Artifactory

```
$ ./gradlew build.example.testcontainers_fat:buildandrun -Dfat.test.localrun=false 
[04/01/2022 13:31:16:077 CDT] 001 ExternalTestServiceDockerClien useRemoteDocker                I Running against remote docker host. Reason: fat.test.localrun set to false
[04/01/2022 13:31:16:077 CDT] 001 ExternalTestServiceDockerClien useArtifactorySubstitutor      I Using Artifactory Substitution for docker images. Reason: USE_REMOTE_DOCKER_HOST set to true
[04/01/2022 13:31:17:460 CDT] 001 ArtifactoryImageNameSubstituto getPrivateRegistryAuthToken    I Got auth token starting with: Y29u....
[04/01/2022 13:31:29:565 CDT] 001 ArtifactoryImageNameSubstituto apply                          I Swapping docker image name from testcontainers/ryuk:0.3.3 --> wasliberty-docker-remote.artifactory.swg-devops.com/testcontainers/ryuk:0.3.3
[04/01/2022 13:31:32:391 CDT] 001 ArtifactoryImageNameSubstituto apply                          I Swapping docker image name from postgres:14.1-alpine --> wasliberty-docker-remote.artifactory.swg-devops.com/postgres:14.1-alpine
```

* Ensure that remote runs can set fat.test.use.artifactory.substitution=true and we still use Artifactory

```
$ ./gradlew build.example.testcontainers_fat:buildandrun -Dfat.test.localrun=false -Dfat.test.use.artifactory.substitution=true
[04/01/2022 13:33:27:880 CDT] 001 ExternalTestServiceDockerClien useRemoteDocker                I Running against remote docker host. Reason: fat.test.localrun set to false
[04/01/2022 13:33:27:880 CDT] 001 ExternalTestServiceDockerClien useArtifactorySubstitutor      I Using Artifactory Substitution for docker images. Reason: fat.test.use.artifactory.substitution set to true
[04/01/2022 13:33:29:662 CDT] 001 ArtifactoryImageNameSubstituto getPrivateRegistryAuthToken    I Got auth token starting with: Y29u....
[04/01/2022 13:33:38:524 CDT] 001 ArtifactoryImageNameSubstituto apply                          I Swapping docker image name from testcontainers/ryuk:0.3.3 --> wasliberty-docker-remote.artifactory.swg-devops.com/testcontainers/ryuk:0.3.3
[04/01/2022 13:33:40:894 CDT] 001 ArtifactoryImageNameSubstituto apply                          I Swapping docker image name from postgres:14.1-alpine --> wasliberty-docker-remote.artifactory.swg-devops.com/postgres:14.1-alpine
```
* Ensure that remote runs can set fat.test.use.artifactory.substitution=false and we throw an error instead of using DockerHub

```
$ ./gradlew build.example.testcontainers_fat:buildandrun -Dfat.test.localrun=false -Dfat.test.use.artifactory.substitution=false
[04/01/2022 13:39:32:290 CDT] 001 ExternalTestServiceDockerClien useRemoteDocker                I Running against remote docker host. Reason: fat.test.localrun set to false
[04/01/2022 13:39:32:290 CDT] 001 Log                            warning                        W fat.test.use.artifactory.substitution set to false
Based on a priority system we decided to use a remote docker host for testing. Therefore, we cannot honor the request to NOT use artifactory. To resolve this issue either remove the fat.test.use.artifactory.substitution property, or force this test to use the a local docker host using fat.test.use.remote.docker=true.
```

* Ensure that local runs using synthetic images do not use the substitution

```
$ ./gradlew build.example.testcontainers_fat:buildandrun -Dfat.test.mode=FULL -Dfat.test.class.name=com.ibm.ws.testcontainers.example.SyntheticImageTest
[04/01/2022 15:25:27:449 CDT] 001 ExternalTestServiceDockerClien useRemoteDocker                I Running against local docker host. Reason: fat.test.localrun set to true
[04/01/2022 15:25:27:449 CDT] 001 ExternalTestServiceDockerClien useArtifactorySubstitutor      I Using Docker default repository for docker images. Reason: USE_REMOTE_DOCKER_HOST set to false
[04/01/2022 15:25:31:135 CDT] 001 Log                            warning                        W WARNING: Cannot use private registry for programmatically built or committed image localhost/testcontainers/4marcqfzpmxrspjt:latest. Consider using a pre-built image instead.
```

* Ensure that remote runs using synthetic images do not use the substitution

```
$ ./gradlew build.example.testcontainers_fat:buildandrun -Dfat.test.mode=FULL -Dfat.test.class.name=com.ibm.ws.testcontainers.example.SyntheticImageTest -Dfat.test.localrun=false 
[04/01/2022 15:39:16:473 CDT] 001 ExternalTestServiceDockerClien useRemoteDocker                I Running against remote docker host. Reason: fat.test.localrun set to false
[04/01/2022 15:39:16:474 CDT] 001 ExternalTestServiceDockerClien useArtifactorySubstitutor      I Using Artifactory Substitution for docker images. Reason: USE_REMOTE_DOCKER_HOST set to true
[04/01/2022 15:39:17:408 CDT] 001 ArtifactoryImageNameSubstituto getPrivateRegistryAuthToken    I Got auth token starting with: Y29u....
[04/01/2022 15:39:26:665 CDT] 001 ArtifactoryImageNameSubstituto apply                          I Swapping docker image name from testcontainers/ryuk:0.3.3 --> wasliberty-docker-remote.artifactory.swg-devops.com/testcontainers/ryuk:0.3.3
[04/01/2022 15:39:31:678 CDT] 001 Log                            warning                        W WARNING: Cannot use private registry for programmatically built or committed image localhost/testcontainers/wpsvjg2yvkqch9ms:latest. Consider using a pre-built image instead.
[04/01/2022 15:39:39:287 CDT] 001 Log                            warning                        W WARNING: Cannot use private registry for programmatically built or committed image sha256:a3006b9cd9d548908bbfa2045b619877e4bac709d18c09df23776a132ccc7dbc. Consider using a pre-built image instead.
```

* Ensure that remote runs that set fat.test.use.artifactory.substitution=true using synthetic images do not use the substitution

```
$ ./gradlew build.example.testcontainers_fat:buildandrun -Dfat.test.mode=FULL -Dfat.test.class.name=com.ibm.ws.testcontainers.example.SyntheticImageTest -Dfat.test.localrun=false -Dfat.test.use.artifactory.substitution=true
[04/01/2022 15:42:16:457 CDT] 001 ExternalTestServiceDockerClien useRemoteDocker                I Running against remote docker host. Reason: fat.test.localrun set to false
[04/01/2022 15:42:16:463 CDT] 001 ExternalTestServiceDockerClien useArtifactorySubstitutor      I Using Artifactory Substitution for docker images. Reason: fat.test.use.artifactory.substitution set to true
[04/01/2022 15:42:17:456 CDT] 001 ArtifactoryImageNameSubstituto getPrivateRegistryAuthToken    I Got auth token starting with: Y29u....
[04/01/2022 15:42:27:581 CDT] 001 ArtifactoryImageNameSubstituto apply                          I Swapping docker image name from testcontainers/ryuk:0.3.3 --> wasliberty-docker-remote.artifactory.swg-devops.com/testcontainers/ryuk:0.3.3
[04/01/2022 15:42:35:192 CDT] 001 Log                            warning                        W WARNING: Cannot use private registry for programmatically built or committed image localhost/testcontainers/gtllwkgkziuqtv24:latest. Consider using a pre-built image instead.
[04/01/2022 15:42:46:154 CDT] 001 Log                            warning                        W WARNING: Cannot use private registry for programmatically built or committed image sha256:e791426aa03e10835edd0420328ee6aca49fd4ed39a0118f7904ad1b929209bd. Consider using a pre-built image instead.
```

# Automated Tests

* Ensure that normal build runs and passes
PASSED: https://wasrtc.hursley.ibm.com:9443/jazz/resource/itemOid/com.ibm.team.build.BuildResult/_pzl8kLQ9Eey_l6cwP43xMA

* Ensure that a build with fat.test.use.artifactory.substitution=false fails (because remote host + dockerhub should fail)

* Ensure that build with fat.test.use.remote.docker=false and fat.test.use.artifactory.substitution=true fails (because test machines do not have docker installed on them, yet)