### PR TITLE
Add AllowedFFDC for CommExceptions when we failover remote LDAPs

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_TDSLDAPTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_TDSLDAPTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,6 +33,7 @@ import com.ibm.ws.security.registry.EntryNotFoundException;
 import com.ibm.ws.security.registry.SearchResult;
 import com.ibm.ws.security.registry.test.UserRegistryServletConnection;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -43,6 +44,7 @@ import componenttest.vulnerability.LeakedPasswordChecker;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
+@AllowedFFDC(value = { "javax.naming.CommunicationException" })
 public class URAPIs_TDSLDAPTest {
     private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.security.wim.adapter.ldap.fat.tds");
     private static final Class<?> c = URAPIs_TDSLDAPTest.class;


### PR DESCRIPTION
If we failover LDAPs at the WIM level due to a `javax.naming.CommunicationException`, we will log an FFDC. When the failover is successful, the test is fine, but then fails with an unexpected FFDC. Adding `AllowedFFDC` on a case by case basis to reduce false BBs. If we can't failover successfully, the test will likely fail due to an Assert or other test check.

RTC 290230