### PR TITLE
Add com.ibm.websphere.logging.WsLevel to the api.basics jar

### DIFF
--- a/dev/com.ibm.websphere.appserver.api.basics/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.basics/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -15,9 +15,9 @@ Bundle-Name: WebSphere Application Manager API
 Bundle-Description: WebSphere Application Manager API, version ${bVersion}
 Bundle-SymbolicName: com.ibm.websphere.appserver.api.basics
 
-Import-Package: com.ibm.websphere.application,com.ibm.websphere.filemonitor,com.ibm.websphere.runtime.update,com.ibm.websphere.security,com.ibm.websphere.security.auth,com.ibm.websphere.security.cred,com.ibm.wsspi.security.registry
+Import-Package: com.ibm.websphere.application,com.ibm.websphere.filemonitor,com.ibm.websphere.logging,com.ibm.websphere.runtime.update,com.ibm.websphere.security,com.ibm.websphere.security.auth,com.ibm.websphere.security.cred,com.ibm.wsspi.security.registry
 
-Export-Package: com.ibm.websphere.application,com.ibm.websphere.filemonitor,com.ibm.websphere.runtime.update,com.ibm.websphere.security,com.ibm.websphere.security.auth,com.ibm.websphere.security.cred,com.ibm.wsspi.security.registry
+Export-Package: com.ibm.websphere.application,com.ibm.websphere.filemonitor,com.ibm.websphere.logging,com.ibm.websphere.runtime.update,com.ibm.websphere.security,com.ibm.websphere.security.auth,com.ibm.websphere.security.cred,com.ibm.wsspi.security.registry
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.basics/pom.xml=com.ibm.websphere.appserver.api.basics.pom}
 
@@ -27,4 +27,5 @@ publish.wlp.jar.suffix: dev/api/ibm
 	com.ibm.websphere.security;version=latest,\
 	com.ibm.ws.kernel.filemonitor,\
 	com.ibm.ws.runtime.update,\
-	com.ibm.ws.app.manager;version=latest
+	com.ibm.ws.app.manager;version=latest,\
+	com.ibm.ws.logging.core


### PR DESCRIPTION
fixes #18844
- Adds back the `com.ibm.websphere.logging.WsLevel` class to the `wlp/dev/api/ibm/com.ibm.websphere.appserver.api.basics.jar` jar file.