### PR TITLE
JAX-WS: Increase timeouts for various tests

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/LibertyCXFNegativePropertiesTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/LibertyCXFNegativePropertiesTest.java
@@ -13,7 +13,6 @@ package com.ibm.ws.jaxws.fat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import java.net.HttpURLConnection;
 import java.net.URL;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -131,7 +130,7 @@ public class LibertyCXFNegativePropertiesTest {
                  "Calling Application with URL=" + url.toString());
         HttpUtils.trustAllCertificates();
         HttpUtils.trustAllHostnames();
-        HttpURLConnection con = HttpUtils.getHttpConnection(url, ExpectedConnection, CONN_TIMEOUT);
+        HttpsURLConnection con = (HttpsURLConnection) HttpUtils.getHttpConnection(url, ExpectedConnection, CONN_TIMEOUT);
         con.disconnect();
     }
 }

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/LibertyCXFNegativePropertiesTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/LibertyCXFNegativePropertiesTest.java
@@ -45,7 +45,7 @@ public class LibertyCXFNegativePropertiesTest {
     public static LibertyServer server;
 
     private final static Class<?> c = LibertyCXFNegativePropertiesTest.class;
-    private static final int CONN_TIMEOUT = 10;
+    private static final int CONN_TIMEOUT = 300;
 
     // *** Stop and Start server between tests ***
     @BeforeClass

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/LibertyCXFNegativePropertiesTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/LibertyCXFNegativePropertiesTest.java
@@ -27,6 +27,7 @@ import com.ibm.ws.jaxws.fat.util.ExplodedShrinkHelper;
 import com.ibm.ws.jaxws.fat.util.TestUtils;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
@@ -38,6 +39,7 @@ import componenttest.topology.utils.HttpUtils;
  * Usage of waitForStringInTraceUsingMark cut the runtime significantly
  */
 @RunWith(FATRunner.class)
+@SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
 public class LibertyCXFNegativePropertiesTest {
 
     @Server("LibertyCXFNegativePropertiesTestServer")

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/LibertyCXFPositivePropertiesTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/LibertyCXFPositivePropertiesTest.java
@@ -12,7 +12,6 @@ package com.ibm.ws.jaxws.fat;
 
 import static org.junit.Assert.assertNotNull;
 
-import java.net.HttpURLConnection;
 import java.net.URL;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -127,7 +126,7 @@ public class LibertyCXFPositivePropertiesTest {
                  "Calling Application with URL=" + url.toString());
         HttpUtils.trustAllCertificates();
         HttpUtils.trustAllHostnames();
-        HttpURLConnection con = HttpUtils.getHttpConnection(url, HttpsURLConnection.HTTP_OK, CONN_TIMEOUT);
+        HttpsURLConnection con = (HttpsURLConnection) HttpUtils.getHttpConnection(url, HttpsURLConnection.HTTP_OK, CONN_TIMEOUT);
         con.disconnect();
     }
 }

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/LibertyCXFPositivePropertiesTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/LibertyCXFPositivePropertiesTest.java
@@ -44,7 +44,7 @@ public class LibertyCXFPositivePropertiesTest {
     public static LibertyServer server;
 
     private final static Class<?> c = LibertyCXFPositivePropertiesTest.class;
-    private static final int CONN_TIMEOUT = 10;
+    private static final int CONN_TIMEOUT = 300;
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/ColocatedDynamicPolicyAttachmentsTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/ColocatedDynamicPolicyAttachmentsTest.java
@@ -119,6 +119,8 @@ public class ColocatedDynamicPolicyAttachmentsTest {
     public static String helloWithOptionalPolicy = "helloWithOptionalPolicy";
     public static String helloWithYouWant = "helloWithYouWant";
 
+    private static final int CONN_TIMEOUT = 300;
+
     @BeforeClass
     public static void setup() throws Exception {
 
@@ -292,7 +294,7 @@ public class ColocatedDynamicPolicyAttachmentsTest {
      */
     public static String executeApp(String url) throws Exception {
         HttpURLConnection con = HttpUtils.getHttpConnection(new URL(url),
-                                                            HttpURLConnection.HTTP_OK, 60);
+                                                            HttpURLConnection.HTTP_OK, CONN_TIMEOUT);
         BufferedReader br = HttpUtils.getConnectionStream(con);
         String result = br.readLine();
         Log.info(ColocatedDynamicPolicyAttachmentsTest.class, "executeApp", "Execute WS-Addressing Policy Attachment test from " + url);
@@ -304,7 +306,7 @@ public class ColocatedDynamicPolicyAttachmentsTest {
      */
     public static String executeFailureApp(String url) throws Exception {
         HttpURLConnection con = HttpUtils.getHttpConnection(new URL(url),
-                                                            HttpURLConnection.HTTP_INTERNAL_ERROR, 60);
+                                                            HttpURLConnection.HTTP_INTERNAL_ERROR, CONN_TIMEOUT);
         BufferedReader br = HttpUtils.getConnectionStream(con);
         String result = br.readLine();
         Log.info(ColocatedDynamicPolicyAttachmentsTest.class, "executeFailureApp", "Execute Failing WS-Addressing Policy Attachment test from " + url);

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/PortComponentRefTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/PortComponentRefTest.java
@@ -67,6 +67,9 @@ public class PortComponentRefTest {
         server.waitForStringInLog("CWWKZ0001I.*testPortComponentRefWeb");
         server.waitForStringInLog("CWWKZ0001I.*testPortComponentRefEJBinWeb");
         server.waitForStringInLog("CWWKZ0001I.*testPortComponentRefApplication");
+        server.waitForStringInLog("CWWKT0016I.*/testPortComponentRefWeb/");
+        server.waitForStringInLog("CWWKT0016I.*/testPortComponentRefApplicationEJB/");
+        server.waitForStringInLog("CWWKT0016I.*/testPortComponentRefApplicationWeb/");
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/PortComponentRefTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/PortComponentRefTest.java
@@ -53,8 +53,6 @@ public class PortComponentRefTest {
 
         ExplodedShrinkHelper.explodedWarToDestination(server, "resources", "testPortComponentRefApplicationWeb", "com.ibm.ws.jaxws.test.pcr.app.web.client");
 
-        server.startServer("PortComponentRefTest.log");
-
         // Replace the service's wsdl port address with the real URL,
         // because the client's <port-component-link> will find and use it so that it doesn't need explicitly specify the wsdl location in service-ref.
         TestUtils.replaceServerFileString(server, "dropins/testPortComponentRefWeb.war/w"
@@ -62,6 +60,8 @@ public class PortComponentRefTest {
                                           "#BASE_URL#", getBaseURL());
         TestUtils.replaceServerFileString(server, "dropins/testPortComponentRefEJBinWeb.war/wsdl/HelloService.wsdl", "#BASE_URL#", getBaseURL());
         TestUtils.replaceServerFileString(server, "resources/testPortComponentRefApplicationEJB.jar/META-INF/wsdl/HelloService.wsdl", "#BASE_URL#", getBaseURL());
+
+        server.startServer("PortComponentRefTest.log");
 
         // Pause for application to start successfully
         server.waitForStringInLog("CWWKZ0001I.*testPortComponentRefWeb");


### PR DESCRIPTION
This pull request increases the timeouts of a couple of test buckets that have their timeouts set to only 10 seconds and are failing a whole lot of builds for this reason. 