### PR TITLE
Copy autoFVT overrides into test directory structure

### DIFF
--- a/dev/com.ibm.ws.transport.iiop.open_fat/build.gradle
+++ b/dev/com.ibm.ws.transport.iiop.open_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -36,3 +36,12 @@ task copyBundles {
 }
 
 addRequiredLibraries { dependsOn copyBundles }
+
+task copyOverridesIntoAutoFVT(type: Copy) {
+    mustRunAfter autoFVT
+    from project.file('override/autoFVT/src/ant')
+    into new File(autoFvtDir,"src/ant")
+    include '*.xml'
+}
+
+zipAutoFVT.dependsOn copyOverridesIntoAutoFVT


### PR DESCRIPTION
Adding gradle instructions to deal with contents of FAT project's /override/autoFVT/ directory
