### PR TITLE
Fix for LDAP range attributes

### DIFF
--- a/dev/com.ibm.websphere.security.wim.base/src/com/ibm/websphere/security/wim/ras/WIMMessageKey.java
+++ b/dev/com.ibm.websphere.security.wim.base/src/com/ibm/websphere/security/wim/ras/WIMMessageKey.java
@@ -1702,4 +1702,9 @@ public interface WIMMessageKey {
      * {1} federated repository attribute to a value greater than zero.
      */
     String FAILED_LOGIN_DELAY_DISABLED = "FAILED_LOGIN_DELAY_DISABLED";
+	
+	/**
+     * RANGE_ATTRIBUTE_PARSING=CWIML1043E: The Distinguished Name {0} failed to have its range attributes parsed with attribute range step of {1}.
+     */
+    String RANGE_ATTRIBUTE_PARSING = "RANGE_ATTRIBUTE_PARSING";
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/resources/com/ibm/ws/security/wim/adapter/ldap/resources/LdapUtilMessages.nlsprops
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/resources/com/ibm/ws/security/wim/adapter/ldap/resources/LdapUtilMessages.nlsprops
@@ -283,3 +283,7 @@ PREF_POOL_SIZE_TOO_BIG.useraction=Ensure that the preferred context pool size is
 LDAP_WIM_CONFIG_UPDATED_FAILED=CWIML4534E: LDAP repository {0} failed to process the configuration updates from federated repositories. Root cause: {1}
 LDAP_WIM_CONFIG_UPDATED_FAILED.explanation=Configuration changes to federated repositories triggered an update to the LDAP repository, but there was an error while processing those changes. 
 LDAP_WIM_CONFIG_UPDATED_FAILED.useraction=Review the logs for the cause of this error and take appropriate corrective actions.
+
+RANGE_ATTRIBUTE_PARSING=CWIML4535E: The Distinguished Name {0} failed to have its range attributes parsed with attribute range step of {1}.
+RANGE_ATTRIBUTE_PARSING.explanation=There was an unexpected error parsing range attributes. This could be due to a NumberFormatException or an unexpected range step.
+RANGE_ATTRIBUTE_PARSING.useraction=Verify the Distinguished Name has valid attributes.

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapAdapter.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapAdapter.java
@@ -638,8 +638,9 @@ public class LdapAdapter extends BaseRepository implements ConfiguredRepository,
                 }
                 Filter userFilter = iLdapConfigMgr.getUserFilter();
                 //If principalName is not a DN and a userFilter exists, create the search
