### PR TITLE
Make mpOpenTracing processing more efficient when Traced annotation is false

### DIFF
--- a/dev/com.ibm.ws.opentracing.1.1/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
+++ b/dev/com.ibm.ws.opentracing.1.1/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
@@ -86,8 +86,9 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
         }
 
         URI incomingUri = incomingRequestContext.getUriInfo().getRequestUri();
-        String incomingURL = incomingUri.toURL().toString();
+        String incomingURL = null;
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            incomingURL = incomingUri.toURL().toString();
             Tr.debug(tc, methodName + " incomingURL", incomingURL);
         }
 
@@ -115,6 +116,9 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
                 process = false;
             }
         } else {
+            if (incomingURL == null) {
+                incomingURL = incomingUri.toURL().toString();
+            }
             buildSpanName = incomingURL;
         }
 

--- a/dev/com.ibm.ws.opentracing.1.1/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
+++ b/dev/com.ibm.ws.opentracing.1.1/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
@@ -85,10 +85,22 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
             }
         }
 
+        String buildSpanName = null;
+        if (helper != null) {
+            buildSpanName = helper.getBuildSpanName(incomingRequestContext, resourceInfo);
+            if (buildSpanName == null) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, methodName + " skipping not traced method");
+                }
+                incomingRequestContext.setProperty(SERVER_SPAN_SKIPPED_ID, true);
+                return;
+            }
+        }
+
         URI incomingUri = incomingRequestContext.getUriInfo().getRequestUri();
-        String incomingURL = null;
+        String  incomingURL = incomingUri.toURL().toString();
+
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            incomingURL = incomingUri.toURL().toString();
             Tr.debug(tc, methodName + " incomingURL", incomingURL);
         }
 
@@ -99,56 +111,34 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
             Tr.debug(tc, methodName + " priorContext", priorOutgoingContext);
         }
 
-        /*
-         * Removing filter processing until microprofile spec for it is approved. Expect to add this code
-         * back in 1Q18 - smf
-         */
-        // boolean process = OpentracingService.process(incomingUri, SpanFilterType.INCOMING);
-        boolean process = true;
-
-        String buildSpanName;
-        if (helper != null) {
-            buildSpanName = helper.getBuildSpanName(incomingRequestContext, resourceInfo);
-            if (buildSpanName == null) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, methodName + " skipping not traced method");
-                }
-                process = false;
-            }
-        } else {
-            if (incomingURL == null) {
-                incomingURL = incomingUri.toURL().toString();
-            }
+        if (buildSpanName == null) {
             buildSpanName = incomingURL;
         }
 
-        if (process) {
-            Tracer.SpanBuilder spanBuilder = tracer.buildSpan(buildSpanName);
-            spanBuilder.withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);
-            spanBuilder.withTag(Tags.HTTP_URL.getKey(), incomingURL);
-            spanBuilder.withTag(Tags.HTTP_METHOD.getKey(), incomingRequestContext.getMethod());
-            spanBuilder.withTag(Tags.COMPONENT.getKey(), TAG_COMPONENT_JAXRS);
-            if (priorOutgoingContext != null) {
-                spanBuilder.asChildOf(priorOutgoingContext);
-            }
-
-            try {
-                Scope scope = spanBuilder.startActive(true);
-
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, methodName + " span", scope.span());
-                }
-
-                incomingRequestContext.setProperty(SERVER_SPAN_PROP_ID, scope);
-            } catch (NoSuchMethodError e) {
-                if (!spanErrorLogged) {
-                    Tr.error(tc, "OPENTRACING_COULD_NOT_START_SPAN", e);
-                    spanErrorLogged = true;
-                }
-            }
+        Tracer.SpanBuilder spanBuilder = tracer.buildSpan(buildSpanName);
+        spanBuilder.withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);
+        spanBuilder.withTag(Tags.HTTP_URL.getKey(), incomingURL);
+        spanBuilder.withTag(Tags.HTTP_METHOD.getKey(), incomingRequestContext.getMethod());
+        spanBuilder.withTag(Tags.COMPONENT.getKey(), TAG_COMPONENT_JAXRS);
+        if (priorOutgoingContext != null) {
+            spanBuilder.asChildOf(priorOutgoingContext);
         }
 
