### PR TITLE
Added verbose flag to installServerFeature command

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallServerTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallServerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -174,7 +174,7 @@ public class InstallServerTest extends FeatureUtilityToolTest {
 
         // replace the server.xml and install from server.xml now
         copyFileToMinifiedRoot("usr/servers/serverX", "../../publish/tmp/autoFeatureServerXml/server.xml");
-        String[] param2s = { "installServerFeatures", "serverX"};
+        String[] param2s = { "installServerFeatures", "serverX", "--verbose"};
         deleteFeaturesAndLafilesFolders(METHOD_NAME);
 
 


### PR DESCRIPTION
The testInstallAutoFeatureServerXml junit test sometimes fails with an exit code of 25, when downloading/processing esa archive files from a maven repository. 

I added the verbose flag to the installServerFeature command when running the testInstallAutoFeatureServerXml junit test. In order to get detailed debug information if a .esa archive file fails to download from either the local or remote maven repository, to narrow down the responsible files the next time this test fails. 