### PR TITLE
additional tests for aged timeout and minpoolsize

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/JDBC41Test.java
+++ b/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/JDBC41Test.java
@@ -81,6 +81,18 @@ public class JDBC41Test extends FATServletClient {
     }
 
     @Test
+    public void testAgedTimeoutWithTLS() throws Exception {
+        FATServletClient.runTest(server, appName + '/' + "BasicTestServlet", "testAgedTimeoutWithTLS");
+        FATServletClient.runTest(server, appName + '/' + "BasicTestServlet", "checkPoolAfterTestAgedTimeoutWithTLS");
+    }
+
+    @Test
+    public void testAgedTimeout90mWithTLS() throws Exception {
+        FATServletClient.runTest(server, appName + '/' + "BasicTestServlet", "testAgedTimeout90mWithTLS");
+        FATServletClient.runTest(server, appName + '/' + "BasicTestServlet", "checkPoolAfterTestAgedTimeout90mWithTLS");
+    }
+
+    @Test
     public void testAgedTimeoutDisabledWithTLS() throws Exception {
         FATServletClient.runTest(server, appName + '/' + "BasicTestServlet", "testAgedTimeoutDisabledWithTLS");
         FATServletClient.runTest(server, appName + '/' + "BasicTestServlet", "checkPoolAfterTestAgedTimeoutDisabledWithTLS");
@@ -96,6 +108,12 @@ public class JDBC41Test extends FATServletClient {
     public void testMinPoolSizeMettWithTLS() throws Exception {
         FATServletClient.runTest(server, appName + '/' + "BasicTestServlet", "testMinPoolSizeMettWithTLS");
         FATServletClient.runTest(server, appName + '/' + "BasicTestServlet", "checkPoolAfterTestMinPoolSizeMettWithTLS");
+    }
+
+    @Test
+    public void testMinPoolSizeNotMettWithTLS() throws Exception {
+        FATServletClient.runTest(server, appName + '/' + "BasicTestServlet", "testMinPoolSizeNotMettWithTLS");
+        FATServletClient.runTest(server, appName + '/' + "BasicTestServlet", "checkPoolAfterTestMinPoolSizeNotMettWithTLS");
     }
 
     @Test

--- a/dev/com.ibm.ws.jdbc_fat_v41/publish/files/server_derby40.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v41/publish/files/server_derby40.xml
@@ -65,6 +65,18 @@
       <connectionManager agedTimeout="-1" connectionTimeout="-1" maxPoolSize="2" numConnectionsPerThreadLocal="1"/>
     </dataSource>
     
+    <dataSource id="dsfat22ctls" fat.modify="true" jndiName="jdbc/dsfat22ctls">
+      <jdbcDriver libraryRef="DerbyLib" fat.modify="true"/>
+      <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <connectionManager agedTimeout="1s" connectionTimeout="-1" maxPoolSize="2" numConnectionsPerThreadLocal="1" reapTime="1s"/>
+    </dataSource>
+    
+    <dataSource id="dsfat22dtls" fat.modify="true" jndiName="jdbc/dsfat22dtls">
+      <jdbcDriver libraryRef="DerbyLib" fat.modify="true"/>
+      <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <connectionManager agedTimeout="90m" connectionTimeout="-1" maxPoolSize="2" numConnectionsPerThreadLocal="1" reapTime="1s"/>
+    </dataSource>
+    
     <dataSource id="dsfat22etls" fat.modify="true" jndiName="jdbc/${id}">
       <jdbcDriver libraryRef="DerbyLib" fat.modify="true"/>
       <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
@@ -93,6 +105,12 @@
       <jdbcDriver libraryRef="DerbyLib" fat.modify="true"/>
       <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
       <connectionManager agedTimeout="-1" maxIdleTime="1s" maxPoolSize="3" minPoolSize="2" numConnectionsPerThreadLocal="3" reapTime="1s"/>
+    </dataSource>
+    
+    <dataSource id="dsfat22ktls" fat.modify="true" jndiName="jdbc/dsfat22ktls">
+      <jdbcDriver libraryRef="DerbyLib" fat.modify="true"/>
+      <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <connectionManager agedTimeout="-1" maxIdleTime="90m" maxPoolSize="3" minPoolSize="2" numConnectionsPerThreadLocal="3" reapTime="1s"/>
     </dataSource>
     
     <dataSource id="dsfat22ltls" fat.modify="true" jndiName="jdbc/${id}">

--- a/dev/com.ibm.ws.jdbc_fat_v41/publish/servers/com.ibm.ws.jdbc.fat.v41/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v41/publish/servers/com.ibm.ws.jdbc.fat.v41/server.xml
@@ -72,6 +72,18 @@
       <connectionManager agedTimeout="-1" connectionTimeout="-1" maxPoolSize="2" numConnectionsPerThreadLocal="1"/>
     </dataSource>
     
+    <dataSource id="dsfat22ctls" fat.modify="true" jndiName="jdbc/dsfat22ctls">
+      <jdbcDriver libraryRef="DerbyLib" fat.modify="true"/>
+      <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <connectionManager agedTimeout="1s" connectionTimeout="-1" maxPoolSize="2" numConnectionsPerThreadLocal="1" reapTime="1s"/>
+    </dataSource>
+    
+    <dataSource id="dsfat22dtls" fat.modify="true" jndiName="jdbc/dsfat22dtls">
+      <jdbcDriver libraryRef="DerbyLib" fat.modify="true"/>
+      <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <connectionManager agedTimeout="90m" connectionTimeout="-1" maxPoolSize="2" numConnectionsPerThreadLocal="1" reapTime="1s"/>
+    </dataSource>
+    
     <dataSource id="dsfat22etls" fat.modify="true" jndiName="jdbc/${id}">
       <jdbcDriver libraryRef="DerbyLib" fat.modify="true"/>
       <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
@@ -100,6 +112,12 @@
       <jdbcDriver libraryRef="DerbyLib" fat.modify="true"/>
       <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
       <connectionManager agedTimeout="-1" maxIdleTime="1s" maxPoolSize="3" minPoolSize="2" numConnectionsPerThreadLocal="3" reapTime="1s"/>
+    </dataSource>
+    
+    <dataSource id="dsfat22ktls" fat.modify="true" jndiName="jdbc/dsfat22ktls">
+      <jdbcDriver libraryRef="DerbyLib" fat.modify="true"/>
+      <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <connectionManager agedTimeout="-1" maxIdleTime="90m" maxPoolSize="3" minPoolSize="2" numConnectionsPerThreadLocal="3" reapTime="1s"/>
     </dataSource>
     
     <dataSource id="dsfat22ltls" fat.modify="true" jndiName="jdbc/${id}">


### PR DESCRIPTION
Addition of new thread local storage tests for the connectionManager for agedTimeout and minPoolSize options.