-        incomingRequestContext.setProperty(SERVER_SPAN_SKIPPED_ID, !process);
+        try {
+            Scope scope = spanBuilder.startActive(true);
+
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, methodName + " span", scope.span());
+            }
+
+            incomingRequestContext.setProperty(SERVER_SPAN_PROP_ID, scope);
+        } catch (NoSuchMethodError e) {
+            if (!spanErrorLogged) {
+                Tr.error(tc, "OPENTRACING_COULD_NOT_START_SPAN", e);
+                spanErrorLogged = true;
+            }
+        }
+        incomingRequestContext.setProperty(SERVER_SPAN_SKIPPED_ID, false);
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
+++ b/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
@@ -105,15 +105,13 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
         }
 
         String incomingURL = null;
+        SpanContext priorOutgoingContext = null;
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             incomingURL = incomingUri.toURL().toString();
             Tr.debug(tc, methodName + " incomingURL", incomingURL);
-        }
 
-        SpanContext priorOutgoingContext = tracer.extract(Format.Builtin.HTTP_HEADERS,
-                                                          new MultivaluedMapToTextMap(incomingRequestContext.getHeaders()));
-
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            priorOutgoingContext = tracer.extract(Format.Builtin.HTTP_HEADERS,
+                new MultivaluedMapToTextMap(incomingRequestContext.getHeaders()));
             Tr.debug(tc, methodName + " priorContext", priorOutgoingContext);
         }
 
@@ -126,7 +124,10 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
             if (buildSpanName == null) {
                 buildSpanName = incomingURL;
             }
-
+            if (priorOutgoingContext == null) {
+                priorOutgoingContext = tracer.extract(Format.Builtin.HTTP_HEADERS,
+                    new MultivaluedMapToTextMap(incomingRequestContext.getHeaders()));
+            }
             Tracer.SpanBuilder spanBuilder = tracer.buildSpan(buildSpanName);
             spanBuilder.withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);
             spanBuilder.withTag(Tags.HTTP_URL.getKey(), incomingURL);

--- a/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
+++ b/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
@@ -119,23 +119,14 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
 
         boolean process = OpentracingService.process(incomingUri, incomingPath, SpanFilterType.INCOMING);
 
-        String buildSpanName;
-        if (helper != null) {
-            buildSpanName = helper.getBuildSpanName(incomingRequestContext, resourceInfo);
-            if (buildSpanName == null) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, methodName + " skipping not traced method");
-                }
-                process = false;
-            }
-        } else {
+        if (process) {
             if (incomingURL == null) {
                 incomingURL = incomingUri.toURL().toString();
             }
-            buildSpanName = incomingURL;
-        }
+            if (buildSpanName == null) {
+                buildSpanName = incomingURL;
+            }
 
-        if (process) {
             Tracer.SpanBuilder spanBuilder = tracer.buildSpan(buildSpanName);
             spanBuilder.withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);
             spanBuilder.withTag(Tags.HTTP_URL.getKey(), incomingURL);

--- a/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
+++ b/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
@@ -108,15 +108,13 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
         }
 
         String incomingURL = null;
+        SpanContext priorOutgoingContext = null;
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             incomingURL = incomingUri.toURL().toString();
             Tr.debug(tc, methodName + " incomingURL", incomingURL);
-        }
 
-        SpanContext priorOutgoingContext = tracer.extract(Format.Builtin.HTTP_HEADERS,
-                                                          new MultivaluedMapToTextMap(incomingRequestContext.getHeaders()));
-
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            priorOutgoingContext = tracer.extract(Format.Builtin.HTTP_HEADERS,
+                new MultivaluedMapToTextMap(incomingRequestContext.getHeaders()));
             Tr.debug(tc, methodName + " priorContext", priorOutgoingContext);
         }
 
@@ -128,6 +126,10 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
             }
             if (buildSpanName == null) {
                 buildSpanName = incomingURL;
+            }
+            if (priorOutgoingContext == null) {
+              priorOutgoingContext = tracer.extract(Format.Builtin.HTTP_HEADERS,
+                  new MultivaluedMapToTextMap(incomingRequestContext.getHeaders()));
             }
             Tracer.SpanBuilder spanBuilder = tracer.buildSpan(buildSpanName);
             spanBuilder.withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);

