### PR TITLE
Update Jakarta EE9 tests

### DIFF
--- a/dev/com.ibm.ws.request.probes/src/com/ibm/ws/request/probe/RequestProbeService.java
+++ b/dev/com.ibm.ws.request.probes/src/com/ibm/ws/request/probe/RequestProbeService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -227,7 +227,8 @@ public class RequestProbeService {
 			try{
 				//Check if this probe extension is interested in 
 				//counter events
-				if(probeExtension.invokeForCounter()){
+				if(probeExtension.invokeForCounter()
+							&& (probeExtension.invokeForEventTypes() == null || probeExtension.invokeForEventTypes().contains(event.getType()))) {
 					probeExtension.processCounter(event);
 				}
 			}catch(Exception e){

--- a/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/RequestTimingEventTest.java
+++ b/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/RequestTimingEventTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,7 +35,6 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.request.timing.app.RequestTimingServlet;
 
-import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
@@ -157,7 +156,6 @@ public class RequestTimingEventTest {
      *
      * @throws Exception
      */
-    @ExpectedFFDC("java.lang.ClassCastException")
     @Mode(TestMode.LITE)
     @Test
     public void testTotalServletRequestsWithEventTiming() throws Exception {
@@ -223,7 +221,6 @@ public class RequestTimingEventTest {
      *
      * @throws Exception
      */
-    @ExpectedFFDC("java.lang.ClassCastException")
     @Mode(TestMode.LITE)
     @Test
     public void testSlowServletRequestWithEventTiming() throws Exception {
@@ -311,7 +308,6 @@ public class RequestTimingEventTest {
      *
      * @throws Exception
      */
-    @ExpectedFFDC("java.lang.ClassCastException")
     @Mode(TestMode.LITE)
     @Test
     public void testHungServletRequestWithEventTiming() throws Exception {
@@ -408,7 +404,7 @@ public class RequestTimingEventTest {
      * allow a test to finish
      *
      * @param countToWaitFor
-     *            Value looked for in CountDownLatch
+     *                           Value looked for in CountDownLatch
      * @throws Exception
      */
     private void waitInServletForCountDownLatch(int countToWaitFor) throws Exception {
@@ -478,9 +474,9 @@ public class RequestTimingEventTest {
      * test
      *
      * @param th
-     *            -- array of threads
+     *                    -- array of threads
      * @param numReqs
-     *            -- number of requests is the number of threads needed
+     *                    -- number of requests is the number of threads needed
      */
     private void createRequestThreads(Thread[] th, int numReqs, String method) {
         // Send N servlet requests to server, last request used to terminate

--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/JakartaEE9Test.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/JakartaEE9Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.jakartaee9.internal.tests;
+
+import java.util.Set;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -27,12 +29,43 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import io.openliberty.jakartaee9.internal.apps.jakartaee9.web.WebProfile9TestServlet;
 
 @RunWith(FATRunner.class)
 public class JakartaEE9Test extends FATServletClient {
+
+    private static Set<String> getCompatFeatures() {
+        Set<String> compatFeatures = EE9FeatureCompatibilityTest.getAllCompatibileFeatures();
+        // remove features so that they don't cause feature conflicts.
+        compatFeatures.remove("jdbc-4.0");
+        compatFeatures.remove("jdbc-4.1");
+        compatFeatures.remove(JavaInfo.JAVA_VERSION < 9 ? "jdbc-4.3" : "jdbc-4.2");
+        compatFeatures.remove("sessionCache-1.0");
+        compatFeatures.remove("facesContainer-3.0");
+        compatFeatures.remove("jsonbContainer-2.0");
+        compatFeatures.remove("jsonpContainer-2.0");
+        compatFeatures.remove("persistenceContainer-3.0");
+
+        // remove client features
+        compatFeatures.remove("jakartaeeClient-9.1");
+        compatFeatures.remove("appSecurityClient-1.0");
+
+        // remove acmeCA-2.0 since it requires additional resources and configuration
+        compatFeatures.remove("acmeCA-2.0");
+
+        // remove noship features
+        compatFeatures.remove("checkpoint-1.0");
+        compatFeatures.remove("jcacheContainer-1.1");
+        compatFeatures.remove("netty-1.0");
+        compatFeatures.remove("noShip-1.0");
+        compatFeatures.remove("scim-2.0");
+        return compatFeatures;
+    }
+
+    private static final String ALL_COMPAT_FEATURES = "AllEE9CompatFeatures";
 
     @ClassRule
     public static RepeatTests repeat = RepeatTests
@@ -44,6 +77,12 @@ public class JakartaEE9Test extends FATServletClient {
                                     .removeFeature("jakartaee-9.1")
                                     .addFeature("webProfile-9.1")
                                     .withID("webProfile91")
+                                    .fullFATOnly())
+                    .andWith(new FeatureReplacementAction()
+                                    .removeFeature("webProfile-9.1")
+                                    .removeFeature("jakartaee-9.1")
+                                    .addFeatures(getCompatFeatures())
+                                    .withID(ALL_COMPAT_FEATURES)
                                     .fullFATOnly());
 
     public static final String APP_NAME = "webProfile9App";
@@ -64,11 +103,26 @@ public class JakartaEE9Test extends FATServletClient {
         ShrinkHelper.exportDropinAppToServer(server, earApp, DeployOptions.SERVER_ONLY);
 
         String consoleName = JakartaEE9Test.class.getSimpleName() + RepeatTestFilter.getRepeatActionsAsString();
+        if (RepeatTestFilter.isRepeatActionActive(ALL_COMPAT_FEATURES)) {
+            // set it to 15 minutes.
+            server.setServerStartTimeout(15 * 60 * 1000L);
+        }
         server.startServer(consoleName + ".log");
     }
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer("SRVE0280E"); // TODO: tracked by OpenLiberty issue #4857
+        String[] toleratedWarnErrors;
+        if (!RepeatTestFilter.isRepeatActionActive(ALL_COMPAT_FEATURES)) {
+            toleratedWarnErrors = new String[] { "SRVE0280E" };// TODO: SRVE0280E tracked by OpenLiberty issue #4857
+        } else {
+            toleratedWarnErrors = new String[] { "SRVE0280E", // TODO: SRVE0280E tracked by OpenLiberty issue #4857
+                                                 "CWWKS5207W", // The remaining ones relate to config not done for the server / app
+                                                 "CWWWC0002W",
+                                                 "CWMOT0010W",
+                                                 "TRAS4352W" // Only happens when running with WebSphere Liberty image due to an auto feature
+            };
+        }
+        server.stopServer(toleratedWarnErrors);
     }
 }


### PR DESCRIPTION
- Disable test that fails due to time out on some build platforms
- Add new test that tests all EE9 compatible features in a single server.  Conflicting features are not included.

- cherry picked the commit from PR #21473 in order to not have a test failure.