### PR TITLE
Validate admin center preferences

### DIFF
--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/Toolbox.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/Toolbox.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
Validate admin center preferences 
- to accept only known keys and values
- if invalid key is used, remove it
- If invalid value is used, set to default value