--- a/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
+++ b/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
@@ -123,10 +123,10 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
         boolean process = OpentracingService.process(incomingUri, incomingPath, SpanFilterType.INCOMING);
 
         if (process) {
+            if (incomingURL == null) {
+                incomingURL = incomingUri.toURL().toString();
+            }
             if (buildSpanName == null) {
-                if (incomingURL == null) {
-                    incomingURL = incomingUri.toURL().toString();
-                }
                 buildSpanName = incomingURL;
             }
             Tracer.SpanBuilder spanBuilder = tracer.buildSpan(buildSpanName);

--- a/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
+++ b/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
@@ -84,10 +84,22 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
             }
         }
 
+        String buildSpanName = null;
+        if (helper != null) {
+            buildSpanName = helper.getBuildSpanName(incomingRequestContext, resourceInfo);
+            if (buildSpanName == null) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, methodName + " skipping not traced method");
+                }
+                incomingRequestContext.setProperty(SERVER_SPAN_SKIPPED_ID, true);
+                return;
+            }
+        }
+
         URI incomingUri = incomingRequestContext.getUriInfo().getRequestUri();
-        String incomingURL = null;
+        String incomingURL = incomingUri.toURL().toString();
+
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            incomingURL = incomingUri.toURL().toString();
             Tr.debug(tc, methodName + " incomingURL", incomingURL);
         }
 
@@ -98,53 +110,32 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
             Tr.debug(tc, methodName + " priorContext", priorOutgoingContext);
         }
 
-        /*
-         * Removing filter processing until microprofile spec for it is approved. Expect to add this code
-         * back in 1Q18 - smf
-         */
-        // boolean process = OpentracingService.process(incomingUri, SpanFilterType.INCOMING);
-        boolean process = true;
-
-        String buildSpanName;
-        if (helper != null) {
-            buildSpanName = helper.getBuildSpanName(incomingRequestContext, resourceInfo);
-            if (buildSpanName == null) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, methodName + " skipping not traced method");
-                }
-                process = false;
-            }
-        } else {
-            if (incomingURL == null) {
-                incomingURL = incomingUri.toURL().toString();
-            }
-            buildSpanName = incomingURL;
+        if (buildSpanName == null) {
+          buildSpanName = incomingURL;
         }
 
-        if (process) {
-            Tracer.SpanBuilder spanBuilder = tracer.buildSpan(buildSpanName);
-            spanBuilder.withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);
-            spanBuilder.withTag(Tags.HTTP_URL.getKey(), incomingURL);
-            spanBuilder.withTag(Tags.HTTP_METHOD.getKey(), incomingRequestContext.getMethod());
-            spanBuilder.asChildOf(priorOutgoingContext);
+        Tracer.SpanBuilder spanBuilder = tracer.buildSpan(buildSpanName);
+        spanBuilder.withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);
+        spanBuilder.withTag(Tags.HTTP_URL.getKey(), incomingURL);
+        spanBuilder.withTag(Tags.HTTP_METHOD.getKey(), incomingRequestContext.getMethod());
+        spanBuilder.asChildOf(priorOutgoingContext);
 
-            try {
-                ActiveSpan activeSpan = spanBuilder.startActive();
+        try {
+            ActiveSpan activeSpan = spanBuilder.startActive();
 
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, methodName + " activeSpan", activeSpan);
-                }
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, methodName + " activeSpan", activeSpan);
+            }
 
-                incomingRequestContext.setProperty(SERVER_SPAN_PROP_ID, activeSpan);
-            } catch (NoSuchMethodError e) {
-                if (!spanErrorLogged) {
-                    Tr.error(tc, "OPENTRACING_COULD_NOT_START_SPAN", e);
-                    spanErrorLogged = true;
-                }
+            incomingRequestContext.setProperty(SERVER_SPAN_PROP_ID, activeSpan);
+        } catch (NoSuchMethodError e) {
+            if (!spanErrorLogged) {
+                Tr.error(tc, "OPENTRACING_COULD_NOT_START_SPAN", e);
+                spanErrorLogged = true;
             }
         }
 
