### PR TITLE
Added a checkpoint with method timeout annotation test to checkpoint_…

### DIFF
--- a/dev/io.openliberty.checkpoint_fat/.classpath
+++ b/dev/io.openliberty.checkpoint_fat/.classpath
@@ -9,11 +9,26 @@
 	<classpathentry kind="src" path="test-applications/ejbapp1/src"/>
 	<classpathentry kind="src" path="test-applications/startupcode/src"/>
 	<classpathentry kind="src" path="test-bundles/test.checkpoint.config.bundle/src"/>
+	<classpathentry kind="src" path="test-applications/timeoutTest/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/com.ibm.websphere.org.eclipse.microprofile/generated/com.ibm.websphere.org.eclipse.microprofile.faulttolerance.1.0.jar">
+		<attributes>
+			<attribute name="bsn" value="com.ibm.websphere.org.eclipse.microprofile.faulttolerance.1.0.jar"/>
+			<attribute name="type" value="PROJECT"/>
+			<attribute name="project" value="com.ibm.websphere.org.eclipse.microprofile"/>
+			<attribute name="version" value="latest"/>
+			<attribute name="index_location" value="platform:/plugin/bndtools.builder/org/bndtools/builder/classpath/empty.index"/>
+		</attributes>
+		<accessrules>
+			<accessrule kind="accessible" pattern="org/eclipse/microprofile/faulttolerance/*"/>
+			<accessrule kind="accessible" pattern="org/eclipse/microprofile/faulttolerance/exceptions/*"/>
+			<accessrule ignoreifbetter="true" kind="discouraged" pattern="**"/>
+		</accessrules>
 	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/io.openliberty.checkpoint_fat/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat/bnd.bnd
@@ -19,8 +19,8 @@ src: \
 	test-applications/ejbapp1/src,\
 	test-applications/inventory/src/java,\
 	test-applications/system/src/java,\
-	test-bundles/test.checkpoint.config.bundle/src
-
+	test-bundles/test.checkpoint.config.bundle/src,\
+	test-applications/timeoutTest/src
 
 fat.project: true
 
@@ -71,7 +71,7 @@ tested.features:\
 	io.jaegertracing:jaeger-tracerresolver;version=1.6.0,\
 	org.apache.thrift:libthrift;version=0.14.1,\
 	com.ibm.ws.org.slf4j.simple;version=latest,\
-	com.ibm.ws.org.slf4j.api;version=latest
-	
+	com.ibm.ws.org.slf4j.api;version=latest,\
+	com.ibm.websphere.org.eclipse.microprofile.faulttolerance.1.0
 
 -sub: *.bnd

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FATSuite.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FATSuite.java
@@ -43,7 +43,8 @@ import componenttest.topology.impl.LibertyServer;
                 CheckpointSPITest.class,
                 MPConfigTest.class,
                 SSLTest.class,
