### PR TITLE
Remove bottleneck when creating and destroying ThreadContextClassLoaders

### DIFF
--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/KeyBasedLockStore.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/KeyBasedLockStore.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.kernel.service.util;
+
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+
+@Trivial
+public final class KeyBasedLockStore<Key, Lock> {
+
+    private final ReferenceQueue<Lock> refQueue = new ReferenceQueue<>();
+    private final ConcurrentHashMap<String, LockWeakRef> lockMap = new ConcurrentHashMap<>();
+    private final Supplier<Lock> lockCreator;
+
+    public KeyBasedLockStore(Supplier<Lock> lockCreator) {
+        this.lockCreator = lockCreator;
+    }
+
+    private final class LockWeakRef extends WeakReference<Lock> {
+        final String key;
+
+        @Trivial
+        public LockWeakRef(Lock referent, String keyValue) {
+            super(referent, refQueue);
+            key = keyValue;
+        }
+    }
+
+    public final Lock getLock(String key) {
+        poll();
+        LockWeakRef lockRef = lockMap.get(key);
+        Lock lock = lockRef != null ? lockRef.get() : null;
+        if (lock != null) {
+            return lock;
+        }
+
+        lock = lockCreator.get();
+
+        while (true) {
+            LockWeakRef retVal = lockMap.putIfAbsent(key, new LockWeakRef(lock, key));
+            if (retVal == null) {
+                return lock;
+            }
+
+            Lock retLock = retVal.get();
+            if (retLock != null) {
+                return retLock;
+            }
+            lockMap.remove(key, retVal);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private final void poll() {
+        LockWeakRef lockRef;
+        while ((lockRef = (LockWeakRef) refQueue.poll()) != null) {
+            lockMap.remove(lockRef.key, lockRef);
+        }
+    }
+}


### PR DESCRIPTION
- Use a lock per application classloader instead of a global lock when creating and destroy TCCLs in ClassLoadingServiceImpl
- Move away from recursion in CanonicalStore.