### PR TITLE
Servlet 6.0 Create WC structure

### DIFF
--- a/dev/io.openliberty.servlet.6.0.internal.factories/bnd.bnd
+++ b/dev/io.openliberty.servlet.6.0.internal.factories/bnd.bnd
@@ -77,6 +77,8 @@ Import-Package: \
     com.ibm.ws.webcontainer.osgi.webapp, \
     com.ibm.wsspi.injectionengine, \
     io.openliberty.webcontainer60.session.impl, \
+    io.openliberty.webcontainer60.osgi.request, \
+    io.openliberty.webcontainer60.osgi.srt, \
     *
 
 -buildpath: \

--- a/dev/io.openliberty.servlet.6.0.internal.factories/src/io/openliberty/servlet/internal/osgi/response/factory/IRequestResponseFactory60Impl.java
+++ b/dev/io.openliberty.servlet.6.0.internal.factories/src/io/openliberty/servlet/internal/osgi/response/factory/IRequestResponseFactory60Impl.java
@@ -16,9 +16,10 @@ import com.ibm.websphere.servlet.request.IRequest;
 import com.ibm.websphere.servlet.response.IResponse;
 import com.ibm.ws.webcontainer.osgi.request.IRequestFactory;
 import com.ibm.ws.webcontainer.osgi.response.IResponseFactory;
-import com.ibm.ws.webcontainer40.osgi.request.IRequest40Impl;
 import com.ibm.ws.webcontainer40.osgi.response.IResponse40Impl;
 import com.ibm.wsspi.http.HttpInboundConnection;
