### PR TITLE
Clean up common warnings that come out of gradle and eclipse builds for most / all projects.

### DIFF
--- a/dev/cnf/build.bnd
+++ b/dev/cnf/build.bnd
@@ -29,6 +29,12 @@ target-dir: ${if;${driver;gradle};build/libs;generated}
 -fixupmessages.nosrc: "bnd's src folder 'src' is not in the Eclipse build path";is:=ignore
 -fixupmessages.missingexport: "Used bundle version * for exported package";is:=error
 -fixupmessages.mrjar: Classes found in the wrong directory:*META-INF/versions
+-fixupmessages.transform: "Eclipse: The Bundle Symbolic * starts with the project name * but then does not end with the subbuilder name";is:=ignore, \
+  "Eclipse: The Bundle Symbolic * is a sub-bundle original.bnd but uses the project name";is:=ignore, \
+  "*: POM will not validate on Central due to missing Bundle-Developers header";is:=ignore, \
+  "Eclipse: The Bundle Symbolic Name* io.openliberty* start with the project name com.ibm.websphere.appserver.api*, which must be the project's directory *com.ibm.websphere.appserver.api* name";is:ignore
+-fixupmessages.nlsprops: "Unused -privatepackage instructions , no such package\\(s\\) on the class path: \\[*.resources*\\]";is:=ignore
+-fixupmessages.fatsubbundles: "Eclipse: The Bundle Symbolic Name * start with the project name *_fat, which must be the project's directory *_fat name";is:=ignore
 
 javac.source: 1.8
 javac.target: 1.8

--- a/dev/cnf/resources/bnd/bundle.props
+++ b/dev/cnf/resources/bnd/bundle.props
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -30,7 +30,7 @@ bFullVersion=${version;==;${bVersion}}.${libertyBundleMicroVersion}
 # and uses the RTC buildLabel for the qualifier. The "generated.build.id" file
 # (included above) will predefine the Build-Identifier header.
 Build-Identifier: SNAPSHOT-${now}
-Bundle-Version: ${bFullVersion}.${if;${driver;gradle};${version.qualifier};eclipse}
+Bundle-Version: ${bFullVersion}.${if;${driver;gradle};${def;version.qualifier};eclipse}
 
 -donotcopy      = (CVS|.svn|.+.bak|nlsbuild|~.+|.+~|.jazzignore)
 -removeheaders  = Include-Resource, Ignore-Package, TODAY, DSTAMP, TSTAMP, Bnd-LastModified

--- a/dev/cnf/resources/bnd/jar.props
+++ b/dev/cnf/resources/bnd/jar.props
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -42,6 +42,6 @@ bFullVersion=${version;==;${bVersion}}.${libertyBundleMicroVersion}
 # This sets the version to the major.minor.micro of the provided bundle version,
 # and uses the RTC buildLabel for the qualifier. The "generated.build.id" file
 # (included above) will predefine the Build-Identifier header.
-Client-Version: ${bFullVersion}.${buildLabel}
+Client-Version: ${bFullVersion}.${def;buildLabel}
 
 Build-Identifier: SNAPSHOT-${now}

