### PR TITLE
Discovery refactoring test fix

### DIFF
--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/AbstractHttpResponseException.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/AbstractHttpResponseException.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.common.http;
+
+abstract class AbstractHttpResponseException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    private String url;
+    private int statusCode;
+    private String nlsMessage;
+    
+    public AbstractHttpResponseException(String url, int statusCode, String nlsMessage) {
+        this(url, statusCode, nlsMessage, null);
+    }
+
+    public AbstractHttpResponseException(String url, int statusCode, String nlsMessage, Exception cause) {
+        super(cause);
+        this.url = url;
+        this.statusCode = statusCode;
+        this.nlsMessage = nlsMessage;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getNlsMessage() {
+        return nlsMessage;
+    }
+
+}

--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/HttpResponseNot200Exception.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/HttpResponseNot200Exception.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.common.http;
+
+public class HttpResponseNot200Exception extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    private String url;
+    private int statusCode;
+    private String errMsg;
+    
+    public HttpResponseNot200Exception(String url, int statusCode, String errMsg) {
+        this.url = url;
+        this.statusCode = statusCode;
+        this.errMsg = errMsg;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getErrMsg() {
+        return errMsg;
+    }
+
+}

--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/HttpResponseNot200Exception.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/HttpResponseNot200Exception.java
@@ -10,30 +10,12 @@
  *******************************************************************************/
 package com.ibm.ws.security.common.http;
 
