### PR TITLE
add social login support for bcl

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientImpl.java
@@ -20,7 +20,6 @@ import java.util.Set;
 
 import javax.security.auth.Subject;
 import javax.security.auth.login.CredentialExpiredException;
-import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -53,11 +52,10 @@ import com.ibm.ws.security.openidconnect.client.web.OidcRedirectServlet;
 import com.ibm.ws.security.openidconnect.clients.common.ClientConstants;
 import com.ibm.ws.security.openidconnect.clients.common.OidcClientConfig;
 import com.ibm.ws.security.openidconnect.clients.common.OidcClientRequest;
-import com.ibm.ws.security.openidconnect.clients.common.OidcSessionCache;
 import com.ibm.ws.security.openidconnect.clients.common.OidcSessionInfo;
+import com.ibm.ws.security.openidconnect.clients.common.OidcSessionUtils;
 import com.ibm.ws.security.openidconnect.clients.common.OidcUtil;
 import com.ibm.ws.webcontainer.security.AuthResult;
-import com.ibm.ws.webcontainer.security.CookieHelper;
 import com.ibm.ws.webcontainer.security.PostParameterHelper;
 import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 import com.ibm.ws.webcontainer.security.ReferrerURLCookieHandler;
@@ -439,31 +437,25 @@ public class OidcClientImpl implements OidcClient, UnprotectedResourceService {
             return;
         }
 
-        // don't logout if state exists (hasn't authenticated yet)
-        if (requestHasStateCookie(req)) {
+        String provider = getOidcProvider(req);
+        if (provider == null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Could not get oidc provider.");
+            }
             return;
         }
 
-        String provider = getOidcProvider(req);
-        if (provider == null) {
+        OidcSessionInfo sessionInfo = OidcSessionInfo.getSessionInfo(req);
+        if (sessionInfo == null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Session info not found from client cookies.");
+            }
             return;
         }
 
         OidcClientConfig oidcClientConfig = oidcClientConfigRef.getService(provider);
 
-        OidcSessionCache oidcSessionCache = oidcClientConfig.getOidcSessionCache();
-        String wasOidcSessionId = CookieHelper.getCookieValue(req.getCookies(), ClientConstants.WAS_OIDC_SESSION);
-        if (!oidcSessionCache.isSessionInvalidated(OidcSessionInfo.getSessionInfo(wasOidcSessionId))) {
-            return;
-        }
-
-        try {
-            req.logout();
-        } catch (ServletException e) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Could not logout invalidated session. An exception is caught : " + e);
-            }
-        }
+        OidcSessionUtils.logoutIfSessionInvalidated(req, sessionInfo, oidcClientConfig);
     }
 
     boolean isRunningBetaMode() {
@@ -477,10 +469,6 @@ public class OidcClientImpl implements OidcClient, UnprotectedResourceService {
             }
             return true;
         }