-                //filter using userFilter and principalName. This is the dynamically created
-                //search filter using PersonAccount objectclasses and loginProperty.
+                //filter using userFilter and principalName. This is the <filters> userFilter
+                //which has an attribute value assertion containing %v. This is replaced by
+                //principalName.
                 if (principalNameDN == null && userFilter != null) {
                     principalName = LdapHelper.encode(principalName, true);
                     sFilter = userFilter.prepare(principalName);
@@ -914,6 +915,9 @@ public class LdapAdapter extends BaseRepository implements ConfiguredRepository,
                 }
             }
         } else {
+            //This property is set in the Bridge classes, so this will be the case if we came through
+            //the WIMUserRegistry. Directly calling WIM through SCIM will also have this set if no filter
+			//was provided - meaning a search for all users or groups.
             if (root.isSetContexts()) {
                 String inputPattern = getContextProperty(root, SchemaConstants.USE_USER_FILTER_FOR_SEARCH);
                 if (inputPattern != null && inputPattern.length() > 0) {
@@ -925,7 +929,7 @@ public class LdapAdapter extends BaseRepository implements ConfiguredRepository,
                     }
                     if (dn == null) {
                         Filter f = iLdapConfigMgr.getUserFilter();
-                        //This will be NOT null if <filters> are defined. This is meant to take
+                        //This filter will be NOT null if <filters> are defined. This is meant to take
                         //precedence over the filter from SearchControl - which already has the
                         //encoded principal.
                         if (f != null) {
@@ -945,7 +949,7 @@ public class LdapAdapter extends BaseRepository implements ConfiguredRepository,
                         }
                         if (dn == null) {
                             Filter f = iLdapConfigMgr.getGroupFilter();
-                            //This will be NOT null if <filters> are defined. This is meant to take
+                            //This filter will be NOT null if <filters> are defined. This is meant to take
                             //precedence over the filter from SearchControl - which already has the
                             //encoded principal.
                             if (f != null) {
@@ -2884,21 +2888,23 @@ public class LdapAdapter extends BaseRepository implements ConfiguredRepository,
                     String value = (String) pNameNode.getValue();
                     String uName = UniqueNameHelper.getValidUniqueName(value);
                     if (uName == null || ignoreDNBaseSearch) {
-                        //principalName is not a DN, so get the principalNameFilter using loginAttributes.
+                        //principalName is not a DN, so generate the filter using loginAttributes.
+                        //This does not include objectclasses yet.
                         //We will encode value in this method (handle special characters in value).
+
                         filter = getPrincipalNameFilter(value, encodeAsterisk);
                     } else {
                         //uName is a valid DN, so we can do an object scope search for DN
                         pNameBase = getDN(uName, SchemaConstants.DO_PERSON_ACCOUNT, null, true, false);
                     }
-
                 } else {
                     //The expression in the node did not include principalName.
                     //eg. expression=//entities[@xsi:type='LoginAccount' and cn='ldap_usercn']
-                    //Generally this means the input/output property mapping was changed
-                    //to something other than principalName.
+                    //Generally this means the security input name property mapping was changed
+                    //to something other than: uniqueId, uniqueName, externalId, externalName.
                     //To generate the search filter, we parse the node, encode
                     //the value, form the filter, and return it.
+                    //Is this also the path for SCIM calls that include their own filter?
                     filter = getSearchFilter(entityTypes, node, encodeAsterisk);
                 }
             } catch (ParseException e) {
@@ -2919,7 +2925,9 @@ public class LdapAdapter extends BaseRepository implements ConfiguredRepository,
             }
         }
 
-        //Filter will be null for DN object scope searches and certificate logins
+        //filter is the login properties and getEntityTypesFilter returns the objectclass filter.
+        //eg. cn=user1 + objectclass=user
+        //filter will be null for DN object scope searches and certificate logins
         if (filter != null) {
             filter = "(&" + iLdapConfigMgr.getEntityTypesFilter(entityTypes) + filter + ")";
         } else {

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapConfigManager.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapConfigManager.java
@@ -1030,6 +1030,10 @@ public class LdapConfigManager {
             entity.setSearchFilter(null);
     }
 
+    /**
+     *
+     * @return The userFilter from the <filters> element in config
+     */
     public Filter getUserFilter() {
         // If there is a filter defined but not initialized, then initialize it.
         if ((iUserFilter != null) && (userFilter == null)) {
@@ -2563,6 +2567,14 @@ public class LdapConfigManager {
         return subTypes;
     }
 
+    /**
+     * Return a combined filter given a set of entity types. This
+     * is only the objectclass portion of the filter. The login/search
+     * attributes are appended later.
+     *
+     * @param entityTypes The entity types whose filters to combine.
+     * @return The filter
+     */
     public String getEntityTypesFilter(Set<String> entityTypes) {
         StringBuffer filter = new StringBuffer();
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapConnection.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapConnection.java
@@ -2046,14 +2046,19 @@ public class LdapConnection {
     }
 
     /**
-     * For the given attributes, check if any of them are range attributes, and if they are, request the rest
-     * of the attributes that fall outside the range.
+     * This method is called to retrieve all range attributes
+     * from LDAP, eg. member;range=0-1499. At this point, a
+     * getAttributes call has already been made. First we parse the results
+     * to obtain the first set of attributes and the range step.
+     * Then we make additional calls to retrieve the rest of the attributes.
      *
-     * @param attributes The attributes returned (so far).
-     * @param dn The distinguished name of the entity containing the attributes.
-     * @param ctx The context to use to request the remainder of the range attributes.
-     * @throws WIMException If there was an error recreating a context in the case of a connection error.
-     * @throws NamingException If there was an error retrieving the attributes from the LDAP server.
+     * We've retrieved all attributes when LDAP returns range=x-* (the asterisk indicates final set).
+     *
+     * @param attributes The attributes returned from LDAP
+     * @param dn         The DN whose attributes are being retrieved
+     * @param ctx        The DirContext used to connect to LDAP and make additional getAttribute calls
+     * @throws WIMException
+     * @throws NamingException
      */
     @FFDCIgnore({ NumberFormatException.class, NamingException.class })
     private void supportRangeAttributes(Attributes attributes, String dn, TimedDirContext ctx) throws WIMException, NamingException {
@@ -2073,38 +2078,41 @@ public class LdapConnection {
                     Tr.debug(tc, METHODNAME + " Range attribute retrieved: " + attrName);
                 }
 
+                //Add the ranged attributes we found to newAttr
                 for (NamingEnumeration<?> neu2 = attr.getAll(); neu2.hasMoreElements();) {
                     newAttr.add(neu2.nextElement());
                 }
 
-                int rangeLow = iAttrRangeStep;
+                //Parse the range attribute for low and high values to make sure
+                //we are using the maximum step range.
+                int localAttrRangeStep = parseRangeAttribute(attrName);
+
+                //The first set of attributes has been added. Now update the range
+                //and retrieve the second set.
+                int rangeLow = localAttrRangeStep;
                 try {
                     rangeLow = Integer.parseInt(attrName.substring(attrName.indexOf('-') + 1)) + 1;
                 } catch (NumberFormatException e) {
                     // continue;
                 }
-                int rangeHigh = rangeLow + iAttrRangeStep - 1;
+                int rangeHigh = rangeLow + localAttrRangeStep - 1;
                 boolean quitLoop = false;
-                boolean lastQuery = false;
                 do {
+                    //Format the getAttributes request
                     String attributeWithRange = null;
-                    if (!lastQuery) {
-                        Object[] args = { Integer.valueOf(rangeLow).toString(),
-                                          Integer.valueOf(rangeHigh).toString()
-                        };
-                        attributeWithRange = attrId + MessageFormat.format(ATTR_RANGE_QUERY, args);
-                    } else {
-                        Object[] args = {
-                                          Integer.valueOf(rangeLow).toString()
-                        };
-                        attributeWithRange = attrId + MessageFormat.format(ATTR_RANGE_LAST_QUERY, args);
-                    }
+                    Object[] args = {
+                                      Integer.toString(rangeLow),
+                                      Integer.toString(rangeHigh)
+                    };
+                    attributeWithRange = attrId + MessageFormat.format(ATTR_RANGE_QUERY, args);
                     Attributes results = null;
                     String[] rAttrIds = {
                                           attributeWithRange
                     };
                     try {
+
                         results = ctx.getAttributes(new LdapName(dn), rAttrIds);
+
                     } catch (NamingException e) {
                         if (ContextManager.isConnectionException(e)) {
                             ctx = iContextManager.reCreateDirContext(ctx, e.toString());
@@ -2114,27 +2122,36 @@ public class LdapConnection {
                         }
                     }
                     Attribute result = results.get(attributeWithRange);
+                    //If the result is null, we didn't find the exact attributeWithRange string
+                    //we were looking for. This could mean there are fewer results left than iAttrRangeStep.
+                    //In this case, LDAP will have sent back range;x-*.
                     if (result == null) {
-                        Object[] args = {
-                                          Integer.valueOf(rangeLow).toString()
+                        Object[] rangeArgs = {
+                                               Integer.toString(rangeLow)
                         };
-                        attributeWithRange = attrId + MessageFormat.format(ATTR_RANGE_LAST_QUERY, args);
+                        String tempRange = attributeWithRange;
+                        attributeWithRange = attrId + MessageFormat.format(ATTR_RANGE_LAST_QUERY, rangeArgs);
+                        if (tc.isDebugEnabled()) {
+                            Tr.debug(tc,
+                                     "Result was null for " + tempRange + ", now parsing results for " + attributeWithRange);
+                        }
                         result = results.get(attributeWithRange);
-                        lastQuery = true;
+                        //If we found a result, this is the last search.
+                        if (result != null)
+                            quitLoop = true;
                     }
+                    //If we found a result, add it to the list. If the result was range;x-*, quit.
+                    //If result is null, there was an issue parsing the results. Quit the loop.
                     if (result != null) {
                         for (NamingEnumeration<?> neu2 = result.getAll(); neu2.hasMoreElements();) {
                             newAttr.add(neu2.nextElement());
                         }
 
-                        if (lastQuery) {
-                            quitLoop = true;
-                        } else {
-                            rangeLow = rangeHigh + 1;
-                            rangeHigh = rangeLow + iAttrRangeStep - 1;
-                        }
+                        rangeLow = rangeHigh + 1;
+                        rangeHigh = rangeLow + localAttrRangeStep - 1;
                     } else {
-                        lastQuery = true;
+                        throw new WIMSystemException(WIMMessageKey.RANGE_ATTRIBUTE_PARSING, Tr.formatMessage(tc, WIMMessageKey.RANGE_ATTRIBUTE_PARSING,
+                                                                                                             WIMMessageHelper.generateMsgParms(dn, localAttrRangeStep)));
                     }
                 } while (!quitLoop);
                 attributes.put(newAttr);
@@ -2144,13 +2161,40 @@ public class LdapConnection {
     }
 
     /**
+     * Find the range returned from LDAP. This will be the maximum LDAP will return so
+     * we want to use this rather than the default attributeRangeStep.
+     *
+     * @param attr The range attribute returned from LDAP, eg. member;range=0-1499
+     * @return The max value of results LDAP will return
+     */
+    private int parseRangeAttribute(String attr) {
+        try {
+            //Find the range by parsing member;range=1500-2999 for low and high.
+            int rangeLow = Integer.parseInt(attr.substring(attr.indexOf('=') + 1, attr.indexOf('-')));
+            int rangeHigh = Integer.parseInt(attr.substring(attr.indexOf('-') + 1));
+            int rangeReturnedFromLDAP = rangeHigh - rangeLow + 1;
+            return rangeReturnedFromLDAP;
+        } catch (NumberFormatException e) {
+            //If there was an issue setting the new iAttrRangeStep, something has gone wrong.
+            //Issue a warning or error saying not all attributes were returned.
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc,
+                         "The range attribute was not parsed correctly. Use current value of iAttrRangeStep.");
+            }
+        }
+        //If there was an issue, return the default.
+        return iAttrRangeStep;
+
+    }
+
+    /**
      * Search using operational attribute specified in the parameter.
      *
-     * @param dn The DN to search on
-     * @param filter The LDAP filter for the search.
+     * @param dn            The DN to search on
+     * @param filter        The LDAP filter for the search.
      * @param inEntityTypes The entity types to search for.
-     * @param propNames The property names to return.
-     * @param oprAttribute The operational attribute.
+     * @param propNames     The property names to return.
+     * @param oprAttribute  The operational attribute.
      * @return The search results or null if there are no results.
      * @throws WIMException If the entity types do not exist or the search failed.
      */

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapEntity.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapEntity.java
@@ -137,6 +137,15 @@ public class LdapEntity {
         return iSearchBaseList;
     }
 
+    /**
+     * iSearchFilter is created using the defined objectclasses.
+     * These will be from user/groupFilter in filters, PersonAccount/Group
+     * EntityType objectclasses, or defaults.
+     * eg. userFilter=(&(|(objectclass=user)(objectclass=person))(cn=%v))
+     * iSearchFilter = (|(objectclass=user)(objectclass=person))
+     *
+     * @return The search filter described above.
+     */
     public String getSearchFilter() {
         return iSearchFilter;
     }
@@ -281,6 +290,15 @@ public class LdapEntity {
         }
     }
 
+    /**
+     * Set the search filter (iSearchFilter) to filter, or if filter is null,
+     * use iObjectClasses from userFilter/groupFilter or PersonAccount/Group
+     * EntityType definitions. Eg. (objectclass=user)
+     * Note that this does not include login properties. These are appended
+     * separately.
+     *
+     * @param filter The filter to use.
+     */
     public void setSearchFilter(String filter) {
         if (filter != null && filter.trim().length() > 0) {
             filter = filter.trim();


### PR DESCRIPTION
We should not rely on the attribute range step property to retrieve range attributes. This will cause an issue if the LDAP server returns fewer than attributeRangeStep. Additionally, it is more efficient to use the max number LDAP will return. Currently, the user cannot set this property, but the framework is there if this is ever added (a few tweaks needed).