+
+import io.openliberty.webcontainer60.osgi.request.IRequest60Impl;
 
 @Component(property = { "service.vendor=IBM", "service.ranking:Integer=60", "servlet.version=6.0" })
 public class IRequestResponseFactory60Impl implements IRequestFactory, IResponseFactory {
@@ -30,8 +31,7 @@ public class IRequestResponseFactory60Impl implements IRequestFactory, IResponse
      */
     @Override
     public IRequest createRequest(HttpInboundConnection inboundConnection) {
-        // there appears to be nothing in IRequestImpl that needs to be different in servlet 3.1, so return the 3.0 version
-        return new IRequest40Impl(inboundConnection);
+        return new IRequest60Impl(inboundConnection);
     }
 
     /*
@@ -41,6 +41,7 @@ public class IRequestResponseFactory60Impl implements IRequestFactory, IResponse
      */
     @Override
     public IResponse createResponse(IRequest ireq, HttpInboundConnection inboundConnection) {
+        //Servlet 6.0 - nothing new in IResponseImpl so return IResponse40Impl
         return new IResponse40Impl(ireq, inboundConnection);
     }
 

--- a/dev/io.openliberty.servlet.6.0.internal.factories/src/io/openliberty/servlet/internal/osgi/srt/factory/SRTConnectionContextPool60Impl.java
+++ b/dev/io.openliberty.servlet.6.0.internal.factories/src/io/openliberty/servlet/internal/osgi/srt/factory/SRTConnectionContextPool60Impl.java
@@ -13,7 +13,8 @@ package io.openliberty.servlet.internal.osgi.srt.factory;
 import org.osgi.service.component.annotations.Component;
 
 import com.ibm.ws.webcontainer.osgi.srt.SRTConnectionContextPool;
-import com.ibm.ws.webcontainer40.osgi.srt.SRTConnectionContext40;
+
+import io.openliberty.webcontainer60.osgi.srt.SRTConnectionContext60;
 
 @Component(property = { "service.vendor=IBM", "service.ranking:Integer=60", "servlet.version=6.0" })
 public class SRTConnectionContextPool60Impl implements SRTConnectionContextPool {
@@ -29,7 +30,7 @@ public class SRTConnectionContextPool60Impl implements SRTConnectionContextPool 
         }
 
         if (context == null) {
-            context = new SRTConnectionContext40();
+            context = new SRTConnectionContext60();
         }
 
         context.nextContext = null;

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal/bnd.bnd
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal/bnd.bnd
@@ -27,7 +27,11 @@ Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
 # Append ";provide:=true" if this bundle also provides an implementation
 # for the exported API.
 Export-Package: \
-    io.openliberty.webcontainer60.session.impl*;provide:=true
+    io.openliberty.webcontainer60.session.impl*;provide:=true,\
+    io.openliberty.webcontainer60.osgi.request*;provide:=true,\
+    io.openliberty.webcontainer60.osgi.srt*;provide:=true,\
+    io.openliberty.webcontainer60.srt*;provide:=true,\
+    io.openliberty.websphere.servlet60*;provide:=true
 
 Private-Package: \
     com.ibm.websphere.security, \

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/osgi/request/IRequest60Impl.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/osgi/request/IRequest60Impl.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.webcontainer60.osgi.request;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.servlet40.IRequest40;
+import com.ibm.ws.webcontainer.osgi.osgi.WebContainerConstants;
+import com.ibm.ws.webcontainer40.osgi.request.IRequest40Impl;
+import com.ibm.wsspi.http.HttpInboundConnection;
+
+import io.openliberty.websphere.servlet60.IRequest60;
+
+
+/**
+ *
+ */
+public class IRequest60Impl extends IRequest40Impl implements IRequest60 {
+
+    private static final TraceComponent tc = Tr.register(IRequest60Impl.class, WebContainerConstants.TR_GROUP, WebContainerConstants.NLS_PROPS);
+
+    /**
+     * @param connection
+     */
+    public IRequest60Impl(HttpInboundConnection connection) {
+        super(connection);
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "constructor", " inboundConnection [" + connection + "]");
+        }
+      
+    }
+}

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/osgi/request/package-info.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/osgi/request/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+package io.openliberty.webcontainer60.osgi.request;

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/osgi/srt/SRTConnectionContext60.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/osgi/srt/SRTConnectionContext60.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.webcontainer60.osgi.srt;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.webcontainer.srt.SRTServletRequest;
+import com.ibm.ws.webcontainer.srt.SRTServletResponse;
+import com.ibm.ws.webcontainer40.osgi.srt.SRTConnectionContext40;
+import com.ibm.ws.webcontainer40.osgi.webapp.WebAppDispatcherContext40;
+import com.ibm.ws.webcontainer40.srt.SRTServletResponse40;
+import com.ibm.wsspi.webcontainer.logging.LoggerFactory;
+
+import io.openliberty.webcontainer60.srt.SRTServletRequest60;
+
+
+public class SRTConnectionContext60 extends SRTConnectionContext40 {
+    protected static final Logger logger = LoggerFactory.getInstance().getLogger("io.openliberty.webcontainer60.osgi.srt");
+    private static final String CLASS_NAME = SRTConnectionContext60.class.getName();
+
+    /**
+     * Used for pooling the SRTConnectionContext objects.
+     */
+    public SRTConnectionContext60 nextContext;
+
+    @Override
+    protected void init() {
+        if (TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
+            logger.logp(Level.FINE, CLASS_NAME, "init", "this [" + this + "] , request ["+ _request +"]");
+        }
+
+        //Reuse 4.0 until there is something new in servlet 6.0 dispatch context 
+        this._dispatchContext = new WebAppDispatcherContext40(_request);
+        _request.setWebAppDispatcherContext(_dispatchContext);
+    }
+
+    @Override
+    protected SRTServletRequest newSRTServletRequest() {
+        return new SRTServletRequest60(this);
+    }
+
+    /*
+     * Reuse SRTServletResponse40 as nothing new in servlet 6.0 response.
+     */
+    @Override
+    protected SRTServletResponse newSRTServletResponse() {
+        return new SRTServletResponse40(this);
+    }
+}

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/osgi/srt/package-info.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/osgi/srt/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+package io.openliberty.webcontainer60.osgi.srt;

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/srt/SRTServletConnection.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/srt/SRTServletConnection.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.webcontainer60.srt;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import jakarta.servlet.ServletConnection;
+
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.wsspi.webcontainer.logging.LoggerFactory;
+
+/*
+ * since: servlet 6.0
+ * https://jakarta.ee/specifications/servlet/6.0/apidocs/jakarta.servlet/jakarta/servlet/servletconnection
+ */
+
+public class SRTServletConnection implements ServletConnection {
+
+    protected static final Logger logger = LoggerFactory.getInstance().getLogger("io.openliberty.webcontainer60.srt");
+    private static final String CLASS_NAME = SRTServletConnection.class.getName();
+    private String connectionID = null;
+
+    public SRTServletConnection() {
+        super();
+
+        if (TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
+            logger.logp(Level.FINE, CLASS_NAME, "constructor", "this [" + this + "]");
+        }
+    }
+
+    protected void setConnectionID(String id) {
+        if (TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
+            logger.logp(Level.FINE, CLASS_NAME, "setConnectionID", "this [" + this + "] , connection id [" + id + "]");
+        }
+
+        connectionID = id;
+    }
+
+    /*
+     * https://jakarta.ee/specifications/servlet/6.0/apidocs/jakarta.servlet/jakarta/servlet/servletconnection#getConnectionId()
+     */
+    @Override
+    public String getConnectionId() {
+        if (TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
+            logger.logp(Level.FINE, CLASS_NAME, "getConnectionId", "this [" + this + "]");
+        }
+
+        return connectionID;
+    }
+
+    /*
+     * https://jakarta.ee/specifications/servlet/6.0/apidocs/jakarta.servlet/jakarta/servlet/servletconnection#getProtocol()
+     */
+    @Override
+    public String getProtocol() {
+        if (TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
+            logger.logp(Level.FINE, CLASS_NAME, "getProtocol", "this [" + this + "]");
+        }
+
+        //to be implemented
+        return null;
+    }
+
+    /*
+     * https://jakarta.ee/specifications/servlet/6.0/apidocs/jakarta.servlet/jakarta/servlet/servletconnection#getProtocolConnectionId()
+     */
+    @Override
+    public String getProtocolConnectionId() {
+        if (TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
+            logger.logp(Level.FINE, CLASS_NAME, "getProtocolConnectionId", "this [" + this + "]");
+        }
+
+        //to be implemented
+        return null;
+    }
+
+    /*
+     * https://jakarta.ee/specifications/servlet/6.0/apidocs/jakarta.servlet/jakarta/servlet/servletconnection#isSecure()
+     */
+    @Override
+    public boolean isSecure() {
+        if (TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
+            logger.logp(Level.FINE, CLASS_NAME, "isSecure", "this [" + this + "]");
+        }
+
+        //to be implemented
+        return false;
+    }
+}

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/srt/SRTServletRequest60.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/srt/SRTServletRequest60.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.webcontainer60.srt;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.ServletConnection;
+
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.servlet.request.IRequest;
+import com.ibm.ws.webcontainer40.srt.SRTServletRequest40;
+import com.ibm.wsspi.webcontainer.logging.LoggerFactory;
+
+import io.openliberty.webcontainer60.osgi.srt.SRTConnectionContext60;
+
+public class SRTServletRequest60 extends SRTServletRequest40 implements HttpServletRequest {
+
+    protected static final Logger logger = LoggerFactory.getInstance().getLogger("io.openliberty.webcontainer60.srt");
+    private static final String CLASS_NAME = SRTServletRequest60.class.getName();
+    
+    private static long startID = 1;
+    private static AtomicLong counter = new AtomicLong(startID);
+
+    public SRTServletRequest60(SRTConnectionContext60 context) {
+        super(context);
+    }
+    
+    @Override
+    public void initForNextRequest(IRequest req) {
+        String methodName = "initForNextRequest";
+
+        if (TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
+            logger.logp(Level.FINE, CLASS_NAME, methodName, "this [" + this + "] , req [" + req +"]");
+        }
+        super.initForNextRequest(req);
+        
+        if (req != null) {
+            super.setSrtRequestId(String.valueOf(counter.getAndIncrement()));
+
+            if (TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
+                logger.logp(Level.FINE, CLASS_NAME, methodName, "this [" + this + "] , requestID [" + this.getRequestId() +"]");
+            }
+            
+            this.setupServletConnection();
+        }
+    }
+    
+    private void setupServletConnection() {
+        SRTServletConnection servletConn = new SRTServletConnection();
+        servletConn.setConnectionID(this.getRequestId());
+        
+        super.setSrtServletConnection(servletConn);
+    }
+    
+    /*
+     * since: servlet 6.0
+     * https://jakarta.ee/specifications/servlet/6.0/apidocs/jakarta.servlet/jakarta/servlet/servletrequest#getRequestId()
+     */
+    @Override
+    public String getRequestId() {
+        String id = super.getSrtRequestId();
+        if (TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
+            logger.logp(Level.FINE, CLASS_NAME, "getRequestId", "this [" + this + "] , requestID ["+ id + "]");
+        } 
+        return id;
+    }
+    
+    /*
+     * since: servlet 6.0
+     * https://jakarta.ee/specifications/servlet/6.0/apidocs/jakarta.servlet/jakarta/servlet/servletrequest#getProtocolRequestId()
+     */
+    @Override
+    public String getProtocolRequestId() {
+        if (TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
+            logger.logp(Level.FINE, CLASS_NAME, "getProtocolRequestId", "this [" + this + "]");
+        } 
+        
+        //to be implemented
+        return null;
+    }
+    
+    /*
+     * since: servlet 6.0
+     * https://jakarta.ee/specifications/servlet/6.0/apidocs/jakarta.servlet/jakarta/servlet/servletrequest#getServletConnection()
+     */
+    @Override
+    public ServletConnection getServletConnection() {
+        if (TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
+            logger.logp(Level.FINE, CLASS_NAME, "getServletConnection", "this [" + this + "]");
+        } 
+        
+        return (ServletConnection) super.getSrtServletConnection();
+    }
+}

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/srt/package-info.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/srt/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+package io.openliberty.webcontainer60.srt;

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/websphere/servlet60/IRequest60.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/websphere/servlet60/IRequest60.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.websphere.servlet60;
+
+import java.util.HashMap;
+
+import com.ibm.websphere.servlet40.IRequest40;
+import com.ibm.wsspi.http.HttpRequest;
+
+/**
+ * Since: Servlet 6.0      
+ */
+public interface IRequest60 extends IRequest40 {
+    
+    default void dummy60() {
+    }
+
+}

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/websphere/servlet60/package-info.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/websphere/servlet60/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+package io.openliberty.websphere.servlet60;


### PR DESCRIPTION
https://github.com/openliberty/open-liberty/issues/20425

This is part 1 of issue [20425](https://github.com/openliberty/open-liberty/issues/20425)
1. Establish Servlet 6.0 request, response, connection context ...structure
2. Establish initial API for new jakarta.servlet.ServletConnection and ServletRequests methods.
3. Update existing core WC classes to support Servlet 6.0
