### PR TITLE
Remove Thread dumps creation for RequestTiming FAT

### DIFF
--- a/dev/com.ibm.ws.request.timing.hung_fat/publish/files/server_hungRequestThreshold2_disableThreadDumps.xml
+++ b/dev/com.ibm.ws.request.timing.hung_fat/publish/files/server_hungRequestThreshold2_disableThreadDumps.xml
@@ -1,0 +1,16 @@
+<server description="new server">
+
+  <!-- Enable features -->
+    <featureManager>
+      <feature>jsp-2.2</feature>
+      <feature>requestTiming-1.0</feature>
+    </featureManager>
+  
+	<httpEndpoint id="defaultHttpEndpoint" host="*" />
+
+	<include location="../fatTestPorts.xml"/>
+  	
+   <requestTiming slowRequestThreshold="0"/>
+   <requestTiming hungRequestThreshold = "2s" enableThreadDumps="false"/>
+  
+</server>


### PR DESCRIPTION
fixes #21047
- In the SOE env, some test machines might be slow, hence there is occurrences where once the request timing test case finishes, and tries to shut down the server, the server is still in the process of generating the thread dumps as part of the requestTiming feature. This causes the server to not be stopped and becomes in an idle state. The FAT's timedExit feature kicks after 2 hours and forcefully shuts down the server. The FAT then, continues, however, since the FAT has been running for more than 2 hours, the FAT itself times out.

This PR disables the creation of thread dumps for certain FULL RequestTiming test cases that do not test for thread dump creation, so the above problem does not happen. There are other test cases in the FAT bucket that tests for thread dump creation.