### PR TITLE
20858 Fix localConnector when allowAttachSelf=false

### DIFF
--- a/dev/com.ibm.ws.jmx.connector.local/src/com/ibm/ws/jmx/connector/local/LocalConnectorActivator.java
+++ b/dev/com.ibm.ws.jmx.connector.local/src/com/ibm/ws/jmx/connector/local/LocalConnectorActivator.java
@@ -70,13 +70,17 @@ public final class LocalConnectorActivator {
                         String localConnectorAddress = null;
                         // Start the JMX agent and retrieve the local connector address.
                         if (JavaInfo.majorVersion() < 9 ||
-                            (JavaInfo.majorVersion() >= 9 && !Boolean.getBoolean("jdk.attach.allowAttachSelf"))) {
+                            (JavaInfo.majorVersion() >= 9 && (!Boolean.getBoolean("jdk.attach.allowAttachSelf") ||
+                                                              System.getProperty("com.ibm.tools.attach.enable", "yes").equalsIgnoreCase("no")))) {
                             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                                 Tr.debug(tc, "Using old code path for self attach using JDK internal APIs",
                                          JavaInfo.majorVersion(),
+                                         System.getProperty("com.ibm.tools.attach.enable", "yes"),
                                          Boolean.getBoolean("jdk.attach.allowAttachSelf"));
-                            // Use JDK internal APIs for Java 8 and older OR if the server was launched in a way that bypassed
-                            // the wlp/bin/server script and therefore did not get the -Djdk.attach.allowAttachSelf=true prop set
+                            // Use JDK internal APIs for Java 8 and older
+                            // OR
+                            // if the server was launched in a way that bypassed the wlp/bin/server script and therefore did not get
+                            // the -Djdk.attach.allowAttachSelf=true prop set or com.ibm.tools.attach.enable was set to no.
                             // TODO: Also go down this path if j2sec is enabled, because the proper API path has permission issues
                             //       which are being looked at under https://github.com/eclipse/openj9/issues/6119
 

--- a/dev/com.ibm.ws.kernel.boot/publish/platform/java/java9.options
+++ b/dev/com.ibm.ws.kernel.boot/publish/platform/java/java9.options
@@ -58,3 +58,9 @@ java.base/java.text=ALL-UNNAMED
 # For https://github.com/OpenLiberty/open-liberty/issues/20818
 --add-opens
 java.base/sun.net.www.protocol.https=ALL-UNNAMED
+# For https://github.com/OpenLiberty/open-liberty/issues/20858
+--add-exports
+jdk.management.agent/jdk.internal.agent=ALL-UNNAMED
+# Also for https://github.com/OpenLiberty/open-liberty/issues/20858
+--add-exports
+java.base/jdk.internal.vm=ALL-UNNAMED


### PR DESCRIPTION
Fixes #20858 

The first issue is fixed by the code change to `localConnectorActivator.java`.

The second issue is fixed by updating the java9.options file with these two entries:
```
--add-exports
jdk.management.agent/jdk.internal.agent=ALL-UNNAMED
--add-exports
java.base/jdk.internal.vm=ALL-UNNAMED
```