### PR TITLE
Cache name separator property

### DIFF
--- a/dev/com.ibm.ws.session.cache/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.session.cache/resources/OSGI-INF/l10n/metatype.properties
@@ -24,6 +24,9 @@ libraryRef.desc=Identifies JCache provider files.
 uri=JCache configuration URI
 uri.desc=Vendor-specific JCache configuration URI, which is passed to the JCache provider when the CacheManager is obtained. This setting is ignored when cacheManagerRef is used.
 
+cacheSeparator=Cache Name Separator
+cacheSeparator.desc=The single character used to separate the session meta cache name. The default value should usually be used. 
+
 properties=JCache Configuration Properties
 properties.desc=List of vendor-specific JCache configuration properties, which are passed to the JCache provider when the CacheManager is obtained. This setting is ignored when cacheManagerRef is used.
 

--- a/dev/com.ibm.ws.session.cache/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.session.cache/resources/OSGI-INF/metatype/metatype.xml
@@ -24,6 +24,7 @@
   <AD id="monitor.target"                 type="String"  default="(|(!(filter>=!))(filter=*Session*))" ibm:final="true" name="internal" description="internal use only"/>
   <AD id="service.ranking"                type="Integer" default="50" ibm:final="true" name="internal" description="internal use only"/> <!-- httpSessionDatabase takes precedence -->
   <AD id="uri" type="String" ibm:type="location" required="false" name="%uri" description="%uri.desc"/>
+  <AD id="cacheSeparator"                 type="String"  required="false" name="%cacheSeparator" description="%cacheSeparator.desc" default="%"/>
   <AD id="properties" required="false"    type="String"  cardinality="1" ibm:type="pid" ibm:reference="com.ibm.ws.session.cache.properties" ibm:flat="true"/>
   <!-- group: performance -->
   <AD id="scheduleInvalidationFirstHour"  type="Integer" required="false" min="0" max="23" ibmui:group="performance" name="%scheduleInval1" description="%scheduleInval.desc"/>

--- a/dev/com.ibm.ws.session.cache/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.session.cache/resources/OSGI-INF/metatype/metatype.xml
@@ -24,7 +24,7 @@
   <AD id="monitor.target"                 type="String"  default="(|(!(filter>=!))(filter=*Session*))" ibm:final="true" name="internal" description="internal use only"/>
   <AD id="service.ranking"                type="Integer" default="50" ibm:final="true" name="internal" description="internal use only"/> <!-- httpSessionDatabase takes precedence -->
   <AD id="uri" type="String" ibm:type="location" required="false" name="%uri" description="%uri.desc"/>
-  <AD id="cacheSeparator"                 type="String"  required="false" name="%cacheSeparator" description="%cacheSeparator.desc" default="%"/>
+  <AD id="cacheSeparator"                 type="String"  required="false" ibm:type="pid" name="%cacheSeparator" description="%cacheSeparator.desc" default="%"/>
   <AD id="properties" required="false"    type="String"  cardinality="1" ibm:type="pid" ibm:reference="com.ibm.ws.session.cache.properties" ibm:flat="true"/>
   <!-- group: performance -->
   <AD id="scheduleInvalidationFirstHour"  type="Integer" required="false" min="0" max="23" ibmui:group="performance" name="%scheduleInval1" description="%scheduleInval.desc"/>

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
@@ -152,10 +152,16 @@ public class CacheHashMap extends BackedHashMap {
             // Build a unique per-application cache name by starting with the application context root and percent encoding
             // the / and : characters (JCache spec does not allow these in cache names)
             // and also the % character (which is necessary because of percent encoding)
-            String a = PERCENT.matcher(_iStore.getId()).replaceAll("%25"); // must be done first to avoid replacing % that is added when replacing the others
-            a = SLASH.matcher(a).replaceAll("%2F");
-            a = COLON.matcher(a).replaceAll("%3A");
-
+            String a = _iStore.getId();
+            if (Character.compare(_smc.getCacheSeparator(), '%') == 0) {
+                a = PERCENT.matcher(a).replaceAll("%25"); // must be done first to avoid replacing % that is added when replacing the others
+                a = SLASH.matcher(a).replaceAll("%2F");
+                a = COLON.matcher(a).replaceAll("%3A");
+            } else {
+                a = SLASH.matcher(a).replaceAll(Character.toString(_smc.getCacheSeparator()));
+                a = COLON.matcher(a).replaceAll(Character.toString(_smc.getCacheSeparator()));
+            }
+            
             // Session Meta Information Cache
 
             String metaCacheName = new StringBuilder(24 + a.length()).append("com.ibm.ws.session.meta.").append(a).toString();

--- a/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionManagerConfig.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionManagerConfig.java
@@ -96,6 +96,8 @@ public class SessionManagerConfig implements Cloneable {
     private String sacKey = "DEFAULT_SAC_KEY";
 
     // The following properties are set via Custom Properties
+    private static char cacheSeparator = '%';
+    
     private static char cloneSeparator = ':';
     private boolean debugSessionCrossover = false;
     private static boolean cloneIdPropertySet = false;
@@ -700,6 +702,13 @@ public class SessionManagerConfig implements Cloneable {
      * 
      * CUSTOM PROPERTIES
      */
+    public static final char getCacheSeparator() {
+        return cacheSeparator;
+    }
+
+    public static final void setCacheSeparator(char c) {
+        cacheSeparator = c;
+    }    
 
     // cloneSeparator
     public static final char getCloneSeparator() {

--- a/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionProperties.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionProperties.java
@@ -34,6 +34,7 @@ final public class SessionProperties {
         FullyQualifiedPropertiesMap.put("SessionIdentifierMaxLength", "idMaxLength");
         FullyQualifiedPropertiesMap.put("CloneSeparatorChange", "cloneSeparatorChange");
         FullyQualifiedPropertiesMap.put("CloneSeparator", "cloneSeparator");
+        FullyQualifiedPropertiesMap.put("CacheSeparator", "cacheSeparator");
         FullyQualifiedPropertiesMap.put("NoAffinitySwitchBack", "noAffinitySwitchBack");
         FullyQualifiedPropertiesMap.put("UseOracleBLOB", "useOracleBlob");
         FullyQualifiedPropertiesMap.put("SessionTableSkipIndexCreation", "skipIndexCreation");
@@ -263,6 +264,22 @@ final public class SessionProperties {
             }
         }
 
+        // httpSessionCache property
+        final String propCacheSeparator = "CacheSeparator";
+        strProp = getStringProperty(propCacheSeparator, xtpProperties);
+        if (strProp != null) {
+            // Must be exactly one char, and cannot be space
+            if ((strProp.length() == 1) && (strProp.trim().length() == 1)) {
+                if (shouldSetAndDoLogging(propCacheSeparator, true, baseServerLevelConfig, xtpProperties, strProp, null, false)) {
+                    char charProp = strProp.charAt(0);
+                    SessionManagerConfig.setCacheSeparator(charProp);
+                }
+            } else {
+                LoggingUtil.SESSION_LOGGER_CORE.logp(Level.WARNING, methodClassName, methodName, invalidPropFoundMessage,
+                                                     new Object[] { strProp });
+            }
+        }        
+        
         // no affinity switch back - stick to new server after failover
         final String propNoAffSwitch = "NoAffinitySwitchBack";
         strProp = getStringProperty(propNoAffSwitch, xtpProperties);


### PR DESCRIPTION
Session custom property CacheSeparator to customize the cache naming

cacheSeparator=Cache Name Separator
cacheSeparator.desc=The single character used to separate the session meta cache name. The default value % should usually be used.