### PR TITLE
Add Startup EJB to Events Test

### DIFF
--- a/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/apps/events/ejb/EJBApplicationScopedBean.java
+++ b/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/apps/events/ejb/EJBApplicationScopedBean.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi20.fat.apps.events.ejb;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.BeforeDestroyed;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.event.Observes;
+
+/**
+ * The expected order of events is...
+ *
+ * observeInit
+ * observeEjbPostConstruct
+ * test
+ * observeEjbPreDestroy
+ * observeDestroy
+ */
+@ApplicationScoped
+public class EJBApplicationScopedBean {
+    private volatile boolean initObserved = false;
+    private volatile boolean testRequested = false;
+    private volatile boolean postConstructObserved = false;
+    private volatile boolean preDestroyObserved = false;
+    private volatile boolean destroyObserved = false;
+
+    protected String logMsg(String msg) {
+        return this.getClass().getSimpleName() + "#" + this.hashCode() + ": " + msg;
+    }
+
+    protected void trace(String method) {
+        System.out.println(logMsg(method));
+    }
+
+    public void observeInit(@Observes
+    @Initialized(ApplicationScoped.class) Object event) {
+        trace("observeInit");
+        initObserved = true;
+        //@Initialized(ApplicationScoped.class) should be seen before any request
+        assertFalse(logMsg("@Initialized(ApplicationScoped.class) was observed after test"), testRequested);
+        //@Initialized(ApplicationScoped.class) should be seen before EJB PostConstruct
+        assertFalse(logMsg("@Initialized(ApplicationScoped.class) was observed after EJB PostConstruct"), postConstructObserved);
+    }
+
+    public void observeEjbPostConstruct() {
+        trace("observeEjbPostConstruct");
+        this.postConstructObserved = true;
+
+        //EJB PostConstruct should be seen after @Initialized(ApplicationScoped.class)
+        assertTrue(logMsg("EJB PostConstruct observed before @Initialized(ApplicationScoped.class)"), initObserved);
+        //EJB PostConstruct should be seen before any request
+        assertFalse(logMsg("EJB PostConstruct was observed after test"), testRequested);
+    }
+
+    public void test() {
+        trace("test");
+        testRequested = true;
+        assertTrue(logMsg("@Initialized(ApplicationScoped.class) was not observed"), initObserved);
+
+        //test should be seen before EJB PreDestroy
+        assertFalse(logMsg("EJB PreDestroy was observed after Startup"), preDestroyObserved);
+    }
+
+    public void observeEjbPreDestroy() {
+        trace("observeEjbPreDestroy");
+        this.preDestroyObserved = true;
+
+        //EJB PreDestroy should be seen after any test request
+        assertTrue(logMsg("EJB PreDestroy was observed before test"), testRequested);
+
+        //test should be seen before EJB PreDestroy
+        assertFalse(logMsg("EJB PreDestroy was observed before Destroy"), destroyObserved);
+    }
+
+    public void observeDestroy(@Observes
+    @BeforeDestroyed(ApplicationScoped.class) Object event) {
+        trace("observeDestroy");
+        this.destroyObserved = true;
+
+        //@BeforeDestroyed(ApplicationScoped.class) should be seen after any request
+        assertTrue(logMsg("Destroy was observed before test"), testRequested);
+    }
+}

