### PR TITLE
interrupt ForkJoinWorkerThreads on deactivate

### DIFF
--- a/dev/com.ibm.ws.concurrent/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.concurrent/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017,2020 IBM Corporation and others.
+    Copyright (c) 2017,2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -42,14 +42,14 @@
  </Designate>
 
  <OCD id="com.ibm.ws.concurrent.managedExecutorService" ibm:alias="managedExecutorService" ibm:supportExtensions="true" ibmui:localization="OSGI-INF/l10n/metatype" name="%managedExecutorService" description="%managedExecutorService.desc">
-  <AD id="concurrencyPolicyRef"                  type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.concurrency.policy.concurrencyPolicy" default="defaultConcurrencyPolicy" cardinality="1" name="%concurrencyPolicy" description="%concurrencyPolicy.desc"/>
+  <AD id="concurrencyPolicyRef"                  type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.concurrency.policy.concurrencyPolicy" default="defaultConcurrencyPolicy" name="%concurrencyPolicy" description="%concurrencyPolicy.desc"/>
   <AD id="ConcurrencyPolicy.target"              type="String"  ibm:final="true" default="(service.pid=${concurrencyPolicyRef})" name="internal" description="internal use only"/>
-  <AD id="contextServiceRef"                     type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.context.service" default="DefaultContextService" cardinality="1" name="%contextServiceRef" description="%contextServiceRef.desc"/>
+  <AD id="contextServiceRef"                     type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.context.service" default="DefaultContextService" name="%contextServiceRef" description="%contextServiceRef.desc"/>
   <AD id="ContextService.target"                 type="String"  ibm:final="true" default="(service.pid=${contextServiceRef})" name="internal" description="internal use only"/>
   <AD id="creates.objectClass"                   type="String"  ibm:final="true" ibm:variable="io.openliberty.concurrency.mes.objectClasses" default="java.util.concurrent.ExecutorService, javax.enterprise.concurrent.ManagedExecutorService, org.eclipse.microprofile.context.ManagedExecutor" cardinality="10" name="internal" description="internal use only"/>
   <AD id="javaCompDefaultName"                   type="String"  required="false" name="internal" description="internal use only" />
   <AD id="jndiName"                              type="String"  required="false" ibm:unique="jndiName" name="%jndiName" description="%jndiName.desc"/>
-  <AD id="longRunningPolicyRef"                  type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.concurrency.policy.concurrencyPolicy" required="false" cardinality="1" name="%longRunningPolicy" description="%longRunningPolicy.desc"/>
+  <AD id="longRunningPolicyRef"                  type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.concurrency.policy.concurrencyPolicy" required="false" cardinality="-1" name="%longRunningPolicy" description="%longRunningPolicy.desc"/>
   <AD id="LongRunningPolicy.target"              type="String"  ibm:final="true" default="(service.pid=${longRunningPolicyRef})" name="internal" description="internal use only"/>
   <AD id="LongRunningPolicy.cardinality.minimum" type="String"  ibm:final="true" default="${count(longRunningPolicyRef)}" name="internal" description="internal use only"/>
   <AD id="service.ranking"                       type="Integer" default="-1000" name="internal" description="internal use only"/>
@@ -62,14 +62,14 @@
  </Designate>
 
  <OCD id="com.ibm.ws.concurrent.managedScheduledExecutorService" ibm:alias="managedScheduledExecutorService" ibm:supportExtensions="true" ibmui:localization="OSGI-INF/l10n/metatype" name="%managedScheduledExecutorService" description="%managedScheduledExecutorService.desc">
-  <AD id="concurrencyPolicyRef"                  type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.concurrency.policy.concurrencyPolicy" default="defaultConcurrencyPolicy" cardinality="1" name="%concurrencyPolicy" description="%concurrencyPolicy.desc"/>
+  <AD id="concurrencyPolicyRef"                  type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.concurrency.policy.concurrencyPolicy" default="defaultConcurrencyPolicy" name="%concurrencyPolicy" description="%concurrencyPolicy.desc"/>
   <AD id="ConcurrencyPolicy.target"              type="String"  ibm:final="true" default="(service.pid=${concurrencyPolicyRef})" name="internal" description="internal use only"/>
