### PR TITLE
Issue #21296: Execute EE9 lite tests for Java less than 11

### DIFF
--- a/dev/com.ibm.ws.el.3.0_fat/fat/src/com/ibm/ws/el/fat/FATSuite.java
+++ b/dev/com.ibm.ws.el.3.0_fat/fat/src/com/ibm/ws/el/fat/FATSuite.java
@@ -32,6 +32,7 @@ import com.ibm.ws.fat.util.FatLogHandler;
 import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.JavaInfo;
 
 /**
  * EL 3.0 Tests
@@ -73,9 +74,17 @@ public class FATSuite {
     }
 
     @ClassRule
-    public static RepeatTests r = RepeatTests
-                    .with(new EmptyAction().fullFATOnly())
-                    .andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly())
-                    .andWith(FeatureReplacementAction.EE10_FEATURES());
+    public static RepeatTests repeat;
 
+    static {
+        // EE10 require Java 11.  If we only specify EE10 for lite mode it will cause no tests to run which causes an error.
+        // If we are running on Java 8 have EE9 be the lite mode test to run.
+        if (JavaInfo.JAVA_VERSION >= 11) {
+            repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
+                            .andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly())
+                            .andWith(FeatureReplacementAction.EE10_FEATURES());
+        } else {
+            repeat = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(FeatureReplacementAction.EE9_FEATURES());
+        }
+    }
 }


### PR DESCRIPTION
fixes #21296