### PR TITLE
Add additional trace to MP Health TCK

### DIFF
--- a/dev/io.openliberty.microprofile.health.3.0.internal_fat_tck/publish/servers/Health30TCKServer/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.health.3.0.internal_fat_tck/publish/servers/Health30TCKServer/bootstrap.properties
@@ -9,4 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:HEALTH=all:com.ibm.ws.webcontainer.extension.*=all
+com.ibm.ws.logging.trace.specification=*=info:HEALTH=all:io.openliberty.microprofile.health30*=all:com.ibm.ws.webcontainer.extension.*=all

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat_tck/publish/servers/Health31TCKServer/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat_tck/publish/servers/Health31TCKServer/bootstrap.properties
@@ -9,4 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:HEALTH=all:com.ibm.ws.webcontainer.extension.*=all
+com.ibm.ws.logging.trace.specification=*=info:HEALTH=all:io.openliberty.microprofile.health31*=all:com.ibm.ws.webcontainer.extension.*=all

--- a/dev/io.openliberty.microprofile.health.4.0.internal_fat_tck/publish/servers/Health40TCKServer/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.health.4.0.internal_fat_tck/publish/servers/Health40TCKServer/bootstrap.properties
@@ -9,4 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:HEALTH=all:com.ibm.ws.webcontainer.extension.*=all
+com.ibm.ws.logging.trace.specification=*=info:HEALTH=all:io.openliberty.microprofile.health31*=all:com.ibm.ws.webcontainer.extension.*=all


### PR DESCRIPTION
- Related to #20833, adding additional trace for better diagnosis for MpHealth 3.1 TCK Test Failure.