### PR TITLE
JAX-RS 2.0 and JAX-WS 2.2: Explict versioning of the com.ibm.ws.cxf.client APIs

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
@@ -43,8 +43,8 @@ Export-Package: \
 	org.apache.cxf.feature,\
 	org.apache.cxf.jaxrs.client;version=3.1.18,\
     com.ibm.ws.cxf.exceptions;version=3.1.18,\
-    com.ibm.ws.cxf.client, \
-    com.ibm.ws.cxf.client.component
+    com.ibm.ws.cxf.client;version=1.0, \
+    com.ibm.ws.cxf.client.component;version=1.0
 
 Import-Package: \
  !com.wordnik.swagger.jaxrs.config, \

--- a/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
@@ -37,83 +37,83 @@ Export-Package: \
 	com.ibm.ws.jaxrs20.injection.*,\
 	com.ibm.ws.jaxrs20.threading,\
 	com.ibm.ws.jaxrs20.providers.api,\
-	com.ibm.websphere.jaxrs.providers.json4j;version=1.1.0,\
-	com.ibm.websphere.jaxrs20.multipart;version=1.1.0,\
+	com.ibm.websphere.jaxrs.providers.json4j;version='1.1.0',\
+	com.ibm.websphere.jaxrs20.multipart;version='1.1.0',\
 	com.ibm.ws.jaxrs20.clientconfig,\
-	org.apache.cxf.feature,\
-	org.apache.cxf.jaxrs.client;version=3.1.18,\
-    com.ibm.ws.cxf.exceptions;version=3.1.18,\
-    com.ibm.ws.cxf.client;version=1.0, \
-    com.ibm.ws.cxf.client.component;version=1.0
+	org.apache.cxf.feature;version='3.1.18',\
+	org.apache.cxf.jaxrs.client;version='3.1.18',\
+	com.ibm.ws.cxf.exceptions;version='3.1.18',\
+	com.ibm.ws.cxf.jaxrs20.client;version='3.1.18',\
+	com.ibm.ws.cxf.jaxrs20.client.component;version='3.1.18'
 
 Import-Package: \
