### PR TITLE
More MP JWT performance improvements

### DIFF
--- a/dev/com.ibm.ws.common.encoder/src/com/ibm/ws/common/internal/encoder/Base64Coder.java
+++ b/dev/com.ibm.ws.common.encoder/src/com/ibm/ws/common/internal/encoder/Base64Coder.java
@@ -311,7 +311,7 @@ public final class Base64Coder {
             return null;
         }
 
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder(b.length);
         for (int i = 0, len = b.length; i < len; i++) {
             sb.append((char) (b[i] & 0xff));
         }

--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/crypto/HashUtils.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/crypto/HashUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,9 @@
  *******************************************************************************/
 package com.ibm.ws.security.common.crypto;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -24,7 +26,7 @@ public class HashUtils {
 
     private static final TraceComponent tc = Tr.register(HashUtils.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
     private static String DEFAULT_ALGORITHM = "SHA-256";
-    private static String DEFAULT_CHARSET = "UTF-8";
+    private static Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 
     /**
      * generate hash code by using SHA-256 If there is some error, log the
@@ -44,12 +46,24 @@ public class HashUtils {
         return digest(input, algorithm, DEFAULT_CHARSET);
     }
 
+    @Sensitive
+    protected static String digest(@Sensitive String input, String algorithm, String charsetName) {
+        try {
+            return digest(input, algorithm, Charset.forName(charsetName));
+        } catch (UnsupportedCharsetException uce) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Exception converting String object : " + uce);
+            }
+            throw new RuntimeException("Exception converting String object : " + uce);
+        }
+    }
+
     /**
      * generate hash code by using specified algorithm and character set. If
      * there is some error, log the error.
      */
     @Sensitive
-    protected static String digest(@Sensitive String input, String algorithm, String charset) {
+    private static String digest(@Sensitive String input, String algorithm, Charset charset) {
         MessageDigest md;
         String output = null;
         if (input != null && input.length() > 0) {
@@ -62,11 +76,6 @@ public class HashUtils {
                     Tr.debug(tc, "Exception instanciating MessageDigest. The algorithm is " + algorithm + nsae);
                 }
                 throw new RuntimeException("Exception instanciating MessageDigest : " + nsae);
-            } catch (UnsupportedEncodingException uee) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "Exception converting String object : " + uee);
-                }
-                throw new RuntimeException("Exception converting String object : " + uee);
             }
         }
         return output;

--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/jwk/utils/JsonUtils.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/jwk/utils/JsonUtils.java
@@ -162,8 +162,8 @@ public class JsonUtils {
     }
 
     // assuming payload not the whole token string