--- a/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/apps/events/ejb/SingletonStartupBean.java
+++ b/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/apps/events/ejb/SingletonStartupBean.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi20.fat.apps.events.ejb;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.inject.Inject;
+
+/**
+ * Singleton statup bean
+ */
+@Singleton
+@Startup
+public class SingletonStartupBean {
+
+    @Inject
+    EJBApplicationScopedBean bean;
+
+    @PostConstruct
+    private void init() {
+        System.out.println("StatelessStartupEJB @PostConstruct");
+        bean.test();
+    }
+
+    public void test() {
+        System.out.println("StatelessStartupEJB test");
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/apps/events/war/StartupEventsServlet.java
+++ b/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/apps/events/war/StartupEventsServlet.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi20.fat.apps.events.war;
+
+import static org.junit.Assert.assertNotNull;
+
+import javax.ejb.EJB;
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import com.ibm.ws.cdi20.fat.apps.events.ejb.SingletonStartupBean;
+
+import componenttest.app.FATServlet;
+
+@WebServlet("/events")
+public class StartupEventsServlet extends FATServlet {
+
+    @Inject
+    private WarApplicationScopedBean warApplicationScopedBean;
+
+    @EJB
+    private SingletonStartupBean ejb;
+
+    @Test
+    public void testWarStartupEvents() {
+        assertNotNull(warApplicationScopedBean);
+        warApplicationScopedBean.test();
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/apps/events/war/WarApplicationScopedBean.java
+++ b/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/apps/events/war/WarApplicationScopedBean.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi20.fat.apps.events.war;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.BeforeDestroyed;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.event.Observes;
+
+@ApplicationScoped
+public class WarApplicationScopedBean {
+    private volatile boolean initObserved = false;
+    private volatile boolean testRequested = false;
+
+    protected String logMsg(String msg) {
+        return this.getClass().getSimpleName() + "#" + this.hashCode() + ": " + msg;
+    }
+
+    protected void trace(String method) {
+        System.out.println(logMsg(method));
+    }
+
+    public void test() {
+        trace("test");
+        testRequested = true;
+        assertTrue(logMsg("@Initialized(ApplicationScoped.class) was not observed"), initObserved);
+    }
+
+    public void observeInit(@Observes
+    @Initialized(ApplicationScoped.class) Object event) {
+        trace("observeInit");
+        initObserved = true;
+        //@Initialized(ApplicationScoped.class) should be seen before any request
+        assertFalse(logMsg("@Initialized(ApplicationScoped.class) was observed after test"), testRequested);
+    }
+
+    public void observeDestroy(@Observes
+    @BeforeDestroyed(ApplicationScoped.class) Object event) {
+        trace("observeDestroy");
+        //@BeforeDestroyed(ApplicationScoped.class) should be seen after any request
+        assertTrue(logMsg("Destroy was observed before test"), testRequested);
+    }
+}

--- a/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/tests/FATSuite.java
+++ b/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/tests/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,8 @@ import org.junit.runners.Suite.SuiteClasses;
                 BasicCdi20Tests.class,
                 BuiltinAnnoLiteralsTest.class,
                 CDIContainerConfigTest.class,
-                SecureAsyncEventsTest.class
+                SecureAsyncEventsTest.class,
+                StartupEventsTest.class
 })
 public class FATSuite {
 

--- a/dev/com.ibm.ws.cdi.2.0_fat/publish/servers/cdi20StartupEventsServer/bootstrap.properties
+++ b/dev/com.ibm.ws.cdi.2.0_fat/publish/servers/cdi20StartupEventsServer/bootstrap.properties
@@ -1,0 +1,1 @@
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.cdi.2.0_fat/publish/servers/cdi20StartupEventsServer/server.xml
+++ b/dev/com.ibm.ws.cdi.2.0_fat/publish/servers/cdi20StartupEventsServer/server.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<server description="Server for testing CDI 2.0">
+    <featureManager>
+        <feature>componenttest-1.0</feature>
+        <feature>servlet-4.0</feature>
+        <feature>osgiconsole-1.0</feature>
+        <feature>cdi-2.0</feature>
+        <feature>ejbLite-3.2</feature>
+    </featureManager>
+    <include location="../fatTestPorts.xml"/>
+</server>

--- a/dev/io.openliberty.cdi.4.0.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.cdi.4.0.internal_fat/bnd.bnd
@@ -20,12 +20,13 @@ src: \
 javac.source: 11
 javac.target: 11
 
-tested.features:
+tested.features: connectors-2.1, xmlbinding-4.0
     
 fat.project: true
 
 -buildpath: \
 	io.openliberty.jakarta.cdi.4.0;version=latest,\
+	io.openliberty.jakarta.enterpriseBeans.4.0;version=latest,\
 	io.openliberty.jakarta.servlet.5.0;version=latest,\
 	io.openliberty.jakarta.annotation.2.0;version=latest,\
 	com.ibm.ws.componenttest.2.0;version=latest

--- a/dev/io.openliberty.cdi.4.0.internal_fat/fat/src/io/openliberty/cdi40/internal/fat/FATSuite.java
+++ b/dev/io.openliberty.cdi.4.0.internal_fat/fat/src/io/openliberty/cdi40/internal/fat/FATSuite.java
@@ -15,19 +15,15 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.annotation.MinimumJavaLevel;
-import io.openliberty.cdi40.internal.fat.bce.BuildCompatibleExtensionsErrorTest;
-import io.openliberty.cdi40.internal.fat.bce.BuildCompatibleExtensionsTest;
-import io.openliberty.cdi40.internal.fat.config.BeansXMLTest;
-import io.openliberty.cdi40.internal.fat.config.LegacyConfigTest;
 import io.openliberty.cdi40.internal.fat.startupEvents.StartupEventsTest;
 
 @MinimumJavaLevel(javaLevel = 11)
 @RunWith(Suite.class)
 @SuiteClasses({
-                BuildCompatibleExtensionsTest.class,
-                BuildCompatibleExtensionsErrorTest.class,
-                LegacyConfigTest.class,
-                BeansXMLTest.class,
+//                BuildCompatibleExtensionsTest.class,
+//                BuildCompatibleExtensionsErrorTest.class,
+//                LegacyConfigTest.class,
+//                BeansXMLTest.class,
                 StartupEventsTest.class
 })
 public class FATSuite {}

--- a/dev/io.openliberty.cdi.4.0.internal_fat/fat/src/io/openliberty/cdi40/internal/fat/bce/BuildCompatibleExtensionsTest.java
+++ b/dev/io.openliberty.cdi.4.0.internal_fat/fat/src/io/openliberty/cdi40/internal/fat/bce/BuildCompatibleExtensionsTest.java
@@ -26,6 +26,7 @@ import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
 import io.openliberty.cdi40.internal.fat.bce.basicear.lib.EarBCEExtension;
 import io.openliberty.cdi40.internal.fat.bce.basicear.lib.LibTestBean;
 import io.openliberty.cdi40.internal.fat.bce.basicear.war1.EarBCETestServlet1;
@@ -41,7 +42,7 @@ import io.openliberty.cdi40.internal.fat.bce.extensionarchivenotscanned.Extensio
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
 
 @RunWith(FATRunner.class)
-public class BuildCompatibleExtensionsTest {
+public class BuildCompatibleExtensionsTest extends FATServletClient {
 
     @Server("cdiBceTestServer")
     @TestServlets({ @TestServlet(contextRoot = "war1", servlet = EarBCETestServlet1.class),

--- a/dev/io.openliberty.cdi.4.0.internal_fat/fat/src/io/openliberty/cdi40/internal/fat/config/BeansXMLTest.java
+++ b/dev/io.openliberty.cdi.4.0.internal_fat/fat/src/io/openliberty/cdi40/internal/fat/config/BeansXMLTest.java
@@ -27,13 +27,14 @@ import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
 import io.openliberty.cdi40.internal.fat.config.beansxml.AllBeansServlet;
 import io.openliberty.cdi40.internal.fat.config.beansxml.AnnotatedBeansServlet;
 import io.openliberty.cdi40.internal.fat.config.beansxml.RequestScopedBean;
 import io.openliberty.cdi40.internal.fat.config.beansxml.UnannotatedBean;
 
 @RunWith(FATRunner.class)
-public class BeansXMLTest {
+public class BeansXMLTest extends FATServletClient {
     public static final String SERVER_NAME = "CDI40Server";
 
     public static final String EMPTY_BEANS_APP_NAME = "EmptyBeans";

--- a/dev/io.openliberty.cdi.4.0.internal_fat/fat/src/io/openliberty/cdi40/internal/fat/config/LegacyConfigTest.java
+++ b/dev/io.openliberty.cdi.4.0.internal_fat/fat/src/io/openliberty/cdi40/internal/fat/config/LegacyConfigTest.java
@@ -35,13 +35,14 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
 import io.openliberty.cdi40.internal.fat.config.beansxml.AllBeansServlet;
 import io.openliberty.cdi40.internal.fat.config.beansxml.RequestScopedBean;
 import io.openliberty.cdi40.internal.fat.config.beansxml.UnannotatedBean;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-public class LegacyConfigTest {
+public class LegacyConfigTest extends FATServletClient {
     public static final String SERVER_NAME = "CDI40Server";
 
     public static final String LEGACY_EMPTY_BEANS_APP_NAME = "LagacyEmptyBeans";

--- a/dev/io.openliberty.cdi.4.0.internal_fat/fat/src/io/openliberty/cdi40/internal/fat/startupEvents/ear/ejb/EjbApplicationScopedBean.java
+++ b/dev/io.openliberty.cdi.4.0.internal_fat/fat/src/io/openliberty/cdi40/internal/fat/startupEvents/ear/ejb/EjbApplicationScopedBean.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.cdi40.internal.fat.startupEvents.ear.ejb;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import io.openliberty.cdi40.internal.fat.startupEvents.sharedLib.AbstractObserver;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.event.Observes;
+
+/**
+ * The expected order of events is...
+ *
+ * observeInit
+ * observeEjbPostConstruct
+ * c_observeStartup1
+ * a_observeStartup2
+ * b_observeStartup3
+ * test
+ * observeEjbPreDestroy
+ * observeShutdown
+ * observeDestroy
+ */
+@ApplicationScoped
+public class EjbApplicationScopedBean extends AbstractObserver {
+
+    private volatile boolean postConstructObserved = false;
+    private volatile boolean preDestroyObserved = false;
+
+    @Override
+    public void observeInit(@Observes @Initialized(ApplicationScoped.class) Object event) {
+        super.observeInit(event);
+        //@Initialized(ApplicationScoped.class) should be seen before EJB PostConstruct
+        assertFalse(logMsg("@Initialized(ApplicationScoped.class) was observed after EJB PostConstruct"), postConstructObserved);
+    }
+
+    public void observeEjbPostConstruct() {
+        trace("observeEjbPostConstruct");
+        this.postConstructObserved = true;
+
+        //EJB PostConstruct should be seen after @Initialized(ApplicationScoped.class)
+        assertTrue(logMsg("EJB PostConstruct observed before @Initialized(ApplicationScoped.class)"), initObserved);
+        //EJB PostConstruct should be seen before any request
+        assertFalse(logMsg("EJB PostConstruct was observed after test"), testRequested);
+    }
+
+    @Override
+    public void test() {
+        super.test();
+
+        //test should be seen before EJB PreDestroy
+        assertFalse(logMsg("EJB PreDestroy was observed after Startup"), preDestroyObserved);
+    }
+
+    public void observeEjbPreDestroy() {
+        trace("observeEjbPreDestroy");
+        this.preDestroyObserved = true;
+
+        //EJB PreDestroy should be seen after any test request
+        assertTrue(logMsg("EJB PreDestroy was observed before test"), testRequested);
+        //EJB PreDestroy should be seen before Shutdown
+        assertFalse(logMsg("EJB PreDestroy was observed after Shutdown"), shutdownObserved);
+    }
+
+}

--- a/dev/io.openliberty.cdi.4.0.internal_fat/fat/src/io/openliberty/cdi40/internal/fat/startupEvents/ear/ejb/StartupSingletonEJB.java
+++ b/dev/io.openliberty.cdi.4.0.internal_fat/fat/src/io/openliberty/cdi40/internal/fat/startupEvents/ear/ejb/StartupSingletonEJB.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.cdi40.internal.fat.startupEvents.ear.ejb;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.ejb.Singleton;
+import jakarta.ejb.Startup;
+import jakarta.inject.Inject;
+
+@Startup
+@Singleton
+public class StartupSingletonEJB {
+
+    @Inject
+    private EjbApplicationScopedBean bean;
+
+    @PostConstruct
+    private void ejbPostConstruct() {
+        bean.observeEjbPostConstruct();
+    }
+
+    public void test() {
+        bean.test();
+    }
+
+    @PreDestroy
+    private void ejbPreDestroy() {
+        bean.observeEjbPreDestroy();
+    }
+}

--- a/dev/io.openliberty.cdi.4.0.internal_fat/fat/src/io/openliberty/cdi40/internal/fat/startupEvents/ear/war/StartupEventsServlet.java
+++ b/dev/io.openliberty.cdi.4.0.internal_fat/fat/src/io/openliberty/cdi40/internal/fat/startupEvents/ear/war/StartupEventsServlet.java
@@ -15,8 +15,10 @@ import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
+import io.openliberty.cdi40.internal.fat.startupEvents.ear.ejb.StartupSingletonEJB;
 import io.openliberty.cdi40.internal.fat.startupEvents.ear.lib.EarLibApplicationScopedBean;
 import io.openliberty.cdi40.internal.fat.startupEvents.sharedLib.SharedLibApplicationScopedBean;
+import jakarta.ejb.EJB;
 import jakarta.inject.Inject;
 import jakarta.servlet.annotation.WebServlet;
 
@@ -31,6 +33,9 @@ public class StartupEventsServlet extends FATServlet {
 
     @Inject
     private SharedLibApplicationScopedBean sharedLibApplicationScopedBean;
+
+    @EJB
+    private StartupSingletonEJB startupSingletonEJB;
 
     @Test
     public void testWarStartupEvents() {
@@ -48,5 +53,11 @@ public class StartupEventsServlet extends FATServlet {
     public void testSharedLibStartupEvents() {
         assertNotNull(sharedLibApplicationScopedBean);
         sharedLibApplicationScopedBean.test();
+    }
+
+    @Test
+    public void testStartupEJBStartupEvents() {
+        assertNotNull(startupSingletonEJB);
+        startupSingletonEJB.test();
     }
 }

--- a/dev/io.openliberty.cdi.4.0.internal_fat/fat/src/io/openliberty/cdi40/internal/fat/startupEvents/sharedLib/AbstractObserver.java
+++ b/dev/io.openliberty.cdi.4.0.internal_fat/fat/src/io/openliberty/cdi40/internal/fat/startupEvents/sharedLib/AbstractObserver.java
@@ -34,77 +34,86 @@ import jakarta.enterprise.event.Startup;
  */
 public abstract class AbstractObserver {
 
-    private volatile boolean initObserved = false;
-    private volatile boolean startupObserved1 = false;
-    private volatile boolean startupObserved2 = false;
-    private volatile boolean startupObserved3 = false;
-    private volatile boolean testRequested = false;
-    private volatile boolean shutdownObserved = false;
-    private volatile boolean destroyObserved = false;
+    protected volatile boolean initObserved = false;
+    protected volatile boolean startupObserved1 = false;
+    protected volatile boolean startupObserved2 = false;
+    protected volatile boolean startupObserved3 = false;
+    protected volatile boolean testRequested = false;
+    protected volatile boolean shutdownObserved = false;
+    protected volatile boolean destroyObserved = false;
 
-    public void test() {
-        System.out.println(this.getClass().getSimpleName() + ": test");
-        testRequested = true;
-        assertTrue("@Initialized(ApplicationScoped.class) was not observed", initObserved);
-        assertTrue("Startup 1 was not observed", startupObserved1);
-        assertTrue("Startup 2 was not observed", startupObserved2);
-        assertTrue("Startup 3 was not observed", startupObserved3);
+    protected String logMsg(String msg) {
+        return this.getClass().getSimpleName() + "#" + this.hashCode() + ": " + msg;
+    }
+
+    protected void trace(String method) {
+        System.out.println(logMsg(method));
     }
 
     public void observeInit(@Observes @Initialized(ApplicationScoped.class) Object event) {
-        System.out.println(this.getClass().getSimpleName() + ": observeInit");
+        trace("observeInit");
         initObserved = true;
         //@Initialized(ApplicationScoped.class) should be seen before Startup
-        assertFalse("@Initialized(ApplicationScoped.class) was observed after Startup", startupObserved1);
+        assertFalse(logMsg("@Initialized(ApplicationScoped.class) was observed after Startup"), startupObserved1);
         //@Initialized(ApplicationScoped.class) should be seen before any request
-        assertFalse("@Initialized(ApplicationScoped.class) was observed after test", testRequested);
+        assertFalse(logMsg("@Initialized(ApplicationScoped.class) was observed after test"), testRequested);
     }
 
     //note the prefixes on these method names and the order they appear in the class is
     //designed to try and make sure that it is the Priority that decides the order, not some other factor
     public void a_observeStartup2(@Observes @Priority(2) Startup startupEvent) {
-        System.out.println(this.getClass().getSimpleName() + ": a_observeStartup2");
+        trace("a_observeStartup2");
         startupObserved2 = true;
         //@Priority(1) Startup should be seen before @Priority(2) Startup
-        assertTrue("Startup 2 was observed before Startup 1", startupObserved1);
+        assertTrue(logMsg("Startup 2 was observed before Startup 1"), startupObserved1);
         //Startup 2 should be seen before any request
-        assertFalse("Startup 2 was observed after test", testRequested);
+        assertFalse(logMsg("Startup 2 was observed after test"), testRequested);
     }
 
     public void c_observeStartup1(@Observes @Priority(1) Startup startupEvent) {
-        System.out.println(this.getClass().getSimpleName() + ": c_observeStartup1");
+        trace("c_observeStartup1");
         startupObserved1 = true;
         //@Initialized(ApplicationScoped.class) should be seen before Startup
-        assertTrue("Startup 1 was observed before @Initialized(ApplicationScoped.class)", initObserved);
+        assertTrue(logMsg("Startup 1 was observed before @Initialized(ApplicationScoped.class)"), initObserved);
         //Startup 1 should be seen before any request
-        assertFalse("Startup 1 was observed after test", testRequested);
+        assertFalse(logMsg("Startup 1 was observed after test"), testRequested);
     }
 
     public void b_observeStartup3(@Observes @Priority(3) Startup startupEvent) {
-        System.out.println(this.getClass().getSimpleName() + ": b_observeStartup3");
+        trace("b_observeStartup3");
         startupObserved3 = true;
         //@Priority(2) Startup should be seen before @Priority(3) Startup
-        assertTrue("Startup 3 was observed before Startup 2", startupObserved2);
+        assertTrue(logMsg("Startup 3 was observed before Startup 2"), startupObserved2);
         //Startup 3 should be seen before any request
-        assertFalse("Startup 3 was observed after test", testRequested);
+        assertFalse(logMsg("Startup 3 was observed after test"), testRequested);
+    }
+
+    public void test() {
+        trace("test");
+        testRequested = true;
+        assertTrue(logMsg("@Initialized(ApplicationScoped.class) was not observed"), initObserved);
+        assertTrue(logMsg("test requested before Startup 1 was observed"), startupObserved1);
+        assertTrue(logMsg("test requested before Startup 2 was observed"), startupObserved2);
+        assertTrue(logMsg("test requested before Startup 3 was observed"), startupObserved3);
+        assertFalse(logMsg("Shutdown observed before test requested"), shutdownObserved);
     }
 
     public void observeShutdown(@Observes Shutdown shutdownEvent) {
-        System.out.println(this.getClass().getSimpleName() + ": observeShutdown");
+        trace("observeShutdown");
         shutdownObserved = true;
-        //Shutdown should be seen before @BeforeDestroyed(ApplicationScoped.class)
-        assertFalse("Shutdown was observed after @BeforeDestroyed(ApplicationScoped.class)", destroyObserved);
         //Shutdown should be seen after any request
-        assertTrue("Shutdown was observed before test", testRequested);
+        assertTrue(logMsg("Shutdown was observed before test"), testRequested);
+        //Shutdown should be seen before @BeforeDestroyed(ApplicationScoped.class)
+        assertFalse(logMsg("Shutdown was observed after @BeforeDestroyed(ApplicationScoped.class)"), destroyObserved);
     }
 
     public void observeDestroy(@Observes @BeforeDestroyed(ApplicationScoped.class) Object event) {
-        System.out.println(this.getClass().getSimpleName() + ": observeDestroy");
+        trace("observeDestroy");
         destroyObserved = true;
         //@BeforeDestroyed(ApplicationScoped.class) should be seen after Shutdown
-        assertTrue("@BeforeDestroyed(ApplicationScoped.class) was observed before Shutdown", shutdownObserved);
+        assertTrue(logMsg("@BeforeDestroyed(ApplicationScoped.class) was observed before Shutdown"), shutdownObserved);
         //@BeforeDestroyed(ApplicationScoped.class) should be seen after any request
-        assertTrue("Shutdown was observed before test", testRequested);
+        assertTrue(logMsg("Shutdown was observed before test"), testRequested);
     }
 
 }

--- a/dev/io.openliberty.cdi.4.0.internal_fat/publish/servers/StartupEventsServer/server.xml
+++ b/dev/io.openliberty.cdi.4.0.internal_fat/publish/servers/StartupEventsServer/server.xml
@@ -5,6 +5,7 @@
         <feature>servlet-6.0</feature>
         <feature>osgiconsole-1.0</feature>
         <feature>cdi-4.0</feature>
+        <feature>enterpriseBeansLite-4.0</feature>
     </featureManager>
     <include location="../fatTestPorts.xml"/>
 


### PR DESCRIPTION
For an EJB module with a Startup Singleton bean, the expected order of events is...
```
observeInit (@Observes @Initialized(ApplicationScoped.class))
observeEjbPostConstruct (@PostConstruct)
c_observeStartup1 (@Observes @Priority(1) Startup)
a_observeStartup2 (@Observes @Priority(2) Startup)
b_observeStartup3 (@Observes @Priority(3) Startup)
test (a request)
observeEjbPreDestroy (@PreDestroy)
observeShutdown (@Observes Shutdown)
observeDestroy (@Observes @BeforeDestroyed(ApplicationScoped.class))
```