### PR TITLE
header lookup performance improvements

### DIFF
--- a/dev/com.ibm.ws.httpservice/test/com/ibm/ws/httpsvc/test/SessionTest.java
+++ b/dev/com.ibm.ws.httpservice/test/com/ibm/ws/httpsvc/test/SessionTest.java
@@ -52,6 +52,9 @@ import com.ibm.wsspi.http.HttpInputStream;
 import com.ibm.wsspi.http.HttpRequest;
 import com.ibm.wsspi.http.HttpResponse;
 import com.ibm.wsspi.http.SSLContext;
+import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
+
+import io.openliberty.http.ext.HttpRequestExt;
 
 /**
  * Test session related apis.
@@ -117,7 +120,7 @@ public class SessionTest {
         }
     }
 
-    private class MockRequest implements HttpRequest {
+    private class MockRequest implements HttpRequestExt {
         public String uri = null;
 
         public MockRequest() {
@@ -151,6 +154,11 @@ public class SessionTest {
 
         @Override
         public String getHeader(String name) {
+            return null;
+        }
+
+        @Override
+        public String getHeader(HttpHeaderKeys key) {
             return null;
         }
 

--- a/dev/com.ibm.ws.transport.http/bnd.bnd
+++ b/dev/com.ibm.ws.transport.http/bnd.bnd
@@ -41,7 +41,8 @@ Export-Package: \
     com.ibm.ws.http.channel.inputstream, \
     com.ibm.ws.http.logging.source, \
     com.ibm.ws.http2, \
-    com.ibm.ws.http2.upgrade
+    com.ibm.ws.http2.upgrade, \
+    io.openliberty.http.ext
 
 Import-Package: \
     !com.ibm.ws.http.logging.source, \

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
@@ -761,7 +761,7 @@ public class HttpDispatcherLink extends InboundApplicationLink implements HttpIn
         // contents of Host and $WS* headers..
         if (useTrustedHeaders()) {
             // If the plugin provided a header, prefer that..
-            String pluginHost = request.getHeader(HttpHeaderKeys.HDR_$WSSN.getName());
+            String pluginHost = request.getHeader(HttpHeaderKeys.HDR_$WSSN);
             if (pluginHost != null)
                 return pluginHost;
         }
@@ -793,7 +793,7 @@ public class HttpDispatcherLink extends InboundApplicationLink implements HttpIn
         // Get the requested port: this takes into consideration whether or not we should trust the
         // contents of Host and $WS* headers..
         if (useTrustedHeaders()) {
-            String pluginPort = request.getHeader(HttpHeaderKeys.HDR_$WSSP.getName());
+            String pluginPort = request.getHeader(HttpHeaderKeys.HDR_$WSSP);
             if (pluginPort != null)
                 return Integer.parseInt(pluginPort);
         }
@@ -811,10 +811,10 @@ public class HttpDispatcherLink extends InboundApplicationLink implements HttpIn
 
             if (scheme == null && isc != null && !isc.useForwardedHeaders()) {
                 //if remoteIp is not enabled, still verify for the x-forwarded-proto
-                scheme = getTrustedHeader(HttpHeaderKeys.HDR_X_FORWARDED_PROTO.getName());
+                scheme = getTrustedHeader(HttpHeaderKeys.HDR_X_FORWARDED_PROTO);
             }
 
-            if (scheme == null && request.getHeader(HttpHeaderKeys.HDR_HOST.getName()) != null) {
+            if (scheme == null && request.getHeader(HttpHeaderKeys.HDR_HOST) != null) {
                 scheme = request.getScheme();
 
             }
@@ -847,6 +847,13 @@ public class HttpDispatcherLink extends InboundApplicationLink implements HttpIn
     public String getTrustedHeader(String headerName) {
         if (useTrustedHeaders() && request != null) {
             return request.getHeader(headerName);
+        }
+        return null;
+    }
+
+    private String getTrustedHeader(HttpHeaderKeys headerKey) {
+        if (useTrustedHeaders() && request != null) {
+            return request.getHeader(headerKey);
         }
         return null;
     }
@@ -918,7 +925,7 @@ public class HttpDispatcherLink extends InboundApplicationLink implements HttpIn
 
         }
         if (remoteAddr == null) {
-            remoteAddr = getTrustedHeader(HttpHeaderKeys.HDR_$WSRA.getName());
+            remoteAddr = getTrustedHeader(HttpHeaderKeys.HDR_$WSRA);
             if (remoteAddr != null) {
                 if (!validateRemoteAddress(remoteAddr)) {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
@@ -1002,7 +1009,7 @@ public class HttpDispatcherLink extends InboundApplicationLink implements HttpIn
         }
         if (remoteHost == null) {
 
-            remoteHost = getTrustedHeader(HttpHeaderKeys.HDR_$WSRH.getName());
+            remoteHost = getTrustedHeader(HttpHeaderKeys.HDR_$WSRH);
             if (remoteHost != null) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                     Tr.debug(tc, "getRemoteHost isTrusted --> true, host --> " + remoteHost);

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpRequestImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpRequestImpl.java
@@ -26,12 +26,14 @@ import com.ibm.wsspi.http.ee7.HttpInputStreamEE7;
 import com.ibm.wsspi.http.ee8.Http2PushBuilder;
 import com.ibm.wsspi.http.ee8.Http2Request;
 
+import io.openliberty.http.ext.HttpRequestExt;
+
 /**
  * Implementation of an HTTP request message provided by the HTTP dispatcher to
  * various containers.
  */
 @Trivial
