### PR TITLE
More Misc JPA FAT fixes

### DIFF
--- a/.github/test-categories/QUARANTINE
+++ b/.github/test-categories/QUARANTINE
@@ -9,6 +9,7 @@ com.ibm.ws.security.oidc.server_fat.spnego
 
 # Not a fat bucket, but still has '_fat' in name
 com.ibm.ws.jpa.tests.beanvalidation_fat.common
+com.ibm.ws.jpa.tests.eclipselink.query_fat.common
 com.ibm.ws.jpa.tests.jpaconfig_fat.common
 com.ibm.ws.jpa.tests.spec10.callback_fat.common
 com.ibm.ws.jpa.tests.spec10.entitymanager_fat.common

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,45 +11,17 @@
 
 package com.ibm.ws.jpa.spec10.embeddable;
 
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
-import com.ibm.ws.jpa.spec10.embeddable.issues.TestOLGH10310_EJB;
-import com.ibm.ws.jpa.spec10.embeddable.issues.TestOLGH10310_Web;
-
-import componenttest.containers.ExternalTestServiceDockerClientStrategy;
-import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.database.container.DatabaseContainerFactory;
+import com.ibm.ws.jpa.spec10.embeddable.tests.AbstractFATSuite;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                TestOLGH10310_Web.class,
-                TestOLGH10310_EJB.class,
-                JPA10EmbeddableBasic_EJB.class,
-                JPA10EmbeddableBasic_WEB.class,
-                JPA10EmbeddableNested_EJB.class,
-                JPA10EmbeddableNested_WEB.class,
-                JPA10EmbeddableRelationship_EJB.class,
-                JPA10EmbeddableRelationship_WEB.class,
+                JPA20Suite.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
-public class FATSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
-                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+public class FATSuite extends AbstractFATSuite {
 
-    //Required to ensure we calculate the correct strategy each run even when
-    //switching between local and remote docker hosts.
-    static {
-        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
-    }
-
-    @ClassRule
-    public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.with(new RepeatWithJPA20());
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/JPA20Suite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/JPA20Suite.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.spec10.embeddable;
+
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.ws.jpa.spec10.embeddable.issues.TestOLGH10310_EJB;
+import com.ibm.ws.jpa.spec10.embeddable.issues.TestOLGH10310_Web;
+import com.ibm.ws.jpa.spec10.embeddable.tests.AbstractFATSuite;
+import com.ibm.ws.jpa.spec10.embeddable.tests.JPA10EmbeddableBasic_EJB;
+import com.ibm.ws.jpa.spec10.embeddable.tests.JPA10EmbeddableBasic_WEB;
+import com.ibm.ws.jpa.spec10.embeddable.tests.JPA10EmbeddableNested_EJB;
+import com.ibm.ws.jpa.spec10.embeddable.tests.JPA10EmbeddableNested_WEB;
+import com.ibm.ws.jpa.spec10.embeddable.tests.JPA10EmbeddableRelationship_EJB;
+import com.ibm.ws.jpa.spec10.embeddable.tests.JPA10EmbeddableRelationship_WEB;
+
+import componenttest.rules.repeater.RepeatTests;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+                TestOLGH10310_Web.class,
+                TestOLGH10310_EJB.class,
+                JPA10EmbeddableBasic_EJB.class,
+                JPA10EmbeddableBasic_WEB.class,
+                JPA10EmbeddableNested_EJB.class,
+                JPA10EmbeddableNested_WEB.class,
+                JPA10EmbeddableRelationship_EJB.class,
+                JPA10EmbeddableRelationship_WEB.class
+})
+public class JPA20Suite extends AbstractFATSuite {
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(new RepeatWithJPA20());
+
+}

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/issues/TestOLGH10310_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/issues/TestOLGH10310_EJB.java
@@ -31,7 +31,7 @@ import com.ibm.ws.jpa.olgh10310.ejb.TestOLGH10310_EJB_SFEx_Servlet;
 import com.ibm.ws.jpa.olgh10310.ejb.TestOLGH10310_EJB_SF_Servlet;
 import com.ibm.ws.jpa.olgh10310.ejb.TestOLGH10310_EJB_SL_Servlet;
 import com.ibm.ws.jpa.spec10.embeddable.FATSuite;
-import com.ibm.ws.jpa.spec10.embeddable.JPAFATServletClient;
+import com.ibm.ws.jpa.spec10.embeddable.tests.JPAFATServletClient;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/issues/TestOLGH10310_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/issues/TestOLGH10310_Web.java
@@ -29,7 +29,7 @@ import com.ibm.websphere.simplicity.config.Application;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.ws.jpa.olgh10310.web.TestOLGH10310Servlet;
 import com.ibm.ws.jpa.spec10.embeddable.FATSuite;
