### PR TITLE
Use full oracle image for DB Rotation

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerType.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerType.java
@@ -38,7 +38,7 @@ public enum DatabaseContainerType {
     Derby("derby.jar", DerbyNoopContainer.class.getCanonicalName(), Properties_derby_embedded.class, DockerImageName.parse("")),
     DerbyClient("derbyclient.jar", DerbyClientContainer.class.getCanonicalName(), Properties_derby_client.class, DockerImageName.parse("")),
     Oracle("ojdbc8_g.jar", OracleContainer.class.getCanonicalName(), Properties_oracle.class, //
-           DockerImageName.parse("kyleaure/oracle-18.4.0-expanded:1.0.slim").asCompatibleSubstituteFor("gvenzl/oracle-xe")),
+           DockerImageName.parse("kyleaure/oracle-18.4.0-expanded:1.0.full").asCompatibleSubstituteFor("gvenzl/oracle-xe")),
     Postgres("postgresql.jar", PostgreSQLContainer.class.getCanonicalName(), Properties_postgresql.class, //
              DockerImageName.parse("postgres:14.1-alpine")),
     SQLServer("mssql-jdbc.jar", MSSQLServerContainer.class.getCanonicalName(), Properties_microsoft_sqlserver.class, //


### PR DESCRIPTION
Changing the Oracle image used for Database Rotation to the Oracle full version.  
The slim version does not allow for distributed transactions and fails with the following error:

```
[5/13/22, 14:18:35:851 CDT] 00000038 com.ibm.ws.rsadapter.impl.WSRdbXaResourceImpl                E DSRA0304E:  XAException occurred. XAException contents and details are: 
The XA Error is            : -3
The XA Error message is    : A resource manager error has occured in the transaction branch.
The Oracle Error code is   : 6550
The Oracle Error message is: Internal XA Error
The cause is               : java.sql.SQLException: ORA-06550: line 1, column 14:
PLS-00201: identifier 'JAVA_XA.XA_START_NEW' must be declared
ORA-06550: line 1, column 7:
PL/SQL: Statement ignored
```

Switching to the full version resolves this issue. 