### PR TITLE
Fix chkpii issues

### DIFF
--- a/dev/io.openliberty.persistence.3.1.thirdparty/resources/org/eclipse/persistence/exceptions/i18n/BeanValidationExceptionResource.nlsprops
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/resources/org/eclipse/persistence/exceptions/i18n/BeanValidationExceptionResource.nlsprops
@@ -31,8 +31,7 @@
 
 7501=Bean validation mode on {0}marshaller is set to an unsupported value, "{1}".
 
-7510=Constraints violated on {0}marshalled bean:
-{1}{2}
+7510=Constraints violated on {0}marshalled bean: {1}{2}
 
 7525=Cannot parse the {0} property, because it is both annotated with @NotNull and has the "xs:nillable=true" attribute.
 

--- a/dev/io.openliberty.persistence.3.1.thirdparty/resources/org/eclipse/persistence/exceptions/i18n/JSONExceptionResource.nlsprops
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/resources/org/eclipse/persistence/exceptions/i18n/JSONExceptionResource.nlsprops
@@ -27,5 +27,5 @@
 #   (single quote must be coded as one single quote '). 
 #
 # -------------------------------------------------------------------------------------------------
-60001=Input JSON document is invalid or doesn't match target object graph.
+60001=Input JSON document is invalid or doesn''t match target object graph.
 

--- a/dev/io.openliberty.persistence.3.1.thirdparty/resources/org/eclipse/persistence/exceptions/i18n/ValidationExceptionResource.nlsprops
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/resources/org/eclipse/persistence/exceptions/i18n/ValidationExceptionResource.nlsprops
@@ -605,7 +605,7 @@
 
 7342=The specified boolean value [{0}] for setting allow native sql queries is invalid, the value must either be "true" or "false".
 
-7343=Multiple VPD identifiers (tenant discriminator context property) have been specified. Entity [{1}] uses [{0}] and Entity [{3]} uses [{2}]. When using a Multitenant VPD strategy, there can only be one tenant discriminator column per entity and its context property must be consistent across all the Multitenant VPD entities.
+7343=Multiple VPD identifiers (tenant discriminator context property) have been specified. Entity [{1}] uses [{0}] and Entity [{3}] uses [{2}]. When using a Multitenant VPD strategy, there can only be one tenant discriminator column per entity and its context property must be consistent across all the Multitenant VPD entities.
 
 7344=VPD (connections and DDL generation) is not supported for the platform: [{0}].
 


### PR DESCRIPTION
The errors are

1. /io.openliberty.persistence.3.1.thirdparty/org/eclipse/persistence/exceptions/i18n/BeanValidationExceptionResource.nlsprops

following line, {1}{2} in a separated line, no line connection with line above, whether it can be contact with previous line? Otherwises, GP won't handle it correctly.
7510=Constraints violated on {0}marshalled bean:
{1}{2} 

`Fix to move it onto the same line`

2. [io.openliberty.persistence.3.1.thirdparty/org/eclipse/persistence/exceptions/i18n/ValidationExceptionResource.nlsprops](https://console.pipeline.g11n.ibm.com/projectdetail.wss?projectID=webfm.webfmapp---io.openliberty.persistence.3.1.thirdparty_org_eclipse_persistence_exceptions_i18n_ValidationExceptionResource.nlsprops&gpToken=2900916385497721419) the line "Multiple VPD identifiers (tenant discriminator context property) have been specified. Entity [{1}] uses [{0}] and Entity [{3]} uses [{2}]. When using a Multitenant VPD strategy, there can only be one tenant discriminator column per entity and its context property must be consistent across all the Multitenant VPD entities."
with error [{3]}

`Fix bracket ordering`

3. /io.openliberty.persistence.3.1.thirdparty/org/eclipse/persistence/exceptions/i18n/JSONExceptionResource.nlsprops
for the line with key 60001
"Input JSON document is invalid or doesn't match target object graph." should be "Input JSON document is invalid or doesn't match target object graph."

`Fix is to add a 2nd quote - required when MESSAGE_FORMAT is set to NLS_MESSAGEFORMAT_ALL whichi requires all quotes to be doubled in messages` 