### PR TITLE
add jsonp pluggability tests

### DIFF
--- a/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/fat/src/io/openliberty/jakarta/jsonp/tck/JsonpTckLauncher.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/fat/src/io/openliberty/jakarta/jsonp/tck/JsonpTckLauncher.java
@@ -41,6 +41,7 @@ import componenttest.topology.utils.MvnUtils;
 public class JsonpTckLauncher {
 
     final static Map<String, String> additionalProps = new HashMap<>();
+    final static Map<String, String> additionalPluggabilityProps = new HashMap<>();
 
     //This is a standalone test no server needed
     @Server
@@ -84,24 +85,44 @@ public class JsonpTckLauncher {
                                            Collections.emptySet() //additional jars
         );
 
-        // Including jakarta.json-tck-tests and jakarta.json-tck-tests-pluggability together causes
-        // exceptions due to collisions, so created 2 separate profiles which are then
-        // run individually
-        additionalProps.put("run-tck-tests-pluggability", "true");
-        int result2 = MvnUtils.runTCKMvnCmd(
-                                            DONOTSTART, //server to run on
-                                            "io.openliberty.jakarta.jsonp.2.1_fat_tck", //bucket name
-                                            this.getClass() + ":launchJsonpTCK", //launching method
-                                            null, //suite file to run
-                                            additionalProps, //additional props
-                                            Collections.emptySet() //additional jars
-        );
-
         resultInfo.put("results_type", "Jakarta");
         resultInfo.put("feature_name", "jsonp");
         resultInfo.put("feature_version", "2.1");
         MvnUtils.preparePublicationFile(resultInfo);
         assertEquals(0, result);
+    }
+
+    /**
+     * Run the TCK (controlled by autoFVT/publish/tckRunner/tck/*)
+     */
+    @Test
+    @AllowedFFDC // The tested exceptions cause FFDC so we have to allow for this.
+    public void launchJsonpPluggabilityTCK() throws Exception {
+
+        Map<String, String> resultInfo = MvnUtils.getResultInfo(DONOTSTART);
+
+        /**
+         * The runTCKMvnCmd will set the following properties for use by arquillian
+         * [ wlp, tck_server, tck_port, tck_failSafeUndeployment, tck_appDeployTimeout, tck_appUndeployTimeout ]
+         * and then run the mvn test command.
+         */
+        // Including jakarta.json-tck-tests and jakarta.json-tck-tests-pluggability together causes
+        // exceptions due to collisions, so created 2 separate profiles which are then
+        // run individually
+        additionalPluggabilityProps.put("run-tck-tests-pluggability", "true");
+        int result2 = MvnUtils.runTCKMvnCmd(
+                                            DONOTSTART, //server to run on
+                                            "io.openliberty.jakarta.jsonp.2.1_fat_tck", //bucket name
+                                            this.getClass() + ":launchJsonpPluggabilityTCK", //launching method
+                                            null, //suite file to run
+                                            additionalPluggabilityProps, //additional props
+                                            Collections.emptySet() //additional jars
+        );
+
+        resultInfo.put("results_type", "Jakarta");
+        resultInfo.put("feature_name", "jsonp-pluggability");
+        resultInfo.put("feature_version", "2.1");
+        MvnUtils.preparePublicationFile(resultInfo);
         assertEquals(0, result2);
 
     }

--- a/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/fat/src/io/openliberty/jakarta/jsonp/tck/JsonpTckLauncher.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/fat/src/io/openliberty/jakarta/jsonp/tck/JsonpTckLauncher.java
@@ -84,10 +84,25 @@ public class JsonpTckLauncher {
                                            Collections.emptySet() //additional jars
         );
 
+        // Including jakarta.json-tck-tests and jakarta.json-tck-tests-pluggability together causes
+        // exceptions due to collisions, so created 2 separate profiles which are then
+        // run individually
+        additionalProps.put("run-tck-tests-pluggability", "true");
+        int result2 = MvnUtils.runTCKMvnCmd(
+                                            DONOTSTART, //server to run on
+                                            "io.openliberty.jakarta.jsonp.2.1_fat_tck", //bucket name
+                                            this.getClass() + ":launchJsonpTCK", //launching method
+                                            null, //suite file to run
+                                            additionalProps, //additional props
+                                            Collections.emptySet() //additional jars
+        );
+
         resultInfo.put("results_type", "Jakarta");
         resultInfo.put("feature_name", "jsonp");
         resultInfo.put("feature_version", "2.1");
         MvnUtils.preparePublicationFile(resultInfo);
         assertEquals(0, result);
+        assertEquals(0, result2);
+
     }
 }

--- a/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -45,23 +45,109 @@
 		<!-- Test versions -->
 		<targetDirectory>${project.basedir}/target</targetDirectory>
 	</properties>
