### PR TITLE
GRPC: recognise appSecurity-5.0

### DIFF
--- a/dev/io.openliberty.grpc.1.0.internal/src/io/openliberty/grpc/internal/servlet/GrpcServerComponent.java
+++ b/dev/io.openliberty.grpc.1.0.internal/src/io/openliberty/grpc/internal/servlet/GrpcServerComponent.java
@@ -280,7 +280,8 @@ public class GrpcServerComponent implements ServletContainerInitializer, Applica
     private void setSecurityEnabled() {
         Set<String> currentFeatureSet = _featureProvisioner.getService().getInstalledFeatures();
         if (currentFeatureSet.contains("appSecurity-2.0") || currentFeatureSet.contains("appSecurity-1.0")
-                || currentFeatureSet.contains("appSecurity-3.0") || currentFeatureSet.contains("appSecurity-4.0")) {
+                || currentFeatureSet.contains("appSecurity-3.0") || currentFeatureSet.contains("appSecurity-4.0")
+                || currentFeatureSet.contains("appSecurity-5.0")) {
             useSecurity = true;
             return;
         }


### PR DESCRIPTION
Add appSecurity-5.0 to grpc's list of security features

Noted this while working on #20947 