### PR TITLE
Synchronized code in WsLogger cause deadlock with session thread

### DIFF
--- a/dev/com.ibm.ws.session/src/com/ibm/ws/session/store/memory/MemorySession.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/session/store/memory/MemorySession.java
@@ -741,7 +741,7 @@ public class MemorySession implements ISession {
      * If HideSessionValues is set, we will only show the attribute names, otherwise we will show the key/value pairs
      */
     @Override
-    public synchronized String toString() {
+    public String toString() {
         StringBuffer sb = new StringBuffer();
         //sb.append("# MemorySession # \n { ").
         sb.append("# ").append(this.getClass().getName()).append(" # \n { ")


### PR DESCRIPTION
    ****************************************************************
    * PROBLEM DESCRIPTION: Enable logging for session may cause deadlock with session manager           
    ****************************************************************
    Synchronized code in WsLogger can caused deadlock in concurrent session method calls