### PR TITLE
change server.xml to use in mem derby db

### DIFF
--- a/dev/com.ibm.ws.jca_fat_bvt/publish/servers/com.ibm.ws.jca.fat.bvt/server.xml
+++ b/dev/com.ibm.ws.jca_fat_bvt/publish/servers/com.ibm.ws.jca.fat.bvt/server.xml
@@ -58,7 +58,7 @@
       <contextService>
         <jeeMetadataContext/>
       </contextService>
-      <properties.RAR1 databaseName="jcabvtdb" createDatabase="true" password="{xor}DR4Nbg8IGw==" userName="RAR1USER"/>
+      <properties.RAR1 databaseName="memory:jcabvtdb" createDatabase="true" password="{xor}DR4Nbg8IGw==" userName="RAR1USER"/>
     </resourceAdapter>
 
     <resourceAdapter location="${server.config.dir}/resourceadapters/JCARAR2.rar">


### PR DESCRIPTION
com.ibm.ws.jca_fat_bvt experienced a test failure due to the derby filesystem db getting deleted during a test. Switching to use in memory database will avoid this issue.