### PR TITLE
cleanup oidc session cache during oidc client logout

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
@@ -49,6 +49,7 @@ import com.ibm.ws.security.openidconnect.clients.common.OidcClientConfig;
 import com.ibm.ws.security.openidconnect.clients.common.OidcClientRequest;
 import com.ibm.ws.security.openidconnect.clients.common.OidcClientUtil;
 import com.ibm.ws.security.openidconnect.clients.common.OidcSessionCache;
+import com.ibm.ws.security.openidconnect.clients.common.OidcSessionHelper;
 import com.ibm.ws.security.openidconnect.clients.common.OidcUtil;
 import com.ibm.ws.security.openidconnect.clients.common.TraceConstants;
 import com.ibm.ws.security.openidconnect.common.Constants;
@@ -205,7 +206,7 @@ public class Jose4jUtil {
         String sid = jwtClaims.getClaimValue("sid", String.class);
         String timestamp = OidcUtil.getTimeStamp();
 
-        String wasOidcSessionId = String.join(":", configId, sub, sid != null ? sid : "", timestamp);
+        String wasOidcSessionId = OidcSessionHelper.createSessionId(configId, sub, sid != null ? sid : "", timestamp);
 
         OidcSessionCache oidcSessionCache = oidcClientConfig.getOidcSessionCache();
         oidcSessionCache.insertSession(sub, sid, wasOidcSessionId);

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/InMemoryOidcSessionCache.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/InMemoryOidcSessionCache.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.clients.common;
 
@@ -72,6 +72,24 @@ public class InMemoryOidcSessionCache implements OidcSessionCache {
         httpSessionsStore.removeSession(sid);
 
         return invalidatedSessions.add(sessionToInvalidate);
+    }
+
+    @Override
+    public boolean invalidateSessionBySessionId(String sub, String oidcSessionId) {
+        if (sub == null || sub.isEmpty()) {
+            return false;
+        }
+
+        OidcSessionsStore httpSessionsStore = subToOidcSessionsMap.get(sub);
+        if (httpSessionsStore == null) {
+            return false;
+        }
+
+        if (!httpSessionsStore.removeSessionBySessionId(oidcSessionId)) {
+            return false;
+        }
+
+        return invalidatedSessions.add(oidcSessionId);
     }
 
     @Override
@@ -145,6 +163,22 @@ public class InMemoryOidcSessionCache implements OidcSessionCache {
             if (sid != null && !sid.isEmpty()) {
                 List<String> removedSession = sidToSessionsMap.remove(sid);
                 return removedSession != null;
+            }
+            return false;
+        }
+
+        public boolean removeSessionBySessionId(String oidcSessionId) {
+            for (String key : sidToSessionsMap.keySet()) {
+                List<String> oidcSessionIds = sidToSessionsMap.get(key);
+                for (int i = 0; i < oidcSessionIds.size(); i++) {
+                    if (oidcSessionIds.get(i).equals(oidcSessionId)) {
+                        oidcSessionIds.remove(i);
+                        if (oidcSessionIds.size() == 0) {
+                            sidToSessionsMap.remove(key);
+                        }
+                        return true;
+                    }
+                }
             }
             return false;
         }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcSessionCache.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcSessionCache.java
@@ -37,6 +37,16 @@ public interface OidcSessionCache {
     public boolean invalidateSession(String sub, String sid);
 
     /**
+     * Invalidate a session in the cache.
+     * The invalidated session still has to be removed by invoking removeSession.
+     * 
+     * @param sub The sub claim.
+     * @param oidcSessionId The id of the oidc session.
+     * @return Whether or not the session was invalidated.
+     */
+    public boolean invalidateSessionBySessionId(String sub, String oidcSessionId);
+
+    /**
      * Invalidate all the sessions belonging to a sub.
      * The invalidated sessions still have to be removed by invoking removeSession on each session.
      *

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcSessionHelper.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcSessionHelper.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.openidconnect.clients.common;
+
+import org.apache.commons.codec.binary.Base64;
+
+/**
+ * Class used to help generate session id's which contain information
+ * about the oidc config id, sub, sid, and timestamp.
+ * The session id's are stored in the WASOidcSession cookie to keep track of
+ * sessions in the RP.
+ */
+public class OidcSessionHelper {
+    private static String DELIMITER = ",";
+
+    /**
+     * Generate a new session id using the config id, sub, sid, and timestamp by
+     * concatenating them using a delimiter and then base64 encoding the result.
+     * It is assumed that the inputs have been validated before creating the session id.
+     * If a value does not exist (e.g., the sid claim), an empty string should be passed in.
+     *
+     * @param configId The oidc config id.
+     * @param sub The sub claim.
+     * @param sid The sid claim.
+     * @param timestamp The current time.
+     * @return A base64 encoded session id.
+     */
+    public static String createSessionId(String configId, String sub, String sid, String timestamp) {
+        String sessionId = String.join(DELIMITER, configId, sub, sid, timestamp);
+        return new String(Base64.encodeBase64(sessionId.getBytes()));
+    }
+
+    /**
+     * Takes a base64 encoded session id and returns an OidcSessionInfo object
+     * which contains the config id, sub, sid, and timestamp embedded in the session id.
+     *
+     * @param encodedSessionId The base64 encoded session id.
+     * @return An OidcSessionInfo object containing info parsed from the session id.
+     */
+    public static OidcSessionInfo getSessionInfo(String encodedSessionId) {
+        if (encodedSessionId == null || encodedSessionId.isEmpty()) {
+            return null;
+        }
+
+        String sessionId = new String(Base64.decodeBase64(encodedSessionId));
+        String[] parts = sessionId.split(DELIMITER);
+        if (parts.length != 4) {
+            return null;
+        }
+
+        return new OidcSessionInfo(parts[0], parts[1], parts[2], parts[3]);
+    }
+}

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcSessionHelper.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcSessionHelper.java
@@ -25,7 +25,6 @@ public class OidcSessionHelper {
      * Generate a new session id using the config id, sub, sid, and timestamp in the
      * format of 'Base64(configId):Base64(sub):Base64(sid):Base64(timestamp)'.
      * It is assumed that the inputs have been validated before creating the session id.
-     * If a value does not exist (e.g., the sid claim), an empty string should be passed in.
      *
      * @param configId The oidc config id.
      * @param sub The sub claim.
@@ -34,6 +33,11 @@ public class OidcSessionHelper {
      * @return A session id in the format 'Base64(configId):Base64(sub):Base64(sid):Base64(timestamp)'.
      */
     public static String createSessionId(String configId, String sub, String sid, String timestamp) {
+        if (configId == null) configId = "";
+        if (sub == null) sub = "";
+        if (sid == null) sid = "";
+        if (timestamp == null) timestamp = "";
+        
         String encodedConfigId = new String(Base64.encodeBase64(configId.getBytes()));
         String encodedSub = new String(Base64.encodeBase64(sub.getBytes()));
         String encodedSid = new String(Base64.encodeBase64(sid.getBytes()));

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcSessionInfo.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcSessionInfo.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.openidconnect.clients.common;
+
+public class OidcSessionInfo {
+    private final String configId;
+    private final String sub;
+    private final String sid;
+    private final String timestamp;
+
+    public OidcSessionInfo(String configId, String sub, String sid, String timestamp) {
+        this.configId = configId;
+        this.sub = sub;
+        this.sid = sid;
+        this.timestamp = timestamp;
+    }
+
+    public String getConfigId() {
+        return this.configId;
+    }
+
+    public String getSub() {
+        return this.sub;
+    }
+
+    public String getSid() {
+        return this.sid;
+    }
+
+    public String getTimestamp() {
+        return this.timestamp;
+    }
+
+}

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/InMemoryOidcSessionCacheTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/InMemoryOidcSessionCacheTest.java
@@ -240,6 +240,97 @@ public class InMemoryOidcSessionCacheTest {
     }
 
     @Test
+    public void test_invalidateSessionBySessionId() {
+        populateCache();
+
+        boolean invalidated = cache.invalidateSessionBySessionId("testsub", "testoidcsessionid1");
+
+        assertTrue("Session should have been invalidated.", invalidated);
+        verifyInvalidatedSessions(true, false, false, false);
+    }
+
+    @Test
+    public void test_invalidateSessionBySessionId_sub2() {
+        populateCache();
+
+        boolean invalidated = cache.invalidateSessionBySessionId("testsub2", "testoidcsessionid4");
+
+        assertTrue("Session should have been invalidated.", invalidated);
+        verifyInvalidatedSessions(false, false, false, true);
+    }
+
+    @Test
+    public void test_invalidateSessionBySessionId_alreadyInvalidated() {
+        populateCache();
+        cache.invalidateSessionBySessionId("testsub", "testoidcsessionid1");
+
+        boolean invalidated = cache.invalidateSessionBySessionId("testsub", "testoidcsessionid1");
+
+        assertFalse("Should return false if the session has already been invalidated.", invalidated);
+        verifyInvalidatedSessions(true, false, false, false);
+    }
+
+    @Test
+    public void test_invalidateSessionBySessionId_sidIsNull() {
+        populateCache();
+
+        boolean invalidated = cache.invalidateSessionBySessionId("testsub", null);
+
+        assertFalse("Sessions should not have been invalidated.", invalidated);
+        verifyInvalidatedSessions(false, false, false, false);
+    }
+
+    @Test
+    public void test_invalidateSessionBySessionId_sidIsEmpty() {
+        populateCache();
+
+        boolean invalidated = cache.invalidateSessionBySessionId("testsub", "");
+
+        assertFalse("Sessions should not have been invalidated.", invalidated);
+        verifyInvalidatedSessions(false, false, false, false);
+    }
+
+    @Test
+    public void test_invalidateSessionBySessionId_sidDoesNotExist() {
+        populateCache();
+
+        boolean invalidated = cache.invalidateSessionBySessionId("testsub", "doesnotexist");
+
+        assertFalse("Should not be able to invalidate a session for a sid that does not exist.", invalidated);
+        verifyInvalidatedSessions(false, false, false, false);
+    }
+
+    @Test
+    public void test_invalidateSessionBySessionId_subIsNull() {
+        populateCache();
+
+        boolean invalidated = cache.invalidateSessionBySessionId(null, "testsid");
+
+        assertFalse("Should not be able to invalidate a session if no sub is provided.", invalidated);
+        verifyInvalidatedSessions(false, false, false, false);
+    }
+
+    @Test
+    public void test_invalidateSessionBySessionId_subIsEmpty() {
+        populateCache();
+
+        boolean invalidated = cache.invalidateSessionBySessionId("", "testsid");
+
+        assertFalse("Should not be able to invalidate a session if the sub is empty.", invalidated);
+        verifyInvalidatedSessions(false, false, false, false);
+    }
+
+    @Test
+    public void test_invalidateSessionBySessionId_subDoesNotExist() {
+        populateCache();
+
+        boolean invalidated = cache.invalidateSessionBySessionId("doesnotexist", "testsid");
+
+        assertFalse("Should not be able to invalidate a session if the sub does not exist.", invalidated);
+        verifyInvalidatedSessions(false, false, false, false);
+    }
+
+    @Test
     public void test_invalidateSessions() {
         populateCache();
 

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcSessionHelperTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcSessionHelperTest.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.openidconnect.clients.common;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+/**
+ *
+ */
+public class OidcSessionHelperTest {
+
+    @Test
+    public void test_createSessionId() {
+        String configId = "testConfigId";
+        String sub = "testSub";
+        String sid = "testSid";
+        String timestamp = "12345";
+
+        String actualSessionId = OidcSessionHelper.createSessionId(configId, sub, sid, timestamp);
+        String expectedSesssionId = "dGVzdENvbmZpZ0lkLHRlc3RTdWIsdGVzdFNpZCwxMjM0NQ==";
+
+        assertEquals("Should have concatenated the parts using ',' and then base64 encoding the result.", expectedSesssionId, actualSessionId);
+    }
+
+    @Test
+    public void test_createSessionId_emptySid() {
+        String configId = "testConfigId";
+        String sub = "testSub";
+        String sid = "";
+        String timestamp = "12345";
+
+        String actualSessionId = OidcSessionHelper.createSessionId(configId, sub, sid, timestamp);
+        String expectedSesssionId = "dGVzdENvbmZpZ0lkLHRlc3RTdWIsLDEyMzQ1";
+
+        assertEquals("Should have concatenated the parts using ',' and then base64 encoding the result.", expectedSesssionId, actualSessionId);
+    }
+
+    @Test
+    public void test_getSessionInfo() {
+        String sessionId = "dGVzdENvbmZpZ0lkLHRlc3RTdWIsdGVzdFNpZCwxMjM0NQ==";
+
+        OidcSessionInfo sessionInfo = OidcSessionHelper.getSessionInfo(sessionId);
+
+        assertEquals("testConfigId", sessionInfo.getConfigId());
+        assertEquals("testSub", sessionInfo.getSub());
+        assertEquals("testSid", sessionInfo.getSid());
+        assertEquals("12345", sessionInfo.getTimestamp());
+    }
+
+    @Test
+    public void test_getSessinoInfo_sidWasEmpty() {
+        String sessionId = "dGVzdENvbmZpZ0lkLHRlc3RTdWIsLDEyMzQ1";
+
+        OidcSessionInfo sessionInfo = OidcSessionHelper.getSessionInfo(sessionId);
+
+        assertEquals("testConfigId", sessionInfo.getConfigId());
+        assertEquals("testSub", sessionInfo.getSub());
+        assertEquals("", sessionInfo.getSid());
+        assertEquals("12345", sessionInfo.getTimestamp());
+    }
+
+    @Test
+    public void test_getSessionInfo_sessionIdIsNull() {
+        String sessionId = null;
+
+        OidcSessionInfo sessionInfo = OidcSessionHelper.getSessionInfo(sessionId);
+
+        assertNull("Expected the sessionInfo to be null, since the sessionId was invalid.", sessionInfo);
+    }
+
+    @Test
+    public void test_getSessionInfo_sessionIdIsEmpty() {
+        String sessionId = "";
+
+        OidcSessionInfo sessionInfo = OidcSessionHelper.getSessionInfo(sessionId);
+
+        assertNull("Expected the sessionInfo to be null, since the sessionId was invalid.", sessionInfo);
+    }
+
+    @Test
+    public void test_getSessionInfo_decodedSessionIdDoesNotHaveFourParts() {
+        String sessionId = "dGVzdENvbmZpZ0lkLHRlc3RTdWI=";
+
+        OidcSessionInfo sessionInfo = OidcSessionHelper.getSessionInfo(sessionId);
+
+        assertNull("Expected the sessionInfo to be null, since the sessionId was invalid.", sessionInfo);
+    }
+
+    @Test
+    public void test_getSessionInfo_sessionIdIsInvalid() {
+        String sessionId = "invalidSessionId";
+
+        OidcSessionInfo sessionInfo = OidcSessionHelper.getSessionInfo(sessionId);
+
+        assertNull("Expected the sessionInfo to be null, since the sessionId was invalid.", sessionInfo);
+    }
+}

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcSessionHelperTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcSessionHelperTest.java
@@ -47,6 +47,58 @@ public class OidcSessionHelperTest {
     }
 
     @Test
+    public void test_createSessionId_configIdIsNull() {
+        String configId = null;
+        String sub = "testSub";
+        String sid = "testSid";
+        String timestamp = "12345";
+
+        String actualSessionId = OidcSessionHelper.createSessionId(configId, sub, sid, timestamp);
+        String expectedSesssionId = ":dGVzdFN1Yg==:dGVzdFNpZA==:MTIzNDU=";
+
+        assertEquals("Expected to replace the configId with an empty string.", expectedSesssionId, actualSessionId);
+    }
+
+    @Test
+    public void test_createSessionId_subIsNull() {
+        String configId = "testConfigId";
+        String sub = null;
+        String sid = "testSid";
+        String timestamp = "12345";
+
+        String actualSessionId = OidcSessionHelper.createSessionId(configId, sub, sid, timestamp);
+        String expectedSesssionId = "dGVzdENvbmZpZ0lk::dGVzdFNpZA==:MTIzNDU=";
+
+        assertEquals("Expected to replace the sub with an empty string.", expectedSesssionId, actualSessionId);
+    }
+
+    @Test
+    public void test_createSessionId_sidIsNull() {
+        String configId = "testConfigId";
+        String sub = "testSub";
+        String sid = null;
+        String timestamp = "12345";
+
+        String actualSessionId = OidcSessionHelper.createSessionId(configId, sub, sid, timestamp);
+        String expectedSesssionId = "dGVzdENvbmZpZ0lk:dGVzdFN1Yg==::MTIzNDU=";
+
+        assertEquals("Expected to replace the sid with an empty string.", expectedSesssionId, actualSessionId);
+    }
+
+    @Test
+    public void test_createSessionId_timestampIsNull() {
+        String configId = "testConfigId";
+        String sub = "testSub";
+        String sid = "testSid";
+        String timestamp = null;
+
+        String actualSessionId = OidcSessionHelper.createSessionId(configId, sub, sid, timestamp);
+        String expectedSesssionId = "dGVzdENvbmZpZ0lk:dGVzdFN1Yg==:dGVzdFNpZA==:";
+
+        assertEquals("Expected to replace the timestamp with an empty string.", expectedSesssionId, actualSessionId);
+    }
+
+    @Test
     public void test_getSessionInfo() {
         String sessionId = "dGVzdENvbmZpZ0lk:dGVzdFN1Yg==:dGVzdFNpZA==:MTIzNDU=";
 
@@ -59,7 +111,7 @@ public class OidcSessionHelperTest {
     }
 
     @Test
-    public void test_getSessinoInfo_sidWasEmpty() {
+    public void test_getSessinoInfo_sidWasEmptyOrNull() {
         String sessionId = "dGVzdENvbmZpZ0lk:dGVzdFN1Yg==::MTIzNDU=";
 
         OidcSessionInfo sessionInfo = OidcSessionHelper.getSessionInfo(sessionId);

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcSessionHelperTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcSessionHelperTest.java
@@ -28,27 +28,27 @@ public class OidcSessionHelperTest {
         String timestamp = "12345";
 
         String actualSessionId = OidcSessionHelper.createSessionId(configId, sub, sid, timestamp);
-        String expectedSesssionId = "dGVzdENvbmZpZ0lkLHRlc3RTdWIsdGVzdFNpZCwxMjM0NQ==";
+        String expectedSesssionId = "dGVzdENvbmZpZ0lk:dGVzdFN1Yg==:dGVzdFNpZA==:MTIzNDU=";
 
-        assertEquals("Should have concatenated the parts using ',' and then base64 encoding the result.", expectedSesssionId, actualSessionId);
+        assertEquals("Expected to the return the session id in the format 'Base64(configId):Base64(sub):Base64(sid):Base64(timestamp)'.", expectedSesssionId, actualSessionId);
     }
 
     @Test
-    public void test_createSessionId_emptySid() {
+    public void test_createSessionId_sidIsEmpty() {
         String configId = "testConfigId";
         String sub = "testSub";
         String sid = "";
         String timestamp = "12345";
 
         String actualSessionId = OidcSessionHelper.createSessionId(configId, sub, sid, timestamp);
-        String expectedSesssionId = "dGVzdENvbmZpZ0lkLHRlc3RTdWIsLDEyMzQ1";
+        String expectedSesssionId = "dGVzdENvbmZpZ0lk:dGVzdFN1Yg==::MTIzNDU=";
 
-        assertEquals("Should have concatenated the parts using ',' and then base64 encoding the result.", expectedSesssionId, actualSessionId);
+        assertEquals("Expected to the return the session id in the format 'Base64(configId):Base64(sub):Base64(sid):Base64(timestamp)'.", expectedSesssionId, actualSessionId);
     }
 
     @Test
     public void test_getSessionInfo() {
-        String sessionId = "dGVzdENvbmZpZ0lkLHRlc3RTdWIsdGVzdFNpZCwxMjM0NQ==";
+        String sessionId = "dGVzdENvbmZpZ0lk:dGVzdFN1Yg==:dGVzdFNpZA==:MTIzNDU=";
 
         OidcSessionInfo sessionInfo = OidcSessionHelper.getSessionInfo(sessionId);
 
@@ -60,7 +60,7 @@ public class OidcSessionHelperTest {
 
     @Test
     public void test_getSessinoInfo_sidWasEmpty() {
-        String sessionId = "dGVzdENvbmZpZ0lkLHRlc3RTdWIsLDEyMzQ1";
+        String sessionId = "dGVzdENvbmZpZ0lk:dGVzdFN1Yg==::MTIzNDU=";
 
         OidcSessionInfo sessionInfo = OidcSessionHelper.getSessionInfo(sessionId);
 
@@ -90,7 +90,7 @@ public class OidcSessionHelperTest {
 
     @Test
     public void test_getSessionInfo_decodedSessionIdDoesNotHaveFourParts() {
-        String sessionId = "dGVzdENvbmZpZ0lkLHRlc3RTdWI=";
+        String sessionId = "dGVzdENvbmZpZ0lk:dGVzdFN1Yg==";
 
         OidcSessionInfo sessionInfo = OidcSessionHelper.getSessionInfo(sessionId);
 


### PR DESCRIPTION
for #20360

when a logout happens in the oidc client, we need to cleanup the oidc session cache by invalidating the session if it is not already invalidated and then removing the invalidated session. the oidc session is looked up and invalidated in the cache based on the information from the session cookie. if there is info on the sid, it can easily lookup and invalidate the session. if there is no sid, it has to look through all the session id's for that sub to find the session to invalidate. the oidc session cookie is also cleared after.