### PR TITLE
fix 19832 - add discovery jvmprops

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.1/build.gradle
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/build.gradle
@@ -82,7 +82,8 @@ autoFVT.doLast {
   def servers = [
     'com.ibm.ws.security.openidconnect.client-1.0_fat.op',
     'com.ibm.ws.security.openidconnect.client-1.0_fat.rp',
-    'com.ibm.ws.security.openidconnect.client-1.0_fat.rpd'
+    'com.ibm.ws.security.openidconnect.client-1.0_fat.rpd',
+    'com.ibm.ws.security.openidconnect.client-1.0_fat.rpd2'
   ]
   servers.each { server ->
     copy { 
@@ -125,7 +126,8 @@ autoFVT.doLast {
    */
   servers = [
     'com.ibm.ws.security.openidconnect.client-1.0_fat.rp',
-    'com.ibm.ws.security.openidconnect.client-1.0_fat.rpd'
+    'com.ibm.ws.security.openidconnect.client-1.0_fat.rpd',
+    'com.ibm.ws.security.openidconnect.client-1.0_fat.rpd2'
   ]
   servers.each { server ->
     copy {

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/FATSuite.java
@@ -22,6 +22,7 @@ import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientConsentTests;
 import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientCookieVerificationTests;
 import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientDiscoveryBasicTests;
 import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientDiscoveryErrorTests;
+import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientDiscoveryJVMPropsTests;
 import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientDiscoveryJWTBasicTests;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
@@ -37,6 +38,7 @@ import componenttest.rules.repeater.RepeatTests;
         OidcClientConsentTests.class,
         OidcClientDiscoveryBasicTests.class,
         OidcClientDiscoveryErrorTests.class,
+        OidcClientDiscoveryJVMPropsTests.class,
         OidcClientDiscoveryJWTBasicTests.class,
         OidcClientCookieVerificationTests.class,
         // OidcCertificationRPBasicProfileTests.class,

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryJVMPropsTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryJVMPropsTests.java
@@ -31,41 +31,37 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
 /**
- * This new class "OidcClientDiscoveryJVMPropsTests.java" is created to revolve
- * issue# 19832. Reasons why this new test is not updated to the existing class
- * (e.g., OidcClientDiscoveryErrorTests.java): 1.
- * com.ibm.ws.config.xml.internal.ConfigRefresher issues CWWKG0027W for the
+ * This new class "OidcClientDiscoveryJVMPropsTests.java" is created to test
+ * issue# 19832. 
+ * Below lists the reasons why this new test is not updated to the existing class
+ * (e.g., OidcClientDiscoveryErrorTests.java): 
+ *
+ * 1.com.ibm.ws.config.xml.internal.ConfigRefresher issues CWWKG0027W for the
  * timeout message after a 1 minute delay of waiting related to the
  * Notifications sent out, for example, CWWKG0017I "The server configuration was
- * successfully updated" 2. When the original server xml (e.g.,
- * rp_server_orig.xml) contains the include of new xml with bad proxy IP (e.g.,
- * 5.6.7.8) in discoveryEndpointUrl, during the reconfigServer invocation in
+ * successfully updated" 
+ * 
+ * 2. When the original server xml (e.g., rp_server_orig.xml) contains the include of new xml with bad proxy IP 
+ * (e.g., 5.6.7.8) in discoveryEndpointUrl, during the reconfigServer invocation in
  * some existing test methods such as OidcClientTestUserIdNotInRegistry(),
- * ConfigRefresher will take on its duty to issue timeout when that happens. 3.
- * The bad proxy IP in discoveryEndpointUrl can take more than 1 minute to
- * attempt the connection when the test running in liberty build framework,
+ * ConfigRefresher will take on its duty to issue timeout when that happens. 
+ * 
+ * 3. The bad proxy IP with "useSystemPropertiesForHttpClientConnections=true" in discoveryEndpointUrl
+ * can take more than 1 minute to attempt the connection when the test running in liberty build framework,
  * which then results CWWKG0027W in messages.log and the AssertionError in junit
- * frmework due to search failure for CWWKG0017I. (FYI - the connection attempt
- * in a local run takes about 20 seconds.)
+ * frmework due to search failure for CWWKG0017I. 
+ * (FYI - the connection attempt in a local run takes about 20 seconds.)
  */
 
 @Mode(TestMode.FULL)
-//issue #19832 to add "org.apache.http.conn.HttpHostConnectException", since the new method requring proxy FFDC, which causes 2 existing methods ('NoRPTrust...' and 'BadRPTrust...') with the same ffdc
-//@AllowedFFDC({ "org.apache.http.NoHttpResponseException", "java.security.cert.CertPathBuilderException", "sun.security.validator.ValidatorException", "javax.net.ssl.SSLHandshakeException", "com.ibm.websphere.ssl.SSLException", "java.lang.Exception", "org.apache.http.conn.HttpHostConnectException" })
 @RunWith(FATRunner.class)
 public class OidcClientDiscoveryJVMPropsTests extends CommonTest {
-	// public static Class<?> thisClass = GenericOidcClientTests.class;
-	// public static HashMap<String, Integer> defRespStatusMap = null;
-
+	
 	public static String[] test_LOGIN_PAGE_ONLY = Constants.GET_LOGIN_PAGE_ONLY;
-
-	// protected static String hostName = "localhost";
 
 	@SuppressWarnings("serial")
 	@BeforeClass
 	public static void setUp() throws Exception {
-
-		//thisClass = OidcClientDiscoveryJVMPropsTests.class;
 
 		List<String> apps = new ArrayList<String>() {
 			{
@@ -91,58 +87,20 @@ public class OidcClientDiscoveryJVMPropsTests extends CommonTest {
 				"rp_server_jvmprops.xml", Constants.OIDC_RP, apps, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS,
 				Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
 
-		// testOPServer.addIgnoredServerException("CWOAU0039W"); // Ignore errors from
-		// the malformed discovery url
-		// testOPServer.addIgnoredServerException("CWWKO0801E");
-		// testRPServer.addIgnoredServerException("CWWKS1859E"); //Ignore exceptions
-		// from bad client secret test
-		// testRPServer.addIgnoredServerException("SRVE8094W");
-		// testRPServer.addIgnoredServerException("SRVE0190E");
-		// testRPServer.addIgnoredServerException("CWWKS1741W"); // Ignore from
-		// sigAlgMismatch2 - message is not always logged
-		// testRPServer.addIgnoredServerException("SRVE8115W"); // Ignore setStatus
-		// WARNING
-		// testRPServer.addIgnoredServerException("CWWKS1521W"); // Ignore message
-		// indicating conflicting configured endpoints are ignored
 		testRPServer.addIgnoredServerException("CWWKS1524E"); // Ignore message indicating unsuccessful response from
 																// endpoint
 		testRPServer.addIgnoredServerException("CWWKS1525E"); // Ignore message indicating discovery failed
-		// testRPServer.addIgnoredServerException("CWWKS1522W"); // Ignore message
-		// indicating conflicting endpoints for issuer identifier
-		// testRPServer.addIgnoredServerException("CWPKI0022E"); // Ignore message
-		// indicating conflicting configured endpoints are ignored
-		// testRPServer.addIgnoredServerException("CWWKG0058E"); // Ignore SSL failure
-		// message
-
-		// override actions that generic tests should use - Need to skip consent form as
-		// httpunit
-		// cannot process the form because of embedded javascript
-
-		// test_GOOD_LOGIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT;
-		// test_GOOD_POST_LOGIN_ACTIONS =
-		// Constants.GOOD_OIDC_POST_LOGIN_ACTIONS_SKIP_CONSENT;
-		// test_GOOD_LOGIN_AGAIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_AGAIN_ACTIONS;
-		// test_FinalAction = Constants.LOGIN_USER;
+		
 		testSettings.setFlowType(Constants.RP_FLOW);
 
-		// Force discovery to run to access login page so that the discovery service is
-		// active. Then, in the actual tests the reconfig will initiate discovery and
-		// cause the
-		// error messages to be generated on discovery failures during the reconfig
-		// (rather than waiting until the first authorization request in the runtime).
-		// CommonTestHelpers helpers = new CommonTestHelpers();
-
-		// try to wait for discovery to have populated the RP config
-		// Don't stop if this fails (there is a chance it could be ready by the time the
-		// tests actually run
 		DiscoveryUtils.waitForRPDiscoveryToBeReady(testSettings);
 
 	}
 
 	/**
-	 * issue# 19832 This tests the configuration attribute
-	 * useSystemPropertiesForHttpClientConnections. A proxy host and port are
-	 * defined in usr/(server)/jvm.options, but won't take effect until this
+	 * issue# 19832 
+         * This tests the configuration attribute useSystemPropertiesForHttpClientConnections. 
+         * A proxy host and port are defined in usr/(server)/jvm.options, but won't take effect until this
 	 * attribute is set to true. When the attribute is set to true, we expect a
 	 * failure because the token retrieval call should be redirected to the
 	 * non-existent proxy server.
@@ -163,15 +121,13 @@ public class OidcClientDiscoveryJVMPropsTests extends CommonTest {
 	 * 
 	 * Expected Results: The discovery should be attempted and should fail with 401
 	 * when the RP tries processing the first authentication request and the
-	 * following messages should be logged: CWWKS1525E: A successful response was
-	 * not returned from the URL <discovery endpoint>. This is the [0] response
+	 * following messages should be logged: 
+         * CWWKS1525E: A successful response was not returned from the URL <discovery endpoint>. This is the [0] response
 	 * status and the [IOException: Connect to 5.6.7.8:8920 [/5.6.7.8] failed:
-	 * Connection timed out: connect java.net.ConnectException: Connection timed
-	 * out: connect] error from the discovery request. CWWKS1524E: The OpenID
-	 * Connect client [jvmProps] failed to obtain Open ID Connect Provider endpoint
-	 * information through the discovery endpoint URL ... CWWKS1534E: The OpenID
-	 * Connect client [client01] requires an authorization endpoint URL, but it is
-	 * not set.
+	 * Connection timed out: connect java.net.ConnectException: Connection timed out: connect] error from the discovery request. 
+         * CWWKS1524E: The OpenID Connect client [jvmProps] failed to obtain Open ID Connect Provider endpoint
+	 * information through the discovery endpoint URL ... 
+         * CWWKS1534E: The OpenID Connect client [client01] requires an authorization endpoint URL, but it is not set.
 	 */
 
 	@Mode(TestMode.LITE)

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryJVMPropsTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryJVMPropsTests.java
@@ -1,0 +1,198 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.security.openidconnect.client.fat.IBM;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonTest;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.Constants;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.DiscoveryUtils;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.TestSettings;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.ValidationData.validationData;
+import com.meterware.httpunit.WebConversation;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+
+/**
+ * This new class "OidcClientDiscoveryJVMPropsTests.java" is created to revolve
+ * issue# 19832. Reasons why this new test is not updated to the existing class
+ * (e.g., OidcClientDiscoveryErrorTests.java): 1.
+ * com.ibm.ws.config.xml.internal.ConfigRefresher issues CWWKG0027W for the
+ * timeout message after a 1 minute delay of waiting related to the
+ * Notifications sent out, for example, CWWKG0017I "The server configuration was
+ * successfully updated" 2. When the original server xml (e.g.,
+ * rp_server_orig.xml) contains the include of new xml with bad proxy IP (e.g.,
+ * 5.6.7.8) in discoveryEndpointUrl, during the reconfigServer invocation in
+ * some existing test methods such as OidcClientTestUserIdNotInRegistry(),
+ * ConfigRefresher will take on its duty to issue timeout when that happens. 3.
+ * The bad proxy IP in discoveryEndpointUrl can take more than 1 minute to
+ * attempt the connection when the test running in liberty build framework,
+ * which then results CWWKG0027W in messages.log and the AssertionError in junit
+ * frmework due to search failure for CWWKG0017I. (FYI - the connection attempt
+ * in a local run takes about 20 seconds.)
+ */
+
+@Mode(TestMode.FULL)
+//issue #19832 to add "org.apache.http.conn.HttpHostConnectException", since the new method requring proxy FFDC, which causes 2 existing methods ('NoRPTrust...' and 'BadRPTrust...') with the same ffdc
+//@AllowedFFDC({ "org.apache.http.NoHttpResponseException", "java.security.cert.CertPathBuilderException", "sun.security.validator.ValidatorException", "javax.net.ssl.SSLHandshakeException", "com.ibm.websphere.ssl.SSLException", "java.lang.Exception", "org.apache.http.conn.HttpHostConnectException" })
+@RunWith(FATRunner.class)
+public class OidcClientDiscoveryJVMPropsTests extends CommonTest {
+	// public static Class<?> thisClass = GenericOidcClientTests.class;
+	// public static HashMap<String, Integer> defRespStatusMap = null;
+
+	public static String[] test_LOGIN_PAGE_ONLY = Constants.GET_LOGIN_PAGE_ONLY;
+
+	// protected static String hostName = "localhost";
+
+	@SuppressWarnings("serial")
+	@BeforeClass
+	public static void setUp() throws Exception {
+
+		//thisClass = OidcClientDiscoveryJVMPropsTests.class;
+
+		List<String> apps = new ArrayList<String>() {
+			{
+				add(Constants.OPENID_APP);
+			}
+		};
+
+		testSettings = new TestSettings();
+
+		// Set config parameters for Access token with X509 Certificate
+		String tokenType = Constants.ACCESS_TOKEN_KEY;
+		String certType = Constants.X509_CERT;
+
+		// Start the OIDC OP server
+		testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.op", "op_server_orig.xml",
+				Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS,
+				Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+
+		DiscoveryUtils.waitForOPDiscoveryToBeReady(testSettings);
+
+		// Start the OIDC RP server and setup default values
+		testRPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.rpd2",
+				"rp_server_jvmprops.xml", Constants.OIDC_RP, apps, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS,
+				Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+
+		// testOPServer.addIgnoredServerException("CWOAU0039W"); // Ignore errors from
+		// the malformed discovery url
+		// testOPServer.addIgnoredServerException("CWWKO0801E");
+		// testRPServer.addIgnoredServerException("CWWKS1859E"); //Ignore exceptions
+		// from bad client secret test
+		// testRPServer.addIgnoredServerException("SRVE8094W");
+		// testRPServer.addIgnoredServerException("SRVE0190E");
+		// testRPServer.addIgnoredServerException("CWWKS1741W"); // Ignore from
+		// sigAlgMismatch2 - message is not always logged
+		// testRPServer.addIgnoredServerException("SRVE8115W"); // Ignore setStatus
+		// WARNING
+		// testRPServer.addIgnoredServerException("CWWKS1521W"); // Ignore message
+		// indicating conflicting configured endpoints are ignored
+		testRPServer.addIgnoredServerException("CWWKS1524E"); // Ignore message indicating unsuccessful response from
+																// endpoint
+		testRPServer.addIgnoredServerException("CWWKS1525E"); // Ignore message indicating discovery failed
+		// testRPServer.addIgnoredServerException("CWWKS1522W"); // Ignore message
+		// indicating conflicting endpoints for issuer identifier
+		// testRPServer.addIgnoredServerException("CWPKI0022E"); // Ignore message
+		// indicating conflicting configured endpoints are ignored
+		// testRPServer.addIgnoredServerException("CWWKG0058E"); // Ignore SSL failure
+		// message
+
+		// override actions that generic tests should use - Need to skip consent form as
+		// httpunit
+		// cannot process the form because of embedded javascript
+
+		// test_GOOD_LOGIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT;
+		// test_GOOD_POST_LOGIN_ACTIONS =
+		// Constants.GOOD_OIDC_POST_LOGIN_ACTIONS_SKIP_CONSENT;
+		// test_GOOD_LOGIN_AGAIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_AGAIN_ACTIONS;
+		// test_FinalAction = Constants.LOGIN_USER;
+		testSettings.setFlowType(Constants.RP_FLOW);
+
+		// Force discovery to run to access login page so that the discovery service is
+		// active. Then, in the actual tests the reconfig will initiate discovery and
+		// cause the
+		// error messages to be generated on discovery failures during the reconfig
+		// (rather than waiting until the first authorization request in the runtime).
+		// CommonTestHelpers helpers = new CommonTestHelpers();
+
+		// try to wait for discovery to have populated the RP config
+		// Don't stop if this fails (there is a chance it could be ready by the time the
+		// tests actually run
+		DiscoveryUtils.waitForRPDiscoveryToBeReady(testSettings);
+
+	}
+
+	/**
+	 * issue# 19832 This tests the configuration attribute
+	 * useSystemPropertiesForHttpClientConnections. A proxy host and port are
+	 * defined in usr/(server)/jvm.options, but won't take effect until this
+	 * attribute is set to true. When the attribute is set to true, we expect a
+	 * failure because the token retrieval call should be redirected to the
+	 * non-existent proxy server.
+	 *
+	 * Testing the full path would require a proxy server, which the FAT framework
+	 * does not have, but it has been done manually.
+	 *
+	 * Note that the proxy properties DO NOT TAKE EFFECT FOR LOCALHOST, so if you
+	 * are debugging, you cannot configure the OP to be "localhost" and expect it to
+	 * work.
+	 *
+	 */
+
+	/**
+	 * Test Purpose: With discovery configured at the RP, attempting to access a
+	 * test servlet specifying invalid OP url with wrong proxy host/port results in
+	 * 401 error with messages logged.
+	 * 
+	 * Expected Results: The discovery should be attempted and should fail with 401
+	 * when the RP tries processing the first authentication request and the
+	 * following messages should be logged: CWWKS1525E: A successful response was
+	 * not returned from the URL <discovery endpoint>. This is the [0] response
+	 * status and the [IOException: Connect to 5.6.7.8:8920 [/5.6.7.8] failed:
+	 * Connection timed out: connect java.net.ConnectException: Connection timed
+	 * out: connect] error from the discovery request. CWWKS1524E: The OpenID
+	 * Connect client [jvmProps] failed to obtain Open ID Connect Provider endpoint
+	 * information through the discovery endpoint URL ... CWWKS1534E: The OpenID
+	 * Connect client [client01] requires an authorization endpoint URL, but it is
+	 * not set.
+	 */
+
+	@Mode(TestMode.LITE)
+	@AllowedFFDC({ "org.apache.http.conn.HttpHostConnectException" })
+	@Test
+	public void OidcClientDiscoveryTestWithJvmProps() throws Exception {
+
+		TestSettings updatedTestSettings = testSettings.copyTestSettings();
+		updatedTestSettings.setScope("openid profile");
+		updatedTestSettings
+				.setTestURL(updatedTestSettings.getTestURL().replace(Constants.DEFAULT_SERVLET, "simple/jvmProps"));
+
+		List<validationData> expectations = vData.addSuccessStatusCodes(null, Constants.GET_LOGIN_PAGE);
+		expectations = vData.addResponseStatusExpectation(expectations, Constants.GET_LOGIN_PAGE,
+				Constants.UNAUTHORIZED_STATUS);
+
+		testRPServer.addIgnoredServerException("CWWKS1534E");
+
+		WebConversation wc = new WebConversation();
+		genericRP(_testName, wc, updatedTestSettings, test_LOGIN_PAGE_ONLY, expectations);
+
+	}
+
+}

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/publish/files/serversettings/oidcClientDiscoveryJvmProxyProps.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/publish/files/serversettings/oidcClientDiscoveryJvmProxyProps.xml
@@ -1,0 +1,40 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+
+<!-- issue# 19832 -->
+
+<server>
+
+	<authFilter id="jvmPropsAuthFilter">
+		<requestUrl
+			id="myRequestUrl"
+			urlPattern="/simple/jvmProps"
+			matchType="contains" />
+	</authFilter>
+
+	<openidConnectClient
+		id="jvmProps"
+		scope="openid profile"
+		clientId="client01"
+		clientSecret="{xor}LDo8LTor"
+		sharedKey="secret"
+		signatureAlgorithm="${oidcSignAlg}"
+		mapIdentityToRegistryUser="true"
+		httpsRequired="false"
+		redirectToRPHostAndPort="http://localhost:${bvt.prop.security_2_HTTP_default}"
+		discoveryEndpointUrl="https://5.6.7.8:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
+		authFilterRef="jvmPropsAuthFilter"
+		jwkEndpointUrl="${oidcJWKValidationURL}"
+		userInfoEndpointEnabled="true"
+	>
+	</openidConnectClient>
+
+</server>

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rpd2/bootstrap.properties
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rpd2/bootstrap.properties
@@ -1,0 +1,24 @@
+###############################################################################
+# Copyright (c) 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+
+bootstrap.include=../testports.properties
+
+com.ibm.ws.logging.trace.specification=*=info=enabled:\
+com.ibm.ws.security.oauth*=all=enabled:\
+com.ibm.ws.security.openidconnect*=all=enabled:\
+com.ibm.ws.security.jwt*=all=enabled:\
+com.ibm.ws.webcontainer.security.*=all=enabled:\
+com.ibm.oauth.*=all=enabled:\
+com.ibm.wsspi.security.oauth20.*=all=enabled:\
+org.apache.http.client.*=all
+
+com.ibm.ws.logging.max.file.size=0
+ds.loglevel=debug

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rpd2/bootstrap.properties
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rpd2/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rpd2/configs/rp_server_jvmprops.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rpd2/configs/rp_server_jvmprops.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+
+<server>
+
+	<include location="${server.config.dir}/imports/oidcClientFeatures.xml" />
+
+        <include location="${server.config.dir}/imports/oidcClientDiscoveryJvmProxyProps.xml"/> 
+
+	<include location="${server.config.dir}/imports/goodSSLSettings.xml" />
+
+	<include location="${server.config.dir}/imports/formlogin_1.xml" />
+
+	<include location="${server.config.dir}/imports/rp_fatTestPorts.xml" />
+
+</server>

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rpd2/jvm.options
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rpd2/jvm.options
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+
+# issue# 19832
+# these properties should only be honored when useSystemPropertiesForHttpClientConnections config attribute set
+-Dhttp.proxyPort=34567
+-Dhttp.proxyHost=1.2.3.4
+-Dhttps.proxyPort=34567
+-Dhttps.proxyHost=1.2.3.4

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rpd2/resources/security/ltpa.keys
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rpd2/resources/security/ltpa.keys
@@ -1,0 +1,8 @@
+#Mon Aug 07 22:42:02 CDT 2017
+com.ibm.websphere.CreationDate=Mon Aug 07 22\:42\:02 CDT 2017
+com.ibm.websphere.ltpa.version=1.0
+com.ibm.websphere.ltpa.3DESKey=SgfkbhxVnbu6QFyUNy0/0yuqY1YDlCP+3/cGjIn+mR4\=
+com.ibm.websphere.CreationHost=localhost
+com.ibm.websphere.ltpa.PrivateKey=OjdDWvPV4Kd+tTbl/wmtZy+w+sPRzzhtM0/JQUOr92izuXC2sE9Meb5BQzJwA9Jd6lL7wYRHskweIb4ECcCkIlT5w+wZ736SjiLj3zRiY7tGhro9UV+bqlGYdWUA0BMereeHvlajhO44T6dYO8XMAHH0Bn6Ve/1WxEbDg/QI5Bqnu5+3TEd88Bti6RzInQ9CQ7B6aRncLhoYM+rHbQ9j48gBa6aPwUZXfNwySNW7vEVffgTTmqpmUJSkz9+W8oXdHB9UVn8HGNY06786nJ6EUcoLoFRO8pIRiu46zrR6OyIfWmjdHBT8kyKZIgwL/0Gkehz+vw3/HaGpzGiYHLFcKjEtAUTqLFTQdfOScWpBJOU\=
+com.ibm.websphere.ltpa.Realm=defaultRealm
+com.ibm.websphere.ltpa.PublicKey=ALOp9Cwz4d7/UHfhdUJNZUqJwq51M8C2yakKHzYRDjyWIvg+IjK2BN5Chg2gmUmTWjw2rmMDWTCHexafesOgC5PWbUT9zUPDDd3IM14YRd9swMHiEgxkcNnKPqpphMLnDr2RNgQkGTXBsHM4VVBhWOA0FiK5Y1AuI7U4/pMGP2zTAQAB

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
@@ -928,9 +928,7 @@ public class OidcClientConfigImpl implements OidcClientConfig {
         try {
             setNextDiscoveryTime(); //
             SSLSocketFactory sslSocketFactory = getSSLSocketFactory(discoveryUrl, sslConfigurationName, sslSupportRef.getService());
-            //orig:
-            //HttpClient client = createHTTPClient(sslSocketFactory, discoveryUrl, hostNameVerificationEnabled);
-            //new:
+            // issue# 19832
             HttpClient client = createHTTPClient(sslSocketFactory, discoveryUrl, hostNameVerificationEnabled, useSystemPropertiesForHttpClientConnections);
             jsonString = getHTTPRequestAsString(client, discoveryUrl);
             if (jsonString != null) {

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
@@ -928,7 +928,10 @@ public class OidcClientConfigImpl implements OidcClientConfig {
         try {
             setNextDiscoveryTime(); //
             SSLSocketFactory sslSocketFactory = getSSLSocketFactory(discoveryUrl, sslConfigurationName, sslSupportRef.getService());
-            HttpClient client = createHTTPClient(sslSocketFactory, discoveryUrl, hostNameVerificationEnabled);
+            //orig:
+            //HttpClient client = createHTTPClient(sslSocketFactory, discoveryUrl, hostNameVerificationEnabled);
+            //new:
+            HttpClient client = createHTTPClient(sslSocketFactory, discoveryUrl, hostNameVerificationEnabled, useSystemPropertiesForHttpClientConnections);
             jsonString = getHTTPRequestAsString(client, discoveryUrl);
             if (jsonString != null) {
                 parseJsonResponse(jsonString);
@@ -1128,54 +1131,33 @@ public class OidcClientConfigImpl implements OidcClientConfig {
         return message;
     }
 
-    public HttpClient createHTTPClient(SSLSocketFactory sslSocketFactory, String url, boolean isHostnameVerification) {
+    // issue# 19832
+    public HttpClient createHTTPClient(SSLSocketFactory sslSocketFactory, String url, boolean isHostnameVerification, boolean useSystemPropertiesForHttpClientConnections) {
 
         HttpClient client = null;
-        boolean addBasicAuthHeader = false;
 
-        //        if (jwkClientId != null && jwkClientSecret != null) {
-        //            addBasicAuthHeader = true;
-        //        }
-
-        BasicCredentialsProvider credentialsProvider = null;
-        if (addBasicAuthHeader) {
-            credentialsProvider = createCredentialsProvider();
+        ClassLoader origCL = ThreadContextHelper.getContextClassLoader();
+        ThreadContextHelper.setClassLoader(getClass().getClassLoader());
+        try {
+            SSLConnectionSocketFactory connectionFactory = null;
+            if (!isHostnameVerification) {
+                connectionFactory = new SSLConnectionSocketFactory(sslSocketFactory, new NoopHostnameVerifier());
+            } else {
+                connectionFactory = new SSLConnectionSocketFactory(sslSocketFactory, new DefaultHostnameVerifier());
+            }
+            client = createBuilder(useSystemPropertiesForHttpClientConnections).setSSLSocketFactory(connectionFactory).build();
+        } finally {
+            ThreadContextHelper.setClassLoader(origCL);
         }
 
-        client = createHttpClient(url.startsWith("https:"), isHostnameVerification, sslSocketFactory, addBasicAuthHeader, credentialsProvider);
         return client;
 
     }
 
-    private HttpClient createHttpClient(boolean isSecure, boolean isHostnameVerification, SSLSocketFactory sslSocketFactory, boolean addBasicAuthHeader, BasicCredentialsProvider credentialsProvider) {
-
-        HttpClient client = null;
-        if (isSecure) {
-            ClassLoader origCL = ThreadContextHelper.getContextClassLoader();
-            ThreadContextHelper.setClassLoader(getClass().getClassLoader());
-            try {
-                SSLConnectionSocketFactory connectionFactory = null;
-                if (!isHostnameVerification) {
-                    connectionFactory = new SSLConnectionSocketFactory(sslSocketFactory, new NoopHostnameVerifier());
-                } else {
-                    connectionFactory = new SSLConnectionSocketFactory(sslSocketFactory, new DefaultHostnameVerifier());
-                }
-                if (addBasicAuthHeader) {
-                    client = HttpClientBuilder.create().setDefaultCredentialsProvider(credentialsProvider).setSSLSocketFactory(connectionFactory).build();
-                } else {
-                    client = HttpClientBuilder.create().setSSLSocketFactory(connectionFactory).build();
-                }
-            } finally {
-                ThreadContextHelper.setClassLoader(origCL);
-            }
-        } else {
-            if (addBasicAuthHeader) {
-                client = HttpClientBuilder.create().setDefaultCredentialsProvider(credentialsProvider).build();
-            } else {
-                client = HttpClientBuilder.create().build();
-            }
-        }
-        return client;
+    // issue# 19832
+    private HttpClientBuilder createBuilder(boolean useSystemProperties) {
+        return useSystemProperties ? HttpClientBuilder.create().disableCookieManagement().useSystemProperties() : HttpClientBuilder.create().disableCookieManagement();
+        
     }
 
     private BasicCredentialsProvider createCredentialsProvider() {


### PR DESCRIPTION
To resolve 19832:

- product update
   -  com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java

- FAT update
   - com.ibm.ws.security.oidc.client_fat.1/build.gradle
   - com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/FATSuite.java
   - com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryJVMPropsTests.java
   - com.ibm.ws.security.oidc.client_fat.1/publish/files/serversettings/oidcClientDiscoveryJvmProxyProps.xml
   - com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rpd2/bootstrap.properties
   - com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rpd2/configs/rp_server_jvmprops.xml
   - com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rpd2/jvm.options
   - com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rpd2/resources/security/ltpa.keys

**Note:** Previous update via https://github.com/OpenLiberty/open-liberty/pull/21197 encountered com.ibm.ws.config.xml.internal.ConfigRefresher's CWWKG0027W for the timeout message after a 1 minute delay of waiting, which resulted unexpected failure in other test methods.  It's decided to have a separate test class to handle the discovery endpoint with jvm props.