### PR TITLE
Reduce sampling from 3 to 1 for UserEnumTest

### DIFF
--- a/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/UserEnumerationTest.java
+++ b/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/UserEnumerationTest.java
@@ -250,7 +250,12 @@ public class UserEnumerationTest {
         final int allowedRatioMax = 130;
 
         final int validityCheckRounds = 10;
-        final int loopTries = 3;
+
+        /*
+         * Since I switched to the CustomRepo instead of LDAP, we were sometimes
+         * sampling ourselves to extra average. Try 1 to 1 comparison.
+         */
+        final int loopTries = 1;
 
         for (int j = 0; j < validityCheckRounds; j++) {
             /*


### PR DESCRIPTION
Reduce the sampling for `UserEnumerationTest`. It looks like now we're averaging out the invalid/valid tests so they are more matchy-matchy which is generally fine, but not consistent for the FAT test. Since we have a more consistent response with the CustomRepo, I think we can compare 1 invalid to 1 valid call instead of the average of 3 to 3. Just changing the loop count for now, if it doesn't work, we can change the loop count again.

RTC 290280