### PR TITLE
Update to bndtools 6.2.0

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -812,7 +812,7 @@ if (isAutomatedBuild && !isIFIXBuild) {
             from 'packaging'
             include 'rules.template'
             into 'packaging/debuild/openliberty/debian'
-            filter { line -> line.replaceAll('@VERSION@', bnd('libertyServiceVersion', 'Unknown')) }
+            filter { line -> line.replaceAll('@VERSION@', bnd.get('libertyServiceVersion', 'Unknown')) }
             rename { it.replace(".template", "") }
         }
 
@@ -826,8 +826,8 @@ if (isAutomatedBuild && !isIFIXBuild) {
             environment "GPG_PASS", rootProject.userProps.getProperty('gpgPassphrase')
             mkdir("packaging/tempPackagingDir/tempTar")
 
-            def rpms = file("./packaging/rpmbuild/RPMS/noarch/openliberty-" + bnd('libertyServiceVersion') + "-1.noarch.rpm")
-            def debs = file("./packaging/debuild/openliberty_" + bnd('libertyServiceVersion') + "-1ubuntu1_all.deb")
+            def rpms = file("./packaging/rpmbuild/RPMS/noarch/openliberty-" + bnd.get('libertyServiceVersion') + "-1.noarch.rpm")
+            def debs = file("./packaging/debuild/openliberty_" + bnd.get('libertyServiceVersion') + "-1ubuntu1_all.deb")
             def packageDate = new Date()
             def formattedRPMDate = packageDate.format("E MMM d y")
             def formattedDEBDate = packageDate.format("E, d MMM y hh:mm:ss Z")
@@ -838,7 +838,7 @@ if (isAutomatedBuild && !isIFIXBuild) {
 
             errorOutput = new ByteArrayOutputStream()
 
-            commandLine 'sh', './buildOsNativePackages.sh', bnd('libertyServiceVersion'), isRelease, formattedRPMDate, formattedDEBDate
+            commandLine 'sh', './buildOsNativePackages.sh', bnd.get('libertyServiceVersion'), isRelease, formattedRPMDate, formattedDEBDate
 
             ignoreExitValue true
 

--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -130,7 +130,7 @@ def pluginsProject = project(':wlp-bndPlugins')
 task updatePluginClasses(type: Copy) {
     dependsOn ':wlp-bndPlugins:jar'
     dependsOn dependabotGenerate
-    from zipTree(bnd('build.bnd.plugins.jar'))
+    from zipTree(bnd.get('build.bnd.plugins.jar'))
     into project.file('bndplugins/classes')
     doLast {
         println 'Refresh bnd Projects after building bnd plugins in ' + project.name
@@ -368,7 +368,7 @@ task createGeneratedReplacementProjects {
     }
 }
 
-def releaserepo = file(bnd('releaserepo', 'release')) /* Release repository. */
+def releaserepo = file(bnd.get('releaserepo', 'release')) /* Release repository. */
 
 import aQute.bnd.gradle.Index
 
@@ -424,16 +424,16 @@ task libertyReleaseVersions {
   inputs.file('resources/bnd/liberty-release.props')
   outputs.file('build/liberty-versions.props')
   doLast {
-    def releaseVersion = bnd('libertyRelease') + '-' + rootProject.userProps.getProperty('version.qualifier')
+    def releaseVersion = bnd.get('libertyRelease') + '-' + rootProject.userProps.getProperty('version.qualifier')
     println 'releaseVersion = ' + releaseVersion
     def libertyVersionsProps = new Properties()
-    libertyVersionsProps.setProperty('libertyBaseVersion', bnd('libertyBaseVersion'))
-    libertyVersionsProps.setProperty('libertyFixpackVersion', bnd('libertyFixpackVersion'))
-    libertyVersionsProps.setProperty('libertyServiceVersion', bnd('libertyServiceVersion'))
-    libertyVersionsProps.setProperty('libertyBetaVersion', bnd('libertyBetaVersion'))
-    libertyVersionsProps.setProperty('libertyRelease', bnd('libertyRelease'))
-    libertyVersionsProps.setProperty('libertyBundleMicroVersion', bnd('libertyBundleMicroVersion'))
-    libertyVersionsProps.setProperty('buildID', bnd('buildID'))
+    libertyVersionsProps.setProperty('libertyBaseVersion', bnd.get('libertyBaseVersion'))
+    libertyVersionsProps.setProperty('libertyFixpackVersion', bnd.get('libertyFixpackVersion'))
+    libertyVersionsProps.setProperty('libertyServiceVersion', bnd.get('libertyServiceVersion'))
+    libertyVersionsProps.setProperty('libertyBetaVersion', bnd.get('libertyBetaVersion'))
+    libertyVersionsProps.setProperty('libertyRelease', bnd.get('libertyRelease'))
+    libertyVersionsProps.setProperty('libertyBundleMicroVersion', bnd.get('libertyBundleMicroVersion'))
+    libertyVersionsProps.setProperty('buildID', bnd.get('buildID'))
     libertyVersionsProps.setProperty('releaseVersion', releaseVersion)
     File libertyVersionsPropsFile = file('build/liberty-versions.props')
     libertyVersionsProps.store(libertyVersionsPropsFile.newWriter(), null)

--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -376,10 +376,10 @@ task ('index', type: Index) {
     description 'Index the release repository. (Does not depend on releaseNeeded)'
     group 'release'
     repositoryName = "OpenLiberty ${version}"
-    destinationDir = releaserepo
+    destinationDirectory = releaserepo
     gzip = true
     /* Bundles to index. */
-    bundles fileTree(destinationDir) {
+    bundles fileTree(destinationDirectory) {
         include '**/*.jar'
         exclude '**/*-latest.jar'
         exclude '**/*-sources.jar'

--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -14,17 +14,17 @@
     <dependency>
       <groupId>biz.aQute.bnd</groupId>
       <artifactId>biz.aQute.bnd.annotation</artifactId>
-      <version>5.3.0</version>
+      <version>6.2.0</version>
     </dependency>
     <dependency>
       <groupId>biz.aQute.bnd</groupId>
       <artifactId>biz.aQute.bnd.transform</artifactId>
-      <version>5.3.0</version>
+      <version>6.2.0</version>
     </dependency>
     <dependency>
       <groupId>biz.aQute.bnd</groupId>
       <artifactId>biz.aQute.bnd</artifactId>
-      <version>5.3.0</version>
+      <version>6.2.0</version>
     </dependency>
     <dependency>
       <groupId>cglib</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -1,6 +1,6 @@
-biz.aQute.bnd:biz.aQute.bnd.annotation:5.3.0
-biz.aQute.bnd:biz.aQute.bnd.transform:5.3.0
-biz.aQute.bnd:biz.aQute.bnd:5.3.0
+biz.aQute.bnd:biz.aQute.bnd.annotation:6.2.0
+biz.aQute.bnd:biz.aQute.bnd.transform:6.2.0
+biz.aQute.bnd:biz.aQute.bnd:6.2.0
 cglib:cglib-nodep:3.3.0
 ch.qos.logback:logback-classic:1.2.3
 ch.qos.logback:logback-core:1.2.3

--- a/dev/cnf/resources/bnd/anttaskdefs.bnd
+++ b/dev/cnf/resources/bnd/anttaskdefs.bnd
@@ -33,7 +33,7 @@ repo.featureTasks.path: ${path;\
     ${repo;wlp-featureTasks},\
     ${repo;com.ibm.ws.kernel.boot.core},\
     ${repo;com.ibm.ws.logging.core},\
-    ${repo;biz.aQute.bnd:biz.aQute.bnd;5.3.0},\
+    ${repo;biz.aQute.bnd:biz.aQute.bnd;6.2.0},\
     ${repo;com.ibm.ws.org.apache.ant},\
     ${repo;com.ibm.ws.componenttest:infra.buildtasks-core;6.0.6},\
     ${repo;org.jsoup:jsoup;1.7.2},\

--- a/dev/com.ibm.websphere.appserver.features/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.features/bnd.bnd
@@ -33,5 +33,5 @@ feature.project: true
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
-	biz.aQute.bnd:biz.aQute.bnd;version=5.3.0;packages=**,\
+	biz.aQute.bnd:biz.aQute.bnd;version=6.2.0;packages=**,\
 	org.apache.aries:org.apache.aries.util;version=1.1.3

--- a/dev/com.ibm.ws.bnd.annotations/bnd.bnd
+++ b/dev/com.ibm.ws.bnd.annotations/bnd.bnd
@@ -24,5 +24,5 @@ Private-Package: com.ibm.ws.bnd.metatype.annotation, \
 publish.wlp.jar.disabled: true
 
 -buildpath: \
-	biz.aQute.bnd.annotation;version=5.3.0, \
+	biz.aQute.bnd.annotation;version=6.2.0, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest

--- a/dev/com.ibm.ws.net.sf.ehcache.core/bnd.overrides
+++ b/dev/com.ibm.ws.net.sf.ehcache.core/bnd.overrides
@@ -36,12 +36,6 @@ Import-Package: \
  org.slf4j,\
  org.xml.sax,\
  org.xml.sax.helpers
-   
-Include-Resource: \
- @lib/ehcache-core-2.5.2.jar!/META-INF/**,\
- @lib/ehcache-core-2.5.2.jar!/templates/**,\
- @lib/ehcache-core-2.5.2.jar!/schemas/**,\
- @lib/ehcache-core-2.5.2.jar!/*xml
 
 Archiver-Version:
 Build-Jdk:

--- a/dev/com.ibm.ws.org.apache.commons.beanutils/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.commons.beanutils/bnd.bnd
@@ -10,7 +10,4 @@
 #*******************************************************************************
 -include= jar:${fileuri;${repo;commons-beanutils:commons-beanutils;1.9.4}}!/META-INF/MANIFEST.MF,bnd.overrides
 
--includeresource: \
-    @${repo;commons-beanutils:commons-beanutils;1.9.4}!/!META-INF/MANIFEST.MF|META-INF/maven/*|META-INF/NOTICE.txt|META-INF/LICENSE.txt
-
 -buildpath: commons-beanutils:commons-beanutils;version=1.9.4

--- a/dev/com.ibm.ws.org.apache.commons.beanutils/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.commons.beanutils/bnd.overrides
@@ -16,3 +16,6 @@ Import-Package: \
 Export-Package: \
   !org.apache.commons.collections.*, \
   org.apache.commons.beanutils.*
+
+Include-Resource: \
+    @${repo;commons-beanutils:commons-beanutils;1.9.4}!/!META-INF/MANIFEST.MF|META-INF/maven/*|META-INF/NOTICE.txt|META-INF/LICENSE.txt

--- a/dev/com.ibm.ws.org.apache.commons.collections/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.commons.collections/bnd.bnd
@@ -10,7 +10,4 @@
 #*******************************************************************************
 -include= jar:${fileuri;${repo;org.apache.commons.collections;3.2.2;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
 
--includeresource: \
-    @${repo;org.apache.commons.collections;3.2.2;EXACT}!/!META-INF/MANIFEST.MF|META-INF/maven/*
-
 -buildpath: commons-collections:commons-collections;strategy=exact;version=3.2.2

--- a/dev/com.ibm.ws.org.apache.commons.collections/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.commons.collections/bnd.overrides
@@ -2,3 +2,6 @@
 bVersion=1.0
 
 Bundle-SymbolicName: com.ibm.ws.org.apache.commons.collections
+
+Include-Resource: \
+    @${repo;org.apache.commons.collections;3.2.2;EXACT}!/!META-INF/MANIFEST.MF|META-INF/maven/*

--- a/dev/com.ibm.ws.org.apache.commons.compress/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.commons.compress/bnd.bnd
@@ -10,9 +10,6 @@
 #*******************************************************************************
 -include= jar:${fileuri;${repo;org.apache.commons:commons-compress;1.21}}!/META-INF/MANIFEST.MF,bnd.overrides
 
--includeresource: \
-    @${repo;org.apache.commons:commons-compress;1.21}!/!META-INF/maven/*
-
 publish.wlp.jar.disabled: true
 
 -buildpath: org.apache.commons:commons-compress;version=1.21

--- a/dev/com.ibm.ws.org.apache.commons.compress/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.commons.compress/bnd.overrides
@@ -2,3 +2,6 @@
 bVersion=1.0
 
 Bundle-SymbolicName: com.ibm.ws.org.apache.commons.compress
+
+Include-Resource: \
+    @${repo;org.apache.commons:commons-compress;1.21}!/!META-INF/maven/*

--- a/dev/com.ibm.ws.org.apache.commons.fileupload/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.commons.fileupload/bnd.bnd
@@ -10,8 +10,6 @@
 #*******************************************************************************
 -include= jar:${fileuri;${repo;org.apache.commons.fileupload;1.3.3;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
 
--includeresource: @${repo;org.apache.commons.fileupload;1.3.3;EXACT}!/!META-INF/MANIFEST.MF|META-INF/maven/*
-
 instrument.disabled: true
 
 jakartaeeMe: true

--- a/dev/com.ibm.ws.org.apache.commons.fileupload/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.commons.fileupload/bnd.overrides
@@ -5,3 +5,6 @@ bVersion=1.0
 Bundle-SymbolicName: com.ibm.ws.org.apache.commons.fileupload; singleton:=true
 
 Private-Package: org.apache.commons.fileupload.portlet
+
+Include-Resource: @${repo;org.apache.commons.fileupload;1.3.3;EXACT}!/!META-INF/MANIFEST.MF|META-INF/maven/*
+

--- a/dev/com.ibm.ws.org.apache.commons.io/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.commons.io/bnd.bnd
@@ -10,6 +10,4 @@
 #*******************************************************************************
 -include= jar:${fileuri;${repo;commons-io:commons-io;2.8.0;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
 
--includeresource: @${repo;commons-io:commons-io;2.8.0;EXACT}!/!META-INF/MANIFEST.MF|META-INF/maven/*
-
 -buildpath: commons-io:commons-io;strategy=exact;version=2.8.0

--- a/dev/com.ibm.ws.org.apache.commons.io/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.commons.io/bnd.overrides
@@ -14,3 +14,6 @@ org.apache.commons.io.input.buffer;version="2.8.0",org.apache.commons.io.input;v
 org.apache.commons.io.monitor;version="2.8.0",org.apache.commons.io.output;version="1.4.9999", \
 org.apache.commons.io.output;version="2.8.0",org.apache.commons.io.serialization;version="2.8.0", \
 org.apache.commons.io;version="2.8.0"
+
+Include-Resource: @${repo;commons-io:commons-io;2.8.0;EXACT}!/!META-INF/MANIFEST.MF|META-INF/maven/*
+

--- a/dev/com.ibm.ws.org.apache.commons.lang3/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.commons.lang3/bnd.bnd
@@ -10,7 +10,4 @@
 #*******************************************************************************
 -include= jar:${fileuri;${repo;org.apache.commons:commons-lang3;3.8;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
 
--includeresource: \
-   @${repo;org.apache.commons:commons-lang3;3.8;EXACT}!/!META-INF/maven/*
-
 -buildpath: org.apache.commons:commons-lang3;version=3.8

--- a/dev/com.ibm.ws.org.apache.commons.lang3/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.commons.lang3/bnd.overrides
@@ -2,3 +2,6 @@
 bVersion=1.0
 
 Bundle-SymbolicName: com.ibm.ws.org.apache.commons.lang3
+
+Include-Resource: \
+   @${repo;org.apache.commons:commons-lang3;3.8;EXACT}!/!META-INF/maven/*

--- a/dev/com.ibm.ws.org.apache.cxf.ws.mex/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.ws.mex/bnd.overrides
@@ -31,17 +31,6 @@ Import-Package: \
 DynamicImport-Package: org.apache.cxf.bus, \
  org.apache.cxf.*
 
-Include-Resource:\
- @build/tmp/lib/cxf-rt-ws-mex-2.6.2.jar!/META-INF/cxf/**, \
- @build/tmp/lib/cxf-rt-ws-mex-2.6.2.jar!/META-INF/DEPENDENCIES, \
- @build/tmp/lib/cxf-rt-ws-mex-2.6.2.jar!/META-INF/LICENSE, \
- @build/tmp/lib/cxf-rt-ws-mex-2.6.2.jar!/META-INF/NOTICE, \
- build/tmp/bnd/cxf-rt-ws-mex-2.6.2
-
--outputmask: com.ibm.ws.org.apache.cxf-rt-ws-mex.2.6.2.jar
-
-publish.wlp.jar.include: com.ibm.ws.org.apache.cxf-rt-ws-mex.2.6.2.jar
-
 Archiver-Version:
 Build-Jdk:
 Built-By:

--- a/dev/fattest.simplicity/bnd.bnd
+++ b/dev/fattest.simplicity/bnd.bnd
@@ -69,7 +69,7 @@ test.project: true
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
 	io.openliberty.jakarta.servlet.5.0;version=latest,\
 	org.eclipse.transformer:org.eclipse.transformer.cli;version=0.3.0.20211005,\
-	biz.aQute.bnd:biz.aQute.bnd.transform;version=5.3.0,\
+	biz.aQute.bnd:biz.aQute.bnd.transform;version=6.2.0,\
 	commons-cli:commons-cli;version=1.4,\
 	org.eclipse.transformer:org.eclipse.transformer;version=0.3.0.20211005,\
 	com.ibm.ws.common.encoder;version=latest,\

--- a/dev/gradle.properties
+++ b/dev/gradle.properties
@@ -13,7 +13,7 @@ bnd_cnf=cnf
 
 # bnd_plugin is the dependency declaration for the bnd gradle plugin
 #bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:+
-bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:5.3.0
+bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:6.2.0
 
 # The URL to the bnd build repo.
 bnd_repourl=https://repo1.maven.org/maven2
@@ -31,7 +31,7 @@ bnd_defaultTask=build
 bnd_preCompileRefresh=false
 
 # By default Gradle will reserve 1GB of heap space.
-# Very large builds might need more memory to hold Gradle’s model and caches.
+# Very large builds might need more memory to hold Gradle's model and caches.
 # Set file encoding to override the system encoding.
 org.gradle.jvmargs=-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 

--- a/dev/io.openliberty.org.apache.commons.codec/bnd.bnd
+++ b/dev/io.openliberty.org.apache.commons.codec/bnd.bnd
@@ -10,7 +10,4 @@
 #*******************************************************************************
 -include= jar:${fileuri;${repo;commons-codec:commons-codec;1.15}}!/META-INF/MANIFEST.MF,bnd.overrides
 
--includeresource: \
-   @${repo;commons-codec:commons-codec;1.15;EXACT}!/!META-INF/maven/*
-
 -buildpath: commons-codec:commons-codec;version=1.15

--- a/dev/io.openliberty.org.apache.commons.codec/bnd.overrides
+++ b/dev/io.openliberty.org.apache.commons.codec/bnd.overrides
@@ -2,3 +2,6 @@
 bVersion=1.15
 
 Bundle-SymbolicName: io.openliberty.org.apache.commons.codec
+
+Include-Resource: \
+   @${repo;commons-codec:commons-codec;1.15;EXACT}!/!META-INF/maven/*

--- a/dev/io.openliberty.org.apache.commons.logging/bnd.bnd
+++ b/dev/io.openliberty.org.apache.commons.logging/bnd.bnd
@@ -10,7 +10,4 @@
 #*******************************************************************************
 -include= jar:${fileuri;${repo;commons-logging:commons-logging;1.2}}!/META-INF/MANIFEST.MF,bnd.overrides
 
--includeresource: \
-   @${repo;commons-logging:commons-logging;1.2;EXACT}!/!META-INF/maven/*
-
 -buildpath: commons-logging:commons-logging;version=1.2

--- a/dev/io.openliberty.org.apache.commons.logging/bnd.overrides
+++ b/dev/io.openliberty.org.apache.commons.logging/bnd.overrides
@@ -2,3 +2,6 @@
 bVersion=1.2
 
 Bundle-SymbolicName: io.openliberty.org.apache.commons.logging
+
+Include-Resource: \
+   @${repo;commons-logging:commons-logging;1.2;EXACT}!/!META-INF/maven/*

--- a/dev/io.openliberty.org.eclipse.microprofile/bnd.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile/bnd.bnd
@@ -28,4 +28,4 @@ instrument.disabled: true
   com.ibm.websphere.javaee.cdi.2.0;version=latest,\
   com.ibm.websphere.javaee.interceptor.1.2;version=latest,\
   com.ibm.websphere.javaee.jaxrs.2.1;version=latest,\
-  biz.aQute.bnd:biz.aQute.bnd;version=5.3.0
+  biz.aQute.bnd:biz.aQute.bnd;version=6.2.0

--- a/dev/wlp-bndPlugins/bnd.bnd
+++ b/dev/wlp-bndPlugins/bnd.bnd
@@ -32,5 +32,5 @@ tool.project: true
 generate.replacement: false
 
 -buildpath: \
-	biz.aQute.bnd:biz.aQute.bnd;version=5.3.0,\
+	biz.aQute.bnd:biz.aQute.bnd;version=6.2.0,\
 	org.apache.aries:org.apache.aries.util;version=1.1.3

--- a/dev/wlp-featureTasks/bnd.bnd
+++ b/dev/wlp-featureTasks/bnd.bnd
@@ -29,5 +29,5 @@ generate.replacement: false
 	com.ibm.ws.kernel.boot.core;version=latest,\
 	com.ibm.ws.org.apache.ant;version=latest,\
 	com.ibm.ws.org.apache.aries.util;version=latest,\
-	biz.aQute.bnd:biz.aQute.bnd;version=5.3.0;packages=**,\
+	biz.aQute.bnd:biz.aQute.bnd;version=6.2.0;packages=**,\
 	com.ibm.ws.componenttest:infra.buildtasks-core;version=6.0.6

--- a/dev/wlp-gradle/biz.aQute.bnd.gradle
+++ b/dev/wlp-gradle/biz.aQute.bnd.gradle
@@ -42,12 +42,12 @@ subprojects {
     apply from: rootProject.file('wlp-gradle/subprojects/assemble.gradle')
 
     // Configure 'buildfat', 'runfat', 'buildandrun', and 'cleanFat' tasks.	
-    if (bndis('fat.project')) {
+    if (bnd.is('fat.project')) {
       apply from: rootProject.file('wlp-gradle/subprojects/fat.gradle')
 
     // Apply OSS Audit plugin to all non-test projects that output bundles.
     // See: https://github.com/OSSIndex/ossindex-gradle-plugin/blob/master/README.md
-    } else if (!bndis('test.project') && !bndProject.isNoBundles()) {
+    } else if (!bnd.is('test.project') && !bndProject.isNoBundles()) {
       apply plugin: 'net.ossindex.audit'
 
       audit {

--- a/dev/wlp-gradle/java.gradle
+++ b/dev/wlp-gradle/java.gradle
@@ -87,8 +87,7 @@ subprojects {
   }
 
   
-  tasks.withType(JavaCompile) {
-    doFirst {
+  tasks.withType(JavaCompile).configureEach({
       // javac 12 has a min target of 1.7, so upgrade any 1.6 projects to 1.7 if running on Java 12
       if (JavaVersion.current().isJava12Compatible()) {
         if ('1.6'.equals(sourceCompatibility)) {
@@ -103,10 +102,9 @@ subprojects {
           release = sourceCompatibility.substring(2);
         if('current'.equals(bnd('javac.args.release')))
           release = JavaVersion.current().getMajorVersion() 
-        options.compilerArgs.addAll([ '--release', release])
+        options.release = Integer.valueOf(release)
       }
-    }
-  }
+  })
 
   tasks.withType(Javadoc) {
     doFirst {

--- a/dev/wlp-gradle/java.gradle
+++ b/dev/wlp-gradle/java.gradle
@@ -64,7 +64,7 @@ subprojects {
           mkdir targetDir
           ant.taskdef(name: 'junitreport', 
                       classname: 'org.apache.tools.ant.taskdefs.optional.junit.XMLResultAggregator', 
-                      classpath: bnd('repo.junitReportTask.path'))
+                      classpath: bnd.get('repo.junitReportTask.path'))
 
           ant.junitreport(todir: targetDir) {
               fileset(dir: resultsDir, includes: 'TEST-*.xml')
@@ -96,11 +96,11 @@ subprojects {
         }
       }
       // For Java 9+ builds, set the --release compiler flag to keep bootclasspath in sync/ 
-      if(JavaVersion.current().isJava9Compatible() && !'off'.equals(bnd('javac.args.release'))) {
+      if(JavaVersion.current().isJava9Compatible() && !'off'.equals(bnd.get('javac.args.release'))) {
         def release = sourceCompatibility
         if(sourceCompatibility.startsWith('1.'))
           release = sourceCompatibility.substring(2);
-        if('current'.equals(bnd('javac.args.release')))
+        if('current'.equals(bnd.get('javac.args.release')))
           release = JavaVersion.current().getMajorVersion() 
         options.release = Integer.valueOf(release)
       }

--- a/dev/wlp-gradle/subprojects/anttaskdefs.gradle
+++ b/dev/wlp-gradle/subprojects/anttaskdefs.gradle
@@ -26,47 +26,47 @@
 rootProject.ext.rasInstrumentationInputFiles = { tasks.getByPath(':wlp-rasInstrumentation:jar') }
 rootProject.ext.rasInstrumentationTaskdef = { ant ->
     ant.taskdef(name: 'instrumentForTrace', classname: 'com.ibm.ws.ras.instrument.internal.buildtasks.InstrumentForTrace',
-                classpath: bnd('repo.rasInstrumentation.path'))
+                classpath: bnd.get('repo.rasInstrumentation.path'))
     ant.taskdef(name: 'instrumentWithFFDC', classname: 'com.ibm.ws.ras.instrument.internal.buildtasks.InstrumentWithFFDC',
-                classpath: bnd('repo.rasInstrumentation.path'))
+                classpath: bnd.get('repo.rasInstrumentation.path'))
 }
 
 rootProject.ext.generateChecksums = { ant ->
     ant.taskdef(name: 'calcChecksums', classname: 'com.ibm.ws.wlp.cs.GenerateChecksums',
-                classpath: bnd('repo.generateChecksums.path'))
+                classpath: bnd.get('repo.generateChecksums.path'))
 }
 
 rootProject.ext.generateZipChecksums = { ant ->
     ant.taskdef(name: 'calcZipChecksums', classname: 'com.ibm.ws.wlp.cs.GenerateZipChecksums',
-                classpath: bnd('repo.generateChecksums.path'))
+                classpath: bnd.get('repo.generateChecksums.path'))
 }
 
 rootProject.ext.nlsTaskdef = { ant ->
     ant.taskdef(resource: 'com/ibm/mantis/nls/antlib.xml',
-                classpath: bnd('repo.nlsTasks.path'))
+                classpath: bnd.get('repo.nlsTasks.path'))
 }
 
 rootProject.ext.portSelectorTaskdef = { ant ->
     ant.taskdef(name: 'portSelector', classname: 'com.ibm.aries.buildtasks.PortSelector',
-                classpath: bnd('repo.portSelector.path'))
+                classpath: bnd.get('repo.portSelector.path'))
 }
 
 rootProject.ext.featureBndTaskdef = { ant ->
     ant.taskdef(resource: 'com/ibm/ws/wlp/feature/tasks/default.properties',
-                classpath: bnd('repo.featureTasks.path'))
+                classpath: bnd.get('repo.featureTasks.path'))
 }
 
 rootProject.ext.repositoryContentTaskdef = { ant ->
     ant.taskdef(resource: 'com/ibm/ws/wlp/repository/default.properties',
-                classpath: bnd('repo.generateRepositoryContent.path'))
+                classpath: bnd.get('repo.generateRepositoryContent.path'))
 }
 
 rootProject.ext.repositoryGeneratorTaskdef = { ant ->
     ant.taskdef(resource: 'com/ibm/ws/repository/generator/default.properties',
-                classpath: bnd('repo.repositoryGenerator.path'))
+                classpath: bnd.get('repo.repositoryGenerator.path'))
 }
 
 rootProject.ext.mavenRepoTaskdef = { ant ->
     ant.taskdef(resource: 'com/ibm/ws/wlp/mavenFeatures/default.properties',
-                classpath: bnd('repo.mavenRepoTasks.path'))
+                classpath: bnd.get('repo.mavenRepoTasks.path'))
 }

--- a/dev/wlp-gradle/subprojects/assemble.gradle
+++ b/dev/wlp-gradle/subprojects/assemble.gradle
@@ -16,20 +16,20 @@
  *
  * Configure 'assemble' to depend on above tasks.
  */
-def publishWlpJarDefault = parseBoolean(bnd('test.project', 'false')) ? 'true' : 'false'
-if (bnd('publish.tool.jar', '').empty && !parseBoolean(bnd('publish.wlp.jar.disabled', publishWlpJarDefault))) {
+def publishWlpJarDefault = parseBoolean(bnd.get('test.project', 'false')) ? 'true' : 'false'
+if (bnd.get('publish.tool.jar', '').empty && !parseBoolean(bnd.get('publish.wlp.jar.disabled', publishWlpJarDefault))) {
     task publishWLPJars(type: Copy) {
         dependsOn jar
-        if ( parseBoolean( bnd('jakartaeeMe', 'true'))) {
+        if ( parseBoolean( bnd.get('jakartaeeMe', 'true'))) {
             dependsOn jakartaeeTransform
         }
         from project.buildDir
-        into buildImage.file('wlp/' + bnd('publish.wlp.jar.suffix', 'lib'))
-        include bnd('publish.wlp.jar.include', '*.jar')
+        into buildImage.file('wlp/' + bnd.get('publish.wlp.jar.suffix', 'lib'))
+        include bnd.get('publish.wlp.jar.include', '*.jar')
         def hasIFIXHeaders = [:]
         def fullVersions = [:]
-        if (parseBoolean(bnd('publish.wlp.jar.rename', 'true'))) {
-            def outerSymbolicName = bnd('Bundle-SymbolicName', project.name)
+        if (parseBoolean(bnd.get('publish.wlp.jar.rename', 'true'))) {
+            def outerSymbolicName = bnd.get('Bundle-SymbolicName', project.name)
             if (outerSymbolicName != null) {
                 int index = outerSymbolicName.indexOf(";")
                 if (index != -1) {
@@ -39,14 +39,14 @@ if (bnd('publish.tool.jar', '').empty && !parseBoolean(bnd('publish.wlp.jar.disa
 
             // store the full version information for the outer project from
             // the projects bnd.bnd file.  
-            def outerVersion = bnd('bVersion')
-            def outerFullVersion = bnd('bFullVersion')
+            def outerVersion = bnd.get('bVersion')
+            def outerFullVersion = bnd.get('bFullVersion')
             fullVersions.put(outerSymbolicName, outerFullVersion)
 
             // iFixed jars should get renamed with a qualifier so they can exist in the filesystem
             // next to the base version of the jar, *except* for jars that are directly
             // referenced in a tool script's classpath...
-            if (((!bnd('IBM-Interim-Fixes', '').empty) || (!bnd('IBM-Test-Fixes', '').empty))
+            if (((!bnd.get('IBM-Interim-Fixes', '').empty) || (!bnd.get('IBM-Test-Fixes', '').empty))
                     && (!project.name.equals("com.ibm.ws.kernel.boot"))
                     && (!project.name.equals("com.ibm.ws.kernel.boot.archive"))
                     && (!project.name.equals("com.ibm.ws.appclient.boot"))
@@ -54,8 +54,8 @@ if (bnd('publish.tool.jar', '').empty && !parseBoolean(bnd('publish.wlp.jar.disa
                 hasIFIXHeaders.put(outerSymbolicName, true)
             }
 
-            if (!bnd('-sub', '').empty) {
-                fileTree(dir: projectDir, include: bnd('-sub', '')).each { subBndFile ->
+            if (!bnd.get('-sub', '').empty) {
+                fileTree(dir: projectDir, include: bnd.get('-sub', '')).each { subBndFile ->
                     Properties subBndProperties = new Properties()
                     subBndFile.withInputStream { subBndProperties.load(it) }
                     def symbolicName = subBndProperties.getProperty("Bundle-SymbolicName")
@@ -95,7 +95,7 @@ if (bnd('publish.tool.jar', '').empty && !parseBoolean(bnd('publish.wlp.jar.disa
 
                 def selectedSymbolicName = symbolicName
                 // If the jar is jakartaee transformed, then see if the pre-transformed bundle has iFix headers.
-                if (it.getSourceName().equals(bnd('jakartaFinalJarName', '')) || symbolicName.endsWith(".jakarta")) {
+                if (it.getSourceName().equals(bnd.get('jakartaFinalJarName', '')) || symbolicName.endsWith(".jakarta")) {
                     selectedSymbolicName = outerSymbolicName
                 }
                     
@@ -110,38 +110,38 @@ if (bnd('publish.tool.jar', '').empty && !parseBoolean(bnd('publish.wlp.jar.disa
     assemble.dependsOn publishWLPJars
 }
 
-if (bnd('publish.wlp.jar.suffix', 'lib').contains('api/ibm') || bnd('publish.wlp.jar.suffix', 'lib').contains('spi/ibm')) {
+if (bnd.get('publish.wlp.jar.suffix', 'lib').contains('api/ibm') || bnd.get('publish.wlp.jar.suffix', 'lib').contains('spi/ibm')) {
     task publishJavadoc(type: Copy) {
         dependsOn zipJavadoc
         from new File(project.buildDir, 'distributions')
-        include bnd('publish.wlp.javadoc.include', '*javadoc.zip')
-        into rootProject.file("build.image/wlp/" + bnd('publish.wlp.jar.suffix', 'lib') + "/javadoc")
+        include bnd.get('publish.wlp.javadoc.include', '*javadoc.zip')
+        into rootProject.file("build.image/wlp/" + bnd.get('publish.wlp.jar.suffix', 'lib') + "/javadoc")
         rename '.javadoc.zip', "_${bnd.bVersion}-javadoc.zip"
     }
     assemble.dependsOn publishJavadoc
 }
 
 task publishToolScripts(type: Copy) {
-    enabled !bnd('publish.tool.script', '').empty
+    enabled !bnd.get('publish.tool.script', '').empty
     dependsOn jar
     from cnf.file('resources/bin')
-    into buildImage.file('wlp/bin/' + bnd('publish.tool.script.subdir', ''))
+    into buildImage.file('wlp/bin/' + bnd.get('publish.tool.script.subdir', ''))
     fileMode 0755
-    rename 'tool(.*)', bnd('publish.tool.script') + '$1'
+    rename 'tool(.*)', bnd.get('publish.tool.script') + '$1'
     filter(org.apache.tools.ant.filters.ReplaceTokens,
-            tokens: [TOOL_JAR: bnd('publish.tool.script.subdir', '') + 'tools/' + bnd('publish.tool.jar', ''),
-                    TOOL_SCRIPT: bnd('publish.tool.script.subdir', '') + bnd('publish.tool.script', ''),
-                    TOOL_SCRIPT_DIR_LENGTH: bnd('publish.tool.script.dir.length', '5'),
-                    TOOL_SCRIPT_RELATIVE: bnd('publish.tool.script.relative', '')])
+            tokens: [TOOL_JAR: bnd.get('publish.tool.script.subdir', '') + 'tools/' + bnd.get('publish.tool.jar', ''),
+                    TOOL_SCRIPT: bnd.get('publish.tool.script.subdir', '') + bnd.get('publish.tool.script', ''),
+                    TOOL_SCRIPT_DIR_LENGTH: bnd.get('publish.tool.script.dir.length', '5'),
+                    TOOL_SCRIPT_RELATIVE: bnd.get('publish.tool.script.relative', '')])
 }
 
 task publishToolJars(type: Copy) {
-    enabled !bnd('publish.tool.jar', '').empty
+    enabled !bnd.get('publish.tool.jar', '').empty
     dependsOn jar
     dependsOn publishToolScripts
     from project.buildDir
-    into buildImage.file('wlp/bin/' + bnd('publish.tool.script.subdir', '') + 'tools')
-    include bnd('publish.tool.jar', '')
+    into buildImage.file('wlp/bin/' + bnd.get('publish.tool.script.subdir', '') + 'tools')
+    include bnd.get('publish.tool.jar', '')
 }
 assemble.dependsOn publishToolJars
 
@@ -185,7 +185,7 @@ task publishBinScripts(type: Copy) {
 }
 assemble.dependsOn publishBinScripts
 
-if (parseBoolean(bnd('publish.wlp.clients', 'true'))) {
+if (parseBoolean(bnd.get('publish.wlp.clients', 'true'))) {
     task publishClientScripts(type: Copy) {
         dependsOn jar
         from project.file('publish/clients')

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -54,7 +54,7 @@ dependencies {
 		'org.apache.derby:derby:10.11.1.1',
 		'com.oracle.database.jdbc.debug:ojdbc8_g:21.1.0.0'
 
-  jakartaTransformer 'biz.aQute.bnd:biz.aQute.bnd.transform:5.3.0',
+  jakartaTransformer 'biz.aQute.bnd:biz.aQute.bnd.transform:6.2.0',
        'commons-cli:commons-cli:1.4',
        project(':com.ibm.ws.org.slf4j.api'),
        project(':com.ibm.ws.org.slf4j.simple'),

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -212,9 +212,9 @@ task autoFVT {
     }
 
     // Check for minimum java level for test execution:
-    def minJavaLevel = bnd('fat.minimum.java.level', bnd('javac.source'))
+    def minJavaLevel = bnd.get('fat.minimum.java.level', bnd.get('javac.source'))
     bndProps.setProperty('fat.minimum.java.level', minJavaLevel)
-    bndProps.setProperty('micro.version', bnd('libertyBundleMicroVersion'))
+    bndProps.setProperty('micro.version', bnd.get('libertyBundleMicroVersion'))
 
     File bndPropsFile = new File(autoFvtDir, 'fat.bnd.properties')
     def bndWriter = new FileWriter(bndPropsFile)
@@ -308,7 +308,7 @@ task autoFVT {
     // Produce a list of features tested by this FAT
     def featureDeps = [] as Set
     // Include features added explictly via bnd.bnd
-    def testedFeatures = bnd('tested.features')
+    def testedFeatures = bnd.get('tested.features')
     if(testedFeatures != null)
       testedFeatures.split(',').each{ featureDeps.add(it.trim().toLowerCase()) }
     // Scan publish/ dir for features

--- a/dev/wlp-gradle/subprojects/tasks.gradle
+++ b/dev/wlp-gradle/subprojects/tasks.gradle
@@ -154,7 +154,7 @@ if ( parseBoolean( bnd('jakartaeeMe', 'false'))) {
   }
 
   dependencies {
-    jakartaeeTransformJars 'biz.aQute.bnd:biz.aQute.bnd.transform:5.3.0',
+    jakartaeeTransformJars 'biz.aQute.bnd:biz.aQute.bnd.transform:6.2.0',
                             'commons-cli:commons-cli:1.4',
                             'org.slf4j:slf4j-api:1.7.36',
                             'org.slf4j:slf4j-simple:1.7.36',

--- a/dev/wlp-gradle/subprojects/tasks.gradle
+++ b/dev/wlp-gradle/subprojects/tasks.gradle
@@ -15,15 +15,15 @@
 defaultTasks 'clean', 'build'
 
 // Project version is the Bundle-Version attribute if a bundle gets released, otherwise the version is the buildID.
-project.version = bnd('Bundle-Version', bnd.buildID)
+project.version = bnd.get('Bundle-Version', bnd.buildID)
 jar {
   version=null
 }
 
-if (parseBoolean(bnd('globalize', 'true'))) {
+if (parseBoolean(bnd.get('globalize', 'true'))) {
   task globalize {
     // Exclude messages from quotation validation if explicitly excluded via bnd.bnd
-    def quotationExcludes = bnd('globalize.quotation.excludes')
+    def quotationExcludes = bnd.get('globalize.quotation.excludes')
 
     ext.destinationDir = new File(buildDir, "src/${name}/java")
 
@@ -132,7 +132,7 @@ if (parseBoolean(bnd('globalize', 'true'))) {
   }
 }
 
-if (parseBoolean(bnd('copy.pii', 'true'))) {
+if (parseBoolean(bnd.get('copy.pii', 'true'))) {
   task copyPiiFiles(type: Copy) {
     ext.destinationDir = rootProject.file("build.pii.package/nlssrc/${project.name}")
     from project.file('resources')
@@ -148,7 +148,7 @@ if (parseBoolean(bnd('copy.pii', 'true'))) {
   task copyPiiFiles { }
 }
 
-if ( parseBoolean( bnd('jakartaeeMe', 'false'))) {
+if ( parseBoolean( bnd.get('jakartaeeMe', 'false'))) {
   configurations {
     jakartaeeTransformJars
   }
@@ -186,7 +186,7 @@ if ( parseBoolean( bnd('jakartaeeMe', 'false'))) {
         def finalBundleJarName = initialBundleJarName.replaceAll( '.jar', '.jakarta.jar' )
         println 'Default jakarta final bundle jar name [ ' + finalBundleJarName + ' ]'
 
-        def localBundleJarName = bnd('jakartaFinalJarName')
+        def localBundleJarName = bnd.get('jakartaFinalJarName')
         if ( (localBundleJarName != null) && !localBundleJarName.isEmpty() ) {
           println 'Local jakarta final bundle jar name [ ' + localBundleJarName + ' ]'
           println 'Ignoring default jakarta final bundle jar name'
@@ -228,7 +228,7 @@ if ( parseBoolean( bnd('jakartaeeMe', 'false'))) {
             def localOption = localEntry[1]
 
             def bndProperty = 'jakartaLocal' + localName
-            def localAddition = bnd(bndProperty)
+            def localAddition = bnd.get(bndProperty)
 
             if ( (localAddition == null) || localAddition.isEmpty() ) {
                 println 'BND [ ' + bndProperty + ' ] is not set'
@@ -247,31 +247,31 @@ if ( parseBoolean( bnd('jakartaeeMe', 'false'))) {
             }
         }
 
-        def finalBundleId = bnd('jakartaFinalBundleId')
+        def finalBundleId = bnd.get('jakartaFinalBundleId')
         if ( (finalBundleId != null) && !finalBundleId.isEmpty() ) {
           println 'BND jakartaFinalBundleId [ ' + finalBundleId + ' ]'
 
-          def initialBundleId = bnd('Bundle-SymbolicName', project.name)
+          def initialBundleId = bnd.get('Bundle-SymbolicName', project.name)
           int index = initialBundleId.indexOf(";")
           if (index != -1) {
             initialBundleId = initialBundleId.substring(0, index)
           }
 
-          def finalBundleVersion = bnd('jakartaFinalBundleVersion')
+          def finalBundleVersion = bnd.get('jakartaFinalBundleVersion')
           if (finalBundleVersion == null) {
             finalBundleVersion = ''
           }
           println 'BND jakartaFinalBundleVersion [ ' + finalBundleVersion + ' ]'
 
-          def finalBundleShortName = bnd('jakartaFinalBundleName')
+          def finalBundleShortName = bnd.get('jakartaFinalBundleName')
           if ( (finalBundleShortName == null) || finalBundleShortName.isEmpty() ) {
-            finalBundleShortName = bnd('Bundle-Name')
+            finalBundleShortName = bnd.get('Bundle-Name')
           }
           println 'BND jakartaFinalBundleName [ ' + finalBundleShortName + ' ]'
 
-          def finalBundleDescription = bnd('jakartaFinalBundleDescription')
+          def finalBundleDescription = bnd.get('jakartaFinalBundleDescription')
           if ( (finalBundleDescription == null) || finalBundleDescription.isEmpty() ) {
-            finalBundleDescription = bnd('Bundle-Description')
+            finalBundleDescription = bnd.get('Bundle-Description')
           }
           println 'BND jakartaFinalBundleDescription [ ' + finalBundleDescription + ' ]'
 
@@ -309,21 +309,21 @@ if ( parseBoolean( bnd('jakartaeeMe', 'false'))) {
 }
 
 compileJava {
-  if (!parseBoolean(bnd('instrument.disabled', 'false'))) {
+  if (!parseBoolean(bnd.get('instrument.disabled', 'false'))) {
     inputs.files { rasInstrumentationInputFiles() }
     outputs.dir compileJava.destinationDir
-    def instrument = fileTree(dir: compileJava.destinationDir, include: bnd('instrument.classesIncludes').split("\\s*,\\s*"), exclude: bnd('instrument.classesExcludes').split("\\s*,\\s*"))
+    def instrument = fileTree(dir: compileJava.destinationDir, include: bnd.get('instrument.classesIncludes').split("\\s*,\\s*"), exclude: bnd.get('instrument.classesExcludes').split("\\s*,\\s*"))
     doLast {
       if (instrument.isEmpty())
         return
       rasInstrumentationTaskdef(ant)
-      ant.instrumentForTrace(ffdc: bnd('instrument.ffdc'), taskInjection: bnd('instrument.taskInjection')) {
-        fileset(dir: compileJava.destinationDir, includes: bnd('instrument.classesIncludes'), excludes: bnd('instrument.classesExcludes'))
+      ant.instrumentForTrace(ffdc: bnd.get('instrument.ffdc'), taskInjection: bnd.get('instrument.taskInjection')) {
+        fileset(dir: compileJava.destinationDir, includes: bnd.get('instrument.classesIncludes'), excludes: bnd.get('instrument.classesExcludes'))
       }
     }
   }
 
-  if (parseBoolean(bnd('globalize', 'true'))) {
+  if (parseBoolean(bnd.get('globalize', 'true'))) {
     dependsOn globalize
   }
 
@@ -382,7 +382,7 @@ task buildfat {
   group = "build"
 }
 
-if (bnd('publish.wlp.jar.suffix', 'lib').contains('api/ibm') || bnd('publish.wlp.jar.suffix', 'lib').contains('spi/ibm')) {
+if (bnd.get('publish.wlp.jar.suffix', 'lib').contains('api/ibm') || bnd.get('publish.wlp.jar.suffix', 'lib').contains('spi/ibm')) {
   task apiSpiJavadoc(type: Javadoc) {
     dependsOn jar
 
@@ -403,7 +403,7 @@ if (bnd('publish.wlp.jar.suffix', 'lib').contains('api/ibm') || bnd('publish.wlp
     classpath += cp
     source = sp
 
-    include bnd('Export-Package', '').split(',').collect {
+    include bnd.get('Export-Package', '').split(',').collect {
       def pkg = it
       int index = pkg.indexOf(";")
       if (index != -1) {
@@ -414,8 +414,8 @@ if (bnd('publish.wlp.jar.suffix', 'lib').contains('api/ibm') || bnd('publish.wlp
       return pkg
     }
     exclude "**/internal/**"
-    title = bnd('Bundle-Name')
-    options.source bnd('javac.source')
+    title = bnd.get('Bundle-Name')
+    options.source bnd.get('javac.source')
     options.memberLevel = 'PUBLIC'
     options.noIndex true
     options.use true
@@ -426,18 +426,18 @@ if (bnd('publish.wlp.jar.suffix', 'lib').contains('api/ibm') || bnd('publish.wlp
 
   task zipJavadoc(type: Zip) {
     dependsOn apiSpiJavadoc
-    archiveName bnd('Bundle-SymbolicName', project.name) + '.javadoc.zip'
+    archiveName bnd.get('Bundle-SymbolicName', project.name) + '.javadoc.zip'
     from new File(project.buildDir, "javadoc")
 
     doLast {
-      if ( parseBoolean( bnd('jakartaeeMe', 'true'))) {
-        def initialJavadocZipName = project.buildDir.path + '/distributions/' + bnd('Bundle-SymbolicName', project.name) + '.javadoc.zip'
+      if ( parseBoolean( bnd.get('jakartaeeMe', 'true'))) {
+        def initialJavadocZipName = project.buildDir.path + '/distributions/' + bnd.get('Bundle-SymbolicName', project.name) + '.javadoc.zip'
         println 'Initial javadoc zip name [ ' + initialJavadocZipName + ' ]'
 
         def finalJavadocZipName = initialJavadocZipName.replaceAll( '.javadoc.zip', '.jakarta.javadoc.zip' )
         println 'Default jakarta javadoc zip name [ ' + finalJavadocZipName + ' ]'
 
-        def finalBundleId = bnd('jakartaFinalBundleId')
+        def finalBundleId = bnd.get('jakartaFinalBundleId')
         if ( (finalBundleId != null) && !finalBundleId.isEmpty() ) {
           finalJavadocZipName = project.buildDir.path + '/distributions/' + finalBundleId + '.javadoc.zip'
         }

--- a/dev/wlp-gradle/subprojects/tasks.gradle
+++ b/dev/wlp-gradle/subprojects/tasks.gradle
@@ -309,26 +309,31 @@ if ( parseBoolean( bnd.get('jakartaeeMe', 'false'))) {
 }
 
 compileJava {
-  if (!parseBoolean(bnd.get('instrument.disabled', 'false'))) {
-    inputs.files { rasInstrumentationInputFiles() }
-    outputs.dir compileJava.destinationDir
-    def instrument = fileTree(dir: compileJava.destinationDir, include: bnd.get('instrument.classesIncludes').split("\\s*,\\s*"), exclude: bnd.get('instrument.classesExcludes').split("\\s*,\\s*"))
-    doLast {
-      if (instrument.isEmpty())
-        return
-      rasInstrumentationTaskdef(ant)
-      ant.instrumentForTrace(ffdc: bnd.get('instrument.ffdc'), taskInjection: bnd.get('instrument.taskInjection')) {
-        fileset(dir: compileJava.destinationDir, includes: bnd.get('instrument.classesIncludes'), excludes: bnd.get('instrument.classesExcludes'))
-      }
-    }
-  }
-
   if (parseBoolean(bnd.get('globalize', 'true'))) {
     dependsOn globalize
   }
 
   options.warnings = false
   options.fork = true
+}
+
+if (!parseBoolean(bnd.get('instrument.disabled', 'false'))) {
+  task instrument {
+    dependsOn compileJava
+    inputs.files { rasInstrumentationInputFiles() }
+    outputs.dir compileJava.destinationDir
+    def instrument = fileTree(dir: compileJava.destinationDir, include: bnd.get('instrument.classesIncludes').split("\\s*,\\s*"), exclude: bnd.get('instrument.classesExcludes').split("\\s*,\\s*"))
+    doLast {
+      if (!instrument.isEmpty()) {
+        rasInstrumentationTaskdef(ant)
+        ant.instrumentForTrace(ffdc: bnd.get('instrument.ffdc'), taskInjection: bnd.get('instrument.taskInjection')) {
+          fileset(dir: compileJava.destinationDir, includes: bnd.get('instrument.classesIncludes'), excludes: bnd.get('instrument.classesExcludes'))
+        }
+      }
+    }
+  }
+
+  jar.dependsOn(instrument)
 }
 
 test {


### PR DESCRIPTION
- Update to bndtools 6.2.0
- Change to use bnd methods instead of bnd() and bndis().  This was changed in 6.0 and old removed in 7.0 likely.
- Switch from using -includeresource to Include-Resource in the bnd.overrides due to Include-Resource being in apache Manfiest files.  This is required due to change in bndtools 6.2.0
- Change on how we configure the compiler.release option to work
- Change destinationDir to destinationDirectory due to change of argument name.
- Clean up non existent Include-Resource properties that are errors now in the new version of bndtools
-  Update instrumentation logic so it works correctly
- With the new version of bndtools, the instrumentation wasn't happening for the io.openliberty.org.jboss.resteasy.common project like it was previously.
- With the change now com.ibm.ws.org.opensaml.opensaml is actually instrumenting correctly as well.