### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/update-openapi-ui.yml
+++ b/.github/workflows/update-openapi-ui.yml
@@ -4,8 +4,14 @@ name: Update OpenAPI UI dependencies
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   update-openapi-ui:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     name: Update OpenAPI UI Dependencies
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
