### PR TITLE
Add support for CRIU unprivileged mode

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -325,7 +325,7 @@ checkCriuUnprivileged()
   # Determine if CRIU supports unprivileged mode
   criu --help | grep -q -e '--unprivileged' && CRIU_SUPPORTS_UNPRIVILEGED=true || CRIU_SUPPORTS_UNPRIVILEGED=false
 
-  # Determine which CRIU mode to use, based on current euid and values of CRIU_SUPPORTS_UNPRIVILEGED and CRIU_UNPRIVILEGED
+  # Determine which CRIU mode to use, based on current euid and value of CRIU_SUPPORTS_UNPRIVILEGED
   DO_CRIU_UNPRIVILEGED=false
   if [ "$(id -u)" != 0 ]; then
     # Not root, unprivileged by default if CRIU supports it

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -30,6 +30,15 @@
 #TODO need to reflect this to criu checkpoint
 #                  Set to 1-4 with 4 being max verbosity. Two "2" is the default.
 #
+# CRIU_UNPRIVILEGED - Use criu in unprivileged mode.
+#                     Set to one of true, True, TRUE, 1
+#                     or false, False, FALSE, 0 to continue
+#                     to use criu in privileged mode.
+#
+# CRIU_EXTRA_ARGS   - Pass extra arguments to `criu restore`. Extra arguments are
+#                     appended to the end of the list of arguments and can therefore
+#                     override existing arguments, if desired.
+#
 # PID_DIR    - The directory that should be used for server pid file(s).
 #              The default value is ${WLP_OUTPUT_DIR}/.pid
 #
@@ -295,6 +304,31 @@ JAVA_AGENT_QUOTED=-javaagent:${WLP_INSTALL_DIR_QUOTED}/bin/tools/ws-javaagent.ja
 if [ -n "${WLP_SKIP_BOOTSTRAP_AGENT}" ]; then
   JAVA_AGENT_QUOTED=
 fi
+
+##
+## Determine if CRIU supports unprivileged mode.
+## Determine which CRIU mode to use, based on current euid, whether or not criu supports unprivileged mode, and the value of the CRIU_UNPRIVILEGED env var.
+## Set DO_CRIU_UNPRIVILEGED based on the above.
+##
+checkCriuUnprivileged()
+{
+  # Determine if CRIU supports unprivileged mode
+  criu --help | grep -q -e '--unprivileged' && CRIU_SUPPORTS_UNPRIVILEGED=true || CRIU_SUPPORTS_UNPRIVILEGED=false
+
+  # Determine which CRIU mode to use, based on current euid and values of CRIU_SUPPORTS_UNPRIVILEGED and CRIU_UNPRIVILEGED
+  DO_CRIU_UNPRIVILEGED=false
+  if [ "$(id -u)" != 0 ]; then
+    # Not root, unprivileged by default if CRIU supports it
+    if [ $CRIU_SUPPORTS_UNPRIVILEGED = true -a "${CRIU_UNPRIVILEGED}" != "false" -a "${CRIU_UNPRIVILEGED}" != "0" -a "${CRIU_UNPRIVILEGED}" != "FALSE" -a "${CRIU_UNPRIVILEGED}" != "False" ]; then
+      DO_CRIU_UNPRIVILEGED=true
+    fi
+  fi
+
+  # Use unprivileged if explicitly requested; if CRIU doesn't support it we'll hit an error later that will be shown to the user
+  if [ "${CRIU_UNPRIVILEGED}" = "true" -o "${CRIU_UNPRIVILEGED}" = "1" -o "${CRIU_UNPRIVILEGED}" = "TRUE" -o "${CRIU_UNPRIVILEGED}" = "True" ]; then
+    DO_CRIU_UNPRIVILEGED=true
+  fi
+}
 
 ##
 ## createServer: Function to launch server create
@@ -932,6 +966,11 @@ javaCmd()
     fi
 
     JVM_OPTIONS_QUOTED="$JVM_OPTIONS_QUOTED -XX:+EnableCRIUSupport $X_WLP_IMMUTABLE_VARS"
+
+    checkCriuUnprivileged
+    if [ $DO_CRIU_UNPRIVILEGED = true ]; then
+      JVM_OPTIONS_QUOTED="$JVM_OPTIONS_QUOTED -Dio.openliberty.checkpoint.criu.unprivileged=true"
+    fi
   fi
   
 
