### PR TITLE
fix 290711 to skip semeru

### DIFF
--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfBspTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfBspTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -39,6 +39,8 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.JavaInfo;
+
 
 @SkipForRepeat({ EE9_FEATURES })
 @Mode(TestMode.FULL)
@@ -114,18 +116,14 @@ public class CxfBspTests {
         WSSampleClientUrl = serviceClientUrl + "/WSSampleSeiClient/ClientServlet";
         Log.info(thisClass, thisMethod, "****portNumber is:" + portNumber + " **portNumberSecure is:" + portNumberSecure);
 
-        String vendorName = System.getProperty("java.vendor");
-        Log.info(thisClass, thisMethod, "JDK Vendor Name is: " + vendorName);
-
-        String javaVersion = System.getProperty("java.version");
-        Log.info(thisClass, thisMethod, "JDK Version is: " + javaVersion);
-
         ibmJDK = true;
-        if ((vendorName.contains("IBM")) & (javaVersion.contains("1.8.0"))) {
-            Log.info(thisClass, thisMethod, "Using an IBM JDK 8");
+        
+        //RTC 290711
+        if (JavaInfo.isSystemClassAvailable("com.ibm.security.auth.module.Krb5LoginModule")) {
+            Log.info(thisClass, thisMethod, "Using an IBM JDK");
         } else {
-            Log.info(thisClass, thisMethod, "Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - certain tests should not run!  WE WILL BE SKIPPING SOME TESTS");
-            System.err.println("Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - certain tests should not run!");
+            Log.info(thisClass, thisMethod, "Using NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition - this test should not run!");
+            System.err.println("Using a NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition - this test should not run!");
             ibmJDK = false;
         }
 
@@ -136,8 +134,8 @@ public class CxfBspTests {
     public void testEcho11Service() throws Exception {
         String thisMethod = "testEcho11Service";
         if (!ibmJDK) {
-            Log.info(thisClass, thisMethod, "Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!  SKIPPING TEST");
-            System.err.println("Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!");
+            Log.info(thisClass, thisMethod, "Using a NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition - this test should not run!  SKIPPING TEST");
+            System.err.println("Using a NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition - this test should not run!");
             return;
         }
 
@@ -165,8 +163,8 @@ public class CxfBspTests {
     public void testEcho12Service() throws Exception {
         String thisMethod = "testEcho12Service";
         if (!ibmJDK) {
-            Log.info(thisClass, thisMethod, "Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!  SKIPPING TEST");
-            System.err.println("Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!");
+            Log.info(thisClass, thisMethod, "Using a NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition - this test should not run!  SKIPPING TEST");
+            System.err.println("Using a NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition - this test should not run!");
             return;
         }
 
@@ -194,8 +192,8 @@ public class CxfBspTests {
     public void testEcho13Service() throws Exception {
         String thisMethod = "testEcho13Service";
         if (!ibmJDK) {
-            Log.info(thisClass, thisMethod, "Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!  SKIPPING TEST");
-            System.err.println("Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!");
+            Log.info(thisClass, thisMethod, "Using a NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition - this test should not run!  SKIPPING TEST");
+            System.err.println("Using a NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition - this test should not run!");
             return;
         }
 
@@ -223,8 +221,8 @@ public class CxfBspTests {
     public void testEcho14Service() throws Exception {
         String thisMethod = "testEcho14Service";
         if (!ibmJDK) {
-            Log.info(thisClass, thisMethod, "Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!  SKIPPING TEST");
-            System.err.println("Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!");
+            Log.info(thisClass, thisMethod, "Using a NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition - this test should not run!  SKIPPING TEST");
+            System.err.println("Using a NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition - this test should not run!");
             return;
         }
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfInteropX509Tests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfInteropX509Tests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -39,6 +39,8 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.JavaInfo;
+
 
 @SkipForRepeat({ EE9_FEATURES })
 @Mode(TestMode.FULL)
@@ -115,18 +117,13 @@ public class CxfInteropX509Tests {
         WSSampleClientUrl = serviceClientUrl + "/WSSampleSeiClient/ClientServlet";
         Log.info(thisClass, thisMethod, "****portNumber is:" + portNumber + " **portNumberSecure is:" + portNumberSecure);
 
-        String vendorName = System.getProperty("java.vendor");
-        Log.info(thisClass, thisMethod, "JDK Vendor Name is: " + vendorName);
-
-        String javaVersion = System.getProperty("java.version");
-        Log.info(thisClass, thisMethod, "JDK Version is: " + javaVersion);
-
         ibmJDK = true;
-        if ((vendorName.contains("IBM")) & (javaVersion.contains("1.8.0"))) {
-            Log.info(thisClass, thisMethod, "Using an IBM JDK 8");
+        //RTC 290711
+        if (JavaInfo.isSystemClassAvailable("com.ibm.security.auth.module.Krb5LoginModule")) {
+            Log.info(thisClass, thisMethod, "Using an IBM JDK");
         } else {
-            Log.info(thisClass, thisMethod, "Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - certain tests should not run!  WE WILL BE SKIPPING SOME TESTS");
-            System.err.println("Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - certain tests should not run!");
+            Log.info(thisClass, thisMethod, "Using NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition - this test should not run!");
+            System.err.println("Using a NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition - this test should not run!");
             ibmJDK = false;
         }
 
@@ -137,8 +134,8 @@ public class CxfInteropX509Tests {
     public void testEcho21Service() throws Exception {
         String thisMethod = "testEcho21Service";
         if (!ibmJDK) {
-            Log.info(thisClass, thisMethod, "Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!  SKIPPING TEST");
-            System.err.println("Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!");
+            Log.info(thisClass, thisMethod, "Using a NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition - this test should not run!  SKIPPING TEST");
+            System.err.println("Using a NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition - this test should not run!");
             return;
         }
 
@@ -166,8 +163,8 @@ public class CxfInteropX509Tests {
     public void testEcho22Service() throws Exception {
         String thisMethod = "testEcho22Service";
         if (!ibmJDK) {
-            Log.info(thisClass, thisMethod, "Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!  SKIPPING TEST");
-            System.err.println("Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!");
+            Log.info(thisClass, thisMethod, "Using a NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition - this test should not run!  SKIPPING TEST");
+            System.err.println("Using a NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition - this test should not run!");
             return;
         }
 
@@ -195,8 +192,8 @@ public class CxfInteropX509Tests {
     public void testEcho23Service() throws Exception {
         String thisMethod = "testEcho23Service";
         if (!ibmJDK) {
-            Log.info(thisClass, thisMethod, "Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!  SKIPPING TEST");
-            System.err.println("Using a NON-IBM JDK or an Open JDK or an IBM JDK 11 - this test should not run!");
+            Log.info(thisClass, thisMethod, "Using a NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition - this test should not run!  SKIPPING TEST");
+            System.err.println("Using a NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition - this test should not run!");
             return;
         }
 


### PR DESCRIPTION
Fix RTC 290711 build break defect to skip IBM Semeru Open Edition java runtime in 2 classes of FAT com.ibm.ws.wssecurity_fat.wsscxf:

com.ibm.ws.wssecurity.fat.cxf.sample.CxfBspTests
com.ibm.ws.wssecurity.fat.cxf.sample.CxfInteropX509Tests

**Reminder:**
When running Personal Builds with specific JDK version, the build properties `soe.platform.requests` should be used to specify the platform and with additional properties `upload.all.test.logs`, the verification can be made easier.  But there is certain requirement (for example, `auto` and `all` should not be used for `fat.buckets.to.run` properties) when using the properties `soe.platform.requests`: 
https://github.ibm.com/websphere/WS-CD-Open/wiki/SOE-(Supported-Operating-Environments)-build#requesting-a-run-as-part-of-a-personal-build
