### PR TITLE
PH46072: Confidential for CVE-2022-22475

### DIFF
--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAToken2.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAToken2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2011, 2019 IBM Corporation and others.
+ * Copyright (c) 2004, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -318,6 +318,7 @@ public class LTPAToken2 implements Token, Serializable {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(this, tc, "Invalid signature of the token " + this);
             }
+            throw new InvalidTokenException("Token Validation Failed");
         }
 
         return verified;


### PR DESCRIPTION
PH46072: IBM WebSphere Application Server Liberty is vulnerable to Identity Spoofing (CVE-2022-22475 CVSS 5.0)