### PR TITLE
container feature for JSON-B 3.0

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonbImpl-3.0.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonbImpl-3.0.0.feature
@@ -1,15 +1,14 @@
-# This private impl feature corresponds to JSON-B 2.1 with the Yasson implementation
+# This private impl feature corresponds to JSON-B 3.0 with the Yasson implementation
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.jsonbImpl-3.0.0
 singleton=true
 visibility=private
 -features=com.ibm.websphere.appserver.eeCompatible-10.0, \
-  com.ibm.websphere.appserver.classloading-1.0, \
+  com.ibm.websphere.appserver.bells-1.0, \
   io.openliberty.jakarta.cdi-4.0, \
   io.openliberty.jsonp-2.1
 -bundles=\
-  com.ibm.ws.org.eclipse.yasson.2.0, \
-  io.openliberty.jakarta.jsonb.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.json.bind:jakarta.json.bind-api:2.0.0"
+  io.openliberty.jakarta.jsonb.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="io.openliberty.jakarta.json.bind:jakarta.json.bind-api:3.0.0"
 kind=noship
 edition=full
 WLP-Activation-Type: parallel

--- a/dev/io.openliberty.jakarta.jsonb.internal_fat/.classpath
+++ b/dev/io.openliberty.jakarta.jsonb.internal_fat/.classpath
@@ -2,6 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/jsonbtestapp/src"/>
+	<classpathentry kind="src" path="test-providers/fake-json-b/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/io.openliberty.jakarta.jsonb.internal_fat/.classpath
+++ b/dev/io.openliberty.jakarta.jsonb.internal_fat/.classpath
@@ -3,6 +3,7 @@
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/jsonbtestapp/src"/>
 	<classpathentry kind="src" path="test-providers/fake-json-b/src"/>
+	<classpathentry kind="src" path="test-applications/jsonbcontainertestapp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/io.openliberty.jakarta.jsonb.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.jakarta.jsonb.internal_fat/bnd.bnd
@@ -14,7 +14,8 @@ bVersion=1.0
 
 src: \
 	fat/src,\
-	test-applications/jsonbtestapp/src
+	test-applications/jsonbtestapp/src,\
+	test-providers/fake-json-b/src
 
 javac.source: 11
 javac.target: 11

--- a/dev/io.openliberty.jakarta.jsonb.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.jakarta.jsonb.internal_fat/bnd.bnd
@@ -14,6 +14,7 @@ bVersion=1.0
 
 src: \
 	fat/src,\
+	test-applications/jsonbcontainertestapp/src,\
 	test-applications/jsonbtestapp/src,\
 	test-providers/fake-json-b/src
 

--- a/dev/io.openliberty.jakarta.jsonb.internal_fat/build.gradle
+++ b/dev/io.openliberty.jakarta.jsonb.internal_fat/build.gradle
@@ -8,19 +8,22 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package io.openliberty.jakarta.jsonb.internal.fat;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+configurations {
+  yasson
+}
 
-import componenttest.custom.junit.runner.AlwaysPassesTest;
+dependencies {
+  yasson 'io.openliberty.org.eclipse:yasson:3.0.0-RC1'
+}
 
