### PR TITLE
Use UnprotectedResourceService interface for OIDC back-channel logout

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/bnd.bnd
+++ b/dev/com.ibm.ws.security.openidconnect.server/bnd.bnd
@@ -31,7 +31,8 @@ WS-TraceGroup: \
 # Append ";provide:=true" if this bundle also provides an implementation
 # for the exported API.
 
--dsannotations: com.ibm.ws.security.openidconnect.web.OidcEndpointServices
+-dsannotations: com.ibm.ws.security.openidconnect.web.OidcEndpointServices, \
+    io.openliberty.security.openidconnect.backchannellogout.BackchannelLogoutService
 -dsannotations-inherit: true
 
 instrument.classesExcludes: com/ibm/ws/security/openidconnect/server/internal/resources/*.class

--- a/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutService.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutService.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.openidconnect.backchannellogout;
+
+import java.util.Iterator;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.security.oauth20.util.OIDCConstants;
+import com.ibm.ws.security.oauth20.web.OAuth20Request.EndpointType;
+import com.ibm.ws.webcontainer.security.UnprotectedResourceService;
+import com.ibm.ws.webcontainer.security.openidconnect.OidcServerConfig;
+import com.ibm.wsspi.kernel.service.utils.ConcurrentServiceReferenceSet;
+import com.ibm.wsspi.kernel.service.utils.ServiceAndServiceReferencePair;
+
+@Component(service = UnprotectedResourceService.class)
+public class BackchannelLogoutService implements UnprotectedResourceService {
+
+    private static TraceComponent tc = Tr.register(BackchannelLogoutService.class);
+
+    private static final ConcurrentServiceReferenceSet<OidcServerConfig> oidcServerConfigRef = new ConcurrentServiceReferenceSet<OidcServerConfig>("oidcServerConfigService");
+
+    @Reference(name = "oidcServerConfigService", service = OidcServerConfig.class, policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MULTIPLE)
+    protected void setOidcClientConfigService(ServiceReference<OidcServerConfig> reference) {
+        oidcServerConfigRef.addReference(reference);
+    }
+
+    protected void unsetOidcClientConfigService(ServiceReference<OidcServerConfig> reference) {
+        oidcServerConfigRef.removeReference(reference);
+    }
+
+    public void activate(ComponentContext cc) {
+        oidcServerConfigRef.activate(cc);
+    }
+
+    public void deactivate(ComponentContext cc) {
+        oidcServerConfigRef.deactivate(cc);
+    }
+
+    @Override
+    public boolean isAuthenticationRequired(HttpServletRequest request) {
+        // TODO
+        return false;
+    }
+
+    @Override
+    public boolean postLogout(HttpServletRequest request, HttpServletResponse response) {
+        // TODO
+        return true;
+    }
+
+    @Override
+    public boolean logout(HttpServletRequest request, HttpServletResponse response, String userName) {
+        if (userName == null || userName.isEmpty()) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "The userName is null or empty, so logout will not be performed.");
+            }
+            return false;
+        }
+        String requestUri = request.getRequestURI();
+        OidcServerConfig oidcServerConfig = getMatchingConfig(requestUri);
+        if (oidcServerConfig == null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Failed to find a matching OIDC provider for the request sent to [" + requestUri + "]");
+            }
+            return false;
+        }
+        String idTokenString = request.getParameter(OIDCConstants.OIDC_LOGOUT_ID_TOKEN_HINT);
+
+        sendBackchannelLogoutRequests(request, oidcServerConfig, userName, idTokenString);
+        return true;
+    }
+
+    private OidcServerConfig getMatchingConfig(String requestUri) {
+        Iterator<ServiceAndServiceReferencePair<OidcServerConfig>> servicesWithRefs = oidcServerConfigRef.getServicesWithReferences();
+        while (servicesWithRefs.hasNext()) {
+            ServiceAndServiceReferencePair<OidcServerConfig> configServiceAndRef = servicesWithRefs.next();
+            OidcServerConfig config = configServiceAndRef.getService();
+            String configId = config.getProviderId();
+            if (isEndpointThatMatchesConfig(requestUri, configId)) {
+                return config;
+            }
+        }
+        return null;
+    }
+
+    boolean isEndpointThatMatchesConfig(String requestUri, String providerId) {
+        return (requestUri.endsWith("/" + providerId + "/" + EndpointType.end_session.name())
+                || requestUri.endsWith("/" + providerId + "/" + EndpointType.logout.name()));
+    }
+
+    void sendBackchannelLogoutRequests(HttpServletRequest request, OidcServerConfig oidcServerConfig, String userName, String idTokenString) {
+        BackchannelLogoutRequestHelper bclRequestCreator = new BackchannelLogoutRequestHelper(request, oidcServerConfig);
+        bclRequestCreator.sendBackchannelLogoutRequests(userName, idTokenString);
+    }
+
+}

--- a/dev/com.ibm.ws.webcontainer.security.feature/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.security.feature/bnd.bnd
@@ -50,7 +50,7 @@ Service-Component: \
     locationAdmin=com.ibm.wsspi.kernel.service.location.WsLocationAdmin; \
     authenticatorFactory=com.ibm.ws.webcontainer.security.WebAuthenticatorFactory; \
     unauthenticatedSubjectService=com.ibm.ws.security.authentication.UnauthenticatedSubjectService; \
-    unprotectedResourceService='com.ibm.ws.webcontainer.security.UnprotectedResourceService(id=SAML20RequestTAI)'; \
+    unprotectedResourceService=com.ibm.ws.webcontainer.security.UnprotectedResourceService; \
     kernelProvisioner=com.ibm.ws.kernel.feature.FeatureProvisioner; \
     multiple:='interceptorService,webAuthenticator'; \
     greedy:='ssoAuthFilter,interceptorService,webAuthenticator,unprotectedResourceService,authenticatorFactory'; \

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/AuthenticateApi.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/AuthenticateApi.java
@@ -31,6 +31,7 @@ import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.websphere.security.audit.AuditEvent;
 import com.ibm.websphere.security.web.PasswordExpiredException;
 import com.ibm.websphere.security.web.UserRevokedException;
+import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.ws.kernel.security.thread.ThreadIdentityException;
 import com.ibm.ws.kernel.security.thread.ThreadIdentityManager;
 import com.ibm.ws.security.SecurityService;
@@ -39,6 +40,7 @@ import com.ibm.ws.security.authentication.AuthenticationException;
 import com.ibm.ws.security.authentication.AuthenticationService;
 import com.ibm.ws.security.authentication.UnauthenticatedSubjectService;
 import com.ibm.ws.security.authentication.cache.AuthCacheService;
+import com.ibm.ws.security.authentication.principals.WSPrincipal;
 import com.ibm.ws.security.authentication.utility.SubjectHelper;
 import com.ibm.ws.security.collaborator.CollaboratorUtils;
 import com.ibm.ws.security.context.SubjectManager;
@@ -186,8 +188,8 @@ public class AuthenticateApi {
      */
     public void logout(HttpServletRequest req, HttpServletResponse res, WebAppSecurityConfig config) throws ServletException {
         // logout when the unprotectedResourceService(s) do
-        logoutUnprotectedResourceServiceRef(req, res);
         createSubjectAndPushItOnThreadAsNeeded(req, res);
+        logoutUnprotectedResourceServiceRef(req, res);
 
         AuthenticationResult authResult = new AuthenticationResult(AuthResult.SUCCESS, subjectManager.getCallerSubject());
         JaspiService jaspiService = getJaspiService();
@@ -239,12 +241,30 @@ public class AuthenticateApi {
             if (!bInitUserName) {
                 bInitUserName = true;
                 userName = getSessionUserName(req, res);
+                if (userName == null) {
+                    userName = getUserNameFromCallerSubject();
+                }
             }
             UnprotectedResourceService service = unprotectedResourceServiceRef.getService(serviceId);
             boolean bLogout = service.logout(req, res, userName);
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(tc, "logout return " + bLogout + " on service " + service);
         }
+    }
+
+    String getUserNameFromCallerSubject() {
+        if (!ProductInfo.getBetaEdition()) {
+            return null;
+        }
+        Subject subject = subjectManager.getCallerSubject();
+        if (subject != null && !subjectHelper.isUnauthenticated(subject)) {
+            Set<WSPrincipal> wsPrincipals = subject.getPrincipals(WSPrincipal.class);
+            if (!wsPrincipals.isEmpty()) {
+                WSPrincipal principal = wsPrincipals.iterator().next();
+                return principal.getName();
+            }
+        }
+        return null;
     }
 
     void postLogout(HttpServletRequest req, HttpServletResponse res) {


### PR DESCRIPTION
Creates a `BackchannelLogoutService` class that extends `UnprotectedResourceService`. This will allow calls to `request.logout()` to also trigger OIDC back-channel logout requests.

Resolves #21377