### PR TITLE
Issue #20939: Separate the com.ibm.websphere.javaee.jcache.1.1 bundle…

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jcache.internal1.1.ee-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jcache.internal1.1.ee-6.0.feature
@@ -9,7 +9,7 @@ singleton=true
   com.ibm.websphere.appserver.eeCompatible-8.0; ibm.tolerates:="6.0,7.0"
 #  com.ibm.websphere.appserver.javax.cdi-1.0; ibm.tolerates:="1.2,2.0"
 -bundles=\
-  com.ibm.websphere.javaee.jcache.1.1
+  com.ibm.websphere.javaee.jcache.1.1.core
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jcache.internal1.1.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jcache.internal1.1.ee-9.0.feature
@@ -8,7 +8,7 @@ singleton=true
   com.ibm.websphere.appserver.eeCompatible-9.0; ibm.tolerates:="10.0"
 #  io.openliberty.jakarta.cdi-3.0; ibm.tolerates:="4.0"
 -bundles=\
-  com.ibm.websphere.javaee.jcache.1.1.jakarta
+  com.ibm.websphere.javaee.jcache.1.1.core.jakarta
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jcacheContainer1.1.internal.ee-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jcacheContainer1.1.internal.ee-6.0.feature
@@ -1,0 +1,10 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName = io.openliberty.jcacheContainer1.1.internal.ee-6.0
+singleton=true
+visibility = private
+-features=\
+  com.ibm.websphere.appserver.eeCompatible-8.0; ibm.tolerates:="6.0,7.0"
+-bundles=\
+  com.ibm.websphere.javaee.jcache.1.1.core; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.cache:cache-api:1.1.0"
+kind=noship
+edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jcacheContainer1.1.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jcacheContainer1.1.internal.ee-9.0.feature
@@ -1,0 +1,10 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName = io.openliberty.jcacheContainer1.1.internal.ee-9.0
+singleton=true
+visibility = private
+-features=\
+  com.ibm.websphere.appserver.eeCompatible-9.0; ibm.tolerates:="10.0"
+-bundles=\
+  com.ibm.websphere.javaee.jcache.1.1.core.jakarta; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.cache:cache-api:1.1.0"
+kind=noship
+edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jcacheContainer-1.1/com.ibm.websphere.appserver.jcacheContainer-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jcacheContainer-1.1/com.ibm.websphere.appserver.jcacheContainer-1.1.feature
@@ -15,8 +15,8 @@ IBM-API-Package: \
  javax.cache.processor; type="spec", \
  javax.cache.spi; type="spec"
 -features=\
+ io.openliberty.jcacheContainer1.1.internal.ee-6.0; ibm.tolerates:="9.0",\
+ com.ibm.websphere.appserver.eeCompatible-8.0; ibm.tolerates:="6.0,7.0,9.0,10.0",\
  com.ibm.websphere.appserver.classloading-1.0
--bundles=\
- com.ibm.websphere.javaee.jcache.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.cache:cache-api:1.1.0"
 kind=noship
 edition=full

--- a/dev/com.ibm.websphere.javaee.jcache.1.1/bnd.bnd
+++ b/dev/com.ibm.websphere.javaee.jcache.1.1/bnd.bnd
@@ -14,18 +14,4 @@
 
 bVersion=1.0
 
-
-Export-Package: \
-   javax.cache.*;version="1.1";thread-context=true
-
-Import-Package: \
-   javax.enterprise.util;resolution:=optional
-
-Include-Resource: \
-  @${repo; javax.cache:cache-api;1.1.0}
-
 instrument.disabled: true
-
--buildpath: \
-	javax.cache:cache-api;version=1.1.0
-

--- a/dev/com.ibm.websphere.javaee.jcache.1.1/original-core.bnd
+++ b/dev/com.ibm.websphere.javaee.jcache.1.1/original-core.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018,2019 IBM Corporation and others.
+# Copyright (c) 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -8,18 +8,17 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
--include= ~../cnf/resources/bnd/bundle.props
-bVersion=1.0
 
-src: \
-	fat/src,\
-	test-applications/sessionCacheApp/src
+Bundle-SymbolicName: com.ibm.websphere.javaee.jcache.1.1.core
 
-fat.project: true
+Export-Package: \
+   javax.cache.*;version="1.1"
 
