### PR TITLE
PR for Issue 21079: Add missing layer of hashing for OAuth JWT access token cache lookups

### DIFF
--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/CacheUtil.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/CacheUtil.java
@@ -105,7 +105,11 @@ public class CacheUtil {
     private OAuth20Token getAccessToken(OAuth20Token idtoken) {
         OAuth20Token access = null;
         if (OIDCConstants.TOKENTYPE_ID_TOKEN.equals(idtoken.getType())) {
-            access = cache.get(((OAuth20TokenImpl) idtoken).getAccessTokenKey());
+            String accessTokenKey = ((OAuth20TokenImpl) idtoken).getAccessTokenKey();
+            if (accessTokenKey != null && OidcOAuth20Util.isJwtToken(accessTokenKey)) {
+                accessTokenKey = HashUtils.digest(accessTokenKey);
+            }
+            access = cache.get(accessTokenKey);
         }
         return access;
 


### PR DESCRIPTION
When looking up access tokens from the cache, the `CacheUtil` class needs to pre-digest the access token string within an ID token if the access token is a JWT.

Fixes #21079