### PR TITLE
Change stream to simple for loop for better performance

### DIFF
--- a/dev/com.ibm.ws.security.authorization.util/src/com/ibm/ws/security/authorization/util/RoleMethodAuthUtil.java
+++ b/dev/com.ibm.ws.security.authorization.util/src/com/ibm/ws/security/authorization/util/RoleMethodAuthUtil.java
@@ -15,7 +15,6 @@ import java.security.Principal;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Stream;
 
 import javax.annotation.security.DenyAll;
 import javax.annotation.security.PermitAll;
@@ -51,9 +50,11 @@ public class RoleMethodAuthUtil {
                     LOG.log(Level.FINEST, "found RolesAllowed in method: {} " + method.getName(),
                             new Object[] { theseroles });
                 }
-                boolean allowed = Stream.of(theseroles).anyMatch(isUserInRoleFunction);
-                if (allowed)
-                    return true;
+                for (String role : theseroles) {
+                    if (isUserInRoleFunction.test(role)) {
+                        return true;
+                    }
+                }
                 checkAuthentication(principal); // throws UnauthenticatedException if not authenticated
                 return false; // authenticated, but not authorized
             } else {
@@ -90,9 +91,11 @@ public class RoleMethodAuthUtil {
                     LOG.log(Level.FINEST, "found RolesAllowed in class: {} " + cls.getName(),
                             new Object[] { theseroles });
                 }
-                boolean allowed = Stream.of(theseroles).anyMatch(isUserInRoleFunction);
-                if (allowed)
-                    return true;
+                for (String role : theseroles) {
+                    if (isUserInRoleFunction.test(role)) {
+                        return true;
+                    }
+                }
                 checkAuthentication(principal); // throws UnauthenticatedException if not authenticated
                 return false; // authenticated, but not authorized
             } else {


### PR DESCRIPTION
The stream/any match looks nice, but is at least 0.5% slower than using a for loop here. 

```
  Parent      0   0.00   1.24           0         112    J:com/ibm/ws/security/authorization/util/RoleMethodAuthUtil.parseMethodSecurity(Ljava/lang/reflect/Method;Ljava/security/Principal;Ljava/util/function/Predicate;)Z
 
    Self      0   0.00   1.24           0         112    J:java/util/stream/ReferencePipeline.anyMatch(Ljava/util/function/Predicate;)Z
 
   Child      0   0.02   1.24           2         112    J:java/util/stream/AbstractPipeline.evaluate(Ljava/util/stream/TerminalOp;)Ljava/lang/Object;
 ```

