### PR TITLE
generic properties list clarification

### DIFF
--- a/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/l10n/metatype.properties
@@ -145,7 +145,7 @@ valTimeout.desc=Specifies a timeout for validation of pooled connections. When s
 # Vendor properties
 
 properties=Generic JDBC Driver Properties
-properties.desc=List of JDBC vendor properties for the data source. For example, databaseName="dbname" serverName="localhost" portNumber="50000". This generic properties list can be used when no vendor-specific properties list type is available for the JDBC driver that you are using. Do not specify multiple properties elements under a data source. Instead, place all property name/value pairs on a single properties or properties.{JDBC_VENDOR_TYPE} element.
+properties.desc=List of JDBC vendor properties for the data source. For example, databaseName="dbname" serverName="localhost" portNumber="50000". Use this generic properties list when no vendor-specific properties list type is available for your JDBC driver. Do not specify multiple properties elements under a data source. Instead, place all property name-value pairs on a single properties or properties.{JDBC_VENDOR_TYPE} element.
 
 properties.datadirect.sqlserver=DataDirect Connect for JDBC (sqlserver) Properties
 properties.datadirect.sqlserver.desc=Data source properties for the DataDirect Connect for JDBC driver for Microsoft SQL Server.

--- a/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2021 IBM Corporation and others.
+# Copyright (c) 2011, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -145,7 +145,7 @@ valTimeout.desc=Specifies a timeout for validation of pooled connections. When s
 # Vendor properties
 
 properties=Generic JDBC Driver Properties
-properties.desc=List of JDBC vendor properties for the data source. For example, databaseName="dbname" serverName="localhost" portNumber="50000".
+properties.desc=List of JDBC vendor properties for the data source. For example, databaseName="dbname" serverName="localhost" portNumber="50000". This generic properties list can be used when no vendor-specific properties list type is available for the JDBC driver that you are using. Do not specify multiple properties lists on a data source.
 
 properties.datadirect.sqlserver=DataDirect Connect for JDBC (sqlserver) Properties
 properties.datadirect.sqlserver.desc=Data source properties for the DataDirect Connect for JDBC driver for Microsoft SQL Server.

--- a/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/l10n/metatype.properties
@@ -145,7 +145,7 @@ valTimeout.desc=Specifies a timeout for validation of pooled connections. When s
 # Vendor properties
 
 properties=Generic JDBC Driver Properties
-properties.desc=List of JDBC vendor properties for the data source. For example, databaseName="dbname" serverName="localhost" portNumber="50000". This generic properties list can be used when no vendor-specific properties list type is available for the JDBC driver that you are using. Do not specify multiple properties lists on a data source.
+properties.desc=List of JDBC vendor properties for the data source. For example, databaseName="dbname" serverName="localhost" portNumber="50000". This generic properties list can be used when no vendor-specific properties list type is available for the JDBC driver that you are using. Do not specify multiple properties elements under a data source. Instead, place all property name/value pairs on a single properties or properties.{JDBC_VENDOR_TYPE} element.
 
 properties.datadirect.sqlserver=DataDirect Connect for JDBC (sqlserver) Properties
 properties.datadirect.sqlserver.desc=Data source properties for the DataDirect Connect for JDBC driver for Microsoft SQL Server.


### PR DESCRIPTION
Adds clarification to the description of the generic data source `<properties>` element.
This addresses the first item of #20971