### PR TITLE
Remove back-channel logout config attributes that aren't used

### DIFF
--- a/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/metatype/metatype.xml
@@ -431,8 +431,6 @@
 
            <AD id="backchannelLogoutUri" name="internal" description="internal use only" required="false" type="String" ibm:beta="true" />
 
-           <AD id="backchannelLogoutSessionRequired" name="internal" description="internal use only" required="false" type="Boolean" default="false" ibm:beta="true" />
-
     </OCD>
     
     <Designate factoryPid="com.ibm.ws.security.oauth20.client">

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/api/OidcOAuth20Client.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/api/OidcOAuth20Client.java
@@ -100,6 +100,4 @@ public interface OidcOAuth20Client extends OAuth20Client {
 
     public String getBackchannelLogoutUri();
 
-    public boolean isBackchannelLogoutSessionRequired();
-
 }

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/internal/LibertyOAuth20Provider.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/internal/LibertyOAuth20Provider.java
@@ -238,7 +238,6 @@ public class LibertyOAuth20Provider implements OAuth20Provider, ConfigurationLis
     public static final String KEY_CLIENT_PROOF_KEY_FOR_CODE_EXCHANGE = "proofKeyForCodeExchange";
     public static final String KEY_CLIENT_PUBLIC_CLIENT = "publicClient";
     public static final String KEY_CLIENT_BACKCHANNEL_LOGOUT_URI = "backchannelLogoutUri";
-    public static final String KEY_CLIENT_BACKCHANNEL_LOGOUT_SESSION_REQUIRED = "backchannelLogoutSessionRequired";
 
     public static final String KEY_ROPC_PREFER_USERSECURITYNAME = "ropcPreferUserSecurityName";
     public static final String KEY_ROPC_PREFER_USERPRINCIPALNAME = "ropcPreferUserPrincipalName";
@@ -1275,11 +1274,6 @@ public class LibertyOAuth20Provider implements OAuth20Provider, ConfigurationLis
         }
         newClient.setPublicClient(publicClient);
         newClient.setBackchannelLogoutUri((String) props.get(KEY_CLIENT_BACKCHANNEL_LOGOUT_URI));
-        boolean isBackchannelLogoutSessionRequired = false;
-        if (props.get(KEY_CLIENT_BACKCHANNEL_LOGOUT_SESSION_REQUIRED) != null) {
-            isBackchannelLogoutSessionRequired = ((Boolean) props.get(KEY_CLIENT_BACKCHANNEL_LOGOUT_SESSION_REQUIRED)).booleanValue();
-        }
-        newClient.setBackchannelLogoutSessionRequired(isBackchannelLogoutSessionRequired);
         // newClient.setAppPasswordLifetime(((Long) props.get(KEY_CLIENT_APP_PASSWORD_LIFETIME)).longValue());
         // newClient.setAppTokenLifetime(((Long) props.get(KEY_CLIENT_APP_TOKEN_LIFETIME)).longValue());
         // newClient.setAppTokenOrPasswordLimit(((Long) props.get(KEY_APP_TOKEN_OR_PASSWORD_LIMIT)).longValue());

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OidcBaseClient.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OidcBaseClient.java
@@ -448,11 +448,6 @@ public class OidcBaseClient extends BaseClient implements Serializable, OidcOAut
         this.backchannelLogoutUri = backchannelLogoutUri;
     }
 
