### PR TITLE
Move and Simplify loginMethod app check

### DIFF
--- a/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/fat/src/com/ibm/ws/webcontainer/security/jacc15/fat/StaticAnnotationsTest.java
+++ b/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/fat/src/com/ibm/ws/webcontainer/security/jacc15/fat/StaticAnnotationsTest.java
@@ -23,8 +23,6 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 
-import com.ibm.websphere.simplicity.Machine;
-import com.ibm.websphere.simplicity.OperatingSystem;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.webcontainer.security.test.servlets.BasicAuthClient;
 import com.ibm.ws.webcontainer.security.test.servlets.SSLBasicAuthClient;
@@ -98,29 +96,17 @@ public class StaticAnnotationsTest {
         JACCFatUtils.installJaccUserFeature(server);
         JACCFatUtils.transformApps(server, "loginmethod.ear");
 
-        if (Machine.getLocalMachine().getOperatingSystem() != OperatingSystem.WINDOWS) {
-            /*
-             * We'll do a manual wait later if we're on a Windows test machine
-             */
-            server.addInstalledAppForValidation("loginmethod");
-        }
         server.startServer(true);
         assertNotNull("FeatureManager did not report update was complete",
                       server.waitForStringInLog("CWWKF0008I"));
         assertNotNull("Security service did not report it was ready",
                       server.waitForStringInLog("CWWKS0008I"));
-        assertNotNull("The application did not report is was started",
-                      server.waitForStringInLog("CWWKZ0001I"));
-
-        if (Machine.getLocalMachine().getOperatingSystem() == OperatingSystem.WINDOWS) {
-            /*
-             * Wait time based on test failure sample: CWWKZ0001I: Application loginmethod started in 290.026 seconds.
-             */
-            Log.info(thisClass, "setup", "Waiting for loginmethod to start: CWWKZ0001I: Application loginmethod started");
-            assertNotNull("The applicaiton loginmethod did not report as started, if this is a Windows run, may need more time to complete",
-                          server.waitForStringInLog("CWWKZ0001I: Application loginmethod started", 300000));
-
-        }
+        /*
+         * Max wait time based on Windows test failure sample: CWWKZ0001I: Application loginmethod started in 290.026 seconds.
+         */
+        Log.info(thisClass, "setup", "Waiting for loginmethod to start: CWWKZ0001I: Application loginmethod started");
+        assertNotNull("The applicaiton loginmethod did not report as started, if this is a Windows run, may need more time to complete",
+                      server.waitForStringInLog("CWWKZ0001I: Application loginmethod started", 300000));
 
         if (server.getValidateApps()) { // If this build is Java 7 or above
             verifyServerStartedWithJaccFeature(server);


### PR DESCRIPTION
Windows machines are taking a long time to start the test app for `StaticAnnotationsTest`, my earlier fix did some Windows checks and didn't realize we were already doing a `CWWKZ0001I`. Simplified the test for all OS doing one `CWWKZ0001I` check with a longer wait.

RTC 290799