### PR TITLE
Reduce trace in DynamicJACCFeatureTest

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/publish/servers/com.ibm.ws.ejbcontainer.security.jacc_fat/bootstrap.properties
+++ b/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/publish/servers/com.ibm.ws.ejbcontainer.security.jacc_fat/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -9,11 +9,12 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 
+# reduced some trace due to slow runtime on Windows
 com.ibm.ws.logging.trace.specification=*=event=enabled:\
-com.ibm.ws.security.*=all=enabled:\
-com.ibm.ws.ejbcontainer.security.*=all=enabled:\
+com.ibm.ws.security.*=debug=enabled:\
+com.ibm.ws.ejbcontainer.security.*=debug=enabled:\
 applications=all:\
-com.ibm.ws.webcontainer.security.*=all=enabled
+com.ibm.ws.webcontainer.security.*=event=enabled
 bootstrap.include=../testports.properties
 -Xdump:system:events=throw+systhrow,filter=java/lang/IllegalArgumentException#jdk/internal/reflect/ConstantPool.getClassAt0,range=1..3,request=exclusive+prepwalk
 -Xdump:system:events=throw+systhrow,filter=java/lang/IllegalArgumentException#sun/reflect/ConstantPool.getClassAt0,range=1..3,request=exclusive+prepwalk


### PR DESCRIPTION
Server startup can be slow on Windows, causing a `Start Server error: The server did not show kernel had started. The server did not show kernel had started. The standard error was: ....`. Try reducing the trace for this test.

RTC 290123