### PR TITLE
Update CPUInfo to handle Semeru version 8 returning IBM as the vendor

### DIFF
--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/CpuInfo.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/CpuInfo.java
@@ -34,6 +34,7 @@ import javax.management.ObjectName;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.FFDCFilter;
 
 import io.openliberty.checkpoint.spi.CheckpointHook;
@@ -92,8 +93,13 @@ public class CpuInfo {
         }
 
         int nsFactor = 1;
-        // adjust for J9 cpuUsage units change from hundred-nanoseconds to nanoseconds in Java8sr5
-        if (JavaInfo.vendor() == JavaInfo.Vendor.IBM) {
+        // Adjust for J9 cpuUsage units change from hundred-nanoseconds to nanoseconds in IBM Java8sr5
+        //
+        // Cannot use JavaInfo.vendor() == JavaInfo.Vendor.IBM because that returns true on Semeru 8 as well
+        // and the format of the string is 1.8.0_xxx-bxx so it will comes out as 8.0.0 so we will
+        // erroneously think it is less than Java 8 SR5.  So using this isSystemClassAvailable check for
+        // a class that is available on IBM Java 8, but not Semeru 8.
+        if (JavaInfo.isSystemClassAvailable("com.ibm.security.auth.module.Krb5LoginModule")) {
             int majorVersion = JavaInfo.majorVersion();
             int minorVersion = JavaInfo.minorVersion();
             int serviceRelease = JavaInfo.serviceRelease();
@@ -442,9 +448,15 @@ public class CpuInfo {
         }
     }
 
+    @Trivial
     public class CPUCount {
         public int get() {
             return AVAILABLE_PROCESSORS.get();
+        }
+
+        @Override
+        public String toString() {
+            return Integer.toString(AVAILABLE_PROCESSORS.get());
         }
     }
 }

--- a/dev/com.ibm.ws.kernel.service/test/com/ibm/ws/kernel/service/test/CpuInfoTest.java
+++ b/dev/com.ibm.ws.kernel.service/test/com/ibm/ws/kernel/service/test/CpuInfoTest.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.kernel.service.test;
+
+import org.junit.Test;
+
+import com.ibm.ws.kernel.service.util.CpuInfo;
+
+import junit.framework.Assert;
+
+/**
+ *
+ */
+public class CpuInfoTest {
+
+    @Test
+    public void test() throws Exception {
+
+        Thread t = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                long startTime = System.currentTimeMillis();
+                while (System.currentTimeMillis() - startTime < 2000);
+            }
+        });
+
+        // prime the initial CPU usage.
+        CpuInfo.getJavaCpuUsage();
+        t.start();
+        t.join();
+
+        double cpuUsage = CpuInfo.getJavaCpuUsage();
+        System.out.println("CPU usage is " + cpuUsage);
+        if (cpuUsage == -1) {
+            Assert.fail("CpuInfo returned -1");
+        }
+    }
+
+}


### PR DESCRIPTION
- Since JavaInfo.vendor() returns IBM for Semeru 8 we were thinking that the CPU time need to be adjusted because the Java version was Java 8 SR 0 because the version is 1.8.0_xxx-bxx for Semeru instead of 1.8.0 SRx FPy.  As such needed to adjust how we detect that the JVM is IBM Java 8
- Updated to add a toString to CPUCount so you can see the CPU count in the trace.
- Added a test so that we can easily test the bad behavior with different versions of Java.  It is only a unit test though so it is part
of the build or run in your IDE.