### PR TITLE
move getOidcSessionCache to ConvergedClientConfig

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutHelper.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutHelper.java
@@ -89,7 +89,7 @@ public class BackchannelLogoutHelper {
             String sub = logoutTokenClaims.getSubject();
             String sid = logoutTokenClaims.getClaimValue("sid", String.class);
 
-            OidcSessionCache oidcSessionCache = clientConfig.getOidcClientConfig().getOidcSessionCache();
+            OidcSessionCache oidcSessionCache = clientConfig.getOidcSessionCache();
             if (sid != null && !sid.isEmpty()) {
                 oidcSessionCache.invalidateSession(sub, sid);
             } else {

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/ConvergedClientConfig.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/ConvergedClientConfig.java
@@ -133,4 +133,6 @@ public interface ConvergedClientConfig extends JwtConsumerConfig {
 
     String getIntrospectionTokenTypeHint();
 
+    public OidcSessionCache getOidcSessionCache();
+
 }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientConfig.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientConfig.java
@@ -87,8 +87,6 @@ public interface OidcClientConfig extends ConvergedClientConfig {
 
     public SingleTableCache getCache();
 
-    public OidcSessionCache getOidcSessionCache();
-
     public boolean getAccessTokenCacheEnabled();
 
     public long getAccessTokenCacheTimeout();

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
@@ -35,7 +35,9 @@ import com.ibm.ws.security.jwt.config.ConsumerUtils;
 import com.ibm.ws.security.jwt.config.JwtConsumerConfig;
 import com.ibm.ws.security.jwt.utils.JwtUtils;
 import com.ibm.ws.security.openidconnect.clients.common.ConvergedClientConfig;
+import com.ibm.ws.security.openidconnect.clients.common.InMemoryOidcSessionCache;
 import com.ibm.ws.security.openidconnect.clients.common.OidcClientConfig;
+import com.ibm.ws.security.openidconnect.clients.common.OidcSessionCache;
 import com.ibm.ws.security.openidconnect.common.ConfigUtils;
 import com.ibm.ws.security.social.SocialLoginConfig;
 import com.ibm.ws.security.social.SocialLoginService;
@@ -133,6 +135,8 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements Conver
     HttpUtils httputils = new HttpUtils();
     ConfigUtils oidcConfigUtils = new ConfigUtils(null);
     DiscoveryConfigUtils discoveryUtil = new DiscoveryConfigUtils();
+
+    private final OidcSessionCache oidcSessionCache = new InMemoryOidcSessionCache();
 
     @Override
     protected void checkForRequiredConfigAttributes(Map<String, Object> props) {
@@ -913,6 +917,11 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements Conver
             return JwtUtils.getPrivateKey(keyAlias, keyStoreRef);
         }
         return null;
+    }
+    
+    @Override
+    public OidcSessionCache getOidcSessionCache() {
+    	return this.oidcSessionCache;
     }
 
 }


### PR DESCRIPTION
for rtc290658

move `getOidcSessionCache` to `ConvergedClientConfig`, to fix the npe in rtc290658 and so `getOidcSessionCache` can be used by social login as well.

still need to add creating the session, check for invalidated sessions, and removing invalidated sessions before backchannel logout can properly be used with social login.

related #20360