-    @Override
-    public boolean isBackchannelLogoutSessionRequired() {
-        return backchannelLogoutSessionRequired;
-    }
-
     @Trivial
     public void setBackchannelLogoutSessionRequired(boolean backchannelLogoutSessionRequired) {
         this.backchannelLogoutSessionRequired = backchannelLogoutSessionRequired;

--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
@@ -154,8 +154,6 @@
          <AD id="keyManagementKeyAlias" name="%keyManagementKeyAlias" description="%keyManagementKeyAlias.desc" required="false" type="String" />
          <AD id="accessTokenCacheEnabled" name="%accessTokenCacheEnabled" description="%accessTokenCacheEnabled.desc" required="false" type="Boolean" default="true" />
          <AD id="accessTokenCacheTimeout" name="%accessTokenCacheTimeout" description="%accessTokenCacheTimeout.desc" required="false" type="String" default="5m" ibm:type="duration" />
-         <AD id="backchannelLogoutSupported" name="internal" description="internal use only" required="false" type="Boolean" default="false" ibm:beta="true" />
-         <AD id="backchannelLogoutSessionRequired" name="internal" description="internal use only" required="false" type="Boolean" default="false" ibm:beta="true" />
      </OCD>
 
     <Designate factoryPid="com.ibm.ws.security.openidconnect.client.oidcClientConfig">

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
@@ -173,8 +173,6 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     public static final String CFG_KEY_KEY_MANAGEMENT_KEY_ALIAS = "keyManagementKeyAlias";
     public static final String CFG_KEY_ACCESS_TOKEN_CACHE_ENABLED = "accessTokenCacheEnabled";
     public static final String CFG_KEY_ACCESS_TOKEN_CACHE_TIMEOUT = "accessTokenCacheTimeout";
-    public static final String CFG_KEY_BACKCHANNEL_LOGOUT_SUPPORTED = "backchannelLogoutSupported";
-    public static final String CFG_KEY_BACKCHANNEL_LOGOUT_SESSION_REQUIRED = "backchannelLogoutSessionRequired";
 
     public static final String OPDISCOVERY_AUTHZ_EP_URL = "authorization_endpoint";
     public static final String OPDISCOVERY_TOKEN_EP_URL = "token_endpoint";
@@ -270,8 +268,6 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     private String keyManagementKeyAlias;
     private boolean accessTokenCacheEnabled = true;
     private long accessTokenCacheTimeout = 1000 * 60 * 5;
-    private boolean backchannelLogoutSupported = false;
-    private boolean backchannelLogoutSessionRequired = false;
 
     private String oidcClientCookieName;
     private boolean authnSessionDisabled;
@@ -548,8 +544,6 @@ public class OidcClientConfigImpl implements OidcClientConfig {
         keyManagementKeyAlias = configUtils.getConfigAttribute(props, CFG_KEY_KEY_MANAGEMENT_KEY_ALIAS);
         accessTokenCacheEnabled = configUtils.getBooleanConfigAttribute(props, CFG_KEY_ACCESS_TOKEN_CACHE_ENABLED, accessTokenCacheEnabled);
         accessTokenCacheTimeout = configUtils.getLongConfigAttribute(props, CFG_KEY_ACCESS_TOKEN_CACHE_TIMEOUT, accessTokenCacheTimeout);
-        backchannelLogoutSupported = configUtils.getBooleanConfigAttribute(props, CFG_KEY_BACKCHANNEL_LOGOUT_SUPPORTED, backchannelLogoutSupported);
-        backchannelLogoutSessionRequired = configUtils.getBooleanConfigAttribute(props, CFG_KEY_BACKCHANNEL_LOGOUT_SESSION_REQUIRED, backchannelLogoutSessionRequired);
         // TODO - 3Q16: Check the validationEndpointUrl to make sure it is valid
         // before continuing to process this config
         // checkValidationEndpointUrl();
@@ -626,8 +620,6 @@ public class OidcClientConfigImpl implements OidcClientConfig {
             Tr.debug(tc, "forwardLoginParameter:" + forwardLoginParameter);
             Tr.debug(tc, "accessTokenCacheEnabled:" + accessTokenCacheEnabled);
             Tr.debug(tc, "accessTokenCacheTimeout:" + accessTokenCacheTimeout);
-            Tr.debug(tc, "backchannelLogoutSupported:" + backchannelLogoutSupported);
-            Tr.debug(tc, "backchannelLogoutSessionRequired:" + backchannelLogoutSessionRequired);
         }
     }
 
@@ -1945,16 +1937,6 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     @Override
     public long getAccessTokenCacheTimeout() {
         return accessTokenCacheTimeout;
-    }
-
-    @Override
-    public boolean isBackchannelLogoutSupported() {
-        return backchannelLogoutSupported;
-    }
-
-    @Override
-    public boolean isBackchannelLogoutSessionRequired() {
-        return backchannelLogoutSessionRequired;
     }
 
     @Override

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
@@ -293,9 +293,5 @@ LOGOUT_TOKEN_EVENTS_MEMBER_VALUE_NOT_JSON=CWWKS1550E: The value for the "{0}" me
 LOGOUT_TOKEN_EVENTS_MEMBER_VALUE_NOT_JSON.explanation=The corresponding member value must be a JSON object. The expected value is "{}", an empty JSON object.
 LOGOUT_TOKEN_EVENTS_MEMBER_VALUE_NOT_JSON.useraction=Ensure that the "events" claim in the logout token is formatted correctly.
 
-LOGOUT_TOKEN_SID_REQUIRED_BUT_MISSING=CWWKS1551E: The logout token is missing the "sid" claim but the {0} OpenID Connect client requires it.
-LOGOUT_TOKEN_SID_REQUIRED_BUT_MISSING.explanation=The OpenID Connect client requires that the logout token contains a session ID to identify the OpenID Connect client session with the OpenID Connect provider.
-LOGOUT_TOKEN_SID_REQUIRED_BUT_MISSING.useraction=Set the backchannelLogoutSessionRequired OpenID Connect client configuration attribute to false, or ensure that the logout token contains a "sid" claim.
-
 # STOP HERE, OIDC SERVER HAS RESERVED 1600 - 1649
 

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidator.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidator.java
@@ -132,18 +132,13 @@ public class LogoutTokenValidator {
     }
 
     /**
-     * Verifies that the Logout Token contains a sub Claim, a sid Claim, or both. Also verifies that a sid claim is present if
-     * the OIDC client requires that it be there.
+     * Verifies that the Logout Token contains a sub Claim, a sid Claim, or both.
      */
     void verifySubAndOrSidPresent(JwtClaims claims) throws MalformedClaimException, BackchannelLogoutException {
         String sub = claims.getSubject();
         String sid = claims.getClaimValue("sid", String.class);
         if (sub == null && sid == null) {
             String errorMsg = Tr.formatMessage(tc, "LOGOUT_TOKEN_MISSING_SUB_AND_SID");
-            throw new BackchannelLogoutException(errorMsg);
-        }
-        if (sid == null && config.isBackchannelLogoutSessionRequired()) {
-            String errorMsg = Tr.formatMessage(tc, "LOGOUT_TOKEN_SID_REQUIRED_BUT_MISSING", new Object[] { config.getId() });
             throw new BackchannelLogoutException(errorMsg);
         }
     }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/ConvergedClientConfig.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/ConvergedClientConfig.java
@@ -133,8 +133,4 @@ public interface ConvergedClientConfig extends JwtConsumerConfig {
 
     String getIntrospectionTokenTypeHint();
 
-    public boolean isBackchannelLogoutSupported();
-
-    public boolean isBackchannelLogoutSessionRequired();
-
 }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidatorTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/backchannellogout/LogoutTokenValidatorTest.java
@@ -48,7 +48,6 @@ public class LogoutTokenValidatorTest extends CommonTestClass {
     final String CWWKS1548E_LOGOUT_TOKEN_EVENTS_CLAIM_MISSING_EXPECTED_MEMBER = "CWWKS1548E";
     final String CWWKS1549E_LOGOUT_TOKEN_CONTAINS_NONCE_CLAIM = "CWWKS1549E";
     final String CWWKS1550E_LOGOUT_TOKEN_EVENTS_MEMBER_VALUE_NOT_JSON = "CWWKS1550E";
-    final String CWWKS1551E_LOGOUT_TOKEN_SID_REQUIRED_BUT_MISSING = "CWWKS1551E";
 
     final String CWWKS1751E_OIDC_IDTOKEN_VERIFY_ISSUER_ERR = "CWWKS1751E";
     final String CWWKS1754E_OIDC_IDTOKEN_VERIFY_AUD_ERR = "CWWKS1754E";
@@ -418,30 +417,8 @@ public class LogoutTokenValidatorTest extends CommonTestClass {
     }
 
     @Test
-    public void test_verifySubAndOrSidPresent_missingSid_sidRequired() throws Exception {
+    public void test_verifySubAndOrSidPresent_hasSubMissingSid() throws Exception {
         JsonObject jsonClaims = getMinimumClaimsNoSid();
-        JwtClaims claims = JwtClaims.parse(jsonClaims.toString());
-        try {
-            mockery.checking(new Expectations() {
-                {
-                    one(clientConfig).isBackchannelLogoutSessionRequired();
-                    will(returnValue(true));
-                    one(clientConfig).getId();
-                    will(returnValue(CONFIG_ID));
-                }
-            });
-            validator.verifySubAndOrSidPresent(claims);
-            fail("Should have thrown an exception but didn't.");
-        } catch (BackchannelLogoutException e) {
-            verifyException(e, CWWKS1551E_LOGOUT_TOKEN_SID_REQUIRED_BUT_MISSING);
-        }
-    }
-
-    @Test
-    public void test_verifySubAndOrSidPresent_hasSidMissingSub_sidRequired() throws Exception {
-        JsonObject jsonClaims = getMinimumClaimsNoSid();
-        jsonClaims.remove(Claims.SUBJECT);
-        jsonClaims.addProperty("sid", SID);
         JwtClaims claims = JwtClaims.parse(jsonClaims.toString());
         try {
             validator.verifySubAndOrSidPresent(claims);
@@ -589,8 +566,6 @@ public class LogoutTokenValidatorTest extends CommonTestClass {
                 will(returnValue(clockSkew));
                 allowing(clientConfig).getIssuerIdentifier();
                 will(returnValue(issuerIdentifier));
-                allowing(clientConfig).isBackchannelLogoutSessionRequired();
-                will(returnValue(false));
             }
         });
         if (sharedKey != null) {

--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
@@ -448,8 +448,6 @@
         <AD id="forwardLoginParameter" name="internal" description="internal use only" required="false" type="String" cardinality="2147483647" />
         <AD id="createSession" name="%createSession" description="%createSession.desc" required="false" type="Boolean" default="false" />
         <AD id="keyManagementKeyAlias" name="%keyManagementKeyAlias" description="%keyManagementKeyAlias.desc" required="false" type="String" />
-        <AD id="backchannelLogoutSupported" name="internal" description="internal use only" required="false" type="Boolean" default="false" ibm:beta="true" />
-        <AD id="backchannelLogoutSessionRequired" name="internal" description="internal use only" required="false" type="Boolean" default="false" ibm:beta="true" />
     </OCD>
     
      <OCD id="com.ibm.ws.security.social.client.param.metatype" name="%oidcClientCustomRequestParam" description="%oidcClientCustomRequestParam.desc" 

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
@@ -129,10 +129,6 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements Conver
     private List<String> forwardLoginParameter = null;
     public static final String CFG_KEY_KEY_MANAGEMENT_KEY_ALIAS = "keyManagementKeyAlias";
     private String keyManagementKeyAlias = null;
-    public static final String CFG_KEY_BACKCHANNEL_LOGOUT_SUPPORTED = "backchannelLogoutSupported";
-    private boolean backchannelLogoutSupported = false;
-    public static final String CFG_KEY_BACKCHANNEL_LOGOUT_SESSION_REQUIRED = "backchannelLogoutSessionRequired";
-    private boolean backchannelLogoutSessionRequired = false;
 
     HttpUtils httputils = new HttpUtils();
     ConfigUtils oidcConfigUtils = new ConfigUtils(null);
@@ -211,8 +207,6 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements Conver
 
         forwardLoginParameter = oidcConfigUtils.readAndSanitizeForwardLoginParameter(props, uniqueId, CFG_KEY_FORWARD_LOGIN_PARAMETER);
         keyManagementKeyAlias = configUtils.getConfigAttribute(props, CFG_KEY_KEY_MANAGEMENT_KEY_ALIAS);
-        backchannelLogoutSupported = configUtils.getBooleanConfigAttribute(props, CFG_KEY_BACKCHANNEL_LOGOUT_SUPPORTED, backchannelLogoutSupported);
-        backchannelLogoutSessionRequired = configUtils.getBooleanConfigAttribute(props, CFG_KEY_BACKCHANNEL_LOGOUT_SESSION_REQUIRED, backchannelLogoutSessionRequired);
 
         if (discovery) {
             String OIDC_CLIENT_DISCOVERY_COMPLETE = "CWWKS6110I: The client [{" + getId() + "}] configuration has been established with the information from the discovery endpoint URL [{" + discoveryEndpointUrl + "}]. This information enables the client to interact with the OpenID Connect provider to process the requests such as authorization and token.";
@@ -410,8 +404,6 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements Conver
             Tr.debug(tc, KEY_resource + " = " + resource);
             Tr.debug(tc, CFG_KEY_FORWARD_LOGIN_PARAMETER + " = " + forwardLoginParameter);
             Tr.debug(tc, CFG_KEY_KEY_MANAGEMENT_KEY_ALIAS + " = " + keyManagementKeyAlias);
-            Tr.debug(tc, CFG_KEY_BACKCHANNEL_LOGOUT_SUPPORTED + " = " + backchannelLogoutSupported);
-            Tr.debug(tc, CFG_KEY_BACKCHANNEL_LOGOUT_SESSION_REQUIRED + " = " + backchannelLogoutSessionRequired);
         }
     }
 
@@ -921,16 +913,6 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements Conver
             return JwtUtils.getPrivateKey(keyAlias, keyStoreRef);
         }
         return null;
-    }
-
-    @Override
-    public boolean isBackchannelLogoutSupported() {
-        return backchannelLogoutSupported;
-    }
-
-    @Override
-    public boolean isBackchannelLogoutSessionRequired() {
-        return backchannelLogoutSessionRequired;
     }
 
 }


### PR DESCRIPTION
Removes the following config attributes:
- OAuth client:
    - `backchannelLogoutSessionRequired`
- RPs (OIDC client and social):
    - `backchannelLogoutSupported`
    - `backchannelLogoutSessionRequired`