### PR TITLE
Eclipse cleanup for Spring Boot apps

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -3093,6 +3093,11 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-crypto</artifactId>
+      <version>5.6.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
       <version>5.6.2</version>
     </dependency>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -614,6 +614,7 @@ org.springframework.boot:spring-boot:2.0.0.RELEASE
 org.springframework.boot:spring-boot:2.6.6
 org.springframework.security:spring-security-config:5.6.2
 org.springframework.security:spring-security-core:5.6.2
+org.springframework.security:spring-security-crypto:5.6.2
 org.springframework.security:spring-security-web:5.6.2
 org.springframework:spring-aop:3.0.7.RELEASE
 org.springframework:spring-asm:3.0.7.RELEASE

--- a/dev/com.ibm.ws.springboot.support.version20.test.app/bnd.bnd
+++ b/dev/com.ibm.ws.springboot.support.version20.test.app/bnd.bnd
@@ -40,4 +40,5 @@ bVersion=1.0
 	org.springframework.security:spring-security-web;strategy=exact;version=5.6.2, \
 	org.springframework.security:spring-security-config;strategy=exact;version=5.6.2, \
 	org.springframework.security:spring-security-core;strategy=exact;version=5.6.2, \
+	org.springframework.security:spring-security-crypto;strategy=exact;version=5.6.2, \
 	com.ibm.websphere.javaee.servlet.4.0

--- a/dev/com.ibm.ws.springboot.support.version20.test.java.app/bnd.bnd
+++ b/dev/com.ibm.ws.springboot.support.version20.test.java.app/bnd.bnd
@@ -24,6 +24,7 @@ bVersion=1.0
 
 
 -testpath: \
+	org.springframework:spring-beans;strategy=exact;version=5.3.18, \
 	org.springframework:spring-context;strategy=exact;version=5.3.18, \
 	org.springframework.boot:spring-boot-autoconfigure;strategy=exact;version=2.6.6, \
 	org.springframework.boot:spring-boot;strategy=exact;version=2.6.6

--- a/dev/com.ibm.ws.springboot.support.version20.test.webanno.app/bnd.bnd
+++ b/dev/com.ibm.ws.springboot.support.version20.test.webanno.app/bnd.bnd
@@ -24,6 +24,7 @@ bVersion=1.0
 
 
 -testpath: \
+	org.springframework:spring-beans;strategy=exact;version=5.3.18, \
 	org.springframework:spring-context;strategy=exact;version=5.3.18, \
 	org.springframework:spring-web;strategy=exact;version=5.3.18, \
 	org.springframework.boot:spring-boot-autoconfigure;strategy=exact;version=2.6.6, \


### PR DESCRIPTION
Update testpath for Spring Boot test apps so they build
cleanly in Eclipse.