- !com.wordnik.swagger.jaxrs.config, \
- !com.wordnik.swagger.jaxrs.listing, \
- com.ibm.websphere.jaxrs20.multipart, \
- !sun.reflect.generics.reflectiveObjects, \
- !javax.cache.*, \
- !javax.json, \
- javax.ws.rs.*, \
- junit.framework.*;resolution:=optional, \
-# com.sun.xml.fastinfoset.*;resolution:=optional, \
- org.apache.xml.resolver.*;resolution:=optional, \
- !org.junit.*;resolution:=optional, \
- !org.apache.velocity.*, \
- org.objectweb.asm.*;resolution:=optional, \
-# net.sf.cglib.*;resolution:=optional;version="[2.1.3,3.0.0)", \
- org.slf4j.*;resolution:=optional;version="[1.5,2)", \
- org.osgi.framework.*, \
- org.apache.neethi;resolution:=optional, \
- org.apache.commons.logging.*;resolution:=optional, \
- javax.activation, \
- javax.annotation;version="[1.2,2)", \
- javax.xml.stream.*, \
- !com.sun.xml.fastinfoset.stax.*, \
- !javax.xml.ws, \
- javax.xml.namespace;resolution:=optional, \
- javax.servlet.*;resolution:=optional;version="[0.0,4)", \
- javax.xml.ws.*;version="[2.2,3)", \
- # org.apache.cxf.ws.policy.*;resolution:=optional, \
- javax.servlet.*;resolution:=optional;version="[0.0,4)", \
- com.ibm.wsspi.classloading, \
- com.ibm.websphere.ras, \
- com.ibm.websphere.ras.annotation, \
- com.ibm.ws.ffdc, \
- com.ibm.ws.webcontainer.extension, \
- com.ibm.ws.webcontainer.osgi, \
- com.ibm.websphere.security, \
- !com.sun.xml.bind.marshaller, \
- !com.ctc.wstx.*, \
- !com.sun.msv.*, \
- !com.sun.xml.fastinfoset.stax.*, \
- !net.sf.cglib.proxy.*, \
- !javax.validation.*, \
- !org.codehaus.stax2.*, \
- !org.apache.log4j.*, \
- !org.apache.xerces.dom, \
- !org.apache.xerces.*, \
- !com.ibm.wsdl.util.xml, \
- !org.springframework.*;resolution:=optional;version="[2.5,4)", \
- !org.apache.aries.*;version="[0.3,2)", \
- !org.osgi.service.blueprint.*, \
- !org.apache.xerces.dom, \
- !com.sun.tools.xjc.reader.internalizer, \
- !org.springframework.*;resolution:=optional;version="[2.5,4)", \
- !org.apache.aries.*;version="[0.3,2)", \
- !org.osgi.service.blueprint.*, \
- !org.apache.aries.*;version="[0.3,2)", \
- !org.osgi.service.blueprint.*, \
- !org.apache.xerces.dom, \
- !org.apache.xerces.*, \
- !org.apache.cxf.ws.policy.*, \
- !javax.wsdl.*, \
- !org.apache.cxf.wsdl.*, \
- !org.joda.time.*, \
- !javax.xml.bind.*, \
- com.ibm.json.xml, \
- com.ibm.json.java, \
- !org.osgi.service.http.*, \
- *
+	!com.wordnik.swagger.jaxrs.config,\
+	!com.wordnik.swagger.jaxrs.listing,\
+	com.ibm.websphere.jaxrs20.multipart,\
+	!sun.reflect.generics.reflectiveObjects,\
+	!javax.cache.*,\
+	!javax.json,\
+	javax.ws.rs.*,\
+	junit.framework.*;'resolution:'=optional,\
+	# com.sun.xml.fastinfoset.*;'resolution:'=optional,\
+	org.apache.xml.resolver.*;'resolution:'=optional,\
+	!org.junit.*;'resolution:'=optional,\
+	!org.apache.velocity.*,\
+	org.objectweb.asm.*;'resolution:'=optional,\
+	# net.sf.cglib.*;'resolution:'=optional;version='[2.1.3,3.0.0)',\
+	org.slf4j.*;'resolution:'=optional;version='[1.5,2)',\
+	org.osgi.framework.*,\
+	org.apache.neethi;'resolution:'=optional,\
+	org.apache.commons.logging.*;'resolution:'=optional,\
+	javax.activation,\
+	javax.annotation;version='[1.2,2)',\
+	javax.xml.stream.*,\
+	!com.sun.xml.fastinfoset.stax.*,\
+	!javax.xml.ws,\
+	javax.xml.namespace;'resolution:'=optional,\
+	javax.servlet.*;'resolution:'=optional;version='[0.0,4)',\
+	javax.xml.ws.*;version='[2.2,3)',\
+	# org.apache.cxf.ws.policy.*;'resolution:'=optional,\
+	javax.servlet.*;'resolution:'=optional;version='[0.0,4)',\
+	com.ibm.wsspi.classloading,\
+	com.ibm.websphere.ras,\
+	com.ibm.websphere.ras.annotation,\
+	com.ibm.ws.ffdc,\
+	com.ibm.ws.webcontainer.extension,\
+	com.ibm.ws.webcontainer.osgi,\
+	com.ibm.websphere.security,\
+	!com.sun.xml.bind.marshaller,\
+	!com.ctc.wstx.*,\
+	!com.sun.msv.*,\
+	!com.sun.xml.fastinfoset.stax.*,\
+	!net.sf.cglib.proxy.*,\
+	!javax.validation.*,\
+	!org.codehaus.stax2.*,\
+	!org.apache.log4j.*,\
+	!org.apache.xerces.dom,\
+	!org.apache.xerces.*,\
+	!com.ibm.wsdl.util.xml,\
+	!org.springframework.*;'resolution:'=optional;version='[2.5,4)',\
+	!org.apache.aries.*;version='[0.3,2)',\
+	!org.osgi.service.blueprint.*,\
+	!org.apache.xerces.dom,\
+	!com.sun.tools.xjc.reader.internalizer,\
+	!org.springframework.*;'resolution:'=optional;version='[2.5,4)',\
+	!org.apache.aries.*;version='[0.3,2)',\
+	!org.osgi.service.blueprint.*,\
+	!org.apache.aries.*;version='[0.3,2)',\
+	!org.osgi.service.blueprint.*,\
+	!org.apache.xerces.dom,\
+	!org.apache.xerces.*,\
+	!org.apache.cxf.ws.policy.*,\
+	!javax.wsdl.*,\
+	!org.apache.cxf.wsdl.*,\
+	!org.joda.time.*,\
+	!javax.xml.bind.*,\
+	com.ibm.json.xml,\
+	com.ibm.json.java,\
+	!org.osgi.service.http.*,\
+	*
 
 # Use dynamicImport-Package for JAXB APIs, with this, Equonix will have a chance to wire
 # those packages to the JAXB-2.2 API if the target bundle is started, or the one from system
