### PR TITLE
Updating SLF4J in OT FAT servers

### DIFF
--- a/dev/com.ibm.ws.microprofile.opentracing.jaeger_fat/publish/servers/jaegerServer1/server.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.jaeger_fat/publish/servers/jaegerServer1/server.xml
@@ -16,6 +16,6 @@
     </library>
 
     <javaPermission
-        codebase="${server.config.dir}/jaegerLib/slf4j-api-1.7.30.jar"
+        codebase="${server.config.dir}/jaegerLib/com.ibm.ws.org.slf4j.api.jar"
         className="java.security.AllPermission" />
 </server>

--- a/dev/com.ibm.ws.microprofile.opentracing.jaeger_fat/publish/servers/jaegerServer2/server.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.jaeger_fat/publish/servers/jaegerServer2/server.xml
@@ -11,6 +11,6 @@
     </application>
 
     <javaPermission
-        codebase="${server.config.dir}/lib/slf4j-api-1.7.30.jar"
+        codebase="${server.config.dir}/lib/com.ibm.ws.org.slf4j.api.jar"
         className="java.security.AllPermission" />
 </server>

--- a/dev/com.ibm.ws.microprofile.opentracing.jaeger_fat/publish/servers/jaegerServer3/server.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.jaeger_fat/publish/servers/jaegerServer3/server.xml
@@ -11,7 +11,7 @@
     </application>
 
     <javaPermission
-        codebase="${server.config.dir}/jaegerLib/slf4j-api-1.7.30.jar"
+        codebase="${server.config.dir}/jaegerLib/com.ibm.ws.org.slf4j.api.jar"
         className="java.security.AllPermission" />
         
             <javaPermission

--- a/dev/com.ibm.ws.microprofile.opentracing.jaeger_fat/publish/servers/jaegerServerInventory/server.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.jaeger_fat/publish/servers/jaegerServerInventory/server.xml
@@ -19,7 +19,7 @@
     </library>
 
     <javaPermission
-        codebase="${server.config.dir}/jaegerLib/slf4j-api-1.7.30.jar"
+        codebase="${server.config.dir}/jaegerLib/com.ibm.ws.org.slf4j.api.jar"
         className="java.security.AllPermission" />
         
     <javaPermission

--- a/dev/com.ibm.ws.microprofile.opentracing.jaeger_fat/publish/servers/jaegerServerSystem/server.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.jaeger_fat/publish/servers/jaegerServerSystem/server.xml
@@ -19,7 +19,7 @@
     </library>
 
     <javaPermission
-        codebase="${server.config.dir}/jaegerLib/slf4j-api-1.7.30.jar"
+        codebase="${server.config.dir}/jaegerLib/com.ibm.ws.org.slf4j.api.jar"
         className="java.security.AllPermission" />
         
     <javaPermission


### PR DESCRIPTION
SLF4J was recently updated but the servers in the OT Jaeger FAT weren't updated.

Fixes https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=290243