-    }
-
-    private boolean requestHasStateCookie(HttpServletRequest req) {
-        return requestHasCookie(req, ClientConstants.WAS_OIDC_STATE_KEY);
     }
 
     private boolean requestHasOidcCookie(HttpServletRequest req) {
@@ -846,12 +834,11 @@ public class OidcClientImpl implements OidcClient, UnprotectedResourceService {
         synchronized (oidcClientConfigRef) {
             Iterator<OidcClientConfig> services = oidcClientConfigRef.getServices();
 
-            String wasOidcSessionId = CookieHelper.getCookieValue(request.getCookies(), ClientConstants.WAS_OIDC_SESSION);
-            OidcSessionInfo sessionInfo = OidcSessionInfo.getSessionInfo(wasOidcSessionId);
-
             while (services.hasNext()) {
                 OidcClientConfig oidcClientConfig = services.next();
-                handleOidcSession(request, response, wasOidcSessionId, sessionInfo, oidcClientConfig);
+                if (isRunningBetaMode()) {
+                    OidcSessionUtils.removeOidcSession(request, response, oidcClientConfig);
+                }
                 OidcClientRequest oidcClientRequest = new OidcClientRequest(request, response, oidcClientConfig, (ReferrerURLCookieHandler) null);
                 if (handleOidcCookie(request, response, oidcClientRequest, userName, bSetSubject)) {
                     bSetSubject = true;
@@ -859,49 +846,6 @@ public class OidcClientImpl implements OidcClient, UnprotectedResourceService {
             }
         }
         return bSetSubject;
-    }
-
-    private void handleOidcSession(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            String oidcSessionId,
-            OidcSessionInfo sessionInfo,
-            OidcClientConfig oidcClientConfig) {
-        if (!isRunningBetaMode()) {
-            return;
-        }
-
-        if (sessionInfo == null) {
-            return;
-        }
-
-        String configId = sessionInfo.getConfigId();
-        if (!oidcClientConfig.getId().equals(configId)) {
-            return;
-        }
-
-        String sub = sessionInfo.getSub();
-        String sid = sessionInfo.getSid();
-
-        OidcSessionCache oidcSessionCache = oidcClientConfig.getOidcSessionCache();
-        if (!oidcSessionCache.isSessionInvalidated(sessionInfo)) {
-            if (sid != null && !sid.isEmpty()) {
-                oidcSessionCache.invalidateSession(sub, sid);
-            } else {
-                oidcSessionCache.invalidateSessionBySessionId(sub, oidcSessionId);
-            }
-        }
-        oidcSessionCache.removeInvalidatedSession(sessionInfo);
-
-        removeOidcSessionCookie(request, response);
-    }
-
-    private void removeOidcSessionCookie(HttpServletRequest request, HttpServletResponse response) {
-        Cookie cookie = new Cookie(ClientConstants.WAS_OIDC_SESSION, "");
-        cookie.setMaxAge(0);
-        cookie.setPath("/");
-        cookie.setSecure(true);
-        response.addCookie(cookie);
     }
 
     /**

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcSessionInfo.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcSessionInfo.java
@@ -12,7 +12,12 @@ package com.ibm.ws.security.openidconnect.clients.common;
 
 import java.util.Objects;
 
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
 import org.apache.commons.codec.binary.Base64;
+
+import com.ibm.ws.webcontainer.security.CookieHelper;
 
 public class OidcSessionInfo {
 
@@ -39,16 +44,16 @@ public class OidcSessionInfo {
         this.timestamp = timestamp;
         this.sessionId = createSessionId();
     }
-
     /**
-     * Takes a base64 encoded session id and returns an OidcSessionInfo object
-     * which contains the config id, sub, sid, and timestamp embedded in the session id.
+     * Gets the base64 encoded session id from the request cookies
+     * and returns an OidcSessionInfo object which contains
+     * the config id, sub, sid, and timestamp embedded in the session id.
      *
-     * @param sessionId
-     *            The base64 encoded session id.
+     * @param request The http servlet request.
      * @return An OidcSessionInfo object containing info parsed from the session id.
      */
-    public static OidcSessionInfo getSessionInfo(String sessionId) {
+    public static OidcSessionInfo getSessionInfo(HttpServletRequest request) {
+        String sessionId = getSessionIdFromCookies(request.getCookies());
         if (sessionId == null || sessionId.isEmpty()) {
             return null;
         }
@@ -65,6 +70,10 @@ public class OidcSessionInfo {
         String timestamp = new String(Base64.decodeBase64(parts[4]));
 
         return new OidcSessionInfo(configId, iss, sub, sid, timestamp);
+    }
+
+    private static String getSessionIdFromCookies(Cookie[] cookies) {
+        return CookieHelper.getCookieValue(cookies, ClientConstants.WAS_OIDC_SESSION);
     }
 
     public String getSessionId() {

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcSessionUtils.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcSessionUtils.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.openidconnect.clients.common;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.webcontainer.security.CookieHelper;
+
+/**
+ * Helper functions used by oidc client and social login
+ * to logout invalidated oidc sessions and cleanup logged out oidc sessions
+ */
+public class OidcSessionUtils {
+
+    private static TraceComponent tc = Tr.register(OidcSessionUtils.class);
+
+    public static void logoutIfSessionInvalidated(HttpServletRequest request, OidcSessionInfo sessionInfo, ConvergedClientConfig clientConfig) {
+        // don't logout if state exists (hasn't authenticated yet)
+        if (requestHasStateCookie(request)) {
+            return;
+        }
+
+        OidcSessionCache oidcSessionCache = clientConfig.getOidcSessionCache();
+        if (!oidcSessionCache.isSessionInvalidated(sessionInfo)) {
+            return;
+        }
+
+        try {
+            request.logout();
+        } catch (ServletException e) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Could not logout invalidated session. An exception is caught : " + e);
+            }
+        }
+    }
+
+    private static boolean requestHasStateCookie(HttpServletRequest request) {
+        return CookieHelper.getCookie(request.getCookies(), ClientConstants.WAS_OIDC_STATE_KEY) != null;
+    }
+
+    public static void removeOidcSession(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            ConvergedClientConfig clientConfig) {
+        OidcSessionInfo sessionInfo = OidcSessionInfo.getSessionInfo(request);
+        if (sessionInfo == null) {
+            return;
+        }
+
+        String configId = sessionInfo.getConfigId();
+        if (!clientConfig.getId().equals(configId)) {
+            return;
+        }
+
+        String sub = sessionInfo.getSub();
+        String sid = sessionInfo.getSid();
+
+        OidcSessionCache oidcSessionCache = clientConfig.getOidcSessionCache();
+        if (!oidcSessionCache.isSessionInvalidated(sessionInfo)) {
+            if (sid != null && !sid.isEmpty()) {
+                oidcSessionCache.invalidateSession(sub, sid);
+            } else {
+                oidcSessionCache.invalidateSessionBySessionId(sub, sessionInfo.getSessionId());
+            }
+        }
+        oidcSessionCache.removeInvalidatedSession(sessionInfo);
+
+        clearWASOidcSessionCookie(request, response);
+    }
+
+    private static void clearWASOidcSessionCookie(HttpServletRequest request, HttpServletResponse response) {
+        CookieHelper.clearCookie(request, response, ClientConstants.WAS_OIDC_SESSION, request.getCookies());
+    }
+
+}

--- a/dev/com.ibm.ws.security.social/bnd.bnd
+++ b/dev/com.ibm.ws.security.social/bnd.bnd
@@ -108,6 +108,15 @@ Service-Component:\
     deactivate:='deactivate'; \
     immediate:=true; \
     properties:="service.vendor=IBM,id=SocialLoginWtihATTAI,TAIName=SocialLoginWtihATTAI,invokeBeforeSSO:Boolean=true,addLTPACookieToResponse:Boolean=false", \
+  com.ibm.ws.security.socialmediasessioninvalidator.tai; \
+    implementation:=com.ibm.ws.security.social.tai.SocialLoginSessionInvalidatorTAI; \
+    provide:='com.ibm.wsspi.security.tai.TrustAssociationInterceptor'; \
+    configuration-policy:=ignore; \
+    modified:='modified'; \
+    activate:='activate'; \
+    deactivate:='deactivate'; \
+    immediate:=true; \
+    properties:="service.vendor=IBM,id=SocialLoginSessionInvalidatorTAI,TAIName=SocialLoginSessionInvalidatorTAI,invokeBeforeSSO:Boolean=true,addLTPACookieToResponse:Boolean=false", \
   com.ibm.ws.security.social.web.EndpointServices; \
     implementation:=com.ibm.ws.security.social.web.EndpointServices; \
     provide:=com.ibm.ws.security.social.web.EndpointServices; \
@@ -132,6 +141,7 @@ Include-Resource: \
 	com.ibm.websphere.security;version=latest,\
 	com.ibm.ws.app.manager.wab;version=latest,\
 	com.ibm.ws.crypto.passwordutil;version=latest,\
+	com.ibm.ws.kernel.boot.core;version=latest,\
 	com.ibm.ws.kernel.service;version=latest,\
 	com.ibm.ws.logging;version=latest,\
 	io.openliberty.org.apache.commons.codec;version=latest,\

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/SocialLoginSessionInvalidatorTAI.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/SocialLoginSessionInvalidatorTAI.java
@@ -1,0 +1,152 @@
+package com.ibm.ws.security.social.tai;
+
+import java.util.Map;
+import java.util.Properties;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.security.WebTrustAssociationException;
+import com.ibm.websphere.security.WebTrustAssociationFailedException;
+import com.ibm.ws.kernel.productinfo.ProductInfo;
+import com.ibm.ws.security.openidconnect.clients.common.OidcSessionInfo;
+import com.ibm.ws.security.openidconnect.clients.common.OidcSessionUtils;
+import com.ibm.ws.security.social.Constants;
+import com.ibm.ws.security.social.SocialLoginConfig;
+import com.ibm.ws.security.social.TraceConstants;
+import com.ibm.ws.security.social.error.SocialLoginException;
+import com.ibm.ws.security.social.internal.OidcLoginConfigImpl;
+import com.ibm.ws.security.social.internal.utils.SocialTaiRequest;
+import com.ibm.ws.security.social.web.utils.SocialWebUtils;
+import com.ibm.wsspi.security.tai.TAIResult;
+import com.ibm.wsspi.security.tai.TrustAssociationInterceptor;
+
+/**
+ * This TAI is ran before SSO and is used only to check if the oidc session 
+ * has been invalidated for the social login flow.
+ * 
+ * If the oidc session has been invalidated, it will log out the session.
+ * 
+ */
+public class SocialLoginSessionInvalidatorTAI implements TrustAssociationInterceptor {
+
+    public static final TraceComponent tc = Tr.register(SocialLoginSessionInvalidatorTAI.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
+    
+    TAIWebUtils taiWebUtils = new TAIWebUtils();
+    TAIRequestHelper taiRequestHelper = new TAIRequestHelper();
+    
+    private static boolean issuedBetaMessage = false;
+
+    @Activate
+    protected void activate(ComponentContext cc, Map<String, Object> props) {
+        // Do nothing for now.
+    }
+
+    @Modified
+    protected void modified(ComponentContext cc, Map<String, Object> props) {
+        // Do nothing for now.
+    }
+
+    @Deactivate
+    protected void deactivate(ComponentContext cc) {
+        // Do nothing for now.
+    }
+
+    /**
+     * The logic to check and logout invalidated sessions is
+     * put into this method, so none of the side effects of TAI's are run.
+     * 
+     * i.e., the TAI result is not relevant for this use case,
+     * but we need to setup a TAI for the social login flow to work.
+     */
+    @Override
+    public boolean isTargetInterceptor(HttpServletRequest req) throws WebTrustAssociationException {
+        if (!isRunningBetaMode()) {
+            return false;
+        }
+        taiRequestHelper.createSocialTaiRequestAndSetRequestAttribute(req);
+        logoutIfSessionInvalidated(req);
+        return false;
+    }
+    
+    boolean isRunningBetaMode() {
+        if (!ProductInfo.getBetaEdition()) {
+            return false;
+        } else {
+            // Running beta exception, issue message if we haven't already issued one for this class
+            if (!issuedBetaMessage) {
+                Tr.info(tc, "BETA: A beta method has been invoked for the class " + this.getClass().getName() + " for the first time.");
+                issuedBetaMessage = !issuedBetaMessage;
+            }
+            return true;
+        }
+    }
+
+    private void logoutIfSessionInvalidated(HttpServletRequest request) {
+        SocialTaiRequest socialTaiRequest = (SocialTaiRequest) request.getAttribute(Constants.ATTRIBUTE_TAI_REQUEST);
+        if (socialTaiRequest == null) {
+            // Should not be null
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Request is missing " + Constants.ATTRIBUTE_TAI_REQUEST + " attribute.");
+            }
+            return;
+        }
+
+        OidcSessionInfo sessionInfo = OidcSessionInfo.getSessionInfo(request);
+        if (sessionInfo == null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Session info coud not be retrieved from client cookies.");
+            }
+            return;
+        }
+        
+        SocialLoginConfig clientConfig = SocialLoginTAI.getSocialLoginConfig(sessionInfo.getConfigId());
+        if (clientConfig == null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Client config for request could not be found. An error must have occurred initializing this request.");
+            }
+            return;
+        }
+        
+        if (clientConfig instanceof OidcLoginConfigImpl) {
+            OidcSessionUtils.logoutIfSessionInvalidated(request, sessionInfo, (OidcLoginConfigImpl) clientConfig);
+        }
+    }
+    
+    @Override
+    public TAIResult negotiateValidateandEstablishTrust(HttpServletRequest request, HttpServletResponse response) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+    
+    @Override
+    public int initialize(Properties props) throws WebTrustAssociationFailedException {
+        // TODO Auto-generated method stub
+        return 0;
+    }
+
+    @Override
+    public String getVersion() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public String getType() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void cleanup() {
+        // TODO Auto-generated method stub
+    }
+
+}

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/SocialLoginSessionInvalidatorTAI.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/SocialLoginSessionInvalidatorTAI.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package com.ibm.ws.security.social.tai;
 
 import java.util.Map;


### PR DESCRIPTION
for #20360

adds backchannel logout capabilities for social login. this required adding a new TAI which runs before SSO which will logout the request if its oidc session has been invalidated.