### PR TITLE
Avoid compiling regular expressions every request.

### DIFF
--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/crypto/KeyAlgorithmChecker.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/crypto/KeyAlgorithmChecker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,13 +28,19 @@ public class KeyAlgorithmChecker {
 
     private static final TraceComponent tc = Tr.register(KeyAlgorithmChecker.class);
 
+    private static final Pattern HSA_PATTERN = Pattern.compile("HS[0-9]{3,}");
+    private static final Pattern RSA_PATTERN = Pattern.compile("RS[0-9]{3,}");
+    private static final Pattern ESA_PATTERN = Pattern.compile("ES[0-9]{3,}");
+    private static final Pattern ALG_PATTERN = Pattern.compile("[RHEP]S([0-9]{3,})", Pattern.CASE_INSENSITIVE);
+
     public static int UNKNOWN_HASH_SIZE = 0;
 
     public boolean isHSAlgorithm(String alg) {
         if (alg == null) {
             return false;
         }
-        return alg.matches("HS[0-9]{3,}");
+        Matcher m = HSA_PATTERN.matcher(alg);
+        return m.matches();
     }
 
     public boolean isPublicKeyValidType(Key key, String supportedSigAlg) {
@@ -57,7 +63,8 @@ public class KeyAlgorithmChecker {
         if (alg == null) {
             return false;
         }
-        return alg.matches("RS[0-9]{3,}");
+        Matcher m = RSA_PATTERN.matcher(alg);
+        return m.matches();
     }
 
     public boolean isValidRSAPublicKey(Key key) {
@@ -70,7 +77,8 @@ public class KeyAlgorithmChecker {
         if (alg == null) {
             return false;
         }
-        return alg.matches("ES[0-9]{3,}");
+        Matcher m = ESA_PATTERN.matcher(alg);
+        return m.matches();
     }
 
     public boolean isValidECPublicKey(String supportedSigAlg, Key key) {
@@ -100,12 +108,10 @@ public class KeyAlgorithmChecker {
     @FFDCIgnore(Exception.class)
     public int getHashSizeFromAlgorithm(String algorithm) {
         int hashSize = UNKNOWN_HASH_SIZE;
-        String algRegex = "[RHEP]S([0-9]{3,})";
-        Pattern algPattern = Pattern.compile(algRegex, Pattern.CASE_INSENSITIVE);
-        Matcher algMatcher = algPattern.matcher(algorithm);
+        Matcher algMatcher = ALG_PATTERN.matcher(algorithm);
         if (!algMatcher.matches()) {
             if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Algorithm [" + algorithm + "] did not match expected regex " + algRegex);
+                Tr.debug(tc, "Algorithm [" + algorithm + "] did not match expected regex " + ALG_PATTERN.toString());
             }
             return hashSize;
         }

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JweHelper.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JweHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,8 @@ import java.security.Key;
 import java.security.KeyStoreException;
 import java.security.PublicKey;
 import java.security.cert.CertificateException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.jose4j.base64url.Base64;
 import org.jose4j.jwe.ContentEncryptionAlgorithmIdentifiers;
@@ -39,6 +41,10 @@ public class JweHelper {
 
     private static final TraceComponent tc = Tr.register(JweHelper.class);
 
+    private static final String NOT_PERIOD = "[^\\.]";
+    private static final Pattern JWS_PATTERN = Pattern.compile("^(" + NOT_PERIOD + "*\\.){2}" + NOT_PERIOD + "*$");
+    private static final Pattern JWE_PATTERN = Pattern.compile("^(" + NOT_PERIOD + "*\\.){4}" + NOT_PERIOD + "*$");
+
     @FFDCIgnore({ Exception.class })
     public static String createJweString(String jws, JwtData jwtData) throws Exception {
         JweHelper helper = new JweHelper();
@@ -60,16 +66,18 @@ public class JweHelper {
         if (jwtString == null || jwtString.isEmpty()) {
             return false;
         }
-        String notPeriod = "[^\\.]";
-        return jwtString.matches("^(" + notPeriod + "*\\.){2}" + notPeriod + "*$");
+
+        Matcher m = JWS_PATTERN.matcher(jwtString);
+        return m.matches();
     }
 
     public static boolean isJwe(String jwtString) {
         if (jwtString == null || jwtString.isEmpty()) {
             return false;
         }
-        String notPeriod = "[^\\.]";
-        return jwtString.matches("^(" + notPeriod + "*\\.){4}" + notPeriod + "*$");
+
+        Matcher m = JWE_PATTERN.matcher(jwtString);
+        return m.matches();
     }
 
     /**


### PR DESCRIPTION
We spend a bit of time compiling regular expressions in the acmeAirMS benchmark. This is an attempt to only do the compile once.

```
  Parent      0   0.00   0.05           0           4    J:java/lang/String.split(Ljava/lang/String;I)[Ljava/lang/String;
  Parent      0   0.00   0.21           0          18    J:com/ibm/ws/security/AccessIdUtil.getUniqueId(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
  Parent      0   0.00   0.33           0          29    J:java/util/regex/Pattern.matches(Ljava/lang/String;Ljava/lang/CharSequence;)Z
 
    Self      0   0.00   0.58           0          51    J:java/util/regex/Pattern.compile(Ljava/lang/String;)Ljava/util/regex/Pattern;
 
   Child      0   0.01   0.58           1          51    J:java/util/regex/Pattern.<init>(Ljava/lang/String;I)V
``` 

Not sure if the change in AccessIdUtil is the best idea. Will there be a lot of realms or just a few? If just a few, will probably be fine, but wondering if it needs to be a a ConcurrentHashMap?