+Import-Package: \
+   javax.enterprise.util;resolution:=optional
+
+Include-Resource: \
+  @${repo; javax.cache:cache-api;1.1.0}
 
 -buildpath: \
-    com.ibm.websphere.javaee.cdi.2.0;version=latest,\
-    com.ibm.websphere.javaee.jcache.1.1.core;version=latest,\
-    com.ibm.websphere.javaee.servlet.4.0;version=latest,\
-    com.ibm.ws.session;version=latest
+	javax.cache:cache-api;version=1.1.0

--- a/dev/com.ibm.websphere.javaee.jcache.1.1/original.bnd
+++ b/dev/com.ibm.websphere.javaee.jcache.1.1/original.bnd
@@ -11,3 +11,19 @@
 
 Bundle-SymbolicName: com.ibm.websphere.javaee.jcache.1.1
 
+Export-Package: \
+   javax.cache;version="1.1";thread-context=true;uses:="javax.cache.configuration,javax.cache.integration,javax.cache.processor,javax.cache.spi",\
+   javax.cache.annotation;version="1.1";thread-context=true;uses:="javax.cache,javax.enterprise.util",\
+   javax.cache.configuration;version="1.1";thread-context=true;uses:="javax.cache.event,javax.cache.expiry,javax.cache.integration",\
+   javax.cache.event;version="1.1";thread-context=true;uses:="javax.cache",\
+   javax.cache.expiry;version="1.1";thread-context=true;uses:="javax.cache.configuration",\
+   javax.cache.integration;version="1.1";thread-context=true;uses:="javax.cache",\
+   javax.cache.management;version="1.1";thread-context=true,\
+   javax.cache.processor;version="1.1";thread-context=true;uses:="javax.cache",\
+   javax.cache.spi;version="1.1";thread-context=true;uses:="javax.cache,javax.cache.configuration"
+
+Import-Package: \
+   javax.enterprise.util;resolution:=optional
+
+Require-Bundle: \
+   com.ibm.websphere.javaee.jcache.1.1.core

--- a/dev/com.ibm.websphere.javaee.jcache.1.1/transformed-core.bnd
+++ b/dev/com.ibm.websphere.javaee.jcache.1.1/transformed-core.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018,2019 IBM Corporation and others.
+# Copyright (c) 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -8,18 +8,19 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
--include= ~../cnf/resources/bnd/bundle.props
-bVersion=1.0
+-include= ~../cnf/resources/bnd/transform.props
 
-src: \
-	fat/src,\
-	test-applications/sessionCacheApp/src
+Bundle-Name: com.ibm.websphere.javaee.jcache.1.1.core Jakarta
+Bundle-SymbolicName: com.ibm.websphere.javaee.jcache.1.1.core.jakarta
 
-fat.project: true
+Export-Package: \
+   javax.cache.*;version="1.1"
 
+Import-Package: \
+   javax.enterprise.util;resolution:=optional
+
+Include-Resource: \
+  @${repo; javax.cache:cache-api;1.1.0}
 
 -buildpath: \
-    com.ibm.websphere.javaee.cdi.2.0;version=latest,\
-    com.ibm.websphere.javaee.jcache.1.1.core;version=latest,\
-    com.ibm.websphere.javaee.servlet.4.0;version=latest,\
-    com.ibm.ws.session;version=latest
+	javax.cache:cache-api;version=1.1.0

--- a/dev/com.ibm.websphere.javaee.jcache.1.1/transformed.bnd
+++ b/dev/com.ibm.websphere.javaee.jcache.1.1/transformed.bnd
@@ -12,3 +12,20 @@
 
 Bundle-Name: com.ibm.websphere.javaee.jcache.1.1 Jakarta
 Bundle-SymbolicName: com.ibm.websphere.javaee.jcache.1.1.jakarta
+
+Export-Package: \
+   javax.cache;version="1.1";thread-context=true;uses:="javax.cache.configuration,javax.cache.integration,javax.cache.processor,javax.cache.spi",\
+   javax.cache.annotation;version="1.1";thread-context=true;uses:="javax.cache,javax.enterprise.util",\
+   javax.cache.configuration;version="1.1";thread-context=true;uses:="javax.cache.event,javax.cache.expiry,javax.cache.integration",\
+   javax.cache.event;version="1.1";thread-context=true;uses:="javax.cache",\
+   javax.cache.expiry;version="1.1";thread-context=true;uses:="javax.cache.configuration",\
+   javax.cache.integration;version="1.1";thread-context=true;uses:="javax.cache",\
+   javax.cache.management;version="1.1";thread-context=true,\
+   javax.cache.processor;version="1.1";thread-context=true;uses:="javax.cache",\
+   javax.cache.spi;version="1.1";thread-context=true;uses:="javax.cache,javax.cache.configuration"
+
+Import-Package: \
+   javax.enterprise.util;resolution:=optional
+
+Require-Bundle: \
+   com.ibm.websphere.javaee.jcache.1.1.core.jakarta