@@ -1293,13 +1332,18 @@ criuRestore()
     CRIU_LOG_LEVEL=2
   fi  
 
+  checkCriuUnprivileged
+  if [ $DO_CRIU_UNPRIVILEGED = true ]; then
+    CRIU_EXTRA_ARGS="--unprivileged $CRIU_EXTRA_ARGS"
+  fi
+
   if $BACKGROUND_RESTORE
   then
     mkdirs "${X_PID_DIR}"
     rmIfExist "${X_PID_FILE}"
     criu restore --cpu-cap=none --file-locks --tcp-established --images-dir=${SERVER_OUTPUT_DIR}/workarea/checkpoint/image \
       --shell-job --verbosity=${CRIU_LOG_LEVEL} --log-file ${X_LOG_DIR}/checkpoint/restore.log --pidfile ${X_PID_FILE} \
-      --restore-detached 
+      --restore-detached ${CRIU_EXTRA_ARGS}
     rc=$?
     PID=`cat ${X_PID_FILE}`
     if [ $rc = 0 ]; then
@@ -1326,7 +1370,7 @@ criuRestore()
     trap "killIfRunning $TAIL_PID" EXIT
 
     criu restore --cpu-cap=none --file-locks --tcp-established --images-dir=${SERVER_OUTPUT_DIR}/workarea/checkpoint/image \
-      --shell-job --verbosity=${CRIU_LOG_LEVEL} --log-file ${X_LOG_DIR}/checkpoint/restore.log
+      --shell-job --verbosity=${CRIU_LOG_LEVEL} --log-file ${X_LOG_DIR}/checkpoint/restore.log ${CRIU_EXTRA_ARGS}
     rc=$?
 
     kill $TAIL_PID

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -312,6 +312,16 @@ fi
 ##
 checkCriuUnprivileged()
 {
+  if [ -n "$CRIU_UNPRIVILEGED" ]; then
+    if [ "${CRIU_UNPRIVILEGED}" = "true" -o "${CRIU_UNPRIVILEGED}" = "1" -o "${CRIU_UNPRIVILEGED}" = "TRUE" -o "${CRIU_UNPRIVILEGED}" = "True" ]; then
+      # Use unprivileged if explicitly requested; if CRIU doesn't support it we'll hit an error later that will be shown to the user
+      DO_CRIU_UNPRIVILEGED=true
+    else
+      DO_CRIU_UNPRIVILEGED=false
+    fi
+    return
+  fi
+
   # Determine if CRIU supports unprivileged mode
   criu --help | grep -q -e '--unprivileged' && CRIU_SUPPORTS_UNPRIVILEGED=true || CRIU_SUPPORTS_UNPRIVILEGED=false
 
@@ -319,14 +329,9 @@ checkCriuUnprivileged()
   DO_CRIU_UNPRIVILEGED=false
   if [ "$(id -u)" != 0 ]; then
     # Not root, unprivileged by default if CRIU supports it
-    if [ $CRIU_SUPPORTS_UNPRIVILEGED = true -a "${CRIU_UNPRIVILEGED}" != "false" -a "${CRIU_UNPRIVILEGED}" != "0" -a "${CRIU_UNPRIVILEGED}" != "FALSE" -a "${CRIU_UNPRIVILEGED}" != "False" ]; then
+    if [ $CRIU_SUPPORTS_UNPRIVILEGED = true ]; then
       DO_CRIU_UNPRIVILEGED=true
     fi
-  fi
-
-  # Use unprivileged if explicitly requested; if CRIU doesn't support it we'll hit an error later that will be shown to the user
-  if [ "${CRIU_UNPRIVILEGED}" = "true" -o "${CRIU_UNPRIVILEGED}" = "1" -o "${CRIU_UNPRIVILEGED}" = "TRUE" -o "${CRIU_UNPRIVILEGED}" = "True" ]; then
-    DO_CRIU_UNPRIVILEGED=true
   fi
 }
 

