### PR TITLE
Reintroduce reverted 21238 once a dependency commit pushes

### DIFF
--- a/dev/cnf/resources/bnd/liberty-release.props
+++ b/dev/cnf/resources/bnd/liberty-release.props
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -12,13 +12,13 @@
 releaseTypeGA=true
 
 libertyBaseVersion=22.0.0
-libertyFixpackVersion=6
+libertyFixpackVersion=7
 libertyServiceVersion=${libertyBaseVersion}.${libertyFixpackVersion}
-libertyBetaVersion=2022.6.0.0
+libertyBetaVersion=2022.7.0.0
 libertyRelease=${if;${releaseTypeGA};${libertyServiceVersion};${libertyBetaVersion}}
 
-libertyBundleMicroVersion=65
-copyrightBuildYear=2020
+libertyBundleMicroVersion=66
+copyrightBuildYear=2022
 buildID=${libertyRelease}-${buildLabel}
 productEdition=BASE_ILAN
 productLicenseType=ILAN


### PR DESCRIPTION
https://github.com/OpenLiberty/open-liberty/pull/21238 was reverted due to it causing a feature checker failure.

Phu is changing a feature checker ignore file to avoid the error that 21238 would trigger.

See discussion at https://ibm-cloud.slack.com/archives/C30NGUQ9E/p1653566291052749 for details.