-  <AD id="contextServiceRef"                     type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.context.service" default="DefaultContextService" cardinality="1" name="%contextServiceRef" description="%contextServiceRef.desc"/>
+  <AD id="contextServiceRef"                     type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.context.service" default="DefaultContextService" name="%contextServiceRef" description="%contextServiceRef.desc"/>
   <AD id="ContextService.target"                 type="String"  ibm:final="true" default="(service.pid=${contextServiceRef})" name="internal" description="internal use only"/>
   <AD id="creates.objectClass"                   type="String"  ibm:final="true" ibm:variable="io.openliberty.concurrency.mses.objectClasses" default="java.util.concurrent.ExecutorService, java.util.concurrent.ScheduledExecutorService, javax.enterprise.concurrent.ManagedExecutorService, javax.enterprise.concurrent.ManagedScheduledExecutorService" cardinality="10" name="internal" description="internal use only"/>
   <AD id="javaCompDefaultName"                   type="String"  required="false" name="internal" description="internal use only" />
   <AD id="jndiName"                              type="String"  required="false" ibm:unique="jndiName" name="%jndiName" description="%jndiName.desc"/>
-  <AD id="longRunningPolicyRef"                  type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.concurrency.policy.concurrencyPolicy" required="false" cardinality="1" name="%longRunningPolicy" description="%longRunningPolicy.desc"/>
+  <AD id="longRunningPolicyRef"                  type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.concurrency.policy.concurrencyPolicy" required="false" cardinality="-1" name="%longRunningPolicy" description="%longRunningPolicy.desc"/>
   <AD id="LongRunningPolicy.target"              type="String"  ibm:final="true" default="(service.pid=${longRunningPolicyRef})" name="internal" description="internal use only"/>
   <AD id="LongRunningPolicy.cardinality.minimum" type="String"  ibm:final="true" default="${count(longRunningPolicyRef)}" name="internal" description="internal use only"/>
   <AD id="service.ranking"                       type="Integer" default="-1000" name="internal" description="internal use only"/>
@@ -82,7 +82,7 @@
  </Designate>
 
  <OCD id="com.ibm.ws.concurrent.managedThreadFactory" ibm:alias="managedThreadFactory" name="%managedThreadFactory" description="%managedThreadFactory.desc">
