### PR TITLE
Reduce size of stored manifests in application classloader

### DIFF
--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/LibertyLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/LibertyLoader.java
@@ -59,5 +59,11 @@ public abstract class LibertyLoader extends SecureClassLoader implements NoClass
         return super.findResources(resName);
     }
 
+    @Override
+    protected final Package definePackage(String packageName, String specTitle, String specVersion, String specVendor, String implTitle, String implVersion, String implVendor,
+                                    URL sealBase) throws IllegalArgumentException {
+        return super.definePackage(packageName, specTitle, specVersion, specVendor, implTitle, implVersion, implVendor, sealBase);
+    }
+
     public abstract Bundle getBundle();
 }

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ShadowClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ShadowClassLoader.java
@@ -179,71 +179,12 @@ class ShadowClassLoader extends LibertyLoader implements Keyed<ClassLoaderIdenti
 
             // Try to avoid defining a package twice
             if (this.getPackage(packageName) == null) {
-                definePackage(classBytesResourceInformation, packageName);
+                classBytesResourceInformation.definePackage(packageName, this);
             }
         }
 
         byte[] bytes = classBytesResourceInformation.getBytes();
         return defineClass(name, bytes, 0, bytes.length);
-    }
-
-    /**
-     * Defines the package for this class by trying to load the manifest for the package and if that fails just sets all of the package properties to <code>null</code>.
-     * 
-     * @param classBytesResourceInformation
-     * @param packageName
-     */
-    @FFDCIgnore(IllegalArgumentException.class)
-    private void definePackage(final ByteResourceInformation classBytesResourceInformation, String packageName) {
-        /*
-         * We don't extend URL classloader so we automatically pass the manifest from the JAR to our supertype, still try to get hold of it though so that we can see if
-         * we can load the information ourselves from it
-         */
-        Manifest manifest = classBytesResourceInformation.getManifest();
-        try {
-            if (manifest == null) {
-                definePackage(packageName, null, null, null, null, null, null, null);
-            } else {
-                String classResourceName = classBytesResourceInformation.getResourcePath();
-
-                /*
-                 * Strip the class name off the end of the package, should always have at least one '/' as we have at least one . in the name, also end with a trailing
-                 * '/' to match the name style for package definitions in manifest files
-                 */
-                String packageResourceName = classResourceName.substring(0, classResourceName.lastIndexOf('/') + 1);
-
-                // Default all of the package info to null
-                String specTitle = null;
-                String specVersion = null;
-                String specVendor = null;
-                String implTitle = null;
-                String implVersion = null;
-                String implVendor = null;
-                URL sealBaseUrl = null;
-
-                // See if there is a package defined in the manifest 
-                Attributes packageAttributes = manifest.getAttributes(packageResourceName);
-                if (packageAttributes != null && !packageAttributes.isEmpty()) {
-                    specTitle = packageAttributes.getValue(Attributes.Name.SPECIFICATION_TITLE);
-                    specVersion = packageAttributes.getValue(Attributes.Name.SPECIFICATION_VERSION);
-                    specVendor = packageAttributes.getValue(Attributes.Name.SPECIFICATION_VENDOR);
-
-                    implTitle = packageAttributes.getValue(Attributes.Name.IMPLEMENTATION_TITLE);
-                    implVersion = packageAttributes.getValue(Attributes.Name.IMPLEMENTATION_VERSION);
-                    implVendor = packageAttributes.getValue(Attributes.Name.IMPLEMENTATION_VENDOR);
-
-                    String sealedValue = packageAttributes.getValue(Attributes.Name.SEALED);
-                    if (sealedValue != null && Boolean.parseBoolean(sealedValue)) {
-                        sealBaseUrl = classBytesResourceInformation.getResourceUrl();
-                    }
-                }
-
-                definePackage(packageName, specTitle, specVersion, specVendor, implTitle, implVersion, implVendor, sealBaseUrl);
-            }
-        } catch (IllegalArgumentException ignored) {
-            // This happens if the package is already defined but it is hard to guard against this in a thread safe way. See:
-            // http://bugs.sun.com/view_bug.do?bug_id=4841786
-        }
     }
 
     /////////////////////////////////////////////////

--- a/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/LibertyClassLoaderTest.java
+++ b/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/LibertyClassLoaderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 IBM Corporation and others.
+ * Copyright (c) 2011, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,20 +15,15 @@ import static com.ibm.ws.classloading.internal.TestUtil.createAppClassloader;
 import static com.ibm.ws.classloading.internal.TestUtil.getClassLoadingService;
 import static com.ibm.ws.classloading.internal.TestUtil.getOtherClassesURL;
 import static com.ibm.ws.classloading.internal.TestUtil.getServletJarURL;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
-import java.util.jar.Manifest;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -81,33 +76,6 @@ public class LibertyClassLoaderTest {
         } catch (ClassFormatError e) {
             assertTrue("Should have traced an error", outputManager.checkForStandardErr("CWWKL0002E"));
         }
-    }
-
-    /**
-     * Validates that we only load the Manifest one time for a particular jar.
-     *
-     * @throws Exception
-     */
-    @Test
-    public void testManifestLoadedOnce() throws Exception {
-        Container c = buildMockContainer("testJar", TestUtil.getTestJarURL());
-
-        List<Manifest> manifests = new ArrayList<>();
-        loader = new AppClassLoader(null, loader.config, Arrays.asList(c), (DeclaredApiAccess) (loader.getParent()), null, null, new GlobalClassloadingConfiguration(), Collections.emptyList()) {
-            @Override
-            public Package definePackage(String name, Manifest manifest, URL sealBase) throws IllegalArgumentException {
-                manifests.add(manifest);
-                return super.definePackage(name, manifest, sealBase);
-            }
-        };
-
-        loader.loadClass("test.StringReturner");
-
-        loader.loadClass("test2.Package2Class");
-
-        assertEquals(2, manifests.size());
-
-        assertSame(manifests.get(0), manifests.get(1));
     }
 
     @Test


### PR DESCRIPTION
- Only keep the manifest attributes that are used by the application classloader.  This reduces footprint.
- Consolidate the definedPackage logic to reduce dual maintenance.