### PR TITLE
Fix retry conditions for UserEnumTest

### DIFF
--- a/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/UserEnumerationTest.java
+++ b/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/UserEnumerationTest.java
@@ -333,7 +333,7 @@ public class UserEnumerationTest {
                                   numTimesUserSeemsInvalid);
                 }
             } else {
-                if (numTimesUserSeemsValid == 0 && i < retry) {
+                if ((validityCheckRounds != numTimesUserSeemsInvalid) && i < retry) {
                     Log.info(c, methodName, "Expected all invalid results, try again.");
                 } else {
                     assertEquals("Should have all invalid user results, valid was " + numTimesUserSeemsValid + " and invalid was " + numTimesUserSeemsInvalid + ".",


### PR DESCRIPTION
Previously added a retry for the UserEnumerationTest, but didn't use the right condition to retry on the "all invalid" option and our Windows boxes can be extra slow/variable.

RTC 291045