--- a/dev/cnf/resources/bnd/liberty-release.props
+++ b/dev/cnf/resources/bnd/liberty-release.props
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@ libertyRelease=${if;${releaseTypeGA};${libertyServiceVersion};${libertyBetaVersi
 
 libertyBundleMicroVersion=66
 copyrightBuildYear=2022
-buildID=${libertyRelease}-${buildLabel}
+buildID=${libertyRelease}-${def;buildLabel}
 productEdition=BASE_ILAN
 productLicenseType=ILAN
 productID=com.ibm.websphere.appserver

--- a/dev/cnf/resources/bnd/rejar.props
+++ b/dev/cnf/resources/bnd/rejar.props
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ bFullVersion=${version;==;${bVersion}}.${libertyBundleMicroVersion}
 # and uses the RTC buildLabel for the qualifier. The "generated.build.id" file
 # (included above) will predefine the Build-Identifier header.
 Build-Identifier: SNAPSHOT-${now}
-Bundle-Version: ${bFullVersion}.${if;${driver;gradle};${version.qualifier};eclipse}
+Bundle-Version: ${bFullVersion}.${if;${driver;gradle};${def;version.qualifier};eclipse}
 
 -donotcopy      = (CVS|.svn|.+.bak|nlsbuild|~.+|.+~|.jazzignore)
 -removeheaders  = Include-Resource, Ignore-Package, TODAY, DSTAMP, TSTAMP, Bnd-LastModified

--- a/dev/cnf/resources/bnd/repos.bnd
+++ b/dev/cnf/resources/bnd/repos.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -10,14 +10,14 @@
 #*******************************************************************************
 
 -connection-settings: \
-  ${if;${artifactory.download.token};server;-dummy}; \
-    id       = https://${artifactory.download.server}; \
-    username = ${artifactory.download.user}; \
-    password = ${artifactory.download.token}, \
-  ${if;${artifactory.upload.token};server;-dummy}; \
-    id       = https://${artifactory.upload.server}; \
-    username = ${artifactory.upload.user}; \
-    password = ${artifactory.upload.token}, \
+  ${if;${isempty;${def;artifactory.download.token}};-dummy;server}; \
+    id       = https://${def;artifactory.download.server}; \
+    username = ${def;artifactory.download.user}; \
+    password = ${def;artifactory.download.token}, \
+  ${if;${isempty;${def;artifactory.upload.token}};-dummy;server}; \
+    id       = https://${def;artifactory.upload.server}; \
+    username = ${def;artifactory.upload.user}; \
+    password = ${def;artifactory.upload.token}, \
   -bnd
 
 -plugin.1.Local: \

--- a/dev/com.ibm.ws.jsp.2.3/bnd.bnd
+++ b/dev/com.ibm.ws.jsp.2.3/bnd.bnd
@@ -54,7 +54,7 @@ Import-Package: \
    javax.servlet.jsp.jstl*;version=1.2, \
    javax.servlet.jsp.resources;version=2.3, \
    javax.servlet.jsp.tagext;version=2.3, \
-   com.ibm.websphere.servlet.*;version="0", \
+   com.ibm.websphere.servlet.*;version=!, \
    com.ibm.wsspi.webcontainer.osgi.*;version=1.0, \
    com.ibm.wsspi.webcontainer, \
    com.ibm.wsspi.webcontainer.*, \

--- a/dev/com.ibm.ws.jsp/bnd.bnd
+++ b/dev/com.ibm.ws.jsp/bnd.bnd
@@ -81,14 +81,14 @@ Import-Package: \
    javax.servlet.jsp.jstl*;version=1.2, \
    javax.servlet.jsp.tagext;version=2.2, \
    !javax.swing*, \
-   com.ibm.websphere.servlet.*;version="0", \
+   com.ibm.websphere.servlet.*;version=!, \
    com.ibm.wsspi.webcontainer.osgi.*;version=1.0, \
-   com.ibm.wsspi.webcontainer;version="0", \
-   com.ibm.wsspi.webcontainer.*;version="0", \
-   com.ibm.ws.webcontainer.extension;version="0", \
-   com.ibm.ws.webcontainer.util;version="0", \
-   com.ibm.ws.webcontainer.servlet;version="0",\
-   com.ibm.ws.webcontainer;version="0", \
+   com.ibm.wsspi.webcontainer;version=!, \
+   com.ibm.wsspi.webcontainer.*;version=!, \
+   com.ibm.ws.webcontainer.extension;version=!, \
+   com.ibm.ws.webcontainer.util;version=!, \
+   com.ibm.ws.webcontainer.servlet;version=!,\
+   com.ibm.ws.webcontainer;version=!, \
    com.ibm.jtc.adapter;resolution:=optional, \
    com.sun.tools.javac;resolution:=optional, \
    org.apache.webbeans.el;resolution:=optional, \

--- a/dev/com.ibm.ws.org.hibernate.validator/bnd.overrides
+++ b/dev/com.ibm.ws.org.hibernate.validator/bnd.overrides
@@ -30,17 +30,17 @@ Import-Package: \
   javax.validation.metadata;version="[2.0.0,3.0.0)", \
   javax.validation.spi;version="[2.0.0,3.0.0)", \
   javax.validation.valueextraction;version="[2.0.0,3.0.0)", \
-  javax.script;version="0", \
+  javax.script;version=!, \
   !javax.xml.bind.*, \
-  javax.xml.namespace;version="0", \
-  javax.xml.stream;version="0", \
-  javax.xml.stream.events;version="0", \
-  javax.xml.stream.util;version="0", \
-  javax.xml.transform;version="0", \
-  javax.xml.transform.stream;version="0", \
-  javax.xml.validation;version="0", \
+  javax.xml.namespace;version=!, \
+  javax.xml.stream;version=!, \
+  javax.xml.stream.events;version=!, \
+  javax.xml.stream.util;version=!, \
+  javax.xml.transform;version=!, \
+  javax.xml.transform.stream;version=!, \
+  javax.xml.validation;version=!, \
   javax.el;version="[2.0.0,4.0.0)";resolution:=optional, \
-  org.xml.sax;version="0", \
+  org.xml.sax;version=!, \
   org.jboss.logging;version="[3.1.0,4.0.0)", \
   com.fasterxml.classmate;version="[1.3.1,2.0.0)", \
   com.fasterxml.classmate.members;version="[1.3.1,2.0.0)", \

--- a/dev/io.openliberty.org.hibernate.validator.7.0/bnd.overrides
+++ b/dev/io.openliberty.org.hibernate.validator.7.0/bnd.overrides
@@ -32,15 +32,15 @@ Import-Package: \
   jakarta.validation.metadata;version="[3.0.0,4.0.0)", \
   jakarta.validation.spi;version="[3.0.0,4.0.0)", \
   jakarta.validation.valueextraction;version="[3.0.0,4.0.0)", \
-  javax.script;version="0", \
-  javax.xml.namespace;version="0", \
-  javax.xml.stream;version="0", \
-  javax.xml.stream.events;version="0", \
-  javax.xml.transform;version="0", \
-  javax.xml.transform.stream;version="0", \
-  javax.xml.validation;version="0", \
+  javax.script;version=!, \
+  javax.xml.namespace;version=!, \
+  javax.xml.stream;version=!, \
+  javax.xml.stream.events;version=!, \
+  javax.xml.transform;version=!, \
+  javax.xml.transform.stream;version=!, \
+  javax.xml.validation;version=!, \
   jakarta.el;version="[4.0.0,6.0.0)";resolution:=optional, \
-  org.xml.sax;version="0", \
+  org.xml.sax;version=!, \
   org.jboss.logging;version="[3.1.0,4.0.0)", \
   com.fasterxml.classmate;version="[1.3,2.0.0)", \
   com.fasterxml.classmate.members;version="[1.3,2.0.0)", \


### PR DESCRIPTION
- Use macros to remove warning message about artifactory properties
- Use version=! instead of version=0 to avoid warning messages.
- Remove bundle name warning messages related to transformed projects and fat test bundle names
- Remove privatepackage warning when a nlsprops file is marked as a private package when the package name includes .resources in it.
- Use def macro for variables that are not defined when running in an Eclipse environment.

