### PR TITLE
use final 3.0.0 TCK for Concurrency

### DIFF
--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -39,7 +39,9 @@
         <targetDirectory>${project.basedir}/target</targetDirectory>
     </properties>
 
-	<repositories> <!-- For artifacts not yet in Maven Central -->
+	<repositories>
+		<!-- For artifacts not yet in Maven Central -->
+		<!-- Enable the following during development of a vNext release to use a staged TCK rather than a local -SNAPSHOT
 		<repository>
 			<id>sonatype-nexus-staging</id>
 			<name>Sonatype Nexus Staging</name>
@@ -51,6 +53,7 @@
 				<enabled>true</enabled>
 			</snapshots>
 		</repository>
+		-->
 	</repositories>
 
     <dependencyManagement>

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/standalone.pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/standalone.pom.xml
@@ -39,7 +39,9 @@
         <targetDirectory>${project.basedir}/target</targetDirectory>
     </properties>
 
-	<repositories> <!-- For artifacts not yet in Maven Central -->
+	<repositories>
+		<!-- For artifacts not yet in Maven Central -->
+		<!-- Enable the following during development of a vNext release to use a staged TCK rather than a local -SNAPSHOT
 		<repository>
 			<id>sonatype-nexus-staging</id>
 			<name>Sonatype Nexus Staging</name>
@@ -51,6 +53,7 @@
 				<enabled>true</enabled>
 			</snapshots>
 		</repository>
+		-->
 	</repositories>
 
     <dependencyManagement>


### PR DESCRIPTION
Point the test bucket for running the Concurrency 3.0 TCK at the final release copy from Maven instead of staging.