-  <AD id="contextServiceRef"                  type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.context.service" default="DefaultContextService" cardinality="1" name="%contextServiceRef" description="%contextServiceRef.desc"/>
+  <AD id="contextServiceRef"                  type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.context.service" default="DefaultContextService" name="%contextServiceRef" description="%contextServiceRef.desc"/>
   <AD id="contextService.target"              type="String"  ibm:final="true" default="(service.pid=${contextServiceRef})" name="internal" description="internal use only"/>
   <AD id="createDaemonThreads"                type="Boolean" default="false"  name="%createDaemonThreads" description="%createDaemonThreads.desc"/>
   <AD id="defaultPriority"                    type="Integer" required="false" max="10" min="1" name="%defaultPriority" description="%defaultPriority.desc"/>

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceWithExecutor.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceWithExecutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -51,6 +51,7 @@ public class ContextServiceWithExecutor implements ContextService {
     /**
      * Constructor when used as a declarative services component.
      */
+    @Trivial
     public ContextServiceWithExecutor(ContextServiceImpl sharedContextSvc, Executor managedExecutor) {
         this.managedExecutor = managedExecutor;
         this.sharedContextSvc = sharedContextSvc;

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedForkJoinWorkerThread.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedForkJoinWorkerThread.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -41,6 +41,7 @@ class ManagedForkJoinWorkerThread extends ForkJoinWorkerThread implements Manage
      * @param threadFactory managed thread factory
      * @param pool          ForkJoinPool in which the thread runs
      */
+    @Trivial
     ManagedForkJoinWorkerThread(ManagedThreadFactoryImpl threadFactory, ForkJoinPool pool) {
         // TODO there is no way to supply the thread group as a parameter to the superclass.
         // ThreadGroupTracker might be able to track these ForkJoinPools per app, but would
@@ -124,6 +125,16 @@ class ManagedForkJoinWorkerThread extends ForkJoinWorkerThread implements Manage
         if (threadFactory.service.isShutdown.get())
             interrupt();
         super.start();
+    }
+
+    /**
+     * Include the instance information in trace:
+     * ManagedForkJoinWorkerThread@07718601:Thread[ForkJoinPool-1-worker-3,3,Default Executor Thread Group]
+     */
+    @Override
+    @Trivial
+    public String toString() {
+        return getClass().getSimpleName() + '@' + Integer.toHexString(hashCode()) + ':' + super.toString();
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedForkJoinWorkerThread.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedForkJoinWorkerThread.java
@@ -13,6 +13,7 @@ package com.ibm.ws.concurrent.internal;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinWorkerThread;
 
@@ -31,6 +32,13 @@ class ManagedForkJoinWorkerThread extends ForkJoinWorkerThread implements Manage
     private static final TraceComponent tc = Tr.register(ManagedForkJoinWorkerThread.class);
 
     /**
+     * Associates ForkJoinWorkerThreads with a ThreadGroup.
+     * Although not actually in the thread group, this allows us to interrupt these
+     * threads upon application stop and/or removal of the configured managedThreadFactory.
+     */
+    static final ConcurrentHashMap<ManagedForkJoinWorkerThread, ThreadGroup> ACTIVE_THREADS = new ConcurrentHashMap<>();
+
+    /**
      * Managed thread factory instance that created this thread.
      */
     private final ManagedThreadFactoryImpl threadFactory;
@@ -43,10 +51,6 @@ class ManagedForkJoinWorkerThread extends ForkJoinWorkerThread implements Manage
      */
     @Trivial
     ManagedForkJoinWorkerThread(ManagedThreadFactoryImpl threadFactory, ForkJoinPool pool) {
-        // TODO there is no way to supply the thread group as a parameter to the superclass.
-        // ThreadGroupTracker might be able to track these ForkJoinPools per app, but would
-        // need to do so in a way that avoids causing a memory leak over time if an application
-        // cycles through a lot of ForkJoinPools without itself restarting.
         super(pool);
         this.threadFactory = threadFactory;
 
@@ -109,6 +113,8 @@ class ManagedForkJoinWorkerThread extends ForkJoinWorkerThread implements Manage
             if (trace && tc.isEntryEnabled())
                 Tr.exit(this, tc, "run", x);
             throw x;
+        } finally {
+            ACTIVE_THREADS.remove(this);
         }
 
         if (trace && tc.isEntryEnabled())
@@ -124,6 +130,9 @@ class ManagedForkJoinWorkerThread extends ForkJoinWorkerThread implements Manage
         // ManagedThreadFactory has shut down [are] required to start with an interrupted status.
         if (threadFactory.service.isShutdown.get())
             interrupt();
+        else
+            ACTIVE_THREADS.put(this, threadFactory.threadGroup);
+
         super.start();
     }
 

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedThreadFactoryService.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedThreadFactoryService.java
@@ -383,7 +383,7 @@ public class ManagedThreadFactoryService implements ResourceFactory, Application
         boolean sameMetaDataIdentity() {
             // Return false if our identity is null (even if the current component's metadata or metadata identity is also null).
             ComponentMetaData cData = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
-            return identifier == null ? false : identifier.equals(metadataIdentifierService.getMetaDataIdentifier(cData));
+            return identifier != null && metadataIdentifierService != null && identifier.equals(metadataIdentifierService.getMetaDataIdentifier(cData));
         }
     }
 }

--- a/dev/com.ibm.ws.concurrent_fat_zcontext/fat/src/test/concurrent/sim/zos/context/SimZOSContextProviderTest.java
+++ b/dev/com.ibm.ws.concurrent_fat_zcontext/fat/src/test/concurrent/sim/zos/context/SimZOSContextProviderTest.java
@@ -12,12 +12,17 @@ package test.concurrent.sim.zos.context;
 
 import static org.junit.Assert.assertNotNull;
 
