### PR TITLE
Allow warning message at serverStop

### DIFF
--- a/dev/com.ibm.ws.app.manager.wab.installer_fat/fat/src/com/ibm/ws/app/manager/wab/installer/fat/ConfigurableWABTests.java
+++ b/dev/com.ibm.ws.app.manager.wab.installer_fat/fat/src/com/ibm/ws/app/manager/wab/installer/fat/ConfigurableWABTests.java
@@ -64,8 +64,9 @@ public class ConfigurableWABTests extends AbstractWABTests {
     @AfterClass
     public static void stopServer() throws Exception {
         if (server != null && server.isStarted()) {
-            // we expect a conflict error from the conflict test
-            server.stopServer("CWWKZ0208E");
+            // ignore conflict error from the conflict test
+            // ignore warning about virtual host not found
+            server.stopServer("CWWKZ0208E", "SRVE9956W");
         }
     }
 


### PR DESCRIPTION
Ignore a warning message from the VirtualHostManager when a WAB uninstall and install are processed concurrently during a FAT test



