### PR TITLE
Add appName LogRecordContext registration to the app manager bundle

### DIFF
--- a/dev/com.ibm.ws.collector.manager/bnd.bnd
+++ b/dev/com.ibm.ws.collector.manager/bnd.bnd
@@ -37,14 +37,9 @@ Import-Package: com.ibm.ejs.ras, \
                 com.ibm.wsspi.collector.manager, \
                 com.ibm.ws.collector.manager.buffer, \
                 com.ibm.websphere.logging, \
-                com.ibm.websphere.logging.hpel, \
                 com.ibm.tools.attach, \
                 org.osgi.service.cm, \
-                com.ibm.wsspi.logging, \
-                com.ibm.ws.threadContext;resolution:=dynamic, \
-                com.ibm.ws.runtime.metadata;resolution:=dynamic, \
-                com.ibm.websphere.csi;resolution:=dynamic, \
-                com.ibm.ws.kernel.productinfo
+                com.ibm.wsspi.logging
 
 Service-Component:\
     com.ibm.ws.collector.manager; \
@@ -77,10 +72,7 @@ Include-Resource: \
 	com.ibm.ws.transport.http;version=latest,\
 	com.ibm.ws.logging;version=latest,\
 	com.ibm.ws.logging.core;version=latest,\
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-	com.ibm.ws.container.service;version=latest,\
-	com.ibm.ws.container.service.compat;version=latest,\
-	com.ibm.ws.kernel.boot.core;version=latest
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.collector.manager/src/com/ibm/ws/collector/manager/internal/CollectorManagerImpl.java
+++ b/dev/com.ibm.ws.collector.manager/src/com/ibm/ws/collector/manager/internal/CollectorManagerImpl.java
@@ -27,11 +27,9 @@ import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.cm.ConfigurationAdmin;
 
-import com.ibm.websphere.logging.hpel.LogRecordContext;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.collector.manager.buffer.BufferManagerImpl;
-import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.ws.logging.collector.CollectorConstants;
 import com.ibm.wsspi.collector.manager.BufferManager;
 import com.ibm.wsspi.collector.manager.CollectorManager;
@@ -60,28 +58,15 @@ public class CollectorManagerImpl implements CollectorManager {
     /* Map of bound handlers */
     private final Map<String, HandlerManager> handlerMgrs = new HashMap<String, HandlerManager>();
 
-    /* Name to use as an extension key for application name */
-    private final static String APPNAME_KEY = "appName";
-
-    /* LogRecordContext callback to retrieve application name */
-    private final static LogRecordContext.Extension APPNAME_CALLBACK = getAppNameCallbackLRCExt();
-
     protected void activate(Map<String, Object> configuration) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
             Tr.event(tc, "Activating " + this);
-        }
-        if (ProductInfo.getBetaEdition()) {
-            LogRecordContext.registerExtension(APPNAME_KEY, APPNAME_CALLBACK);
         }
     }
 
     protected void deactivate(int reason) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
             Tr.event(tc, " Deactivating " + this, " reason = " + reason);
-        }
-
-        if (ProductInfo.getBetaEdition()) {
-            LogRecordContext.unregisterExtension(APPNAME_KEY);
         }
 
         //Unregister all BufferManagers created. This will also deactivate sources.
@@ -434,27 +419,5 @@ public class CollectorManagerImpl implements CollectorManager {
 
     private synchronized void retrieveBundleContext() {
         bundleContext = FrameworkUtil.getBundle(this.getClass()).getBundleContext();
-    }
-
-    private static LogRecordContext.Extension getAppNameCallbackLRCExt() {
-        LogRecordContext.Extension appNameCBExt = null;
-
-        if (ProductInfo.getBetaEdition()) {
-            appNameCBExt = new LogRecordContext.Extension() {
-                @Override
-                public String getValue() {
-                    com.ibm.ws.runtime.metadata.ComponentMetaData metaData = com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
-                    if (metaData != null) {
-                        com.ibm.websphere.csi.J2EEName name = metaData.getJ2EEName();
-                        if (name != null) {
-                            return name.getApplication();
-                        }
-                    }
-                    return null;
-                }
-            };
-
-        }
-        return appNameCBExt;
     }
 }

--- a/dev/com.ibm.ws.logging.json_fat/publish/servers/com.ibm.ws.logging.json.AppNameExtensionServer/jvm.options
+++ b/dev/com.ibm.ws.logging.json_fat/publish/servers/com.ibm.ws.logging.json.AppNameExtensionServer/jvm.options
@@ -1,1 +1,0 @@
--Dcom.ibm.ws.beta.edition=true


### PR DESCRIPTION
- Removes the Beta guard for the https://github.com/OpenLiberty/open-liberty/issues/19641 feature.
- Also, moves the LogRecordContext registration of the appName to the ApplicationManager class, under the app manager bundle from the collector manager bundle, as the bundle will only get activated when applications are present, thus elminating classloading issues for the `com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl` bundle, since its is not part of the kernel.