### PR TITLE
xmlWS-3.0: Drop unnecessary CXF bundle lifecycle methods to debug

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/bus/osgi/CXFExtensionBundleListener.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/bus/osgi/CXFExtensionBundleListener.java
@@ -100,7 +100,7 @@ public class CXFExtensionBundleListener implements SynchronousBundleListener {
         for (Extension ext : orig) {
             names.add(ext.getName());
         }
-        LOG.info("Adding the extensions from bundle " + bundle.getSymbolicName()
+        LOG.finest("Adding the extensions from bundle " + bundle.getSymbolicName()
                  + " (" + bundle.getBundleId() + ") " + names);
         List<OSGiExtension> list = extensions.get(bundle.getBundleId());
         if (list == null) {
@@ -120,7 +120,7 @@ public class CXFExtensionBundleListener implements SynchronousBundleListener {
     protected void unregister(final long bundleId) {
         List<OSGiExtension> list = extensions.remove(bundleId);
         if (list != null) {
-            LOG.info("Removing the extensions for bundle " + bundleId);
+            LOG.finest("Removing the extensions for bundle " + bundleId);
             ExtensionRegistry.removeExtensions(list);
         }
     }


### PR DESCRIPTION
This pull request removes the messages below from appearing in messages.log by dropping the logging level to `finest`

`[4/4/22, 21:22:40:856 CDT] 00000017 m.ws.org.apache.cxf.cxf.core.3.2:1.0.64.202204041745(id=98)] I Adding the extensions from bundle com.ibm.ws.org.apache.cxf.cxf.rt.management.3.2 (123) [org.apache.cxf.management.InstrumentationManager]`

and

`[4/4/22, 21:22:44:170 CDT] 0000003b m.ws.org.apache.cxf.cxf.core.3.2:1.0.64.202204041745(id=98)] I Removing the extensions for bundle 127`