--- a/dev/com.ibm.ws.jcache_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jcache_fat/bnd.bnd
@@ -20,5 +20,5 @@ fat.project: true
 
 -buildpath: \
 	com.ibm.websphere.javaee.cdi.2.0;version=latest,\
-    com.ibm.websphere.javaee.jcache.1.1;version=latest,\
+    com.ibm.websphere.javaee.jcache.1.1.core;version=latest,\
     com.ibm.websphere.javaee.servlet.4.0;version=latest

--- a/dev/com.ibm.ws.security.authentication.builtin/bnd.bnd
+++ b/dev/com.ibm.ws.security.authentication.builtin/bnd.bnd
@@ -141,7 +141,7 @@ instrument.classesExcludes: com/ibm/ws/security/authentication/internal/resource
 	com.ibm.ws.security.mp.jwt.proxy;version=latest,\
 	com.ibm.websphere.security.authentication;version=latest,\
 	io.openliberty.jcache.internal;version=latest,\
-	com.ibm.websphere.javaee.jcache.1.1;version=latest,\
+	com.ibm.websphere.javaee.jcache.1.1.core;version=latest,\
 	org.eclipse.osgi,\
 	osgi.core
 

--- a/dev/com.ibm.ws.session.cache/bnd.bnd
+++ b/dev/com.ibm.ws.session.cache/bnd.bnd
@@ -45,7 +45,7 @@ Service-Component=com.ibm.ws.session.cache;\
 -buildpath: \
 	com.ibm.websphere.appserver.spi.kernel.service,\
 	com.ibm.websphere.appserver.spi.logging,\
-    com.ibm.websphere.javaee.jcache.1.1;version=latest,\
+    com.ibm.websphere.javaee.jcache.1.1.core;version=latest,\
     com.ibm.websphere.javaee.servlet.3.0;version=latest,\
     com.ibm.websphere.javaee.transaction.1.1;version=latest,\
 	com.ibm.websphere.org.osgi.core,\

--- a/dev/com.ibm.ws.session.cache_fat/bnd.bnd
+++ b/dev/com.ibm.ws.session.cache_fat/bnd.bnd
@@ -24,6 +24,6 @@ tested.features: \
 
 -buildpath: \
     com.ibm.websphere.javaee.cdi.2.0;version=latest,\
-    com.ibm.websphere.javaee.jcache.1.1;version=latest,\
+    com.ibm.websphere.javaee.jcache.1.1.core;version=latest,\
     com.ibm.websphere.javaee.servlet.4.0;version=latest,\
     com.ibm.ws.session;version=latest

--- a/dev/com.ibm.ws.session.cache_fat_config/bnd.bnd
+++ b/dev/com.ibm.ws.session.cache_fat_config/bnd.bnd
@@ -25,7 +25,7 @@ tested.features: \
 
 
 -buildpath: \
-    com.ibm.websphere.javaee.jcache.1.1;version=latest,\
+    com.ibm.websphere.javaee.jcache.1.1.core;version=latest,\
     com.ibm.websphere.javaee.servlet.4.0;version=latest,\
     com.ibm.websphere.org.osgi.core,\
     com.ibm.websphere.org.osgi.service.component,\

--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/bnd.bnd
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/bnd.bnd
@@ -22,7 +22,7 @@ tested.features: \
 	monitor-1.0
 
 -buildpath: \
-    com.ibm.websphere.javaee.jcache.1.1;version=latest,\
+    com.ibm.websphere.javaee.jcache.1.1.core;version=latest,\
     com.ibm.websphere.javaee.servlet.4.0;version=latest,\
     com.ibm.websphere.org.osgi.core,\
     com.ibm.websphere.org.osgi.service.component,\

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/bnd.bnd
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/bnd.bnd
@@ -28,7 +28,7 @@ tested.features: \
 
 -buildpath: \
     com.ibm.websphere.javaee.cdi.2.0;version=latest,\