@@ -153,7 +153,7 @@ Include-Resource: \
  	com.ibm.ws.jaxrs20.clientconfig.JAXRSClientConfigImpl, \
  	com.ibm.ws.jaxrs20.providers.customexceptionmapper.CustomExceptionMapperRegister, \
  	com.ibm.ws.jaxrs20.providers.security.SecurityAnnoProviderRegister, \
- 	com.ibm.ws.cxf.client.component.*
+ 	com.ibm.ws.cxf.jaxrs20.client.component.*
 
 -dependson: com.ibm.ws.org.codehaus.jackson
 

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/cxf/jaxrs20/client/AsyncClientRunnableWrapper.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/cxf/jaxrs20/client/AsyncClientRunnableWrapper.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.cxf.client;
+package com.ibm.ws.cxf.jaxrs20.client;
 
 import org.apache.cxf.message.Message;
 

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/cxf/jaxrs20/client/component/AsyncClientRunnableWrapperManager.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/cxf/jaxrs20/client/component/AsyncClientRunnableWrapperManager.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.cxf.client.component;
+package com.ibm.ws.cxf.jaxrs20.client.component;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -20,9 +20,9 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 
-import com.ibm.ws.cxf.client.AsyncClientRunnableWrapper;
+import com.ibm.ws.cxf.jaxrs20.client.AsyncClientRunnableWrapper;
 