-    public static Map claimsFromJsonObject(String jsonFormattedString) throws JoseException {
-        Map claimsMap = new ConcurrentHashMap<String, Object>();
+    public static Map<String, Object> claimsFromJsonObject(String jsonFormattedString) throws JoseException {
+        Map<String, Object> claimsMap = new ConcurrentHashMap<>();
         if (jsonFormattedString == null) {
             return claimsMap;
         }

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/TokenImpl.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/TokenImpl.java
@@ -27,7 +27,6 @@ public class TokenImpl implements JwtToken {
 
     public TokenImpl(BuilderImpl jwtBuilder, JwtConfig config) throws JwtException {
         // claims = jwtBuilder.getClaims();
-        claims = new ClaimsImpl();
         try {
             createToken(jwtBuilder, config);
         } catch (Exception e) {

--- a/dev/com.ibm.ws.security.mp.jwt.1.1.config/src/com/ibm/ws/security/mp/jwt/v11/config/impl/MpConfigProxyServiceImpl.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1.config/src/com/ibm/ws/security/mp/jwt/v11/config/impl/MpConfigProxyServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.security.mp.jwt.v11.config.impl;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -38,6 +39,16 @@ public class MpConfigProxyServiceImpl implements MpConfigProxyService {
     public static final TraceComponent tc = Tr.register(MpConfigProxyServiceImpl.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
 
     static private String MP_VERSION = "1.1";
+
+    protected static final Set<String> acceptableMpConfigPropNames;
+
+    static {
+        Set<String> mpConfigPropNames = new HashSet<>();
+        mpConfigPropNames.add(MpConstants.ISSUER);
+        mpConfigPropNames.add(MpConstants.PUBLIC_KEY);
+        mpConfigPropNames.add(MpConstants.KEY_LOCATION);
+        acceptableMpConfigPropNames = Collections.unmodifiableSet(mpConfigPropNames);
+    }
 
     @Activate
     protected void activate(ComponentContext cc, Map<String, Object> props) {
@@ -88,10 +99,6 @@ public class MpConfigProxyServiceImpl implements MpConfigProxyService {
 
     @Override
     public Set<String> getSupportedConfigPropertyNames() {
-        Set<String> acceptableMpConfigPropNames = new HashSet<String>();
-        acceptableMpConfigPropNames.add(MpConstants.ISSUER);
-        acceptableMpConfigPropNames.add(MpConstants.PUBLIC_KEY);
-        acceptableMpConfigPropNames.add(MpConstants.KEY_LOCATION);
         return acceptableMpConfigPropNames;
     }
 

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/tai/TAIJwtUtils.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/tai/TAIJwtUtils.java
@@ -141,7 +141,7 @@ public class TAIJwtUtils {
         //        }
         //        jwtclaims.setStringClaim(org.eclipse.microprofile.jwt.Claims.raw_token.name(), compact);
         //        fixJoseTypes(jwtclaims);
-        DefaultJsonWebTokenImpl token = new DefaultJsonWebTokenImpl(compact, type, username);
+        DefaultJsonWebTokenImpl token = new DefaultJsonWebTokenImpl(compact, type, username, jwtToken);
         if (tc.isDebugEnabled()) {
             Tr.exit(tc, methodName, token);
         }

--- a/dev/com.ibm.ws.security.mp.jwt/test/com/ibm/ws/security/mp/jwt/tai/TAIMappingHelperTest.java
+++ b/dev/com.ibm.ws.security.mp.jwt/test/com/ibm/ws/security/mp/jwt/tai/TAIMappingHelperTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,13 @@
  *******************************************************************************/
 package com.ibm.ws.security.mp.jwt.tai;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JUnit4Mockery;
 import org.jmock.lib.legacy.ClassImposteriser;
@@ -23,7 +28,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
+import com.ibm.websphere.security.jwt.JwtToken;
+import com.ibm.ws.security.common.jwk.utils.JsonUtils;
+import com.ibm.ws.security.jwt.internal.ConsumerUtil;
+import com.ibm.ws.security.jwt.internal.JwtConsumerConfigImpl;
 import com.ibm.ws.security.mp.jwt.error.MpJwtProcessingException;
+import com.ibm.ws.security.mp.jwt.impl.DefaultJsonWebTokenImpl;
 
 import test.common.SharedOutputManager;
 
@@ -100,4 +110,56 @@ public class TAIMappingHelperTest {
         }
     }
 
+    @Test
+    public void testClaimsProcessedTheSame() {
+        //decoded payload claims : {"token_type":"Bearer","aud":"aud1","sub":"testuser","upn":"testuser","groups":["group1-abc","group2-def","testuser-group"],"iss":"https://9.24.8.103:8947/jwt/jwkEnabled","exp":1504212390,"iat":1504205190}
+        String jwt = "eyJraWQiOiJXYlVqSEN5b3V5ZEoySEFKc1dOMSIsImFsZyI6IlJTMjU2In0.eyJ0b2tlbl90eXBlIjoiQmVhcmVyIiwiYXVkIjoiYXVkMSIsInN1YiI6InRlc3R1c2VyIiwidXBuIjoidGVzdHVzZXIiLCJncm91cHMiOlsiZ3JvdXAxLWFiYyIsImdyb3VwMi1kZWYiLCJ0ZXN0dXNlci1ncm91cCJdLCJpc3MiOiJodHRwczovLzkuMjQuOC4xMDM6ODk0Ny9qd3QvandrRW5hYmxlZCIsImV4cCI6MTUwNDIxMjM5MCwiaWF0IjoxNTA0MjA1MTkwfQ.egKHKw1hfEAmZMBwI1_vPFxZIzXd9UWjLqz1MvlcvT3FHNKyV3CQ8KVSb-DrHll5J57QgJxY_vBiKgZgKkDJn6rKB4LNivV-_mcsCWawjKkmFDjesMLiSFKLfLWpfbt7qVbnRNT7ysMlXMDDJguRHRj_l1M70VAQT9gaCrPsoMvDAzOtTBS0iLnRATFCddYwQsw82Ma4rfTo5Hq-ouQWgRYerxkNswZJRnahsUKoSh4ptjYBmNySBTIF7X0WL9q0gr3SzJA59rLbQLaIhLzv8lYn7GRL05ifegQX41y11peG0_-ySN3nvaYvynwwbVvsJhRWbOc9B9LiYCX_qpxuXA";
+
+        try {
+            ConsumerUtil consumerUtil = new ConsumerUtil(null);
+            JwtConsumerConfigImpl config = new JwtConsumerConfigImpl() {
+                @Override
+                public boolean isValidationRequired() {
+                    return false;
+                }
+            };
+            JwtToken jwtToken = consumerUtil.parseJwt(jwt, config);
+
+            String payload = JsonUtils.getPayload(jwtToken.compact());
+            payload = JsonUtils.decodeFromBase64String(payload);
+            Map<String, Object> claims = JsonUtils.claimsFromJsonObject(payload);
+
+            // The claims variable is the old way that the claims were created in
+            // TAIMappingHelper.  This test validates that the old way matches with the
+            // new way where we use the claims from the jwtToken.
+            assertEquals(claims, jwtToken.getClaims());
+
+            TAIMappingHelper helper = new TAIMappingHelper(jwtToken);
+            helper.createJwtPrincipalAndPopulateCustomProperties(jwtToken, false);
+            JsonWebToken mpJwtToken = helper.getJwtPrincipal();
+
+            // The claims from JsonWebToken were previously calculated using the payload (json string)
+            // from JwtToken.  This test validates that the new logic using the claims from JwtToken
+            // matches getting the Claims from the payload by using clone on the JsonWebToken since
+            // clone uses the payload (json string) to parse the claims.
+            JsonWebToken clone = ((DefaultJsonWebTokenImpl) mpJwtToken).clone();
+
+            Set<String> mpClaimNames = mpJwtToken.getClaimNames();
+            Set<String> expectedMpClaimNames = clone.getClaimNames();
+            assertEquals(mpClaimNames, expectedMpClaimNames);
+            assertEquals(9, mpClaimNames.size());
+
+            for (String mpClaimName : mpClaimNames) {
+                Object expectedClaim = clone.getClaim(mpClaimName);
+                Object claim = mpJwtToken.getClaim(mpClaimName);
+                if (expectedClaim instanceof Object[]) {
+                    assertArrayEquals((Object[]) expectedClaim, (Object[]) claim);
+                } else {
+                    assertEquals(expectedClaim, claim);
+                }
+            }
+        } catch (Exception e) {
+            outputMgr.failWithThrowable(testName.getMethodName(), e);
+        }
+    }
 }

--- a/dev/io.openliberty.security.mp.jwt.1.2.config/src/io/openliberty/security/mp/jwt/v12/config/impl/MpConfigProxyServiceImpl.java
+++ b/dev/io.openliberty.security.mp.jwt.1.2.config/src/io/openliberty/security/mp/jwt/v12/config/impl/MpConfigProxyServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package io.openliberty.security.mp.jwt.v12.config.impl;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -34,6 +35,19 @@ public class MpConfigProxyServiceImpl extends com.ibm.ws.security.mp.jwt.v11.con
     public static final TraceComponent tc = Tr.register(MpConfigProxyServiceImpl.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
 
     static private String MP_VERSION = "1.2";
+
+    private static final Set<String> acceptableMpConfigPropNames12;
+
+    static {
+        Set<String> mpConfigPropNames = new HashSet<>();
+        mpConfigPropNames.addAll(com.ibm.ws.security.mp.jwt.v11.config.impl.MpConfigProxyServiceImpl.acceptableMpConfigPropNames);
+        mpConfigPropNames.add(MpConstants.PUBLIC_KEY_ALG);
+        mpConfigPropNames.add(MpConstants.DECRYPT_KEY_LOCATION);
+        mpConfigPropNames.add(MpConstants.VERIFY_AUDIENCES);
+        mpConfigPropNames.add(MpConstants.TOKEN_HEADER);
+        mpConfigPropNames.add(MpConstants.TOKEN_COOKIE);
+        acceptableMpConfigPropNames12 = Collections.unmodifiableSet(mpConfigPropNames);
+    }
 
     @Override
     @Activate
@@ -60,15 +74,7 @@ public class MpConfigProxyServiceImpl extends com.ibm.ws.security.mp.jwt.v11.con
 
     @Override
     public Set<String> getSupportedConfigPropertyNames() {
-        Set<String> allSupportedProps = super.getSupportedConfigPropertyNames();
-        Set<String> acceptableMpConfigPropNames12 = new HashSet<String>();
-        acceptableMpConfigPropNames12.add(MpConstants.PUBLIC_KEY_ALG);
-        acceptableMpConfigPropNames12.add(MpConstants.DECRYPT_KEY_LOCATION);
-        acceptableMpConfigPropNames12.add(MpConstants.VERIFY_AUDIENCES);
-        acceptableMpConfigPropNames12.add(MpConstants.TOKEN_HEADER);
-        acceptableMpConfigPropNames12.add(MpConstants.TOKEN_COOKIE);
-        allSupportedProps.addAll(acceptableMpConfigPropNames12);
-        return allSupportedProps;
+        return acceptableMpConfigPropNames12;
     }
 
 }


### PR DESCRIPTION
- Continuation of some of the changes in #20700
- Update to not parse the json string to create the JsonWebToken by using the claims in the JwtToken
- Change not to create the supported config property names over and over instead of using a constant
- Add test that shows that the #20700 and this PR's changes do not change behavior.
- Some additional small changes found along the way from looking at profiles.