### PR TITLE
Ignore invalid app warning

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/fat/src/com/ibm/ws/concurrent/mp/v1_3/fat/tck/MPContextPropagationTCKLauncher.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/fat/src/com/ibm/ws/concurrent/mp/v1_3/fat/tck/MPContextPropagationTCKLauncher.java
@@ -10,24 +10,18 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent.mp.v1_3.fat.tck;
 
+import java.util.Map;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.utils.MvnUtils;
-
 
 @RunWith(FATRunner.class)
 public class MPContextPropagationTCKLauncher {
@@ -42,7 +36,7 @@ public class MPContextPropagationTCKLauncher {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer("CWWKZ0014W"); // Updates after the app is deleted. Can occur due to Arquillian use.
     }
 
     @AllowedFFDC({ "java.lang.IllegalStateException", // transaction cannot be propagated to 2 threads at the same time


### PR DESCRIPTION
It is possible while using Arquillian that the application server is trying to verify the installation/modification of an application just as Arquillian is removing it. Resulting in the warning: 

CWWKZ0014W: The application BasicCDITest could not be started as it could not be found at location C:\Users\jazz_build\Build\jazz-build-engines\wasrtc\EBCPROD\build\dev\image\output\wlp\usr\servers\tckServerForMPContextPropagation13\dropins\BasicCDITest.war.

However, we can see in the application server that the app was installed, used, and removed correctly: 
```
[5/9/22, 20:31:23:295 PDT] 0000002f bm.ws.app.manager.war.internal.WARDeployedAppInfoFactoryImpl I CWWKZ0136I: The BasicCDITest application is using the archive file at the C:\Users\jazz_build\Build\jazz-build-engines\wasrtc\EBCPROD\build\dev\image\output\wlp\usr\servers\tckServerForMPContextPropagation13\dropins\BasicCDITest.war location.
[5/9/22, 20:31:32:326 PDT] 0000002f com.ibm.ws.app.manager.AppMessageHelper                      A CWWKZ0001I: Application BasicCDITest started in 9.044 seconds.
[5/9/22, 20:31:36:404 PDT] 00000034 com.ibm.ws.http.internal.VirtualHostImpl                     A CWWKT0017I: Web application removed (default_host): http://ebcprh11941502-n.fyre.ibm.com:8010/BasicCDITest/
[5/9/22, 20:31:39:373 PDT] 00000034 com.ibm.ws.app.manager.AppMessageHelper                      A CWWKZ0009I: The application BasicCDITest has stopped successfully.
[5/9/22, 20:31:39:373 PDT] 00000034 com.ibm.ws.app.manager.AppMessageHelper                      W CWWKZ0014W: The application BasicCDITest could not be started as it could not be found at location C:\Users\jazz_build\Build\jazz-build-engines\wasrtc\EBCPROD\build\dev\image\output\wlp\usr\servers\tckServerForMPContextPropagation13\dropins\BasicCDITest.war.
```

This is already being ignored in the previous version of this TCK: 
https://github.com/OpenLiberty/open-liberty/blob/37cd7b601a51206096dd36ca8923274261a33f1e/dev/com.ibm.ws.concurrent.mp.1.2_fat_tck/fat/src/com/ibm/ws/concurrent/mp/v1_2/fat/tck/MPContextPropagationTCKLauncher.java#L42-L45