### PR TITLE
check all maven repo before throwing exception

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
+++ b/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
@@ -112,7 +112,6 @@ public class FeatureUtility {
 
         map = new InstallKernelMap();
         info(Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("STATE_INITIALIZING"));
-        map.put("req.ol.json.coord", "io.openliberty.features");
         Map<String, Object> envMap = (Map<String, Object>) map.get("environment.variable.map");
         
         if (envMap == null) {


### PR DESCRIPTION
fixes #20933 

Manually tested following scenarios:
`repo1` has helloWorld feature and `repo2` has simpleActivator feature.
1. Add repo1 and repo2 to featureUtility.properties then install simpleActivator -> Checks repo1 first, then finds simpleActivator in repo2. 
2. Add repo1 and repo2 to featureUtility.properties then install helloWorld and simpleActivator feature -> finds helloWorld1 from repo1 and simpleActivator from repo2