### PR TITLE
xmlWS-3.0: Ensure xmlWS-3.0 conforms to WSDL Publishing Requirements

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/WebServiceInWebXMLTest_Lite.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/WebServiceInWebXMLTest_Lite.java
@@ -29,9 +29,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
@@ -160,10 +158,24 @@ public class WebServiceInWebXMLTest_Lite {
                    line.contains("xml version="));
     }
 
-    /*
-     * TODO: Fix jaxws-2.3 no longer printing message CWWKW0037E when WSDL is not generated (correct behavior no longer prints error).
+    /**
+     * TestDescription: This test verifies that the check added to our AbstractJaxWsWebEndpoint class properly
+     * verifies that the SEI or WebServiceProider publishes a WSDL according to the requirements in the JAX-WS 2.2 spec,
+     * if the check fails the code will add the LibertyJaxWsCompatibleWSDLGetInterceptor which overrides the default WSDLGetInterceptor
+     * from CXF, with the sole purpose of responding with a 404 response. See the following for the SPEC publishing rules:
+     *
+     * SEI-based Endpoints:
+     *
+     * - For publishing to succeed, a SEI-based endpoint MUST have an associated contract.
+     * - If the wsdlLocation annotation element is the empty string, then a JAX-WS implementation must obey the following rules, depending on the binding used by the endpoint:
+     * - SOAP 1.1/HTTP Binding A JAX-WS implementation MUST generate a WSDL description for the end- point based on the rules in section 5.2.5.3 below.
+     * - SOAP 1.2/HTTP Binding A JAX-WS implementation MUST NOT generate a WSDL description for the endpoint.
+     * - HTTP Binding A JAX-WS implementation MUST NOT generate a WSDL description for the endpoint.
+     *
+     * Provider-based Endpoints:
+     *
+     * If the wsdlLocation annotation element is the empty string, then a JAX-WS implementation MUST NOT generate a WSDL description for the endpoint.
      */
