### PR TITLE
Fix queryTestCatalogXmlSKST.xml for RTC 290432

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/svlquery/web/svlquery.war/WEB-INF/classes/META-INF/queryTestCatalogXmlSKST.xml
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/svlquery/web/svlquery.war/WEB-INF/classes/META-INF/queryTestCatalogXmlSKST.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- AtestCatalog metadata in xml -->
-<entity-mappings xmlns="http://java.sun.com/xml/ns/persistence/orm" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence/orm_2_0.xsd" version="2.0">
+<entity-mappings xmlns="http://java.sun.com/xml/ns/persistence/orm" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence/orm http://java.sun.com/xml/ns/persistence/orm_2_0.xsd" version="2.0">
   <package>com.ibm.ws.query.entities.xml</package>
 
   <!-- <named-queries> -->


### PR DESCRIPTION
As the title says, fix a bad schema file header in a test's ORM.XML file.