### PR TITLE
Fixed featureUtility viewSettings to show repos

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/cli/ViewSettingsAction.java
+++ b/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/cli/ViewSettingsAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/cli/ViewSettingsAction.java
+++ b/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/cli/ViewSettingsAction.java
@@ -143,7 +143,7 @@ public class ViewSettingsAction implements ActionHandler {
                 } catch (UnsupportedCryptoAlgorithmException ucae) {
                     throw new InstallException(Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("ERROR_TOOL_PWD_CRYPTO_UNSUPPORTED"), ucae, InstallException.CONNECTION_FAILED);
                 }
-//                }
+           }
 
                 sb.append(PropertiesUtils.getMessage("FIELD_NAME") + " " + r).append(InstallUtils.NEWLINE);
                 sb.append(PropertiesUtils.getMessage("FIELD_LOCATION") + " " + url).append(InstallUtils.NEWLINE);
@@ -158,8 +158,7 @@ public class ViewSettingsAction implements ActionHandler {
                     }
                 }
                 sb.append(InstallUtils.NEWLINE);
-            }
-        }
+           }
 
         System.out.println(PropertiesUtils.getMessage("MSG_CONFIG_REPO_LABEL"));
         System.out.println(PropertiesUtils.CmdlineConstants.DASHES);


### PR DESCRIPTION
The featureUtility viewSettings command shows 'No repositories configured' when username and password is not set, instead of <Unspecified> for the username and password fields.

In this pull request, I changed an else-statement in line 136 of ViewSettingsAction.java so that the stringBuilder for the 'Configured Repositories' message displays regardless of having a username/password. Fixes #21004