### PR TITLE
Eclipse cleanup for Tx FAT renames

### DIFF
--- a/dev/com.ibm.ws.transaction.core_fat.baseDB/.project
+++ b/dev/com.ibm.ws.transaction.core_fat.baseDB/.project
@@ -22,54 +22,54 @@
 	</natures>
 	<linkedResources>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-com.ibm.ws.transaction.fat.eventListener</name>
+			<name>com.ibm.ws.transaction.core_fat.base-com.ibm.ws.transaction.fat.eventListener</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/com.ibm.ws.transaction.fat.eventListener/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/com.ibm.ws.transaction.fat.eventListener/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-com.ibm.ws.transaction.fat.remoteTester</name>
+			<name>com.ibm.ws.transaction.core_fat.base-com.ibm.ws.transaction.fat.remoteTester</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/com.ibm.ws.transaction.fat.remoteTester/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/com.ibm.ws.transaction.fat.remoteTester/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-commitPriority</name>
+			<name>com.ibm.ws.transaction.core_fat.base-commitPriority</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/commitPriority/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/commitPriority/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-eventlistener</name>
+			<name>com.ibm.ws.transaction.core_fat.base-eventlistener</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/eventlistener/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/eventlistener/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-fatsrc</name>
+			<name>com.ibm.ws.transaction.core_fat.base-fatsrc</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/fat/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/fat/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transaction</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transaction</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transaction/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transaction/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactional</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactional</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactional/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactional/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactionalEJB</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactionalEJB</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactionalEJB/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactionalEJB/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactionscoped</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactionscoped</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactionscoped/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactionscoped/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-utdecorator</name>
+			<name>com.ibm.ws.transaction.core_fat.base-utdecorator</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/utdecorator/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/utdecorator/src</locationURI>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/dev/com.ibm.ws.transaction.core_fat.cdi/.project
+++ b/dev/com.ibm.ws.transaction.core_fat.cdi/.project
@@ -22,54 +22,54 @@
 	</natures>
 	<linkedResources>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-com.ibm.ws.transaction.fat.eventListener</name>
+			<name>com.ibm.ws.transaction.core_fat.base-com.ibm.ws.transaction.fat.eventListener</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/com.ibm.ws.transaction.fat.eventListener/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/com.ibm.ws.transaction.fat.eventListener/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-com.ibm.ws.transaction.fat.remoteTester</name>
+			<name>com.ibm.ws.transaction.core_fat.base-com.ibm.ws.transaction.fat.remoteTester</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/com.ibm.ws.transaction.fat.remoteTester/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/com.ibm.ws.transaction.fat.remoteTester/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-commitPriority</name>
+			<name>com.ibm.ws.transaction.core_fat.base-commitPriority</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/commitPriority/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/commitPriority/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-eventlistener</name>
+			<name>com.ibm.ws.transaction.core_fat.base-eventlistener</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/eventlistener/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/eventlistener/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-fatsrc</name>
+			<name>com.ibm.ws.transaction.core_fat.base-fatsrc</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/fat/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/fat/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transaction</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transaction</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transaction/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transaction/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactional</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactional</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactional/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactional/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactionalEJB</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactionalEJB</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactionalEJB/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactionalEJB/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactionscoped</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactionscoped</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactionscoped/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactionscoped/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-utdecorator</name>
+			<name>com.ibm.ws.transaction.core_fat.base-utdecorator</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/utdecorator/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/utdecorator/src</locationURI>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/dev/com.ibm.ws.transaction.core_fat.commitPriority/.classpath
+++ b/dev/com.ibm.ws.transaction.core_fat.commitPriority/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="test-applications/commitPriority/src"/>
 	<classpathentry exported="true" kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>

--- a/dev/com.ibm.ws.transaction.core_fat.heuristics/.project
+++ b/dev/com.ibm.ws.transaction.core_fat.heuristics/.project
@@ -22,54 +22,54 @@
 	</natures>
 	<linkedResources>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-com.ibm.ws.transaction.fat.eventListener</name>
+			<name>com.ibm.ws.transaction.core_fat.base-com.ibm.ws.transaction.fat.eventListener</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/com.ibm.ws.transaction.fat.eventListener/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/com.ibm.ws.transaction.fat.eventListener/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-com.ibm.ws.transaction.fat.remoteTester</name>
+			<name>com.ibm.ws.transaction.core_fat.base-com.ibm.ws.transaction.fat.remoteTester</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/com.ibm.ws.transaction.fat.remoteTester/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/com.ibm.ws.transaction.fat.remoteTester/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-commitPriority</name>
+			<name>com.ibm.ws.transaction.core_fat.base-commitPriority</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/commitPriority/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/commitPriority/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-eventlistener</name>
+			<name>com.ibm.ws.transaction.core_fat.base-eventlistener</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/eventlistener/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/eventlistener/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-fatsrc</name>
+			<name>com.ibm.ws.transaction.core_fat.base-fatsrc</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/fat/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/fat/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transaction</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transaction</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transaction/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transaction/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactional</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactional</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactional/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactional/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactionalEJB</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactionalEJB</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactionalEJB/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactionalEJB/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactionscoped</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactionscoped</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactionscoped/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactionscoped/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-utdecorator</name>
+			<name>com.ibm.ws.transaction.core_fat.base-utdecorator</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/utdecorator/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/utdecorator/src</locationURI>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/dev/com.ibm.ws.transaction.core_fat.heuristicsDB/.project
+++ b/dev/com.ibm.ws.transaction.core_fat.heuristicsDB/.project
@@ -22,54 +22,54 @@
 	</natures>
 	<linkedResources>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-com.ibm.ws.transaction.fat.eventListener</name>
