### PR TITLE
AppSecurity-5.0 still requires request context

### DIFF
--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
@@ -500,13 +500,13 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
          * Tried to future-proof this check by iterating over all the
          * installed features and finding the version of appSecurity installed,
          * but that introduced a performance degradation. So for now, checking
-         * for the appSecurity-3.0/4.0 features directly.
+         * for the appSecurity-3.0/4.0/5.0 features directly.
          */
         if (WebContainer.getServletContainerSpecLevel() < WebContainer.SPEC_LEVEL_40) {
             return false;
         }
         Set<String> features = provisionerService.getInstalledFeatures();
-        return features.contains("appSecurity-3.0") || features.contains("appSecurity-4.0");
+        return features.contains("appSecurity-3.0") || features.contains("appSecurity-4.0") || features.contains("appSecurity-5.0");
     }
 
     /**


### PR DESCRIPTION
Add appSecurity-5.0 (EE10) to the list of features which mean the
WebAppSecurityCollaborator reports that CDI is needed.

Fixes RTC 289901