### PR TITLE
Skip custom RW FATs on iSeries for acmeCA

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeConfigVariationsTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeConfigVariationsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -386,7 +386,7 @@ public class AcmeConfigVariationsTest {
 			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration);
 			assertNotNull("Expected CWPKI2042E in logs.", server.waitForStringInLog("CWPKI2042E"));
 
-			if (AcmeFatUtils.isWindows(testName.getMethodName())) {
+			if (AcmeFatUtils.isWindows(testName.getMethodName()) || AcmeFatUtils.isISeries(testName.getMethodName())) {
 				acmeCA.setSubjectDN("cn=domain1.com");
 				acmeCA.setAccountKeyFile(null);
 			} else {

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSwapDirectoriesTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSwapDirectoriesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -248,9 +248,10 @@ public class AcmeSwapDirectoriesTest {
 	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
 	public void update_directoryURI_filePermissions() throws Exception {
         Assume.assumeTrue(!AcmeFatUtils.isWindows(testName.getMethodName()));
-		/*
-		 * Configure the acmeCA-2.0 feature.
-		 */
+        Assume.assumeTrue(!AcmeFatUtils.isISeries(testName.getMethodName()));
+        /*
+         * Configure the acmeCA-2.0 feature.
+         */
 		AcmeFatUtils.configureAcmeCA(server, caContainer, ORIGINAL_CONFIG, false, false, false, DOMAINS_1);
 
 		try {
@@ -318,7 +319,7 @@ public class AcmeSwapDirectoriesTest {
 			AcmeFatUtils.waitForAcmeToCreateCertificate(server);
 
 			if (acmefile.exists()) {
-				fail("The ACME file should not exist.");
+				fail("The ACME file should not exist. Running test on OS: " + System.getProperty("os.name"));
 			}
 			Log.info(this.getClass(), testName.getMethodName(), "TEST 2: FINISH.");
 				

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
@@ -880,6 +880,22 @@ public class AcmeFatUtils {
  		}
  		return false;
  	}
+ 	
+ 	/**
+ 	 * Check if the test is running on iSeries / OS/400
+ 	 * @param methodName the name of the method being run.
+ 	 * @return True if the test is running on iSeries.
+ 	 */
+ 	public static boolean isISeries(String methodName) {
+ 		if (System.getProperty("os.name").toLowerCase().startsWith("os/400")) {
+ 			// iSeries not enforcing the setReadable/setWriteable
+ 			Log.info(AcmeFatUtils.class, methodName,
+ 					"Skipping unreadable/unwriteable file tests on iSeries: "
+ 							+ System.getProperty("os.name", "unknown"));
+ 			return true;
+ 		}
+ 		return false;
+ 	}
 
  	/**
  	 * Handle adding CWPKI2045W as an allowed warning message to all stopServer requests.


### PR DESCRIPTION
We have some acmeCA tests that programmatically set some config related files to unreadable/unwritable in the JUNIT FAT. This works on most OS, but not Windows and not iSeries currently. Add a check and skip on iSeries OS.

RTC 290401