### PR TITLE
[20897] - update optional monitor imports to dynamic

### DIFF
--- a/dev/io.openliberty.jaxrs30/bnd.bnd
+++ b/dev/io.openliberty.jaxrs30/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -19,8 +19,8 @@ Bundle-SymbolicName: io.openliberty.jaxrs30.javaee
 
 Import-Package: \
   com.ibm.websphere.jaxrs20.multipart, \
-  com.ibm.websphere.jaxrs.monitor;resolution:=optional, \
-  com.ibm.websphere.monitor.jmx;resolution:=optional, \
+  com.ibm.websphere.jaxrs.monitor;resolution:=dynamic, \
+  com.ibm.websphere.monitor.jmx;resolution:=dynamic, \
   com.ibm.websphere.ras, \
   com.ibm.ws.jaxrs20.multipart.impl;resolution:=optional, \
   jakarta.activation, \
@@ -31,7 +31,7 @@ Import-Package: \
   jakarta.ws.rs.ext, \
   jakarta.ws.rs.sse, \
   org.jboss.resteasy.plugins.providers.multipart
-  
+
 
 Export-Package: \
   com.ibm.websphere.jaxrs20.multipart, \
@@ -54,7 +54,7 @@ publish.wlp.jar.suffix: dev/api/ibm
  com.ibm.websphere.javaee.jaxrs.2.1;version=latest, \
  io.openliberty.jakarta.restfulWS.3.0;version=latest, \
  javax.activation:activation;version=1.1
- 
+
 jakartaeeMe: true
 jakartaFinalJarName: io.openliberty.jaxrs30.jar
 jakartaFinalBundleId: io.openliberty.jaxrs30


### PR DESCRIPTION
Similar to https://github.com/OpenLiberty/open-liberty/pull/18004 but for `restfulWS-3.0`