### PR TITLE
OpenAPI 1.x: fix required properties names

### DIFF
--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/core/jackson/ModelResolver.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/core/jackson/ModelResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -450,7 +450,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                     if (property.getRef() == null) {
                         Boolean required = md.getRequired();
                         if (required != null && !Boolean.FALSE.equals(required)) {
-                            addRequiredItem(model, propName);
+                            addRequiredItem(model, ((SchemaImpl) property).getName());
                         }
                         if (property.getReadOnly() == null) {
                             if (isReadOnly) {

--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/annotations/RequiredCustomNameApplication.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/annotations/RequiredCustomNameApplication.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.openapi.fat.annotations;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@ApplicationPath("/")
+@Path("/")
+public class RequiredCustomNameApplication extends Application {
+
+    @Produces(MediaType.APPLICATION_JSON)
+    @GET
+    public RequiredCustomNameDataObject testGet() {
+        return new RequiredCustomNameDataObject();
+    }
+
+    public static class RequiredCustomNameDataObject {
+
+        @Schema(name = "test_a", required = true)
+        public String testA;
+
+        @Schema(required = true)
+        public String testB;
+    }
+}


### PR DESCRIPTION
When the `name` property of `@Schema` is set on a required field, the defined name is used for the `properties` map but not for the `required` array.

Fixes #21441