### PR TITLE
Added generation of Open Liberty fixpack swid tags

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -89,18 +89,31 @@ task copySwidTagToBuildImage (type:Copy) {
     dependsOn jar
     from project.file('publish')
     into project.file('wlp/lib/versions/tags')
-    include 'ibm.com_Open_Liberty*.swidtag'
+    include 'ibm.com_Open_Liberty-22.*.swidtag'
     filter(ReplaceTokens,
-           tokens: [ VERSION: bnd.libertyRelease ])
+           tokens: [VERSION: bnd.libertyRelease ])
 }
 
-assemble {
+task copySwidFixpackTagToBuildImage (type:Copy) {
+    dependsOn jar
+    from project.file('publish')
+    into project.file('wlp/lib/versions/tags')
+    include 'ibm.com_Open_Liberty-release.swidtag'
+    rename { filename ->
+        filename.replace("release", bnd.libertyRelease)
+    }
+    filter(ReplaceTokens,
+           tokens: [PRODUCT_VERSION: bnd.libertyRelease, PRODUCT_EDITION: bnd.productEdition])
+}
+
+assemble { 
     dependsOn copyPropertiesToBuildImage
     dependsOn addServiceFingerprint
     dependsOn copyReadmeToBuildImage
     dependsOn copyBetaLicenseToBuildImage
     dependsOn copyLicenseToBuildImage
     dependsOn copySwidTagToBuildImage
+    dependsOn copySwidFixpackTagToBuildImage
 }
 
 File packageDir = new File(project.buildDir, 'openliberty')
@@ -884,4 +897,4 @@ if (isAutomatedBuild && !isIFIXBuild) {
         }
         publish.dependsOn buildOsNativePackages
     }
-}
+} 

--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -89,21 +89,21 @@ task copySwidTagToBuildImage (type:Copy) {
     dependsOn jar
     from project.file('publish')
     into project.file('wlp/lib/versions/tags')
-    include 'ibm.com_Open_Liberty-22.*.swidtag'
+    include 'ibm.com_Open_Liberty-*.swidtag'
     filter(ReplaceTokens,
-           tokens: [VERSION: bnd.libertyRelease ])
+           tokens: [ VERSION: bnd.libertyRelease ])
 }
 
 task copySwidFixpackTagToBuildImage (type:Copy) {
     dependsOn jar
     from project.file('publish')
     into project.file('wlp/lib/versions/tags')
-    include 'ibm.com_Open_Liberty-release.swidtag'
+    include 'ibm.com_Open_Liberty_release.swidtag'
     rename { filename ->
-        filename.replace("release", bnd.libertyRelease)
+        filename.replace("_release", "-" + bnd.libertyRelease)
     }
     filter(ReplaceTokens,
-           tokens: [PRODUCT_VERSION: bnd.libertyRelease, PRODUCT_EDITION: bnd.productEdition])
+           tokens: [PRODUCT_VERSION: bnd.libertyRelease])
 }
 
 assemble { 

--- a/dev/build.image/publish/ibm.com_Open_Liberty-release.swidtag
+++ b/dev/build.image/publish/ibm.com_Open_Liberty-release.swidtag
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SoftwareIdentity name="Open Liberty" patch="true" tagId="ibm.com-0ca5af184810448c851299b2c615ebb6-22.0.0" version="@PRODUCT_VERSION@" versionScheme="multipartnumeric" xml:lang="en" xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.iso.org/iso/19770/-2/2015-current/schema.xsd schema.xsd">
+    <Meta persistentId="0ca5af184810448c851299b2c615ebb6"/>
+    <Meta generator="4-1-20210113"/>
+    <Meta revision="@PRODUCT_EDITION@"/>
+    <Link href="swid:ibm.com-0ca5af184810448c851299b2c615ebb6-22.0.0" rel="ancestor"/>
+    <Entity name="IBM" regid="ibm.com" role="licensor tagCreator softwareCreatorXX"/>
+</SoftwareIdentity>

--- a/dev/build.image/publish/ibm.com_Open_Liberty_release.swidtag
+++ b/dev/build.image/publish/ibm.com_Open_Liberty_release.swidtag
@@ -2,7 +2,7 @@
 <SoftwareIdentity name="Open Liberty" patch="true" tagId="ibm.com-0ca5af184810448c851299b2c615ebb6-22.0.0" version="@PRODUCT_VERSION@" versionScheme="multipartnumeric" xml:lang="en" xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.iso.org/iso/19770/-2/2015-current/schema.xsd schema.xsd">
     <Meta persistentId="0ca5af184810448c851299b2c615ebb6"/>
     <Meta generator="4-1-20210113"/>
-    <Meta revision="@PRODUCT_EDITION@"/>
+    <Meta revision="@PRODUCT_VERSION@"/>
     <Link href="swid:ibm.com-0ca5af184810448c851299b2c615ebb6-22.0.0" rel="ancestor"/>
-    <Entity name="IBM" regid="ibm.com" role="licensor tagCreator softwareCreatorXX"/>
+    <Entity name="IBM" regid="ibm.com" role="licensor tagCreator softwareCreator"/>
 </SoftwareIdentity>


### PR DESCRIPTION
When upgrading Open Liberty to Websphere Liberty, the software identification tag for Open Liberty remains as an embedded product. But only the product tag remains, when swid tags are supposed to be in pairs of both a product tag and a fixpack tag.

In this PR, I made a new hardcopy file template (ibm.com_Open_Liberty-release.swidtag) for the fixpack swid tag, and added a new gradle task (copySwidFixpackTagToBuildImage) in build.image that copies over, renames, and generates a dynamic fixpack swid tag based on the template. for [#26345](https://github.ibm.com/websphere/WS-CD-Open/issues/26345)

