### PR TITLE
Added LogRecordContext Extensions to Tr message and trace

### DIFF
--- a/dev/com.ibm.ws.logging.core/src/com/ibm/ws/logging/internal/WsLogRecord.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/ws/logging/internal/WsLogRecord.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2005 IBM Corporation and others.
+ * Copyright (c) 2004, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
 import com.ibm.ejs.ras.TraceNLS;
+import com.ibm.websphere.logging.hpel.LogRecordContext;
 import com.ibm.websphere.ras.DataFormatHelper;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.wsspi.logging.LogRecordExt;
@@ -525,6 +526,10 @@ public class WsLogRecord extends LogRecord implements java.io.Serializable, LogR
         else {
             retMe.setLocalizable(REQUIRES_NO_LOCALIZATION);
         }
+        
+        // Get Extensions when messages are logged with Tr.
+        LogRecordContext.getExtensions(retMe.getExtensions());  
+        
         return retMe;
     }
 

--- a/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/ExtensionsMessagesLogTest.java
+++ b/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/ExtensionsMessagesLogTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.logging.json.fat;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * Tests if all the messages logged by Liberty (TR or JUL) contains the LogRecordContext extensions that are registered by the Liberty Kernel (e.g. ext_thread).
+ * This test uses a kernel-only Liberty server, so less messages are logged in the messages.log, and thus, will be easier to check each log line.
+ */
+@RunWith(FATRunner.class)
+public class ExtensionsMessagesLogTest {
+
+    protected static final Class<?> c = ExtensionsMessagesLogTest.class;
+
+    public static final String KERNEL_SERVER_NAME = "com.ibm.ws.logging.json.KernelOnlyExtServer";
+
+    @Server(KERNEL_SERVER_NAME)
+    public static LibertyServer server; // Server with no applications or features installed, just the Liberty kernel.
+
+    @Before
+    public void setUp() throws Exception {
+        if (server != null && !server.isStarted()) {
+            server.startServer();
+        }
+    }
+
+    @After
+    public void cleanUp() throws Exception {
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    /*
+     * This test verifies if all the liberty JSON log messages contain the LogRecordContext extension (e.g. ext_thread).
+     * Most of the Liberty initialization messages at start up are logged using Tr, whereas later messages are logged using JUL.
+     * Hence, the LRC extensions should be included, regardless of the logging mechanism that is used to log the message.
+     */
+    @Test
+    public void testKernelLibertyMessagesContainLRCExtensions() throws Exception {
+        final String method = "testKernelLibertyMessagesContainLRCExtentions";
+        List<String> lines = server.findStringsInLogs("\\{.*\"type\":\"liberty_message\".*\\}");
+
+        // Check if the ext_thread LogRecordContext extensions exists in each log line
+        for (String line : lines) {
+            if (line.contains("product = ")) {
+                // Skip the header JSON entry, as it will not contain LogRecordContext Extensions.
+                Log.info(c, method, "Skipping Liberty Log Header Line : " + line);
+                continue;
+            }
+            Log.info(c, method, "Liberty Log Line : " + line);
+            assertTrue("LogRecordContext Extensions was not found for line : " + line, line.contains("ext_thread"));
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/FATSuite.java
+++ b/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/FATSuite.java
@@ -27,7 +27,8 @@ import org.junit.runners.Suite.SuiteClasses;
                 ConsoleFormatTest.class,
                 JsonConfigBootstrapTest.class,
                 ContainerEnvVarTest.class,
-                AppNameExtensionTest.class
+                AppNameExtensionTest.class,
+                ExtensionsMessagesLogTest.class
 })
 public class FATSuite {
 

--- a/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/TestUtils.java
+++ b/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/TestUtils.java
@@ -45,6 +45,8 @@ public class TestUtils {
             url = url + "/ExtURL";
         } else if (type.equals("exception")) {
             url = url + "/ExceptionURL";
+        } else if (type.equals("ExceptionExtURL")) {
+            url = url + "/ExceptionExtURL";
         }
         Log.info(c, "runApp", "---> Running the application with url : " + url);
 

--- a/dev/com.ibm.ws.logging.json_fat/publish/servers/com.ibm.ws.logging.json.KernelOnlyExtServer/bootstrap.properties
+++ b/dev/com.ibm.ws.logging.json_fat/publish/servers/com.ibm.ws.logging.json.KernelOnlyExtServer/bootstrap.properties
@@ -1,0 +1,13 @@
+###############################################################################
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+
+

--- a/dev/com.ibm.ws.logging.json_fat/publish/servers/com.ibm.ws.logging.json.KernelOnlyExtServer/server.env
+++ b/dev/com.ibm.ws.logging.json_fat/publish/servers/com.ibm.ws.logging.json.KernelOnlyExtServer/server.env
@@ -1,0 +1,2 @@
+WLP_LOGGING_MESSAGE_FORMAT=json
+WLP_LOGGING_MESSAGE_SOURCE=message,accessLog,ffdc,trace

--- a/dev/com.ibm.ws.logging.json_fat/publish/servers/com.ibm.ws.logging.json.KernelOnlyExtServer/server.xml
+++ b/dev/com.ibm.ws.logging.json_fat/publish/servers/com.ibm.ws.logging.json.KernelOnlyExtServer/server.xml
@@ -1,0 +1,19 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Server for testing Liberty logging in a server">
+
+    <include location="../fatTestPorts.xml"/>
+    
+    <httpEndpoint id="defaultHttpEndpoint" httpPort="${bvt.prop.HTTP_default}" httpsPort="${bvt.prop.HTTP_default.secure}">
+        <accessLogging enabled="true"  filepath="${server.output.dir}/logs/http_defaultEndpoint_access.log" logFormat="%h %u %t &quot;%r&quot; %s %b %D %{User-agent}i"/>
+    </httpEndpoint>
+
+</server>

--- a/dev/com.ibm.ws.logging.json_fat/test-applications/LogstashApp/src/com/ibm/logs/ExceptionExtServlet.java
+++ b/dev/com.ibm.ws.logging.json_fat/test-applications/LogstashApp/src/com/ibm/logs/ExceptionExtServlet.java
@@ -1,0 +1,51 @@
+package com.ibm.logs;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.ibm.websphere.logging.hpel.LogRecordContext;
+
+@WebServlet("/ExceptionExtURL")
+public class ExceptionExtServlet extends HttpServlet {
+
+    /**
+     * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
+     */
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+        String loggerName = "com.ibm.logs.ExceptionExtServlet";
+        String logMessage = "Test Exception Extension Message";
+
+        java.util.logging.Logger logger = java.util.logging.Logger.getLogger(loggerName);
+
+        String key = request.getParameter("key");
+        String value = request.getParameter("value");
+        String msg = request.getParameter("msg");
+        if (msg != null) {
+            logMessage = msg;
+        }
+
+        //Populating LogRecord with extensions
+
+        if (key == null) {
+            LogRecordContext.addExtension("testExtensionException", "testValue");
+        } else {
+            LogRecordContext.addExtension(key, value);
+        }
+
+        logger.logp(java.util.logging.Level.INFO, loggerName, "Method.Info", logMessage);
+
+        try {
+            throw new Throwable("Test Throwable");
+        } catch (Throwable t) {
+            throw new IOException(t.getMessage());
+        }
+
+    }
+}

--- a/dev/com.ibm.ws.logging.json_fat/test-applications/LogstashApp/src/web.xml
+++ b/dev/com.ibm.ws.logging.json_fat/test-applications/LogstashApp/src/web.xml
@@ -48,6 +48,13 @@
     <load-on-startup>1</load-on-startup>
   </servlet>
   
+  <servlet id="ExceptionExtServlet">
+    <servlet-name>ExceptionExtServlet</servlet-name>
+    <display-name>ExceptionExtServlet</display-name>
+    <servlet-class>com.ibm.logs.ExceptionExtServlet</servlet-class>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+  
   <!-- SERVLET MAPPINGS -->        
   <servlet-mapping id="ServletMapping_Default">
     <servlet-name>Logstash Servlet</servlet-name>
@@ -77,6 +84,11 @@
   <servlet-mapping id="ExceptionServlet">
     <servlet-name>ExceptionServlet</servlet-name>
     <url-pattern>/ExceptionURL</url-pattern>
+  </servlet-mapping>
+  
+  <servlet-mapping id="ExceptionExtServlet">
+    <servlet-name>ExceptionExtServlet</servlet-name>
+    <url-pattern>/ExceptionExtURL</url-pattern>
   </servlet-mapping>
 
 </web-app>


### PR DESCRIPTION
fixes #21381
fixes #20256

- Adds `LogRecordContext.getExtensions()` call to the `WsLogRecord.createWsLogRecord()` method which includes the logging extensions for logs generated using Tr.
- Adds additional test cases to test if the LogRecordContext extension fields exists for all JSON logs/trace (JUL and Tr) - e.g. `ext_thread`.
- Adds a new test case to test if the LogRecordContext extension fields exists if an exception is logged in JSON.