### PR TITLE
remove compilation workaround for Trigger and LastExecution

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/TriggerService.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/TriggerService.java
@@ -13,6 +13,9 @@ package com.ibm.ws.concurrent;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
+import javax.enterprise.concurrent.LastExecution;
+import javax.enterprise.concurrent.Trigger;
+
 /**
  * Invokes trigger operations on a Concurrency 3.0+ ZonedTrigger or Concurrency 1.0/2.0 Trigger,
  * depending on which feature is enabled and whether the trigger implements ZonedTrigger.
@@ -26,8 +29,7 @@ public interface TriggerService {
      * @param trigger           Trigger or ZonedTrigger.
      * @return next time to run the task. Null if the task should not run again.
      */
-    // TODO switch Object to LastExecution and Trigger once projects can compile against Jakartified artifacts
-    ZonedDateTime getNextRunTime(Object lastExecution, ZonedDateTime taskScheduledTime, Object trigger);
+    ZonedDateTime getNextRunTime(LastExecution previous, ZonedDateTime taskScheduledTime, Trigger trigger);
 
     /**
      * Returns the time zone id for the trigger.
@@ -35,8 +37,7 @@ public interface TriggerService {
      * @param trigger Trigger or ZonedTrigger.
      * @return ZonedId of the ZonedTrigger. Otherwise the default ZoneId.
      */
-    // TODO switch Object to Trigger once projects can compile against Jakartified artifacts
-    ZoneId getZoneId(Object trigger);
+    ZoneId getZoneId(Trigger trigger);
 
     /**
      * Invokes skipRun on the Trigger, using the signature with ZonedDateTime if possible.
@@ -46,6 +47,5 @@ public interface TriggerService {
      * @param trigger           Trigger or ZonedTrigger.
      * @return true if the execution of the task should be skipped. Otherwise false.
      */
-    // TODO switch Object to LastExecution and Trigger once projects can compile against Jakartified artifacts
-    boolean skipRun(Object lastExecution, ZonedDateTime nextExecutionTime, Object trigger);
+    boolean skipRun(LastExecution lastExecution, ZonedDateTime nextExecutionTime, Trigger trigger);
 }

--- a/dev/com.ibm.ws.concurrent_fat_zcontext/test-applications/SimZOSContextWeb/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.concurrent_fat_zcontext/test-applications/SimZOSContextWeb/resources/WEB-INF/web.xml
@@ -9,10 +9,7 @@
     Contributors:
         IBM Corporation - initial API and implementation
  -->
- <!-- TODO
- <web-app version="6.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"> 
-  -->
-<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"> 
+<web-app version="6.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd">
 
   <!-- For testing access to the application component namespace -->
   <env-entry>
@@ -20,5 +17,17 @@
     <env-entry-type>java.lang.String</env-entry-type>
     <env-entry-value>1value</env-entry-value>
   </env-entry>
+
+  <context-service>
+    <name>java:comp/concurrent/zosWLMContextPropagateOrNew</name>
+    <cleared>Security</cleared>
+    <cleared>SyncToOSThread</cleared>
+    <cleared>Transaction</cleared>
+    <propagated>Classification</propagated>
+    <unchanged>Remaining</unchanged>
+    <property><name>daemonTransactionClass</name><value>DAEMON_TX</value></property>
+    <property><name>defaultTransactionClass</name><value>DEFAULT_TX</value></property>
+    <property><name>wlm</name><value>PropagateOrNew</value></property>
+  </context-service>
 
 </web-app>

--- a/dev/io.openliberty.concurrent.internal.basictrigger/original.bnd
+++ b/dev/io.openliberty.concurrent.internal.basictrigger/original.bnd
@@ -9,6 +9,6 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 
-Bundle-Name: Trigger interoperability for Concurrency 1.0 and 2.0
+Bundle-Name: Trigger interoperability for Concurrency 1.0
 Bundle-SymbolicName: io.openliberty.concurrent.internal.basictrigger
-Bundle-Description: Trigger interoperability for Java EE Concurrency 1.0 and Jakarta Concurrency 2.0; version=${bVersion}
+Bundle-Description: Trigger interoperability for Java EE Concurrency 1.0; version=${bVersion}