+			<name>com.ibm.ws.transaction.core_fat.base-com.ibm.ws.transaction.fat.eventListener</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/com.ibm.ws.transaction.fat.eventListener/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/com.ibm.ws.transaction.fat.eventListener/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-com.ibm.ws.transaction.fat.remoteTester</name>
+			<name>com.ibm.ws.transaction.core_fat.base-com.ibm.ws.transaction.fat.remoteTester</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/com.ibm.ws.transaction.fat.remoteTester/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/com.ibm.ws.transaction.fat.remoteTester/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-commitPriority</name>
+			<name>com.ibm.ws.transaction.core_fat.base-commitPriority</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/commitPriority/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/commitPriority/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-eventlistener</name>
+			<name>com.ibm.ws.transaction.core_fat.base-eventlistener</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/eventlistener/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/eventlistener/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-fatsrc</name>
+			<name>com.ibm.ws.transaction.core_fat.base-fatsrc</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/fat/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/fat/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transaction</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transaction</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transaction/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transaction/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactional</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactional</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactional/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactional/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactionalEJB</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactionalEJB</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactionalEJB/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactionalEJB/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactionscoped</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactionscoped</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactionscoped/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactionscoped/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-utdecorator</name>
+			<name>com.ibm.ws.transaction.core_fat.base-utdecorator</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/utdecorator/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/utdecorator/src</locationURI>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/dev/com.ibm.ws.transaction.core_fat.misc/.classpath
+++ b/dev/com.ibm.ws.transaction.core_fat.misc/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="fat/src" including="com/ibm/ws/transaction/test/FATSuite.java"/>
+	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="com.ibm.ws.transaction.core_fat.base-fatsrc" excluding="com/ibm/ws/transaction/test/FATSuite.java"/>
 	<classpathentry kind="src" path="com.ibm.ws.transaction.core_fat.base-eventlistener"/>
 	<classpathentry kind="src" path="com.ibm.ws.transaction.core_fat.base-com.ibm.ws.transaction.fat.eventListener"/>

--- a/dev/com.ibm.ws.transaction.core_fat.misc/.project
+++ b/dev/com.ibm.ws.transaction.core_fat.misc/.project
@@ -22,54 +22,54 @@
 	</natures>
 	<linkedResources>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-com.ibm.ws.transaction.fat.eventListener</name>
+			<name>com.ibm.ws.transaction.core_fat.base-com.ibm.ws.transaction.fat.eventListener</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/com.ibm.ws.transaction.fat.eventListener/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/com.ibm.ws.transaction.fat.eventListener/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-com.ibm.ws.transaction.fat.remoteTester</name>
+			<name>com.ibm.ws.transaction.core_fat.base-com.ibm.ws.transaction.fat.remoteTester</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/com.ibm.ws.transaction.fat.remoteTester/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/com.ibm.ws.transaction.fat.remoteTester/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-commitPriority</name>
+			<name>com.ibm.ws.transaction.core_fat.base-commitPriority</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/commitPriority/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/commitPriority/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-eventlistener</name>
+			<name>com.ibm.ws.transaction.core_fat.base-eventlistener</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/eventlistener/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/eventlistener/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-fatsrc</name>
+			<name>com.ibm.ws.transaction.core_fat.base-fatsrc</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/fat/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/fat/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transaction</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transaction</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transaction/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transaction/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactional</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactional</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactional/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactional/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactionalEJB</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactionalEJB</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactionalEJB/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactionalEJB/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactionscoped</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactionscoped</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactionscoped/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactionscoped/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-utdecorator</name>
+			<name>com.ibm.ws.transaction.core_fat.base-utdecorator</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/utdecorator/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/utdecorator/src</locationURI>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/dev/com.ibm.ws.transaction.core_fat.startup/.project
+++ b/dev/com.ibm.ws.transaction.core_fat.startup/.project
@@ -22,49 +22,49 @@
 	</natures>
 	<linkedResources>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-com.ibm.ws.transaction.fat.eventListener</name>
