### PR TITLE
JAX-RS + JAX-WS: Remove CXF client bundle

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.cxf.common-3.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.cxf.common-3.2.feature
@@ -8,7 +8,6 @@ IBM-App-ForceRestart: uninstall, \
 Subsystem-Name: Internal Apache CXF 3.2 Common Feature for JAX-RS and JAX-WS
 -bundles=\
  com.ibm.websphere.org.osgi.service.http; location:="dev/api/spec/,lib/", \
- com.ibm.ws.cxf.client, \
  com.ibm.ws.org.apache.cxf.cxf.core.3.2, \
  com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2, \
  com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlws.common-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlws.common-3.0.feature
@@ -29,7 +29,6 @@ IBM-API-Package:\
   com.ibm.websphere.appserver.internal.slf4j-1.7
 -bundles=\
  io.openliberty.org.osgi.service.http; location:="dev/api/spec/,lib/", \
- com.ibm.ws.cxf.client, \
  com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2.jakarta, \
  com.ibm.ws.org.apache.cxf.cxf.rt.bindings.xml.3.2.jakarta, \
  com.ibm.ws.org.apache.cxf.cxf.core.3.2.jakarta, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlws.common-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlws.common-4.0.feature
@@ -29,7 +29,6 @@ IBM-API-Package:\
   com.ibm.websphere.appserver.internal.slf4j-1.7
 -bundles=\
  io.openliberty.org.osgi.service.http; location:="dev/api/spec/,lib/", \
- com.ibm.ws.cxf.client, \
  com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2.jakarta, \
  com.ibm.ws.org.apache.cxf.cxf.rt.bindings.xml.3.2.jakarta, \
  com.ibm.ws.org.apache.cxf.cxf.core.3.2.jakarta, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jaxrsClient-2.0/com.ibm.websphere.appserver.jaxrsClient-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jaxrsClient-2.0/com.ibm.websphere.appserver.jaxrsClient-2.0.feature
@@ -9,8 +9,7 @@ IBM-ShortName: jaxrsClient-2.0
 Subsystem-Name: Java RESTful Services Client 2.0
 -features=com.ibm.websphere.appserver.jaxrs.common-2.0, \
   com.ibm.websphere.appserver.eeCompatible-7.0
--bundles=com.ibm.ws.jaxrs.2.0.client, \
- com.ibm.ws.cxf.client
+-bundles=com.ibm.ws.jaxrs.2.0.client
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
@@ -42,7 +42,9 @@ Export-Package: \
 	com.ibm.ws.jaxrs20.clientconfig,\
 	org.apache.cxf.feature,\
 	org.apache.cxf.jaxrs.client;version=3.1.18,\
-	com.ibm.ws.cxf.exceptions;version=3.1.18
+	com.ibm.ws.cxf.exceptions;version=3.1.18,\
+    com.ibm.ws.cxf.client, \
+    com.ibm.ws.cxf.client.component
 
 Import-Package: \
  !com.wordnik.swagger.jaxrs.config, \
@@ -150,7 +152,8 @@ Include-Resource: \
 -dsannotations: com.ibm.ws.jaxrs20.component.*, \
  	com.ibm.ws.jaxrs20.clientconfig.JAXRSClientConfigImpl, \
  	com.ibm.ws.jaxrs20.providers.customexceptionmapper.CustomExceptionMapperRegister, \
- 	com.ibm.ws.jaxrs20.providers.security.SecurityAnnoProviderRegister
+ 	com.ibm.ws.jaxrs20.providers.security.SecurityAnnoProviderRegister, \
+ 	com.ibm.ws.cxf.client.component.*
 
 -dependson: com.ibm.ws.org.codehaus.jackson
 

--- a/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
@@ -42,7 +42,7 @@ Export-Package: \
 	com.ibm.ws.jaxrs20.clientconfig,\
 	org.apache.cxf.feature,\
 	org.apache.cxf.jaxrs.client;version=3.1.18,\