-@RunWith(Suite.class)
-@SuiteClasses({
-                AlwaysPassesTest.class,
-                JsonBContainerTest.class,
-                JsonBTest.class,
-})
-public class FATSuite {
+task copyYasson(type: Copy) {
+  mustRunAfter jar
+  from configurations.yasson
+  into new File(autoFvtDir, 'publish/shared/resources/yasson/3.0.0')
+  rename 'yasson-.*.jar', 'yasson.jar'
+}
+
+addRequiredLibraries {
+  dependsOn copyYasson
 }

--- a/dev/io.openliberty.jakarta.jsonb.internal_fat/fat/src/io/openliberty/jakarta/jsonb/internal/fat/JsonBContainerTest.java
+++ b/dev/io.openliberty.jakarta.jsonb.internal_fat/fat/src/io/openliberty/jakarta/jsonb/internal/fat/JsonBContainerTest.java
@@ -29,15 +29,14 @@ import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
-import test.jsonb.web.JsonBTestServlet;
+import test.jsonb.container.web.JsonBContainerTestServlet;
 
 @MinimumJavaLevel(javaLevel = 11)
 @RunWith(FATRunner.class)
 public class JsonBContainerTest extends FATServletClient {
 
-    // TODO write tests specifically for JSON-B container instead of reusing the jsonb-3.0 tests
     @Server("io.openliberty.jakarta.jsonb.internal.fat.container")
-    @TestServlet(servlet = JsonBTestServlet.class, contextRoot = "jsonbcontainertestapp")
+    @TestServlet(servlet = JsonBContainerTestServlet.class, contextRoot = "jsonbcontainertestapp")
     public static LibertyServer server;
 
     @BeforeClass
@@ -52,7 +51,7 @@ public class JsonBContainerTest extends FATServletClient {
 
         ShrinkHelper.exportToServer(server, "providers", fake_json_b);
 
-        ShrinkHelper.defaultApp(server, "jsonbcontainertestapp", "test.jsonb.web");
+        ShrinkHelper.defaultApp(server, "jsonbcontainertestapp", "test.jsonb.container.web");
         server.startServer();
     }
 

--- a/dev/io.openliberty.jakarta.jsonb.internal_fat/fat/src/io/openliberty/jakarta/jsonb/internal/fat/JsonBContainerTest.java
+++ b/dev/io.openliberty.jakarta.jsonb.internal_fat/fat/src/io/openliberty/jakarta/jsonb/internal/fat/JsonBContainerTest.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.jakarta.jsonb.internal.fat;
+
+import java.io.File;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.test.json.b.FakeProvider;
+
+import com.ibm.websphere.simplicity.RemoteFile;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import test.jsonb.web.JsonBTestServlet;
+
+@MinimumJavaLevel(javaLevel = 11)
+@RunWith(FATRunner.class)
+public class JsonBContainerTest extends FATServletClient {
+
+    // TODO write tests specifically for JSON-B container instead of reusing the jsonb-3.0 tests
+    @Server("io.openliberty.jakarta.jsonb.internal.fat.container")
+    @TestServlet(servlet = JsonBTestServlet.class, contextRoot = "jsonbcontainertestapp")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        RemoteFile yasson = server.getFileFromLibertySharedDir("resources/yasson/3.0.0/yasson.jar");
+
+        JavaArchive fake_json_b = ShrinkWrap.create(ZipImporter.class, "fake-json-b.jar")
+                        .importFrom(new File(yasson.getAbsolutePath()))
+                        .as(JavaArchive.class)
+                        .addPackage("org.test.json.b")
+                        .addAsServiceProvider(jakarta.json.bind.spi.JsonbProvider.class, FakeProvider.class);
+
+        ShrinkHelper.exportToServer(server, "providers", fake_json_b);
+
+        ShrinkHelper.defaultApp(server, "jsonbcontainertestapp", "test.jsonb.web");
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/io.openliberty.jakarta.jsonb.internal_fat/publish/servers/io.openliberty.jakarta.jsonb.internal.fat.container/bootstrap.properties
+++ b/dev/io.openliberty.jakarta.jsonb.internal_fat/publish/servers/io.openliberty.jakarta.jsonb.internal.fat.container/bootstrap.properties
@@ -1,0 +1,20 @@
+###############################################################################
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+com.ibm.ws.logging.trace.specification=*=info:\
+logservice=all:\
+org.eclipse.yasson.*=all:\
+com.ibm.ws.classloading.internal.ClassLoadingServiceImpl=all:\
+com.ibm.ws.classloading.internal.ThreadContextClassLoader=all:\
+JSONB=all
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+ds.loglevel=debug
+bootstrap.include=../testports.properties

--- a/dev/io.openliberty.jakarta.jsonb.internal_fat/publish/servers/io.openliberty.jakarta.jsonb.internal.fat.container/server.xml
+++ b/dev/io.openliberty.jakarta.jsonb.internal_fat/publish/servers/io.openliberty.jakarta.jsonb.internal.fat.container/server.xml
@@ -1,0 +1,39 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+    <featureManager>
+      <feature>componenttest-2.0</feature>
+      <feature>jsonbContainer-3.0</feature>
+      <feature>servlet-6.0</feature>
+    </featureManager>
+
+	<include location="../fatTestPorts.xml"/>    
+    
+    <application location="jsonbcontainertestapp.war">
+      <classloader commonLibraryRef="FakeJsonBProvider"/>
+    </application>
+
+    <bell libraryRef="FakeJsonBProvider"/>
+
+    <library id="FakeJsonBProvider">
+      <file name="${server.config.dir}/providers/fake-json-b.jar"/>
+    </library>
+
+    <javaPermission codebase="${server.config.dir}/apps/jsonbcontainertestapp.war"
+                    className="java.util.PropertyPermission" name="jsonb.creator-parameters-required" actions="read"/>
+
+    <javaPermission codebase="${server.config.dir}/providers/fake-json-b.jar"
+                    className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+    <javaPermission codebase="${server.config.dir}/providers/fake-json-b.jar"
+                    className="java.util.PropertyPermission" name="jsonb.creator-parameters-required" actions="read"/>
+
+    <variable name="onError" value="FAIL"/>
+</server>

--- a/dev/io.openliberty.jakarta.jsonb.internal_fat/test-applications/jsonbcontainertestapp/src/test/jsonb/container/web/JsonBContainerTestServlet.java
+++ b/dev/io.openliberty.jakarta.jsonb.internal_fat/test-applications/jsonbcontainertestapp/src/test/jsonb/container/web/JsonBContainerTestServlet.java
@@ -1,0 +1,233 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jsonb.container.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import jakarta.json.JsonValue;
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.JsonbException;
+import jakarta.json.bind.annotation.JsonbCreator;
+import jakarta.json.bind.annotation.JsonbNillable;
+import jakarta.json.bind.annotation.JsonbProperty;
+import jakarta.json.bind.annotation.JsonbSubtype;
+import jakarta.json.bind.annotation.JsonbTypeInfo;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/JsonBContainerTestServlet")
+public class JsonBContainerTestServlet extends FATServlet {
+
+    Jsonb jsonb;
+
+    @Override
+    public void destroy() {
+        try {
+            jsonb.close();
+        } catch (Exception x) {
+            throw new Error(x);
+        }
+    }
+
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        jsonb = JsonbBuilder.create();
+    }
+
+    public static class TestCreatorParameters {
+        private final String name;
+
+        @JsonbCreator
+        public TestCreatorParameters(@JsonbProperty("first-name") String first, //
+                                     @JsonbProperty("middle-name") String middle, //
+                                     @JsonbProperty("last-name") String last) {
+            name = first + (middle == null ? ' ' : ' ' + middle + ' ') + last;
+        }
+
+        public String getFirstName() {
+            return name.substring(0, name.indexOf(' '));
+        }
+
+        public String getLastName() {
+            return name.substring(name.lastIndexOf(' ') + 1);
+        }
+
+        public String getMiddleName() {
+            int start = name.indexOf(' ') + 1;
+            int end = name.lastIndexOf(' ');
+            return end > start ? name.substring(start, end) : null;
+        }
+    }
+
+    /**
+     * jsonbContainer feature is used to add a fake JSON-B provider that switches the
+     * default for CREATOR_PARAMETERS_REQUIRED to true.
+     */
+    @Test
+    public void testCreatorParametersRequired() throws Exception {
+        try (Jsonb jsonb = JsonbBuilder.create()) {
+            TestCreatorParameters instance = new TestCreatorParameters("First", null, "Last");
+
+            String json = jsonb.toJson(instance);
+            assertFalse(json, json.contains("middle-name"));
+
+            TestCreatorParameters copy = jsonb.fromJson(json, TestCreatorParameters.class);
+            fail("JsonbCreator parameter was not required. " + copy.name);
+        } catch (JsonbException x) {
+            // expect: JsonbCreator parameter middle-name is missing in json document.
+            if (x.getMessage() == null || !x.getMessage().contains("middle"))
+                throw x;
+        }
+    }
+
+    /**
+     * JsonbNillable is allowed on methods and fields and determines if a JSON null value
+     * is written versus omitting the property entirely.
+     * The jsonbContainer is used to add a fake JSON-B provider that switches the
+     * default PROPERTY_NAMING_STRATEGY to LOWER_CASE_WITH_DASHES.
+     */
+    @Test
+    public void testNillableMethodsAndFields() throws Exception {
+        TestNillableMethodsAndFields instance = new TestNillableMethodsAndFields();
+        instance.firstName = "Me";
+        instance.lastName = "Myself";
+
+        String json = jsonb.toJson(instance);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = jsonb.fromJson(json, Map.class);
+
+        assertTrue(json, map.containsKey("middle-name")); // Nillable field
+        assertTrue(json, map.containsKey("home-phone")); // Nillable method
+        assertFalse(json, map.containsKey("cell-phone")); // Not nillable
+
+        assertEquals("Me", map.get("first-name"));
+        assertEquals(null, map.get("middle-name"));
+        assertEquals("Myself", map.get("last-name"));
+        assertEquals(null, map.get("home-phone"));
+    }
+
+    public static class TestNillableMethodsAndFields {
+        public String firstName, lastName;
+
+        @JsonbNillable
+        public String middleName;
+
+        public Long cellPhone; // not nillable
+        private Long homePhone;
+
+        public Long getHomePhone() {
+            return homePhone;
+        }
+
+        @JsonbNillable
+        public void setHomePhone(Long value) {
+            homePhone = value;
+        }
+    }
+
+    /**
+     * JSON null deserializes as JsonValue.NULL rather than Java null.
+     *
+     * https://github.com/eclipse-ee4j/jsonb-api/issues/181
+     */
+    @Test
+    public void testNullJsonValue() throws Exception {
+        TestNullJsonValue instance = jsonb.fromJson("{ \"jsonval\": null }", TestNullJsonValue.class);
+        assertNotNull(instance);
+        assertEquals(JsonValue.NULL, instance.jsonval);
+    }
+
+    public static class TestNullJsonValue {
+        public JsonValue jsonval;
+    }
+
+    // TODO make different
+    /**
+     * Tests polymorphic types in JSON-B.
+     *
+     * https://github.com/eclipse-ee4j/jsonb-api/issues/147
+     */
+    @Test
+    public void testPolymorphism() throws Exception {
+        TestPolymorphism.LifeForm[] list = new TestPolymorphism.LifeForm[5];
+
+        TestPolymorphism.Animal m = new TestPolymorphism.Animal();
+        m.species = "Alces alces";
+        m.maxSpeedMPH = 35;
+        list[0] = m;
+
+        TestPolymorphism.Animal b = new TestPolymorphism.Animal();
+        b.species = "Ursus americanus";
+        b.maxSpeedMPH = 35;
+        list[1] = b;
+
+        TestPolymorphism.Plant h = new TestPolymorphism.Plant();
+        h.species = "Corylus americana";
+        h.pollination = "wind";
+        list[2] = h;
+
+        TestPolymorphism.Plant t = new TestPolymorphism.Plant();
+        t.species = "Erythronium albidum";
+        t.pollination = "insects";
+        list[3] = t;
+
+        TestPolymorphism.Animal l = new TestPolymorphism.Animal();
+        l.species = "Gavia immer";
+        l.maxSpeedMPH = 70;
+        list[4] = l;
+
+        String json = jsonb.toJson(list);
+
+        System.out.println("testPolymorphism JSON:");
+        System.out.println(json);
+
+        TestPolymorphism.LifeForm[] lifeForms = jsonb.fromJson(json, TestPolymorphism.LifeForm[].class);
+
+        TestPolymorphism.Animal a = (TestPolymorphism.Animal) lifeForms[0];
+        assertEquals(m.species, a.species);
+        assertEquals(m.maxSpeedMPH, a.maxSpeedMPH);
+
+        TestPolymorphism.Plant p = (TestPolymorphism.Plant) lifeForms[2];
+        assertEquals(h.species, p.species);
+        assertEquals(h.pollination, p.pollination);
+    }
+
+    public static interface TestPolymorphism {
+        @JsonbTypeInfo({
+                         @JsonbSubtype(alias = "animal", type = Animal.class),
+                         @JsonbSubtype(alias = "plant", type = Plant.class)
+        })
+        public static class LifeForm {
+            public String species;
+        }
+
+        public static class Animal extends LifeForm {
+            public int maxSpeedMPH;
+        }
+
+        public static class Plant extends LifeForm {
+            public String pollination;
+        }
+    }
+}

--- a/dev/io.openliberty.jakarta.jsonb.internal_fat/test-providers/fake-json-b/resources/META-INF/services/jakarta.json.bind.spi.JsonbProvider
+++ b/dev/io.openliberty.jakarta.jsonb.internal_fat/test-providers/fake-json-b/resources/META-INF/services/jakarta.json.bind.spi.JsonbProvider
@@ -1,0 +1,1 @@
+org.test.json.b.FakeProvider

--- a/dev/io.openliberty.jakarta.jsonb.internal_fat/test-providers/fake-json-b/src/org/test/json/b/FakeProvider.java
+++ b/dev/io.openliberty.jakarta.jsonb.internal_fat/test-providers/fake-json-b/src/org/test/json/b/FakeProvider.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.json.b;
+
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.JsonbException;
+import jakarta.json.bind.spi.JsonbProvider;
+
+/**
+ * A fake JSON-B provider that delegates to Yasson.
+ */
+public class FakeProvider extends JsonbProvider {
+    @Override
+    public JsonbBuilder create() {
+        try {
+            JsonbProvider provider = (JsonbProvider) Class.forName("org.eclipse.yasson.JsonBindingProvider")
+                            .getConstructor()
+                            .newInstance();
+
+            JsonbBuilder builder = provider.create();
+
+            return builder;
+        } catch (Exception x) {
+            throw new JsonbException(x.getMessage(), x);
+        }
+    }
+}

--- a/dev/io.openliberty.jakarta.jsonb.internal_fat/test-providers/fake-json-b/src/org/test/json/b/FakeProvider.java
+++ b/dev/io.openliberty.jakarta.jsonb.internal_fat/test-providers/fake-json-b/src/org/test/json/b/FakeProvider.java
@@ -11,7 +11,9 @@
 package org.test.json.b;
 
 import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.JsonbConfig;
 import jakarta.json.bind.JsonbException;
+import jakarta.json.bind.config.PropertyNamingStrategy;
 import jakarta.json.bind.spi.JsonbProvider;
 
 /**
@@ -25,7 +27,12 @@ public class FakeProvider extends JsonbProvider {
                             .getConstructor()
                             .newInstance();
 
-            JsonbBuilder builder = provider.create();
+            // Change some defaults so that tests can know this is the fake provider:
+            JsonbConfig config = new JsonbConfig()
+                            .setProperty(JsonbConfig.CREATOR_PARAMETERS_REQUIRED, true)
+                            .setProperty(JsonbConfig.PROPERTY_NAMING_STRATEGY, PropertyNamingStrategy.LOWER_CASE_WITH_DASHES);
+
+            JsonbBuilder builder = provider.create().withConfig(config);
 
             return builder;
         } catch (Exception x) {


### PR DESCRIPTION
Get the jsonbContainer-3.0 feature working and add some initial tests.  Currently, we only know of Yasson as a JSON-B provider, but we can create a fake JSON-B provider that delegates to Yasson for the jsonbContainer feature to bring in.