### PR TITLE
Adjust waiting for loginmethod to start on DynamicAnnotationsTest

### DIFF
--- a/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/fat/src/com/ibm/ws/webcontainer/security/jacc15/fat/DynamicAnnotationsTest.java
+++ b/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/fat/src/com/ibm/ws/webcontainer/security/jacc15/fat/DynamicAnnotationsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 IBM Corporation and others.
+ * Copyright (c) 2011, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -98,8 +98,6 @@ public class DynamicAnnotationsTest {
          */
         Assume.assumeTrue(!LDAPUtils.USE_LOCAL_LDAP_SERVER);
 
-        server.addInstalledAppForValidation("loginmethod");
-
         JACCFatUtils.installJaccUserFeature(server);
         JACCFatUtils.transformApps(server, "loginmethod.ear");
 
@@ -108,8 +106,12 @@ public class DynamicAnnotationsTest {
                       server.waitForStringInLog("CWWKF0008I"));
         assertNotNull("Security service did not report it was ready",
                       server.waitForStringInLog("CWWKS0008I"));
-        assertNotNull("The application did not report is was started",
-                      server.waitForStringInLog("CWWKZ0001I"));
+        /*
+         * Max wait time based on Windows test failure sample: CWWKZ0001I: Application loginmethod started in 290.026 seconds.
+         */
+        Log.info(thisClass, "setup", "Waiting for loginmethod to start: CWWKZ0001I: Application loginmethod started");
+        assertNotNull("The applicaiton loginmethod did not report as started, if this is a Windows run, may need more time to complete",
+                      server.waitForStringInLog("CWWKZ0001I: Application loginmethod started", 300000));
 
         assertNotNull("JACC feature did not report it was starting", server.waitForStringInLog("CWWKS2850I"));
         assertNotNull("JACC feature did not report it was ready", server.waitForStringInLog("CWWKS2851I"));


### PR DESCRIPTION
On some Windows runs, we need a longer time waiting for the loginmethod app to start in `DynamicAnnotationsTest`. Did a similar update to `StaticAnnotationsTest`.

RTC 290912