+			<name>com.ibm.ws.transaction.core_fat.base-com.ibm.ws.transaction.fat.eventListener</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/com.ibm.ws.transaction.fat.eventListener/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/com.ibm.ws.transaction.fat.eventListener/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-com.ibm.ws.transaction.fat.remoteTester</name>
+			<name>com.ibm.ws.transaction.core_fat.base-com.ibm.ws.transaction.fat.remoteTester</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/com.ibm.ws.transaction.fat.remoteTester/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/com.ibm.ws.transaction.fat.remoteTester/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-commitPriority</name>
+			<name>com.ibm.ws.transaction.core_fat.base-commitPriority</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/commitPriority/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/commitPriority/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-eventlistener</name>
+			<name>com.ibm.ws.transaction.core_fat.base-eventlistener</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/eventlistener/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/eventlistener/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transaction</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transaction</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transaction/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transaction/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactional</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactional</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactional/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactional/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactionalEJB</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactionalEJB</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactionalEJB/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactionalEJB/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactionscoped</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactionscoped</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactionscoped/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactionscoped/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-utdecorator</name>
+			<name>com.ibm.ws.transaction.core_fat.base-utdecorator</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/utdecorator/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/utdecorator/src</locationURI>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/dev/com.ibm.ws.transaction.core_fat.xa/.project
+++ b/dev/com.ibm.ws.transaction.core_fat.xa/.project
@@ -22,54 +22,54 @@
 	</natures>
 	<linkedResources>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-com.ibm.ws.transaction.fat.eventListener</name>
+			<name>com.ibm.ws.transaction.core_fat.base-com.ibm.ws.transaction.fat.eventListener</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/com.ibm.ws.transaction.fat.eventListener/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/com.ibm.ws.transaction.fat.eventListener/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-com.ibm.ws.transaction.fat.remoteTester</name>
+			<name>com.ibm.ws.transaction.core_fat.base-com.ibm.ws.transaction.fat.remoteTester</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/com.ibm.ws.transaction.fat.remoteTester/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/com.ibm.ws.transaction.fat.remoteTester/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-commitPriority</name>
+			<name>com.ibm.ws.transaction.core_fat.base-commitPriority</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/commitPriority/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/commitPriority/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-eventlistener</name>
+			<name>com.ibm.ws.transaction.core_fat.base-eventlistener</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/eventlistener/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/eventlistener/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-fatsrc</name>
+			<name>com.ibm.ws.transaction.core_fat.base-fatsrc</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/fat/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/fat/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transaction</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transaction</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transaction/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transaction/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactional</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactional</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactional/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactional/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactionalEJB</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactionalEJB</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactionalEJB/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactionalEJB/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactionscoped</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactionscoped</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactionscoped/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactionscoped/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-utdecorator</name>
+			<name>com.ibm.ws.transaction.core_fat.base-utdecorator</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/utdecorator/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/utdecorator/src</locationURI>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/dev/com.ibm.ws.transaction.core_fat.xaDB/.project
+++ b/dev/com.ibm.ws.transaction.core_fat.xaDB/.project
@@ -22,54 +22,54 @@
 	</natures>
 	<linkedResources>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-com.ibm.ws.transaction.fat.eventListener</name>
+			<name>com.ibm.ws.transaction.core_fat.base-com.ibm.ws.transaction.fat.eventListener</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/com.ibm.ws.transaction.fat.eventListener/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/com.ibm.ws.transaction.fat.eventListener/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-com.ibm.ws.transaction.fat.remoteTester</name>
+			<name>com.ibm.ws.transaction.core_fat.base-com.ibm.ws.transaction.fat.remoteTester</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/com.ibm.ws.transaction.fat.remoteTester/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/com.ibm.ws.transaction.fat.remoteTester/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-commitPriority</name>
+			<name>com.ibm.ws.transaction.core_fat.base-commitPriority</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/commitPriority/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/commitPriority/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-eventlistener</name>
+			<name>com.ibm.ws.transaction.core_fat.base-eventlistener</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/eventlistener/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/eventlistener/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-fatsrc</name>
+			<name>com.ibm.ws.transaction.core_fat.base-fatsrc</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/fat/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/fat/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transaction</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transaction</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transaction/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transaction/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactional</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactional</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactional/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactional/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactionalEJB</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactionalEJB</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactionalEJB/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactionalEJB/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-transactionscoped</name>
+			<name>com.ibm.ws.transaction.core_fat.base-transactionscoped</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-applications/transactionscoped/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-applications/transactionscoped/src</locationURI>
 		</link>
 		<link>
-			<name>com.ibm.ws.transaction.core_fat.1-utdecorator</name>
+			<name>com.ibm.ws.transaction.core_fat.base-utdecorator</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.1/test-bundles/utdecorator/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.transaction.core_fat.base/test-bundles/utdecorator/src</locationURI>
 		</link>
 	</linkedResources>
 </projectDescription>


### PR DESCRIPTION
Update .project links with new Tx FAT project names and minor .classpath corrections.
