### PR TITLE
Reject Concurrent Asynch on EJBs

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta/.classpath
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/.classpath
@@ -3,6 +3,8 @@
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/ConcurrencyTestEJB/src"/>
 	<classpathentry kind="src" path="test-applications/ConcurrencyTestWeb/src"/>
+	<classpathentry kind="src" path="test-applications/ConcurrencyJSPTestApp/src"/>
+	<classpathentry kind="src" path="test-applications/ConcurrencyTestError/src"/>
 	<classpathentry kind="src" path="test-libraries/LocationUtils/src"/>
 	<classpathentry kind="src" path="test-libraries/PriorityContext/src"/>
 	<classpathentry kind="src" path="test-libraries/StatUtils/src"/>

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/bnd.bnd
@@ -15,6 +15,7 @@ src: \
 	fat/src,\
 	test-applications/ConcurrencyTestEJB/src,\
 	test-applications/ConcurrencyTestWeb/src,\
+	test-applications/ConcurrencyTestError/src,\
 	test-applications/ConcurrencyJSPTestApp/src,\
 	test-libraries/LocationUtils/src,\
 	test-libraries/PriorityContext/src,\

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/fat/src/test/jakarta/concurrency/ConcurrencyErrorTest.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/fat/src/test/jakarta/concurrency/ConcurrencyErrorTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package test.jakarta.concurrency;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -31,12 +31,14 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
+import test.jakarta.concurrency.ejb.error.AsynchClassBean;
 import test.jakarta.concurrency.ejb.error.AsynchInterfaceBean;
 import test.jakarta.concurrency.ejb.error.AsynchInterfaceLocal;
 import test.jakarta.concurrency.ejb.error.GenericAsynchBean;
 import test.jakarta.concurrency.ejb.error.GenericLocal;
 import test.jakarta.concurrency.web.error.ConcurrencyBeanErrorServlet;
-import test.jakarta.concurrency.web.error.ConcurrentInterfaceWarningServlet;
+import test.jakarta.concurrency.web.error.ConcurrencyClassErrorServlet;
+import test.jakarta.concurrency.web.error.ConcurrencyInterfaceWarningServlet;
 
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 11)
@@ -44,39 +46,53 @@ public class ConcurrencyErrorTest extends FATServletClient {
 
     public static final String APP_NAME_1 = "AppInterfaceWarning";
     public static final String APP_NAME_2 = "AppBeanError";
+    public static final String APP_NAME_3 = "AppClassError";
 
     public static final String WAR_NAME_1 = "WebInterfaceWarning";
     public static final String WAR_NAME_2 = "WebBeanError";
+    public static final String WAR_NAME_3 = "WebClassError";
 
     @Server("com.ibm.ws.concurrent.fat.jakarta.error")
     public static LibertyServer server;
 
     private static EnterpriseArchive AppInterfaceWarning;
     private static EnterpriseArchive AppBeanError;
+    private static EnterpriseArchive AppClassError;
 
     @BeforeClass
     public static void setUp() throws Exception {
         //Web archive for interface warning
         WebArchive WebInterfaceWarning = ShrinkHelper.buildDefaultApp("WebInterfaceWarning", "test.jakarta.concurrency.web.error")
-                        .deleteClass(ConcurrencyBeanErrorServlet.class);
+                        .deleteClasses(ConcurrencyBeanErrorServlet.class, ConcurrencyClassErrorServlet.class);
 
         //Web archive for bean error
         WebArchive WebBeanError = ShrinkHelper.buildDefaultApp("WebBeanError", "test.jakarta.concurrency.web.error")
-                        .deleteClass(ConcurrentInterfaceWarningServlet.class);
+                        .deleteClasses(ConcurrencyInterfaceWarningServlet.class, ConcurrencyClassErrorServlet.class);
+
+        //Web archive for class bean error
+        WebArchive WebClassError = ShrinkHelper.buildDefaultApp("WebClassError", "test.jakarta.concurrency.web.error")
+                        .deleteClasses(ConcurrencyInterfaceWarningServlet.class, ConcurrencyBeanErrorServlet.class);
 
         //EJB where asynch methods are on the interface
         JavaArchive EJBInterfaceWarning = ShrinkHelper.buildJavaArchive("EJBInterfaceWarning", "test.jakarta.concurrency.ejb.error")
-                        .deleteClasses(GenericAsynchBean.class, GenericLocal.class);
+                        .deleteClasses(GenericAsynchBean.class, GenericLocal.class, AsynchClassBean.class);
 
         //EJB where asynch methods are on the bean
         JavaArchive EJBBeanError = ShrinkHelper.buildJavaArchive("EJBBeanError", "test.jakarta.concurrency.ejb.error")
-                        .deleteClasses(AsynchInterfaceBean.class, AsynchInterfaceLocal.class);
+                        .deleteClasses(AsynchInterfaceBean.class, AsynchInterfaceLocal.class, AsynchClassBean.class);
+
+        //EJB where asynch methods are on the class
+        JavaArchive EJBClassError = ShrinkHelper.buildJavaArchive("EJBClassError", "test.jakarta.concurrency.ejb.error")
+                        .deleteClasses(AsynchInterfaceBean.class, AsynchInterfaceLocal.class, GenericAsynchBean.class);
 
         AppInterfaceWarning = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME_1 + ".ear");
         AppInterfaceWarning.addAsModules(WebInterfaceWarning, EJBInterfaceWarning);
 
         AppBeanError = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME_2 + ".ear");
         AppBeanError.addAsModules(WebBeanError, EJBBeanError);
+
+        AppClassError = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME_3 + ".ear");
+        AppClassError.addAsModules(WebClassError, EJBClassError);
 
         server.startServer();
 
