### PR TITLE
Enable trace if task threads fail to stop

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/publish/servers/com.ibm.ws.concurrent.persistent.fat.oneexec/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/publish/servers/com.ibm.ws.concurrent.persistent.fat.oneexec/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2014, 2015, 2019 IBM Corporation and others.
+# Copyright (c) 2014, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 
-com.ibm.ws.logging.trace.specification=*=info=enabled:persistentExecutor=all
+com.ibm.ws.logging.trace.specification=*=info=enabled:persistentExecutor=all:com.ibm.ws.runtime.update.*=all
 com.ibm.ws.logging.max.file.size=0
 
 osgi.console=5678


### PR DESCRIPTION
During the server quiesce period for this test, we have observed a warning being produced that states that 6 threads did not complete.

```
CWWKE1107W: 6 threads did not complete during the quiesce period.
CWWKE1102W: The quiesce operation did not complete. The server will now stop. 
```

We were able to verify that these are referring to user threads, and not threads related to the persistent executor quiesce listeners.
Adding this trace will help us further debug this issue if it happens again.
