### PR TITLE
Fix test failure in RTC 290257. Sometimes the short TTL is leading to…

### DIFF
--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheAuthenticationCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheAuthenticationCacheTest.java
@@ -42,7 +42,7 @@ public class JCacheAuthenticationCacheTest extends BaseTestCase {
 
     private static BasicAuthClient basicAuthClient1;
     private static BasicAuthClient basicAuthClient2;
-    private static final int TTL_SECONDS = 10;
+    private static final Integer TTL_SECONDS = TestPluginHelper.getTestPlugin().skipTtlTest() ? null : 15;
 
     @Server("io.openliberty.jcache.internal.fat.auth.cache.1")
     public static LibertyServer server1;

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheJwtAuthenticationCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheJwtAuthenticationCacheTest.java
@@ -40,7 +40,7 @@ import io.openliberty.jcache.internal.fat.plugins.TestPluginHelper;
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class JCacheJwtAuthenticationCacheTest extends BaseTestCase {
-    private static final int TTL_SECONDS = 10;
+    private static final Integer TTL_SECONDS = TestPluginHelper.getTestPlugin().skipTtlTest() ? null : 15;
 
     @Server("io.openliberty.jcache.internal.fat.jwt.auth.cache.1")
     public static LibertyServer server1;


### PR DESCRIPTION
… entries being evicted before the test has a chance to use them.