-    com.ibm.websphere.javaee.jcache.1.1;version=latest,\
+    com.ibm.websphere.javaee.jcache.1.1.core;version=latest,\
     com.ibm.websphere.javaee.servlet.4.0;version=latest,\
     com.ibm.ws.session;version=latest,\
     io.openliberty.org.testcontainers;version=latest

--- a/dev/com.ibm.ws.webcontainer.security/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.security/bnd.bnd
@@ -101,7 +101,7 @@ instrument.classesExcludes: com/ibm/ws/webcontainer/security/resources/*.class
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.ws.security.mp.jwt.proxy;version=latest,\
 	io.openliberty.jcache.internal;version=latest,\
-	com.ibm.websphere.javaee.jcache.1.1;version=latest,\
+	com.ibm.websphere.javaee.jcache.1.1.core;version=latest,\
 	com.ibm.ws.kernel.boot.core;version=latest
 	
 

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/HttpSessionCache.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/HttpSessionCache.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ public class HttpSessionCache extends ConfigElement {
     private String writeInterval;
     private String uri;
     private String useInvalidatedId;
+    private String cacheManagerRef;
 
     // nested element names
     @XmlElement(name = "library")
@@ -44,6 +45,10 @@ public class HttpSessionCache extends ConfigElement {
 
     public ConfigElementList<HttpSessionCacheProperties> getProperties() {
         return properties == null ? (properties = new ConfigElementList<HttpSessionCacheProperties>()) : properties;
+    }
+
+    public String getCacheManagerRef() {
+        return this.cacheManagerRef;
     }
 
     public String getScheduleInvalidationFirstHour() {
@@ -72,6 +77,11 @@ public class HttpSessionCache extends ConfigElement {
 
     public String getWriteInterval() {
         return this.writeInterval;
+    }
+
+    @XmlAttribute
+    public void setCacheManagerRef(String cacheManagerRef) {
+        this.cacheManagerRef = cacheManagerRef;
     }
 
     @XmlAttribute
@@ -121,6 +131,8 @@ public class HttpSessionCache extends ConfigElement {
             buf.append("id=").append(getId()).append(' ');
         if (libraryRef != null)
             buf.append("libraryRef=").append(libraryRef).append(' ');
+        if (cacheManagerRef != null)
+            buf.append("cacheManagerRef=").append(cacheManagerRef).append(' ');
         if (scheduleInvalidationFirstHour != null)
             buf.append("scheduleInvalidationFirstHour=").append(scheduleInvalidationFirstHour).append(' ');
         if (scheduleInvalidationSecondHour != null)

--- a/dev/io.openliberty.jcache.internal/bnd.bnd
+++ b/dev/io.openliberty.jcache.internal/bnd.bnd
@@ -36,7 +36,7 @@ instrument.classesExcludes: io/openliberty/jcache/internal/resources/*.class
 
 -buildpath: \
 	com.ibm.websphere.appserver.spi.kernel.service;version=latest,\
-	com.ibm.websphere.javaee.jcache.1.1;version=latest,\
+	com.ibm.websphere.javaee.jcache.1.1.core;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.websphere.org.osgi.service.component,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/publish/servers/io.openliberty.jcache.internal.fat.provider.in.app.1/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/publish/servers/io.openliberty.jcache.internal.fat.provider.in.app.1/server.xml
@@ -37,17 +37,16 @@
     <!-- 
         Configure the CachingProvider and CacheManager.
      -->
-	<cache id="AuthCache" name="AuthCache">
-		<cacheManager>
+	<cache id="AuthCache" name="AuthCache" cacheManagerRef="CacheManager"/>
+	<cacheManager id="CacheManager">
 
-			<properties
-				hazelcast.config.location="file:${shared.resource.dir}/hazelcast/${hazelcast.config.file}" />
+		<properties
+			hazelcast.config.location="file:${shared.resource.dir}/hazelcast/${hazelcast.config.file}" />
 
-			<cachingProvider
-				libraryRef="HazelcastLib,CustomLoginLib" />
+		<cachingProvider
+			libraryRef="HazelcastLib,CustomLoginLib" />
 
-		</cacheManager>
-	</cache>
+	</cacheManager>
 
 	<!-- 
 		Configure the authentication cache to use the JCache. 

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/fat/src/io/openliberty/jcache/internal/fat/docker/InfinispanContainer.java
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/fat/src/io/openliberty/jcache/internal/fat/docker/InfinispanContainer.java
@@ -185,6 +185,15 @@ public class InfinispanContainer extends GenericContainer<InfinispanContainer> {
     public void deleteCache(String name) throws Exception {
         final String METHOD_NAME = "deleteCache(String)";
 
+        /*
+         * Session cache appears to double escape the "/" in their cache names, and the cache name
+         * results in "%2F", which when we pass it in here gets escaped again and doesn't match the
+         * literal "%2F" in the cache name. Fix it here.
+         */
+        if (name.startsWith("com.ibm.ws.session")) {
+            name = name.replace("%", "%25");
+        }
+
         HttpDelete request = new HttpDelete(getRESTEndpoint() + "caches/" + name);
 
         try (CloseableHttpClient httpClient = HttpClients.createDefault()) {

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.provider.in.app.1/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.provider.in.app.1/server.xml
@@ -34,22 +34,21 @@
 	<include
 		location="${shared.resource.dir}/configs/appProviderInApp.xml" />
 
-    <!-- 
-        Configure the CachingProvider and CacheManager.
-     -->
-	<cache id="AuthCache" name="AuthCache">
-		<cacheManager
-		    uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+        <!-- 
+            Configure the CachingProvider and CacheManager.
+          -->
+	<cache id="AuthCache" name="AuthCache" cacheManagerRef="CacheManager" />
+	<cacheManager id="CacheManager"
+		uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
 
-			<properties
-				infinispan.client.hotrod.uri="${infinispan.client.hotrod.uri}" />
+		<properties
+			infinispan.client.hotrod.uri="${infinispan.client.hotrod.uri}" />
 
-			<cachingProvider
-				providerClass="org.infinispan.jcache.remote.JCachingProvider"
-				libraryRef="InfinispanLib,CustomLoginLib" />
+		<cachingProvider
+			providerClass="org.infinispan.jcache.remote.JCachingProvider"
+			libraryRef="InfinispanLib,CustomLoginLib" />
 
-		</cacheManager>
-	</cache>
+	</cacheManager>
 
 	<!-- 
 		Configure the authentication cache to use the JCache. 

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/test-applications/providerinapp/src/web/providerinapp/ProviderInAppServlet.java
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/test-applications/providerinapp/src/web/providerinapp/ProviderInAppServlet.java
@@ -39,27 +39,31 @@ public class ProviderInAppServlet extends HttpServlet {
 
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        final String methodName = "doPost";
+        System.out.print("ProviderInAppServlet." + methodName + ": starting test...");
+
         /*
-         * Connect to the remote Infinispan server.
+         * Default the test to fail
+         */
+        response.setStatus(500);
+
+        /*
+         * Connect to the remote Infinispan server and insert a value into the cache.
          */
         ConfigurationBuilder builder = new ConfigurationBuilder();
         builder.uri(System.getProperty("infinispan.client.hotrod.uri")).security().authentication().realm("default").saslMechanism("DIGEST-MD5");
         RemoteCacheManager cacheManager = new RemoteCacheManager(builder.build(), true);
-
-        /*
-         * Get the remote cache.
-         */
         RemoteCache<String, String> cache = cacheManager.administration().createCache("test", DefaultTemplate.DIST_ASYNC);
+        cache.put(KEY, VALUE);
 
         /*
-         * Add a key and retrieve it back out of the cache.
+         * Verify we can retrieve the value.
          */
-        cache.put(KEY, VALUE);
         if (VALUE.equals(cache.get(KEY))) {
+            System.out.print("ProviderInAppServlet: value matches");
             response.setStatus(200);
         } else {
-            System.out.print("ProviderInAppServlet: value not does not match");
-            response.setStatus(500);
+            System.out.print("ProviderInAppServlet: value does not match");
         }
     }
 }


### PR DESCRIPTION
…s into two separate bundles. One of the bundles will be a shim bundle that depends on / requires the other bundle. It sole purpose is to export the javax.cache.* bundles with thread-context=true, as is done today. It will only be used for sessionCache feature. The other bundle, will be much like the existing bundle, but will not include the thread-context=true on the package exports. This bundle should be the bundle that is used by every other feature outside of sessionCache from here on out.
