### PR TITLE
Move ltpa processing from checkpoint to restore time

### DIFF
--- a/dev/com.ibm.ws.security.token.ltpa/bnd.bnd
+++ b/dev/com.ibm.ws.security.token.ltpa/bnd.bnd
@@ -28,6 +28,10 @@ Export-Package: com.ibm.ws.security.token.ltpa
 Private-Package: \
   com.ibm.ws.security.token.ltpa.internal.*
 
+-ds-felix-extensions=true
+-dsannotations: \
+  com.ibm.ws.security.token.ltpa.internal.LTPAConfigurationImpl
+
 # Update the metatype.xml for your component in the resources/OSGI-INF/metatype folder
 Include-Resource: \
     OSGI-INF/metatype=resources/OSGI-INF/metatype, \
@@ -37,18 +41,6 @@ Include-Resource: \
 IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml
 
 Service-Component: \
-  com.ibm.ws.security.token.ltpa.LTPAConfiguration; \
-    implementation:=com.ibm.ws.security.token.ltpa.internal.LTPAConfigurationImpl; \
-    activate:=activate; \
-    deactivate:=deactivate; \
-    modified:=modified; \
-    configuration-policy:=require; \
-    immediate:=true; \
-    locationService=com.ibm.wsspi.kernel.service.location.WsLocationAdmin; \
-    executorService=java.util.concurrent.ExecutorService; \
-    ltpaKeysChangeNotifier=com.ibm.ws.security.token.ltpa.internal.LTPAKeysChangeNotifier; \
-    dynamic:='ltpaKeysChangeNotifier'; \
-    properties:='service.vendor=IBM,tokenType=Ltpa2', \
   com.ibm.ws.security.token.ltpa.LTPATokenService; \
     implementation:=com.ibm.ws.security.token.ltpa.internal.LTPATokenService; \
     provide:='com.ibm.ws.security.token.TokenService'; \
@@ -87,10 +79,12 @@ instrument.classesExcludes: com/ibm/ws/security/token/ltpa/internal/resources/*.
 	com.ibm.websphere.org.osgi.service.component,\
 	com.ibm.websphere.appserver.spi.kernel.filemonitor,\
 	com.ibm.websphere.appserver.spi.kernel.service,\
+	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.kernel.service;version=latest, \
 	com.ibm.ws.crypto.ltpakeyutil;version=latest, \
 	com.ibm.ws.logging;version=latest, \
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
+	com.ibm.ws.kernel.boot.core;version=latest
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.security.token.ltpa/test/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImplTest.java
+++ b/dev/com.ibm.ws.security.token.ltpa/test/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImplTest.java
@@ -35,8 +35,6 @@ import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
 
-import test.common.SharedOutputManager;
-
 import com.ibm.ws.security.filemonitor.SecurityFileMonitor;
 import com.ibm.ws.security.token.ltpa.LTPAConfiguration;
 import com.ibm.ws.security.token.ltpa.LTPAKeyInfoManager;
@@ -45,6 +43,8 @@ import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
 import com.ibm.wsspi.kernel.service.location.WsResource;
 import com.ibm.wsspi.kernel.service.utils.SerializableProtectedString;
 import com.ibm.wsspi.security.ltpa.TokenFactory;
+
+import test.common.SharedOutputManager;
 
 /**
  *
@@ -147,6 +147,10 @@ public class LTPAConfigurationImplTest {
     }
 
     class LTPAConfigurationImplTestDouble extends LTPAConfigurationImpl {
+
+        public LTPAConfigurationImplTestDouble() {
+            super(null);
+        }
 
         public boolean wasUnsetFileMonitorRegistrationCalled = false;
         public boolean wasSetFileMonitorRegistrationCalled = false;

--- a/dev/com.ibm.ws.security.token.ltpa/test/com/ibm/ws/security/token/ltpa/internal/LTPAKeyCreateTaskTest.java
+++ b/dev/com.ibm.ws.security.token.ltpa/test/com/ibm/ws/security/token/ltpa/internal/LTPAKeyCreateTaskTest.java
@@ -28,11 +28,11 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 
-import test.common.SharedOutputManager;
-
 import com.ibm.ws.security.token.ltpa.LTPAConfiguration;
 import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
 import com.ibm.wsspi.kernel.service.utils.SerializableProtectedString;
+
+import test.common.SharedOutputManager;
 
 /**
  *
@@ -68,7 +68,8 @@ public class LTPAKeyCreateTaskTest {
         }
 
         @Override
-        void createRequiredCollaborators() throws Exception {}
+        void createRequiredCollaborators() throws Exception {
+        }
     }
 
     @Before
@@ -121,7 +122,7 @@ public class LTPAKeyCreateTaskTest {
         });
         setupLocationServiceExpecatations();
 
-        LTPAConfigurationImpl config = setupActivatedLTPAConfiguration(new LTPAConfigurationImpl() {
+        LTPAConfigurationImpl config = setupActivatedLTPAConfiguration(new LTPAConfigurationImpl(null) {
             @Override
             public void configReady() {
                 throw new IllegalStateException();
@@ -157,7 +158,7 @@ public class LTPAKeyCreateTaskTest {
         });
         setupLocationServiceExpecatations();
 
-        LTPAConfigurationImpl config = setupActivatedLTPAConfiguration(new LTPAConfigurationImpl());
+        LTPAConfigurationImpl config = setupActivatedLTPAConfiguration(new LTPAConfigurationImpl(null));
 
         LTPAKeyCreateTask creator = new LTPAKeyCreateTask(null, config);
 
@@ -205,6 +206,11 @@ public class LTPAKeyCreateTaskTest {
     }
 
     private class LTPAConfigurationImplDouble extends LTPAConfigurationImpl {
+
+        public LTPAConfigurationImplDouble() {
+            super(null);
+        }
+
         public boolean wasConfigReadyCalled = false;
 
         @Override


### PR DESCRIPTION
When trying to checkpoint acmeair microservice applications, I see the following error:
**[ERROR   ] CWWKS4106E: LTPA configuration error. Unable to create or read LTPA key file: /criu/20220620/wlp/usr/servers/AcmeAuth/resources/security/ltpa.keys**

Moving the call to  `com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImpl.setupRuntimeLTPAInfrastructure()` to restore time avoids the error with no effect on performance. We need to make sure we don't run into any issues with this fix where we are improperly caching anything that happens at checkpoint time because the environment may be different during restore.

This fix for this particular problem may be folded into the ssl checkpoint issue (https://github.com/OpenLiberty/open-liberty/issues/21342).