### PR TITLE
Create Faces 4.0 Placeholder Bundles for EL 5.0

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.faces-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.faces-4.0.feature
@@ -2,7 +2,7 @@
 symbolicName=io.openliberty.jakarta.faces-4.0
 singleton=true
 -features=com.ibm.websphere.appserver.eeCompatible-10.0
--bundles=io.openliberty.jakarta.faces.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="org.apache.myfaces.core:myfaces-api:3.0.1"
+-bundles=io.openliberty.jakarta.faces.4.0; location:="dev/api/spec/,lib/"; mavenCoordinates="org.apache.myfaces.core:myfaces-api:3.0.1"
 kind=noship
 edition=full
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/faces-4.0/io.openliberty.faces-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/faces-4.0/io.openliberty.faces-4.0.feature
@@ -44,7 +44,7 @@ Subsystem-Name: Jakarta Server Faces 4.0
   io.openliberty.pages-3.1, \
   io.openliberty.jakarta.cdi-4.0, \
   io.openliberty.jakarta.faces-4.0
--bundles=io.openliberty.org.apache.myfaces.3.0, \
+-bundles=io.openliberty.org.apache.myfaces.4.0, \
  com.ibm.ws.org.apache.commons.beanutils.1.9.4, \
  com.ibm.ws.org.apache.commons.collections, \
  com.ibm.ws.org.apache.commons.discovery.0.2, \
@@ -54,7 +54,7 @@ Subsystem-Name: Jakarta Server Faces 4.0
  com.ibm.ws.cdi.interfaces.jakarta, \
  com.ibm.ws.org.apache.commons.digester.1.8, \
  io.openliberty.jakarta.jstl.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api:2.0.0", \
- io.openliberty.faces.3.0.thirdparty; location:="dev/api/third-party/"
+ io.openliberty.faces.4.0.thirdparty; location:="dev/api/third-party/"
 kind=noship
 edition=full
 WLP-Activation-Type: parallel

--- a/dev/io.openliberty.faces.4.0.thirdparty/.classpath
+++ b/dev/io.openliberty.faces.4.0.thirdparty/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.faces.4.0.thirdparty/.gitignore
+++ b/dev/io.openliberty.faces.4.0.thirdparty/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/generated/

--- a/dev/io.openliberty.faces.4.0.thirdparty/.project
+++ b/dev/io.openliberty.faces.4.0.thirdparty/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.faces.4.0.thirdparty</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.faces.4.0.thirdparty/.settings/bndtools.core.prefs
+++ b/dev/io.openliberty.faces.4.0.thirdparty/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.faces.4.0.thirdparty/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/io.openliberty.faces.4.0.thirdparty/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,12 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/io.openliberty.faces.4.0.thirdparty/bnd.bnd
+++ b/dev/io.openliberty.faces.4.0.thirdparty/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2021 IBM Corporation and others.
+# Copyright (c) 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/io.openliberty.faces.4.0.thirdparty/bnd.bnd
+++ b/dev/io.openliberty.faces.4.0.thirdparty/bnd.bnd
@@ -1,0 +1,38 @@
+#*******************************************************************************
+# Copyright (c) 2020, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+Fragment-Host: io.openliberty.org.apache.myfaces.4.0;bundle-version=1.0
+
+Bundle-Name: Open Liberty Jakarta MyFaces Third Party API (4.0 Placeholder)
+Bundle-SymbolicName: io.openliberty.faces.4.0.thirdparty
+Implementation-Version: 3.0.1
+
+#Don't export the org.apache.myfaces.buildtools package as that is only needed for compilation.  The jar that contains the
+# org.apache.myfaces.buildtools package is from myfaces-builder-annotations-1.0.9.jar
+Export-Package: \
+  org.apache.myfaces.renderkit.html;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.shared.config;version=${Implementation-Version}, \
+  org.apache.myfaces.shared.renderkit;version=${Implementation-Version}, \
+  org.apache.myfaces.shared.renderkit.html;version=${Implementation-Version}, \
+  org.apache.myfaces.shared.renderkit.html.util;version=${Implementation-Version}
+
+instrument.ffdc: false
+instrument.classesExcludes: \
+  org/**/*.class
+
+publish.wlp.jar.suffix: dev/api/third-party
+
+-fixupmessages.missingexport: "Used bundle version * for exported package";is:=ignore
+
+-buildpath: io.openliberty.org.apache.myfaces.4.0;version=project, \
+    org.apache.myfaces.core:myfaces-impl;version=${Implementation-Version},\

