### PR TITLE
PR for Issue 20577: Update error message for social BCL requests with wrong HTTP method

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutException.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutException.java
@@ -18,11 +18,6 @@ public class BackchannelLogoutException extends Exception {
 
     private final int responseCode;
 
-    public BackchannelLogoutException(int responseCode) {
-        super();
-        this.responseCode = responseCode;
-    }
-
     public BackchannelLogoutException(String errorMsg) {
         this(errorMsg, HttpServletResponse.SC_BAD_REQUEST);
     }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutHelper.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutHelper.java
@@ -69,7 +69,7 @@ public class BackchannelLogoutHelper {
         }
         String httpMethod = request.getMethod();
         if (!"POST".equalsIgnoreCase(httpMethod)) {
-            throw new BackchannelLogoutException(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+            throw new BackchannelLogoutException("HTTP " + HttpServletResponse.SC_METHOD_NOT_ALLOWED + " Method Not Allowed (" + httpMethod + ")", HttpServletResponse.SC_METHOD_NOT_ALLOWED);
         }
         String logoutTokenParameter = request.getParameter(LOGOUT_TOKEN_PARAM_NAME);
         if (logoutTokenParameter == null || logoutTokenParameter.isEmpty()) {


### PR DESCRIPTION
Updates the runtime to include "HTTP 405" and the HTTP method used when a non-HTTP POST request is sent to the back-channel logout servlet. Before, an exception message had not been provided so the runtime would emit
```
CWWKS1541E: The back-channel logout request sent to [/ibm/api/social-login/backchannel_logout/client01] encountered an error. null
```
Now the runtime will emit the more helpful:
```
CWWKS1541E: The back-channel logout request sent to [/ibm/api/social-login/backchannel_logout/client01] encountered an error. HTTP 405 Method Not Allowed (GET)
```

For #20577 