### PR TITLE
Issue 21066: Add a warning message when failed login delay is disabled

### DIFF
--- a/dev/com.ibm.websphere.security.wim.base/src/com/ibm/websphere/security/wim/ras/WIMMessageKey.java
+++ b/dev/com.ibm.websphere.security.wim.base/src/com/ibm/websphere/security/wim/ras/WIMMessageKey.java
@@ -1695,4 +1695,11 @@ public interface WIMMessageKey {
      * LDAP_WIM_CONFIG_UPDATED_FAILED.useraction=Review the logs for the cause of this error and take appropriate corrective actions.
      */
     String LDAP_WIM_CONFIG_UPDATED_FAILED = "LDAP_WIM_CONFIG_UPDATED_FAILED";
+
+    /**
+     * CWIMK0012W: The failed login delay for the federated repositories is disabled. This disablement exposes the server to user enumeration attacks. To enable delay for failed
+     * logins, remove the {0} and the {1} federated repository attributes so that the default minimum and maximum values of 0 and 5000 milliseconds are used. Alternatively, set the
+     * {1} federated repository attribute to a value greater than zero.
+     */
+    String FAILED_LOGIN_DELAY_DISABLED = "FAILED_LOGIN_DELAY_DISABLED";
 }

--- a/dev/com.ibm.ws.security.wim.core/resources/com/ibm/ws/security/wim/util/resources/WimUtilMessages.nlsprops
+++ b/dev/com.ibm.ws.security.wim.core/resources/com/ibm/ws/security/wim/util/resources/WimUtilMessages.nlsprops
@@ -72,6 +72,11 @@ MISSING_REGISTRY_DEFINITION=CWIMK0011E: The user registry operation could not be
 MISSING_REGISTRY_DEFINITION.explanation=A user registry was not defined or could not be initialized due to a configuration error. A valid user registry includes an LDAP registry or other supported registries or repositories.
 MISSING_REGISTRY_DEFINITION.useraction=If a user registry was defined in the configuration file, review the logs for configuration errors during server start up. Add or correct the user registry definition in the server.xml file.
 
+FAILED_LOGIN_DELAY_DISABLED=CWIMK0012W: The failed login delay for the federated repositories is disabled. This disablement exposes the server to user enumeration attacks. To enable delay for failed logins, remove the {0} and the {1} federated repository attributes so that the default minimum and maximum values of 0 and 5000 milliseconds are used. Alternatively, set the {1} federated repository attribute to a value greater than zero. 
+FAILED_LOGIN_DELAY_DISABLED.explanation=When the failed login delay is disabled, the server is vulnerable to a user enumeration style attack.
+FAILED_LOGIN_DELAY_DISABLED.useraction=Enable the failed login delay by removing the attributes to use the default minimum and maximum padding delay of zero and 5000 milliseconds or set the attributes to a custom configuration. 
+
+
 ENTITY_IDENTIFIER_NOT_SPECIFIED=CWIML1009E: The user registry operation could not be completed. The identifier of the entity was not found. Specify the correct identifier as the input parameter. 
 ENTITY_IDENTIFIER_NOT_SPECIFIED.explanation=The identifier of the entity was not specified. The system cannot find the entity. The user registry operation cannot continue without finding this entity. 
 ENTITY_IDENTIFIER_NOT_SPECIFIED.useraction=Ensure that the entity in the input object contains an identifier property.

--- a/dev/com.ibm.ws.security.wim.core/src/com/ibm/ws/security/wim/ConfigManager.java
+++ b/dev/com.ibm.ws.security.wim.core/src/com/ibm/ws/security/wim/ConfigManager.java
@@ -335,6 +335,8 @@ public class ConfigManager implements RuntimeUpdateListener {
                 Tr.debug(tc,
                          "failed response login delay is enabled with the following min/max (ms): " + failResponseDelayMin + " and " + failResponseDelayMax);
             }
+        } else {
+            Tr.warning(tc, WIMMessageKey.FAILED_LOGIN_DELAY_DISABLED, CONFIG_PROP_FAIL_RESPONSE_DELAY_MIN, CONFIG_PROP_FAIL_RESPONSE_DELAY_MAX);
         }
         updatedConfig.put(CONFIG_PROP_FAIL_RESPONSE_DELAY_MAX, failResponseDelayMax);
         updatedConfig.put(CONFIG_PROP_FAIL_RESPONSE_DELAY_MIN, failResponseDelayMin);

--- a/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/UserEnumerationTest.java
+++ b/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/UserEnumerationTest.java
@@ -99,7 +99,7 @@ public class UserEnumerationTest {
     @AfterClass
     public static void teardownClass() throws Exception {
         if (libertyServer != null) {
-            libertyServer.stopServer("CWIML4537E", "CWIML4529E"); // Messages we get for invalid users
+            libertyServer.stopServer("CWIML4537E", "CWIML4529E", "CWIMK0012W"); // Messages we get for invalid users
         }
     }
 
@@ -149,6 +149,9 @@ public class UserEnumerationTest {
          */
         assertFalse("Should have logged that delay is disabled",
                     libertyServer.findStringsInLogsAndTrace("failed response login delay is disabled: failedLoginDelayMax=0").isEmpty());
+
+        assertFalse("Should have logged that delay is disabled with official warning - CWIMK0012W",
+                    libertyServer.findStringsInLogsAndTrace("CWIMK0012W").isEmpty());
 
         runLoginTestCommon(false);
     }


### PR DESCRIPTION
Fixes #21066 

Add a warning when the failed login delay is disabled for Federated Repositories. Also moved the login delay sleep into its own method.

`CWIMK0012W: The failed login delay for the federated repositories is disabled. This disablement exposes the server to user enumeration attacks. To enable delay for failed logins, remove the failedLoginDelayMin and the failedLoginDelayMax federated repository attributes so that the default minimum and maximum values of 0 and 5000 milliseconds are used. Alternatively, set the failedLoginDelayMax federated repository attribute to a value greater than zero. `