--- a/dev/io.openliberty.concurrent.internal.basictrigger/src/io/openliberty/concurrent/internal/basictrigger/BasicTriggerService.java
+++ b/dev/io.openliberty.concurrent.internal.basictrigger/src/io/openliberty/concurrent/internal/basictrigger/BasicTriggerService.java
@@ -33,8 +33,8 @@ public class BasicTriggerService implements TriggerService {
     private static final TraceComponent tc = Tr.register(BasicTriggerService.class);
 
     @Override
-    public ZonedDateTime getNextRunTime(Object lastExecution, ZonedDateTime taskScheduledTime, Object trigger) {
-        Date nextExecutionDate = ((Trigger) trigger).getNextRunTime((LastExecution) lastExecution, Date.from(taskScheduledTime.toInstant()));
+    public ZonedDateTime getNextRunTime(LastExecution lastExecution, ZonedDateTime taskScheduledTime, Trigger trigger) {
+        Date nextExecutionDate = trigger.getNextRunTime(lastExecution, Date.from(taskScheduledTime.toInstant()));
         return nextExecutionDate == null //
                         ? null //
                         : nextExecutionDate.toInstant().atZone(taskScheduledTime.getZone());
@@ -42,12 +42,12 @@ public class BasicTriggerService implements TriggerService {
 
     @Override
     @Trivial
-    public ZoneId getZoneId(Object trigger) {
+    public ZoneId getZoneId(Trigger trigger) {
         return ZoneId.systemDefault();
     }
 
     @Override
-    public boolean skipRun(Object lastExecution, ZonedDateTime nextExecutionTime, Object trigger) {
-        return ((Trigger) trigger).skipRun((LastExecution) lastExecution, Date.from(nextExecutionTime.toInstant()));
+    public boolean skipRun(LastExecution lastExecution, ZonedDateTime nextExecutionTime, Trigger trigger) {
+        return trigger.skipRun(lastExecution, Date.from(nextExecutionTime.toInstant()));
     }
 }

--- a/dev/io.openliberty.concurrent.internal.basictrigger/transformed.bnd
+++ b/dev/io.openliberty.concurrent.internal.basictrigger/transformed.bnd
@@ -10,6 +10,6 @@
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/transform.props
 
-Bundle-Name: Trigger interoperability for Concurrency 1.0 and 2.0 Jakarta
+Bundle-Name: Trigger interoperability for Jakarta Concurrency 2.0
 Bundle-SymbolicName: io.openliberty.concurrent.internal.basictrigger.jakarta
-Bundle-Description: Trigger interoperability for Java EE Concurrency 1.0 and Jakarta Concurrency 2.0; version=${bVersion}; Jakarta Enabled
+Bundle-Description: Trigger interoperability for Jakarta Concurrency 2.0; version=${bVersion}; Jakarta Enabled

--- a/dev/io.openliberty.concurrent.internal/bnd.bnd
+++ b/dev/io.openliberty.concurrent.internal/bnd.bnd
@@ -52,7 +52,7 @@ instrument.classesExcludes: io/openliberty/concurrent/internal/resources/*.class
   com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
   com.ibm.wsspi.org.osgi.service.metatype;version=latest,\
   com.ibm.ws.concurrency.policy;version=latest,\
-  com.ibm.ws.concurrent;version=latest,\
+  com.ibm.ws.concurrent.jakarta;version=latest,\
   com.ibm.ws.config;version=latest,\
   com.ibm.ws.container.service;version=latest,\
   com.ibm.ws.context;version=latest,\

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/trigger/ZonedTriggerService.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/trigger/ZonedTriggerService.java
@@ -34,12 +34,12 @@ public class ZonedTriggerService implements TriggerService {
     private static final TraceComponent tc = Tr.register(ZonedTriggerService.class);
 
     @Override
-    public ZonedDateTime getNextRunTime(Object lastExecution, ZonedDateTime taskScheduledTime, Object trigger) {
+    public ZonedDateTime getNextRunTime(LastExecution lastExecution, ZonedDateTime taskScheduledTime, Trigger trigger) {
         ZonedDateTime nextExecTime;
         if (trigger instanceof ZonedTrigger) {
-            nextExecTime = ((ZonedTrigger) trigger).getNextRunTime((LastExecution) lastExecution, taskScheduledTime);
+            nextExecTime = ((ZonedTrigger) trigger).getNextRunTime(lastExecution, taskScheduledTime);
         } else {
-            Date nextExecutionDate = ((Trigger) trigger).getNextRunTime((LastExecution) lastExecution, Date.from(taskScheduledTime.toInstant()));
+            Date nextExecutionDate = trigger.getNextRunTime(lastExecution, Date.from(taskScheduledTime.toInstant()));
             nextExecTime = nextExecutionDate == null //
                             ? null //
                             : nextExecutionDate.toInstant().atZone(taskScheduledTime.getZone());
@@ -49,7 +49,7 @@ public class ZonedTriggerService implements TriggerService {
 
     @Override
     @Trivial
-    public ZoneId getZoneId(Object trigger) {
+    public ZoneId getZoneId(Trigger trigger) {
         ZoneId zone = trigger instanceof ZonedTrigger //
                         ? ((ZonedTrigger) trigger).getZoneId() //
                         : ZoneId.systemDefault();
@@ -60,12 +60,12 @@ public class ZonedTriggerService implements TriggerService {
     }
 
     @Override
-    public boolean skipRun(Object lastExecution, ZonedDateTime nextExecutionTime, Object trigger) {
+    public boolean skipRun(LastExecution lastExecution, ZonedDateTime nextExecutionTime, Trigger trigger) {
         boolean skip;
         if (trigger instanceof ZonedTrigger) {
-            skip = ((ZonedTrigger) trigger).skipRun((LastExecution) lastExecution, nextExecutionTime);
+            skip = ((ZonedTrigger) trigger).skipRun(lastExecution, nextExecutionTime);
         } else {
-            skip = ((Trigger) trigger).skipRun((LastExecution) lastExecution, Date.from(nextExecutionTime.toInstant()));
+            skip = trigger.skipRun(lastExecution, Date.from(nextExecutionTime.toInstant()));
         }
         return skip;
     }


### PR DESCRIPTION
The workaround to declare the Trigger and LastExecution method parameters as Object is no longer needed now that projects can depend on Jakarta-transformed bundles.