### PR TITLE
wsSecurity-1.1: Clean up WSS4j and Santario logging issues. 

### DIFF
--- a/dev/com.ibm.ws.org.apache.santuario.xmlsec/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.santuario.xmlsec/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019,2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -9,6 +9,8 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= jar:${fileuri;${repo;org.apache.santuario:xmlsec;1.5.2.ibm}}!/META-INF/MANIFEST.MF,bnd.overrides
+
+instrument.disabled: true
 
 -includeresource: \
    @${repo;org.apache.santuario:xmlsec;1.5.2.ibm;EXACT}!/!META-INF/maven/*,\

--- a/dev/com.ibm.ws.org.apache.ws.security.wss4j/.classpath
+++ b/dev/com.ibm.ws.org.apache.ws.security.wss4j/.classpath
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.org.apache.ws.security.wss4j/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.ws.security.wss4j/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019,2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -9,5 +9,10 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= jar:${fileuri;${repo;org.apache.ws.security:wss4j;1.6.7.ibm-s20130913-2015}}!/META-INF/MANIFEST.MF,bnd.overrides
+
+instrument.disabled: true
+
+-includeresource: \
+   @${repo;org.apache.ws.security:wss4j;1.6.7.ibm-s20130913-2015}!/!META-INF/maven/*
 
 -buildpath: org.apache.ws.security:wss4j;version=1.6.7.ibm-s20130913-2015

--- a/dev/com.ibm.ws.org.apache.ws.security.wss4j/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.ws.security.wss4j/bnd.bnd
@@ -10,9 +10,12 @@
 #*******************************************************************************
 -include= jar:${fileuri;${repo;org.apache.ws.security:wss4j;1.6.7.ibm-s20130913-2015}}!/META-INF/MANIFEST.MF,bnd.overrides
 
-instrument.disabled: true
-
 -includeresource: \
-   @${repo;org.apache.ws.security:wss4j;1.6.7.ibm-s20130913-2015}!/!META-INF/maven/*
+  @${repo;org.apache.ws.security:wss4j;1.6.7.ibm-s20130913-2015}!/!META-INF/maven/*,\
+  org/apache/ws/security=${bin}/org/apache/ws/security
 
--buildpath: org.apache.ws.security:wss4j;version=1.6.7.ibm-s20130913-2015
+-buildpath: \
+	org.apache.ws.security:wss4j;version='1.6.7.ibm-s20130913-2015',\
+	com.ibm.ws.org.apache.santuario.xmlsec.1.5.2;version=latest,\
+	com.ibm.ws.logging.core;version=latest,\
+	org.apache.commons.logging


### PR DESCRIPTION
This pull request disables trace injection in `com.ibm.ws.org.apache.santuario.xmlsec` and cleans up improper trace being sent to message.log from the `com.ibm.ws.org.apache.ws.security.wss4j` bundle