+import java.util.Collections;
+
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.ManagedThreadFactory;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
 
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
@@ -50,5 +55,36 @@ public class SimZOSContextProviderTest extends FATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         server.stopServer();
+    }
+
+    /**
+     * Verify that ForkJoinWorkerThreads which are created by a ManagedThreadFactory are
+     * interrupted upon deactivate of the ManagedThreadFactory just as other managed threads are.
+     */
+    @Test
+    public void testInterruptOnDeactivate() throws Exception {
+        // Add <managedThreadFactory id="tf-testInterruptOnDeactivate" jndiName="concurrent/testInterruptOnDeactivate-threadFactory"/>
+        ServerConfiguration config = server.getServerConfiguration();
+        ManagedThreadFactory threadFactory = new ManagedThreadFactory();
+        threadFactory.setId("tf-testInterruptOnDeactivate");
+        threadFactory.setJndiName("concurrent/testInterruptOnDeactivate-threadFactory");
+        config.getManagedThreadFactories().add(threadFactory);
+
+        // save
+        server.setMarkToEndOfLog();
+        server.updateServerConfiguration(config);
+        server.waitForConfigUpdateInLogUsingMark(Collections.emptySet());
+
+        runTest(server, "SimZOSContextWeb", "testInterruptOnDeactivate_threadStart");
+
+        // Remove the managedThreadFactory
+        config.getManagedThreadFactories().remove(threadFactory);
+
+        // save
+        server.setMarkToEndOfLog();
+        server.updateServerConfiguration(config);
+        server.waitForConfigUpdateInLogUsingMark(Collections.singleton("SimZOSContextWeb"));
+
+        runTest(server, "SimZOSContextWeb", "testInterruptOnDeactivate_waitForInterrupt");
     }
 }

--- a/dev/com.ibm.ws.concurrent_fat_zcontext/publish/files/features/simulatedZOSContextProviders-1.0.mf
+++ b/dev/com.ibm.ws.concurrent_fat_zcontext/publish/files/features/simulatedZOSContextProviders-1.0.mf
@@ -5,5 +5,6 @@ Subsystem-Version: 1.0.0
 Subsystem-Content: test.concurrent.sim.zos.syncToOSThread; version="[1,1.0.100)",
  test.concurrent.sim.zos.wlm; version="[1,1.0.100)"
 Subsystem-Type: osgi.subsystem.feature
-IBM-API-Package: test.concurrent.sim.context.zos.wlm; type="internal"
+IBM-API-Package: test.concurrent.cache; type="internal",
+ test.concurrent.sim.context.zos.wlm; type="internal"
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.concurrent_fat_zcontext/test-bundles/zosWLMContext/src/test/concurrent/cache/TestCache.java
+++ b/dev/com.ibm.ws.concurrent_fat_zcontext/test-bundles/zosWLMContext/src/test/concurrent/cache/TestCache.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.concurrent.cache;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Used by tests to cache objects across application restart.
+ * This has nothing to do with the simulated z/OS contexts.
+ */
+public class TestCache {
+    public static ConcurrentHashMap<String, Object> instance = new ConcurrentHashMap<>();
+}

--- a/dev/com.ibm.ws.concurrent_fat_zcontext/test-bundles/zosWLMContext/src/test/concurrent/cache/package-info.java
+++ b/dev/com.ibm.ws.concurrent_fat_zcontext/test-bundles/zosWLMContext/src/test/concurrent/cache/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+package test.concurrent.cache;

--- a/dev/com.ibm.ws.concurrent_fat_zcontext/zosWLMContext.bnd
+++ b/dev/com.ibm.ws.concurrent_fat_zcontext/zosWLMContext.bnd
@@ -15,7 +15,8 @@ Bundle-Name: fake z/OS WLM context provider bundle
 Bundle-SymbolicName: test.concurrent.sim.zos.wlm
 Bundle-Description: Provides a fake context provider that is configured similarly to z/OS WLM context.
 
-Export-Package: test.concurrent.sim.context.zos.wlm.*
+Export-Package: test.concurrent.sim.context.zos.wlm.*,\
+  test.concurrent.cache.*
 
 Include-Resource:\
  OSGI-INF/metatype/metatype.xml=test-bundles/zosWLMContext/resources/OSGI-INF/metatype/metatype.xml


### PR DESCRIPTION
Add code to cause ForkJoinWorkerThreads which are created by a ManagedThreadFactory to be interrupted when that ManagedThreadFactory goes away, and add tests.  This already being done for other managed threads that are created by ManagedThreadFactory, via the ThreadGroup, but ForkJoinWorkerThread threads are not able to be part of the ThreadGroup, so it needs to handled separately for them.