### PR TITLE
Enable JPA FAT for LITE testing v2

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation20_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation20_Web.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -45,7 +45,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+@Mode(TestMode.LITE)
 public class BeanValidation20_Web extends JPAFATServletClient {
 
     @Rule

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation_Web.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -45,7 +45,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+@Mode(TestMode.LITE)
 public class BeanValidation_Web extends JPAFATServletClient {
 
     @Rule

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA20.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA20.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,12 +16,9 @@ import java.io.File;
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
 import componenttest.common.apiservices.Bootstrap;
-import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.rules.repeater.EE6FeatureReplacementAction;
 
-/**
- *
- */
-public class RepeatWithJPA20 implements RepeatTestAction {
+public class RepeatWithJPA20 extends EE6FeatureReplacementAction {
     public static final String ID = "JPA20";
 
     @Override
@@ -30,7 +27,7 @@ public class RepeatWithJPA20 implements RepeatTestAction {
             Bootstrap b = Bootstrap.getInstance();
             String installRoot = b.getValue("libertyInstallPath");
             File jpa20Feature = new File(installRoot + "/lib/features/com.ibm.websphere.appserver.jpa-2.0.mf");
-            return jpa20Feature.exists();
+            return jpa20Feature.exists() && super.isEnabled();
         } catch (Exception e) {
             return false;
         }

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA21.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA21.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,17 +13,18 @@ package com.ibm.ws.jpa.tests.beanvalidation;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE7FeatureReplacementAction;
 
-/**
- *
- */
-public class RepeatWithJPA21 implements RepeatTestAction {
+public class RepeatWithJPA21 extends EE7FeatureReplacementAction {
     public static final String ID = "JPA21";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Allow the default repeat action to run on LITE mode
+     */
+    public RepeatWithJPA21() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.LITE);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA21Hibernate.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA21Hibernate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,17 +13,18 @@ package com.ibm.ws.jpa.tests.beanvalidation;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE7FeatureReplacementAction;
 
-/**
- *
- */
-public class RepeatWithJPA21Hibernate implements RepeatTestAction {
+public class RepeatWithJPA21Hibernate extends EE7FeatureReplacementAction {
     public static final String ID = "JPA21_HIBERNATE";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Restrict Hibernate tests to run on FULL mode
+     */
+    public RepeatWithJPA21Hibernate() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA21OpenJPA.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA21OpenJPA.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,17 +13,18 @@ package com.ibm.ws.jpa.tests.beanvalidation;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE7FeatureReplacementAction;
 
-/**
- *
- */
-public class RepeatWithJPA21OpenJPA implements RepeatTestAction {
+public class RepeatWithJPA21OpenJPA extends EE7FeatureReplacementAction {
     public static final String ID = "JPA21_OPENJPA";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Restrict OpenJPA tests to run on FULL mode
+     */
+    public RepeatWithJPA21OpenJPA() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA22.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA22.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,17 +13,18 @@ package com.ibm.ws.jpa.tests.beanvalidation;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
 
-/**
- *
- */
-public class RepeatWithJPA22 implements RepeatTestAction {
+public class RepeatWithJPA22 extends EE8FeatureReplacementAction {
     public static final String ID = "JPA22";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Allow the default repeat action to run on LITE mode
+     */
+    public RepeatWithJPA22() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.LITE);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA22Hibernate.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA22Hibernate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,17 +13,18 @@ package com.ibm.ws.jpa.tests.beanvalidation;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
 
-/**
- *
- */
-public class RepeatWithJPA22Hibernate implements RepeatTestAction {
+public class RepeatWithJPA22Hibernate extends EE8FeatureReplacementAction {
     public static final String ID = "JPA22_HIBERNATE";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Restrict Hibernate tests to run on FULL mode
+     */
+    public RepeatWithJPA22Hibernate() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA22OpenJPA.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA22OpenJPA.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,17 +13,18 @@ package com.ibm.ws.jpa.tests.beanvalidation;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
 
-/**
- *
- */
-public class RepeatWithJPA22OpenJPA implements RepeatTestAction {
+public class RepeatWithJPA22OpenJPA extends EE8FeatureReplacementAction {
     public static final String ID = "JPA22_OPENJPA";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Restrict OpenJPA tests to run on FULL mode
+     */
+    public RepeatWithJPA22OpenJPA() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/FATSuite.java
@@ -37,6 +37,6 @@ public class FATSuite extends AbstractFATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests
                     .with(new RepeatWithJPA30())
-                    .with(new RepeatWithJPA30Hibernate());
+                    .andWith(new RepeatWithJPA30Hibernate());
 
 }

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA30.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA30.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,18 +13,18 @@ package com.ibm.ws.jpa.tests.beanvalidation;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.JakartaEE9Action;
-import componenttest.rules.repeater.RepeatTestAction;
 
-/**
- *
- */
-public class RepeatWithJPA30 extends JakartaEE9Action implements RepeatTestAction {
+public class RepeatWithJPA30 extends JakartaEE9Action {
     public static final String ID = "JPA30";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Allow the default repeat action to run on LITE mode
+     */
+    public RepeatWithJPA30() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.LITE);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA30Hibernate.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA30Hibernate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,18 +13,18 @@ package com.ibm.ws.jpa.tests.beanvalidation;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.JakartaEE9Action;
-import componenttest.rules.repeater.RepeatTestAction;
 
-/**
- *
- */
-public class RepeatWithJPA30Hibernate extends JakartaEE9Action implements RepeatTestAction {
+public class RepeatWithJPA30Hibernate extends JakartaEE9Action {
     public static final String ID = "JPA30_HIBERNATE";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Restrict Hibernate tests to run on FULL mode
+     */
+    public RepeatWithJPA30Hibernate() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA31.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA31.java
@@ -13,19 +13,19 @@ package com.ibm.ws.jpa.tests.beanvalidation;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.JakartaEE10Action;
-import componenttest.rules.repeater.RepeatTestAction;
 
-/**
- *
- */
-public class RepeatWithJPA31 extends JakartaEE10Action implements RepeatTestAction {
+public class RepeatWithJPA31 extends JakartaEE10Action {
     public static final String ID = "JPA31";
 
-//     @Override
-//     public boolean isEnabled() {
-//         return true;
-//     }
+    /**
+     * Allow the default repeat action to run on LITE mode
+     */
+    public RepeatWithJPA31() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.LITE);
+    }
 
     @Override
     public String toString() {
@@ -38,10 +38,4 @@ public class RepeatWithJPA31 extends JakartaEE10Action implements RepeatTestActi
         FATSuite.repeatPhase = "jpa31-cfg.xml";
         FATSuite.provider = JPAPersistenceProvider.DEFAULT;
     }
-
-//    // Overriding this method will disable Jakarta EE9 transformer
-//    @Override
-//    public String getID() {
-//        return ID;
-//    }
 }

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA31Hibernate.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/beanvalidation/RepeatWithJPA31Hibernate.java
@@ -13,19 +13,19 @@ package com.ibm.ws.jpa.tests.beanvalidation;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.JakartaEE10Action;
-import componenttest.rules.repeater.RepeatTestAction;
 
-/**
- *
- */
-public class RepeatWithJPA31Hibernate extends JakartaEE10Action implements RepeatTestAction {
+public class RepeatWithJPA31Hibernate extends JakartaEE10Action {
     public static final String ID = "JPA31_HIBERNATE";
 
-//    @Override
-//    public boolean isEnabled() {
-//        return true;
-//    }
+    /**
+     * Restrict Hibernate tests to run on FULL mode
+     */
+    public RepeatWithJPA31Hibernate() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
+    }
 
     @Override
     public String toString() {

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_fat.common/fat/src/com/ibm/ws/jpa/tests/jpaconfig/tests/DefaultProperties_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_fat.common/fat/src/com/ibm/ws/jpa/tests/jpaconfig/tests/DefaultProperties_Web.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -49,7 +49,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+@Mode(TestMode.LITE)
 public class DefaultProperties_Web extends JPAFATServletClient {
 
     @Rule

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA21.java
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA21.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,17 +13,18 @@ package com.ibm.ws.jpa.tests.jpaconfig;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE7FeatureReplacementAction;
 
-/**
- *
- */
-public class RepeatWithJPA21 implements RepeatTestAction {
+public class RepeatWithJPA21 extends EE7FeatureReplacementAction {
     public static final String ID = "JPA21";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Allow the default repeat action to run on LITE mode
+     */
+    public RepeatWithJPA21() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.LITE);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA21Hibernate.java
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA21Hibernate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,17 +11,20 @@
 
 package com.ibm.ws.jpa.tests.jpaconfig;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-/**
- *
- */
-public class RepeatWithJPA21Hibernate implements RepeatTestAction {
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE7FeatureReplacementAction;
+
+public class RepeatWithJPA21Hibernate extends EE7FeatureReplacementAction {
     public static final String ID = "JPA21_HIBERNATE";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Restrict Hibernate tests to run on FULL mode
+     */
+    public RepeatWithJPA21Hibernate() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
     }
 
     @Override
@@ -32,6 +35,7 @@ public class RepeatWithJPA21Hibernate implements RepeatTestAction {
     @Override
     public void setup() throws Exception {
         FATSuite.repeatPhase = "hibernate21-cfg.xml";
+        FATSuite.provider = JPAPersistenceProvider.DEFAULT;
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA21OpenJPA.java
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA21OpenJPA.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,17 +13,18 @@ package com.ibm.ws.jpa.tests.jpaconfig;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE7FeatureReplacementAction;
 
-/**
- *
- */
-public class RepeatWithJPA21OpenJPA implements RepeatTestAction {
+public class RepeatWithJPA21OpenJPA extends EE7FeatureReplacementAction {
     public static final String ID = "JPA21_OPENJPA";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Restrict OpenJPA tests to run on FULL mode
+     */
+    public RepeatWithJPA21OpenJPA() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA22.java
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA22.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,17 +13,18 @@ package com.ibm.ws.jpa.tests.jpaconfig;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
 
-/**
- *
- */
-public class RepeatWithJPA22 implements RepeatTestAction {
+public class RepeatWithJPA22 extends EE8FeatureReplacementAction {
     public static final String ID = "JPA22";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Allow the default repeat action to run on LITE mode
+     */
+    public RepeatWithJPA22() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.LITE);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA22Hibernate.java
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA22Hibernate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,17 +11,20 @@
 
 package com.ibm.ws.jpa.tests.jpaconfig;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-/**
- *
- */
-public class RepeatWithJPA22Hibernate implements RepeatTestAction {
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
+
+public class RepeatWithJPA22Hibernate extends EE8FeatureReplacementAction {
     public static final String ID = "JPA22_HIBERNATE";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Restrict Hibernate tests to run on FULL mode
+     */
+    public RepeatWithJPA22Hibernate() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
     }
 
     @Override
@@ -32,6 +35,7 @@ public class RepeatWithJPA22Hibernate implements RepeatTestAction {
     @Override
     public void setup() throws Exception {
         FATSuite.repeatPhase = "hibernate22-cfg.xml";
+        FATSuite.provider = JPAPersistenceProvider.DEFAULT;
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA22OpenJPA.java
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA22OpenJPA.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,17 +13,18 @@ package com.ibm.ws.jpa.tests.jpaconfig;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
 
-/**
- *
- */
-public class RepeatWithJPA22OpenJPA implements RepeatTestAction {
+public class RepeatWithJPA22OpenJPA extends EE8FeatureReplacementAction {
     public static final String ID = "JPA22_OPENJPA";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Restrict OpenJPA tests to run on FULL mode
+     */
+    public RepeatWithJPA22OpenJPA() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA30.java
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA30.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,18 +13,18 @@ package com.ibm.ws.jpa.tests.jpaconfig;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.JakartaEE9Action;
-import componenttest.rules.repeater.RepeatTestAction;
 
-/**
- *
- */
-public class RepeatWithJPA30 extends JakartaEE9Action implements RepeatTestAction {
+public class RepeatWithJPA30 extends JakartaEE9Action {
     public static final String ID = "JPA30";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Allow the default repeat action to run on LITE mode
+     */
+    public RepeatWithJPA30() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.LITE);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA30Hibernate.java
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA30Hibernate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,18 +11,20 @@
 
 package com.ibm.ws.jpa.tests.jpaconfig;
 
-import componenttest.rules.repeater.JakartaEE9Action;
-import componenttest.rules.repeater.RepeatTestAction;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-/**
- *
- */
-public class RepeatWithJPA30Hibernate extends JakartaEE9Action implements RepeatTestAction {
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE9Action;
+
+public class RepeatWithJPA30Hibernate extends JakartaEE9Action {
     public static final String ID = "JPA30_HIBERNATE";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Restrict Hibernate tests to run on FULL mode
+     */
+    public RepeatWithJPA30Hibernate() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
     }
 
     @Override
@@ -34,6 +36,7 @@ public class RepeatWithJPA30Hibernate extends JakartaEE9Action implements Repeat
     public void setup() throws Exception {
         super.setup();
         FATSuite.repeatPhase = "hibernate30-cfg.xml";
+        FATSuite.provider = JPAPersistenceProvider.DEFAULT;
     }
 
 //    // Overriding this method will disable Jakarta EE9 transformer

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA31.java
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA31.java
@@ -13,19 +13,19 @@ package com.ibm.ws.jpa.tests.jpaconfig;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.JakartaEE10Action;
-import componenttest.rules.repeater.RepeatTestAction;
 
-/**
- *
- */
-public class RepeatWithJPA31 extends JakartaEE10Action implements RepeatTestAction {
+public class RepeatWithJPA31 extends JakartaEE10Action {
     public static final String ID = "JPA31";
 
-//     @Override
-//     public boolean isEnabled() {
-//         return true;
-//     }
+    /**
+     * Allow the default repeat action to run on LITE mode
+     */
+    public RepeatWithJPA31() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.LITE);
+    }
 
     @Override
     public String toString() {
@@ -38,10 +38,4 @@ public class RepeatWithJPA31 extends JakartaEE10Action implements RepeatTestActi
         FATSuite.repeatPhase = "jpa31-cfg.xml";
         FATSuite.provider = JPAPersistenceProvider.DEFAULT;
     }
-
-//  // Overriding this method will disable Jakarta EE9 transformer
-//  @Override
-//  public String getID() {
-//      return ID;
-//  }
 }

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA31Hibernate.java
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/jpaconfig/RepeatWithJPA31Hibernate.java
@@ -11,19 +11,21 @@
 
 package com.ibm.ws.jpa.tests.jpaconfig;
 
-import componenttest.rules.repeater.JakartaEE10Action;
-import componenttest.rules.repeater.RepeatTestAction;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-/**
- *
- */
-public class RepeatWithJPA31Hibernate extends JakartaEE10Action implements RepeatTestAction {
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
+
+public class RepeatWithJPA31Hibernate extends JakartaEE10Action {
     public static final String ID = "JPA31_HIBERNATE";
 
-//    @Override
-//    public boolean isEnabled() {
-//        return true;
-//    }
+    /**
+     * Restrict Hibernate tests to run on FULL mode
+     */
+    public RepeatWithJPA31Hibernate() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
+    }
 
     @Override
     public String toString() {
@@ -34,5 +36,6 @@ public class RepeatWithJPA31Hibernate extends JakartaEE10Action implements Repea
     public void setup() throws Exception {
         super.setup();
         FATSuite.repeatPhase = "hibernate31-cfg.xml";
+        FATSuite.provider = JPAPersistenceProvider.DEFAULT;
     }
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA20.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA20.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,13 +16,22 @@ import java.io.File;
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
 import componenttest.common.apiservices.Bootstrap;
-import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE6FeatureReplacementAction;
 
 /**
  *
  */
-public class RepeatWithJPA20 implements RepeatTestAction {
+public class RepeatWithJPA20 extends EE6FeatureReplacementAction {
     public static final String ID = "JPA20";
+
+    /**
+     * Allow the default repeat action to run on LITE mode
+     */
+    public RepeatWithJPA20() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.LITE);
+    }
 
     @Override
     public boolean isEnabled() {
@@ -30,7 +39,7 @@ public class RepeatWithJPA20 implements RepeatTestAction {
             Bootstrap b = Bootstrap.getInstance();
             String installRoot = b.getValue("libertyInstallPath");
             File jpa20Feature = new File(installRoot + "/lib/features/com.ibm.websphere.appserver.jpa-2.0.mf");
-            return jpa20Feature.exists();
+            return jpa20Feature.exists() && super.isEnabled();
         } catch (Exception e) {
             return false;
         }

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA21.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA21.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,17 +11,20 @@
 
 package com.ibm.ws.jpa.tests.spec10.entity;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-/**
- *
- */
-public class RepeatWithJPA21 implements RepeatTestAction {
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE7FeatureReplacementAction;
+
+public class RepeatWithJPA21 extends EE7FeatureReplacementAction {
     public static final String ID = "JPA21";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Allow the default repeat action to run on LITE mode
+     */
+    public RepeatWithJPA21() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.LITE);
     }
 
     @Override
@@ -32,6 +35,7 @@ public class RepeatWithJPA21 implements RepeatTestAction {
     @Override
     public void setup() throws Exception {
         FATSuite.repeatPhase = "jpa21-cfg.xml";
+        FATSuite.provider = JPAPersistenceProvider.DEFAULT;
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA21Hibernate.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA21Hibernate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,17 +13,18 @@ package com.ibm.ws.jpa.tests.spec10.entity;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE7FeatureReplacementAction;
 
-/**
- *
- */
-public class RepeatWithJPA21Hibernate implements RepeatTestAction {
+public class RepeatWithJPA21Hibernate extends EE7FeatureReplacementAction {
     public static final String ID = "JPA21_HIBERNATE";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Restrict Hibernate tests to run on FULL mode
+     */
+    public RepeatWithJPA21Hibernate() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA21OpenJPA.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA21OpenJPA.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,17 +13,18 @@ package com.ibm.ws.jpa.tests.spec10.entity;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE7FeatureReplacementAction;
 
-/**
- *
- */
-public class RepeatWithJPA21OpenJPA implements RepeatTestAction {
+public class RepeatWithJPA21OpenJPA extends EE7FeatureReplacementAction {
     public static final String ID = "JPA21_OPENJPA";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Restrict OpenJPA tests to run on FULL mode
+     */
+    public RepeatWithJPA21OpenJPA() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA22.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA22.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,17 +11,20 @@
 
 package com.ibm.ws.jpa.tests.spec10.entity;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-/**
- *
- */
-public class RepeatWithJPA22 implements RepeatTestAction {
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
+
+public class RepeatWithJPA22 extends EE8FeatureReplacementAction {
     public static final String ID = "JPA22";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Allow the default repeat action to run on LITE mode
+     */
+    public RepeatWithJPA22() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.LITE);
     }
 
     @Override
@@ -32,6 +35,7 @@ public class RepeatWithJPA22 implements RepeatTestAction {
     @Override
     public void setup() throws Exception {
         FATSuite.repeatPhase = "jpa22-cfg.xml";
+        FATSuite.provider = JPAPersistenceProvider.DEFAULT;
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA22Hibernate.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA22Hibernate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,17 +13,18 @@ package com.ibm.ws.jpa.tests.spec10.entity;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
 
-/**
- *
- */
-public class RepeatWithJPA22Hibernate implements RepeatTestAction {
+public class RepeatWithJPA22Hibernate extends EE8FeatureReplacementAction {
     public static final String ID = "JPA22_HIBERNATE";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Restrict Hibernate tests to run on FULL mode
+     */
+    public RepeatWithJPA22Hibernate() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA22OpenJPA.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA22OpenJPA.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,17 +13,18 @@ package com.ibm.ws.jpa.tests.spec10.entity;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
 
-/**
- *
- */
-public class RepeatWithJPA22OpenJPA implements RepeatTestAction {
+public class RepeatWithJPA22OpenJPA extends EE8FeatureReplacementAction {
     public static final String ID = "JPA22_OPENJPA";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Restrict OpenJPA tests to run on FULL mode
+     */
+    public RepeatWithJPA22OpenJPA() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA30.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA30.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,18 +11,20 @@
 
 package com.ibm.ws.jpa.tests.spec10.entity;
 
-import componenttest.rules.repeater.JakartaEE9Action;
-import componenttest.rules.repeater.RepeatTestAction;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-/**
- *
- */
-public class RepeatWithJPA30 extends JakartaEE9Action implements RepeatTestAction {
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE9Action;
+
+public class RepeatWithJPA30 extends JakartaEE9Action {
     public static final String ID = "JPA30";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Allow the default repeat action to run on LITE mode
+     */
+    public RepeatWithJPA30() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.LITE);
     }
 
     @Override
@@ -34,6 +36,7 @@ public class RepeatWithJPA30 extends JakartaEE9Action implements RepeatTestActio
     public void setup() throws Exception {
         super.setup();
         FATSuite.repeatPhase = "jpa30-cfg.xml";
+        FATSuite.provider = JPAPersistenceProvider.DEFAULT;
     }
 
 //    // Overriding this method will disable Jakarta EE9 transformer

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA30Hibernate.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA30Hibernate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,18 +13,18 @@ package com.ibm.ws.jpa.tests.spec10.entity;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.JakartaEE9Action;
-import componenttest.rules.repeater.RepeatTestAction;
 
-/**
- *
- */
-public class RepeatWithJPA30Hibernate extends JakartaEE9Action implements RepeatTestAction {
+public class RepeatWithJPA30Hibernate extends JakartaEE9Action {
     public static final String ID = "JPA30_HIBERNATE";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Restrict Hibernate tests to run on FULL mode
+     */
+    public RepeatWithJPA30Hibernate() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA31.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA31.java
@@ -11,19 +11,21 @@
 
 package com.ibm.ws.jpa.tests.spec10.entity;
 
-import componenttest.rules.repeater.JakartaEE10Action;
-import componenttest.rules.repeater.RepeatTestAction;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-/**
- *
- */
-public class RepeatWithJPA31 extends JakartaEE10Action implements RepeatTestAction {
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
+
+public class RepeatWithJPA31 extends JakartaEE10Action {
     public static final String ID = "JPA31";
 
-//     @Override
-//     public boolean isEnabled() {
-//         return true;
-//     }
+    /**
+     * Allow the default repeat action to run on LITE mode
+     */
+    public RepeatWithJPA31() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.LITE);
+    }
 
     @Override
     public String toString() {
@@ -34,5 +36,6 @@ public class RepeatWithJPA31 extends JakartaEE10Action implements RepeatTestActi
     public void setup() throws Exception {
         super.setup();
         FATSuite.repeatPhase = "jpa31-cfg.xml";
+        FATSuite.provider = JPAPersistenceProvider.DEFAULT;
     }
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA31Hibernate.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entity/RepeatWithJPA31Hibernate.java
@@ -13,19 +13,19 @@ package com.ibm.ws.jpa.tests.spec10.entity;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.JakartaEE10Action;
-import componenttest.rules.repeater.RepeatTestAction;
 
-/**
- *
- */
-public class RepeatWithJPA31Hibernate extends JakartaEE10Action implements RepeatTestAction {
+public class RepeatWithJPA31Hibernate extends JakartaEE10Action {
     public static final String ID = "JPA31_HIBERNATE";
 
-//    @Override
-//    public boolean isEnabled() {
-//        return true;
-//    }
+    /**
+     * Restrict Hibernate tests to run on FULL mode
+     */
+    public RepeatWithJPA31Hibernate() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
+    }
 
     @Override
     public String toString() {

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/olgh/TestOLGH14137_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/olgh/TestOLGH14137_Web.java
@@ -49,7 +49,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+@Mode(TestMode.LITE)
 public class TestOLGH14137_Web extends JPAFATServletClient {
 
     @Rule

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/olgh/TestOLGH17369_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/olgh/TestOLGH17369_Web.java
@@ -49,7 +49,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+@Mode(TestMode.LITE)
 public class TestOLGH17369_Web extends JPAFATServletClient {
 
     @Rule

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/olgh/TestOLGH17373_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/olgh/TestOLGH17373_Web.java
@@ -49,7 +49,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+@Mode(TestMode.LITE)
 public class TestOLGH17373_Web extends JPAFATServletClient {
 
     @Rule

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/olgh/TestOLGH17376_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/olgh/TestOLGH17376_Web.java
@@ -49,7 +49,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+@Mode(TestMode.LITE)
 public class TestOLGH17376_Web extends JPAFATServletClient {
 
     @Rule

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/olgh/TestOLGH17407_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/olgh/TestOLGH17407_Web.java
@@ -49,7 +49,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+@Mode(TestMode.LITE)
 public class TestOLGH17407_Web extends JPAFATServletClient {
 
     @Rule

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/olgh/TestOLGH19185_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/olgh/TestOLGH19185_Web.java
@@ -49,7 +49,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+@Mode(TestMode.LITE)
 public class TestOLGH19185_Web extends JPAFATServletClient {
 
     @Rule

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/olgh/TestOLGH19342_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/olgh/TestOLGH19342_Web.java
@@ -49,7 +49,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+@Mode(TestMode.LITE)
 public class TestOLGH19342_Web extends JPAFATServletClient {
 
     @Rule

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/olgh/TestOLGH19998_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/olgh/TestOLGH19998_Web.java
@@ -49,7 +49,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+@Mode(TestMode.LITE)
 public class TestOLGH19998_Web extends JPAFATServletClient {
 
     @Rule

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/olgh/TestOLGH20890_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/olgh/TestOLGH20890_Web.java
@@ -49,7 +49,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+@Mode(TestMode.LITE)
 public class TestOLGH20890_Web extends JPAFATServletClient {
 
     @Rule

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/olgh/TestOLGH8014_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/olgh/TestOLGH8014_Web.java
@@ -49,7 +49,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+@Mode(TestMode.LITE)
 public class TestOLGH8014_Web extends JPAFATServletClient {
 
     @Rule

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA20.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA20.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,13 +16,19 @@ import java.io.File;
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
 import componenttest.common.apiservices.Bootstrap;
-import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE6FeatureReplacementAction;
 
-/**
- *
- */
-public class RepeatWithJPA20 implements RepeatTestAction {
+public class RepeatWithJPA20 extends EE6FeatureReplacementAction {
     public static final String ID = "JPA20";
+
+    /**
+     * Allow the default repeat action to run on LITE mode
+     */
+    public RepeatWithJPA20() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.LITE);
+    }
 
     @Override
     public boolean isEnabled() {
@@ -30,7 +36,7 @@ public class RepeatWithJPA20 implements RepeatTestAction {
             Bootstrap b = Bootstrap.getInstance();
             String installRoot = b.getValue("libertyInstallPath");
             File jpa20Feature = new File(installRoot + "/lib/features/com.ibm.websphere.appserver.jpa-2.0.mf");
-            return jpa20Feature.exists();
+            return jpa20Feature.exists() && super.isEnabled();
         } catch (Exception e) {
             return false;
         }

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA21.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA21.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,17 +11,20 @@
 
 package com.ibm.ws.jpa.tests.spec10.query;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-/**
- *
- */
-public class RepeatWithJPA21 implements RepeatTestAction {
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE7FeatureReplacementAction;
+
+public class RepeatWithJPA21 extends EE7FeatureReplacementAction {
     public static final String ID = "JPA21";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Allow the default repeat action to run on LITE mode
+     */
+    public RepeatWithJPA21() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.LITE);
     }
 
     @Override
@@ -32,6 +35,7 @@ public class RepeatWithJPA21 implements RepeatTestAction {
     @Override
     public void setup() throws Exception {
         FATSuite.repeatPhase = "jpa21-cfg.xml";
+        FATSuite.provider = JPAPersistenceProvider.DEFAULT;
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA21Hibernate.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA21Hibernate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,17 +13,18 @@ package com.ibm.ws.jpa.tests.spec10.query;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE7FeatureReplacementAction;
 
-/**
- *
- */
-public class RepeatWithJPA21Hibernate implements RepeatTestAction {
+public class RepeatWithJPA21Hibernate extends EE7FeatureReplacementAction {
     public static final String ID = "JPA21_HIBERNATE";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Restrict Hibernate tests to run on FULL mode
+     */
+    public RepeatWithJPA21Hibernate() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA21OpenJPA.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA21OpenJPA.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,17 +13,18 @@ package com.ibm.ws.jpa.tests.spec10.query;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE7FeatureReplacementAction;
 
-/**
- *
- */
-public class RepeatWithJPA21OpenJPA implements RepeatTestAction {
+public class RepeatWithJPA21OpenJPA extends EE7FeatureReplacementAction {
     public static final String ID = "JPA21_OPENJPA";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Restrict OpenJPA tests to run on FULL mode
+     */
+    public RepeatWithJPA21OpenJPA() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA22.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA22.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,17 +11,20 @@
 
 package com.ibm.ws.jpa.tests.spec10.query;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-/**
- *
- */
-public class RepeatWithJPA22 implements RepeatTestAction {
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
+
+public class RepeatWithJPA22 extends EE8FeatureReplacementAction {
     public static final String ID = "JPA22";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Allow the default repeat action to run on LITE mode
+     */
+    public RepeatWithJPA22() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.LITE);
     }
 
     @Override
@@ -32,6 +35,7 @@ public class RepeatWithJPA22 implements RepeatTestAction {
     @Override
     public void setup() throws Exception {
         FATSuite.repeatPhase = "jpa22-cfg.xml";
+        FATSuite.provider = JPAPersistenceProvider.DEFAULT;
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA22Hibernate.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA22Hibernate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,17 +13,18 @@ package com.ibm.ws.jpa.tests.spec10.query;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
 
-/**
- *
- */
-public class RepeatWithJPA22Hibernate implements RepeatTestAction {
+public class RepeatWithJPA22Hibernate extends EE8FeatureReplacementAction {
     public static final String ID = "JPA22_HIBERNATE";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Restrict Hibernate tests to run on FULL mode
+     */
+    public RepeatWithJPA22Hibernate() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA22OpenJPA.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA22OpenJPA.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,17 +13,18 @@ package com.ibm.ws.jpa.tests.spec10.query;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
 
-/**
- *
- */
-public class RepeatWithJPA22OpenJPA implements RepeatTestAction {
+public class RepeatWithJPA22OpenJPA extends EE8FeatureReplacementAction {
     public static final String ID = "JPA22_OPENJPA";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Restrict OpenJPA tests to run on FULL mode
+     */
+    public RepeatWithJPA22OpenJPA() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA30.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA30.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,18 +11,20 @@
 
 package com.ibm.ws.jpa.tests.spec10.query;
 
-import componenttest.rules.repeater.JakartaEE9Action;
-import componenttest.rules.repeater.RepeatTestAction;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-/**
- *
- */
-public class RepeatWithJPA30 extends JakartaEE9Action implements RepeatTestAction {
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE9Action;
+
+public class RepeatWithJPA30 extends JakartaEE9Action {
     public static final String ID = "JPA30";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Allow the default repeat action to run on LITE mode
+     */
+    public RepeatWithJPA30() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.LITE);
     }
 
     @Override
@@ -34,6 +36,7 @@ public class RepeatWithJPA30 extends JakartaEE9Action implements RepeatTestActio
     public void setup() throws Exception {
         super.setup();
         FATSuite.repeatPhase = "jpa30-cfg.xml";
+        FATSuite.provider = JPAPersistenceProvider.DEFAULT;
     }
 
 //    // Overriding this method will disable Jakarta EE9 transformer

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA30Hibernate.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA30Hibernate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,18 +13,18 @@ package com.ibm.ws.jpa.tests.spec10.query;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.JakartaEE9Action;
-import componenttest.rules.repeater.RepeatTestAction;
 
-/**
- *
- */
-public class RepeatWithJPA30Hibernate extends JakartaEE9Action implements RepeatTestAction {
+public class RepeatWithJPA30Hibernate extends JakartaEE9Action {
     public static final String ID = "JPA30_HIBERNATE";
 
-    @Override
-    public boolean isEnabled() {
-        return true;
+    /**
+     * Restrict Hibernate tests to run on FULL mode
+     */
+    public RepeatWithJPA30Hibernate() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA31.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA31.java
@@ -11,19 +11,21 @@
 
 package com.ibm.ws.jpa.tests.spec10.query;
 
-import componenttest.rules.repeater.JakartaEE10Action;
-import componenttest.rules.repeater.RepeatTestAction;
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
-/**
- *
- */
-public class RepeatWithJPA31 extends JakartaEE10Action implements RepeatTestAction {
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
+
+public class RepeatWithJPA31 extends JakartaEE10Action {
     public static final String ID = "JPA31";
 
-//     @Override
-//     public boolean isEnabled() {
-//         return true;
-//     }
+    /**
+     * Allow the default repeat action to run on LITE mode
+     */
+    public RepeatWithJPA31() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.LITE);
+    }
 
     @Override
     public String toString() {
@@ -34,6 +36,6 @@ public class RepeatWithJPA31 extends JakartaEE10Action implements RepeatTestActi
     public void setup() throws Exception {
         super.setup();
         FATSuite.repeatPhase = "jpa31-cfg.xml";
+        FATSuite.provider = JPAPersistenceProvider.DEFAULT;
     }
-
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA31Hibernate.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA31Hibernate.java
@@ -13,19 +13,19 @@ package com.ibm.ws.jpa.tests.spec10.query;
 
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.JakartaEE10Action;
-import componenttest.rules.repeater.RepeatTestAction;
 
-/**
- *
- */
-public class RepeatWithJPA31Hibernate extends JakartaEE10Action implements RepeatTestAction {
+public class RepeatWithJPA31Hibernate extends JakartaEE10Action {
     public static final String ID = "JPA31_HIBERNATE";
 
-//    @Override
-//    public boolean isEnabled() {
-//        return true;
-//    }
+    /**
+     * Restrict Hibernate tests to run on FULL mode
+     */
+    public RepeatWithJPA31Hibernate() {
+        // Used in componenttest.rules.repeater.RepeatTestAction.isEnabled() to determine if the test should run
+        withTestMode(TestMode.FULL);
+    }
 
     @Override
     public String toString() {


### PR DESCRIPTION
for #21260

Changes:

`com.ibm.ws.jpa.tests.spec10.query` 
LITE Current runtime: 5-7 minutes
LITE New runtime: 12-14 minutes

`com.ibm.ws.jpa.tests.spec10.entity`
LITE Current runtime: 10 minutes
LITE New runtime: 7 minutes
* This is actually because the FAT has existing LITE testing, but it runs against EclipseLink (default), Hibernate, and OpenJPA. This PR reduces that to just EclipseLink; allocating Hibernate and OpenJPA repeat actions to FULL

`com.ibm.ws.jpa.tests.jpaconfig`
LITE Current runtime: 3 minutes
LITE New runtime: 5 minutes

`com.ibm.ws.jpa.tests.beanvalidation`
LITE Current runtime: 3min
LITE New runtime:  4min