+	
+	<!-- Including jakarta.json-tck-tests and jakarta.json-tck-tests-pluggability together causes
+	      execeptions due to collisions, so need to create 2 separate profiles which are then
+	      run separately by the JsonTCKLauncher  -->
+	<profiles>
+		<!-- runs just the tck tests -->
+	    <profile>
+	        <id>tck-tests</id>
+	        <activation>
+        		<activeByDefault>true</activeByDefault>
+      		</activation>
+	        <dependencies>
+				<!-- tck - jsonp - external artifact -->
+				<dependency>
+					<groupId>jakarta.json</groupId>
+					<artifactId>jakarta.json-tck-tests</artifactId>
+					<version>${jakarta.json.tck.version}</version>
+					<scope>test</scope>
+					<!-- Try to force TCK to  use version 1.6 instead of 1.4 -->
+				    <exclusions>
+				        <exclusion>
+				            <groupId>org.netbeans.tools</groupId>
+				            <artifactId>sigtest-maven-plugin</artifactId>
+				        </exclusion>
+				    </exclusions>
+				</dependency>
+	        </dependencies>
+	        
+	        <build>
+		        <plugins>
+			        <plugin>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<version>3.0.0-M5</version>
+						<configuration>
+							<trimStackTrace>false</trimStackTrace>
+							<failIfNoTests>true</failIfNoTests>
+							<forkCount>1</forkCount>
+		                    <reuseForks>false</reuseForks>
+							<dependenciesToScan>jakarta.json:jakarta.json-tck-tests</dependenciesToScan>
+							<systemPropertyVariables>
+								<jimage.dir>${project.build.directory}/jdk11-bundle</jimage.dir>
+								<signature.sigTestClasspath>${project.build.directory}/signaturedirectory/jakarta.json-api.jar:${project.build.directory}/jdk11-bundle/java.base:${project.build.directory}/jdk11-bundle/java.rmi:${project.build.directory}/jdk11-bundle/java.sql:${project.build.directory}/jdk11-bundle/java.naming</signature.sigTestClasspath>
+							</systemPropertyVariables>
+							<excludes>
+								<exclude>${exclude.tests}</exclude>
+							</excludes>
+						</configuration>
+					</plugin>
+				</plugins>
+	        </build>
+	    </profile>
+	    
+	    <!-- runs just the tck pluggability tests -->
+	    <profile>
+	        <id>tck-tests-pluggability</id>
+	        <activation>
+		        <property>
+	            	<name>run-tck-tests-pluggability</name>
+	            	<value>true</value>
+	        	</property>
+        	</activation>
+	        <dependencies>
+	            <dependency>
+					<groupId>jakarta.json</groupId>
+					<artifactId>jakarta.json-tck-tests-pluggability</artifactId>
+					<version>${jakarta.json.tck.version}</version>
+					<scope>test</scope>
+					<!-- Try to force TCK to  use version 1.6 instead of 1.4 -->
+				    <exclusions>
+				        <exclusion>
+				            <groupId>org.netbeans.tools</groupId>
+				            <artifactId>sigtest-maven-plugin</artifactId>
+				        </exclusion>
+				    </exclusions>
+				</dependency>
+	        </dependencies>
+	        
+	        <build>
+		        <plugins>
+			        <plugin>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<version>3.0.0-M5</version>
+						<configuration>
+							<trimStackTrace>false</trimStackTrace>
+							<failIfNoTests>true</failIfNoTests>
+							<forkCount>1</forkCount>
+		                    <reuseForks>false</reuseForks>
+							<dependenciesToScan>jakarta.json:jakarta.json-tck-tests-pluggability</dependenciesToScan>
+							<systemPropertyVariables>
+								<jimage.dir>${project.build.directory}/jdk11-bundle</jimage.dir>
+							</systemPropertyVariables>
+							<excludes>
+								<exclude>${exclude.tests}</exclude>
+							</excludes>
+						</configuration>
+					</plugin>
+				</plugins>
+	        </build>
+	    </profile>
+	</profiles>
 
 
 	<dependencies>
-		<!-- tck - jsonp - external artifact -->
-		<dependency>
-			<groupId>jakarta.json</groupId>
-			<artifactId>jakarta.json-tck-tests</artifactId>
-			<version>${jakarta.json.tck.version}</version>
-			<scope>test</scope>
-			<!-- Try to force TCK to  use version 1.6 instead of 1.4 -->
-		    <exclusions>
-		        <exclusion>
-		            <groupId>org.netbeans.tools</groupId>
-		            <artifactId>sigtest-maven-plugin</artifactId>
-		        </exclusion>
-		    </exclusions>
-		</dependency>
 		<!-- api - jsonp - internal bundle -->
 		<dependency>
 			<groupId>jakarta.json</groupId>
@@ -70,7 +156,7 @@
 			<systemPath>${io.openliberty.jakarta.jsonp.2.1}</systemPath> 
 			<scope>system</scope>
 		</dependency>
-		<!-- impl - jsonp - passon - internal bundle -->
+		<!-- impl - jsonp - parsson - internal bundle -->
 		<dependency>
 			<groupId>org.eclipse.parsson</groupId>
 			<artifactId>parsson</artifactId>
@@ -109,24 +195,6 @@
 			            </configuration>
 			        </execution>
 			    </executions>
-			</plugin>
-			<plugin>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.0.0-M5</version>
-				<configuration>
-					<trimStackTrace>false</trimStackTrace>
-					<failIfNoTests>true</failIfNoTests>
-					<forkCount>1</forkCount>
-                    <reuseForks>false</reuseForks>
-					<dependenciesToScan>jakarta.json:jakarta.json-tck-tests</dependenciesToScan>
-					<systemPropertyVariables>
-						<jimage.dir>${project.build.directory}/jdk11-bundle</jimage.dir>
-						<signature.sigTestClasspath>${project.build.directory}/signaturedirectory/jakarta.json-api.jar:${project.build.directory}/jdk11-bundle/java.base:${project.build.directory}/jdk11-bundle/java.rmi:${project.build.directory}/jdk11-bundle/java.sql:${project.build.directory}/jdk11-bundle/java.naming</signature.sigTestClasspath>
-					</systemPropertyVariables>
-					<excludes>
-						<exclude>${exclude.tests}</exclude>
-					</excludes>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Adding the jsonp pluggability tests. I had to create separate profiles in the pom and make 2 calls to maven to run the test suites separately because including the 2 artifact dependencies together caused exceptions due to collisions.