### PR TITLE
Fix JPA JAR File FAT for JPA 3.1

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.jarfile_fat/publish/shared/config/jpa31.xml
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.jarfile_fat/publish/shared/config/jpa31.xml
@@ -1,0 +1,8 @@
+<server>
+    <featureManager>
+        <feature>enterpriseBeansLite-4.0</feature>
+        <feature>servlet-6.0</feature>
+        <feature>persistence-3.1</feature>
+        <feature>componenttest-2.0</feature>
+    </featureManager>
+</server>


### PR DESCRIPTION
Missed a file during check-in of enabling JPA 3.1 for all existing JPA FATs