### PR TITLE
Ensure Oracle UCP 2PC works

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ucp/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ucp/server.xml
@@ -48,6 +48,11 @@
     	<properties.oracle.ucp maxPoolSize="3" connectionWaitTimeout="30" URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}" />
     </dataSource>
     
+    <dataSource id="ucpXADS2" jndiName="jdbc/ucpXADS2" type="javax.sql.XADataSource">
+    	<jdbcDriver libraryRef="UCPDBLib" />
+    	<properties.oracle.ucp maxPoolSize="3" connectionWaitTimeout="30" URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}" />
+    </dataSource>
+    
     <dataSource id="ucpConnectionPoolDS" jndiName="jdbc/ucpConnectionPoolDS" type="javax.sql.ConnectionPoolDataSource" >
     	<jdbcDriver libraryRef="UCPDBLib" />
     	<properties.oracle.ucp URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}" />

--- a/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oracleucpfat/src/ucp/web/OracleUCPTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oracleucpfat/src/ucp/web/OracleUCPTestServlet.java
@@ -74,6 +74,17 @@ import oracle.ucp.jdbc.PoolXADataSource;
                                                        maxStatements = 10,
                                                        properties = {
                                                                       "validationTimeout=30"
+                                                       }),
+                                 @DataSourceDefinition(
+                                                       name = "java:comp/env/jdbc/dsdXAUCPDS2",
+                                                       className = "oracle.ucp.jdbc.PoolXADataSourceImpl",
+                                                       url = "${env.URL}",
+                                                       initialPoolSize = 1,
+                                                       user = "${env.USER}",
+                                                       password = "${env.PASSWORD}",
+                                                       maxStatements = 10,
+                                                       properties = {
+                                                                      "validationTimeout=30"
                                                        })
 })
 
@@ -90,6 +101,9 @@ public class OracleUCPTestServlet extends FATServlet {
     @Resource(lookup = "jdbc/ucpXADS", shareable = false)
     private DataSource ucpXADS;
 
+    @Resource(lookup = "jdbc/ucpXADS2", shareable = false)
+    private DataSource ucpXADS2;
+
     @Resource(lookup = "jdbc/ucpDS", shareable = true)
     private DataSource sharedUCPDS;
 
@@ -101,6 +115,9 @@ public class OracleUCPTestServlet extends FATServlet {
 
     @Resource(lookup = "java:comp/env/jdbc/dsdXAUCPDS", shareable = false)
     private DataSource dsdXAUCPDS;
+
+    @Resource(lookup = "java:comp/env/jdbc/dsdXAUCPDS2", shareable = false)
+    private DataSource dsdXAUCPDS2;
 
     @Resource(lookup = "jdbc/ucpDSAuthData")
     private DataSource ucpDSAuthData;
@@ -217,7 +234,7 @@ public class OracleUCPTestServlet extends FATServlet {
         Connection con2 = null;
 
         try {
-            con2 = ucpXADS.getConnection();
+            con2 = ucpXADS2.getConnection();
             tran.begin();
 
             //Add a new row to the db
@@ -497,7 +514,7 @@ public class OracleUCPTestServlet extends FATServlet {
         Connection con2 = null;
 
         try {
-            con2 = dsdXAUCPDS.getConnection();
+            con2 = dsdXAUCPDS2.getConnection();
             tran.begin();
 
             //Add a new row to the db


### PR DESCRIPTION
Use two different data sources to ensure that we participate in a 2PC when testing Oracle UCP XA connections. 