### PR TITLE
New methods to add hooks directly to the CheckpointPhase

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/BootstrapChildFirstJarClassloader.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/BootstrapChildFirstJarClassloader.java
@@ -30,6 +30,8 @@ public final class BootstrapChildFirstJarClassloader extends JarFileClassLoader 
     static final String KERNEL_BOOT_CLASS_PREFIX = "com.ibm.ws.kernel.boot.";
     static final String KERNEL_BOOT_RESOURCE_PREFIX = "com/ibm/ws/kernel/boot/";
     static final int KERNEL_BOOT_PREFIX_LENGTH = KERNEL_BOOT_CLASS_PREFIX.length();
+    static final String CHECKPOINT_CLASS_PREFIX = "io.openliberty.checkpoint.";
+    static final int CHECKPOINT_CLASS_LENGTH = CHECKPOINT_CLASS_PREFIX.length();
 
     static <E> Enumeration<E> compoundEnumerations(Enumeration<E> e1, Enumeration<E> e2) {
         if (e2 == null || !e2.hasMoreElements())
@@ -53,14 +55,14 @@ public final class BootstrapChildFirstJarClassloader extends JarFileClassLoader 
      * Delegates to constructor of superclass (JarFileClassLoader)
      *
      * @param urls
-     *            the URLs from which to load classes and resources
+     *                   the URLs from which to load classes and resources
      * @param parent
-     *            the parent class loader for delegation
+     *                   the parent class loader for delegation
      *
      * @throws java.lang.SecurityException
-     *             if a security manager exists and its
-     *             checkCreateClassLoader method doesn't allow creation of a
-     *             class loader.
+     *                                         if a security manager exists and its
+     *                                         checkCreateClassLoader method doesn't allow creation of a
+     *                                         class loader.
      */
     public BootstrapChildFirstJarClassloader(URL[] urls, ClassLoader parent) {
         super(urls, false, parent);
@@ -75,7 +77,8 @@ public final class BootstrapChildFirstJarClassloader extends JarFileClassLoader 
         if (name == null || name.length() == 0)
             return null;
 
-        if (name.regionMatches(0, KERNEL_BOOT_CLASS_PREFIX, 0, KERNEL_BOOT_PREFIX_LENGTH)) {
+        if (name.regionMatches(0, KERNEL_BOOT_CLASS_PREFIX, 0, KERNEL_BOOT_PREFIX_LENGTH) ||
+            name.regionMatches(0, CHECKPOINT_CLASS_PREFIX, 0, CHECKPOINT_CLASS_LENGTH)) {
             return super.loadClass(name, resolve);
         }
 
@@ -130,7 +133,7 @@ public final class BootstrapChildFirstJarClassloader extends JarFileClassLoader 
     public Enumeration<URL> findResources(String resourceName) throws IOException {
         return Collections.<URL> enumeration(Collections.<URL> emptyList());
     }
-    
+
     @Override
     protected void addURL(URL url) {
         super.addURL(url);

--- a/dev/com.ibm.ws.kernel.boot.core/src/io/openliberty/checkpoint/spi/CheckpointPhase.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/io/openliberty/checkpoint/spi/CheckpointPhase.java
@@ -10,8 +10,14 @@
  *******************************************************************************/
 package io.openliberty.checkpoint.spi;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
+
+import com.ibm.websphere.ras.annotation.Trivial;
 
 /**
  * Phase which a checkpoint is being taken. This enum is registered as a
@@ -74,16 +80,167 @@ public enum CheckpointPhase {
         return phases.get(p.trim().toUpperCase());
     }
 
-    // Using static so this applies to all phases
-    static volatile boolean RESTORED = false;
+    private volatile boolean restored = false;
+    private volatile boolean noMoreAddHooks = false;
+    private final List<CheckpointHook> singleThreadedHooks = new ArrayList<>();
+    private final List<CheckpointHook> multiThreadedHooks = new ArrayList<>();
+
+    /**
+     * Convert a String to a checkpoint phase and then set the phase
+     * as the checkpoint phase in progress.
+     *
+     * @param p The string value
+     * @return The matching phase or null if there is no match. String comparison
+     *         is case insensitive.
+     */
+    static synchronized void setPhase(String p) {
+        if (phaseSet) {
+            // This should only be called once. Ignore if called multiple times.
+            // For embedded launches this may be called multiple times.
+            return;
+        }
+        debug(() -> "phase set to: " + p);
+        CheckpointPhase phase = p == null ? null : phases.get(p.trim().toUpperCase());
+        THE_PHASE = phase;
+        phaseSet = true;
+    }
+
+    static boolean phaseSet = false;
+    static CheckpointPhase THE_PHASE = null;
 
     /**
      * Returns true if the process has been restored
      *
      * @return true if the process has been restored
      */
-    public boolean restored() {
-        return RESTORED;
+    final public boolean restored() {
+        return restored;
     }
 
+    /**
+     * Adds a {@code CheckpointHook} for this checkpoint phase.
+     * The hook will be run to prepare and restore a checkpoint
+     * process while the JVM is in single-threaded mode.
+     *
+     * @param hook the hook to be used to prepare and restore
+     *                 a checkpoint process.
+     * @throws IllegalStateException if the phase is in progress.
+     * @see CheckpointHook#MULTI_THREADED_HOOK
+     */
+    final public void addSingleThreadedHook(CheckpointHook hook) {
+        addHook(hook, false);
+    }
+
+    /**
+     * Adds a {@code CheckpointHook} for this checkpoint phase.
+     * The hook will be run to prepare and restore a checkpoint
+     * process while the JVM is in multi-threaded mode.
+     *
+     * @param hook the hook to be used to prepare and restore
+     *                 a checkpoint process.
+     * @throws IllegalStateException if the phase is in progress.
+     * @see CheckpointHook#MULTI_THREADED_HOOK
+     */
+    final public void addMultiThreadedHook(CheckpointHook hook) {
+        addHook(hook, true);
+    }
+
+    private synchronized void addHook(CheckpointHook hook, boolean multiThreaded) {
+        if (this != THE_PHASE) {
+            throw new IllegalStateException("Cannot add hooks to a checkpoint phase that is not in progress.");
+        }
+        if (noMoreAddHooks) {
+            throw new IllegalStateException("Cannot add more hooks once prepare has started for the process.");
+        }
+
+        if (restored) {
+            return;
+        }
+        debug(() -> "Hook added: " + hook + " " + multiThreaded);
+        if (multiThreaded) {
+            multiThreadedHooks.add(hook);
+        } else {
+            singleThreadedHooks.add(hook);
+        }
+    }
+
+    private synchronized List<CheckpointHook> getAndClearHooks(boolean multiThreaded) {
+        debug(() -> "Calling getHooks: " + multiThreaded);
+        // once we get any hooks do not allow more adds
+        noMoreAddHooks = true;
+        List<CheckpointHook> current = multiThreaded ? multiThreadedHooks : singleThreadedHooks;
+        ArrayList<CheckpointHook> hooks = new ArrayList<>(current);
+        current.clear();
+        return hooks;
+    }
+
+    /**
+     * Returns the checkpoint phase in progress. If there is no
+     * checkpoint phase in progress then {@code null} is returned.
+     * Once a non-null result is returned that same phase instance
+     * will always be returned.
+     *
+     * @return the current checkpoint phase in progress.
+     */
+    public static synchronized CheckpointPhase getPhase() {
+        return THE_PHASE;
+    }
+
+    private final static boolean DEBUG = debugEnabled();
+
+    private static boolean debugEnabled() {
+        return System.getProperty("io.openliberty.checkpoint.debug") != null;
+    }
+
+    @Trivial
+    /**
+     * Print debug message to system out. The normal trace in liberty is not available
+     * this low.
+     *
+     * @param message the message supplier
+     */
+    private static void debug(Supplier<String> message) {
+        if (DEBUG) {
+            System.out.println("DEBUG CheckpointPhase: current phase - " + String.valueOf(THE_PHASE) + " - " + message.get());
+        }
+    }
+
+    final CheckpointHook createCheckpointHook(boolean multiThreaded) {
+        return new CheckpointPhaseHookImpl(multiThreaded);
+    }
+
+    final static class CheckpointPhaseHookImpl implements CheckpointHook {
+        private volatile List<CheckpointHook> hooks = Collections.emptyList();
+        private final boolean multiThreaded;
+
+        CheckpointPhaseHookImpl(boolean multiThreaded) {
+            this.multiThreaded = multiThreaded;
+        }
+
+        @Override
+        public void prepare() {
+            CheckpointPhase phase = CheckpointPhase.getPhase();
+            debug(() -> "prepare phase: " + phase);
+            if (phase != null) {
+                // phase should never be null if prepare is being called!
+                hooks = phase.getAndClearHooks(multiThreaded);
+            }
+            for (CheckpointHook hook : hooks) {
+                debug(() -> "prepare operation on static hook: " + hook);
+                hook.prepare();
+            }
+            // reverse for restore call during checkpoint
+            Collections.reverse(hooks);
+        }
+
+        @Override
+        public void restore() {
+            for (CheckpointHook hook : hooks) {
+                debug(() -> "prepare operation on static hook: " + hook);
+                hook.restore();
+            }
+            // release references to hooks now
+            hooks.clear();
+        }
+    }
 }

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerClasspathTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerClasspathTest.java
@@ -51,6 +51,7 @@ public class ServerClasspathTest {
                                                         "com.ibm.sharedclasses.spi", // Open JDK 9
                                                         "openj9",
                                                         "com.ibm.gpu" // Semeru 11.0.15
+                                                        , "io.openliberty.checkpoint.spi" // added checkpoint stuff
     };
 
     @BeforeClass

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerClasspathTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerClasspathTest.java
@@ -20,16 +20,19 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
 /**
  * Tests what can and cannot be loaded by the server's JVM classpath.
  */
+@RunWith(FATRunner.class)
 public class ServerClasspathTest {
 
     private static final String SERVER_NAME = "com.ibm.ws.kernel.boot.classpath.fat";

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerCleanTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerCleanTest.java
@@ -15,15 +15,18 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
 /**
  * This test bucket tests the server clean up function during the startup process.
  */
+@RunWith(FATRunner.class)
 public class ServerCleanTest {
     private static final Class<?> c = ServerCleanTest.class;
 

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerEnvTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerEnvTest.java
@@ -23,16 +23,19 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
 /**
  * This test bucket tests the server startup process.
  */
+@RunWith(FATRunner.class)
 public class ServerEnvTest {
     private static final Class<?> c = ServerEnvTest.class;
 
@@ -192,7 +195,7 @@ public class ServerEnvTest {
      * Create the server.env file in the specified directory
      *
      * @param fileContents
-     * @param dir directory for server.env
+     * @param dir          directory for server.env
      * @throws IOException
      */
     private String createServerEnvFile(String fileContents, File dir) throws IOException {

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerStartAsServiceTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerStartAsServiceTest.java
@@ -26,15 +26,18 @@ import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
 /**
  * This test bucket tests the server startup process.
  */
+@RunWith(FATRunner.class)
 public class ServerStartAsServiceTest {
     private static final Class<?> c = ServerStartAsServiceTest.class;
 

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerStartTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerStartTest.java
@@ -27,17 +27,20 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.OperatingSystem;
 import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
 /**
  * This test bucket tests the server startup process.
  */
+@RunWith(FATRunner.class)
 public class ServerStartTest {
     private static final Class<?> c = ServerStartTest.class;
 

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ShutdownTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ShutdownTest.java
@@ -24,13 +24,16 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
+@RunWith(FATRunner.class)
 public class ShutdownTest {
     private static final Class<?> c = ShutdownTest.class;
 

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/CreateCommandTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/CreateCommandTest.java
@@ -18,15 +18,18 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.Machine;
 import com.ibm.websphere.simplicity.ProgramOutput;
 
 import componenttest.common.apiservices.Bootstrap;
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.utils.FileUtils;
 import componenttest.topology.utils.LibertyServerUtils;
 
+@RunWith(FATRunner.class)
 public class CreateCommandTest {
 
     private final static String serverName = "com.ibm.ws.kernel.boot.commandline.CreateCommandTest";

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/DumpCommandTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/DumpCommandTest.java
@@ -23,18 +23,21 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.OperatingSystem;
 import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
 /**
  *
  */
+@RunWith(FATRunner.class)
 public class DumpCommandTest {
     private static final Class<?> c = DumpCommandTest.class;
 

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/PauseResumeCommandTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/PauseResumeCommandTest.java
@@ -16,15 +16,18 @@ import static org.junit.Assert.assertTrue;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
 /**
  *
  */
+@RunWith(FATRunner.class)
 public class PauseResumeCommandTest {
 
     private static final Class<?> c = PauseResumeCommandTest.class;

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/StartCommandTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/StartCommandTest.java
@@ -17,17 +17,20 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.Machine;
 import com.ibm.websphere.simplicity.ProgramOutput;
 
 import componenttest.common.apiservices.Bootstrap;
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.utils.LibertyServerUtils;
 
 /**
  *
  */
+@RunWith(FATRunner.class)
 public class StartCommandTest {
 
     private final static String defaultServerName = "defaultServer";

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandport/ServerCommandPortTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandport/ServerCommandPortTest.java
@@ -20,11 +20,13 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.RemoteFile;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.JavaInfo.Vendor;
 import componenttest.topology.impl.LibertyServer;
@@ -35,6 +37,7 @@ import componenttest.topology.utils.HttpUtils;
  * This test bucket validates the functionality of the server command port, the port that is used by the server script
  * to communicate with a running server, if required.
  */
+@RunWith(FATRunner.class)
 public class ServerCommandPortTest {
     private static final Class<?> c = ServerCommandPortTest.class;
 

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/internal/commands/LogLevelPropertyTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/internal/commands/LogLevelPropertyTest.java
@@ -19,10 +19,13 @@ import java.util.Map;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
+@RunWith(FATRunner.class)
 public class LogLevelPropertyTest {
 
     private static LibertyServer server;

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/osgi/OSGiEmbedManagerTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/osgi/OSGiEmbedManagerTest.java
@@ -14,12 +14,15 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
+@RunWith(FATRunner.class)
 public class OSGiEmbedManagerTest {
 
     private static final String SERVER_NAME = "com.ibm.ws.kernel.osgi.fat";

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/provisioning/KernelChangeTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/provisioning/KernelChangeTest.java
@@ -18,13 +18,16 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
 /**
  *
  */
+@RunWith(FATRunner.class)
 public class KernelChangeTest {
     private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.kernel.bootstrap.fat");
 
@@ -68,7 +71,7 @@ public class KernelChangeTest {
         server.renameLibertyServerRootFile("bootstrap.properties", "bootstrap.properties.hpel");
         server.renameLibertyServerRootFile("bootstrap.properties.orig", "bootstrap.properties");
 
-        // Start the server WITHOUT HPEL again 
+        // Start the server WITHOUT HPEL again
         server.startServer("part3.console.log", false, false);
 
         // Make sure no error messages in console.log

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/provisioning/ProvisioningTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/provisioning/ProvisioningTest.java
@@ -22,13 +22,16 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
+@RunWith(FATRunner.class)
 public class ProvisioningTest {
 
     private static final Class<?> c = ProvisioningTest.class;

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/wsspi/kernel/embeddable/EmbeddedServerAddProductExtensionTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/wsspi/kernel/embeddable/EmbeddedServerAddProductExtensionTest.java
@@ -31,15 +31,18 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
+import org.junit.runner.RunWith;
 import org.junit.runners.model.Statement;
 
 import com.ibm.websphere.simplicity.OperatingSystem;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 import junit.framework.AssertionFailedError;
 
+@RunWith(FATRunner.class)
 public class EmbeddedServerAddProductExtensionTest {
 
     static final Class<?> c = EmbeddedServerAddProductExtensionTest.class;
@@ -146,7 +149,8 @@ public class EmbeddedServerAddProductExtensionTest {
     }
 
     @Test
-    public void testAddProductExtension() throws Throwable {}
+    public void testAddProductExtension() throws Throwable {
+    }
 
     private static void embeddedServerTestHelper(final String REMOTE_METHOD_NAME) throws Throwable {
         final String METHOD_NAME = "embeddedServerTestHelper";

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/wsspi/kernel/embeddable/EmbeddedServerMergeProductExtensionTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/wsspi/kernel/embeddable/EmbeddedServerMergeProductExtensionTest.java
@@ -16,9 +16,11 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
@@ -28,6 +30,7 @@ import componenttest.topology.impl.LibertyServerFactory;
  * 2) WLP_PRODUCT_EXT_DIR environment variable
  * 3) etc/extensions install directory.
  */
+@RunWith(FATRunner.class)
 public class EmbeddedServerMergeProductExtensionTest {
 
     private static final Class<?> c = EmbeddedServerMergeProductExtensionTest.class;

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/wsspi/kernel/embeddable/EmbeddedServerTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/wsspi/kernel/embeddable/EmbeddedServerTest.java
@@ -32,15 +32,18 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
+import org.junit.runner.RunWith;
 import org.junit.runners.model.Statement;
 
 import com.ibm.websphere.simplicity.OperatingSystem;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 import junit.framework.AssertionFailedError;
 
+@RunWith(FATRunner.class)
 public class EmbeddedServerTest {
 
     static final Class<?> c = EmbeddedServerTest.class;
@@ -154,8 +157,8 @@ public class EmbeddedServerTest {
         // and build script copy does not pick them up.
         outputAutoFVTDirectory.mkdirs();
         Log.info(c, METHOD_NAME, "Copying directory from " +
-                        ls.getUserDir() + "/../NonDefaultUser" + " to " +
-                        outputAutoFVTDirectory.getAbsolutePath());
+                                 ls.getUserDir() + "/../NonDefaultUser" + " to " +
+                                 outputAutoFVTDirectory.getAbsolutePath());
 
         File srcDir = new File(ls.getUserDir() + "/../NonDefaultUser");
         copyDirectory(srcDir, outputAutoFVTDirectory.getAbsoluteFile());
@@ -178,10 +181,12 @@ public class EmbeddedServerTest {
     }
 
     @Test
-    public void testForceStoppingAStartedServer() throws Throwable {}
+    public void testForceStoppingAStartedServer() throws Throwable {
+    }
 
     @Test
-    public void testBadArgument() throws Throwable {}
+    public void testBadArgument() throws Throwable {
+    }
 
     @Test
     public void testLaunchException() throws Throwable {

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/location/internal/Activator.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/location/internal/Activator.java
@@ -27,14 +27,13 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.pseudo.internal.PseudoContextFactory;
-import com.ibm.ws.kernel.service.util.CpuInfo;
 import com.ibm.wsspi.kernel.service.location.VariableRegistry;
 import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
 import com.ibm.wsspi.kernel.service.utils.FrameworkState;
 
 import io.openliberty.checkpoint.spi.CheckpointHook;
 
-public class Activator implements BundleActivator, CheckpointHook {
+public class Activator implements BundleActivator {
     private static final TraceComponent tc = Tr.register(Activator.class);
 
     /** Reference to active BundleContext (will be null between stop and start) */
@@ -89,12 +88,6 @@ public class Activator implements BundleActivator, CheckpointHook {
             // need to write a message about that to the log either
             shutdownFramework();
         }
-    }
-
-    // Hook to reset timer
-    @Override
-    public void restore() {
-        CpuInfo.resetTimer();
     }
 
     @Override

--- a/dev/io.openliberty.checkpoint/bnd.bnd
+++ b/dev/io.openliberty.checkpoint/bnd.bnd
@@ -41,7 +41,5 @@ WS-TraceGroup: checkpoint
 
 -dsannotations: \
     io.openliberty.checkpoint.internal.CheckpointImpl, \
-    io.openliberty.checkpoint.internal.CheckpointApplications, \
-    io.openliberty.checkpoint.internal.CheckpointFeatures, \
     io.openliberty.checkpoint.internal.CheckpointOSGiConsole
 

--- a/dev/io.openliberty.checkpoint_fat/test-applications/ejbapp1/src/ejbapp1/TimerTest.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/ejbapp1/src/ejbapp1/TimerTest.java
@@ -38,6 +38,7 @@ public class TimerTest {
         System.out.println("TIMER - Ran again: " + deltaMillis);
         // here we assume if delta is less than 800 millis then something is wrong
         if (deltaMillis < 800) {
+            System.out.println("TIMER RUN TOO FAST: " + deltaMillis);
             failed.set(true);
         }
         if (numRun.addAndGet(1) == 5) {

--- a/dev/io.openliberty.checkpoint_fat/test-bundles/test.checkpoint.config.bundle/src/test/checkpoint/config/bundle/TestStaticHookRegister.java
+++ b/dev/io.openliberty.checkpoint_fat/test-bundles/test.checkpoint.config.bundle/src/test/checkpoint/config/bundle/TestStaticHookRegister.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
+package test.checkpoint.config.bundle;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.osgi.service.component.annotations.Component;
+
+import io.openliberty.checkpoint.fat.TestSPIConfig;
+import io.openliberty.checkpoint.spi.CheckpointHook;
+import io.openliberty.checkpoint.spi.CheckpointPhase;
+
+@Component
+public class TestStaticHookRegister {
+    private final AtomicBoolean singleThreadedPrepare = new AtomicBoolean();
+    private final AtomicBoolean singleThreadedRestore = new AtomicBoolean();
+    private final AtomicBoolean multiThreadedPrepare = new AtomicBoolean();
+    private final AtomicBoolean multiThreadedRestore = new AtomicBoolean();
+
+    private final CheckpointHook single = new CheckpointHook() {
+        @Override
+        public void prepare() {
+            if (singleThreadedRestore.get() || multiThreadedRestore.get()) {
+                System.out.println(TestSPIConfig.STATIC_SINGLE_PREPARE + "FAILED - restore called before prepare single already called once");
+            } else if (!singleThreadedPrepare.compareAndSet(false, true)) {
+                System.out.println(TestSPIConfig.STATIC_SINGLE_PREPARE + "FAILED - prepare single already called once");
+            } else if (!multiThreadedPrepare.get()) {
+                System.out.println(TestSPIConfig.STATIC_SINGLE_PREPARE + "FAILED - prepare single called before multi");
+            } else {
+                System.out.println(TestSPIConfig.STATIC_SINGLE_PREPARE + "SUCCESS");
+            }
+        }
+
+        @Override
+        public void restore() {
+            if (!singleThreadedPrepare.get() && !multiThreadedPrepare.get()) {
+                System.out.println(TestSPIConfig.STATIC_SINGLE_PREPARE + "FAILED - restore called before prepare single already called once");
+            } else if (!singleThreadedRestore.compareAndSet(false, true)) {
+                System.out.println(TestSPIConfig.STATIC_SINGLE_RESTORE + "FAILED - restore single already called once");
+            } else if (multiThreadedRestore.get()) {
+                System.out.println(TestSPIConfig.STATIC_SINGLE_RESTORE + "FAILED - restore single not called before multi");
+            } else {
+                System.out.println(TestSPIConfig.STATIC_SINGLE_RESTORE + "SUCCESS");
+            }
+        }
+    };
+
+    private final CheckpointHook multiple = new CheckpointHook() {
+        @Override
+        public void prepare() {
+            if (singleThreadedRestore.get() || multiThreadedRestore.get()) {
+                System.out.println(TestSPIConfig.STATIC_MULTI_PREPARE + "FAILED - restore called before prepare multi already called once");
+            } else if (!multiThreadedPrepare.compareAndSet(false, true)) {
+                System.out.println(TestSPIConfig.STATIC_MULTI_PREPARE + "FAILED - prepare multi already called once");
+            } else if (singleThreadedPrepare.get()) {
+                System.out.println(TestSPIConfig.STATIC_MULTI_PREPARE + "FAILED - prepare multi called aflter single");
+            } else {
+                System.out.println(TestSPIConfig.STATIC_MULTI_PREPARE + "SUCCESS");
+            }
+        }
+
+        @Override
+        public void restore() {
+            if (!singleThreadedPrepare.get() && !multiThreadedPrepare.get()) {
+                System.out.println(TestSPIConfig.STATIC_MULTI_PREPARE + "FAILED - restore called before prepare multi already called once");
+            } else if (!multiThreadedRestore.compareAndSet(false, true)) {
+                System.out.println(TestSPIConfig.STATIC_MULTI_RESTORE + "FAILED - restore multi already called once");
+            } else if (!singleThreadedRestore.get()) {
+                System.out.println(TestSPIConfig.STATIC_MULTI_RESTORE + "FAILED - restore multi called before single");
+            } else {
+                System.out.println(TestSPIConfig.STATIC_MULTI_RESTORE + "SUCCESS");
+            }
+        }
+    };
+
+    public TestStaticHookRegister() {
+        CheckpointPhase phase = CheckpointPhase.getPhase();
+        if (phase != null) {
+            phase.addSingleThreadedHook(single);
+
+            phase.addMultiThreadedHook(multiple);
+
+        }
+    }
+}

--- a/dev/io.openliberty.checkpoint_fat/test.checkpoint.config.bundle.bnd
+++ b/dev/io.openliberty.checkpoint_fat/test.checkpoint.config.bundle.bnd
@@ -21,4 +21,5 @@ Private-Package: \
  test.checkpoint.config.bundle
 
 -dsannotations: \
- test.checkpoint.config.bundle.TestCheckpointHook
+ test.checkpoint.config.bundle.TestCheckpointHook, \
+ test.checkpoint.config.bundle.TestStaticHookRegister


### PR DESCRIPTION
In order to make it easier for static code to participate in checkpoint new methods are added to CheckpointPhase to allow static hooks to be added instead of requiring hooks to be registered as OSGi services.