### PR TITLE
Fix isEnabled impl for JPA31 Runners

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA31.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA31.java
@@ -22,10 +22,10 @@ import componenttest.rules.repeater.RepeatTestAction;
 public class RepeatWithJPA31 extends JakartaEE10Action implements RepeatTestAction {
     public static final String ID = "JPA31";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
-    }
+//     @Override
+//     public boolean isEnabled() {
+//         return true;
+//     }
 
     @Override
     public String toString() {

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA31.java
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA31.java
@@ -22,10 +22,10 @@ import componenttest.rules.repeater.RepeatTestAction;
 public class RepeatWithJPA31 extends JakartaEE10Action implements RepeatTestAction {
     public static final String ID = "JPA31";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
-    }
+//     @Override
+//     public boolean isEnabled() {
+//         return true;
+//     }
 
     @Override
     public String toString() {

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA31.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA31.java
@@ -20,10 +20,10 @@ import componenttest.rules.repeater.RepeatTestAction;
 public class RepeatWithJPA31 extends JakartaEE10Action implements RepeatTestAction {
     public static final String ID = "JPA31";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
-    }
+//     @Override
+//     public boolean isEnabled() {
+//         return true;
+//     }
 
     @Override
     public String toString() {

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.defaultPersistenceUnit_fat/fat/src/com/ibm/ws/jpa/tests/spec10/injection/dpu/RepeatWithJPA31.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.defaultPersistenceUnit_fat/fat/src/com/ibm/ws/jpa/tests/spec10/injection/dpu/RepeatWithJPA31.java
@@ -9,10 +9,10 @@ import componenttest.rules.repeater.RepeatTestAction;
 public class RepeatWithJPA31 extends JakartaEE10Action implements RepeatTestAction {
     public static final String ID = "JPA31";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
-    }
+//     @Override
+//     public boolean isEnabled() {
+//         return true;
+//     }
 
     @Override
     public String toString() {

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.ejbinwar_fat/fat/src/com/ibm/ws/jpa/tests/spec10/injection/ejb_in_war/RepeatWithJPA31.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.ejbinwar_fat/fat/src/com/ibm/ws/jpa/tests/spec10/injection/ejb_in_war/RepeatWithJPA31.java
@@ -16,10 +16,10 @@ import componenttest.rules.repeater.RepeatTestAction;
 public class RepeatWithJPA31 extends JakartaEE10Action implements RepeatTestAction {
     public static final String ID = "JPA31";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
-    }
+//     @Override
+//     public boolean isEnabled() {
+//         return true;
+//     }
 
     @Override
     public String toString() {

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.jarfile_fat/fat/src/com/ibm/ws/jpa/RepeatWithJPA31.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.jarfile_fat/fat/src/com/ibm/ws/jpa/RepeatWithJPA31.java
@@ -16,10 +16,10 @@ import componenttest.rules.repeater.RepeatTestAction;
 public class RepeatWithJPA31 extends JakartaEE10Action implements RepeatTestAction {
     public static final String ID = "JPA31";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
-    }
+//     @Override
+//     public boolean isEnabled() {
+//         return true;
+//     }
 
     @Override
     public String toString() {

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/injection/common/RepeatWithJPA31.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/injection/common/RepeatWithJPA31.java
@@ -17,10 +17,10 @@ import componenttest.rules.repeater.RepeatTestAction;
 public class RepeatWithJPA31 extends JakartaEE10Action implements RepeatTestAction {
     public static final String ID = "JPA31";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
-    }
+//    @Override
+//    public boolean isEnabled() {
+//        return true;
+//    }
 
     @Override
     public String toString() {

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA31.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA31.java
@@ -20,10 +20,10 @@ import componenttest.rules.repeater.RepeatTestAction;
 public class RepeatWithJPA31 extends JakartaEE10Action implements RepeatTestAction {
     public static final String ID = "JPA31";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
-    }
+//     @Override
+//     public boolean isEnabled() {
+//         return true;
+//     }
 
     @Override
     public String toString() {

--- a/dev/com.ibm.ws.persistence_fat/fat/src/com/ibm/ws/persistence/fat/ConsumerTest_JPA31.java
+++ b/dev/com.ibm.ws.persistence_fat/fat/src/com/ibm/ws/persistence/fat/ConsumerTest_JPA31.java
@@ -22,6 +22,7 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
+import componenttest.annotation.MinimumJavaLevel;
 //import componenttest.custom.junit.runner.OnlyRunInJava7Rule;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -32,6 +33,7 @@ import componenttest.topology.utils.FATServletClient;
 import persistence_fat.consumer.web.ConsumerServlet;
 
 @RunWith(FATRunner.class)
+@MinimumJavaLevel(javaLevel = 11)
 public class ConsumerTest_JPA31 extends FATServletClient {
     private static final String APP_NAME = "consumer";
 


### PR DESCRIPTION
`RepeatWithJPA31.java` overrode the `isEnabled()` method and just returns true (which clobbers `componenttest.rules.repeater.FeatureReplacementAction.isEnabled()` 's jdk level check):

```
public class RepeatWithJPA31 extends JakartaEE10Action implements RepeatTestAction {
    public static final String ID = "JPA31";

    [@Override](https://wasrtc.hursley.ibm.com:9443/jazz/users/Override)
    public boolean isEnabled() {
        return true;
    }
```

This copy/paste mistake needs to be removed in order for the JPA 3.1 FAT portion to not be executed with JDKs < 11.