### PR TITLE
Pre-initalize SSLSocketFactory during checkpoint

### DIFF
--- a/dev/com.ibm.ws.ssl/bnd.bnd
+++ b/dev/com.ibm.ws.ssl/bnd.bnd
@@ -38,6 +38,7 @@ Import-Package: \
 	sun.security.pkcs11;resolution:=optional, \
     com.ibm.security.cmskeystore;resolution:=optional, \
     !*.internal.*, \
+    ${defaultPackageImport}, \
     *
 
 Private-Package: \

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/internal/SSLComponent.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/internal/SSLComponent.java
@@ -52,6 +52,8 @@ import com.ibm.ws.ssl.provider.AbstractJSSEProvider;
 import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
 import com.ibm.wsspi.kernel.service.location.WsLocationConstants;
 
+import io.openliberty.checkpoint.spi.CheckpointPhase;
+
 /**
  * Component for the SSL configuration bundle.
  */
@@ -85,6 +87,13 @@ public class SSLComponent extends GenericSSLConfigService implements SSLSupportO
     private boolean transportSecurityEnabled;
 
     private ExtComponentContext componentContext;
+
+    private final CheckpointPhase checkpointPhase;
+
+    @Activate
+    public SSLComponent(@Reference(cardinality = ReferenceCardinality.OPTIONAL) CheckpointPhase checkpointPhase) {
+        this.checkpointPhase = checkpointPhase;
+    }
 
     /**
      * DS method to activate this component.
@@ -332,6 +341,9 @@ public class SSLComponent extends GenericSSLConfigService implements SSLSupportO
                                                              isServer,
                                                              transportSecurityEnabled,
                                                              repertoirePIDMap);
+                if (checkpointPhase != null) {
+                    SSLSocketFactory.getDefault();
+                }
             } catch (SSLException e) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
                     Tr.event(tc, "Exception processing SSL configuration; " + e);

--- a/dev/com.ibm.ws.ssl/test/com/ibm/ws/ssl/internal/SSLComponentTest.java
+++ b/dev/com.ibm.ws.ssl/test/com/ibm/ws/ssl/internal/SSLComponentTest.java
@@ -176,7 +176,7 @@ public class SSLComponentTest {
 
     @Before
     public void setUp() {
-        sslComponent = new SSLComponent();
+        sslComponent = new SSLComponent(null);
 
         mock.checking(new Expectations() {
             {


### PR DESCRIPTION
Profiling criu restore time to first response using acmeair microservices applications shows time being spent in javax/net/ssl/SSLSocketFactory.getDefault() during the first request to the application. If we can move this call into the criu checkpoint phase, we can reduce the restore time up to 20%.