-@Component(name = "com.ibm.ws.cxf.client.component.AsyncClientRunnableWrapperManager",
+@Component(name = "com.ibm.ws.cxf.jaxrs20.client.component.AsyncClientRunnableWrapperManager",
            property = { "service.vendor=IBM" })
 public class AsyncClientRunnableWrapperManager {
 

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/cxf/jaxrs20/client/component/package-info.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/cxf/jaxrs20/client/component/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 /**
- * @version 1.0
+ * @version 3.1.18
  */
-@org.osgi.annotation.versioning.Version("1.0")
-package com.ibm.ws.cxf.client.component;
+@org.osgi.annotation.versioning.Version("3.1.18")
+package com.ibm.ws.cxf.jaxrs20.client.component;

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/cxf/jaxrs20/client/package-info.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/cxf/jaxrs20/client/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 /**
- * @version 1.0
+ * @version 3.1.18
  */
-@org.osgi.annotation.versioning.Version("1.0")
-package com.ibm.ws.cxf.client.component;
+@org.osgi.annotation.versioning.Version("3.1.18")
+package com.ibm.ws.cxf.jaxrs20.client;

--- a/dev/com.ibm.ws.jaxrs.2.0.concurrent/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.concurrent/bnd.bnd
@@ -17,7 +17,6 @@ Bundle-Description: IBM JAX-RS-2.0 Concurrency support; version=${bVersion}
 
 WS-TraceGroup: JAXRS
 
-
 # Technically we should never have allowed javax.validation packages at the 1.0 version
 # but to maintain backwards compatibility we will allow it 
 Import-Package: \
@@ -31,13 +30,13 @@ Import-Package: \
   com.ibm.wsspi.threadcontext, \
   org.osgi.framework, \
   org.osgi.service.component, \
-  com.ibm.ws.cxf.client;version="[1.0,1.1)"
-     
+  com.ibm.ws.cxf.jaxrs20.client.*;version="[3.0,3.2)"
+  
 # If you need use MESSAGE, you must enable this Private-Package, or message will translate wrong
 Private-Package:\
-  com.ibm.ws.jaxrs2x.concurrent.*
+  com.ibm.ws.jaxrs20.concurrent.*
   
--dsannotations: com.ibm.ws.jaxrs2x.concurrent.component.*
+-dsannotations: com.ibm.ws.jaxrs20.concurrent.component.*
  
 -buildpath: \
 	org.apache.cxf.cxf-core;strategy=exact;version=3.1.18,\
@@ -52,5 +51,4 @@ Private-Package:\
 	com.ibm.ws.concurrent;version=latest,\
 	com.ibm.ws.context;version=latest,\
 	com.ibm.ws.kernel.service;version=latest,\
-	com.ibm.ws.logging.core;version=latest,\
-	com.ibm.ws.cxf.client;version=latest
+	com.ibm.ws.logging.core;version=latest

--- a/dev/com.ibm.ws.jaxrs.2.0.concurrent/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.concurrent/bnd.bnd
@@ -31,7 +31,7 @@ Import-Package: \
   com.ibm.wsspi.threadcontext, \
   org.osgi.framework, \
   org.osgi.service.component, \
-  com.ibm.ws.cxf.client
+  com.ibm.ws.cxf.client;version="[1.0,1.1)"
      
 # If you need use MESSAGE, you must enable this Private-Package, or message will translate wrong
 Private-Package:\

--- a/dev/com.ibm.ws.jaxrs.2.0.concurrent/src/com/ibm/ws/jaxrs20/concurrent/component/ManagedExecutorRunnableWrapper.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.concurrent/src/com/ibm/ws/jaxrs20/concurrent/component/ManagedExecutorRunnableWrapper.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2018,2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs20.concurrent.component;
+
+import java.util.concurrent.Executor;
+
+import org.apache.cxf.message.Message;
+import org.osgi.service.component.annotations.Component;
+
+import com.ibm.ws.concurrent.WSManagedExecutorService;
+import com.ibm.ws.context.service.serializable.ContextualRunnable;
+import com.ibm.ws.cxf.jaxrs20.client.AsyncClientRunnableWrapper;
+import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
+
+@Component(name = "com.ibm.ws.jaxrs20.concurrent.component.ManagedExecutorRunnableWrapper",
+           service = AsyncClientRunnableWrapper.class,
+           immediate = true,
+           property = { "service.vendor=IBM" })
+public class ManagedExecutorRunnableWrapper implements AsyncClientRunnableWrapper {
+
+    @Override
+    public void prepare(Message message) {
+        Executor executor = message.getExchange().get(Executor.class);
+        if (executor instanceof WSManagedExecutorService) {
+            final ThreadContextDescriptor tcd = ((WSManagedExecutorService) executor).captureThreadContext(null);
+            message.put(ThreadContextDescriptor.class, tcd);
+        }
+    }
+
+    @Override
+    public Runnable wrap(Message message, Runnable runnable) {
+        Runnable ret = runnable;
+        Executor executor = message.getExchange().get(Executor.class);
+        if (executor instanceof WSManagedExecutorService) {
+            ThreadContextDescriptor tcd = message.get(ThreadContextDescriptor.class);
+            if (tcd != null) {
+                ret = new ContextualRunnable(tcd, runnable, null);
+            }
+
+        }
+        return ret;
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1.concurrent/.classpath
+++ b/dev/com.ibm.ws.jaxrs.2.1.concurrent/.classpath
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jaxrs.2.1.concurrent/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.1.concurrent/bnd.bnd
@@ -31,7 +31,7 @@ Import-Package: \
   com.ibm.wsspi.threadcontext, \
   org.osgi.framework, \
   org.osgi.service.component, \
-  com.ibm.ws.cxf.client
+  com.ibm.ws.cxf.client;version="[2.0,2.1)"
      
 # If you need use MESSAGE, you must enable this Private-Package, or message will translate wrong
 Private-Package:\

--- a/dev/com.ibm.ws.jaxrs.2.1.concurrent/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.1.concurrent/bnd.bnd
@@ -21,23 +21,35 @@ WS-TraceGroup: JAXRS
 # Technically we should never have allowed javax.validation packages at the 1.0 version
 # but to maintain backwards compatibility we will allow it 
 Import-Package: \
-  org.apache.cxf.*;version="[3.2,4)", \
-  com.ibm.websphere.ras.*, \
-  com.ibm.ws.context.service.serializable.*, \
-  com.ibm.ws.jaxrs20.client, \
-  com.ibm.ws.ffdc, \
-  com.ibm.ws.concurrent, \
-  com.ibm.wsspi.kernel.service.utils, \
-  com.ibm.wsspi.threadcontext, \
-  org.osgi.framework, \
-  org.osgi.service.component, \
-  com.ibm.ws.cxf.client;version="[2.0,2.1)"
+	org.apache.cxf.*;version='[3.2,4)',\
+	com.ibm.websphere.ras.*,\
+	com.ibm.ws.context.service.serializable.*,\
+	com.ibm.ws.jaxrs20.client,\
+	com.ibm.ws.ffdc,\
+	com.ibm.ws.concurrent,\
+	com.ibm.wsspi.kernel.service.utils,\
+	com.ibm.wsspi.threadcontext,\
+	org.osgi.framework,\
+	org.osgi.service.component,\
+	com.ibm.ws.cxf.jaxrs21.client;version='[3.2,4)'
      
 # If you need use MESSAGE, you must enable this Private-Package, or message will translate wrong
 Private-Package:\
-  com.ibm.ws.jaxrs2x.concurrent.*
+  com.ibm.ws.jaxrs21.concurrent.*
   
--dsannotations: com.ibm.ws.jaxrs2x.concurrent.component.*
+-dsannotations: com.ibm.ws.jaxrs21.concurrent.component.*
 
 -buildpath: \
-  com.ibm.ws.jaxrs.2.0.concurrent
+    com.ibm.ws.org.apache.cxf.cxf.core.3.2,\
+    com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2,\
+	com.ibm.websphere.org.osgi.core;version=latest,\
+	com.ibm.websphere.org.osgi.service.component;version=latest,\
+	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
+	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+	com.ibm.ws.jaxrs.2.0.client;version=latest,\
+	com.ibm.ws.jaxrs.2.0.common;version=latest,\
+	com.ibm.ws.container.service;version=latest,\
+	com.ibm.ws.concurrent;version=latest,\
+	com.ibm.ws.context;version=latest,\
+	com.ibm.ws.kernel.service;version=latest,\
+	com.ibm.ws.logging.core;version=latest

--- a/dev/com.ibm.ws.jaxrs.2.1.concurrent/src/com/ibm/ws/jaxrs21/concurrent/component/ManagedExecutorRunnableWrapper.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.concurrent/src/com/ibm/ws/jaxrs21/concurrent/component/ManagedExecutorRunnableWrapper.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.jaxrs2x.concurrent.component;
+package com.ibm.ws.jaxrs21.concurrent.component;
 
 import java.util.concurrent.Executor;
 
@@ -17,10 +17,10 @@ import org.osgi.service.component.annotations.Component;
 
 import com.ibm.ws.concurrent.WSManagedExecutorService;
 import com.ibm.ws.context.service.serializable.ContextualRunnable;
-import com.ibm.ws.cxf.client.AsyncClientRunnableWrapper;
+import com.ibm.ws.cxf.jaxrs21.client.AsyncClientRunnableWrapper;
 import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 
-@Component(name = "com.ibm.ws.jaxrs2x.concurrent.component.ManagedExecutorRunnableWrapper",
+@Component(name = "com.ibm.ws.jaxrs21.concurrent.component.ManagedExecutorRunnableWrapper",
            service = AsyncClientRunnableWrapper.class,
            immediate = true,
            property = { "service.vendor=IBM" })

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.overrides
@@ -99,9 +99,8 @@ Export-Package: \
   org.apache.cxf.ws.addressing.v200408;version=${exportVer},\
   org.apache.cxf.ws.addressing.wsdl;version=${exportVer},\
   org.apache.cxf.wsdl.http;version=${exportVer},\
-  com.ibm.ws.cxf.client;version=2.0, \
-  com.ibm.ws.cxf.client.component;version=2.0
-
+  com.ibm.ws.cxf.jaxrs21.client;version=${exportVer},\
+  com.ibm.ws.cxf.jaxrs21.client.component;version=${exportVer}
 
 Private-Package: \
   com.ibm.ws.cxf.core
@@ -135,10 +134,13 @@ Import-Package: \
   javax.xml.bind.annotation.adapters;version=!, \
   javax.xml.bind.attachment;version=!, \
   !javax.xml.ws.*, \
+  org.apache.cxf.helpers;version="[${exportVer},4.0.0)", \
+  com.ibm.ws.cxf.jaxrs21.client;version="[${exportVer},${exportVer}]", \
+  com.ibm.ws.cxf.jaxrs21.client.component;version="[${exportVer},${exportVer}]", \
   *
 
 -dsannotations: \
-  com.ibm.ws.cxf.client.component.*
+  com.ibm.ws.cxf.jaxrs21.client.component.*
  	
 DynamicImport-Package: \
   com.ctc.wstx.*,\
@@ -146,5 +148,5 @@ DynamicImport-Package: \
   com.sun.xml.bind.*,\
   org.glassfish.jaxb.*,\
   javax.xml.ws,\
-  org.apache.cxf.bus,\
-  org.apache.cxf.*
+  org.apache.cxf.bus;version="[${exportVer},4.0.0)", \
+  org.apache.cxf.*;version="[${exportVer},4.0.0)"

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.overrides
@@ -99,8 +99,9 @@ Export-Package: \
   org.apache.cxf.ws.addressing.v200408;version=${exportVer},\
   org.apache.cxf.ws.addressing.wsdl;version=${exportVer},\
   org.apache.cxf.wsdl.http;version=${exportVer},\
-  com.ibm.ws.cxf.client, \
-  com.ibm.ws.cxf.client.component
+  com.ibm.ws.cxf.client;version=2.0, \
+  com.ibm.ws.cxf.client.component;version=2.0
+
 
 Private-Package: \
   com.ibm.ws.cxf.core

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/com/ibm/ws/cxf/jaxrs21/client/AsyncClientRunnableWrapper.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/com/ibm/ws/cxf/jaxrs21/client/AsyncClientRunnableWrapper.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.cxf.client;
+package com.ibm.ws.cxf.jaxrs21.client;
 
 import org.apache.cxf.message.Message;
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/com/ibm/ws/cxf/jaxrs21/client/component/AsyncClientRunnableWrapperManager.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/com/ibm/ws/cxf/jaxrs21/client/component/AsyncClientRunnableWrapperManager.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.cxf.client.component;
+package com.ibm.ws.cxf.jaxrs21.client.component;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -20,9 +20,9 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 
-import com.ibm.ws.cxf.client.AsyncClientRunnableWrapper;
+import com.ibm.ws.cxf.jaxrs21.client.AsyncClientRunnableWrapper;
 
-@Component(name = "com.ibm.ws.cxf.client.component.AsyncClientRunnableWrapperManager",
+@Component(name = "com.ibm.ws.cxf.jaxrs21.client.component.AsyncClientRunnableWrapperManager",
            property = { "service.vendor=IBM" })
 public class AsyncClientRunnableWrapperManager {
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/com/ibm/ws/cxf/jaxrs21/client/component/package-info.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/com/ibm/ws/cxf/jaxrs21/client/component/package-info.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 /**
- * @version 1.0
+ * @version "3.2.4"
  */
-@org.osgi.annotation.versioning.Version("1.0")
-package com.ibm.ws.cxf.client;
+@org.osgi.annotation.versioning.Version("3.2.4")
+package com.ibm.ws.cxf.jaxrs21.client.component;

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/com/ibm/ws/cxf/jaxrs21/client/package-info.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/com/ibm/ws/cxf/jaxrs21/client/package-info.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 /**
- * @version 1.0
+ * @version "3.2.4"
  */
-@org.osgi.annotation.versioning.Version("1.0")
-package com.ibm.ws.cxf.client;
+@org.osgi.annotation.versioning.Version("3.2.4")
+package com.ibm.ws.cxf.jaxrs21.client;

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.bnd
@@ -23,7 +23,6 @@
   javax.activation:activation;version=1.1,\
   org.apache.cxf:cxf-rt-transports-http;strategy=exact;version=3.4.3,\
   com.ibm.websphere.javaee.servlet.4.0;version=latest,\
-  com.ibm.ws.cxf.client,\
   com.ibm.ws.logging.core,\
   com.ibm.ws.org.apache.cxf.cxf.core.3.2;version=latest,\
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.overrides
@@ -25,7 +25,7 @@ Import-Package: \
   org.apache.cxf.ws.policy.*;resolution:=optional, \
   org.apache.cxf.wsdl;resolution:=optional, \
   !org.osgi.service.blueprint.*,\
-  com.ibm.ws.cxf.client.*,\
+  com.ibm.ws.cxf.client.*;version="[2.0,2.1)",\
   *
 
 Service-Component: \

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.overrides
@@ -25,7 +25,8 @@ Import-Package: \
   org.apache.cxf.ws.policy.*;resolution:=optional, \
   org.apache.cxf.wsdl;resolution:=optional, \
   !org.osgi.service.blueprint.*,\
-  com.ibm.ws.cxf.client.*;version="[2.0,2.1)",\
+  javax.servlet.*;resolution:=optional;version="[2.6.0,3.0.0)",\
+  com.ibm.ws.cxf.jaxrs21.client.*;version="[3.2,4)",\
   *
 
 Service-Component: \

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/HTTPConduit.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/HTTPConduit.java
@@ -93,7 +93,7 @@ import org.apache.cxf.ws.addressing.EndpointReferenceType;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.cxf.client.component.AsyncClientRunnableWrapperManager;
+import com.ibm.ws.cxf.jaxrs21.client.component.AsyncClientRunnableWrapperManager;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2/bnd.bnd
@@ -18,6 +18,5 @@
 -buildpath: org.apache.cxf:cxf-rt-transports-http-hc;version=3.4.3,\
  com.ibm.ws.org.apache.cxf.cxf.core.3.2;version=latest,\
  com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2;version=latest,\
- com.ibm.ws.cxf.client,\
  com.ibm.ws.org.apache.httpcomponents;version=latest,\
  com.ibm.ws.logging.core;version=latest

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2/bnd.overrides
@@ -4,6 +4,6 @@ bVersion=1.0
 Bundle-SymbolicName: com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2
 
 Import-Package: \
-  com.ibm.ws.cxf.client.*,\
+  com.ibm.ws.cxf.client.*;version="[2.0,2.1)",\
   *
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2/bnd.overrides
@@ -4,6 +4,6 @@ bVersion=1.0
 Bundle-SymbolicName: com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2
 
 Import-Package: \
-  com.ibm.ws.cxf.client.*;version="[2.0,2.1)",\
+  com.ibm.ws.cxf.jaxrs21.client.*;version="[3.2,4)",\
   *
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2/src/org/apache/cxf/transport/http/asyncclient/AsyncHTTPConduit.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2/src/org/apache/cxf/transport/http/asyncclient/AsyncHTTPConduit.java
@@ -96,7 +96,7 @@ import org.apache.http.nio.reactor.IOSession;
 import org.apache.http.nio.util.HeapByteBufferAllocator;
 
 import com.ibm.websphere.ras.annotation.Trivial;
-import com.ibm.ws.cxf.client.component.AsyncClientRunnableWrapperManager;
+import com.ibm.ws.cxf.jaxrs21.client.component.AsyncClientRunnableWrapperManager;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 /**


### PR DESCRIPTION
This PR sets specific versions on the `com.ibm.ws.cxf.client` APIs that are exported by the `com.ibm.ws.jaxrs.2.0.common` and the `com.ibm.ws.org.apache.cxf.cxf.core.3.2` in order to prevent export conflicts when both bundles are available in the runtime. 