### PR TITLE
Add trace if quiesce reports threads during PureAnnFATs

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/publish/servers/com.ibm.ws.ejbcontainer.security.jacc_fat.mergebindings/bootstrap.properties
+++ b/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/publish/servers/com.ibm.ws.ejbcontainer.security.jacc_fat.mergebindings/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -14,7 +14,8 @@ com.ibm.ws.security.*=all=enabled:\
 com.ibm.ws.ejbcontainer.security.*=all=enabled:\
 applications=all:\
 com.ibm.ws.webcontainer.security.*=all=enabled:\
-com.ibm.ws.container.service.security.*=all
+com.ibm.ws.container.service.security.*=all:\
+com.ibm.ws.runtime.update.internal.RuntimeUpdateManagerImpl=all=enabled
 bootstrap.include=../testports.properties
 -Xdump:system:events=throw+systhrow,filter=java/lang/IllegalArgumentException#jdk/internal/reflect/ConstantPool.getClassAt0,range=1..3,request=exclusive+prepwalk
 -Xdump:system:events=throw+systhrow,filter=java/lang/IllegalArgumentException#sun/reflect/ConstantPool.getClassAt0,range=1..3,request=exclusive+prepwalk

--- a/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/publish/servers/com.ibm.ws.ejbcontainer.security.jacc_fat/bootstrap.properties
+++ b/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/publish/servers/com.ibm.ws.ejbcontainer.security.jacc_fat/bootstrap.properties
@@ -14,7 +14,8 @@ com.ibm.ws.logging.trace.specification=*=event=enabled:\
 com.ibm.ws.security.*=debug=enabled:\
 com.ibm.ws.ejbcontainer.security.*=debug=enabled:\
 applications=all:\
-com.ibm.ws.webcontainer.security.*=event=enabled
+com.ibm.ws.webcontainer.security.*=event=enabled:\
+com.ibm.ws.runtime.update.internal.RuntimeUpdateManagerImpl=all=enabled
 bootstrap.include=../testports.properties
 -Xdump:system:events=throw+systhrow,filter=java/lang/IllegalArgumentException#jdk/internal/reflect/ConstantPool.getClassAt0,range=1..3,request=exclusive+prepwalk
 -Xdump:system:events=throw+systhrow,filter=java/lang/IllegalArgumentException#sun/reflect/ConstantPool.getClassAt0,range=1..3,request=exclusive+prepwalk


### PR DESCRIPTION
Adding `com.ibm.ws.runtime.update.internal.RuntimeUpdateManagerImpl=all=enabled` trace to two tests that recently hit the warning `com.ibm.ws.runtime.update.internal.RuntimeUpdateManagerImpl  W CWWKE1107W: 3 threads did not complete during the quiesce period.` If this is an ongoing problem, hopefully we'll have the info to debug it next time.

RTC 290937