@@ -87,15 +103,15 @@ public class ConcurrencyErrorTest extends FATServletClient {
         runTest(server, WAR_NAME_1, "testMethod");
 
         //App checker should log a warning, not an error.
-        assertNull(server.waitForStringInTraceUsingMark("CNTR9426E"));
-        assertNotNull(server.waitForStringInTraceUsingMark("CNTR9427W"));
+        assertNull(server.waitForStringInTraceUsingMark("CNTR0342E"));
+        assertNotNull(server.waitForStringInTraceUsingMark("CNTR0343W"));
     }
 
     @AfterClass
     public static void tearDown() throws Exception {
         if (server.isStarted()) {
-            server.stopServer("CNTR9427W", //Warning Jakarta Concurrent Asynchronous on EJB Interface method
-                              "CNTR9426E", //Error Jakarta Concurrent Asynchronous on EJB method
+            server.stopServer("CNTR0343W", //Warning Jakarta Concurrent Asynchronous on EJB Interface method
+                              "CNTR0342E", //Error Jakarta Concurrent Asynchronous on EJB method
                               "CNTR0020E" //Generic EJB threw an exception
             );
         }
@@ -111,17 +127,48 @@ public class ConcurrencyErrorTest extends FATServletClient {
         server.setTraceMarkToEndOfDefaultTrace();
         ShrinkHelper.exportDropinAppToServer(server, AppBeanError);
 
+        boolean testRan = false;
+
         //Attempt to use application
         try {
             runTest(server, WAR_NAME_2, "testMethod");
-            fail("Should not have been able to connect to servlet.");
+            testRan = true;
         } catch (AssertionError e) {
             //Expected
         }
 
+        assertFalse("Test application should not have been installed and allowed to run.", testRan);
+
         //MethodAttribUtils should have thrown and error, not a warning.
-        assertNotNull(server.waitForStringInTraceUsingMark("CNTR9426E"));
-        assertNull(server.waitForStringInTraceUsingMark("CNTR9427W"));
+        assertNotNull(server.waitForStringInTraceUsingMark("CNTR0342E"));
+        assertNull(server.waitForStringInTraceUsingMark("CNTR0343W"));
+    }
+
+    @Test
+    @ExpectedFFDC({ "com.ibm.ejs.container.EJBConfigurationException", //Root exception thrown by EJB Container
+                    "jakarta.ejb.EJBException", //caused by EJBConfigurationException and thrown to injectionengine
+                    "com.ibm.wsspi.injectionengine.InjectionException", //caused by EJBException and thrown to Servlet
+                    "jakarta.servlet.UnavailableException", //caused by InjectionException
+    })
+    public void testClassApplicationFailsToInstall() throws Exception {
+        server.setTraceMarkToEndOfDefaultTrace();
+        ShrinkHelper.exportDropinAppToServer(server, AppClassError);
+
+        boolean testRan = false;
+
+        //Attempt to use application
+        try {
+            runTest(server, WAR_NAME_3, "testMethod");
+            testRan = true;
+        } catch (AssertionError e) {
+            //Expected
+        }
+
+        assertFalse("Test application should not have been installed and allowed to run.", testRan);
+
+        //MethodAttribUtils should have thrown and error, not a warning.
+        assertNotNull(server.waitForStringInTraceUsingMark("CNTR0342E"));
+        assertNull(server.waitForStringInTraceUsingMark("CNTR0343W"));
     }
 
     @Test

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/fat/src/test/jakarta/concurrency/ConcurrencyErrorTest.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/fat/src/test/jakarta/concurrency/ConcurrencyErrorTest.java
@@ -95,7 +95,8 @@ public class ConcurrencyErrorTest extends FATServletClient {
     public static void tearDown() throws Exception {
         if (server.isStarted()) {
             server.stopServer("CNTR9427W", //Warning Jakarta Concurrent Asynchronous on EJB Interface method
-                              "CNTR9426E" //Error Jakarta Concurrent Asynchronous on EJB method
+                              "CNTR9426E", //Error Jakarta Concurrent Asynchronous on EJB method
+                              "CNTR0020E" //Generic EJB threw an exception
             );
         }
     }

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/fat/src/test/jakarta/concurrency/ConcurrencyErrorTest.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/fat/src/test/jakarta/concurrency/ConcurrencyErrorTest.java
@@ -1,0 +1,148 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.concurrency;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import test.jakarta.concurrency.ejb.error.AsynchInterfaceBean;
+import test.jakarta.concurrency.ejb.error.AsynchInterfaceLocal;
+import test.jakarta.concurrency.ejb.error.GenericAsynchBean;
+import test.jakarta.concurrency.ejb.error.GenericLocal;
+import test.jakarta.concurrency.web.error.ConcurrencyBeanErrorServlet;
+import test.jakarta.concurrency.web.error.ConcurrentInterfaceWarningServlet;
+
+@RunWith(FATRunner.class)
+@MinimumJavaLevel(javaLevel = 11)
+public class ConcurrencyErrorTest extends FATServletClient {
+
+    public static final String APP_NAME_1 = "AppInterfaceWarning";
+    public static final String APP_NAME_2 = "AppBeanError";
+
+    public static final String WAR_NAME_1 = "WebInterfaceWarning";
+    public static final String WAR_NAME_2 = "WebBeanError";
+
+    @Server("com.ibm.ws.concurrent.fat.jakarta.error")
+    public static LibertyServer server;
+
+    private static EnterpriseArchive AppInterfaceWarning;
+    private static EnterpriseArchive AppBeanError;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        //Web archive for interface warning
+        WebArchive WebInterfaceWarning = ShrinkHelper.buildDefaultApp("WebInterfaceWarning", "test.jakarta.concurrency.web.error")
+                        .deleteClass(ConcurrencyBeanErrorServlet.class);
+
+        //Web archive for bean error
+        WebArchive WebBeanError = ShrinkHelper.buildDefaultApp("WebBeanError", "test.jakarta.concurrency.web.error")
+                        .deleteClass(ConcurrentInterfaceWarningServlet.class);
+
+        //EJB where asynch methods are on the interface
+        JavaArchive EJBInterfaceWarning = ShrinkHelper.buildJavaArchive("EJBInterfaceWarning", "test.jakarta.concurrency.ejb.error")
+                        .deleteClasses(GenericAsynchBean.class, GenericLocal.class);
+
+        //EJB where asynch methods are on the bean
+        JavaArchive EJBBeanError = ShrinkHelper.buildJavaArchive("EJBBeanError", "test.jakarta.concurrency.ejb.error")
+                        .deleteClasses(AsynchInterfaceBean.class, AsynchInterfaceLocal.class);
+
+        AppInterfaceWarning = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME_1 + ".ear");
+        AppInterfaceWarning.addAsModules(WebInterfaceWarning, EJBInterfaceWarning);
+
+        AppBeanError = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME_2 + ".ear");
+        AppBeanError.addAsModules(WebBeanError, EJBBeanError);
+
+        server.startServer();
+
+        server.setTraceMarkToEndOfDefaultTrace();
+        ShrinkHelper.exportDropinAppToServer(server, AppInterfaceWarning);
+
+        //Attempt to use application
+        runTest(server, WAR_NAME_1, "testMethod");
+
+        //App checker should log a warning, not an error.
+        assertNull(server.waitForStringInTraceUsingMark("CNTR9426E"));
+        assertNotNull(server.waitForStringInTraceUsingMark("CNTR9427W"));
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server.isStarted()) {
+            server.stopServer("CNTR9427W", //Warning Jakarta Concurrent Asynchronous on EJB Interface method
+                              "CNTR9426E" //Error Jakarta Concurrent Asynchronous on EJB method
+            );
+        }
+    }
+
+    @Test
+    @ExpectedFFDC({ "com.ibm.ejs.container.EJBConfigurationException", //Root exception thrown by EJB Container
+                    "jakarta.ejb.EJBException", //caused by EJBConfigurationException and thrown to injectionengine
+                    "com.ibm.wsspi.injectionengine.InjectionException", //caused by EJBException and thrown to Servlet
+                    "jakarta.servlet.UnavailableException", //caused by InjectionException
+    })
+    public void testBeanApplicationFailsToInstall() throws Exception {
+        server.setTraceMarkToEndOfDefaultTrace();
+        ShrinkHelper.exportDropinAppToServer(server, AppBeanError);
+
+        //Attempt to use application
+        try {
+            runTest(server, WAR_NAME_2, "testMethod");
+            fail("Should not have been able to connect to servlet.");
+        } catch (AssertionError e) {
+            //Expected
+        }
+
+        //MethodAttribUtils should have thrown and error, not a warning.
+        assertNotNull(server.waitForStringInTraceUsingMark("CNTR9426E"));
+        assertNull(server.waitForStringInTraceUsingMark("CNTR9427W"));
+    }
+
+    @Test
+    public void getThreadName() throws Exception {
+        runTest(server, WAR_NAME_1, testName);
+    }
+
+    @Test
+    public void getThreadNameNonAsyc() throws Exception {
+        runTest(server, WAR_NAME_1, testName);
+    }
+
+    @Test
+    @ExpectedFFDC("java.lang.IllegalStateException")
+    public void getState() throws Exception {
+        runTest(server, WAR_NAME_1, testName);
+    }
+
+    @Test
+    @ExpectedFFDC("java.lang.IllegalStateException")
+    public void getStateFromService() throws Exception {
+        runTest(server, WAR_NAME_1, testName);
+    }
+
+}

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/fat/src/test/jakarta/concurrency/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/fat/src/test/jakarta/concurrency/FATSuite.java
@@ -20,7 +20,8 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
 @SuiteClasses({
                 AlwaysPassesTest.class,
                 ConcurrencyTest.class,
-                ConcurrencyJSPTest.class
+                ConcurrencyJSPTest.class,
+                ConcurrencyErrorTest.class
 })
 public class FATSuite {
 }

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/publish/servers/com.ibm.ws.concurrent.fat.jakarta.error/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/publish/servers/com.ibm.ws.concurrent.fat.jakarta.error/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:concurrent=all:context=all:concurrencyPolicy=all:EJBContainer=all:MetaData=all

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/publish/servers/com.ibm.ws.concurrent.fat.jakarta.error/jvm.options
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/publish/servers/com.ibm.ws.concurrent.fat.jakarta.error/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.ibm.websphere.ejbcontainer.checkEJBApplicationConfiguration=true

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/publish/servers/com.ibm.ws.concurrent.fat.jakarta.error/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/publish/servers/com.ibm.ws.concurrent.fat.jakarta.error/server.xml
@@ -1,0 +1,23 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+  <featureManager>
+    <feature>componenttest-2.0</feature>
+    <feature>concurrent-3.0</feature> <!-- Ensure the asynchronous annotation is available -->
+    <feature>enterpriseBeansLite-4.0</feature>
+    <feature>jndi-1.0</feature>
+    <feature>servlet-6.0</feature>
+  </featureManager>
+
+  <include location="../fatTestPorts.xml"/>
+
+</server>

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/resources/META-INF/ejb-jar.xml
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/resources/META-INF/ejb-jar.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<ejb-jar version="4.0" metadata-complete="false"
+         xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/ejb-jar_4_0.xsd">
+	<!-- Intentionally left empty -->
+</ejb-jar>

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/ejb/error/AsynchClassBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/ejb/error/AsynchClassBean.java
@@ -1,0 +1,57 @@
+/**
+ *
+ */
+package test.jakarta.concurrency.ejb.error;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.util.concurrent.CompletableFuture;
+
+import jakarta.ejb.Local;
+import jakarta.ejb.Stateless;
+import jakarta.enterprise.concurrent.Asynchronous;
+
+/**
+ * This bean has a class that uses the Jakarta Concurrency @Asynchronous annotation.
+ * This annotation is only allowed on CDI bean methods, and should be rejected on a class level.
+ * This application should not be installed and hence none of these methods should be run.
+ */
+@Asynchronous
+@Stateless
+@Local(GenericLocal.class)
+public class AsynchClassBean {
+
+    public void getThreadName() {
+        System.out.println("Thread name async: " + Thread.currentThread().getName());
+    }
+
+    public void getThreadNameNonAsyc() {
+        System.out.println("Thread name non-async:" + Thread.currentThread().getName());
+    }
+
+    public CompletableFuture<String> getState(String city) {
+        if (city == "Rochester")
+            return Asynchronous.Result.complete("Minnesota");
+        else
+            return Asynchronous.Result.complete(null);
+    }
+
+    public CompletableFuture<String> getStateFromService(String city) {
+
+        CompletableFuture<String> future = Asynchronous.Result.getFuture();
+
+        assertNotNull(future);
+
+        try {
+            if (city == "Rochester")
+                future.complete("Minnesota");
+            else
+                future.complete(null);
+        } catch (Exception x) {
+            future.completeExceptionally(x);
+        }
+
+        return future;
+    }
+
+}

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/ejb/error/AsynchInterfaceBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/ejb/error/AsynchInterfaceBean.java
@@ -1,0 +1,51 @@
+/**
+ *
+ */
+package test.jakarta.concurrency.ejb.error;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.util.concurrent.CompletableFuture;
+
+import jakarta.ejb.Local;
+import jakarta.ejb.Stateless;
+import jakarta.enterprise.concurrent.Asynchronous;
+
+@Stateless
+@Local(AsynchInterfaceLocal.class)
+public class AsynchInterfaceBean {
+
+    public void getThreadName() {
+        System.out.println("Thread name async: " + Thread.currentThread().getName());
+    }
+
+    public void getThreadNameNonAsyc() {
+        System.out.println("Thread name non-async:" + Thread.currentThread().getName());
+    }
+
+    public CompletableFuture<String> getState(String city) {
+        if (city == "Rochester")
+            return Asynchronous.Result.complete("Minnesota");
+        else
+            return Asynchronous.Result.complete(null);
+    }
+
+    public CompletableFuture<String> getStateFromService(String city) {
+
+        CompletableFuture<String> future = Asynchronous.Result.getFuture();
+
+        assertNotNull(future);
+
+        try {
+            if (city == "Rochester")
+                future.complete("Minnesota");
+            else
+                future.complete(null);
+        } catch (Exception x) {
+            future.completeExceptionally(x);
+        }
+
+        return future;
+    }
+
+}

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/ejb/error/AsynchInterfaceBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/ejb/error/AsynchInterfaceBean.java
@@ -1,6 +1,13 @@
-/**
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  *
- */
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package test.jakarta.concurrency.ejb.error;
 
 import static org.junit.Assert.assertNotNull;

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/ejb/error/AsynchInterfaceLocal.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/ejb/error/AsynchInterfaceLocal.java
@@ -1,0 +1,29 @@
+/**
+ *
+ */
+package test.jakarta.concurrency.ejb.error;
+
+import java.util.concurrent.CompletableFuture;
+
+import jakarta.enterprise.concurrent.Asynchronous;
+
+/**
+ * This generic interface is using the Jakarta Concurrency @Asynchronous annotations.
+ * Since users should not expect annotations on methods to be inherited from interfaces
+ * (only super-classes) these annotations should be ignored.
+ * The application should be installed, and a warning given to the user.
+ */
+public interface AsynchInterfaceLocal {
+
+    @Asynchronous
+    public void getThreadName();
+
+    public void getThreadNameNonAsyc();
+
+    @Asynchronous
+    public CompletableFuture<String> getState(String city);
+
+    @Asynchronous(executor = "java:comp/DefaultManagedExecutorService")
+    public CompletableFuture<String> getStateFromService(String city);
+
+}

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/ejb/error/AsynchInterfaceLocal.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/ejb/error/AsynchInterfaceLocal.java
@@ -1,6 +1,13 @@
-/**
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  *
- */
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package test.jakarta.concurrency.ejb.error;
 
 import java.util.concurrent.CompletableFuture;

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/ejb/error/GenericAsynchBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/ejb/error/GenericAsynchBean.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.concurrency.ejb.error;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.util.concurrent.CompletableFuture;
+
+import jakarta.ejb.Local;
+import jakarta.ejb.Stateless;
+import jakarta.enterprise.concurrent.Asynchronous;
+
+/**
+ * This bean has methods that use the Jakarta Concurrency @Asynchronous annotation.
+ * This annotation is only allowed on CDI beans, not EJBs.
+ * This application should not be installed and hence none of these methods should be run.
+ */
+@Stateless
+@Local(GenericLocal.class)
+public class GenericAsynchBean {
+
+    @Asynchronous
+    public void getThreadName() {
+        System.out.println("Thread name async: " + Thread.currentThread().getName());
+    }
+
+    public void getThreadNameNonAsyc() {
+        System.out.println("Thread name non-async:" + Thread.currentThread().getName());
+    }
+
+    @Asynchronous
+    public CompletableFuture<String> getState(String city) {
+        if (city == "Rochester")
+            return Asynchronous.Result.complete("Minnesota");
+        else
+            return Asynchronous.Result.complete(null);
+    }
+
+    @Asynchronous(executor = "java:comp/DefaultManagedExecutorService")
+    public CompletableFuture<String> getStateFromService(String city) {
+
+        CompletableFuture<String> future = Asynchronous.Result.getFuture();
+
+        assertNotNull(future);
+
+        try {
+            if (city == "Rochester")
+                future.complete("Minnesota");
+            else
+                future.complete(null);
+        } catch (Exception x) {
+            future.completeExceptionally(x);
+        }
+
+        return future;
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/ejb/error/GenericLocal.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/ejb/error/GenericLocal.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.concurrency.ejb.error;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Generic local interface for EJB
+ */
+public interface GenericLocal {
+
+    public void getThreadName();
+
+    public void getThreadNameNonAsyc();
+
+    public CompletableFuture<String> getState(String city);
+
+    public CompletableFuture<String> getStateFromService(String city);
+
+}

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/web/error/ConcurrencyBeanErrorServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/web/error/ConcurrencyBeanErrorServlet.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.concurrency.web.error;
+
+import jakarta.ejb.EJB;
+import jakarta.servlet.annotation.WebServlet;
+
+import componenttest.app.FATServlet;
+import test.jakarta.concurrency.ejb.error.GenericLocal;
+
+//This servlet should never be installed as it uses a mis-configured EJB.
+@SuppressWarnings("serial")
+@WebServlet("/*")
+public class ConcurrencyBeanErrorServlet extends FATServlet {
+
+    @EJB
+    GenericLocal ejb;
+
+    public void testMethod() {
+        return;
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/web/error/ConcurrencyClassErrorServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/web/error/ConcurrencyClassErrorServlet.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.concurrency.web.error;
+
+import jakarta.ejb.EJB;
+import jakarta.servlet.annotation.WebServlet;
+
+import componenttest.app.FATServlet;
+import test.jakarta.concurrency.ejb.error.GenericLocal;
+
+//This servlet should never be installed as it uses a mis-configured EJB.
+@SuppressWarnings("serial")
+@WebServlet("/*")
+public class ConcurrencyClassErrorServlet extends FATServlet {
+
+    @EJB
+    GenericLocal ejb;
+
+    public void testMethod() {
+        return;
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/web/error/ConcurrencyInterfaceWarningServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/web/error/ConcurrencyInterfaceWarningServlet.java
@@ -20,9 +20,10 @@ import jakarta.servlet.annotation.WebServlet;
 import componenttest.app.FATServlet;
 import test.jakarta.concurrency.ejb.error.AsynchInterfaceLocal;
 
+//This servlet should never be installed as it uses a mis-configured EJB.
 @SuppressWarnings("serial")
 @WebServlet("/*")
-public class ConcurrentInterfaceWarningServlet extends FATServlet {
+public class ConcurrencyInterfaceWarningServlet extends FATServlet {
 
     @EJB
     AsynchInterfaceLocal ejb;

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/web/error/ConcurrentInterfaceWarningServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestError/src/test/jakarta/concurrency/web/error/ConcurrentInterfaceWarningServlet.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.concurrency.web.error;
+
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.Future;
+
+import jakarta.ejb.EJB;
+import jakarta.servlet.annotation.WebServlet;
+
+import componenttest.app.FATServlet;
+import test.jakarta.concurrency.ejb.error.AsynchInterfaceLocal;
+
+@SuppressWarnings("serial")
+@WebServlet("/*")
+public class ConcurrentInterfaceWarningServlet extends FATServlet {
+
+    @EJB
+    AsynchInterfaceLocal ejb;
+
+    public void testMethod() {
+        return;
+    }
+
+    public void getThreadName() {
+        try {
+            ejb.getThreadName();
+        } catch (Exception e) {
+            fail("Should have been able to execute method since Jakarta Ansychronous anotation was on the interface.");
+        }
+    }
+
+    public void getThreadNameNonAsyc() {
+        try {
+            ejb.getThreadNameNonAsyc();
+        } catch (Exception e) {
+            fail("Should have been able to execute method since Jakarta Ansychronous anotation was on the interface.");
+        }
+    }
+
+    public void getState() {
+        try {
+            Future<String> future = ejb.getState("Rochester");
+            fail("Should not have been able to get a future object from a bean method.");
+        } catch (Exception e) {
+            //expected TODO ensure consistent behavior
+        }
+    }
+
+    public void getStateFromService() {
+        try {
+            Future<String> future = ejb.getStateFromService("Rochester");
+            fail("Should not have been able to get a future object from a bean method.");
+        } catch (Exception e) {
+            //expected TODO ensure consistent behavior
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.ejbcontainer.core/resources/com/ibm/ejs/container/container.nlsprops
+++ b/dev/com.ibm.ws.ejbcontainer.core/resources/com/ibm/ejs/container/container.nlsprops
@@ -2223,10 +2223,10 @@ CNTR9425E_NO_URL_SPEC_SPECIFIED=CNTR9425E: The embeddable Enterprise JavaBeans (
 CNTR9425E_NO_URL_SPEC_SPECIFIED.explanation=The properties that the embeddable Enterprise JavaBeans (EJB) container uses contain a URL resource with no specification specified.
 CNTR9425E_NO_URL_SPEC_SPECIFIED.useraction=Add a specification property for this URL resource to the properties file.
 
-CNTR9426E_INCORRECT_ASYNC_ANNO=CNTR9426E: The {0} bean in the {1} module of the {2} application has one or more methods with the Jakarta Concurrent Asynchronous annotation.
-CNTR9426E_INCORRECT_ASYNC_ANNO.explanation=Jakarta Concurrent Asynchronous annotations are only valid for CDI beans, not EJBs.
-CNTR9426E_INCORRECT_ASYNC_ANNO.useraction=Remove the Jakarta Concurrent Asynchronous annotation from method.
+CNTR9426E_INCORRECT_ASYNC_ANNO=CNTR9426E: The {0} bean in the {1} module of the {2} application has one or more methods with the Jakarta Concurrency Asynchronous annotation, which must only be used on CDI beans and is not valid on Jakarta Enterprise Beans.
+CNTR9426E_INCORRECT_ASYNC_ANNO.explanation=Jakarta Concurrency Asynchronous annotations are only valid for CDI beans, not Jakarta Enterprise Beans.
+CNTR9426E_INCORRECT_ASYNC_ANNO.useraction=Remove the Jakarta Concurrency Asynchronous annotation from the method.
 
-CNTR9427W_INCORRECT_ASYNC_ANNO_INTERFACE=CNTR9427W: The {0} interface has one or more methods with the Jakarta Concurrent Asynchronous annotation.
-CNTR9427W_INCORRECT_ASYNC_ANNO_INTERFACE.explanation=Jakarta Concurrent Asynchronous annotations are only valid for CDI beans, not EJBs or Interfaces.
-CNTR9427W_INCORRECT_ASYNC_ANNO_INTERFACE.useraction=Remove the Jakarta Concurrent Asynchronous annotation from interface method.
+CNTR9427W_INCORRECT_ASYNC_ANNO_INTERFACE=CNTR9427W: The Jakarta Concurrency Asynchronous annotation must only be used on CDI beans. It is not valid on the {0} interface.
+CNTR9427W_INCORRECT_ASYNC_ANNO_INTERFACE.explanation=Jakarta Concurrency Asynchronous annotations are only valid for CDI beans, not Jakarta Enterprise Beans or Interfaces.
+CNTR9427W_INCORRECT_ASYNC_ANNO_INTERFACE.useraction=Remove the Jakarta Concurrency Asynchronous annotation from the interface method.

--- a/dev/com.ibm.ws.ejbcontainer.core/resources/com/ibm/ejs/container/container.nlsprops
+++ b/dev/com.ibm.ws.ejbcontainer.core/resources/com/ibm/ejs/container/container.nlsprops
@@ -2223,3 +2223,10 @@ CNTR9425E_NO_URL_SPEC_SPECIFIED=CNTR9425E: The embeddable Enterprise JavaBeans (
 CNTR9425E_NO_URL_SPEC_SPECIFIED.explanation=The properties that the embeddable Enterprise JavaBeans (EJB) container uses contain a URL resource with no specification specified.
 CNTR9425E_NO_URL_SPEC_SPECIFIED.useraction=Add a specification property for this URL resource to the properties file.
 
+CNTR9426E_INCORRECT_ASYNC_ANNO=CNTR9426E: The {0} bean in the {1} module of the {2} application has one or more methods with the Jakarta Concurrent Asynchronous annotation.
+CNTR9426E_INCORRECT_ASYNC_ANNO.explanation=Jakarta Concurrent Asynchronous annotations are only valid for CDI beans, not EJBs.
+CNTR9426E_INCORRECT_ASYNC_ANNO.useraction=Remove the Jakarta Concurrent Asynchronous annotation from method.
+
+CNTR9427W_INCORRECT_ASYNC_ANNO_INTERFACE=CNTR9427W: The {0} interface has one or more methods with the Jakarta Concurrent Asynchronous annotation.
+CNTR9427W_INCORRECT_ASYNC_ANNO_INTERFACE.explanation=Jakarta Concurrent Asynchronous annotations are only valid for CDI beans, not EJBs or Interfaces.
+CNTR9427W_INCORRECT_ASYNC_ANNO_INTERFACE.useraction=Remove the Jakarta Concurrent Asynchronous annotation from interface method.

--- a/dev/com.ibm.ws.ejbcontainer.core/resources/com/ibm/ejs/container/container.nlsprops
+++ b/dev/com.ibm.ws.ejbcontainer.core/resources/com/ibm/ejs/container/container.nlsprops
@@ -1566,6 +1566,14 @@ UNABLE_TO_BIND_REMOTE_BINDING_CNTR0341W=CNTR0341W: Unable to bind the {0} interf
 UNABLE_TO_BIND_REMOTE_BINDING_CNTR0341W.explanation=The remote enterprise bean binding cannot be created because the CORBA name server is not available.
 UNABLE_TO_BIND_REMOTE_BINDING_CNTR0341W.useraction=Check the log file for exceptions that are related to the ORB or CORBA name server initialization.
 
+CNTR0342E_INCORRECT_ASYNC_ANNO=CNTR0342E: The {0} bean in the {1} module of the {2} application has one or more methods with the jakarta.enterprise.concurrent.Asynchronous annotation, which must not be used on enterprise beans. The jakarta.ejb.Asynchronous annotation provides asynchronous methods for enterprise beans.
+CNTR0342E_INCORRECT_ASYNC_ANNO.explanation=The Jakarta Concurrency specification does not allow the jakarta.enterprise.concurrent.Asynchronous annotation to be used on Jakarta Enterprise Beans.
+CNTR0342E_INCORRECT_ASYNC_ANNO.useraction=Remove the jakarta.enterprise.concurrent.Asynchronous annotation from the method or class. Use the jakarta.ejb.Asynchronous annotation to identify asynchronous enterprise bean methods.
+
+CNTR0343W_INCORRECT_ASYNC_ANNO_INTERFACE=CNTR0343W: The {0} business interface contains a jakarta.enterprise.concurrent.Asynchronous annotation. Asynchronous annotations are not valid on any interface, and the Jakarta Enterprise Beans container ignores them.
+CNTR0343W_INCORRECT_ASYNC_ANNO_INTERFACE.explanation=The jakarta.enterprise.concurrent.Asynchronous annotation must not be used with Jakarta Enterprise Beans. The Jakarta Enterprise Beans container ignores these annotations on interfaces. Unless the methods are declared asynchronous in the ejb-jar.xml deployment descriptor or the jakarta.ejb.Asynchronous annotation is specified on the bean class or a bean class method, the bean methods run synchronously.
+CNTR0343W_INCORRECT_ASYNC_ANNO_INTERFACE.useraction=Remove any jakarta.enterprise.concurrent.Asynchronous annotation from the specified business interface and verify that the jakarta.ejb.Asynchronous annotation is specified correctly in the bean class.
+
 #-------------------------------------------------------------------------------
 #
 # CNTR4000 to CNTR4999 reserved for Liberty.
@@ -2222,11 +2230,3 @@ CNTR9424E_NO_URL_JNDINAME_SPECIFIED.useraction=Add a name property for this URL 
 CNTR9425E_NO_URL_SPEC_SPECIFIED=CNTR9425E: The embeddable Enterprise JavaBeans (EJB) container properties for the {0} URL resource do not contain the property, specification.
 CNTR9425E_NO_URL_SPEC_SPECIFIED.explanation=The properties that the embeddable Enterprise JavaBeans (EJB) container uses contain a URL resource with no specification specified.
 CNTR9425E_NO_URL_SPEC_SPECIFIED.useraction=Add a specification property for this URL resource to the properties file.
-
-CNTR9426E_INCORRECT_ASYNC_ANNO=CNTR9426E: The {0} bean in the {1} module of the {2} application has one or more methods with the Jakarta Concurrency Asynchronous annotation, which must only be used on CDI beans and is not valid on Jakarta Enterprise Beans.
-CNTR9426E_INCORRECT_ASYNC_ANNO.explanation=Jakarta Concurrency Asynchronous annotations are only valid for CDI beans, not Jakarta Enterprise Beans.
-CNTR9426E_INCORRECT_ASYNC_ANNO.useraction=Remove the Jakarta Concurrency Asynchronous annotation from the method.
-
-CNTR9427W_INCORRECT_ASYNC_ANNO_INTERFACE=CNTR9427W: The Jakarta Concurrency Asynchronous annotation must only be used on CDI beans. It is not valid on the {0} interface.
-CNTR9427W_INCORRECT_ASYNC_ANNO_INTERFACE.explanation=Jakarta Concurrency Asynchronous annotations are only valid for CDI beans, not Jakarta Enterprise Beans or Interfaces.
-CNTR9427W_INCORRECT_ASYNC_ANNO_INTERFACE.useraction=Remove the Jakarta Concurrency Asynchronous annotation from the interface method.

--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/BeanMetaData.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/BeanMetaData.java
@@ -1130,6 +1130,12 @@ public class BeanMetaData extends com.ibm.ws.runtime.metadata.MetaDataImpl imple
     public boolean ivHasAsynchMethod = false;
 
     /**
+     * Set to true when this bean has one or more methods annotated with the Concurrent asynchronous annotation.
+     * Default is false.
+     */
+    public boolean ivHasConcurrentAsynchMethod = false;
+
+    /**
      * Stateful AfterBegin session synchronization method when bean does
      * not implement the SessionSynchronization interface.
      */
@@ -1614,7 +1620,8 @@ public class BeanMetaData extends com.ibm.ws.runtime.metadata.MetaDataImpl imple
                                               "ExPC Ids                    = " + Arrays.toString(ivExPcPuIds), // F743-30682
                                               "WebService Endpoint Created = " + ivWebServiceEndpointCreated, // d497921
                                               "Component NameSpace :  nsid = " + getJavaNameSpaceID(), // d508455
-                                              "Has aysnchronous method(s)  = " + ivHasAsynchMethod,
+                                              "Has asynchronous method(s)  = " + ivHasAsynchMethod,
+                                              "Has concurr asych method(s) = " + ivHasConcurrentAsynchMethod,
                                               "Singleton Concurrency Type  = " + singletonConcurrency, //F743-1752CodRev
                                               "Synch AfterBegin            = " + ivAfterBegin, // F743-25855
                                               "Synch BeforeCompletion      = " + ivBeforeCompletion, // F743-25855
@@ -2448,6 +2455,17 @@ public class BeanMetaData extends com.ibm.ws.runtime.metadata.MetaDataImpl imple
             }
 
         } // Validation of asynchronous methods
+
+        if (ivHasConcurrentAsynchMethod) {
+
+            // Concurrent Asynch methods are not allowed on EJBs
+            Tr.error(tc, "CNTR9426E_INCORRECT_ASYNC_ANNO",
+                     new Object[] { j2eeName.getComponent(), j2eeName.getModule(), j2eeName.getApplication() });
+
+            throw new EJBConfigurationException( //
+                            Tr.formatMessage(tc, "CNTR9426E_INCORRECT_ASYNC_ANNO", new Object[] { j2eeName.getComponent(), j2eeName.getModule(), j2eeName.getApplication() }));
+
+        } // Validation of Concurrent asynchronous methods
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
             Tr.exit(tc, "validate");

--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/BeanMetaData.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/BeanMetaData.java
@@ -1130,12 +1130,6 @@ public class BeanMetaData extends com.ibm.ws.runtime.metadata.MetaDataImpl imple
     public boolean ivHasAsynchMethod = false;
 
     /**
-     * Set to true when this bean has one or more methods annotated with the Concurrent asynchronous annotation.
-     * Default is false.
-     */
-    public boolean ivHasConcurrentAsynchMethod = false;
-
-    /**
      * Stateful AfterBegin session synchronization method when bean does
      * not implement the SessionSynchronization interface.
      */
@@ -1621,7 +1615,6 @@ public class BeanMetaData extends com.ibm.ws.runtime.metadata.MetaDataImpl imple
                                               "WebService Endpoint Created = " + ivWebServiceEndpointCreated, // d497921
                                               "Component NameSpace :  nsid = " + getJavaNameSpaceID(), // d508455
                                               "Has asynchronous method(s)  = " + ivHasAsynchMethod,
-                                              "Has concurr asych method(s) = " + ivHasConcurrentAsynchMethod,
                                               "Singleton Concurrency Type  = " + singletonConcurrency, //F743-1752CodRev
                                               "Synch AfterBegin            = " + ivAfterBegin, // F743-25855
                                               "Synch BeforeCompletion      = " + ivBeforeCompletion, // F743-25855
@@ -2455,17 +2448,6 @@ public class BeanMetaData extends com.ibm.ws.runtime.metadata.MetaDataImpl imple
             }
 
         } // Validation of asynchronous methods
-
-        if (ivHasConcurrentAsynchMethod) {
-
-            // Concurrent Asynch methods are not allowed on EJBs
-            Tr.error(tc, "CNTR9426E_INCORRECT_ASYNC_ANNO",
-                     new Object[] { j2eeName.getComponent(), j2eeName.getModule(), j2eeName.getApplication() });
-
-            throw new EJBConfigurationException( //
-                            Tr.formatMessage(tc, "CNTR9426E_INCORRECT_ASYNC_ANNO", new Object[] { j2eeName.getComponent(), j2eeName.getModule(), j2eeName.getApplication() }));
-
-        } // Validation of Concurrent asynchronous methods
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
             Tr.exit(tc, "validate");

--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/util/MethodAttribUtils.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/util/MethodAttribUtils.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ejs.container.util;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -339,6 +340,53 @@ public class MethodAttribUtils {
         return (asynchMethodFound);
 
     } // getAsynchronousMethods
+
+    /**
+     * <code>getConcurrentAsynchronousMethods<code> checks all beanMethods to determine
+     * if any beans are annotated with the Jakarta Concurrent Asynchronous annotation.
+     * Returns true when found, or false otherwise.
+     *
+     * @param beanMethods Input array of Method objects representing the methods of this EJB.
+     *
+     * @return True if at least one method was found on this bean to have the Concurrent Asynchronous annotation.
+     */
+    public static boolean getConcurrentAsynchronousMethods(Method[] beanMethods) {
+        final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
+
+        if (isTraceOn && tc.isEntryEnabled())
+            Tr.entry(tc, "getConcurrentAsynchronousMethods");
+
+        boolean asynchMethodFound = false;
+        Annotation[] asynchMethodAnnotations = null;
+
+        for (Method beanMethod : beanMethods) {
+            if (beanMethod == null)
+                continue; //onto next method
+
+            asynchMethodAnnotations = beanMethod.getAnnotations();
+
+            if (asynchMethodAnnotations == null)
+                continue; //onto next method
+
+            for (Annotation beanAnno : asynchMethodAnnotations) {
+                if (beanAnno.annotationType().getName().contains("jakarta.enterprise.concurrent.Asynchronous")) {
+                    asynchMethodFound = true;
+                    break; //stop looking at annotations
+                }
+            }
+
+            if (asynchMethodFound) {
+                break; //stop looking at methods
+            }
+        }
+
+        if (isTraceOn && tc.isEntryEnabled()) {
+            Tr.exit(tc, "getConcurrentAsynchronousMethods", asynchMethodFound);
+        }
+
+        return (asynchMethodFound);
+
+    } // getConcurrentAsynchronousMethods
 
     /**
      * Check all methods for method-level Security annotations. Specifically

--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/util/MethodAttribUtils.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/util/MethodAttribUtils.java
@@ -369,7 +369,7 @@ public class MethodAttribUtils {
                 continue; //onto next method
 
             for (Annotation beanAnno : asynchMethodAnnotations) {
-                if (beanAnno.annotationType().getName().contains("jakarta.enterprise.concurrent.Asynchronous")) {
+                if ("jakarta.enterprise.concurrent.Asynchronous".equals(beanAnno.annotationType().getName())) {
                     asynchMethodFound = true;
                     break; //stop looking at annotations
                 }

--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/metadata/ejb/AppConfigChecker.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/metadata/ejb/AppConfigChecker.java
@@ -104,7 +104,7 @@ final class AppConfigChecker {
                 for (Method m : iface.getMethods()) {
                     for (Annotation anno : m.getAnnotations()) {
                         if ("jakarta.enterprise.concurrent.Asynchronous".equals(anno.annotationType().getName())) {
-                            Tr.warning(tc, "CNTR9427W_INCORRECT_ASYNC_ANNO_INTERFACE", iface.getName());
+                            Tr.warning(tc, "CNTR0343W_INCORRECT_ASYNC_ANNO_INTERFACE", iface.getName());
                             return;
                         }
                     }

--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/metadata/ejb/AppConfigChecker.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/metadata/ejb/AppConfigChecker.java
@@ -25,18 +25,16 @@ import com.ibm.ws.javaee.dd.ejb.EnterpriseBean;
 import com.ibm.ws.javaee.dd.ejb.Session;
 
 /**
- * 
+ *
  * Helper class for validating proper metadata configuration for an EJB-based
  * application. This class is intended to be invoked from the EJBMDOrchestrator
  * class during metadata processing. It is intended to include various app
  * validation only if it will be logged. The <code>isValidationLoggable</code>
  * method can be used to determine if logging will occur.
- * 
+ *
  */
-final class AppConfigChecker
-{
-    private AppConfigChecker()
-    {
+final class AppConfigChecker {
+    private AppConfigChecker() {
         // Do not allow instances to be created
     }
 
@@ -47,9 +45,9 @@ final class AppConfigChecker
      * annotations may exist in interface methods.
      * Note: This method will always log the message - make sure to gate this
      * method by calling {@link isValidationLoggable}.
-     * 
+     *
      * @param ifaces - array of interfaces to scan for async annotations
-     * @param tc - the trace component to log if any async annotations are detected - must be non-null
+     * @param tc     - the trace component to log if any async annotations are detected - must be non-null
      */
     //F743-13921
     static void validateAsyncOnInterfaces(Class<?>[] ifaces, TraceComponent tc) {
@@ -105,7 +103,7 @@ final class AppConfigChecker
 
                 for (Method m : iface.getMethods()) {
                     for (Annotation anno : m.getAnnotations()) {
-                        if (anno.annotationType().getName() == "jakarta.enterprise.concurrent.Asynchronous") {
+                        if ("jakarta.enterprise.concurrent.Asynchronous".equals(anno.annotationType().getName())) {
                             Tr.warning(tc, "CNTR9427W_INCORRECT_ASYNC_ANNO_INTERFACE", iface.getName());
                             return;
                         }
@@ -125,9 +123,9 @@ final class AppConfigChecker
      * annotations may exist in interface methods.
      * Note: This method will always log the message - make sure to gate this
      * method by calling {@link isValidationLoggable}.
-     * 
+     *
      * @param ifaces - array of interfaces to scan for StatefulTimeout annotations
-     * @param tc - the trace component to log if any StatefulTimeout annotations are detected - must be non-null
+     * @param tc     - the trace component to log if any StatefulTimeout annotations are detected - must be non-null
      */
     //F743-6605
     static void validateStatefulTimeoutOnInterfaces(Class<?>[] ifaces, TraceComponent tc) {
@@ -152,18 +150,18 @@ final class AppConfigChecker
      * Logs a warning message (via the passed-in trace component) if the
      * passed-in bean is not a SFSB, yet contains a <code>@StatefulTimeout</code>
      * annotation or a stateful-timeout DD element.
-     * 
+     *
      * Logs a warning message (via the passed-in trace component) if the
      * passed-in bean is a SFSB and contains a stateful-timeout DD element
      * lacking a timeout element.
-     * 
-     * 
+     *
+     *
      * Note: make sure to gate this method by calling {@link isValidationLoggable}.
-     * 
-     * 
+     *
+     *
      * @param cdo - component data object, containing XML info about the stateful-timeout element, if present
      * @param bmd - metadata for the bean to check for the StatefulTimeout annotation
-     * @param tc - the trace component to log if any StatefulTimeout annotations are detected - must be non-null
+     * @param tc  - the trace component to log if any StatefulTimeout annotations are detected - must be non-null
      */
     //F743-6605
     static void validateStatefulTimeoutOnSFSB(BeanMetaData bmd, TraceComponent tc) {
@@ -173,7 +171,7 @@ final class AppConfigChecker
 
             if (bmd.type != InternalConstants.TYPE_STATEFUL_SESSION) {
                 Tr.warning(tc, "STATEFUL_TIMEOUT_ON_NON_SFSB_CNTR0304W", new Object[] { bmd.getName(), bmd.getModuleMetaData().getName(),
-                                                                                       bmd.getModuleMetaData().getApplicationMetaData().getName() }); // F743-6605.1, d641570
+                                                                                        bmd.getModuleMetaData().getApplicationMetaData().getName() }); // F743-6605.1, d641570
             }
 
         }

--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/metadata/ejb/EJBMDOrchestrator.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/metadata/ejb/EJBMDOrchestrator.java
@@ -1296,6 +1296,9 @@ public abstract class EJBMDOrchestrator {
                                                                               methodInterface); //d599046
         }
 
+        //Set a flag if any method is annotated with the concurrency Asychronous annotation.
+        bmd.ivHasConcurrentAsynchMethod |= MethodAttribUtils.getConcurrentAsynchronousMethods(ejbMethods);
+
         // F743-1752.1 start
         // Get Lock and AccessTimeout metadata if EJB is a Singleton session bean and
         // it uses container managed concurrency control.
@@ -6846,6 +6849,8 @@ public abstract class EJBMDOrchestrator {
             AppConfigChecker.validateStatefulTimeoutOnInterfaces(bmd.ivBusinessLocalInterfaceClasses, tc); // F743-6605
             AppConfigChecker.validateStatefulTimeoutOnInterfaces(bmd.ivBusinessRemoteInterfaceClasses, tc); // F743-6605
             AppConfigChecker.validateStatefulTimeoutOnSFSB(bmd, tc); // F743-6605
+            AppConfigChecker.validateCorrectAsycOnMethods(bmd.ivBusinessLocalInterfaceClasses, tc);
+            AppConfigChecker.validateCorrectAsycOnMethods(bmd.ivBusinessRemoteInterfaceClasses, tc);
         }
 
         // ----------------------------------------------------------------------

--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/metadata/ejb/EJBMDOrchestrator.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/metadata/ejb/EJBMDOrchestrator.java
@@ -202,11 +202,11 @@ public abstract class EJBMDOrchestrator {
      * the metadata framework's generic ModuleDataObject. This occurs at application start
      * time.
      *
-     * @param ejbAMD is the container's metadata for the application containing this module
-     * @param mid the data needed to initialize a bean module.
+     * @param ejbAMD                is the container's metadata for the application containing this module
+     * @param mid                   the data needed to initialize a bean module.
      * @param statefulFailoverCache is an EJB Container configuration object that indicates whether
-     *            or not SFSB failover is active for this module.
-     * @param container used to obtain container-level SFSB failover values.
+     *                                  or not SFSB failover is active for this module.
+     * @param container             used to obtain container-level SFSB failover values.
      *
      * @return EJBModuleMetaDataImpl is the Container's internal format for module
      *         configuration data.
@@ -312,18 +312,18 @@ public abstract class EJBMDOrchestrator {
      * Later when an application wants to use the bean (ie. bean start) the remainder of
      * BMD will be filled in.
      *
-     * @param bid the data needed to initialize a bean.
-     * @param mmd is the Module's configuration data in the EJB Container's
-     *            internal format.
-     * @param container is the EJB Container in the current process.
-     * @param initAtStartup is the global default configuration for initializing beans
-     *                      at startup.
+     * @param bid              the data needed to initialize a bean.
+     * @param mmd              is the Module's configuration data in the EJB Container's
+     *                             internal format.
+     * @param container        is the EJB Container in the current process.
+     * @param initAtStartup    is the global default configuration for initializing beans
+     *                             at startup.
      * @param initAtStartupSet indicates that the initAtStartup parameter was explicitly
-     *                         configured and not a default value. 
+     *                             configured and not a default value.
      * @return BeanMetaData the EJB Container's internal format for bean configuration
      *         data.
      * @throws EJBConfigurationException - for customer configuration errors
-     * @throws ContainerException - for internal problems creating the meta data
+     * @throws ContainerException        - for internal problems creating the meta data
      */
     public BeanMetaData createBeanMetaData(BeanInitData bid,
                                            EJBModuleMetaDataImpl mmd,
@@ -559,7 +559,7 @@ public abstract class EJBMDOrchestrator {
     /**
      * Create the persister needed to support CMP 1.1 beans.
      *
-     * @param bmd is the EJB Container's internal format for bean configuration data.
+     * @param bmd                       is the EJB Container's internal format for bean configuration data.
      * @param defaultDataSourceJNDIName the default data source JNDI name
      * @return Persister provides persistence services for CMP 1.1 beans.
      * @throws ContainerException - for internal problems creating persister
@@ -595,7 +595,7 @@ public abstract class EJBMDOrchestrator {
      * for bean instances of this EJB type.
      *
      * @param bmd current metadata for the bean
-     * @throws ContainerException - for internal problems initializing bean metadata
+     * @throws ContainerException        - for internal problems initializing bean metadata
      * @throws EJBConfigurationException - for customer configuration errors
      */
     //  F743-17630 refactored method F743-17630CodRv
@@ -1294,10 +1294,13 @@ public abstract class EJBMDOrchestrator {
             bmd.ivHasAsynchMethod |= MethodAttribUtils.getAsynchronousMethods(ejbMethods,
                                                                               asynchMethodFlags,
                                                                               methodInterface); //d599046
-        }
 
-        //Set a flag if any method is annotated with the concurrency Asychronous annotation.
-        bmd.ivHasConcurrentAsynchMethod |= MethodAttribUtils.getConcurrentAsynchronousMethods(ejbMethods);
+            //If any business methods or classes contain the concurrent asynchronous annotation then this call WILL throw an EJBConfigurationException
+            MethodAttribUtils.verifyNoConcurrentAsynchronousMethods(ejbMethods,
+                                                                    bmd.j2eeName.getComponent(),
+                                                                    bmd.j2eeName.getModule(),
+                                                                    bmd.j2eeName.getApplication());
+        }
 
         // F743-1752.1 start
         // Get Lock and AccessTimeout metadata if EJB is a Singleton session bean and
@@ -2081,7 +2084,7 @@ public abstract class EJBMDOrchestrator {
      * provides EJB inheritance support.
      *
      * @param moduleConfig <code>EJBModuleConfigData</code> holding module information.
-     * @param mmd <code>EJBModuleMetaDataImpl</code> metadata for a module.
+     * @param mmd          <code>EJBModuleMetaDataImpl</code> metadata for a module.
      *
      * @throws EJBConfigurationException for customer configuration errors.
      */
@@ -2124,10 +2127,10 @@ public abstract class EJBMDOrchestrator {
      * Get the failover instance ID to use for SFSB failover if enabled
      * for this EJB module.
      *
-     * @param mmd the module metadata
+     * @param mmd                   the module metadata
      * @param statefulFailoverCache is the failover cache that is used to hold created failover instances.
-     *            Note, this method should not be called if statefulFailoverCache is null (otherwise,
-     *            a NullPointerException will occur).
+     *                                  Note, this method should not be called if statefulFailoverCache is null (otherwise,
+     *                                  a NullPointerException will occur).
      * @return String
      **/
     protected abstract String getFailoverInstanceId(EJBModuleMetaDataImpl mmd, SfFailoverCache statefulFailoverCache);
@@ -2136,7 +2139,7 @@ public abstract class EJBMDOrchestrator {
      * Get whether SFSB failover is enabled for this SFSB at either
      * the module, application, or EJB container level (in that order).
      *
-     * @param mmd the module metadata
+     * @param mmd       the module metadata
      * @param container the container
      * @return true if enabled.
      */
@@ -2225,13 +2228,13 @@ public abstract class EJBMDOrchestrator {
      * there may also be additional instances in use.
      *
      * @param bmd is the configuration data to be updated with the
-     *            calculated pool limits. The bmd variables set by this
-     *            method include:
+     *                calculated pool limits. The bmd variables set by this
+     *                method include:
      *
-     *            bmd.minPoolSize
-     *            bmd.maxPoolSize,
-     *            bmd.ivInitialPoolSize
-     *            bmd.ivMaxCreation.
+     *                bmd.minPoolSize
+     *                bmd.maxPoolSize,
+     *                bmd.ivInitialPoolSize
+     *                bmd.ivMaxCreation.
      */
     private void processBeanPoolLimits(BeanMetaData bmd) throws EJBConfigurationException {
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
@@ -2918,7 +2921,7 @@ public abstract class EJBMDOrchestrator {
      * @param beanType
      * @param classNameToLoad
      *
-     * @throws ContainerException - for internal errors
+     * @throws ContainerException        - for internal errors
      * @throws EJBConfigurationException - for customer configuration errors
      *
      */
@@ -3317,7 +3320,7 @@ public abstract class EJBMDOrchestrator {
      * Gets a managed object factory for the specified ManagedBean class, or null if
      * instances of the class do not need to be managed.
      *
-     * @param bmd the bean metadata
+     * @param bmd   the bean metadata
      * @param klass the ManagedBean class
      */
     protected <T> ManagedObjectFactory<T> getManagedBeanManagedObjectFactory(BeanMetaData bmd, Class<T> klass) throws EJBConfigurationException {
@@ -3342,7 +3345,7 @@ public abstract class EJBMDOrchestrator {
      * Gets a managed object factory for the specified interceptor class, or null if
      * instances of the class do not need to be managed.
      *
-     * @param bmd the bean metadata
+     * @param bmd   the bean metadata
      * @param klass the interceptor class
      */
     protected <T> ManagedObjectFactory<T> getInterceptorManagedObjectFactory(BeanMetaData bmd, Class<T> klass) throws EJBConfigurationException {
@@ -3367,7 +3370,7 @@ public abstract class EJBMDOrchestrator {
      * Gets a managed object factory for the specified EJB class, or null if
      * instances of the class do not need to be managed.
      *
-     * @param bmd the bean metadata
+     * @param bmd   the bean metadata
      * @param klass the bean implementation class
      */
     protected <T> ManagedObjectFactory<T> getEJBManagedObjectFactory(BeanMetaData bmd, Class<T> klass) throws EJBConfigurationException {
@@ -3397,7 +3400,7 @@ public abstract class EJBMDOrchestrator {
      * @param cdo
      * @param bmd
      *
-     * @throws ContainerException for internal errors
+     * @throws ContainerException        for internal errors
      * @throws EJBConfigurationException for customer configuration errors
      *
      */
@@ -3682,7 +3685,7 @@ public abstract class EJBMDOrchestrator {
      *
      * @param cdo
      * @param bmd
-     * @throws ContainerException for internal errors
+     * @throws ContainerException        for internal errors
      * @throws EJBConfigurationException for customer configuration errors
      */
     // F743-506
@@ -3718,7 +3721,7 @@ public abstract class EJBMDOrchestrator {
      * not directly provided by the customer). This includes both classes
      * generated by EJBDeploy and JITDeploy.
      *
-     * @throws ContainerException for internal errors
+     * @throws ContainerException         for internal errors
      * @throws EJBConfigurationsException for customer configuration errors
      */
     private void loadGeneratedImplementationClasses(BeanMetaData bmd,
@@ -4332,14 +4335,14 @@ public abstract class EJBMDOrchestrator {
      * specify a class name using the new algoritm. <p>
      *
      * @param classLoader Application class loader to be used
-     * @param className Name of the class to load
-     * @param nameUtil Name Utility instance used to generate the
-     *            name of the generated class to load
+     * @param className   Name of the class to load
+     * @param nameUtil    Name Utility instance used to generate the
+     *                        name of the generated class to load
      *
      * @return the loaded class or null if the class name was null.
      *
      * @throws ClassNotFoundException if a class by the specified
-     *             class name could not be loaded.
+     *                                    class name could not be loaded.
      */
     private Class<?> loadGeneratedClass(ClassLoader classLoader,
                                         String className,
@@ -4452,7 +4455,7 @@ public abstract class EJBMDOrchestrator {
      * Returns a class loader that can be used to define a proxy for the
      * specified interface.
      *
-     * @param bmd the bean metadata
+     * @param bmd  the bean metadata
      * @param intf the interface to proxy
      * @return the loader
      * @throws EJBConfigurationException
@@ -4505,13 +4508,13 @@ public abstract class EJBMDOrchestrator {
      * Defines a wrapper proxy class and obtains its constructor that accepts a
      * WrapperProxyStte.
      *
-     * @param bmd the bean metadata
+     * @param bmd            the bean metadata
      * @param proxyClassName the wrapper proxy class name
      * @param interfaceClass the interface class to proxy
-     * @param methods the methods to define on the proxy
+     * @param methods        the methods to define on the proxy
      * @return the constructor with a WrapperProxyState parameter
      * @throws EJBConfigurationException if a class loader cannot be found
-     * @throws ClassNotFoundException if class generation fails
+     * @throws ClassNotFoundException    if class generation fails
      */
     private Constructor<?> getWrapperProxyConstructor(BeanMetaData bmd,
                                                       String proxyClassName,
@@ -5072,13 +5075,13 @@ public abstract class EJBMDOrchestrator {
      * haven't explicitly indicated if they are for 0 or 1 parm methods, and
      * figure out which group they belong in.
      *
-     * @param timers0ParmByMethodName mapping of method names for methods that
-     *            take 0 parms, and the timers that target them
-     * @param timers1ParmByMethodName mapping of method names for methods that
-     *            take 1 parm, and the timers that target them
+     * @param timers0ParmByMethodName           mapping of method names for methods that
+     *                                              take 0 parms, and the timers that target them
+     * @param timers1ParmByMethodName           mapping of method names for methods that
+     *                                              take 1 parm, and the timers that target them
      * @param timersUnspecifiedParmByMethodName mapping of method names and the
-     *            timers that target them, for timers that have an unspecified parm list in xml
-     * @param beanClass the base ejb class
+     *                                              timers that target them, for timers that have an unspecified parm list in xml
+     * @param beanClass                         the base ejb class
      * @parma bmd BeanMetaData
      */
     private void mapUnspecifiedTimers(Map<String, List<com.ibm.ws.javaee.dd.ejb.Timer>> timers0ParmByMethodName,
@@ -5226,13 +5229,13 @@ public abstract class EJBMDOrchestrator {
      * method name, and adds them to the correct group of timers (timers targeting 1 parm
      * methods, or timers targeting 0 parm methods).
      *
-     * @param methodToTimers mapping of methodNames to the timers that are associated
-     *            with that method; represents either the set of timers targeting 1 parm methods
-     *            or the set of timers targeting 0 parm methods
-     * @param methodName the name of a method that is targeted by timers defined in
-     *            xml with unspecified parameter lists
+     * @param methodToTimers                    mapping of methodNames to the timers that are associated
+     *                                              with that method; represents either the set of timers targeting 1 parm methods
+     *                                              or the set of timers targeting 0 parm methods
+     * @param methodName                        the name of a method that is targeted by timers defined in
+     *                                              xml with unspecified parameter lists
      * @param timersUnspecifiedParmByMethodName mapping of method names and the timers
-     *            with unspecified parameter lists that are associated with those methods
+     *                                              with unspecified parameter lists that are associated with those methods
      */
     private void addUnspecifiedTimersToMap(Map<String, List<com.ibm.ws.javaee.dd.ejb.Timer>> methodToTimers,
                                            String methodName,
@@ -5256,10 +5259,10 @@ public abstract class EJBMDOrchestrator {
      * Verifies that every timer defined in xml was successfully associated
      * with a Method.
      *
-     * @param timers1ParmByMethodName List of timers defined in xml with 1 parm.
-     * @param timers0ParmByMethodName List of timers defined in xml with 0 parms.
+     * @param timers1ParmByMethodName           List of timers defined in xml with 1 parm.
+     * @param timers0ParmByMethodName           List of timers defined in xml with 0 parms.
      * @param timersUnspecifiedParmByMethodName List of timers defined in xml with unspecified parms.
-     * @param bmd BeanMetaData
+     * @param bmd                               BeanMetaData
      * @throws EJBConfigurationException
      */
     private void dealWithUnsatisifedXMLTimers(Map<String, List<com.ibm.ws.javaee.dd.ejb.Timer>> timers1ParmByMethodName,
@@ -5293,7 +5296,7 @@ public abstract class EJBMDOrchestrator {
      * were successfully mapped to a Method.
      *
      * @param xmlTimers List of Timer instances representing timers defined in xml.
-     * @param bmd BeanMetaData
+     * @param bmd       BeanMetaData
      * @return
      * @throws EJBConfigurationException
      */
@@ -5329,12 +5332,12 @@ public abstract class EJBMDOrchestrator {
      * Sticks a timer defined in xml into the correct list, based on the number
      * of parameters specified in xml for the timer.
      *
-     * @param timers1ParmByMethodName list of timers specified in xml with 1 parm
-     * @param timers0ParmByMethodName list of timers specified in xml with 0 parms
+     * @param timers1ParmByMethodName           list of timers specified in xml with 1 parm
+     * @param timers0ParmByMethodName           list of timers specified in xml with 0 parms
      * @param timersUnspecifiedParmByMethodName list of timers specified in xml with undefined parms
-     * @param parmCount number of parms explicitily defined for the timer in xml (1, 0, or -1 for undefined)
-     * @param methodName name of the Method that should be the recipient of the timer callback
-     * @param timer The Timer instance representing the timer defined in xml
+     * @param parmCount                         number of parms explicitily defined for the timer in xml (1, 0, or -1 for undefined)
+     * @param methodName                        name of the Method that should be the recipient of the timer callback
+     * @param timer                             The Timer instance representing the timer defined in xml
      */
     private void addTimerToCorrectMap(Map<String, List<com.ibm.ws.javaee.dd.ejb.Timer>> timers1ParmByMethodName,
                                       Map<String, List<com.ibm.ws.javaee.dd.ejb.Timer>> timers0ParmByMethodName,
@@ -5370,11 +5373,11 @@ public abstract class EJBMDOrchestrator {
     //F743-15870
     /**
      *
-     * @param methodParams MethodParams representing the parameters defined in xml for the timer.
-     * @param bmd BeanMetaData
-     * @param methodName The name of the Method that will receive the timer callback.
+     * @param methodParams               MethodParams representing the parameters defined in xml for the timer.
+     * @param bmd                        BeanMetaData
+     * @param methodName                 The name of the Method that will receive the timer callback.
      * @param programaticallyCreatedFlow indicates if the programatically created or automatically created
-     *            timer processing invoke the method.
+     *                                       timer processing invoke the method.
      * @return -1 if the parms are undefined, 0 if explicitly set to no parm, 1 if explicitly set to 1 parm
      * @throws EJBConfigurationException
      */
@@ -5469,11 +5472,11 @@ public abstract class EJBMDOrchestrator {
      * <li> parameters must either be empty or Timer
      * </ul>
      *
-     * @param bmd bean metadata for the bean being processed
+     * @param bmd    bean metadata for the bean being processed
      * @param method the session synchronization method
      *
      * @throws EJBConfigurationException thrown if the method has not been
-     *             coded properly based on the rules in the specification
+     *                                       coded properly based on the rules in the specification
      */
     private void validateTimeoutCallbackMethod(BeanMetaData bmd, MethodMap.MethodInfo methodInfo) // d666251
                     throws EJBConfigurationException {
@@ -5603,11 +5606,11 @@ public abstract class EJBMDOrchestrator {
     /**
      * Processes a Schedule annotation.
      *
-     * @param timerMethod the existing timer method metadata, or null if no
-     *            timer metadata has been created for this method
-     * @param method the method for this automatic timer
+     * @param timerMethod  the existing timer method metadata, or null if no
+     *                         timer metadata has been created for this method
+     * @param method       the method for this automatic timer
      * @param timerMethods the list of timer method metadata
-     * @param schedule the annotation
+     * @param schedule     the annotation
      * @return the processed automatic timer metadata
      */
     // F743-506
@@ -5693,10 +5696,10 @@ public abstract class EJBMDOrchestrator {
      * for all module versions to ensure ivCallbackKind is initialized.
      *
      * @param bmd is the BeanMetaData for the EJB. <b>Note: </b> The {@link #finishBMDInit(BeanMetaData, ComponentDataObject, String)} and the
-     *            {@link #finishBMDInit(BeanMetaData, ComponentDataObject, InjectionEngine)} methods are required to be called prior to this method.
+     *                {@link #finishBMDInit(BeanMetaData, ComponentDataObject, InjectionEngine)} methods are required to be called prior to this method.
      *
      * @throws EJBConfigurationException is thrown if an error in interceptor configuration
-     *             (either annotation or WCCM) is detected.
+     *                                       (either annotation or WCCM) is detected.
      */
     // d367572.3 added entire method. // d367572.4 re-wrote method.
     private void initializeInterceptorMD(BeanMetaData bmd, final Map<Method, ArrayList<EJBMethodInfoImpl>> methodInfoMap) // d430356
@@ -6003,7 +6006,7 @@ public abstract class EJBMDOrchestrator {
      * Note, this method must only be called if the bean is a SFSB and
      * it is in a EJB 3 module.
      *
-     * @param bmd is the BeanMetaData for the SFSB.
+     * @param bmd     is the BeanMetaData for the SFSB.
      * @param methods is the array of Method objects for all public methods of the EJB.
      *
      * @throws EJBConfigurationException if any customer configuration error is detected.
@@ -6237,7 +6240,7 @@ public abstract class EJBMDOrchestrator {
      * since the method might appear in more than one method interface array that exists
      * for the EJB.
      *
-     * @param bmd is the BeanMetaData for the EJB.
+     * @param bmd             is the BeanMetaData for the EJB.
      * @param allMethodsOfEJB is the array of Method objects for all public methods of the EJB.
      *
      * @return a Map of java reflection Method object to ArrayList of EJBMethodInfoImpl
@@ -6317,7 +6320,7 @@ public abstract class EJBMDOrchestrator {
      * Find the EJBMethodInfo in a specified array of EJBMethodInfo
      * that contains a specified Method object.
      *
-     * @param methodInfos is the array of EJBMethodInfo objects to search.
+     * @param methodInfos  is the array of EJBMethodInfo objects to search.
      *
      * @param targetMethod is the target of the search.
      *
@@ -7503,12 +7506,12 @@ public abstract class EJBMDOrchestrator {
      * against the specification, including the restriction that the
      * class may not also implement the SessionSynchronization interface. <p>
      *
-     * @param bmd bean metadata for the bean being processed
+     * @param bmd  bean metadata for the bean being processed
      * @param bean the XML representation of the session enterprise bean
      *
      * @throws EJBConfigurationException thrown if any of the session
-     *             synchronization were not defined within the rules of the
-     *             specification.
+     *                                       synchronization were not defined within the rules of the
+     *                                       specification.
      */
     // F743-25855
     private void processSessionSynchronizationMD(BeanMetaData bmd, Session bean) throws EJBConfigurationException {
@@ -7582,14 +7585,14 @@ public abstract class EJBMDOrchestrator {
      * synchronization method from XML. If the session synchronization method
      * was not specified in XML, then null will be returned. <p>
      *
-     * @param bmd bean metadata for the bean being processed
-     * @param namedMethod session synchronization method from XML, may be null
+     * @param bmd            bean metadata for the bean being processed
+     * @param namedMethod    session synchronization method from XML, may be null
      * @param expectedParams expected parameters for session synchronization method
-     * @param xmlType the xml element type; used for configuration errors
+     * @param xmlType        the xml element type; used for configuration errors
      *
      * @return the Method associated with the XML configuration
      * @throws EJBConfigurationException thrown if a corresponding method cannot
-     *             be found on the bean class, or the parameters are not correct.
+     *                                       be found on the bean class, or the parameters are not correct.
      */
     // F743-25855
     private Method getSessionSynchMethod(BeanMetaData bmd,
@@ -7694,7 +7697,7 @@ public abstract class EJBMDOrchestrator {
      *
      * @param bmd bean metadata for the bean being processed
      * @throws EJBConfigurationException thrown if multiple methods have
-     *             been coded with the same annotation.
+     *                                       been coded with the same annotation.
      */
     // F743-25855
     private void findAnnotatedSessionSynchMethods(BeanMetaData bmd) throws EJBConfigurationException {
@@ -7774,13 +7777,13 @@ public abstract class EJBMDOrchestrator {
      * <li> parameters must be null or boolean, depending on which method
      * </ul>
      *
-     * @param bmd bean metadata for the bean being processed
-     * @param method the session synchronization method
+     * @param bmd            bean metadata for the bean being processed
+     * @param method         the session synchronization method
      * @param expectedParams the expected parameters for the method
-     * @param methodType the xml type of the session synchronization method
+     * @param methodType     the xml type of the session synchronization method
      *
      * @throws EJBConfigurationException thrown if the method has not been
-     *             coded properly based on the rules in the specification
+     *                                       coded properly based on the rules in the specification
      */
     // F743-25855
     private void validateSessionSynchronizationMethod(BeanMetaData bmd,
@@ -7865,9 +7868,9 @@ public abstract class EJBMDOrchestrator {
      * prevent the methods from being overridden in the generated proxy/wrapper. <p>
      *
      * @param listenerMethods
-     *            methods declared on the listener interface or message-driven
-     *            bean implementation when the listener interface has no
-     *            methods.
+     *                            methods declared on the listener interface or message-driven
+     *                            bean implementation when the listener interface has no
+     *                            methods.
      *
      * @return the listener methods excluding methods that overlap with the
      *         MessageEndpoint interface.


### PR DESCRIPTION
Ensure Jakarta EE 10 Concurrency compliance by rejecting the use of `@Asynchronous` on EJBs. 

Spec Documentation: https://github.com/jakartaee/concurrency/blob/master/specification/src/main/asciidoc/jakarta-concurrency.adoc#5-asynchronous-methods

> The jakarta.enterprise.concurrent.Asynchronous annotation annotates a CDI managed bean method to run asynchronously. The CDI managed bean must not be a Jakarta Enterprise Bean, and neither the method nor its class can be annotated with the MicroProfile Asynchronous annotation.

Behavior:
If the `jakarta.enterprise.concurrent.Asynchronous` annotation is used on a Jakarta Enterprise Bean method then we will both log and throw an error to notify the user that the annotation they used is not supported within the EJB container.

If the `jakarta.enterprise.concurrent.Asynchronous` annotation is used on a Jakarta Enterprise Interface method then we will log a warning to notify the user that the annotation they used is not supported within the EJB container.  However, since users should not expect interface method annotations to be inherited and the specification offers no guidance on how to handle this situation we will allow the application to be installed and used. 