-import com.ibm.ws.jpa.spec10.embeddable.JPAFATServletClient;
+import com.ibm.ws.jpa.spec10.embeddable.tests.JPAFATServletClient;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/tests/AbstractFATSuite.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.spec10.embeddable.tests;
+
+import org.junit.ClassRule;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+import componenttest.containers.ExternalTestServiceDockerClientStrategy;
+import componenttest.topology.database.container.DatabaseContainerFactory;
+
+public class AbstractFATSuite {
+    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+
+    //Required to ensure we calculate the correct strategy each run even when
+    //switching between local and remote docker hosts.
+    static {
+        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
+    }
+
+    @ClassRule
+    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+}

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/tests/JPA10EmbeddableBasic_WEB.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/tests/JPA10EmbeddableBasic_WEB.java
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa.spec10.embeddable;
+package com.ibm.ws.jpa.spec10.embeddable.tests;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -26,10 +26,11 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.Application;
+import com.ibm.websphere.simplicity.config.ClassloaderElement;
+import com.ibm.websphere.simplicity.config.ConfigElementList;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
-import com.ibm.ws.jpa.embeddable.nested.ejb.TestEmbeddableNested_EJB_SFEx_Servlet;
-import com.ibm.ws.jpa.embeddable.nested.ejb.TestEmbeddableNested_EJB_SF_Servlet;
-import com.ibm.ws.jpa.embeddable.nested.ejb.TestEmbeddableNested_EJB_SL_Servlet;
+import com.ibm.ws.jpa.embeddable.basic.web.TestEmbeddableBasicServlet;
+import com.ibm.ws.jpa.spec10.embeddable.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -44,11 +45,12 @@ import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-public class JPA10EmbeddableNested_EJB extends JPAFATServletClient {
-    private final static String CONTEXT_ROOT = "embeddableNestedEjb";
-    private final static String RESOURCE_ROOT = "test-applications/embeddable/nested/";
-    private final static String appFolder = "ejb";
-    private final static String appName = "embeddableNestedEjb";
+public class JPA10EmbeddableBasic_WEB extends JPAFATServletClient {
+
+    private final static String CONTEXT_ROOT = "embeddableBasicWeb";
+    private final static String RESOURCE_ROOT = "test-applications/embeddable/basic/";
+    private final static String appFolder = "web";
+    private final static String appName = "embeddableBasicWeb";
     private final static String appNameEar = appName + ".ear";
 
     private final static Set<String> dropSet = new HashSet<String>();
@@ -57,15 +59,13 @@ public class JPA10EmbeddableNested_EJB extends JPAFATServletClient {
     private static long timestart = 0;
 
     static {
-        dropSet.add("JPA10_EMBEDDABLE_NESTED_DROP_${dbvendor}.ddl");
-        createSet.add("JPA10_EMBEDDABLE_NESTED_CREATE_${dbvendor}.ddl");
+        dropSet.add("JPA10_EMBEDDABLE_BASIC_DROP_${dbvendor}.ddl");
+        createSet.add("JPA10_EMBEDDABLE_BASIC_CREATE_${dbvendor}.ddl");
     }
 
     @Server("JPA10Server")
     @TestServlets({
-                    @TestServlet(servlet = TestEmbeddableNested_EJB_SL_Servlet.class, path = CONTEXT_ROOT + "/" + "TestEmbeddableNested_EJB_SL_Servlet"),
-                    @TestServlet(servlet = TestEmbeddableNested_EJB_SF_Servlet.class, path = CONTEXT_ROOT + "/" + "TestEmbeddableNested_EJB_SF_Servlet"),
-                    @TestServlet(servlet = TestEmbeddableNested_EJB_SFEx_Servlet.class, path = CONTEXT_ROOT + "/" + "TestEmbeddableNested_EJB_SFEx_Servlet")
+                    @TestServlet(servlet = TestEmbeddableBasicServlet.class, path = CONTEXT_ROOT + "/" + "TestEmbeddableBasicServlet")
     })
     public static LibertyServer server;
 
@@ -74,7 +74,7 @@ public class JPA10EmbeddableNested_EJB extends JPAFATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         PrivHelper.generateCustomPolicy(server, FATSuite.JAXB_PERMS);
-        bannerStart(JPA10EmbeddableNested_EJB.class);
+        bannerStart(JPA10EmbeddableBasic_WEB.class);
         timestart = System.currentTimeMillis();
 
         int appStartTimeout = server.getAppStartTimeout();
@@ -99,7 +99,7 @@ public class JPA10EmbeddableNested_EJB extends JPAFATServletClient {
 
         final Set<String> ddlSet = new HashSet<String>();
 
-        System.out.println(JPA10EmbeddableNested_EJB.class.getName() + " Setting up database tables...");
+        System.out.println(JPA10EmbeddableBasic_WEB.class.getName() + " Setting up database tables...");
 
         ddlSet.clear();
         for (String ddlName : dropSet) {
@@ -117,20 +117,15 @@ public class JPA10EmbeddableNested_EJB extends JPAFATServletClient {
     }
 
     private static void setupTestApplication() throws Exception {
-        JavaArchive ejbApp = ShrinkWrap.create(JavaArchive.class, appName + ".jar");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.embeddable.nested.ejblocal");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.embeddable.nested.model");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.embeddable.nested.testlogic");
-        ShrinkHelper.addDirectory(ejbApp, RESOURCE_ROOT + appFolder + "/" + appName + ".jar");
-
         WebArchive webApp = ShrinkWrap.create(WebArchive.class, appName + ".war");
-        webApp.addPackages(true, "com.ibm.ws.jpa.embeddable.nested.ejb");
+        webApp.addPackages(true, "com.ibm.ws.jpa.embeddable.basic.model");
+        webApp.addPackages(true, "com.ibm.ws.jpa.embeddable.basic.testlogic");
+        webApp.addPackages(true, "com.ibm.ws.jpa.embeddable.basic.web");
         ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + appFolder + "/" + appName + ".war");
 
         final JavaArchive testApiJar = buildTestAPIJar();
 
         final EnterpriseArchive app = ShrinkWrap.create(EnterpriseArchive.class, appNameEar);
-        app.addAsModule(ejbApp);
         app.addAsModule(webApp);
         app.addAsLibrary(testApiJar);
         ShrinkHelper.addDirectory(app, RESOURCE_ROOT + appFolder, new org.jboss.shrinkwrap.api.Filter<ArchivePath>() {
@@ -150,11 +145,12 @@ public class JPA10EmbeddableNested_EJB extends JPAFATServletClient {
         Application appRecord = new Application();
         appRecord.setLocation(appNameEar);
         appRecord.setName(appName);
-//        ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
-//        ClassloaderElement loader = new ClassloaderElement();
-//        loader.setApiTypeVisibility("+third-party");
-////        loader.getCommonLibraryRefs().add("HibernateLib");
-//        cel.add(loader);
+
+        // For OpenJPA, Oracle CLOB support
+        ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
+        ClassloaderElement loader = new ClassloaderElement();
+        loader.getCommonLibraryRefs().add("AnonymousJDBCLib");
+        cel.add(loader);
 
         server.setMarkToEndOfLog();
         ServerConfiguration sc = server.getServerConfiguration();
@@ -182,8 +178,7 @@ public class JPA10EmbeddableNested_EJB extends JPAFATServletClient {
             }
 
             server.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
-                              "WTRN0074E: Exception caught from before_completion synchronization operation", // RuntimeException test, expected
-                              "CWWJP0055E" // TODO: OpenJPA throws a MetaDataException while parsing the XML nested embeddables
+                              "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
             );
         } finally {
             try {
@@ -197,7 +192,7 @@ public class JPA10EmbeddableNested_EJB extends JPAFATServletClient {
             } catch (Throwable t) {
                 t.printStackTrace();
             }
-            bannerEnd(JPA10EmbeddableNested_EJB.class, timestart);
+            bannerEnd(JPA10EmbeddableBasic_WEB.class, timestart);
         }
     }
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/tests/JPA10EmbeddableNested_WEB.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/tests/JPA10EmbeddableNested_WEB.java
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa.spec10.embeddable;
+package com.ibm.ws.jpa.spec10.embeddable.tests;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -28,6 +28,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.Application;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.ws.jpa.embeddable.nested.web.TestEmbeddableNestedServlet;
+import com.ibm.ws.jpa.spec10.embeddable.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/tests/JPA10EmbeddableRelationship_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/tests/JPA10EmbeddableRelationship_EJB.java
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa.spec10.embeddable;
+package com.ibm.ws.jpa.spec10.embeddable.tests;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -26,12 +26,11 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.Application;
-import com.ibm.websphere.simplicity.config.ClassloaderElement;
-import com.ibm.websphere.simplicity.config.ConfigElementList;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
-import com.ibm.ws.jpa.embeddable.basic.ejb.TestEmbeddableBasic_EJB_SFEx_Servlet;
-import com.ibm.ws.jpa.embeddable.basic.ejb.TestEmbeddableBasic_EJB_SF_Servlet;
-import com.ibm.ws.jpa.embeddable.basic.ejb.TestEmbeddableBasic_EJB_SL_Servlet;
+import com.ibm.ws.jpa.embeddable.relationship.ejb.TestEmbeddableRelationship_EJB_SFEx_Servlet;
+import com.ibm.ws.jpa.embeddable.relationship.ejb.TestEmbeddableRelationship_EJB_SF_Servlet;
+import com.ibm.ws.jpa.embeddable.relationship.ejb.TestEmbeddableRelationship_EJB_SL_Servlet;
+import com.ibm.ws.jpa.spec10.embeddable.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -46,12 +45,11 @@ import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-public class JPA10EmbeddableBasic_EJB extends JPAFATServletClient {
-
-    private final static String CONTEXT_ROOT = "embeddableBasicEjb";
-    private final static String RESOURCE_ROOT = "test-applications/embeddable/basic/";
+public class JPA10EmbeddableRelationship_EJB extends JPAFATServletClient {
+    private final static String CONTEXT_ROOT = "embeddableRelationshipEjb";
+    private final static String RESOURCE_ROOT = "test-applications/embeddable/relationship/";
     private final static String appFolder = "ejb";
-    private final static String appName = "embeddableBasicEjb";
+    private final static String appName = "embeddableRelationshipEjb";
     private final static String appNameEar = appName + ".ear";
 
     private final static Set<String> dropSet = new HashSet<String>();
@@ -60,15 +58,15 @@ public class JPA10EmbeddableBasic_EJB extends JPAFATServletClient {
     private static long timestart = 0;
 
     static {
-        dropSet.add("JPA10_EMBEDDABLE_BASIC_DROP_${dbvendor}.ddl");
-        createSet.add("JPA10_EMBEDDABLE_BASIC_CREATE_${dbvendor}.ddl");
+        dropSet.add("JPA10_EMBEDDABLE_RELATIONSHIP_DROP_${dbvendor}.ddl");
+        createSet.add("JPA10_EMBEDDABLE_RELATIONSHIP_CREATE_${dbvendor}.ddl");
     }
 
     @Server("JPA10Server")
     @TestServlets({
-                    @TestServlet(servlet = TestEmbeddableBasic_EJB_SL_Servlet.class, path = CONTEXT_ROOT + "/" + "TestEmbeddableBasic_EJB_SL_Servlet"),
-                    @TestServlet(servlet = TestEmbeddableBasic_EJB_SF_Servlet.class, path = CONTEXT_ROOT + "/" + "TestEmbeddableBasic_EJB_SF_Servlet"),
-                    @TestServlet(servlet = TestEmbeddableBasic_EJB_SFEx_Servlet.class, path = CONTEXT_ROOT + "/" + "TestEmbeddableBasic_EJB_SFEx_Servlet")
+                    @TestServlet(servlet = TestEmbeddableRelationship_EJB_SL_Servlet.class, path = CONTEXT_ROOT + "/" + "TestEmbeddableRelationship_EJB_SL_Servlet"),
+                    @TestServlet(servlet = TestEmbeddableRelationship_EJB_SF_Servlet.class, path = CONTEXT_ROOT + "/" + "TestEmbeddableRelationship_EJB_SF_Servlet"),
+                    @TestServlet(servlet = TestEmbeddableRelationship_EJB_SFEx_Servlet.class, path = CONTEXT_ROOT + "/" + "TestEmbeddableRelationship_EJB_SFEx_Servlet")
     })
     public static LibertyServer server;
 
@@ -77,7 +75,7 @@ public class JPA10EmbeddableBasic_EJB extends JPAFATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         PrivHelper.generateCustomPolicy(server, FATSuite.JAXB_PERMS);
-        bannerStart(JPA10EmbeddableBasic_EJB.class);
+        bannerStart(JPA10EmbeddableRelationship_EJB.class);
         timestart = System.currentTimeMillis();
 
         int appStartTimeout = server.getAppStartTimeout();
@@ -102,7 +100,7 @@ public class JPA10EmbeddableBasic_EJB extends JPAFATServletClient {
 
         final Set<String> ddlSet = new HashSet<String>();
 
-        System.out.println(JPA10EmbeddableBasic_EJB.class.getName() + " Setting up database tables...");
+        System.out.println(JPA10EmbeddableRelationship_EJB.class.getName() + " Setting up database tables...");
 
         ddlSet.clear();
         for (String ddlName : dropSet) {
@@ -121,13 +119,13 @@ public class JPA10EmbeddableBasic_EJB extends JPAFATServletClient {
 
     private static void setupTestApplication() throws Exception {
         JavaArchive ejbApp = ShrinkWrap.create(JavaArchive.class, appName + ".jar");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.embeddable.basic.ejblocal");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.embeddable.basic.model");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.embeddable.basic.testlogic");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.embeddable.relationship.ejblocal");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.embeddable.relationship.model");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.embeddable.relationship.testlogic");
         ShrinkHelper.addDirectory(ejbApp, RESOURCE_ROOT + appFolder + "/" + appName + ".jar");
 
         WebArchive webApp = ShrinkWrap.create(WebArchive.class, appName + ".war");
-        webApp.addPackages(true, "com.ibm.ws.jpa.embeddable.basic.ejb");
+        webApp.addPackages(true, "com.ibm.ws.jpa.embeddable.relationship.ejb");
         ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + appFolder + "/" + appName + ".war");
 
         final JavaArchive testApiJar = buildTestAPIJar();
@@ -153,12 +151,11 @@ public class JPA10EmbeddableBasic_EJB extends JPAFATServletClient {
         Application appRecord = new Application();
         appRecord.setLocation(appNameEar);
         appRecord.setName(appName);
-
-        // For OpenJPA, Oracle CLOB support
-        ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
-        ClassloaderElement loader = new ClassloaderElement();
-        loader.getCommonLibraryRefs().add("AnonymousJDBCLib");
-        cel.add(loader);
+//        ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
+//        ClassloaderElement loader = new ClassloaderElement();
+//        loader.setApiTypeVisibility("+third-party");
+////        loader.getCommonLibraryRefs().add("HibernateLib");
+//        cel.add(loader);
 
         server.setMarkToEndOfLog();
         ServerConfiguration sc = server.getServerConfiguration();
@@ -186,7 +183,8 @@ public class JPA10EmbeddableBasic_EJB extends JPAFATServletClient {
             }
 
             server.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
-                              "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
+                              "WTRN0074E: Exception caught from before_completion synchronization operation", // RuntimeException test, expected
+                              "CWWJP0055E" // TODO: OpenJPA throws a MetaDataException while parsing the XML nested embeddables
             );
         } finally {
             try {
@@ -200,7 +198,7 @@ public class JPA10EmbeddableBasic_EJB extends JPAFATServletClient {
             } catch (Throwable t) {
                 t.printStackTrace();
             }
-            bannerEnd(JPA10EmbeddableBasic_EJB.class, timestart);
+            bannerEnd(JPA10EmbeddableRelationship_EJB.class, timestart);
         }
     }
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/tests/JPA10EmbeddableRelationship_WEB.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/tests/JPA10EmbeddableRelationship_WEB.java
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa.spec10.embeddable;
+package com.ibm.ws.jpa.spec10.embeddable.tests;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -27,9 +27,8 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.Application;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
-import com.ibm.ws.jpa.embeddable.relationship.ejb.TestEmbeddableRelationship_EJB_SFEx_Servlet;
-import com.ibm.ws.jpa.embeddable.relationship.ejb.TestEmbeddableRelationship_EJB_SF_Servlet;
-import com.ibm.ws.jpa.embeddable.relationship.ejb.TestEmbeddableRelationship_EJB_SL_Servlet;
+import com.ibm.ws.jpa.embeddable.relationship.web.TestEmbeddableRelationshipServlet;
+import com.ibm.ws.jpa.spec10.embeddable.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -44,11 +43,11 @@ import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-public class JPA10EmbeddableRelationship_EJB extends JPAFATServletClient {
-    private final static String CONTEXT_ROOT = "embeddableRelationshipEjb";
+public class JPA10EmbeddableRelationship_WEB extends JPAFATServletClient {
+    private final static String CONTEXT_ROOT = "embeddableRelationshipWeb";
     private final static String RESOURCE_ROOT = "test-applications/embeddable/relationship/";
-    private final static String appFolder = "ejb";
-    private final static String appName = "embeddableRelationshipEjb";
+    private final static String appFolder = "web";
+    private final static String appName = "embeddableRelationshipWeb";
     private final static String appNameEar = appName + ".ear";
 
     private final static Set<String> dropSet = new HashSet<String>();
@@ -63,9 +62,7 @@ public class JPA10EmbeddableRelationship_EJB extends JPAFATServletClient {
 
     @Server("JPA10Server")
     @TestServlets({
-                    @TestServlet(servlet = TestEmbeddableRelationship_EJB_SL_Servlet.class, path = CONTEXT_ROOT + "/" + "TestEmbeddableRelationship_EJB_SL_Servlet"),
-                    @TestServlet(servlet = TestEmbeddableRelationship_EJB_SF_Servlet.class, path = CONTEXT_ROOT + "/" + "TestEmbeddableRelationship_EJB_SF_Servlet"),
-                    @TestServlet(servlet = TestEmbeddableRelationship_EJB_SFEx_Servlet.class, path = CONTEXT_ROOT + "/" + "TestEmbeddableRelationship_EJB_SFEx_Servlet")
+                    @TestServlet(servlet = TestEmbeddableRelationshipServlet.class, path = CONTEXT_ROOT + "/" + "TestEmbeddableRelationshipServlet")
     })
     public static LibertyServer server;
 
@@ -74,7 +71,7 @@ public class JPA10EmbeddableRelationship_EJB extends JPAFATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         PrivHelper.generateCustomPolicy(server, FATSuite.JAXB_PERMS);
-        bannerStart(JPA10EmbeddableRelationship_EJB.class);
+        bannerStart(JPA10EmbeddableRelationship_WEB.class);
         timestart = System.currentTimeMillis();
 
         int appStartTimeout = server.getAppStartTimeout();
@@ -99,7 +96,7 @@ public class JPA10EmbeddableRelationship_EJB extends JPAFATServletClient {
 
         final Set<String> ddlSet = new HashSet<String>();
 
-        System.out.println(JPA10EmbeddableRelationship_EJB.class.getName() + " Setting up database tables...");
+        System.out.println(JPA10EmbeddableRelationship_WEB.class.getName() + " Setting up database tables...");
 
         ddlSet.clear();
         for (String ddlName : dropSet) {
@@ -117,20 +114,15 @@ public class JPA10EmbeddableRelationship_EJB extends JPAFATServletClient {
     }
 
     private static void setupTestApplication() throws Exception {
-        JavaArchive ejbApp = ShrinkWrap.create(JavaArchive.class, appName + ".jar");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.embeddable.relationship.ejblocal");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.embeddable.relationship.model");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.embeddable.relationship.testlogic");
-        ShrinkHelper.addDirectory(ejbApp, RESOURCE_ROOT + appFolder + "/" + appName + ".jar");
-
         WebArchive webApp = ShrinkWrap.create(WebArchive.class, appName + ".war");
-        webApp.addPackages(true, "com.ibm.ws.jpa.embeddable.relationship.ejb");
+        webApp.addPackages(true, "com.ibm.ws.jpa.embeddable.relationship.model");
+        webApp.addPackages(true, "com.ibm.ws.jpa.embeddable.relationship.testlogic");
+        webApp.addPackages(true, "com.ibm.ws.jpa.embeddable.relationship.web");
         ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + appFolder + "/" + appName + ".war");
 
         final JavaArchive testApiJar = buildTestAPIJar();
 
         final EnterpriseArchive app = ShrinkWrap.create(EnterpriseArchive.class, appNameEar);
-        app.addAsModule(ejbApp);
         app.addAsModule(webApp);
         app.addAsLibrary(testApiJar);
         ShrinkHelper.addDirectory(app, RESOURCE_ROOT + appFolder, new org.jboss.shrinkwrap.api.Filter<ArchivePath>() {
@@ -197,7 +189,7 @@ public class JPA10EmbeddableRelationship_EJB extends JPAFATServletClient {
             } catch (Throwable t) {
                 t.printStackTrace();
             }
-            bannerEnd(JPA10EmbeddableRelationship_EJB.class, timestart);
+            bannerEnd(JPA10EmbeddableRelationship_WEB.class, timestart);
         }
     }
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/tests/JPAFATServletClient.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/tests/JPAFATServletClient.java
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa.spec10.embeddable;
+package com.ibm.ws.jpa.spec10.embeddable.tests;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/tests/SkipDatabaseRule.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/fat/src/com/ibm/ws/jpa/spec10/embeddable/tests/SkipDatabaseRule.java
@@ -1,7 +1,7 @@
 /**
  *
  */
-package com.ibm.ws.jpa.spec10.embeddable;
+package com.ibm.ws.jpa.spec10.embeddable.tests;
 
 import java.util.regex.Pattern;
 

--- a/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,47 +11,17 @@
 
 package com.ibm.ws.jpa.tests.spec20;
 
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
-import componenttest.containers.ExternalTestServiceDockerClientStrategy;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.database.container.DatabaseContainerFactory;
+import com.ibm.ws.jpa.tests.spec20.tests.AbstractFATSuite;
 
 @RunWith(Suite.class)
 @SuiteClasses({
                 JPA20FATSuite.class,
-//                TestOLGH9018_EJB.class,
-//                TestOLGH9018_WEB.class,
-//                TestOLGH9339_EJB.class,
-//                TestOLGH9339_WEB.class,
-//                TestOLGH10515_EJB.class,
-//                TestOLGH10515_WEB.class,
-//                TestOLGH16686_EJB.class,
-//                TestOLGH16686_WEB.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
-public class FATSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
-                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";" };
+public class FATSuite extends AbstractFATSuite {
 
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE7_FEATURES())
-                    .andWith(new RepeatWithJPA20())
-                    .andWith(FeatureReplacementAction.EE9_FEATURES())
-                    .andWith(FeatureReplacementAction.EE10_FEATURES());
-
-    //Required to ensure we calculate the correct strategy each run even when
-    //switching between local and remote docker hosts.
-    static {
-        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
-    }
-
-    @ClassRule
-    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
 }

--- a/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/JPA20FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/JPA20FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,9 +11,31 @@
 
 package com.ibm.ws.jpa.tests.spec20;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.ws.jpa.tests.spec20.tests.JPA20Cache_WEB;
+import com.ibm.ws.jpa.tests.spec20.tests.JPA20CriteriaQuery_EJB;
+import com.ibm.ws.jpa.tests.spec20.tests.JPA20CriteriaQuery_WEB;
+import com.ibm.ws.jpa.tests.spec20.tests.JPA20DerivedIdentity_EJB;
+import com.ibm.ws.jpa.tests.spec20.tests.JPA20DerivedIdentity_WEB;
+import com.ibm.ws.jpa.tests.spec20.tests.JPA20Query_EJB;
+import com.ibm.ws.jpa.tests.spec20.tests.JPA20Query_WEB;
+import com.ibm.ws.jpa.tests.spec20.tests.JPA20Util_EJB;
+import com.ibm.ws.jpa.tests.spec20.tests.JPA20Util_WEB;
+import com.ibm.ws.jpa.tests.spec20.tests.olgh.TestOLGH10515_EJB;
+import com.ibm.ws.jpa.tests.spec20.tests.olgh.TestOLGH10515_WEB;
+import com.ibm.ws.jpa.tests.spec20.tests.olgh.TestOLGH16686_EJB;
+import com.ibm.ws.jpa.tests.spec20.tests.olgh.TestOLGH16686_WEB;
+import com.ibm.ws.jpa.tests.spec20.tests.olgh.TestOLGH9018_EJB;
+import com.ibm.ws.jpa.tests.spec20.tests.olgh.TestOLGH9018_WEB;
+import com.ibm.ws.jpa.tests.spec20.tests.olgh.TestOLGH9339_EJB;
+import com.ibm.ws.jpa.tests.spec20.tests.olgh.TestOLGH9339_WEB;
+
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
 
 /**
  * Test cases for functionality introduced with JPA 2.0.
@@ -22,6 +44,14 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({
 //                JPA20Example_EJB.class,
 //                JPA20Example_WEB.class,
+                TestOLGH9018_EJB.class,
+                TestOLGH9018_WEB.class,
+                TestOLGH9339_EJB.class,
+                TestOLGH9339_WEB.class,
+                TestOLGH10515_EJB.class,
+                TestOLGH10515_WEB.class,
+                TestOLGH16686_EJB.class,
+                TestOLGH16686_WEB.class,
 
                 JPA20Cache_WEB.class,
                 JPA20CriteriaQuery_EJB.class,
@@ -36,4 +66,10 @@ import org.junit.runners.Suite.SuiteClasses;
 })
 public class JPA20FATSuite {
 
+    @ClassRule
+    public static RepeatTests r = RepeatTests.withoutModification()
+                    .andWith(FeatureReplacementAction.EE7_FEATURES())
+                    .andWith(new RepeatWithJPA20())
+                    .andWith(FeatureReplacementAction.EE9_FEATURES())
+                    .andWith(FeatureReplacementAction.EE10_FEATURES());
 }

--- a/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/AbstractFATSuite.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.tests.spec20.tests;
+
+import org.junit.ClassRule;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+import componenttest.containers.ExternalTestServiceDockerClientStrategy;
+import componenttest.topology.database.container.DatabaseContainerFactory;
+
+public class AbstractFATSuite {
+    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+
+    //Required to ensure we calculate the correct strategy each run even when
+    //switching between local and remote docker hosts.
+    static {
+        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
+    }
+
+    @ClassRule
+    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+}

--- a/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/JPA20CriteriaQuery_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/JPA20CriteriaQuery_EJB.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa.tests.spec20.olgh;
+package com.ibm.ws.jpa.tests.spec20.tests;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -27,7 +27,9 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.Application;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
-import com.ibm.ws.jpa.olgh10515.web.TestOLGH10515Servlet;
+import com.ibm.ws.jpa.fvt.criteriaquery.ejb.TestCriteriaQuery_EJB_SFEx_Servlet;
+import com.ibm.ws.jpa.fvt.criteriaquery.ejb.TestCriteriaQuery_EJB_SF_Servlet;
+import com.ibm.ws.jpa.fvt.criteriaquery.ejb.TestCriteriaQuery_EJB_SL_Servlet;
 import com.ibm.ws.jpa.tests.spec20.FATSuite;
 import com.ibm.ws.jpa.tests.spec20.JPAFATServletClient;
 
@@ -44,11 +46,11 @@ import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-public class TestOLGH10515_WEB extends JPAFATServletClient {
-    private final static String CONTEXT_ROOT = "olgh10515Web";
-    private final static String RESOURCE_ROOT = "test-applications/olgh10515/";
-    private final static String appFolder = "web";
-    private final static String appName = "olgh10515Web";
+public class JPA20CriteriaQuery_EJB extends JPAFATServletClient {
+    private final static String CONTEXT_ROOT = "criteriaqueryEjb";
+    private final static String RESOURCE_ROOT = "test-applications/criteriaquery/";
+    private final static String appFolder = "ejb";
+    private final static String appName = "criteriaqueryEjb";
     private final static String appNameEar = appName + ".ear";
 
     private final static Set<String> dropSet = new HashSet<String>();
@@ -58,14 +60,16 @@ public class TestOLGH10515_WEB extends JPAFATServletClient {
     private static long timestart = 0;
 
     static {
-        dropSet.add("OLGH10515_DROP_${dbvendor}.ddl");
-        createSet.add("OLGH10515_CREATE_${dbvendor}.ddl");
-        populateSet.add("OLGH10515_POPULATE_${dbvendor}.ddl");
+        dropSet.add("JPA_CRITERIAQUERY_DROP_${dbvendor}.ddl");
+        createSet.add("JPA_CRITERIAQUERY_CREATE_${dbvendor}.ddl");
+        populateSet.add("JPA_CRITERIAQUERY_POPULATE_${dbvendor}.ddl");
     }
 
-    @Server("JPA20Server")
+    @Server("JPA20CriteriaQueryEJBServer")
     @TestServlets({
-                    @TestServlet(servlet = TestOLGH10515Servlet.class, path = CONTEXT_ROOT + "/" + "TestOLGH10515Servlet")
+                    @TestServlet(servlet = TestCriteriaQuery_EJB_SL_Servlet.class, path = CONTEXT_ROOT + "/" + "TestCriteriaQuery_EJB_SL_Servlet"),
+                    @TestServlet(servlet = TestCriteriaQuery_EJB_SF_Servlet.class, path = CONTEXT_ROOT + "/" + "TestCriteriaQuery_EJB_SF_Servlet"),
+                    @TestServlet(servlet = TestCriteriaQuery_EJB_SFEx_Servlet.class, path = CONTEXT_ROOT + "/" + "TestCriteriaQuery_EJB_SFEx_Servlet")
     })
     public static LibertyServer server;
 
@@ -74,7 +78,7 @@ public class TestOLGH10515_WEB extends JPAFATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         PrivHelper.generateCustomPolicy(server, FATSuite.JAXB_PERMS);
-        bannerStart(TestOLGH10515_WEB.class);
+        bannerStart(JPA20CriteriaQuery_EJB.class);
         timestart = System.currentTimeMillis();
 
         //Get driver name
@@ -111,15 +115,20 @@ public class TestOLGH10515_WEB extends JPAFATServletClient {
     }
 
     private static void setupTestApplication() throws Exception {
+        JavaArchive ejbApp = ShrinkWrap.create(JavaArchive.class, appName + ".jar");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.fvt.criteriaquery.ejblocal");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.fvt.criteriaquery.model");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.fvt.criteriaquery.testlogic");
+        ShrinkHelper.addDirectory(ejbApp, RESOURCE_ROOT + appFolder + "/" + appName + ".jar");
+
         WebArchive webApp = ShrinkWrap.create(WebArchive.class, appName + ".war");
-        webApp.addPackages(true, "com.ibm.ws.jpa.olgh10515.model");
-        webApp.addPackages(true, "com.ibm.ws.jpa.olgh10515.testlogic");
-        webApp.addPackages(true, "com.ibm.ws.jpa.olgh10515.web");
+        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.criteriaquery.ejb");
         ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + appFolder + "/" + appName + ".war");
 
         final JavaArchive testApiJar = buildTestAPIJar();
 
         final EnterpriseArchive app = ShrinkWrap.create(EnterpriseArchive.class, appNameEar);
+        app.addAsModule(ejbApp);
         app.addAsModule(webApp);
         app.addAsLibrary(testApiJar);
         ShrinkHelper.addDirectory(app, RESOURCE_ROOT + appFolder, new org.jboss.shrinkwrap.api.Filter<ArchivePath>() {
@@ -180,7 +189,7 @@ public class TestOLGH10515_WEB extends JPAFATServletClient {
             } catch (Throwable t) {
                 t.printStackTrace();
             }
-            bannerEnd(TestOLGH10515_WEB.class, timestart);
+            bannerEnd(JPA20CriteriaQuery_EJB.class, timestart);
         }
     }
 }

--- a/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/JPA20CriteriaQuery_WEB.java
+++ b/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/JPA20CriteriaQuery_WEB.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa.tests.spec20;
+package com.ibm.ws.jpa.tests.spec20.tests;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -27,7 +27,9 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.Application;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
-import com.ibm.ws.jpa.query.web.TestQueryServlet;
+import com.ibm.ws.jpa.fvt.criteriaquery.web.TestCriteriaQueryServlet;
+import com.ibm.ws.jpa.tests.spec20.FATSuite;
+import com.ibm.ws.jpa.tests.spec20.JPAFATServletClient;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -42,26 +44,28 @@ import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-public class JPA20Query_WEB extends JPAFATServletClient {
-    private final static String CONTEXT_ROOT = "queryWeb";
-    private final static String RESOURCE_ROOT = "test-applications/query/";
+public class JPA20CriteriaQuery_WEB extends JPAFATServletClient {
+    private final static String CONTEXT_ROOT = "criteriaqueryWeb";
+    private final static String RESOURCE_ROOT = "test-applications/criteriaquery/";
     private final static String appFolder = "web";
-    private final static String appName = "queryWeb";
+    private final static String appName = "criteriaqueryWeb";
     private final static String appNameEar = appName + ".ear";
 
     private final static Set<String> dropSet = new HashSet<String>();
     private final static Set<String> createSet = new HashSet<String>();
+    private final static Set<String> populateSet = new HashSet<String>();
 
     private static long timestart = 0;
 
     static {
-        dropSet.add("JPA20_QUERY_DROP_${dbvendor}.ddl");
-        createSet.add("JPA20_QUERY_CREATE_${dbvendor}.ddl");
+        dropSet.add("JPA_CRITERIAQUERY_DROP_${dbvendor}.ddl");
+        createSet.add("JPA_CRITERIAQUERY_CREATE_${dbvendor}.ddl");
+        populateSet.add("JPA_CRITERIAQUERY_POPULATE_${dbvendor}.ddl");
     }
 
-    @Server("JPA20Server")
+    @Server("JPA20CriteriaQueryWebServer")
     @TestServlets({
-                    @TestServlet(servlet = TestQueryServlet.class, path = CONTEXT_ROOT + "/" + "TestQueryServlet")
+                    @TestServlet(servlet = TestCriteriaQueryServlet.class, path = CONTEXT_ROOT + "/" + "TestCriteriaQueryServlet")
     })
     public static LibertyServer server;
 
@@ -70,7 +74,7 @@ public class JPA20Query_WEB extends JPAFATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         PrivHelper.generateCustomPolicy(server, FATSuite.JAXB_PERMS);
-        bannerStart(JPA20Query_WEB.class);
+        bannerStart(JPA20CriteriaQuery_WEB.class);
         timestart = System.currentTimeMillis();
 
         int appStartTimeout = server.getAppStartTimeout();
@@ -95,8 +99,6 @@ public class JPA20Query_WEB extends JPAFATServletClient {
 
         final Set<String> ddlSet = new HashSet<String>();
 
-        System.out.println("TestQuery_Web Setting up database tables...");
-
         ddlSet.clear();
         for (String ddlName : dropSet) {
             ddlSet.add(ddlName.replace("${dbvendor}", getDbVendor().name()));
@@ -109,20 +111,20 @@ public class JPA20Query_WEB extends JPAFATServletClient {
         }
         executeDDL(server, ddlSet, false);
 
-//        ddlSet.clear();
-//        for (String ddlName : populateSet) {
-//            ddlSet.add(ddlName.replace("${dbvendor}", getDbVendor().name()));
-//        }
-//        executeDDL(server, ddlSet, false);
+        ddlSet.clear();
+        for (String ddlName : populateSet) {
+            ddlSet.add(ddlName.replace("${dbvendor}", getDbVendor().name()));
+        }
+        executeDDL(server, ddlSet, false);
 
         setupTestApplication();
     }
 
     private static void setupTestApplication() throws Exception {
         WebArchive webApp = ShrinkWrap.create(WebArchive.class, appName + ".war");
-        webApp.addPackages(true, "com.ibm.ws.jpa.query.model");
-        webApp.addPackages(true, "com.ibm.ws.jpa.query.testlogic");
-        webApp.addPackages(true, "com.ibm.ws.jpa.query.web");
+        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.criteriaquery.model");
+        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.criteriaquery.testlogic");
+        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.criteriaquery.web");
         ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + appFolder + "/" + appName + ".war");
 
         final JavaArchive testApiJar = buildTestAPIJar();
@@ -147,11 +149,6 @@ public class JPA20Query_WEB extends JPAFATServletClient {
         Application appRecord = new Application();
         appRecord.setLocation(appNameEar);
         appRecord.setName(appName);
-//        ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
-//        ClassloaderElement loader = new ClassloaderElement();
-//        loader.setApiTypeVisibility("+third-party");
-////        loader.getCommonLibraryRefs().add("HibernateLib");
-//        cel.add(loader);
 
         server.setMarkToEndOfLog();
         ServerConfiguration sc = server.getServerConfiguration();
@@ -193,7 +190,7 @@ public class JPA20Query_WEB extends JPAFATServletClient {
             } catch (Throwable t) {
                 t.printStackTrace();
             }
-            bannerEnd(JPA20Query_WEB.class, timestart);
+            bannerEnd(JPA20CriteriaQuery_WEB.class, timestart);
         }
     }
 }

--- a/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/JPA20DerivedIdentity_WEB.java
+++ b/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/JPA20DerivedIdentity_WEB.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa.tests.spec20;
+package com.ibm.ws.jpa.tests.spec20.tests;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -27,9 +27,9 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.Application;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
-import com.ibm.ws.jpa.query.ejb.TestQuery_EJB_SFEx_Servlet;
-import com.ibm.ws.jpa.query.ejb.TestQuery_EJB_SF_Servlet;
-import com.ibm.ws.jpa.query.ejb.TestQuery_EJB_SL_Servlet;
+import com.ibm.ws.jpa.fvt.derivedidentity.tests.web.DerivedIdentityWebTestServlet;
+import com.ibm.ws.jpa.tests.spec20.FATSuite;
+import com.ibm.ws.jpa.tests.spec20.JPAFATServletClient;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -44,11 +44,11 @@ import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-public class JPA20Query_EJB extends JPAFATServletClient {
-    private final static String CONTEXT_ROOT = "queryEjb";
-    private final static String RESOURCE_ROOT = "test-applications/query/";
-    private final static String appFolder = "ejb";
-    private final static String appName = "queryEjb";
+public class JPA20DerivedIdentity_WEB extends JPAFATServletClient {
+    private final static String CONTEXT_ROOT = "DerivedIdentityWeb";
+    private final static String RESOURCE_ROOT = "test-applications/derivedIdentity/";
+    private final static String appFolder = "apps/DerivedIdentityWeb.ear";
+    private final static String appName = "DerivedIdentityWeb";
     private final static String appNameEar = appName + ".ear";
 
     private final static Set<String> dropSet = new HashSet<String>();
@@ -57,15 +57,13 @@ public class JPA20Query_EJB extends JPAFATServletClient {
     private static long timestart = 0;
 
     static {
-        dropSet.add("JPA20_QUERY_DROP_${dbvendor}.ddl");
-        createSet.add("JPA20_QUERY_CREATE_${dbvendor}.ddl");
+        dropSet.add("JPA20_DERIVEDIDENTITY_DROP_${dbvendor}.ddl");
+        createSet.add("JPA20_DERIVEDIDENTITY_CREATE_${dbvendor}.ddl");
     }
 
-    @Server("JPA20Server")
+    @Server("JPA20DerivedIdentityWebServer")
     @TestServlets({
-                    @TestServlet(servlet = TestQuery_EJB_SL_Servlet.class, path = CONTEXT_ROOT + "/" + "TestQuery_EJB_SL_Servlet"),
-                    @TestServlet(servlet = TestQuery_EJB_SF_Servlet.class, path = CONTEXT_ROOT + "/" + "TestQuery_EJB_SF_Servlet"),
-                    @TestServlet(servlet = TestQuery_EJB_SFEx_Servlet.class, path = CONTEXT_ROOT + "/" + "TestQuery_EJB_SFEx_Servlet")
+                    @TestServlet(servlet = DerivedIdentityWebTestServlet.class, path = CONTEXT_ROOT + "/" + "DerivedIdentityWebTestServlet")
     })
     public static LibertyServer server;
 
@@ -74,7 +72,7 @@ public class JPA20Query_EJB extends JPAFATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         PrivHelper.generateCustomPolicy(server, FATSuite.JAXB_PERMS);
-        bannerStart(JPA20Query_EJB.class);
+        bannerStart(JPA20DerivedIdentity_WEB.class);
         timestart = System.currentTimeMillis();
 
         int appStartTimeout = server.getAppStartTimeout();
@@ -99,7 +97,7 @@ public class JPA20Query_EJB extends JPAFATServletClient {
 
         final Set<String> ddlSet = new HashSet<String>();
 
-        System.out.println("TestQuery_EJB Setting up database tables...");
+        System.out.println("Setting up database tables...");
 
         ddlSet.clear();
         for (String ddlName : dropSet) {
@@ -123,20 +121,15 @@ public class JPA20Query_EJB extends JPAFATServletClient {
     }
 
     private static void setupTestApplication() throws Exception {
-        JavaArchive ejbApp = ShrinkWrap.create(JavaArchive.class, appName + ".jar");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.query.ejblocal");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.query.model");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.query.testlogic");
-        ShrinkHelper.addDirectory(ejbApp, RESOURCE_ROOT + appFolder + "/" + appName + ".jar");
-
         WebArchive webApp = ShrinkWrap.create(WebArchive.class, appName + ".war");
-        webApp.addPackages(true, "com.ibm.ws.jpa.query.ejb");
+        webApp.addPackages(true, "com.ibm.ws.jpa.commonentities.datamodel");
+        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.derivedidentity.testlogic");
+        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.derivedidentity.tests.web");
         ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + appFolder + "/" + appName + ".war");
 
         final JavaArchive testApiJar = buildTestAPIJar();
 
         final EnterpriseArchive app = ShrinkWrap.create(EnterpriseArchive.class, appNameEar);
-        app.addAsModule(ejbApp);
         app.addAsModule(webApp);
         app.addAsLibrary(testApiJar);
         ShrinkHelper.addDirectory(app, RESOURCE_ROOT + appFolder, new org.jboss.shrinkwrap.api.Filter<ArchivePath>() {
@@ -156,11 +149,6 @@ public class JPA20Query_EJB extends JPAFATServletClient {
         Application appRecord = new Application();
         appRecord.setLocation(appNameEar);
         appRecord.setName(appName);
-//        ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
-//        ClassloaderElement loader = new ClassloaderElement();
-//        loader.setApiTypeVisibility("+third-party");
-////        loader.getCommonLibraryRefs().add("HibernateLib");
-//        cel.add(loader);
 
         server.setMarkToEndOfLog();
         ServerConfiguration sc = server.getServerConfiguration();
@@ -202,7 +190,7 @@ public class JPA20Query_EJB extends JPAFATServletClient {
             } catch (Throwable t) {
                 t.printStackTrace();
             }
-            bannerEnd(JPA20Query_EJB.class, timestart);
+            bannerEnd(JPA20DerivedIdentity_WEB.class, timestart);
         }
     }
 }

--- a/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/JPA20Query_WEB.java
+++ b/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/JPA20Query_WEB.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa.tests.spec20.olgh;
+package com.ibm.ws.jpa.tests.spec20.tests;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -27,7 +27,7 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.Application;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
-import com.ibm.ws.jpa.olgh9018.web.TestOLGH9018Servlet;
+import com.ibm.ws.jpa.query.web.TestQueryServlet;
 import com.ibm.ws.jpa.tests.spec20.FATSuite;
 import com.ibm.ws.jpa.tests.spec20.JPAFATServletClient;
 
@@ -44,11 +44,11 @@ import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-public class TestOLGH9018_WEB extends JPAFATServletClient {
-    private final static String CONTEXT_ROOT = "olgh9018Web";
-    private final static String RESOURCE_ROOT = "test-applications/olgh9018/";
+public class JPA20Query_WEB extends JPAFATServletClient {
+    private final static String CONTEXT_ROOT = "queryWeb";
+    private final static String RESOURCE_ROOT = "test-applications/query/";
     private final static String appFolder = "web";
-    private final static String appName = "olgh9018Web";
+    private final static String appName = "queryWeb";
     private final static String appNameEar = appName + ".ear";
 
     private final static Set<String> dropSet = new HashSet<String>();
@@ -57,13 +57,13 @@ public class TestOLGH9018_WEB extends JPAFATServletClient {
     private static long timestart = 0;
 
     static {
-        dropSet.add("OLGH9018_DROP_${dbvendor}.ddl");
-        createSet.add("OLGH9018_CREATE_${dbvendor}.ddl");
+        dropSet.add("JPA20_QUERY_DROP_${dbvendor}.ddl");
+        createSet.add("JPA20_QUERY_CREATE_${dbvendor}.ddl");
     }
 
     @Server("JPA20Server")
     @TestServlets({
-                    @TestServlet(servlet = TestOLGH9018Servlet.class, path = CONTEXT_ROOT + "/" + "TestOLGH9018Servlet")
+                    @TestServlet(servlet = TestQueryServlet.class, path = CONTEXT_ROOT + "/" + "TestQueryServlet")
     })
     public static LibertyServer server;
 
@@ -72,8 +72,18 @@ public class TestOLGH9018_WEB extends JPAFATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         PrivHelper.generateCustomPolicy(server, FATSuite.JAXB_PERMS);
-        bannerStart(TestOLGH9018_WEB.class);
+        bannerStart(JPA20Query_WEB.class);
         timestart = System.currentTimeMillis();
+
+        int appStartTimeout = server.getAppStartTimeout();
+        if (appStartTimeout < (120 * 1000)) {
+            server.setAppStartTimeout(120 * 1000);
+        }
+
+        int configUpdateTimeout = server.getConfigUpdateTimeout();
+        if (configUpdateTimeout < (120 * 1000)) {
+            server.setConfigUpdateTimeout(120 * 1000);
+        }
 
         //Get driver name
         server.addEnvVar("DB_DRIVER", DatabaseContainerType.valueOf(testContainer).getDriverName());
@@ -87,6 +97,8 @@ public class TestOLGH9018_WEB extends JPAFATServletClient {
 
         final Set<String> ddlSet = new HashSet<String>();
 
+        System.out.println("TestQuery_Web Setting up database tables...");
+
         ddlSet.clear();
         for (String ddlName : dropSet) {
             ddlSet.add(ddlName.replace("${dbvendor}", getDbVendor().name()));
@@ -99,14 +111,20 @@ public class TestOLGH9018_WEB extends JPAFATServletClient {
         }
         executeDDL(server, ddlSet, false);
 
+//        ddlSet.clear();
+//        for (String ddlName : populateSet) {
+//            ddlSet.add(ddlName.replace("${dbvendor}", getDbVendor().name()));
+//        }
+//        executeDDL(server, ddlSet, false);
+
         setupTestApplication();
     }
 
     private static void setupTestApplication() throws Exception {
         WebArchive webApp = ShrinkWrap.create(WebArchive.class, appName + ".war");
-        webApp.addPackages(true, "com.ibm.ws.jpa.olgh9018.model");
-        webApp.addPackages(true, "com.ibm.ws.jpa.olgh9018.testlogic");
-        webApp.addPackages(true, "com.ibm.ws.jpa.olgh9018.web");
+        webApp.addPackages(true, "com.ibm.ws.jpa.query.model");
+        webApp.addPackages(true, "com.ibm.ws.jpa.query.testlogic");
+        webApp.addPackages(true, "com.ibm.ws.jpa.query.web");
         ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + appFolder + "/" + appName + ".war");
 
         final JavaArchive testApiJar = buildTestAPIJar();
@@ -131,6 +149,11 @@ public class TestOLGH9018_WEB extends JPAFATServletClient {
         Application appRecord = new Application();
         appRecord.setLocation(appNameEar);
         appRecord.setName(appName);
+//        ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
+//        ClassloaderElement loader = new ClassloaderElement();
+//        loader.setApiTypeVisibility("+third-party");
+////        loader.getCommonLibraryRefs().add("HibernateLib");
+//        cel.add(loader);
 
         server.setMarkToEndOfLog();
         ServerConfiguration sc = server.getServerConfiguration();
@@ -172,7 +195,7 @@ public class TestOLGH9018_WEB extends JPAFATServletClient {
             } catch (Throwable t) {
                 t.printStackTrace();
             }
-            bannerEnd(TestOLGH9018_WEB.class, timestart);
+            bannerEnd(JPA20Query_WEB.class, timestart);
         }
     }
 }

--- a/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/JPA20Util_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/JPA20Util_EJB.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa.tests.spec20.olgh;
+package com.ibm.ws.jpa.tests.spec20.tests;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -27,9 +27,8 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.Application;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
-import com.ibm.ws.jpa.olgh9339.ejb.TestOLGH9339_EJB_SFEx_Servlet;
-import com.ibm.ws.jpa.olgh9339.ejb.TestOLGH9339_EJB_SF_Servlet;
-import com.ibm.ws.jpa.olgh9339.ejb.TestOLGH9339_EJB_SL_Servlet;
+import com.ibm.ws.jpa.fvt.util.tests.ejb.UtilEJBSFTestServlet;
+import com.ibm.ws.jpa.fvt.util.tests.ejb.UtilEJBSLTestServlet;
 import com.ibm.ws.jpa.tests.spec20.FATSuite;
 import com.ibm.ws.jpa.tests.spec20.JPAFATServletClient;
 
@@ -46,30 +45,28 @@ import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-public class TestOLGH9339_EJB extends JPAFATServletClient {
-    private final static String CONTEXT_ROOT = "olgh9339Ejb";
-    private final static String RESOURCE_ROOT = "test-applications/olgh9339/";
-    private final static String appFolder = "ejb";
-    private final static String appName = "olgh9339Ejb";
+public class JPA20Util_EJB extends JPAFATServletClient {
+    private final static String CONTEXT_ROOT = "UtilEJB";
+    private final static String RESOURCE_ROOT = "test-applications/util/";
+    private final static String appFolder = "UtilEJB.ear";
+    private final static String appName = "UtilEJB";
     private final static String appNameEar = appName + ".ear";
 
     private final static Set<String> dropSet = new HashSet<String>();
     private final static Set<String> createSet = new HashSet<String>();
-    private final static Set<String> populateSet = new HashSet<String>();
 
     private static long timestart = 0;
 
     static {
-        dropSet.add("OLGH9339_DROP_${dbvendor}.ddl");
-        createSet.add("OLGH9339_CREATE_${dbvendor}.ddl");
-        populateSet.add("OLGH9339_POPULATE_${dbvendor}.ddl");
+        dropSet.add("JPA20_UTIL_DROP_${dbvendor}.ddl");
+        createSet.add("JPA20_UTIL_CREATE_${dbvendor}.ddl");
     }
 
-    @Server("JPA20Server")
+    @Server("JPA20UtilEJBServer")
     @TestServlets({
-                    @TestServlet(servlet = TestOLGH9339_EJB_SL_Servlet.class, path = CONTEXT_ROOT + "/" + "TestOLGH9339_EJB_SL_Servlet"),
-                    @TestServlet(servlet = TestOLGH9339_EJB_SF_Servlet.class, path = CONTEXT_ROOT + "/" + "TestOLGH9339_EJB_SF_Servlet"),
-                    @TestServlet(servlet = TestOLGH9339_EJB_SFEx_Servlet.class, path = CONTEXT_ROOT + "/" + "TestOLGH9339_EJB_SFEx_Servlet")
+                    @TestServlet(servlet = UtilEJBSLTestServlet.class, path = CONTEXT_ROOT + "/" + "UtilEJBSLTestServlet"),
+                    @TestServlet(servlet = UtilEJBSFTestServlet.class, path = CONTEXT_ROOT + "/" + "UtilEJBSFTestServlet"),
+
     })
     public static LibertyServer server;
 
@@ -78,8 +75,18 @@ public class TestOLGH9339_EJB extends JPAFATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         PrivHelper.generateCustomPolicy(server, FATSuite.JAXB_PERMS);
-        bannerStart(TestOLGH9339_EJB.class);
+        bannerStart(JPA20Util_EJB.class);
         timestart = System.currentTimeMillis();
+
+        int appStartTimeout = server.getAppStartTimeout();
+        if (appStartTimeout < (120 * 1000)) {
+            server.setAppStartTimeout(120 * 1000);
+        }
+
+        int configUpdateTimeout = server.getConfigUpdateTimeout();
+        if (configUpdateTimeout < (120 * 1000)) {
+            server.setConfigUpdateTimeout(120 * 1000);
+        }
 
         //Get driver name
         server.addEnvVar("DB_DRIVER", DatabaseContainerType.valueOf(testContainer).getDriverName());
@@ -93,6 +100,8 @@ public class TestOLGH9339_EJB extends JPAFATServletClient {
 
         final Set<String> ddlSet = new HashSet<String>();
 
+        System.out.println("Setting up database tables...");
+
         ddlSet.clear();
         for (String ddlName : dropSet) {
             ddlSet.add(ddlName.replace("${dbvendor}", getDbVendor().name()));
@@ -105,24 +114,24 @@ public class TestOLGH9339_EJB extends JPAFATServletClient {
         }
         executeDDL(server, ddlSet, false);
 
-        ddlSet.clear();
-        for (String ddlName : populateSet) {
-            ddlSet.add(ddlName.replace("${dbvendor}", getDbVendor().name()));
-        }
-        executeDDL(server, ddlSet, false);
+//        ddlSet.clear();
+//        for (String ddlName : populateSet) {
+//            ddlSet.add(ddlName.replace("${dbvendor}", getDbVendor().name()));
+//        }
+//        executeDDL(server, ddlSet, false);
 
         setupTestApplication();
     }
 
     private static void setupTestApplication() throws Exception {
         JavaArchive ejbApp = ShrinkWrap.create(JavaArchive.class, appName + ".jar");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.olgh9339.ejblocal");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.olgh9339.model");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.olgh9339.testlogic");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.fvt.util.ejblocal");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.fvt.util.entities");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.fvt.util.testlogic");
         ShrinkHelper.addDirectory(ejbApp, RESOURCE_ROOT + appFolder + "/" + appName + ".jar");
 
         WebArchive webApp = ShrinkWrap.create(WebArchive.class, appName + ".war");
-        webApp.addPackages(true, "com.ibm.ws.jpa.olgh9339.ejb");
+        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.util.tests.ejb");
         ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + appFolder + "/" + appName + ".war");
 
         final JavaArchive testApiJar = buildTestAPIJar();
@@ -189,7 +198,7 @@ public class TestOLGH9339_EJB extends JPAFATServletClient {
             } catch (Throwable t) {
                 t.printStackTrace();
             }
-            bannerEnd(TestOLGH9339_EJB.class, timestart);
+            bannerEnd(JPA20Util_EJB.class, timestart);
         }
     }
 }

--- a/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/olgh/TestOLGH10515_WEB.java
+++ b/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/olgh/TestOLGH10515_WEB.java
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa.tests.spec20.olgh;
+package com.ibm.ws.jpa.tests.spec20.tests.olgh;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -27,9 +27,7 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.Application;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
-import com.ibm.ws.jpa.olgh16686.ejb.TestOLGH16686_EJB_SFEx_Servlet;
-import com.ibm.ws.jpa.olgh16686.ejb.TestOLGH16686_EJB_SF_Servlet;
-import com.ibm.ws.jpa.olgh16686.ejb.TestOLGH16686_EJB_SL_Servlet;
+import com.ibm.ws.jpa.olgh10515.web.TestOLGH10515Servlet;
 import com.ibm.ws.jpa.tests.spec20.FATSuite;
 import com.ibm.ws.jpa.tests.spec20.JPAFATServletClient;
 
@@ -46,28 +44,28 @@ import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-public class TestOLGH16686_EJB extends JPAFATServletClient {
-    private final static String CONTEXT_ROOT = "olgh16686Ejb";
-    private final static String RESOURCE_ROOT = "test-applications/olgh16686/";
-    private final static String appFolder = "ejb";
-    private final static String appName = "olgh16686Ejb";
+public class TestOLGH10515_WEB extends JPAFATServletClient {
+    private final static String CONTEXT_ROOT = "olgh10515Web";
+    private final static String RESOURCE_ROOT = "test-applications/olgh10515/";
+    private final static String appFolder = "web";
+    private final static String appName = "olgh10515Web";
     private final static String appNameEar = appName + ".ear";
 
     private final static Set<String> dropSet = new HashSet<String>();
     private final static Set<String> createSet = new HashSet<String>();
+    private final static Set<String> populateSet = new HashSet<String>();
 
     private static long timestart = 0;
 
     static {
-        dropSet.add("OLGH16686_DROP_${dbvendor}.ddl");
-        createSet.add("OLGH16686_CREATE_${dbvendor}.ddl");
+        dropSet.add("OLGH10515_DROP_${dbvendor}.ddl");
+        createSet.add("OLGH10515_CREATE_${dbvendor}.ddl");
+        populateSet.add("OLGH10515_POPULATE_${dbvendor}.ddl");
     }
 
     @Server("JPA20Server")
     @TestServlets({
-                    @TestServlet(servlet = TestOLGH16686_EJB_SL_Servlet.class, path = CONTEXT_ROOT + "/" + "TestOLGH16686_EJB_SL_Servlet"),
-                    @TestServlet(servlet = TestOLGH16686_EJB_SF_Servlet.class, path = CONTEXT_ROOT + "/" + "TestOLGH16686_EJB_SF_Servlet"),
-                    @TestServlet(servlet = TestOLGH16686_EJB_SFEx_Servlet.class, path = CONTEXT_ROOT + "/" + "TestOLGH16686_EJB_SFEx_Servlet")
+                    @TestServlet(servlet = TestOLGH10515Servlet.class, path = CONTEXT_ROOT + "/" + "TestOLGH10515Servlet")
     })
     public static LibertyServer server;
 
@@ -76,7 +74,7 @@ public class TestOLGH16686_EJB extends JPAFATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         PrivHelper.generateCustomPolicy(server, FATSuite.JAXB_PERMS);
-        bannerStart(TestOLGH16686_EJB.class);
+        bannerStart(TestOLGH10515_WEB.class);
         timestart = System.currentTimeMillis();
 
         //Get driver name
@@ -103,24 +101,25 @@ public class TestOLGH16686_EJB extends JPAFATServletClient {
         }
         executeDDL(server, ddlSet, false);
 
+        ddlSet.clear();
+        for (String ddlName : populateSet) {
+            ddlSet.add(ddlName.replace("${dbvendor}", getDbVendor().name()));
+        }
+        executeDDL(server, ddlSet, false);
+
         setupTestApplication();
     }
 
     private static void setupTestApplication() throws Exception {
-        JavaArchive ejbApp = ShrinkWrap.create(JavaArchive.class, appName + ".jar");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.olgh16686.ejblocal");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.olgh16686.model");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.olgh16686.testlogic");
-        ShrinkHelper.addDirectory(ejbApp, RESOURCE_ROOT + appFolder + "/" + appName + ".jar");
-
         WebArchive webApp = ShrinkWrap.create(WebArchive.class, appName + ".war");
-        webApp.addPackages(true, "com.ibm.ws.jpa.olgh16686.ejb");
+        webApp.addPackages(true, "com.ibm.ws.jpa.olgh10515.model");
+        webApp.addPackages(true, "com.ibm.ws.jpa.olgh10515.testlogic");
+        webApp.addPackages(true, "com.ibm.ws.jpa.olgh10515.web");
         ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + appFolder + "/" + appName + ".war");
 
         final JavaArchive testApiJar = buildTestAPIJar();
 
         final EnterpriseArchive app = ShrinkWrap.create(EnterpriseArchive.class, appNameEar);
-        app.addAsModule(ejbApp);
         app.addAsModule(webApp);
         app.addAsLibrary(testApiJar);
         ShrinkHelper.addDirectory(app, RESOURCE_ROOT + appFolder, new org.jboss.shrinkwrap.api.Filter<ArchivePath>() {
@@ -181,7 +180,7 @@ public class TestOLGH16686_EJB extends JPAFATServletClient {
             } catch (Throwable t) {
                 t.printStackTrace();
             }
-            bannerEnd(TestOLGH16686_EJB.class, timestart);
+            bannerEnd(TestOLGH10515_WEB.class, timestart);
         }
     }
 }

--- a/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/olgh/TestOLGH16686_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/olgh/TestOLGH16686_EJB.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa.tests.spec20;
+package com.ibm.ws.jpa.tests.spec20.tests.olgh;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -27,9 +27,11 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.Application;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
-import com.ibm.ws.jpa.fvt.criteriaquery.ejb.TestCriteriaQuery_EJB_SFEx_Servlet;
-import com.ibm.ws.jpa.fvt.criteriaquery.ejb.TestCriteriaQuery_EJB_SF_Servlet;
-import com.ibm.ws.jpa.fvt.criteriaquery.ejb.TestCriteriaQuery_EJB_SL_Servlet;
+import com.ibm.ws.jpa.olgh16686.ejb.TestOLGH16686_EJB_SFEx_Servlet;
+import com.ibm.ws.jpa.olgh16686.ejb.TestOLGH16686_EJB_SF_Servlet;
+import com.ibm.ws.jpa.olgh16686.ejb.TestOLGH16686_EJB_SL_Servlet;
+import com.ibm.ws.jpa.tests.spec20.FATSuite;
+import com.ibm.ws.jpa.tests.spec20.JPAFATServletClient;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -44,30 +46,28 @@ import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-public class JPA20CriteriaQuery_EJB extends JPAFATServletClient {
-    private final static String CONTEXT_ROOT = "criteriaqueryEjb";
-    private final static String RESOURCE_ROOT = "test-applications/criteriaquery/";
+public class TestOLGH16686_EJB extends JPAFATServletClient {
+    private final static String CONTEXT_ROOT = "olgh16686Ejb";
+    private final static String RESOURCE_ROOT = "test-applications/olgh16686/";
     private final static String appFolder = "ejb";
-    private final static String appName = "criteriaqueryEjb";
+    private final static String appName = "olgh16686Ejb";
     private final static String appNameEar = appName + ".ear";
 
     private final static Set<String> dropSet = new HashSet<String>();
     private final static Set<String> createSet = new HashSet<String>();
-    private final static Set<String> populateSet = new HashSet<String>();
 
     private static long timestart = 0;
 
     static {
-        dropSet.add("JPA_CRITERIAQUERY_DROP_${dbvendor}.ddl");
-        createSet.add("JPA_CRITERIAQUERY_CREATE_${dbvendor}.ddl");
-        populateSet.add("JPA_CRITERIAQUERY_POPULATE_${dbvendor}.ddl");
+        dropSet.add("OLGH16686_DROP_${dbvendor}.ddl");
+        createSet.add("OLGH16686_CREATE_${dbvendor}.ddl");
     }
 
-    @Server("JPA20CriteriaQueryEJBServer")
+    @Server("JPA20Server")
     @TestServlets({
-                    @TestServlet(servlet = TestCriteriaQuery_EJB_SL_Servlet.class, path = CONTEXT_ROOT + "/" + "TestCriteriaQuery_EJB_SL_Servlet"),
-                    @TestServlet(servlet = TestCriteriaQuery_EJB_SF_Servlet.class, path = CONTEXT_ROOT + "/" + "TestCriteriaQuery_EJB_SF_Servlet"),
-                    @TestServlet(servlet = TestCriteriaQuery_EJB_SFEx_Servlet.class, path = CONTEXT_ROOT + "/" + "TestCriteriaQuery_EJB_SFEx_Servlet")
+                    @TestServlet(servlet = TestOLGH16686_EJB_SL_Servlet.class, path = CONTEXT_ROOT + "/" + "TestOLGH16686_EJB_SL_Servlet"),
+                    @TestServlet(servlet = TestOLGH16686_EJB_SF_Servlet.class, path = CONTEXT_ROOT + "/" + "TestOLGH16686_EJB_SF_Servlet"),
+                    @TestServlet(servlet = TestOLGH16686_EJB_SFEx_Servlet.class, path = CONTEXT_ROOT + "/" + "TestOLGH16686_EJB_SFEx_Servlet")
     })
     public static LibertyServer server;
 
@@ -76,7 +76,7 @@ public class JPA20CriteriaQuery_EJB extends JPAFATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         PrivHelper.generateCustomPolicy(server, FATSuite.JAXB_PERMS);
-        bannerStart(JPA20CriteriaQuery_EJB.class);
+        bannerStart(TestOLGH16686_EJB.class);
         timestart = System.currentTimeMillis();
 
         //Get driver name
@@ -103,24 +103,18 @@ public class JPA20CriteriaQuery_EJB extends JPAFATServletClient {
         }
         executeDDL(server, ddlSet, false);
 
-        ddlSet.clear();
-        for (String ddlName : populateSet) {
-            ddlSet.add(ddlName.replace("${dbvendor}", getDbVendor().name()));
-        }
-        executeDDL(server, ddlSet, false);
-
         setupTestApplication();
     }
 
     private static void setupTestApplication() throws Exception {
         JavaArchive ejbApp = ShrinkWrap.create(JavaArchive.class, appName + ".jar");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.fvt.criteriaquery.ejblocal");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.fvt.criteriaquery.model");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.fvt.criteriaquery.testlogic");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.olgh16686.ejblocal");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.olgh16686.model");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.olgh16686.testlogic");
         ShrinkHelper.addDirectory(ejbApp, RESOURCE_ROOT + appFolder + "/" + appName + ".jar");
 
         WebArchive webApp = ShrinkWrap.create(WebArchive.class, appName + ".war");
-        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.criteriaquery.ejb");
+        webApp.addPackages(true, "com.ibm.ws.jpa.olgh16686.ejb");
         ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + appFolder + "/" + appName + ".war");
 
         final JavaArchive testApiJar = buildTestAPIJar();
@@ -187,7 +181,7 @@ public class JPA20CriteriaQuery_EJB extends JPAFATServletClient {
             } catch (Throwable t) {
                 t.printStackTrace();
             }
-            bannerEnd(JPA20CriteriaQuery_EJB.class, timestart);
+            bannerEnd(TestOLGH16686_EJB.class, timestart);
         }
     }
 }

--- a/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/olgh/TestOLGH9018_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/olgh/TestOLGH9018_EJB.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa.tests.spec20;
+package com.ibm.ws.jpa.tests.spec20.tests.olgh;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -27,7 +27,11 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.Application;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
-import com.ibm.ws.jpa.example.web.TestExampleServlet;
+import com.ibm.ws.jpa.olgh9018.ejb.TestOLGH9018_EJB_SFEx_Servlet;
+import com.ibm.ws.jpa.olgh9018.ejb.TestOLGH9018_EJB_SF_Servlet;
+import com.ibm.ws.jpa.olgh9018.ejb.TestOLGH9018_EJB_SL_Servlet;
+import com.ibm.ws.jpa.tests.spec20.FATSuite;
+import com.ibm.ws.jpa.tests.spec20.JPAFATServletClient;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -42,28 +46,28 @@ import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-public class JPA20Example_WEB extends JPAFATServletClient {
-    private final static String CONTEXT_ROOT = "exampleWeb";
-    private final static String RESOURCE_ROOT = "test-applications/example/";
-    private final static String appFolder = "web";
-    private final static String appName = "exampleWeb";
+public class TestOLGH9018_EJB extends JPAFATServletClient {
+    private final static String CONTEXT_ROOT = "olgh9018Ejb";
+    private final static String RESOURCE_ROOT = "test-applications/olgh9018/";
+    private final static String appFolder = "ejb";
+    private final static String appName = "olgh9018Ejb";
     private final static String appNameEar = appName + ".ear";
 
     private final static Set<String> dropSet = new HashSet<String>();
     private final static Set<String> createSet = new HashSet<String>();
-    private final static Set<String> populateSet = new HashSet<String>();
 
     private static long timestart = 0;
 
     static {
-        dropSet.add("JPA20_EXAMPLE_DROP_${dbvendor}.ddl");
-        createSet.add("JPA20_EXAMPLE_CREATE_${dbvendor}.ddl");
-        populateSet.add("JPA20_EXAMPLE_POPULATE_${dbvendor}.ddl");
+        dropSet.add("OLGH9018_DROP_${dbvendor}.ddl");
+        createSet.add("OLGH9018_CREATE_${dbvendor}.ddl");
     }
 
     @Server("JPA20Server")
     @TestServlets({
-                    @TestServlet(servlet = TestExampleServlet.class, path = CONTEXT_ROOT + "/" + "TestExampleServlet")
+                    @TestServlet(servlet = TestOLGH9018_EJB_SL_Servlet.class, path = CONTEXT_ROOT + "/" + "TestOLGH9018_EJB_SL_Servlet"),
+                    @TestServlet(servlet = TestOLGH9018_EJB_SF_Servlet.class, path = CONTEXT_ROOT + "/" + "TestOLGH9018_EJB_SF_Servlet"),
+                    @TestServlet(servlet = TestOLGH9018_EJB_SFEx_Servlet.class, path = CONTEXT_ROOT + "/" + "TestOLGH9018_EJB_SFEx_Servlet")
     })
     public static LibertyServer server;
 
@@ -72,18 +76,8 @@ public class JPA20Example_WEB extends JPAFATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         PrivHelper.generateCustomPolicy(server, FATSuite.JAXB_PERMS);
-        bannerStart(JPA20Example_WEB.class);
+        bannerStart(TestOLGH9018_EJB.class);
         timestart = System.currentTimeMillis();
-
-        int appStartTimeout = server.getAppStartTimeout();
-        if (appStartTimeout < (120 * 1000)) {
-            server.setAppStartTimeout(120 * 1000);
-        }
-
-        int configUpdateTimeout = server.getConfigUpdateTimeout();
-        if (configUpdateTimeout < (120 * 1000)) {
-            server.setConfigUpdateTimeout(120 * 1000);
-        }
 
         //Get driver name
         server.addEnvVar("DB_DRIVER", DatabaseContainerType.valueOf(testContainer).getDriverName());
@@ -97,8 +91,6 @@ public class JPA20Example_WEB extends JPAFATServletClient {
 
         final Set<String> ddlSet = new HashSet<String>();
 
-        System.out.println("TestExample_Web Setting up database tables...");
-
         ddlSet.clear();
         for (String ddlName : dropSet) {
             ddlSet.add(ddlName.replace("${dbvendor}", getDbVendor().name()));
@@ -111,25 +103,24 @@ public class JPA20Example_WEB extends JPAFATServletClient {
         }
         executeDDL(server, ddlSet, false);
 
-//        ddlSet.clear();
-//        for (String ddlName : populateSet) {
-//            ddlSet.add(ddlName.replace("${dbvendor}", getDbVendor().name()));
-//        }
-//        executeDDL(server, ddlSet, false);
-
         setupTestApplication();
     }
 
     private static void setupTestApplication() throws Exception {
+        JavaArchive ejbApp = ShrinkWrap.create(JavaArchive.class, appName + ".jar");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.olgh9018.ejblocal");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.olgh9018.model");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.olgh9018.testlogic");
+        ShrinkHelper.addDirectory(ejbApp, RESOURCE_ROOT + appFolder + "/" + appName + ".jar");
+
         WebArchive webApp = ShrinkWrap.create(WebArchive.class, appName + ".war");
-        webApp.addPackages(true, "com.ibm.ws.jpa.example.model");
-        webApp.addPackages(true, "com.ibm.ws.jpa.example.testlogic");
-        webApp.addPackages(true, "com.ibm.ws.jpa.example.web");
+        webApp.addPackages(true, "com.ibm.ws.jpa.olgh9018.ejb");
         ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + appFolder + "/" + appName + ".war");
 
         final JavaArchive testApiJar = buildTestAPIJar();
 
         final EnterpriseArchive app = ShrinkWrap.create(EnterpriseArchive.class, appNameEar);
+        app.addAsModule(ejbApp);
         app.addAsModule(webApp);
         app.addAsLibrary(testApiJar);
         ShrinkHelper.addDirectory(app, RESOURCE_ROOT + appFolder, new org.jboss.shrinkwrap.api.Filter<ArchivePath>() {
@@ -149,11 +140,6 @@ public class JPA20Example_WEB extends JPAFATServletClient {
         Application appRecord = new Application();
         appRecord.setLocation(appNameEar);
         appRecord.setName(appName);
-//        ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
-//        ClassloaderElement loader = new ClassloaderElement();
-//        loader.setApiTypeVisibility("+third-party");
-////        loader.getCommonLibraryRefs().add("HibernateLib");
-//        cel.add(loader);
 
         server.setMarkToEndOfLog();
         ServerConfiguration sc = server.getServerConfiguration();
@@ -195,7 +181,7 @@ public class JPA20Example_WEB extends JPAFATServletClient {
             } catch (Throwable t) {
                 t.printStackTrace();
             }
-            bannerEnd(JPA20Example_WEB.class, timestart);
+            bannerEnd(TestOLGH9018_EJB.class, timestart);
         }
     }
 }

--- a/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/olgh/TestOLGH9018_WEB.java
+++ b/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/olgh/TestOLGH9018_WEB.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa.tests.spec20;
+package com.ibm.ws.jpa.tests.spec20.tests.olgh;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -27,7 +27,9 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.Application;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
-import com.ibm.ws.jpa.fvt.derivedidentity.tests.web.DerivedIdentityWebTestServlet;
+import com.ibm.ws.jpa.olgh9018.web.TestOLGH9018Servlet;
+import com.ibm.ws.jpa.tests.spec20.FATSuite;
+import com.ibm.ws.jpa.tests.spec20.JPAFATServletClient;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -42,11 +44,11 @@ import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-public class JPA20DerivedIdentity_WEB extends JPAFATServletClient {
-    private final static String CONTEXT_ROOT = "DerivedIdentityWeb";
-    private final static String RESOURCE_ROOT = "test-applications/derivedIdentity/";
-    private final static String appFolder = "apps/DerivedIdentityWeb.ear";
-    private final static String appName = "DerivedIdentityWeb";
+public class TestOLGH9018_WEB extends JPAFATServletClient {
+    private final static String CONTEXT_ROOT = "olgh9018Web";
+    private final static String RESOURCE_ROOT = "test-applications/olgh9018/";
+    private final static String appFolder = "web";
+    private final static String appName = "olgh9018Web";
     private final static String appNameEar = appName + ".ear";
 
     private final static Set<String> dropSet = new HashSet<String>();
@@ -55,13 +57,13 @@ public class JPA20DerivedIdentity_WEB extends JPAFATServletClient {
     private static long timestart = 0;
 
     static {
-        dropSet.add("JPA20_DERIVEDIDENTITY_DROP_${dbvendor}.ddl");
-        createSet.add("JPA20_DERIVEDIDENTITY_CREATE_${dbvendor}.ddl");
+        dropSet.add("OLGH9018_DROP_${dbvendor}.ddl");
+        createSet.add("OLGH9018_CREATE_${dbvendor}.ddl");
     }
 
-    @Server("JPA20DerivedIdentityWebServer")
+    @Server("JPA20Server")
     @TestServlets({
-                    @TestServlet(servlet = DerivedIdentityWebTestServlet.class, path = CONTEXT_ROOT + "/" + "DerivedIdentityWebTestServlet")
+                    @TestServlet(servlet = TestOLGH9018Servlet.class, path = CONTEXT_ROOT + "/" + "TestOLGH9018Servlet")
     })
     public static LibertyServer server;
 
@@ -70,18 +72,8 @@ public class JPA20DerivedIdentity_WEB extends JPAFATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         PrivHelper.generateCustomPolicy(server, FATSuite.JAXB_PERMS);
-        bannerStart(JPA20DerivedIdentity_WEB.class);
+        bannerStart(TestOLGH9018_WEB.class);
         timestart = System.currentTimeMillis();
-
-        int appStartTimeout = server.getAppStartTimeout();
-        if (appStartTimeout < (120 * 1000)) {
-            server.setAppStartTimeout(120 * 1000);
-        }
-
-        int configUpdateTimeout = server.getConfigUpdateTimeout();
-        if (configUpdateTimeout < (120 * 1000)) {
-            server.setConfigUpdateTimeout(120 * 1000);
-        }
 
         //Get driver name
         server.addEnvVar("DB_DRIVER", DatabaseContainerType.valueOf(testContainer).getDriverName());
@@ -95,8 +87,6 @@ public class JPA20DerivedIdentity_WEB extends JPAFATServletClient {
 
         final Set<String> ddlSet = new HashSet<String>();
 
-        System.out.println("Setting up database tables...");
-
         ddlSet.clear();
         for (String ddlName : dropSet) {
             ddlSet.add(ddlName.replace("${dbvendor}", getDbVendor().name()));
@@ -109,20 +99,14 @@ public class JPA20DerivedIdentity_WEB extends JPAFATServletClient {
         }
         executeDDL(server, ddlSet, false);
 
-//        ddlSet.clear();
-//        for (String ddlName : populateSet) {
-//            ddlSet.add(ddlName.replace("${dbvendor}", getDbVendor().name()));
-//        }
-//        executeDDL(server, ddlSet, false);
-
         setupTestApplication();
     }
 
     private static void setupTestApplication() throws Exception {
         WebArchive webApp = ShrinkWrap.create(WebArchive.class, appName + ".war");
-        webApp.addPackages(true, "com.ibm.ws.jpa.commonentities.datamodel");
-        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.derivedidentity.testlogic");
-        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.derivedidentity.tests.web");
+        webApp.addPackages(true, "com.ibm.ws.jpa.olgh9018.model");
+        webApp.addPackages(true, "com.ibm.ws.jpa.olgh9018.testlogic");
+        webApp.addPackages(true, "com.ibm.ws.jpa.olgh9018.web");
         ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + appFolder + "/" + appName + ".war");
 
         final JavaArchive testApiJar = buildTestAPIJar();
@@ -188,7 +172,7 @@ public class JPA20DerivedIdentity_WEB extends JPAFATServletClient {
             } catch (Throwable t) {
                 t.printStackTrace();
             }
-            bannerEnd(JPA20DerivedIdentity_WEB.class, timestart);
+            bannerEnd(TestOLGH9018_WEB.class, timestart);
         }
     }
 }

--- a/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/olgh/TestOLGH9339_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.spec20_fat/fat/src/com/ibm/ws/jpa/tests/spec20/tests/olgh/TestOLGH9339_EJB.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa.tests.spec20;
+package com.ibm.ws.jpa.tests.spec20.tests.olgh;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -27,9 +27,11 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.Application;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
-import com.ibm.ws.jpa.example.ejb.TestExample_EJB_SFEx_Servlet;
-import com.ibm.ws.jpa.example.ejb.TestExample_EJB_SF_Servlet;
-import com.ibm.ws.jpa.example.ejb.TestExample_EJB_SL_Servlet;
+import com.ibm.ws.jpa.olgh9339.ejb.TestOLGH9339_EJB_SFEx_Servlet;
+import com.ibm.ws.jpa.olgh9339.ejb.TestOLGH9339_EJB_SF_Servlet;
+import com.ibm.ws.jpa.olgh9339.ejb.TestOLGH9339_EJB_SL_Servlet;
+import com.ibm.ws.jpa.tests.spec20.FATSuite;
+import com.ibm.ws.jpa.tests.spec20.JPAFATServletClient;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -44,11 +46,11 @@ import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-public class JPA20Example_EJB extends JPAFATServletClient {
-    private final static String CONTEXT_ROOT = "exampleEjb";
-    private final static String RESOURCE_ROOT = "test-applications/example/";
+public class TestOLGH9339_EJB extends JPAFATServletClient {
+    private final static String CONTEXT_ROOT = "olgh9339Ejb";
+    private final static String RESOURCE_ROOT = "test-applications/olgh9339/";
     private final static String appFolder = "ejb";
-    private final static String appName = "exampleEjb";
+    private final static String appName = "olgh9339Ejb";
     private final static String appNameEar = appName + ".ear";
 
     private final static Set<String> dropSet = new HashSet<String>();
@@ -58,16 +60,16 @@ public class JPA20Example_EJB extends JPAFATServletClient {
     private static long timestart = 0;
 
     static {
-        dropSet.add("JPA20_EXAMPLE_DROP_${dbvendor}.ddl");
-        createSet.add("JPA20_EXAMPLE_CREATE_${dbvendor}.ddl");
-        populateSet.add("JPA20_EXAMPLE_POPULATE_${dbvendor}.ddl");
+        dropSet.add("OLGH9339_DROP_${dbvendor}.ddl");
+        createSet.add("OLGH9339_CREATE_${dbvendor}.ddl");
+        populateSet.add("OLGH9339_POPULATE_${dbvendor}.ddl");
     }
 
     @Server("JPA20Server")
     @TestServlets({
-                    @TestServlet(servlet = TestExample_EJB_SL_Servlet.class, path = CONTEXT_ROOT + "/" + "TestExample_EJB_SL_Servlet"),
-                    @TestServlet(servlet = TestExample_EJB_SF_Servlet.class, path = CONTEXT_ROOT + "/" + "TestExample_EJB_SF_Servlet"),
-                    @TestServlet(servlet = TestExample_EJB_SFEx_Servlet.class, path = CONTEXT_ROOT + "/" + "TestExample_EJB_SFEx_Servlet")
+                    @TestServlet(servlet = TestOLGH9339_EJB_SL_Servlet.class, path = CONTEXT_ROOT + "/" + "TestOLGH9339_EJB_SL_Servlet"),
+                    @TestServlet(servlet = TestOLGH9339_EJB_SF_Servlet.class, path = CONTEXT_ROOT + "/" + "TestOLGH9339_EJB_SF_Servlet"),
+                    @TestServlet(servlet = TestOLGH9339_EJB_SFEx_Servlet.class, path = CONTEXT_ROOT + "/" + "TestOLGH9339_EJB_SFEx_Servlet")
     })
     public static LibertyServer server;
 
@@ -76,18 +78,8 @@ public class JPA20Example_EJB extends JPAFATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         PrivHelper.generateCustomPolicy(server, FATSuite.JAXB_PERMS);
-        bannerStart(JPA20Example_EJB.class);
+        bannerStart(TestOLGH9339_EJB.class);
         timestart = System.currentTimeMillis();
-
-        int appStartTimeout = server.getAppStartTimeout();
-        if (appStartTimeout < (120 * 1000)) {
-            server.setAppStartTimeout(120 * 1000);
-        }
-
-        int configUpdateTimeout = server.getConfigUpdateTimeout();
-        if (configUpdateTimeout < (120 * 1000)) {
-            server.setConfigUpdateTimeout(120 * 1000);
-        }
 
         //Get driver name
         server.addEnvVar("DB_DRIVER", DatabaseContainerType.valueOf(testContainer).getDriverName());
@@ -101,8 +93,6 @@ public class JPA20Example_EJB extends JPAFATServletClient {
 
         final Set<String> ddlSet = new HashSet<String>();
 
-        System.out.println("TestExample_EJB Setting up database tables...");
-
         ddlSet.clear();
         for (String ddlName : dropSet) {
             ddlSet.add(ddlName.replace("${dbvendor}", getDbVendor().name()));
@@ -115,24 +105,24 @@ public class JPA20Example_EJB extends JPAFATServletClient {
         }
         executeDDL(server, ddlSet, false);
 
-//        ddlSet.clear();
-//        for (String ddlName : populateSet) {
-//            ddlSet.add(ddlName.replace("${dbvendor}", getDbVendor().name()));
-//        }
-//        executeDDL(server, ddlSet, false);
+        ddlSet.clear();
+        for (String ddlName : populateSet) {
+            ddlSet.add(ddlName.replace("${dbvendor}", getDbVendor().name()));
+        }
+        executeDDL(server, ddlSet, false);
 
         setupTestApplication();
     }
 
     private static void setupTestApplication() throws Exception {
         JavaArchive ejbApp = ShrinkWrap.create(JavaArchive.class, appName + ".jar");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.example.ejblocal");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.example.model");
-        ejbApp.addPackages(true, "com.ibm.ws.jpa.example.testlogic");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.olgh9339.ejblocal");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.olgh9339.model");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.olgh9339.testlogic");
         ShrinkHelper.addDirectory(ejbApp, RESOURCE_ROOT + appFolder + "/" + appName + ".jar");
 
         WebArchive webApp = ShrinkWrap.create(WebArchive.class, appName + ".war");
-        webApp.addPackages(true, "com.ibm.ws.jpa.example.ejb");
+        webApp.addPackages(true, "com.ibm.ws.jpa.olgh9339.ejb");
         ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + appFolder + "/" + appName + ".war");
 
         final JavaArchive testApiJar = buildTestAPIJar();
@@ -158,11 +148,6 @@ public class JPA20Example_EJB extends JPAFATServletClient {
         Application appRecord = new Application();
         appRecord.setLocation(appNameEar);
         appRecord.setName(appName);
-//        ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
-//        ClassloaderElement loader = new ClassloaderElement();
-//        loader.setApiTypeVisibility("+third-party");
-////        loader.getCommonLibraryRefs().add("HibernateLib");
-//        cel.add(loader);
 
         server.setMarkToEndOfLog();
         ServerConfiguration sc = server.getServerConfiguration();
@@ -204,7 +189,7 @@ public class JPA20Example_EJB extends JPAFATServletClient {
             } catch (Throwable t) {
                 t.printStackTrace();
             }
-            bannerEnd(JPA20Example_EJB.class, timestart);
+            bannerEnd(TestOLGH9339_EJB.class, timestart);
         }
     }
 }


### PR DESCRIPTION
1) Fixing build break where the `com.ibm.ws.jpa.tests.spec10.embeddable_fat` is running 0 tests on some OpenLiberty builds, as it relies on EE6 features.
2) Add `com.ibm.ws.jpa.tests.eclipselink.query_fat.common` to the test categories QUARANTINE file like all the other JPA FAT common projects need to
3) Fix minor issue in `com.ibm.ws.jpa.tests.spec20_fat` where the OLGH tests had been disabled in the past and need to be re-enabled. Also, renamed the packages to be more inline with other FAT framework