### PR TITLE
Add default LTPA keys for ConfigManagerFeatureTest

### DIFF
--- a/dev/com.ibm.ws.security.wim.core_fat/publish/servers/com.ibm.ws.security.wim.core.fat.mod/resources/security/ltpa.keys
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/servers/com.ibm.ws.security.wim.core.fat.mod/resources/security/ltpa.keys
@@ -1,0 +1,8 @@
+#Sun Jan 15 15:01:21 CST 2012
+com.ibm.websphere.CreationDate=Sun Jan 15 15\:01\:21 CST 2012
+com.ibm.websphere.CreationHost=localhost
+com.ibm.websphere.ltpa.Realm=PreGeneratedLTPAKeys
+com.ibm.websphere.ltpa.version=1.0
+com.ibm.websphere.ltpa.3DESKey=xpUAUsH4SZc+VuiAqzL+Tz+MfBmb+6vv3/cGjIn+mR4\=
+com.ibm.websphere.ltpa.PublicKey=AMan4Qo5MKIeYf26TJbTZwRdYai7rWRVXDwy/6XI1iq+CVxny1O74rE4cn7wXalID05hKwm/HUxvFd72Y3dABzL1bTUpl1uE6SQNePrcdrQC8rmtichsdvY0baiGYexURYP7fbHF5Z70RfQGCPYnuZTB9jsHdh4HJlrOlsx6K2mJAQAB
+com.ibm.websphere.ltpa.PrivateKey=TkjZeR/1L6khA7UKNjBRI1T+nbwEWXv1AWVSOCEgpKfLvw8iAkIc7+8I2zfc3j88XciTxDuagepUDoWCXHJ1ithSptZSLnHBASD7Ki1dLTKY7jszPXmIIwoa8YaQFtuuNeSJ7r6r8krSB5ml5sk7aTF0Sed8TFrx1aDEQRIZCovZV8BQX29bBZC99gTqk3chCpcOVRqcxvQRGzdP0PenvaA9afeflV5t4Iw8errfmHjedNVDog90ZVVAeecO+ZLqn7yAHh98ZTdV9IEVyqnFI7XQljrMJsNt3zl/tB7ktQ6VuyxJmlQdDbmvJ+F6DZeR9lVC991a/Ks0i1VKVOrwhPxJYLX2Xz7MWpLu09pwapo\=


### PR DESCRIPTION
Add default LTPA keys instead of creating from scratch for this short run test, `ConfigManagerFeatureTest` -- otherwise the test is over before the LTPA keys are finished on slower build systems, causing FFDCs to be flagged.

RTC 290524