### PR TITLE
Better debug info for errorpaths

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/fat/src/com/ibm/ws/concurrent/persistent/fat/errorpaths/PersistentExecutorErrorPathsTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/fat/src/com/ibm/ws/concurrent/persistent/fat/errorpaths/PersistentExecutorErrorPathsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -94,7 +94,7 @@ public class PersistentExecutorErrorPathsTest {
     @BeforeClass
     public static void setUp() throws Exception {
     	ShrinkHelper.defaultDropinApp(server, APP_NAME, "web");
-        server.startServer();
+        server.startServer("PersistentExecutorErrorPathsTest.log");
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/fat/src/com/ibm/ws/concurrent/persistent/fat/errorpaths/PersistentExecutorErrorPathsTestWithFailoverAndPollingEnabled.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/fat/src/com/ibm/ws/concurrent/persistent/fat/errorpaths/PersistentExecutorErrorPathsTestWithFailoverAndPollingEnabled.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019,2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -156,7 +156,7 @@ public class PersistentExecutorErrorPathsTestWithFailoverAndPollingEnabled {
         server.updateServerConfiguration(config);
 
     	ShrinkHelper.defaultDropinApp(server, APP_NAME, "web");
-        server.startServer();
+        server.startServer("PersistentExecutorErrorPathsTestWithFailoverAndPollingEnabled.log");
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/fat/src/com/ibm/ws/concurrent/persistent/fat/errorpaths/PersistentExecutorErrorPathsTestWithFailoverEnabledNoPolling.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/fat/src/com/ibm/ws/concurrent/persistent/fat/errorpaths/PersistentExecutorErrorPathsTestWithFailoverEnabledNoPolling.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019,2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -105,7 +105,7 @@ public class PersistentExecutorErrorPathsTestWithFailoverEnabledNoPolling {
         server.updateServerConfiguration(config);
 
     	ShrinkHelper.defaultDropinApp(server, APP_NAME, "web");
-        server.startServer();
+        server.startServer("PersistentExecutorErrorPathsTestWithFailoverEnabledNoPolling.log");
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/DerbyShutdownTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/DerbyShutdownTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package web;
 
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -25,9 +27,16 @@ public class DerbyShutdownTask implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         int count = counter.incrementAndGet();
+        System.out.println("Attempt to call DerbyShutdownTask #" + count);
         if (count == 1) {
             DataSource schedDBShutdown = (DataSource) new InitialContext().lookup("jdbc/schedDBShutdown");
-            schedDBShutdown.getConnection().close(); // Expected to raise SQLException
+            try (Connection con = schedDBShutdown.getConnection()) {
+            	//DO NOTHING - just creating connection to shutdown database
+            } catch (SQLException e) {
+            	System.out.println("DerbyShutdownTask caught and rethrew exception " + e.getMessage());
+            	e.printStackTrace(System.out);
+            	throw e;
+            }
         }
         return count;
     }


### PR DESCRIPTION
The testShutDownDerbyDuringTaskExecution test has failed due to the Derby database being shut down prior to test execution. Introducing some better debug info to help in determining if this was a one-off derby issue, or if there is a flaw in the test strategy. 