-	com.ibm.ws.cxf.exceptions;version=3.1.18,\
+    com.ibm.ws.cxf.exceptions;version=3.1.18,\
     com.ibm.ws.cxf.client, \
     com.ibm.ws.cxf.client.component
 

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/cxf/client/AsyncClientRunnableWrapper.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/cxf/client/AsyncClientRunnableWrapper.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2018-2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cxf.client;
+
+import org.apache.cxf.message.Message;
+
+/**
+ * Implementations of this interface will wrap the JAX-RS Async Client
+ * runnable with a new runnable (or return the original runnable). For
+ * example, an implementation could wrap the runnable to ensure that it
+ * has the necessary Java EE contexts when the runnable is executed on
+ * another thread.
+ */
+public interface AsyncClientRunnableWrapper {
+
+    void prepare(Message message);
+
+    Runnable wrap(Message message, Runnable runnable);
+}

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/cxf/client/component/AsyncClientRunnableWrapperManager.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/cxf/client/component/AsyncClientRunnableWrapperManager.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2018-2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cxf.client.component;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.apache.cxf.message.Message;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import com.ibm.ws.cxf.client.AsyncClientRunnableWrapper;
+
+@Component(name = "com.ibm.ws.cxf.client.component.AsyncClientRunnableWrapperManager",
+           property = { "service.vendor=IBM" })
+public class AsyncClientRunnableWrapperManager {
+
+    private static final List<AsyncClientRunnableWrapper> wrappers = new CopyOnWriteArrayList<>();
+
+    public static void prepare(Message message) {
+        for (AsyncClientRunnableWrapper wrapper : wrappers) {
+            try {
+                wrapper.prepare(message);
+            } catch (Throwable t) {
+                // auto FFDC - process FFDC and then continue
+            }
+        }
+    }
+
+    public static Runnable wrap(Message message, Runnable runnable) {
+        Runnable ret = runnable;
+        for (AsyncClientRunnableWrapper wrapper : wrappers) {
+            try {
+                ret = wrapper.wrap(message, ret);
+            } catch (Throwable t) {
+                // auto FFDC - process FFDC and then continue
+            }
+        }
+        return ret;
+    }
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE,
+               policy = ReferencePolicy.DYNAMIC,
+               policyOption = ReferencePolicyOption.GREEDY)
+    protected void addWrapper(AsyncClientRunnableWrapper wrapper) {
+        wrappers.add(wrapper);
+    }
+
+    protected void removeWrapper(AsyncClientRunnableWrapper wrapper) {
+        wrappers.remove(wrapper);
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/cxf/client/component/package-info.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/cxf/client/component/package-info.java
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+package com.ibm.ws.cxf.client.component;

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/cxf/client/package-info.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/cxf/client/package-info.java
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+package com.ibm.ws.cxf.client;

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.overrides
@@ -138,7 +138,7 @@ Import-Package: \
   *
 
 -dsannotations: \
- 	com.ibm.ws.cxf.client.component.*
+  com.ibm.ws.cxf.client.component.*
  	
 DynamicImport-Package: \
   com.ctc.wstx.*,\

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.overrides
@@ -99,7 +99,9 @@ Export-Package: \
   org.apache.cxf.ws.addressing.v200403;version=${exportVer},\
   org.apache.cxf.ws.addressing.v200408;version=${exportVer},\
   org.apache.cxf.ws.addressing.wsdl;version=${exportVer},\
-  org.apache.cxf.wsdl.http;version=${exportVer}
+  org.apache.cxf.wsdl.http;version=${exportVer},\
+  com.ibm.ws.cxf.client, \
+  com.ibm.ws.cxf.client.component
 
 Private-Package: \
   com.ibm.ws.cxf.core
@@ -135,6 +137,9 @@ Import-Package: \
   !javax.xml.ws.*, \
   *
 
+-dsannotations: \
+ 	com.ibm.ws.cxf.client.component.*
+ 	
 DynamicImport-Package: \
   com.ctc.wstx.*,\
   com.sun.xml.messaging.saaj.*,\

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/com/ibm/ws/cxf/client/AsyncClientRunnableWrapper.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/com/ibm/ws/cxf/client/AsyncClientRunnableWrapper.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2018-2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cxf.client;
+
+import org.apache.cxf.message.Message;
+
+/**
+ * Implementations of this interface will wrap the JAX-RS Async Client
+ * runnable with a new runnable (or return the original runnable). For
+ * example, an implementation could wrap the runnable to ensure that it
+ * has the necessary Java EE contexts when the runnable is executed on
+ * another thread.
+ */
+public interface AsyncClientRunnableWrapper {
+
+    void prepare(Message message);
+
+    Runnable wrap(Message message, Runnable runnable);
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/com/ibm/ws/cxf/client/component/AsyncClientRunnableWrapperManager.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/com/ibm/ws/cxf/client/component/AsyncClientRunnableWrapperManager.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2018-2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cxf.client.component;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.apache.cxf.message.Message;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import com.ibm.ws.cxf.client.AsyncClientRunnableWrapper;
+
+@Component(name = "com.ibm.ws.cxf.client.component.AsyncClientRunnableWrapperManager",
+           property = { "service.vendor=IBM" })
+public class AsyncClientRunnableWrapperManager {
+
+    private static final List<AsyncClientRunnableWrapper> wrappers = new CopyOnWriteArrayList<>();
+
+    public static void prepare(Message message) {
+        for (AsyncClientRunnableWrapper wrapper : wrappers) {
+            try {
+                wrapper.prepare(message);
+            } catch (Throwable t) {
+                // auto FFDC - process FFDC and then continue
+            }
+        }
+    }
+
+    public static Runnable wrap(Message message, Runnable runnable) {
+        Runnable ret = runnable;
+        for (AsyncClientRunnableWrapper wrapper : wrappers) {
+            try {
+                ret = wrapper.wrap(message, ret);
+            } catch (Throwable t) {
+                // auto FFDC - process FFDC and then continue
+            }
+        }
+        return ret;
+    }
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE,
+               policy = ReferencePolicy.DYNAMIC,
+               policyOption = ReferencePolicyOption.GREEDY)
+    protected void addWrapper(AsyncClientRunnableWrapper wrapper) {
+        wrappers.add(wrapper);
+    }
+
+    protected void removeWrapper(AsyncClientRunnableWrapper wrapper) {
+        wrappers.remove(wrapper);
+    }
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/com/ibm/ws/cxf/client/component/package-info.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/com/ibm/ws/cxf/client/component/package-info.java
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+package com.ibm.ws.cxf.client.component;

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/com/ibm/ws/cxf/client/package-info.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/com/ibm/ws/cxf/client/package-info.java
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+package com.ibm.ws.cxf.client;


### PR DESCRIPTION
This pull request removes the `com.ibm.ws.cxf.client` bundle that was used to minimize code duplication across jaxrs-2.1 and jaxrs-2.0, by putting the code in `com.ibm.ws.jaxws.2.0.common` and `com.ibm.ws.org.apache.cxf.cxf.core.3.2`, as the code is dependent on `org.apache.cxf.message.Message` and each version of the JAX-RS feature needs to have the cxf.client apis use the applicable version of CXF. 