-public class HttpRequestImpl implements Http2Request {
+public class HttpRequestImpl implements Http2Request, HttpRequestExt {
     private HttpRequestMessage message = null;
     private HttpInputStreamImpl body = null;
     private boolean useEE7Streams = false;
@@ -110,6 +112,15 @@ public class HttpRequestImpl implements Http2Request {
     @Override
     public String getHeader(String name) {
         return this.message.getHeader(name).asString();
+    }
+
+    /*
+     * @see com.ibm.websphere.http.HttpRequestExt#getHeader(com.ibm.wsspi.http.channel.values.HttpHeaderKeys)
+     */
+
+    @Override
+    public String getHeader(HttpHeaderKeys key) {
+        return this.message.getHeader(key).asString();
     }
 
     /*

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpResponseImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpResponseImpl.java
@@ -30,12 +30,14 @@ import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 import com.ibm.wsspi.http.channel.values.VersionValues;
 import com.ibm.wsspi.http.ee7.HttpOutputStreamEE7;
 
+import io.openliberty.http.ext.HttpResponseExt;
+
 /**
  * Implementation of the public HTTP transport response message for the dispatcher
  * and container traffic.
  */
 @Trivial
-public class HttpResponseImpl implements HttpResponse {
+public class HttpResponseImpl implements HttpResponse, HttpResponseExt {
     private HttpInboundServiceContext isc = null;
     private HttpResponseMessage message = null;
     private HttpOutputStreamImpl body = null;
@@ -145,11 +147,27 @@ public class HttpResponseImpl implements HttpResponse {
     }
 
     /*
+     * @see com.ibm.websphere.http.HttpResponseExt#setHeader(com.ibm.wsspi.http.channel.values.HttpHeaderKeys, java.lang.String)
+     */
+    @Override
+    public void setHeader(HttpHeaderKeys key, String value) {
+        this.message.setHeader(key, value);
+    }
+
+    /*
      * @see com.ibm.websphere.http.HttpResponse#removeHeader(java.lang.String)
      */
     @Override
     public void removeHeader(String name) {
         this.message.removeHeader(name);
+    }
+
+    /*
+     * @see io.openliberty.http.ext.HttpHeaderResponseExt#removeHeader(com.ibm.wsspi.http.channel.values.HttpHeaderKeys)
+     */
+    @Override
+    public void removeHeader(HttpHeaderKeys key) {
+        this.message.removeHeader(key);
     }
 
     /*
@@ -196,6 +214,14 @@ public class HttpResponseImpl implements HttpResponse {
     @Override
     public String getHeader(String name) {
         return this.message.getHeader(name).asString();
+    }
+
+    /*
+     * @see io.openliberty.http.ext.HttpHeaderResponseExt#getHeader(com.ibm.wsspi.http.channel.values.HttpHeaderKeys)
+     */
+    @Override
+    public String getHeader(HttpHeaderKeys key) {
+        return this.message.getHeader(key).asString();
     }
 
     /*

--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/ext/HttpRequestExt.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/ext/HttpRequestExt.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.http.ext;
+
+import com.ibm.wsspi.http.HttpRequest;
+import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
+
+/**
+ *
+ */
+public interface HttpRequestExt extends HttpRequest {
+
+    /**
+     * Access the first instance found for the given header key. This might be
+     * null if no instance was found.
+     *
+     * @param key
+     * @return String
+     */
+    default String getHeader(HttpHeaderKeys key) {
+        return getHeader(key.getName());
+    }
+
+}

--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/ext/HttpResponseExt.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/ext/HttpResponseExt.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.http.ext;
+
+import com.ibm.wsspi.http.HttpResponse;
+import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
+
+/**
+ *
+ */
+public interface HttpResponseExt extends HttpResponse {
+
+    /**
+     * Access the first instance found for the given header key. This might be
+     * null if no instance was found.
+     *
+     * @param key
+     * @return String
+     */
+    default String getHeader(HttpHeaderKeys key) {
+        return getHeader(key.getName());
+    }
+
+    /**
+     * Set a header on the message using the provided name and value pair. This
+     * will replace any currently existing instances of the header name.
+     *
+     * @param key
+     * @param value
+     */
+    default void setHeader(HttpHeaderKeys key, String value) {
+        setHeader(key.getName(), value);
+    }
+
+    /**
+     * Remove the target header from the message.
+     *
+     * @param key
+     */
+    default void removeHeader(HttpHeaderKeys key) {
+        removeHeader(key.getName());
+    }
+
+}

--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/ext/package-info.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/ext/package-info.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+@org.osgi.annotation.versioning.Version("1.0")
+package io.openliberty.http.ext;
+

--- a/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/dispatcher/internal/HttpDispatcherTest.java
+++ b/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/dispatcher/internal/HttpDispatcherTest.java
@@ -705,7 +705,7 @@ public class HttpDispatcherTest {
         // No dispatcher, no private header
         context.checking(new Expectations() {
             {
-                one(mockRequest).getHeader(HttpHeaderKeys.HDR_$WSSN.getName());
+                one(mockRequest).getHeader(HttpHeaderKeys.HDR_$WSSN);
                 will(returnValue(null));
 
                 one(mockRequest).getVirtualHost();
@@ -731,7 +731,7 @@ public class HttpDispatcherTest {
         // No dispatcher, $WSSN header
         context.checking(new Expectations() {
             {
-                one(mockRequest).getHeader(HttpHeaderKeys.HDR_$WSSN.getName());
+                one(mockRequest).getHeader(HttpHeaderKeys.HDR_$WSSN);
                 will(returnValue(host));
             }
         });
@@ -749,7 +749,7 @@ public class HttpDispatcherTest {
 
         context.checking(new Expectations() {
             {
-                one(mockRequest).getHeader(HttpHeaderKeys.HDR_$WSSN.getName());
+                one(mockRequest).getHeader(HttpHeaderKeys.HDR_$WSSN);
                 will(returnValue(host));
             }
         });
@@ -791,7 +791,7 @@ public class HttpDispatcherTest {
 
         context.checking(new Expectations() {
             {
-                one(mockRequest).getHeader(HttpHeaderKeys.HDR_$WSSN.getName());
+                one(mockRequest).getHeader(HttpHeaderKeys.HDR_$WSSN);
                 will(returnValue(host));
             }
         });
@@ -834,7 +834,7 @@ public class HttpDispatcherTest {
         // No dispatcher, no private headers
         context.checking(new Expectations() {
             {
-                one(mockRequest).getHeader(HttpHeaderKeys.HDR_$WSSP.getName());
+                one(mockRequest).getHeader(HttpHeaderKeys.HDR_$WSSP);
                 will(returnValue(null));
 
                 one(mockRequest).getVirtualPort();
@@ -859,13 +859,13 @@ public class HttpDispatcherTest {
         // No dispatcher, no private headers
         context.checking(new Expectations() {
             {
-                one(mockRequest).getHeader(HttpHeaderKeys.HDR_$WSSP.getName());
+                one(mockRequest).getHeader(HttpHeaderKeys.HDR_$WSSP);
                 will(returnValue(null));
 
                 one(mockRequest).getVirtualPort();
                 will(returnValue(-1));
 
-                one(mockRequest).getHeader(HttpHeaderKeys.HDR_HOST.getName());
+                one(mockRequest).getHeader(HttpHeaderKeys.HDR_HOST);
                 will(returnValue(""));
 
                 one(mockRequest).getScheme();
@@ -883,7 +883,7 @@ public class HttpDispatcherTest {
         // No dispatcher, WSSP: 1234
         context.checking(new Expectations() {
             {
-                one(mockRequest).getHeader(HttpHeaderKeys.HDR_$WSSP.getName());
+                one(mockRequest).getHeader(HttpHeaderKeys.HDR_$WSSP);
                 will(returnValue("1234"));
             }
         });
@@ -908,7 +908,7 @@ public class HttpDispatcherTest {
                 one(mockRequest).getVirtualPort();
                 will(returnValue(-1));
 
-                one(mockRequest).getHeader(HttpHeaderKeys.HDR_HOST.getName());
+                one(mockRequest).getHeader(HttpHeaderKeys.HDR_HOST);
                 will(returnValue(""));
 
                 one(mockRequest).getScheme();

--- a/dev/com.ibm.ws.webcontainer/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer/bnd.bnd
@@ -134,6 +134,7 @@ Import-Package: \
 	com.ibm.wsspi.injectionengine, \
 	com.ibm.ws.runtime.metadata, \
 	com.ibm.ws.runtime.update, \
+	io.openliberty.http.ext, \
 	com.ibm.ejs.util, \
     com.ibm.ws.threadContext, \
     com.ibm.ejs.j2c, \

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/response/IResponseImpl.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/response/IResponseImpl.java
@@ -28,8 +28,11 @@ import com.ibm.ws.webcontainer.osgi.osgi.WebContainerConstants;
 import com.ibm.wsspi.http.HttpCookie;
 import com.ibm.wsspi.http.HttpInboundConnection;
 import com.ibm.wsspi.http.HttpResponse;
+import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 import com.ibm.wsspi.webcontainer.WebContainerRequestState;
 import com.ibm.wsspi.webcontainer.util.WrappingEnumeration;
+
+import io.openliberty.http.ext.HttpResponseExt;
 
 /**
  * Implementation of a servlet response wrapping the HTTP dispatcher provided
@@ -157,6 +160,11 @@ public class IResponseImpl implements IResponse
     return (null != this.response.getHeader(name));
   }
 
+  public boolean containsHeader(HttpHeaderKeys key)
+  {
+    return (null != ((HttpResponseExt)this.response).getHeader(key));
+  }
+
   public boolean containsHeader(byte[] name)
   {
     return containsHeader(new String(name));
@@ -202,6 +210,11 @@ public class IResponseImpl implements IResponse
     this.response.removeHeader(name);
   }
 
+  public void removeHeader(HttpHeaderKeys key)
+  {
+      ((HttpResponseExt)this.response).removeHeader(key);
+  }
+
   public void removeHeader(byte[] name)
   {
     this.response.removeHeader(new String(name));
@@ -216,14 +229,14 @@ public class IResponseImpl implements IResponse
   public void setContentLanguage(String value)
   {
       //PM25421
-      if (response.getHeader("Content-Language") != null){
+      if (((HttpResponseExt)response).getHeader(HttpHeaderKeys.HDR_CONTENT_LANGUAGE) != null){
           if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())  {
               Tr.debug(tc, "setContentLanguage(String)", "Ignored as the Content-Language already set");
           }
           return;
       }
 
-    this.response.setHeader("Content-Language", value);
+      ((HttpResponseExt)this.response).setHeader(HttpHeaderKeys.HDR_CONTENT_LANGUAGE, value);
   }
   
   public void setContentLength(int length) {
@@ -233,24 +246,24 @@ public class IResponseImpl implements IResponse
   public void setContentLanguage(byte[] value)
   {
       //PM25421
-      if (response.getHeader("Content-Language") != null){
+      if (((HttpResponseExt)response).getHeader(HttpHeaderKeys.HDR_CONTENT_LANGUAGE) != null){
           if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())  {
               Tr.debug(tc, "setContentLanguage(byte[])", "Ignored as the Content-Language already set");
           }
           return;
       }
 
-      this.response.setHeader("Content-Language", new String(value));
+      ((HttpResponseExt)this.response).setHeader(HttpHeaderKeys.HDR_CONTENT_LANGUAGE, new String(value));
   }
 
   public void setContentType(String value)
   {
-    this.response.setHeader("Content-Type", value);
+      ((HttpResponseExt)this.response).setHeader(HttpHeaderKeys.HDR_CONTENT_TYPE, value);
   }
 
   public void setContentType(byte[] value)
   {
-    this.response.setHeader("Content-Type", new String(value));
+      ((HttpResponseExt)this.response).setHeader(HttpHeaderKeys.HDR_CONTENT_TYPE, new String(value));
   }
 
   public void setDateHeader(String name, long t)
@@ -271,6 +284,11 @@ public class IResponseImpl implements IResponse
   public void setHeader(String name, String s)
   {
     this.response.setHeader(name, s);
+  }
+
+  public void setHeader(HttpHeaderKeys key, String s)
+  {
+      ((HttpResponseExt)this.response).setHeader(key, s);
   }
 
   public void setHeader(byte[] name, byte[] bs)
@@ -377,6 +395,11 @@ public class IResponseImpl implements IResponse
   public String getHeader(String name)
   {
     return this.response.getHeader(name);
+  }
+
+  public String getHeader(HttpHeaderKeys key)
+  {
+    return ((HttpResponseExt)this.response).getHeader(key);
   }
 
   public String getHeader(byte[] name)

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletRequest.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletRequest.java
@@ -346,7 +346,7 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
 
             this._request = req;
             _srtRequestHelper = getRequestHelper();
-            
+
             if (TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) {
                 logger.logp(Level.FINE, CLASS_NAME,"initForNextRequest", "this->"+this+" , _srtRequestHelper [" + _srtRequestHelper +"]");
             }

--- a/dev/com.ibm.ws.webcontainer/test/com/ibm/ws/webcontainer/osgi/request/IRequestImplTest.java
+++ b/dev/com.ibm.ws.webcontainer/test/com/ibm/ws/webcontainer/osgi/request/IRequestImplTest.java
@@ -28,8 +28,10 @@ import org.junit.rules.TestRule;
 import com.ibm.wsspi.http.HttpInboundConnection;
 import com.ibm.wsspi.http.HttpRequest;
 import com.ibm.wsspi.http.SSLContext;
+import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 import com.ibm.wsspi.webcontainer.WCCustomProperties;
 
+import io.openliberty.http.ext.HttpRequestExt;
 import test.common.SharedOutputManager;
 
 /**
@@ -45,7 +47,7 @@ public class IRequestImplTest {
         }
     };
     private final HttpInboundConnection conn = mock.mock(HttpInboundConnection.class);
-    private final HttpRequest request = mock.mock(HttpRequest.class);
+    private final HttpRequestExt request = mock.mock(HttpRequestExt.class);
     private final SSLContext sslCtx = mock.mock(SSLContext.class);
 
     @Rule
@@ -73,11 +75,11 @@ public class IRequestImplTest {
                 // called by getScheme()
                 one(conn).useTrustedHeaders();
                 will(returnValue(true));
-                one(conn).getTrustedHeader("$WSSC");
+                one(request).getHeader(HttpHeaderKeys.HDR_$WSSC);
                 will(returnValue(null));
-                one(conn).getTrustedHeader("$WSIS");
+                one(request).getHeader(HttpHeaderKeys.HDR_$WSIS);
                 will(returnValue(null));
-                one(conn).getTrustedHeader("X-Forwarded-Proto");
+                one(request).getHeader(HttpHeaderKeys.HDR_X_FORWARDED_PROTO);
                 will(returnValue(null));
                 one(request).getScheme();
                 will(returnValue("http"));
@@ -106,7 +108,7 @@ public class IRequestImplTest {
                 // called by getScheme()
                 one(conn).useTrustedHeaders();
                 will(returnValue(true));
-                one(request).getHeader("Host");
+                one(request).getHeader(HttpHeaderKeys.HDR_HOST);
                 will(returnValue("localhost:9080"));
                 one(request).getHeader("myPrivateHeader");
                 will(returnValue("true"));
@@ -135,11 +137,11 @@ public class IRequestImplTest {
                 // called by getScheme()
                 one(conn).useTrustedHeaders();
                 will(returnValue(true));
-                one(conn).getTrustedHeader("$WSSC");
+                one(request).getHeader(HttpHeaderKeys.HDR_$WSSC);
                 will(returnValue("wssc-scheme"));
-                one(conn).getTrustedHeader("$WSIS");
+                one(request).getHeader(HttpHeaderKeys.HDR_$WSIS);
                 will(returnValue("true"));
-                one(conn).getTrustedHeader("X-Forwarded-Proto");
+                one(request).getHeader(HttpHeaderKeys.HDR_X_FORWARDED_PROTO);
                 will(returnValue("XFP-scheme"));
                 one(request).getScheme();
                 will(returnValue("http"));
@@ -168,11 +170,11 @@ public class IRequestImplTest {
                 // called by getScheme()
                 one(conn).useTrustedHeaders();
                 will(returnValue(true));
-                one(conn).getTrustedHeader("$WSSC");
+                one(request).getHeader(HttpHeaderKeys.HDR_$WSSC);
                 will(returnValue(null));
-                one(conn).getTrustedHeader("$WSIS");
+                one(request).getHeader(HttpHeaderKeys.HDR_$WSIS);
                 will(returnValue("true"));
-                one(conn).getTrustedHeader("X-Forwarded-Proto");
+                one(request).getHeader(HttpHeaderKeys.HDR_X_FORWARDED_PROTO);
                 will(returnValue("XFP-scheme"));
                 one(request).getScheme();
                 will(returnValue("http"));
@@ -201,11 +203,11 @@ public class IRequestImplTest {
                 // called by getScheme()
                 one(conn).useTrustedHeaders();
                 will(returnValue(true));
-                one(conn).getTrustedHeader("$WSSC");
+                one(request).getHeader(HttpHeaderKeys.HDR_$WSSC);
                 will(returnValue(null));
-                one(conn).getTrustedHeader("$WSIS");
+                one(request).getHeader(HttpHeaderKeys.HDR_$WSIS);
                 will(returnValue(null));
-                one(conn).getTrustedHeader("X-Forwarded-Proto");
+                one(request).getHeader(HttpHeaderKeys.HDR_X_FORWARDED_PROTO);
                 will(returnValue("XFP-scheme"));
                 one(request).getScheme();
                 will(returnValue("http"));
@@ -234,11 +236,11 @@ public class IRequestImplTest {
                 // called by getScheme()
                 one(conn).useTrustedHeaders();
                 will(returnValue(false)); // <------
-                one(conn).getTrustedHeader("$WSSC");
+                one(request).getHeader(HttpHeaderKeys.HDR_$WSSC);
                 will(returnValue("WSSC_scheme"));
-                one(conn).getTrustedHeader("$WSIS");
+                one(request).getHeader(HttpHeaderKeys.HDR_$WSIS);
                 will(returnValue("true"));
-                one(conn).getTrustedHeader("X-Forwarded-Proto");
+                one(request).getHeader(HttpHeaderKeys.HDR_X_FORWARDED_PROTO);
                 will(returnValue("XFP-scheme"));
                 one(request).getScheme();
                 will(returnValue("http"));
@@ -277,9 +279,9 @@ public class IRequestImplTest {
                 // called by getScheme()
                 one(conn).useTrustedHeaders();
                 will(returnValue(true));
-                one(conn).getTrustedHeader("$WSIS");
+                one(request).getHeader(HttpHeaderKeys.HDR_$WSIS);
                 will(returnValue(null));
-                one(conn).getTrustedHeader("X-Forwarded-Proto");
+                one(request).getHeader(HttpHeaderKeys.HDR_X_FORWARDED_PROTO);
                 will(returnValue(null));
                 one(conn).getSSLContext();
                 will(returnValue(null));
@@ -308,7 +310,7 @@ public class IRequestImplTest {
                 // called by getScheme()
                 one(conn).useTrustedHeaders();
                 will(returnValue(true));
-                one(request).getHeader("Host");
+                one(request).getHeader(HttpHeaderKeys.HDR_HOST);
                 will(returnValue("localhost:9080"));
                 one(request).getHeader("myPrivateHeader");
                 will(returnValue("true"));
@@ -337,11 +339,11 @@ public class IRequestImplTest {
                 // called by getScheme()
                 one(conn).useTrustedHeaders();
                 will(returnValue(true));
-                one(conn).getTrustedHeader("$WSSC");
+                one(request).getHeader(HttpHeaderKeys.HDR_$WSSC);
                 will(returnValue(null));
-                one(conn).getTrustedHeader("$WSIS");
+                one(request).getHeader(HttpHeaderKeys.HDR_$WSIS);
                 will(returnValue("true"));
-                one(conn).getTrustedHeader("X-Forwarded-Proto");
+                one(request).getHeader(HttpHeaderKeys.HDR_X_FORWARDED_PROTO);
                 will(returnValue("XFP-scheme"));
                 one(conn).getSSLContext();
                 will(returnValue(null));
@@ -370,11 +372,11 @@ public class IRequestImplTest {
                 // called by getScheme()
                 one(conn).useTrustedHeaders();
                 will(returnValue(true));
-                one(conn).getTrustedHeader("$WSSC");
+                one(request).getHeader(HttpHeaderKeys.HDR_$WSSC);
                 will(returnValue(null));
-                one(conn).getTrustedHeader("$WSIS");
+                one(request).getHeader(HttpHeaderKeys.HDR_$WSIS);
                 will(returnValue(null));
-                one(conn).getTrustedHeader("X-Forwarded-Proto");
+                one(request).getHeader(HttpHeaderKeys.HDR_X_FORWARDED_PROTO);
                 will(returnValue("https"));
                 one(conn).getSSLContext();
                 will(returnValue(null));
@@ -403,11 +405,11 @@ public class IRequestImplTest {
                 // called by getScheme()
                 one(conn).useTrustedHeaders();
                 will(returnValue(false)); // <------
-                one(conn).getTrustedHeader("$WSSC");
+                one(request).getHeader(HttpHeaderKeys.HDR_$WSSC);
                 will(returnValue("https"));
-                one(conn).getTrustedHeader("$WSIS");
+                one(request).getHeader(HttpHeaderKeys.HDR_$WSIS);
                 will(returnValue("true"));
-                one(conn).getTrustedHeader("X-Forwarded-Proto");
+                one(request).getHeader(HttpHeaderKeys.HDR_X_FORWARDED_PROTO);
                 will(returnValue("wss"));
                 one(conn).getSSLContext();
                 will(returnValue(null));
@@ -436,11 +438,11 @@ public class IRequestImplTest {
                 // called by getScheme()
                 one(conn).useTrustedHeaders();
                 will(returnValue(false)); // <------
-                one(conn).getTrustedHeader("$WSSC");
+                one(request).getHeader(HttpHeaderKeys.HDR_$WSSC);
                 will(returnValue("https"));
-                one(conn).getTrustedHeader("$WSIS");
+                one(request).getHeader(HttpHeaderKeys.HDR_$WSIS);
                 will(returnValue("true"));
-                one(conn).getTrustedHeader("X-Forwarded-Proto");
+                one(request).getHeader(HttpHeaderKeys.HDR_X_FORWARDED_PROTO);
                 will(returnValue("wss"));
                 one(conn).getSSLContext();
                 will(returnValue(sslCtx));


### PR DESCRIPTION
Looking up header keys by name is slow, and lots of code checks for headers that are not present. This change uses header keys rather than names where possible, and skips attempts to look up keys for headers which have not been added to the request/response being processed.