--- a/dev/io.openliberty.checkpoint/src/io/openliberty/checkpoint/internal/criu/ExecuteCRIU.java
+++ b/dev/io.openliberty.checkpoint/src/io/openliberty/checkpoint/internal/criu/ExecuteCRIU.java
@@ -24,9 +24,10 @@ public interface ExecuteCRIU {
      * @param logFileName
      * @param workDir
      * @param envProps
+     * @param unprivileged
      * @throws CheckpointFailedException
      */
-    default void dump(Runnable prepare, Runnable restore, File imageDir, String logFileName, File workDir, File envProps) throws CheckpointFailedException {
+    default void dump(Runnable prepare, Runnable restore, File imageDir, String logFileName, File workDir, File envProps, boolean unprivileged) throws CheckpointFailedException {
         // do nothing
     };
 

--- a/dev/io.openliberty.checkpoint/src/io/openliberty/checkpoint/internal/openj9/J9CRIUSupport.java
+++ b/dev/io.openliberty.checkpoint/src/io/openliberty/checkpoint/internal/openj9/J9CRIUSupport.java
@@ -45,7 +45,7 @@ public class J9CRIUSupport {
         final CheckpointFailedException criuSupportException = new CheckpointFailedException(type, msg, null);
         return new ExecuteCRIU() {
             @Override
-            public void dump(Runnable prepare, Runnable restore, File imageDir, String logFileName, File workDir, File envProps) throws CheckpointFailedException {
+            public void dump(Runnable prepare, Runnable restore, File imageDir, String logFileName, File workDir, File envProps, boolean unprivileged) throws CheckpointFailedException {
                 throw criuSupportException;
             }
 

--- a/dev/io.openliberty.checkpoint/test/io/openliberty/checkpoint/internal/CheckpointImplTest.java
+++ b/dev/io.openliberty.checkpoint/test/io/openliberty/checkpoint/internal/CheckpointImplTest.java
@@ -99,7 +99,8 @@ public class CheckpointImplTest {
         }
 
         @Override
-        public void dump(Runnable prepare, Runnable restore, File imageDir, String logFileName, File workDir, File envProps) throws CheckpointFailedException {
+        public void dump(Runnable prepare, Runnable restore, File imageDir, String logFileName, File workDir, File envProps,
+                         boolean unprivileged) throws CheckpointFailedException {
             singleThreaded.set(true);
             try {
                 prepare.run();

--- a/dev/io.openliberty.org.eclipse.openj9.criu/src/org/eclipse/openj9/criu/CRIUSupport.java
+++ b/dev/io.openliberty.org.eclipse.openj9.criu/src/org/eclipse/openj9/criu/CRIUSupport.java
@@ -215,6 +215,18 @@ public final class CRIUSupport {
 	}
 
 	/**
+	 * Controls whether CRIU will be invoked in privileged or unprivileged mode.
+	 * <p>
+	 * Default: false
+	 *
+	 * @param unprivileged
+	 * @return this
+	 */
+	public CRIUSupport setUnprivileged(boolean unprivileged) {
+		return this;
+	}
+
+	/**
 	 * Append new environment variables to the set returned by ProcessEnvironment.getenv(...) upon
 	 * restore. All pre-existing (environment variables from checkpoint run) env
 	 * vars are retained. All environment variables specified in the envFile are


### PR DESCRIPTION
This PR adds support for CRIU unprivileged mode to the checkpoint feature and the server script.

Regarding the checkpoint feature implementation:

> If the io.openliberty.checkpoint.criu.unprivileged property is set to
> to true, set unprivileged mode to true before invoking CRIU dump.
> 
> If NoSuchMethodError is thrown it means that the JVM does not support
> unprivileged mode, in which case throw an exception to that effect.

Regarding the server script implementation:

> Introduce the CRIU_EXTRA_ARGS env var to allow the user to
> pass extra arguments to `criu restore`.
> 
> Introduce the CRIU_UNPRIVILEGED env var to allow the user to
> control/override whether CRIU is invoked in privileged or unprivileged
> mode.
> 
> Check whether CRIU supports unprivileged mode by looking for
> "--unprivileged" in the output of `criu --help`.
> 
> If the script is invoked as root or CRIU doesn't support unprivileged
> mode or CRIU_UNPRIVILEGED is false, invoke CRIU in privileged mode.
> 
> If the script is invoked as non-root and CRIU supports unprivileged
> mode, or CRIU_UNPRIVILEGED is true, invoke CRIU in unprivileged mode.