--- a/dev/io.openliberty.jakarta.faces.4.0/.classpath
+++ b/dev/io.openliberty.jakarta.faces.4.0/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.jakarta.faces.4.0/.gitignore
+++ b/dev/io.openliberty.jakarta.faces.4.0/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/generated/

--- a/dev/io.openliberty.jakarta.faces.4.0/.project
+++ b/dev/io.openliberty.jakarta.faces.4.0/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.jakarta.faces.4.0</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.jakarta.faces.4.0/.settings/bndtools.core.prefs
+++ b/dev/io.openliberty.jakarta.faces.4.0/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.jakarta.faces.4.0/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/io.openliberty.jakarta.faces.4.0/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,12 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/io.openliberty.jakarta.faces.4.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.faces.4.0/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2021 IBM Corporation and others.
+# Copyright (c) 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/io.openliberty.jakarta.faces.4.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.faces.4.0/bnd.bnd
@@ -1,0 +1,44 @@
+#*******************************************************************************
+# Copyright (c) 2020, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+Bundle-SymbolicName: io.openliberty.jakarta.faces.4.0; singleton:=true
+Bundle-Description:  Jakarta Server Faces, MyFaces 3.0 API (4.0 Placeholder)
+Implementation-Version: 3.0.1
+
+Export-Package: jakarta.faces.*; version=${Implementation-Version}
+
+DynamicImport-Package: \
+  com.ibm.ws.jsf.spi, \
+  com.ibm.ws.managedobject, \
+  org.apache.myfaces.cdi.util, \
+  org.apache.myfaces.spi
+
+Include-Resource: \
+	@${repo;org.apache.myfaces.core.api;${Implementation-Version};EXACT}!/jakarta/faces, \
+	@${repo;org.apache.myfaces.core.api;${Implementation-Version};EXACT}!/META-INF/**
+
+instrument.disabled: true
+
+publish.wlp.jar.suffix: dev/api/spec
+
+-buildpath: \
+	org.apache.myfaces.core:myfaces-api;version=${Implementation-Version},\
+	io.openliberty.jakarta.cdi.3.0;version=latest,\
+	io.openliberty.jakarta.expressionLanguage.4.0;version=latest,\
+	org.apache.myfaces.buildtools:myfaces-builder-annotations;version=1.0.9,\
+	io.openliberty.jakarta.validation.3.0;version=latest,\
+	io.openliberty.jakarta.jstl.2.0;version=latest,\
+	io.openliberty.jakarta.pages.3.0;version=latest,\
+	io.openliberty.jakarta.servlet.5.0;version=latest, \
+	io.openliberty.jakarta.websocket.2.0;version=latest, \
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest

--- a/dev/io.openliberty.jakarta.faces.4.0/build.gradle
+++ b/dev/io.openliberty.jakarta.faces.4.0/build.gradle
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+// Global vars
+File downloadSrcDir = project.file('build/source')
+File downloadJavadocDir = project.file('build/javadoc')
+
+configurations {
+    sourceJar
+    javadocJar
+}
+
+dependencies {
+   sourceJar 'org.apache.myfaces.core:myfaces-api:3.0.1:sources'
+   javadocJar 'org.apache.myfaces.core:myfaces-api:3.0.1:javadoc'
+}
+
+task copySource(type: Copy) {
+    from configurations.sourceJar
+    into downloadSrcDir
+}
+
+task copyJavadoc(type: Copy) {
+    from configurations.javadocJar
+    into downloadJavadocDir
+}
+
+assemble {
+    dependsOn copySource
+    dependsOn copyJavadoc
+}
+
+task deleteJars(type:Delete) {
+    doLast {
+        println "deleteJars task, deleting " + downloadSrcDir
+        file(downloadSrcDir).deleteDir()
+
+        println "deleteJars task, deleting " + downloadJavadocDir
+        file(downloadJavadocDir).deleteDir()
+    }
+}
+
+clean {
+    dependsOn deleteJars
+}

--- a/dev/io.openliberty.jakarta.faces.4.0/build.gradle
+++ b/dev/io.openliberty.jakarta.faces.4.0/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.org.apache.myfaces.4.0/.classpath
+++ b/dev/io.openliberty.org.apache.myfaces.4.0/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+    <classpathentry kind="src" path="src"/>
+    <classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+    <classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.org.apache.myfaces.4.0/.gitignore
+++ b/dev/io.openliberty.org.apache.myfaces.4.0/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/generated/

--- a/dev/io.openliberty.org.apache.myfaces.4.0/.project
+++ b/dev/io.openliberty.org.apache.myfaces.4.0/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.org.apache.myfaces.4.0</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.org.apache.myfaces.4.0/.settings/bndtools.core.prefs
+++ b/dev/io.openliberty.org.apache.myfaces.4.0/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.org.apache.myfaces.4.0/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/io.openliberty.org.apache.myfaces.4.0/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,12 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/io.openliberty.org.apache.myfaces.4.0/bnd.bnd
+++ b/dev/io.openliberty.org.apache.myfaces.4.0/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2021 IBM Corporation and others.
+# Copyright (c) 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/io.openliberty.org.apache.myfaces.4.0/bnd.bnd
+++ b/dev/io.openliberty.org.apache.myfaces.4.0/bnd.bnd
@@ -1,0 +1,142 @@
+#*******************************************************************************
+# Copyright (c) 2020, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+Bundle-SymbolicName: io.openliberty.org.apache.myfaces.4.0
+Bundle-Description:  Jakarta Server Faces, MyFaces 3.0 Implementation (4.0 Placeholder)
+
+Implementation-Version: 3.0.1
+
+-fixupmessages.missingexport: "Used bundle version * for exported package";is:=ignore
+
+instrument.ffdc: false
+instrument.classesExcludes: \
+  org/**/*.class
+
+Include-Resource: \
+  @${repo;org.apache.myfaces.core.impl;${Implementation-Version};EXACT}!/META-INF/**, \
+  @${repo;io.openliberty.jakarta.faces.3.0}!/META-INF/resources/**, \
+  @${repo;io.openliberty.jakarta.faces.3.0}!/META-INF/internal-resources/**, \
+  META-INF=@src/META-INF
+
+Service-Component: \
+  io.openliberty.faces_3_0.taglib; \
+    implementation:=com.ibm.ws.faces.taglibconfig.FacesGlobalTagLibConfig; \
+    provide:='com.ibm.wsspi.jsp.taglib.config.GlobalTagLibConfig'; \
+    properties:="service.vendor=IBM", \
+  io.openliberty.faces_3_0.cdiextension; \
+    implementation:=com.ibm.ws.jsf.shared.ext.CdiExtension; \
+    provide:='com.ibm.ws.cdi.extension.WebSphereCDIExtension'; \
+    properties:="service.vendor=IBM,\
+    bean.defining.annotations=jakarta.faces.flow.FlowScoped;jakarta.faces.view.ViewScoped,\
+    api.classes=jakarta.faces.flow.builder.FlowDefinition;jakarta.faces.flow.builder.FlowBuilderParameter,\
+    extension.classes.only=true",\
+  io.openliberty.faces_30.dd; \
+    implementation:=com.ibm.ws.javaee.version.FacesVersion; \
+    provide:=com.ibm.ws.javaee.version.FacesVersion; \
+    properties:="version:Integer=30"
+
+# Not used directly, so these packages needs to be dynamically imported
+DynamicImport-Package: \
+  com.ibm.ws.jsf.cdi, \
+  com.ibm.ws.jsf.config.annotion,\
+  com.ibm.ws.jsf.config.resource,\
+  com.ibm.ws.jsf.ee, \
+  com.ibm.ws.jsf.spi.impl, \
+  com.ibm.ws.jsf.extprocessor
+
+# Don't export the org.apache.myfaces.buildtools package as that is only needed for compilation.  The jar that contains the
+# org.apache.myfaces.buildtools package is myfaces-builder-annotations-1.0.9.jar
+# Additionally, a subset of these org.apache.myfaces packages are exported by the thirdparty.faces-3.0 bundle - so we exclude them here.
+Export-Package: \
+  !org.apache.myfaces.buildtools.*, \
+  !org.apache.myfaces.renderkit.html, \
+  !org.apache.myfaces.shared.config, \
+  !org.apache.myfaces.shared.renderkit, \
+  !org.apache.myfaces.shared.renderkit.html, \
+  !org.apache.myfaces.shared.renderkit.html.util, \
+  com.ibm.ws.faces.taglibconfig, \
+  org.apache.myfaces.application;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.application.viewstate;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.cdi.model;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.cdi.view;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.cdi.util;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.component;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.component.search;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.component.visit;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.context;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.context.servlet;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.config.annotation;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.config.impl.digester.elements;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.el.convert;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.flow;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.flow.cdi;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.lifecycle;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.push.cdi;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.renderkit;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.shared.context.flash;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.shared.taglib;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.shared.taglib.core;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.shared.util;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.spi.impl;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.taglib.core;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.taglib.html;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.compiler;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.component;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.el;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.impl;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.pool;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.pool.impl;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.tag;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.tag.composite;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.tag.jsf;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.tag.jsf.core;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.tag.jsf.html;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.tag.jstl.core;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.tag.jstl.fn;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.tag.ui;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.util;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.webapp;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.*;version=${Implementation-Version}
+
+# Import everything we need except for the below exclusions that will not be needed at runtime.
+Import-Package: \
+  !com.ibm.ws.jsf.ee, \
+  !com.google.inject, \
+  !jakarta.ejb, \
+  !jakarta.persistence, \
+  !org.apache.tomcat, \
+  *
+
+-buildpath: \
+  org.apache.myfaces.core:myfaces-impl;version=${Implementation-Version},\
+  io.openliberty.jakarta.faces.4.0;version=latest,\
+  com.ibm.ws.classloading;version=latest,\
+  com.ibm.ws.webcontainer;version=latest,\
+  com.ibm.ws.serialization;version=latest,\
+  com.ibm.ws.container.service;version=latest,\
+  com.ibm.ws.adaptable.module;version=latest,\
+  com.ibm.ws.anno;version=latest,\
+  com.ibm.ws.managedobject;version=latest,\
+  com.ibm.ws.jsp;version=latest,\
+  io.openliberty.jakarta.expressionLanguage.4.0;version=latest,\
+  io.openliberty.jakarta.servlet.5.0;version=latest, \
+  io.openliberty.jakarta.cdi.3.0;version=latest,\
+  com.ibm.ws.logging.core,\
+  com.ibm.websphere.appserver.spi.kernel.service,\
+  com.ibm.websphere.org.osgi.core;version=latest,\
+  com.ibm.websphere.org.osgi.service.component;version=latest,\
+  com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+  org.apache.myfaces.buildtools:myfaces-builder-annotations;version=1.0.9,\
+  io.openliberty.faces.internal;version=latest

--- a/dev/io.openliberty.org.apache.myfaces.4.0/build.gradle
+++ b/dev/io.openliberty.org.apache.myfaces.4.0/build.gradle
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+// Local vars
+File downloadSrcDir = project.file('build/source')
+
+configurations {
+    sourceJar
+}
+
+dependencies {
+   sourceJar 'org.apache.myfaces.core:myfaces-impl:3.0.1:sources'
+}
+
+task copySource(type: Copy) {
+    from configurations.sourceJar
+    into downloadSrcDir
+}
+
+assemble {
+    dependsOn copySource
+}
+
+task deleteJars(type:Delete) {
+    doLast {
+        println "deleteJars task, deleting " + downloadSrcDir
+        file(downloadSrcDir).deleteDir()
+    }
+}
+
+clean {
+    dependsOn deleteJars
+}

--- a/dev/io.openliberty.org.apache.myfaces.4.0/build.gradle
+++ b/dev/io.openliberty.org.apache.myfaces.4.0/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.org.apache.myfaces.4.0/src/META-INF/beans.xml
+++ b/dev/io.openliberty.org.apache.myfaces.4.0/src/META-INF/beans.xml
@@ -1,0 +1,10 @@
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd" version="3.0"
+  bean-discovery-mode="none">
+  <scan>
+
+    <exclude name="com.ibm.ws.faces.**" />
+    <exclude name="org.apache.myfaces.**"/>
+
+  </scan>
+</beans>

--- a/dev/io.openliberty.org.apache.myfaces.4.0/src/com/ibm/ws/faces/taglibconfig/FacesGlobalTagLibConfig.java
+++ b/dev/io.openliberty.org.apache.myfaces.4.0/src/com/ibm/ws/faces/taglibconfig/FacesGlobalTagLibConfig.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.faces.taglibconfig;
+
+import java.net.URL;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import com.ibm.wsspi.jsp.taglib.config.GlobalTagLibConfig;
+import com.ibm.wsspi.jsp.taglib.config.TldPathConfig;
+
+/**
+ * The FacesGlobalTagLibConfig provides the definition of the tag libraries provided by the
+ * JSF code and how those tag libraries can be located.
+ *
+ * The values are provided are derived from the taglibcacheconfig.xml file
+ * (Version 1.2 of the WASX.SERV1 file SERV1/ws/code/jsf.myfaces/src-ibm/2.0.0-SNAPSHOT/META-INF/taglibcacheconfig.xml)
+ *
+ */
+public class FacesGlobalTagLibConfig extends GlobalTagLibConfig {
+    public FacesGlobalTagLibConfig() {
+        super();
+
+        setJarName("jsf-tld.jar");
+
+        addtoTldPathList(new TldPathConfig("META-INF/myfaces_core.tld", "http://java.sun.com/jsf/core", "true"));
+        addtoTldPathList(new TldPathConfig("META-INF/myfaces_html.tld", "http://java.sun.com/jsf/html", null));
+
+        setClassloader(AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+            public ClassLoader run() {
+                return FacesGlobalTagLibConfig.class.getClassLoader();
+            }
+        }));
+
+        setJarURL(AccessController.doPrivileged(new PrivilegedAction<URL>() {
+            public URL run() {
+                return getClassloader().getResource("META-INF/myfaces_core.tld");
+            }
+        }));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void addtoTldPathList(TldPathConfig tldPathConfig) {
+        getTldPathList().add(tldPathConfig);
+    }
+}

--- a/dev/io.openliberty.org.apache.myfaces.4.0/src/com/ibm/ws/faces/taglibconfig/package-info.java
+++ b/dev/io.openliberty.org.apache.myfaces.4.0/src/com/ibm/ws/faces/taglibconfig/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+package com.ibm.ws.faces.taglibconfig;


### PR DESCRIPTION
fixes #20774


I don't think any tests should be enabled here as no development has really started here.  Faces-4.0 is no-ship, as well. 

Using the 4.0 snapshot api and implementation would have is too much hassle as this point as we are focusing on EL 5.0 & Servlet 6.0.  I think keeping it as faces 3.0 is fine for now. 


Buildpaths will be updated to use EL 5.0 the EL 5.0 PR. 
 