-public class HttpResponseNot200Exception extends Exception {
+public class HttpResponseNot200Exception extends AbstractHttpResponseException {
 
     private static final long serialVersionUID = 1L;
 
-    private String url;
-    private int statusCode;
-    private String errMsg;
-    
     public HttpResponseNot200Exception(String url, int statusCode, String errMsg) {
-        this.url = url;
-        this.statusCode = statusCode;
-        this.errMsg = errMsg;
+        super(url, statusCode, errMsg);
     }
-
-    public String getUrl() {
-        return url;
-    }
-
-    public int getStatusCode() {
-        return statusCode;
-    }
-
-    public String getErrMsg() {
-        return errMsg;
-    }
-
+    
 }

--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/HttpResponseNullOrEmptyException.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/HttpResponseNullOrEmptyException.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.common.http;
+
+public class HttpResponseNullOrEmptyException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    private String url;
+    private int statusCode;
+    private String errMsg;
+    
+    public HttpResponseNullOrEmptyException(String url, int statusCode, String errMsg) {
+        this.url = url;
+        this.statusCode = statusCode;
+        this.errMsg = errMsg;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getErrMsg() {
+        return errMsg;
+    }
+
+}

--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/SocialLoginWrapperException.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/SocialLoginWrapperException.java
@@ -10,12 +10,17 @@
  *******************************************************************************/
 package com.ibm.ws.security.common.http;
 
-public class HttpResponseNullOrEmptyException extends AbstractHttpResponseException {
+/**
+ * Wrapper class used for wrapping exceptions that emit social login specific NLS messages in the security.common bundle. Wrapping
+ * the exceptions should allow calling classes to emit their own error or warning messages if they choose, rather than emitting
+ * social login NLS messages that may be unrelated or misleading.
+ */
+public class SocialLoginWrapperException extends AbstractHttpResponseException {
 
     private static final long serialVersionUID = 1L;
 
-    public HttpResponseNullOrEmptyException(String url, int statusCode, String errMsg) {
-        super(url, statusCode, errMsg);
+    public SocialLoginWrapperException(String url, int statusCode, String nlsMessage, Exception cause) {
+        super(url, statusCode, nlsMessage, cause);
     }
 
 }

--- a/dev/com.ibm.ws.security.common/test/com/ibm/ws/security/common/http/HttpUtilsTest.java
+++ b/dev/com.ibm.ws.security.common/test/com/ibm/ws/security/common/http/HttpUtilsTest.java
@@ -394,7 +394,7 @@ public class HttpUtilsTest extends CommonTestClass {
         }
     }
 
-    /******************************************* createHTTPClient *******************************************/
+    /******************************************* createHttpClient *******************************************/
 
     /**
      * Tests:
@@ -402,20 +402,16 @@ public class HttpUtilsTest extends CommonTestClass {
      * - URL: null
      * - Verify hostname: false
      * Expects:
-     * - IllegalArgumentException should be thrown because of the null SSL socket factory
+     * - Client should not be null
      */
     @Test
-    public void test_createHTTPClient_nullSslSocketFactory() {
+    public void test_createHttpClient_nullSslSocketFactory() {
         try {
             SSLSocketFactory sslSocketFactory = null;
             String url = null;
 
-            try {
-                utils.createHTTPClient(sslSocketFactory, url, false);
-                fail("Should have thrown an IllegalArgumentException but did not.");
-            } catch (IllegalArgumentException e) {
-                // Expected to be thrown because of the invalid URL
-            }
+            HttpClient client = utils.createHttpClient(sslSocketFactory, url, false);
+            assertNotNull("HttpClient object should not have been null but was.", client);
 
             verifyNoLogMessage(outputMgr, MSG_BASE);
 
@@ -432,11 +428,11 @@ public class HttpUtilsTest extends CommonTestClass {
      * - Client should not be null
      */
     @Test
-    public void test_createHTTPClient_nullUrl_doNotVerifyHostname() {
+    public void test_createHttpClient_nullUrl_doNotVerifyHostname() {
         try {
             String url = null;
 
-            HttpClient client = utils.createHTTPClient(sslSocketFactory, url, false);
+            HttpClient client = utils.createHttpClient(sslSocketFactory, url, false);
             assertNotNull("HttpClient object should not have been null but was.", client);
 
             verifyNoLogMessage(outputMgr, MSG_BASE);
@@ -454,11 +450,11 @@ public class HttpUtilsTest extends CommonTestClass {
      * - Client should not be null
      */
     @Test
-    public void test_createHTTPClient_emptyUrl_doNotVerifyHostname() {
+    public void test_createHttpClient_emptyUrl_doNotVerifyHostname() {
         try {
             String url = "";
 
-            HttpClient client = utils.createHTTPClient(sslSocketFactory, url, false);
+            HttpClient client = utils.createHttpClient(sslSocketFactory, url, false);
             assertNotNull("HttpClient object should not have been null but was.", client);
 
             verifyNoLogMessage(outputMgr, MSG_BASE);
@@ -476,11 +472,11 @@ public class HttpUtilsTest extends CommonTestClass {
      * - Client should not be null
      */
     @Test
-    public void test_createHTTPClient_invalidUrl_verifyHostname() {
+    public void test_createHttpClient_invalidUrl_verifyHostname() {
         try {
             String url = "some invalid URL";
 
-            HttpClient client = utils.createHTTPClient(sslSocketFactory, url, false);
+            HttpClient client = utils.createHttpClient(sslSocketFactory, url, false);
             assertNotNull("HttpClient object should not have been null but was.", client);
 
             verifyNoLogMessage(outputMgr, MSG_BASE);
@@ -498,224 +494,11 @@ public class HttpUtilsTest extends CommonTestClass {
      * - Client should not be null
      */
     @Test
-    public void test_createHTTPClient_validUrl_verifyHostname() {
+    public void test_createHttpClient_validUrl_verifyHostname() {
         try {
             String url = "http://localhost";
 
-            HttpClient client = utils.createHTTPClient(sslSocketFactory, url, false);
-            assertNotNull("HttpClient object should not have been null but was.", client);
-
-            verifyNoLogMessage(outputMgr, MSG_BASE);
-
-        } catch (Throwable t) {
-            outputMgr.failWithThrowable(testName.getMethodName(), t);
-        }
-    }
-
-    /**
-     * Tests:
-     * - URL: Valid HTTP URL
-     * - Username: null
-     * - Password: null
-     * Expects:
-     * - IllegalArgumentException should be thrown because of the null username
-     */
-    @Test
-    public void test_createHTTPClient_withCredentials_nullUsername_nullPassword() {
-        try {
-            String url = "http://localhost";
-            String username = null;
-            String password = null;
-
-            try {
-                utils.createHTTPClient(sslSocketFactory, url, false, username, password);
-                fail("Should have thrown an IllegalArgumentException but did not.");
-            } catch (IllegalArgumentException e) {
-                // Expected to be thrown because of the invalid URL
-            }
-
-            verifyNoLogMessage(outputMgr, MSG_BASE);
-
-        } catch (Throwable t) {
-            outputMgr.failWithThrowable(testName.getMethodName(), t);
-        }
-    }
-
-    /**
-     * Tests:
-     * - URL: Valid HTTP URL
-     * - Verify hostname: false
-     * - Username: null
-     * - Password: Empty
-     * Expects:
-     * - IllegalArgumentException should be thrown because of the null username
-     */
-    @Test
-    public void test_createHTTPClient_withCredentials_nullUsername_emptyPassword() {
-        try {
-            String url = "http://localhost";
-            String username = null;
-            String password = "";
-
-            try {
-                utils.createHTTPClient(sslSocketFactory, url, false, username, password);
-                fail("Should have thrown an IllegalArgumentException but did not.");
-            } catch (IllegalArgumentException e) {
-                // Expected to be thrown because of the invalid URL
-            }
-
-            verifyNoLogMessage(outputMgr, MSG_BASE);
-
-        } catch (Throwable t) {
-            outputMgr.failWithThrowable(testName.getMethodName(), t);
-        }
-    }
-
-    /**
-     * Tests:
-     * - URL: Valid HTTP URL
-     * - Verify hostname: false
-     * - Username: Empty
-     * - Password: null
-     * Expects:
-     * - Client should not be null
-     */
-    @Test
-    public void test_createHTTPClient_withCredentials_emptyUsername_nullPassword() {
-        try {
-            String url = "http://localhost";
-            String username = "";
-            String password = null;
-
-            HttpClient client = utils.createHTTPClient(sslSocketFactory, url, false, username, password);
-            assertNotNull("HttpClient object should not have been null but was.", client);
-
-            verifyNoLogMessage(outputMgr, MSG_BASE);
-
-        } catch (Throwable t) {
-            outputMgr.failWithThrowable(testName.getMethodName(), t);
-        }
-    }
-
-    /**
-     * Tests:
-     * - SSL socket factory: null
-     * - URL: Valid HTTP URL
-     * Expects:
-     * - Client should not be null - a valid HTTP URL means the SSL socket factory shouldn't be used
-     */
-    @Test
-    public void test_createHTTPClient_withCredentials_nullSslSocketFactory_validHttpUrl() {
-        try {
-            SSLSocketFactory sslSocketFactory = null;
-            String url = "http://localhost";
-            String username = "";
-            String password = "";
-
-            HttpClient client = utils.createHTTPClient(sslSocketFactory, url, false, username, password);
-            assertNotNull("HttpClient object should not have been null but was.", client);
-
-            verifyNoLogMessage(outputMgr, MSG_BASE);
-
-        } catch (Throwable t) {
-            outputMgr.failWithThrowable(testName.getMethodName(), t);
-        }
-    }
-
-    /**
-     * Tests:
-     * - SSL socket factory: null
-     * - URL: Invalid
-     * Expects:
-     * - A URL that doesn't start with "http:" will attempt to use the SSL socket factory
-     * - IllegalArgumentException should be thrown because of the null SSL socket factory
-     */
-    @Test
-    public void test_createHTTPClient_withCredentials_nullSslSocketFactory_invalidUrl() {
-        try {
-            SSLSocketFactory sslSocketFactory = null;
-            String url = "some invalid URL";
-            String username = "my username";
-            String password = "pass\n\r word";
-
-            try {
-                utils.createHTTPClient(sslSocketFactory, url, false, username, password);
-                fail("Should have thrown an IllegalArgumentException but did not.");
-            } catch (IllegalArgumentException e) {
-                // Expected to be thrown because of the invalid URL
-            }
-
-            verifyNoLogMessage(outputMgr, MSG_BASE);
-
-        } catch (Throwable t) {
-            outputMgr.failWithThrowable(testName.getMethodName(), t);
-        }
-    }
-
-    /**
-     * Tests:
-     * - SSL socket factory: null
-     * - URL: HTTP URL with mixed casing of the HTTP scheme
-     * Expects:
-     * - Client should not be null - a valid HTTP URL means the SSL socket factory shouldn't be used
-     */
-    @Test
-    public void test_createHTTPClient_withCredentials_nullSslSocketFactory_httpUrlMixedCase() {
-        try {
-            SSLSocketFactory sslSocketFactory = null;
-            String url = "hTtP://localhost";
-            String username = "username";
-            String password = "password";
-
-            HttpClient client = utils.createHTTPClient(sslSocketFactory, url, false, username, password);
-            assertNotNull("HttpClient object should not have been null but was.", client);
-
-            verifyNoLogMessage(outputMgr, MSG_BASE);
-
-        } catch (Throwable t) {
-            outputMgr.failWithThrowable(testName.getMethodName(), t);
-        }
-    }
-
-    /**
-     * Tests:
-     * - URL: Non-HTTP URL
-     * - Verify host name: true
-     * Expects:
-     * - Client should not be null
-     */
-    @Test
-    public void test_createHTTPClient_withCredentials_verifyHostName() {
-        try {
-            String url = "https://localhost";
-            String username = "username";
-            String password = "password";
-
-            HttpClient client = utils.createHTTPClient(sslSocketFactory, url, true, username, password);
-            assertNotNull("HttpClient object should not have been null but was.", client);
-
-            verifyNoLogMessage(outputMgr, MSG_BASE);
-
-        } catch (Throwable t) {
-            outputMgr.failWithThrowable(testName.getMethodName(), t);
-        }
-    }
-
-    /**
-     * Tests:
-     * - URL: Non-HTTP URL
-     * - Verify host name: false
-     * Expects:
-     * - Client should not be null
-     */
-    @Test
-    public void test_createHTTPClient_withCredentials_doNotVerifyHostName() {
-        try {
-            String url = "ftp://example";
-            String username = "username";
-            String password = "password";
-
-            HttpClient client = utils.createHTTPClient(sslSocketFactory, url, false, username, password);
+            HttpClient client = utils.createHttpClient(sslSocketFactory, url, false);
             assertNotNull("HttpClient object should not have been null but was.", client);
 
             verifyNoLogMessage(outputMgr, MSG_BASE);

--- a/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutRequest.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutRequest.java
@@ -95,7 +95,7 @@ public class BackchannelLogoutRequest implements Callable<BackchannelLogoutReque
             sslSocketFactory = sslSupportService.getSSLSocketFactory();
         }
         // TODO - host name verification?
-        return httpUtils.createHTTPClient(sslSocketFactory, url, false);
+        return httpUtils.createHttpClient(sslSocketFactory, url, false);
     }
 
     HttpPost createHttpPost() {

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.security.social.internal;
 
+import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.Key;
 import java.util.ArrayList;
@@ -23,13 +24,16 @@ import javax.net.ssl.SSLSocketFactory;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 
+import com.ibm.ejs.ras.TraceNLS;
 import com.ibm.json.java.JSONObject;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.common.config.DiscoveryConfigUtils;
+import com.ibm.ws.security.common.http.HttpResponseNot200Exception;
 import com.ibm.ws.security.common.http.HttpUtils;
+import com.ibm.ws.security.common.http.HttpResponseNullOrEmptyException;
 import com.ibm.ws.security.common.jwk.impl.JWKSet;
 import com.ibm.ws.security.jwt.config.ConsumerUtils;
 import com.ibm.ws.security.jwt.config.JwtConsumerConfig;
@@ -241,7 +245,7 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements Conver
         discoveryUtil = discoveryUtil.initialConfig(getId(), discoveryEndpointUrl, discoveryPollingRate).discoveryDocumentResult(null).discoveryDocumentHash(discoveryDocumentHash).discoveredConfig(signatureAlgorithm, tokenEndpointAuthMethod, scope);
     }
 
-    @FFDCIgnore({ Exception.class })
+    @FFDCIgnore({ Exception.class, HttpResponseNullOrEmptyException.class, HttpResponseNot200Exception.class })
     public boolean handleDiscoveryEndpoint(String discoveryUrl) {
 
         String jsonString = null;
@@ -256,7 +260,7 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements Conver
             }
 
             SSLSocketFactory sslSocketFactory = getSSLSocketFactory();
-            jsonString = httputils.getHttpRequest(sslSocketFactory, discoveryUrl, hostNameVerificationEnabled, null, null); // do not need to add basic auth header
+            jsonString = fetchDiscoveryData(discoveryUrl, sslSocketFactory);
             if (jsonString != null) {
                 parseJsonResponse(jsonString);
                 if (discoveryjson != null) {
@@ -264,6 +268,8 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements Conver
                 }
             }
 
+        } catch (HttpResponseNullOrEmptyException e) {
+        } catch (HttpResponseNot200Exception e) {
         } catch (Exception e) {
             if (tc.isDebugEnabled()) {
                 Tr.debug(tc, "Fail to get successful discovery response : ", e.getCause());
@@ -274,6 +280,36 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements Conver
             Tr.error(tc, "OIDC_CLIENT_DISCOVERY_SSL_ERROR", getId(), discoveryUrl);
         }
         return valid;
+    }
+
+    @FFDCIgnore({ IOException.class, HttpResponseNullOrEmptyException.class, HttpResponseNot200Exception.class })
+    String fetchDiscoveryData(String discoveryUrl, SSLSocketFactory sslSocketFactory) throws Exception {
+        try {
+            return httputils.getHttpJsonRequest(sslSocketFactory, discoveryUrl, hostNameVerificationEnabled, useSystemPropertiesForHttpClientConnections);
+        } catch (IOException ioex) {
+            String errMsg = "IOException: " + ioex.getMessage() + " " + ioex.getCause();
+            String message = TraceNLS.getFormattedMessage(getClass(),
+                    "com.ibm.ws.security.common.internal.resources.SSOCommonMessages", "OIDC_CLIENT_DISCOVERY_ERROR",
+                    new Object[] { discoveryUrl, errMsg }, "Error processing discovery request");
+            Tr.error(tc, message, new Object[0]);
+            throw ioex;
+        } catch (HttpResponseNullOrEmptyException e) {
+            logErrorMessage(e.getUrl(), e.getStatusCode(), e.getErrMsg());
+            throw e;
+        } catch (HttpResponseNot200Exception e) {
+            logErrorMessage(e.getUrl(), e.getStatusCode(), e.getErrMsg());
+            throw e;
+        }
+    }
+
+    private String logErrorMessage(String url, int iStatusCode, String errMsg) {
+        String defaultMessage = "Error processing discovery request";
+
+        String message = TraceNLS.getFormattedMessage(getClass(),
+                "com.ibm.ws.security.common.internal.resources.SSOCommonMessages", "OIDC_CLIENT_DISC_RESPONSE_ERROR",
+                new Object[] { url, Integer.valueOf(iStatusCode), errMsg }, defaultMessage);
+        Tr.error(tc, message, new Object[0]);
+        return message;
     }
 
     /**

--- a/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
+++ b/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
@@ -14,6 +14,11 @@
 
 bVersion=1.0
 
+WS-TraceGroup: \
+	OPENIDCONNECT
+
+Private-Package: io.openliberty.security.oidcclientcore.internal.resources.*
+
 Import-Package: \
     org.apache.http.*;resolution:=optional, \
     *

--- a/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
+++ b/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
@@ -16,7 +16,3 @@
 #NLS_ENCODING=UNICODE
 # -------------------------------------------------------------------------------------------------
 # Message prefix block: CWWKS2400 - CWWKS2499
-
-DISCOVERY_URL_NOT_VALID=CWWKS2400E: The given Discovery URL {0} is invalid.
-DISCOVERY_URL_NOT_VALID.explanation=Discovery URLs need to start with https.
-DISCOVERY_URL_NOT_VALID.useraction=Ensure that the given Discovery URL starts with https before fetching discovery data.

--- a/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
+++ b/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
@@ -1,0 +1,22 @@
+###############################################################################
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#CMVCPATHNAME io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
+#COMPONENTPREFIX CWWKS
+#COMPONENTNAMEFOR Security OIDC Client Core
+#ISMESSAGEFILE TRUE
+#NLS_MESSAGEFORMAT_VAR
+#NLS_ENCODING=UNICODE
+# -------------------------------------------------------------------------------------------------
+# Message prefix block: CWWKS2400 - CWWKS2499
+
+DISCOVERY_URL_NOT_VALID=CWWKS2400E: The given Discovery URL {0} is invalid.
+DISCOVERY_URL_NOT_VALID.explanation=Discovery URLs need to start with https.
+DISCOVERY_URL_NOT_VALID.useraction=Ensure that the given Discovery URL starts with https before fetching discovery data.

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/discovery/DiscoveryHandler.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/discovery/DiscoveryHandler.java
@@ -30,15 +30,7 @@ public class DiscoveryHandler {
     }
 
     public String fetchDiscoveryData(String discoveryUrl, boolean hostNameVerificationEnabled, boolean useSystemProperties) throws Exception {
-        if (!isValidDiscoveryUrl(discoveryUrl)) {
-            String errorMsg = Tr.formatMessage(tc, "DISCOVERY_URL_NOT_VALID", discoveryUrl);
-            throw new Exception(errorMsg);
-        }
-        return httpUtils.getHttpRequest(sslSocketFactory, discoveryUrl, hostNameVerificationEnabled, useSystemProperties);
-    }
-
-    private boolean isValidDiscoveryUrl(String discoveryUrl) {
-        return discoveryUrl != null && discoveryUrl.startsWith("https");
+        return httpUtils.getHttpJsonRequest(sslSocketFactory, discoveryUrl, hostNameVerificationEnabled, useSystemProperties);
     }
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/discovery/DiscoveryHandler.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/discovery/DiscoveryHandler.java
@@ -12,7 +12,7 @@ package io.openliberty.security.oidcclientcore.discovery;
 
 import javax.net.ssl.SSLSocketFactory;
 
-import com.ibm.json.java.JSONObject;
+//import com.ibm.json.java.JSONObject;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.security.common.http.HttpUtils;
@@ -29,13 +29,12 @@ public class DiscoveryHandler {
         this.httpUtils = new HttpUtils();
     }
 
-    public JSONObject fetchDiscoveryData(String discoveryUrl, boolean hostNameVerificationEnabled) throws Exception {
+    public String fetchDiscoveryData(String discoveryUrl, boolean hostNameVerificationEnabled, boolean useSystemProperties) throws Exception {
         if (!isValidDiscoveryUrl(discoveryUrl)) {
             String errorMsg = Tr.formatMessage(tc, "DISCOVERY_URL_NOT_VALID", discoveryUrl);
             throw new Exception(errorMsg);
         }
-        String jsonString = httpUtils.getHttpRequest(sslSocketFactory, discoveryUrl, hostNameVerificationEnabled, null, null);
-        return JSONObject.parse(jsonString);
+        return httpUtils.getHttpRequest(sslSocketFactory, discoveryUrl, hostNameVerificationEnabled, useSystemProperties);
     }
 
     private boolean isValidDiscoveryUrl(String discoveryUrl) {

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/discovery/InvalidDiscoveryUrlException.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/discovery/InvalidDiscoveryUrlException.java
@@ -6,14 +6,16 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- * IBM Corporation - initial API and implementation
+ *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-
-/**
- * @version 1.0.0
- */
-@org.osgi.annotation.versioning.Version("1.0.0")
-@TraceOptions(traceGroup = TraceConstants.TRACE_GROUP, messageBundle = TraceConstants.MESSAGE_BUNDLE)
 package io.openliberty.security.oidcclientcore.discovery;
 
-import com.ibm.websphere.ras.annotation.TraceOptions;
+public class InvalidDiscoveryUrlException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public InvalidDiscoveryUrlException(String msg) {
+        super(msg);
+    }
+
+}

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/discovery/TraceConstants.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/discovery/TraceConstants.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oidcclientcore.discovery;
+
+/**
+ *
+ */
+public class TraceConstants {
+
+    public static final String TRACE_GROUP = "OpenIdConnect";
+    public static final String MESSAGE_BUNDLE = "io.openliberty.security.oidcclientcore.internal.resources.OidcClientCoreMessages";
+
+}

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/discovery/package-info.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/discovery/package-info.java
@@ -13,4 +13,7 @@
  * @version 1.0.0
  */
 @org.osgi.annotation.versioning.Version("1.0.0")
+@TraceOptions(traceGroup = "JAKARTASEC", messageBundle = TraceConstants.MESSAGE_BUNDLE)
 package io.openliberty.security.oidcclientcore.discovery;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;


### PR DESCRIPTION
First pass shot at refactoring some OIDC discovery code to yank out some discovery-specific code from the common security bundle.

Discovery-related changes:
- `com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl` calls the new `DiscoveryHandler.fetchDiscoveryData()` method when the server is running beta mode.

Refactoring changes:
- The `HttpUtils` class has had its various `createHttpClient` methods consolidated.
- A new `AbstractHttpResponseException` class is created to encapsulate errors with an HTTP response.
    - `HttpResponseNot200Exception` and `HttpResponseNullOrEmptyException` extend this class.
- The old `HttpUtils.getHTTPRequestAsString()` method has been refactored in various ways:
    - Renamed to `getHttpJsonRequest()` since the method was previously hard-coded to expect a JSON response.
    - A separate `getHttpRequestAsString()` method is created to send a general HTTP GET request. One of its arguments is a `List<NameValuePair> headers` to provide headers. (Callers can, for instance, pass in `Content-Type: application/json` if they expect JSON back.)

Exception handling in HttpUtils:
- Because the HttpUtils class had specific NLS messages for social login discovery, those messages need to continue to be emitted for the social login feature.
- The new `getHttpRequestAsString()` and `extractResponseAsString()` methods now throw `AbstractHttpResponseException` and `SocialLoginWrapperException` exceptions.
- The `SocialLoginWrapperException` class wraps exceptions that emit social login specific NLS messages in the security.common bundle. Wrapping the exceptions should allow calling classes to emit their own error or warning messages if they choose, rather than emitting social login NLS messages that may be unrelated or misleading.
- The social login discovery code will use this exception to continue to emit existing discovery-related NLS messages.
- The OIDC discovery code uses the exception to get at the underlying cause to continue to include that information in the existing discovery-related NLS messages.