### PR TITLE
Extend transaction timeout

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorWithFailoverEnabledTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorWithFailoverEnabledTest.java
@@ -103,6 +103,7 @@ public class PersistentExecutorWithFailoverEnabledTest extends FATServletClient 
     }
 
     @Test
+    @AllowedFFDC({"javax.transaction.RollbackException", "javax.resource.ResourceException", "java.sql.SQLException"})
     public void testBlockAfterCancelByIdFE() throws Exception {
         runTest(server, APP_NAME, "testBlockAfterCancelByIdFE");
     }

--- a/dev/com.ibm.ws.concurrent.persistent_fat/test-applications/schedtest/src/web/SchedulerFATServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/test-applications/schedtest/src/web/SchedulerFATServlet.java
@@ -376,7 +376,6 @@ public class SchedulerFATServlet extends HttpServlet {
         final Phaser blocker = new Phaser(1);
         Future<Boolean> cancelAndBlockFuture = unmanagedExecutor.submit(new Callable<Boolean>() {
             public Boolean call() throws Exception {
-            	tran.setTransactionTimeout(12); //Increase transaction timeout to 12 seconds to accommodate slow test infrastructure. 
                 tran.begin();
                 try {
                     System.out.println("About to cancel " + statusO);

--- a/dev/com.ibm.ws.concurrent.persistent_fat/test-applications/schedtest/src/web/SchedulerFATServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/test-applications/schedtest/src/web/SchedulerFATServlet.java
@@ -376,6 +376,7 @@ public class SchedulerFATServlet extends HttpServlet {
         final Phaser blocker = new Phaser(1);
         Future<Boolean> cancelAndBlockFuture = unmanagedExecutor.submit(new Callable<Boolean>() {
             public Boolean call() throws Exception {
+            	tran.setTransactionTimeout(12); //Increase transaction timeout to 12 seconds to accommodate slow test infrastructure. 
                 tran.begin();
                 try {
                     System.out.println("About to cancel " + statusO);


### PR DESCRIPTION
It is possible in this test case that slow test infrastructure could cause the transaction to timeout before we ever to the point of creating a connection to the database.
Such as in this example: 

```
[6/20/22, 19:13:47:895 PDT] 00000039 com.ibm.tx.jta.embeddable.impl.EmbeddableTimeoutManager      I WTRN0006W: Transaction 00000181840977780000000110243C747B412CFA493A8491E8D368653FC90440A550EFAF00000181840977780000000110243C747B412CFA493A8491E8D368653FC90440A550EFAF00000001 has timed out after 6 seconds.
```

```
[6/20/22, 19:13:49:973 PDT] 00000025 com.ibm.ejs.j2c.XATransactionWrapper                         E J2CA0026E: Method addSync caught javax.transaction.RollbackException: Transaction rolled back
    at com.ibm.tx.jta.impl.TransactionImpl.registerSynchronization(TransactionImpl.java:2232)
    at com.ibm.tx.jta.embeddable.impl.EmbeddableTranManagerSet.registerSynchronization(EmbeddableTranManagerSet.java:229)
    at com.ibm.tx.jta.embeddable.impl.EmbeddableTranManagerSet.registerSynchronization(EmbeddableTranManagerSet.java:216)
    at com.ibm.ws.transaction.services.TransactionManagerService.registerSynchronization(TransactionManagerService.java:409)
    at com.ibm.ejs.j2c.XATransactionWrapper.addSync(XATransactionWrapper.java:170)
    at com.ibm.ejs.j2c.ConnectionManager.initializeForUOW(ConnectionManager.java:973)
    at com.ibm.ejs.j2c.ConnectionManager.involveMCInTran(ConnectionManager.java:692)
    at com.ibm.ejs.j2c.ConnectionManager.allocateConnection(ConnectionManager.java:308)
    at com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource.getConnection(WSJdbcDataSource.java:140)
    at com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource.getConnection(WSJdbcDataSource.java:114)
    at web.DBIncrementTask.call(DBIncrementTask.java:44)
```

Based on feedback - instead of extending the transaction timeout, we could instead allow these FFDCs since they didn't actually affect the outcome of the test itself. 