### PR TITLE
21121 Remove TCCL visibility from JCache API

### DIFF
--- a/dev/com.ibm.websphere.javaee.jcache.1.1/bnd.bnd
+++ b/dev/com.ibm.websphere.javaee.jcache.1.1/bnd.bnd
@@ -16,7 +16,7 @@ bVersion=1.0
 
 
 Export-Package: \
-   javax.cache.*;version="1.1";thread-context=true
+   javax.cache.*;version="1.1"
 
 Import-Package: \
    javax.enterprise.util;resolution:=optional


### PR DESCRIPTION
Remove the thread-context=true attribute from the JCache API bundle, com.ibm.websphere.jcache.1.1
