### PR TITLE
Updated server script to check if server is existent

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -1008,7 +1008,7 @@ javaCmd()
     "${JAVA_CMD}" "$@" >> "${JAVA_CMD_LOG}" 2>&1 &
   elif [ $ACTION = "run" ] || [ $ACTION = "debug" ]; then
     exec "${JAVA_CMD}" "$@"
-  elif [ $ACTION = "checkpoint" ]; then
+  elif [ $ACTION = "checkpoint" ] && [ -f "${SERVER_CONFIG_DIR}/server.xml" ]; then
     # Tail is used to print the content of the log file to the console
     # output. This is done so we can restore in the foreground (run)
     # and in the background (start)


### PR DESCRIPTION
Updated the bin/server script to check if SERVER_OUTPUT_DIR exists before executing the run, debug, and checkpoint commands. If the server does not exist, the script issues a "no existing server" message and terminates with exit code 2.

fixes #18585

