### PR TITLE
Add additional permissions to json bundles

### DIFF
--- a/.github/test-categories/JAVAEE
+++ b/.github/test-categories/JAVAEE
@@ -7,3 +7,4 @@ com.ibm.ws.javaee.ddmodel_fat
 com.ibm.ws.javamail.1.6_fat
 com.ibm.ws.jaxb_fat
 io.openliberty.jakartaee9.internal_fat
+io.openliberty.jakartaee10.internal_fat

--- a/.github/test-categories/JCA
+++ b/.github/test-categories/JCA
@@ -1,5 +1,7 @@
 com.ibm.ws.jca_fat
+com.ibm.ws.jca_fat_example
 com.ibm.ws.jca_fat_bval
+com.ibm.ws.jca_fat_bvt
 com.ibm.ws.jca_fat_classloading
 com.ibm.ws.jca_fat_configprops
 com.ibm.ws.jca_fat_derbyra

--- a/dev/io.openliberty.jakarta.jsonb.internal_fat/publish/servers/io.openliberty.jakarta.jsonb.internal.fat.container/server.xml
+++ b/dev/io.openliberty.jakarta.jsonb.internal_fat/publish/servers/io.openliberty.jakarta.jsonb.internal.fat.container/server.xml
@@ -34,16 +34,6 @@
                     className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
     <javaPermission codebase="${server.config.dir}/providers/fake-json-b.jar"
                     className="java.util.PropertyPermission" name="jsonb.creator-parameters-required" actions="read"/>
-                    
-    <!-- FIXME The next two permissions should not be needed as the jsonp-2.1 feature auto enables
-               <javaPermission className="java.util.PropertyPermission" name="jakarta.json.provider" actions="read"/>
-         This permission doesn't seem to be honored by the security component. 
-         Is this due to the different classloaders used for applications vs API? 
-     -->
-    <javaPermission codebase="${server.config.dir}/apps/jsonbcontainertestapp.war" 
-    				className="java.util.PropertyPermission" name="jakarta.json.provider" actions="read"/>
-    <javaPermission codebase="${server.config.dir}/providers/fake-json-b.jar" 
-    				className="java.util.PropertyPermission" name="jakarta.json.provider" actions="read"/>
 
     <variable name="onError" value="FAIL"/>
 </server>

--- a/dev/io.openliberty.jakarta.jsonb.internal_fat/publish/servers/io.openliberty.jakarta.jsonb.internal.fat/server.xml
+++ b/dev/io.openliberty.jakarta.jsonb.internal_fat/publish/servers/io.openliberty.jakarta.jsonb.internal.fat/server.xml
@@ -21,13 +21,5 @@
 
     <javaPermission className="java.util.PropertyPermission" actions="read" name="jsonb.creator-parameters-required"/>
     
-    <!-- FIXME The next permission should not be needed as the jsonp-2.1 feature auto enables
-               <javaPermission className="java.util.PropertyPermission" name="jakarta.json.provider" actions="read"/>
-         This permission doesn't seem to be honored by the security component. 
-         Is this due to the different classloaders used for applications vs API? 
-     -->
-     <javaPermission codebase="${server.config.dir}/apps/jsonbtestapp.war" 
-    				className="java.util.PropertyPermission" name="jakarta.json.provider" actions="read"/>
-
     <variable name="onError" value="FAIL"/>
 </server>

--- a/dev/io.openliberty.jakarta.jsonp.2.1/resources/OSGI-INF/wlp/defaultInstances.xml
+++ b/dev/io.openliberty.jakarta.jsonp.2.1/resources/OSGI-INF/wlp/defaultInstances.xml
@@ -9,5 +9,5 @@
         IBM Corporation - initial API and implementation
  -->
 <server>
-  <javaPermission className="java.util.PropertyPermission"  name="jakarta.json.provider" actions="read" />
+  <javaPermission id="jakarta.json.provider" className="java.util.PropertyPermission"  name="jakarta.json.provider" actions="read" />
 </server> 


### PR DESCRIPTION
The JSONP API fails to use a doPrivlaged actions to lookup system properties.
An issue has been opened against the JSONP API for this: https://github.com/eclipse-ee4j/jsonp/issues/378
In the meantime work around the issue by adding in the correct permissions.
This PR will fix #20959 
Default permissions are not honored unless they are given an ID.