-                MPOpenTracingJaegerTraceTest.class
+                MPOpenTracingJaegerTraceTest.class,
+                MPFaultToleranceTimeoutTest.class
 })
 public class FATSuite {
     public static void copyAppsAppToDropins(LibertyServer server, String appName) throws Exception {

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/MPFaultToleranceTimeoutTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/MPFaultToleranceTimeoutTest.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.checkpoint.fat;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfCheckpointNotSupported;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import io.openliberty.checkpoint.spi.CheckpointPhase;
+
+@RunWith(FATRunner.class)
+@SkipIfCheckpointNotSupported
+public class MPFaultToleranceTimeoutTest {
+
+    public static final String APP_NAME = "timeoutTest";
+
+    @Server("timeoutServer")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void copyAppToDropins() throws Exception {
+        ShrinkHelper.defaultApp(server, APP_NAME, "timeoutTest");
+        FATSuite.copyAppsAppToDropins(server, APP_NAME);
+    }
+
+    @Test
+    public void testCheckpointTimeout() throws Exception {
+        ServerConfiguration config = server.getServerConfiguration();
+
+        config.getVariables().get(0).setValue("true");
+        server.updateServerConfiguration(config);
+
+        server.setCheckpoint(CheckpointPhase.APPLICATIONS, false, server -> {
+            String result = server.waitForStringInLogUsingMark("TIMEOUT CALLED", 20000);
+            assertNotNull("Timeout call not found at checkpoint", result);
+        });
+        server.startServer();
+        Thread.sleep(22000);
+        server.checkpointRestore();
+        String result = server.waitForStringInLogUsingMark("TIMEOUT OCCURED", 20000);
+        assertNotNull("Timeout not found in log", result);
+    }
+
+    @Test
+    public void testCheckpointNoTimeout() throws Exception {
+        ServerConfiguration config = server.getServerConfiguration();
+
+        config.getVariables().get(0).setValue("false");
+        server.updateServerConfiguration(config);
+        server.setCheckpoint(CheckpointPhase.APPLICATIONS, false, server -> {
+            String result = server.waitForStringInLogUsingMark("TIMEOUT CALLED", 20000);
+            assertNotNull("Timeout call not found at checkpoint", result);
+        });
+        server.startServer();
+        Thread.sleep(22000);
+        server.checkpointRestore();
+        assertNotNull("Timeout occured", server.waitForStringInLog("timeout did not occur", 20000));
+    }
+
+    @After
+    public void stopServer() throws Exception {
+        server.stopServer();
+    }
+
+}

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/timeoutServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/timeoutServer/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:checkpoint=all

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/timeoutServer/jvm.options
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/timeoutServer/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/timeoutServer/server.xml
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/timeoutServer/server.xml
@@ -1,0 +1,21 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="new server">
+    <featureManager>
+      <feature>ejbLite-3.2</feature>
+      <feature>cdi-2.0</feature>
+      <feature>jaxrs-2.1</feature>
+      <feature>mpFaultTolerance-3.0</feature>
+      <feature>checkpoint-1.0</feature>
+    </featureManager>
+    <variable name="timeout" defaultValue="true"/>
+    <webApplication id="testingApp" location="testingApp.war" name="testingApp"/>
+</server>

--- a/dev/io.openliberty.checkpoint_fat/test-applications/timeoutTest/src/timeoutTest/TimeoutService.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/timeoutTest/src/timeoutTest/TimeoutService.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package timeoutTest;
+
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
+
+@ApplicationScoped
+public class TimeoutService {
+
+    @Inject
+    @ConfigProperty(name = "timeout")
+    private Boolean createTimeout;
+
+    @Asynchronous
+    public Future<Void> spawnTimeoutThread() {
+        Future<Void> completable = CompletableFuture.runAsync(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    System.out.println(produceTimeout());
+                } catch (TimeoutException te) {
+                    System.out.println("TIMEOUT OCCURED");
+                    System.out.println(te.getClass().getName());
+                } catch (Exception e) {
+                    System.out.println("Exception Thrown");
+                    System.out.println(e.getClass().getName());
+                }
+            }
+        });
+        return completable;
+    }
+
+    @Timeout(value = 20, unit = ChronoUnit.SECONDS)
+    public String produceTimeout() throws TimeoutException, InterruptedException {
+        if (createTimeout) {
+            Thread.sleep(Long.MAX_VALUE);
+        } else {
+            Thread.sleep(15000);
+        }
+        return "timeout did not occur";
+    }
+
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/timeoutTest/src/timeoutTest/TimeoutStartup.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/timeoutTest/src/timeoutTest/TimeoutStartup.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package timeoutTest;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.inject.Inject;
+
+@Startup
+@Singleton
+public class TimeoutStartup {
+
+    @Inject
+    TimeoutService timeoutTester;
+
+    @PostConstruct
+    public void getProperties() {
+        System.out.println("TIMEOUT CALLED");
+        timeoutTester.spawnTimeoutThread();
+    }
+
+}


### PR DESCRIPTION
…fat FATSuite

Created a test-case to check the method timeout behavior when a timeout is invoked during a checkpoint. When the checkpoint command is run, the server will spawn a thread which starts a timeout. When the server is restored, the timeout method should resume ignoring time passed in which the server was inactive.