-    @SkipForRepeat({ "jaxws-2.3", JakartaEE9Action.ID })
     @Test
     public void testSameWebServiceDiffBindingType_WSDL() throws Exception {
         String method = "testSameWebServiceDiffBindingType_WSDL";

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/support/LibertyJaxWsCompatibleWSDLGetInterceptor.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/support/LibertyJaxWsCompatibleWSDLGetInterceptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2012 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,14 +20,11 @@ import javax.xml.stream.XMLStreamWriter;
 
 import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.common.util.UrlUtils;
-import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.frontend.WSDLGetInterceptor;
-import org.apache.cxf.frontend.WSDLGetOutInterceptor;
-import org.apache.cxf.frontend.WSDLGetUtils;
+
+import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.interceptor.Fault;
-import org.apache.cxf.interceptor.Interceptor;
-import org.apache.cxf.interceptor.OutgoingChainInterceptor;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageImpl;
 import org.apache.cxf.service.model.EndpointInfo;
@@ -44,10 +41,9 @@ import com.ibm.websphere.ras.TraceComponent;
  * a. Report an error if the binding is not of SOAP 1.1 binding type, and the WSDL file is not included in the user applications.
  * b. Report an error If wsdlLocation is configured for the target endpoint, while the physical file could not be located.
  */
+
 public class LibertyJaxWsCompatibleWSDLGetInterceptor extends WSDLGetInterceptor {
 
-    private Interceptor<Message> wsdlGetOutInterceptor = WSDLGetOutInterceptor.INSTANCE;
-    private static final String TRANSFORM_SKIP = "transform.skip";
     private static final TraceComponent tc = Tr.register(LibertyJaxWsCompatibleWSDLGetInterceptor.class);
 
     private static final Document noWSDLDoc;
@@ -84,77 +80,114 @@ public class LibertyJaxWsCompatibleWSDLGetInterceptor extends WSDLGetInterceptor
 
     }
 
+    public Document getDocument(Message message, String base, Map<String, String> params, String ctxUri, EndpointInfo endpointInfo) {
 
-    private Document getDocument(WSDLGetUtils utils,
-                                Message message, String base,
-                                Map<String, String> params, String ctxUri) {
-       // cannot have two wsdl's being generated for the same endpoint at the same
-       // time as the addresses may get mixed up
-       // For WSDL's the WSDLWriter does not share any state between documents.
-       // For XSD's, the WSDLGetUtils makes a copy of any XSD schema documents before updating
-       // any addresses and returning them, so for both WSDL and XSD this is the only part that needs
-       // to be synchronized.
-       synchronized (message.getExchange().getEndpoint()) {
-           return utils.getDocument(message, base, params, ctxUri,
-                                    message.getExchange().getEndpoint().getEndpointInfo());
-       }
-   }
+        if (wsdlLoationExisted) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isWarningEnabled()) {
+                Tr.warning(tc, "warn.no.wsdl.generate", implBeanClazzName);
+            }
+            return noWSDLDoc;
+        }
+        else {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isWarningEnabled()) {
+                Tr.warning(tc, "error.no.wsdl.find", new Object[] { wsdlLocation, implBeanClazzName });
+            }
+            return noWSDLLocationDoc;
+        }
+    }
 
     /*
      * Extend from the base class and just customize the response to 404
      */
     @Override
     public void handleMessage(Message message) throws Fault {
-        String method = (String)message.get(Message.HTTP_REQUEST_METHOD);
-        String query = (String)message.get(Message.QUERY_STRING);
-
+        String method = (String) message.get(Message.HTTP_REQUEST_METHOD);
+        String query = (String) message.get(Message.QUERY_STRING);
         if (!"GET".equals(method) || StringUtils.isEmpty(query)) {
             return;
         }
+        String baseUri = (String) message.get(Message.REQUEST_URL);
+        String ctx = (String) message.get(Message.PATH_INFO);
 
-        String baseUri = (String)message.get(Message.REQUEST_URL);
-        String ctx = (String)message.get(Message.PATH_INFO);
+        //cannot have two wsdl's being written for the same endpoint at the same
+        //time as the addresses may get mixed up
+        synchronized (message.getExchange().getEndpoint()) {
+            Map<String, String> map = UrlUtils.parseQueryString(query);
+            if (isRecognizedQuery(map, baseUri, ctx, message.getExchange().getEndpoint().getEndpointInfo())) {
 
-        WSDLGetUtils utils = (WSDLGetUtils)message.getContextualProperty(WSDLGetUtils.class.getName());
-        if (utils == null) {
-            utils = new WSDLGetUtils();
-            message.put(WSDLGetUtils.class, utils);
-        }
-        Map<String, String> map = UrlUtils.parseQueryString(query);
-        if (isRecognizedQuery(map)) {
-            Document doc = getDocument(utils, message, baseUri, map, ctx);
+                try {
 
-            Endpoint e = message.getExchange().getEndpoint();
-            Message mout = new MessageImpl();
-            mout.setExchange(message.getExchange());
-            mout = e.getBinding().createMessage(mout);
-            mout.setInterceptorChain(OutgoingChainInterceptor.getOutInterceptorChain(message.getExchange()));
-            message.getExchange().setOutMessage(mout);
+                	Conduit c = message.getExchange().getDestination().getBackChannel(message);
+                    Endpoint e = message.getExchange().getEndpoint();
+                    
+                    Message mout = new MessageImpl();
+                    mout.setExchange(message.getExchange());
+                    message.getExchange().setOutMessage(mout);
+                    //Customize the response to 404
+                    mout.put(Message.RESPONSE_CODE, HttpURLConnection.HTTP_NOT_FOUND);
+                    mout.put(Message.CONTENT_TYPE, "text/xml");
+                    c.prepare(mout);
+                    OutputStream os = mout.getContent(OutputStream.class);
 
-            mout.put(DOCUMENT_HOLDER, doc);
-            mout.put(Message.CONTENT_TYPE, "text/xml");
-            
-            mout.put(Message.RESPONSE_CODE, HttpURLConnection.HTTP_NOT_FOUND);
+                    Document doc = getDocument(message,
+                                               baseUri,
+                                               map,
+                                               ctx,
+                                               message.getExchange().getEndpoint().getEndpointInfo());
 
-            // just remove the interceptor which should not be used
-            cleanUpOutInterceptors(mout);
+                    String enc = null;
+                    try {
+                        enc = doc.getXmlEncoding();
+                    } catch (Exception ex) {
+                        //ignore - not dom level 3
+                    }
+                    if (enc == null) {
+                        enc = "utf-8";
+                    }
 
-            // notice this is being added after the purge above, don't swap the order!
-            mout.getInterceptorChain().add(wsdlGetOutInterceptor);
-
-            message.getExchange().put(TRANSFORM_SKIP, Boolean.TRUE);
-            // skip the service executor and goto the end of the chain.
-            message.getInterceptorChain().doInterceptStartingAt(
-                    message,
-                    OutgoingChainInterceptor.class.getName());
+                    XMLStreamWriter writer = null;
+                    try {
+                        writer = StaxUtils.createXMLStreamWriter(os, enc);
+                        StaxUtils.writeNode(doc, writer, true);
+                        message.getInterceptorChain().abort();
+                        writer.flush();
+                        os.flush();
+                    } catch (IOException ex) {
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isInfoEnabled()) {
+                            Tr.info(tc, "error.write.wsdl.stream", ex);
+                        }
+                        //LOG.log(Level.FINE, "Failure writing full wsdl to the stream", ex);
+                        //we can ignore this.   Likely, whatever has requested the WSDL
+                        //has closed the connection before reading the entire wsdl.  
+                        //WSDL4J has a tendency to not read the closing tags and such
+                        //and thus can sometimes hit this.   In anycase, it's 
+                        //pretty much ignorable and nothing we can do about it (cannot
+                        //send a fault or anything anyway
+                    } finally {
+                        if (writer != null) 
+                                writer.close();
+                        if (os != null) 
+                            os.close();
+                    }
+                } catch (IOException e) {
+                    throw new Fault(e);
+                } catch (XMLStreamException e) {
+                    throw new Fault(e);
+                } finally {
+                    message.getExchange().setOutMessage(null);
+                }
+            }
         }
     }
 
-    // Replaced the isRecognizedQuery() from CXF 2.6.2 with this method which
-    // is a direct copy of the WSDLGetInterceptor.isRecognizedQuery(map) in CXF 3.3
-    // I was required to copy it as it changed from a public to private method from CXF 2.6 -> CXF 3.3
-    private boolean isRecognizedQuery(Map<String, String> map) {
-        return map.containsKey("wsdl") || map.containsKey("xsd");
+    public boolean isRecognizedQuery(Map<String, String> map,
+                                     String baseUri,
+                                     String ctx, 
+                                     EndpointInfo endpointInfo) {
+        if (map.containsKey("wsdl")
+            || map.containsKey("xsd")) {
+            return true;
+        }
+        return false;
     }
-
 }

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/support/LibertyJaxWsCompatibleWSDLGetInterceptor.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/support/LibertyJaxWsCompatibleWSDLGetInterceptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2019,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
This pull request does two things:

1. Fixes the `LibertyJaxWsCompatibleWSDLGetInterceptor.java` to work properly with the changes to CXF since 2.6.2, and allows the code that verifies JAX-WS 2.2 WSDL publishing requirements are met. 
2. Re-enables the xmlWS-3.0 feature to test against the jaxws-2.2 test code.