### PR TITLE
AuthenticateApi logout fall back to get user name from caller subject if session user is anonymous

### DIFF
--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/AuthenticateApi.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/AuthenticateApi.java
@@ -241,7 +241,7 @@ public class AuthenticateApi {
             if (!bInitUserName) {
                 bInitUserName = true;
                 userName = getSessionUserName(req, res);
-                if (userName == null) {
+                if (userName == null || "anonymous".equals(userName)) {
                     userName = getUserNameFromCallerSubject();
                 }
             }


### PR DESCRIPTION
The user name "anonymous" is returned from the HTTP session when session security is disabled. In that case, the `logoutUnprotectedResourceServiceRef()` method should fall back to getting the user name from the caller subject just as if the user name was `null`.