-        incomingRequestContext.setProperty(SERVER_SPAN_SKIPPED_ID, !process);
+        incomingRequestContext.setProperty(SERVER_SPAN_SKIPPED_ID, false);
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
+++ b/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
@@ -85,8 +85,9 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
         }
 
         URI incomingUri = incomingRequestContext.getUriInfo().getRequestUri();
-        String incomingURL = incomingUri.toURL().toString();
+        String incomingURL = null;
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            incomingURL = incomingUri.toURL().toString();
             Tr.debug(tc, methodName + " incomingURL", incomingURL);
         }
 
@@ -114,6 +115,9 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
                 process = false;
             }
         } else {
+            if (incomingURL == null) {
+                incomingURL = incomingUri.toURL().toString();
+            }
             buildSpanName = incomingURL;
         }
 

--- a/dev/io.openliberty.opentracing.2.0.internal/src/io/openliberty/opentracing/internal/OpentracingConfiguration.java
+++ b/dev/io.openliberty.opentracing.2.0.internal/src/io/openliberty/opentracing/internal/OpentracingConfiguration.java
@@ -19,27 +19,12 @@ import org.eclipse.microprofile.config.ConfigProvider;
 public class OpentracingConfiguration {
 
     public static final String MP_OT_SERVER_SKIP_PATTERN_KEY = "mp.opentracing.server.skip-pattern";
-    public static final String MP_OT_SERVER_SKIP_PATTERN_MAY_CHANGE_KEY = "mp.opentracing.server.skip-pattern.may.change";
     public static final String MP_OT_SERVER_OPERATION_NAME_PROVIDER_KEY = "mp.opentracing.server.operation-name-provider";
     public static final String MP_OT_SERVER_OPERATION_NAME_PROVIDER_HTTP_PATH = "http-path";
 
-    private static boolean MP_OT_SERVER_SKIP_PATTERN_MAY_CHANGE = false;
-    private static boolean MP_OT_SERVER_SKIP_PATTERN_IS_SET = false;
-    private static String MP_OT_SERVER_SKIP_PATTERN = null;
-
-    static {
-        Config config = ConfigProvider.getConfig(Thread.currentThread().getContextClassLoader());
-        MP_OT_SERVER_SKIP_PATTERN_MAY_CHANGE = config.getOptionalValue(MP_OT_SERVER_SKIP_PATTERN_MAY_CHANGE_KEY, Boolean.class).orElse(false);
-    }
-
     public static String getServerSkipPattern() {
-        if (!MP_OT_SERVER_SKIP_PATTERN_IS_SET || MP_OT_SERVER_SKIP_PATTERN_MAY_CHANGE) {
-            Config config = ConfigProvider.getConfig(Thread.currentThread().getContextClassLoader());
-            MP_OT_SERVER_SKIP_PATTERN = config.getOptionalValue(MP_OT_SERVER_SKIP_PATTERN_KEY, String.class).orElse(null);
-            MP_OT_SERVER_SKIP_PATTERN_IS_SET = true;
-        }
-
-        return MP_OT_SERVER_SKIP_PATTERN;
+        Config config = ConfigProvider.getConfig(Thread.currentThread().getContextClassLoader());
+        return config.getOptionalValue(MP_OT_SERVER_SKIP_PATTERN_KEY, String.class).orElse(null);
     }
 
     static String getOpertionNameProvider() {

--- a/dev/io.openliberty.opentracing.2.0.internal/src/io/openliberty/opentracing/internal/OpentracingConfiguration.java
+++ b/dev/io.openliberty.opentracing.2.0.internal/src/io/openliberty/opentracing/internal/OpentracingConfiguration.java
@@ -19,12 +19,27 @@ import org.eclipse.microprofile.config.ConfigProvider;
 public class OpentracingConfiguration {
 
     public static final String MP_OT_SERVER_SKIP_PATTERN_KEY = "mp.opentracing.server.skip-pattern";
+    public static final String MP_OT_SERVER_SKIP_PATTERN_MAY_CHANGE_KEY = "mp.opentracing.server.skip-pattern.may.change";
     public static final String MP_OT_SERVER_OPERATION_NAME_PROVIDER_KEY = "mp.opentracing.server.operation-name-provider";
     public static final String MP_OT_SERVER_OPERATION_NAME_PROVIDER_HTTP_PATH = "http-path";
 
-    public static String getServerSkipPattern() {
+    private static boolean MP_OT_SERVER_SKIP_PATTERN_MAY_CHANGE = false;
+    private static boolean MP_OT_SERVER_SKIP_PATTERN_IS_SET = false;
+    private static String MP_OT_SERVER_SKIP_PATTERN = null;
+
+    static {
         Config config = ConfigProvider.getConfig(Thread.currentThread().getContextClassLoader());
-        return config.getOptionalValue(MP_OT_SERVER_SKIP_PATTERN_KEY, String.class).orElse(null);
+        MP_OT_SERVER_SKIP_PATTERN_MAY_CHANGE = config.getOptionalValue(MP_OT_SERVER_SKIP_PATTERN_MAY_CHANGE_KEY, Boolean.class).orElse(false);
+    }
+
+    public static String getServerSkipPattern() {
+        if (!MP_OT_SERVER_SKIP_PATTERN_IS_SET || MP_OT_SERVER_SKIP_PATTERN_MAY_CHANGE) {
+            Config config = ConfigProvider.getConfig(Thread.currentThread().getContextClassLoader());
+            MP_OT_SERVER_SKIP_PATTERN = config.getOptionalValue(MP_OT_SERVER_SKIP_PATTERN_KEY, String.class).orElse(null);
+            MP_OT_SERVER_SKIP_PATTERN_IS_SET = true;
+        }
+
+        return MP_OT_SERVER_SKIP_PATTERN;
     }
 
     static String getOpertionNameProvider() {

--- a/dev/io.openliberty.opentracing.2.0.internal/src/io/openliberty/opentracing/internal/OpentracingContainerFilter.java
+++ b/dev/io.openliberty.opentracing.2.0.internal/src/io/openliberty/opentracing/internal/OpentracingContainerFilter.java
@@ -123,10 +123,10 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
         boolean process = OpentracingService.process(incomingUri, incomingPath, SpanFilterType.INCOMING);
 
         if (process) {
+            if (incomingURL == null) {
+                incomingURL = incomingUri.toURL().toString();
+            }
             if (buildSpanName == null) {
-                if (incomingURL == null) {
-                    incomingURL = incomingUri.toURL().toString();
-                }
                 buildSpanName = incomingURL;
             }
 

--- a/dev/io.openliberty.opentracing.2.0.internal/src/io/openliberty/opentracing/internal/OpentracingContainerFilter.java
+++ b/dev/io.openliberty.opentracing.2.0.internal/src/io/openliberty/opentracing/internal/OpentracingContainerFilter.java
@@ -108,15 +108,13 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
         }
 
         String incomingURL = null;
+        SpanContext priorOutgoingContext = null;
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             incomingURL = incomingUri.toURL().toString();
             Tr.debug(tc, methodName + " incomingURL", incomingURL);
-        }
 
-        SpanContext priorOutgoingContext = tracer.extract(Format.Builtin.HTTP_HEADERS,
-                                                          new MultivaluedMapToTextMap(incomingRequestContext.getHeaders()));
-
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            priorOutgoingContext = tracer.extract(Format.Builtin.HTTP_HEADERS,
+                new MultivaluedMapToTextMap(incomingRequestContext.getHeaders()));
             Tr.debug(tc, methodName + " priorContext", priorOutgoingContext);
         }
 
@@ -129,7 +127,10 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
             if (buildSpanName == null) {
                 buildSpanName = incomingURL;
             }
-
+            if (priorOutgoingContext == null) {
+                priorOutgoingContext = tracer.extract(Format.Builtin.HTTP_HEADERS,
+                    new MultivaluedMapToTextMap(incomingRequestContext.getHeaders()));
+            }
             Tracer.SpanBuilder spanBuilder = tracer.buildSpan(buildSpanName);
             spanBuilder.withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);
             spanBuilder.withTag(Tags.HTTP_URL.getKey(), incomingURL);


### PR DESCRIPTION
Avoid extra processing when rest endpoint is annotated with Traced(false).

fixes #21288 