### PR TITLE
PR for Issue 21372: Update BCL code to check http URIs for public client

### DIFF
--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OidcBaseClientValidator.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OidcBaseClientValidator.java
@@ -692,7 +692,7 @@ public class OidcBaseClientValidator {
             throw new OidcServerException(new BrowserAndServerLogMessage(tc, "OAUTH_CLIENT_REGISTRATION_VALUE_URI_INVALID_SCHEME", new Object[] { logoutUri, OidcBaseClient.SN_BACKCHANNEL_LOGOUT_URI }),
                     OIDCConstants.ERROR_INVALID_CLIENT_METADATA, HttpServletResponse.SC_BAD_REQUEST);
         }
-        if (scheme.equalsIgnoreCase("http") && !client.isConfidential()) {
+        if (scheme.equalsIgnoreCase("http") && client.isPublicClient()) {
             throw new OidcServerException(new BrowserAndServerLogMessage(tc, "OAUTH_CLIENT_REGISTRATION_VALUE_URI_HTTP_SCHEME_CLIENT_NOT_CONFIDENTIAL", new Object[] { logoutUri, OidcBaseClient.SN_BACKCHANNEL_LOGOUT_URI, client.getClientId() }),
                     OIDCConstants.ERROR_INVALID_CLIENT_METADATA, HttpServletResponse.SC_BAD_REQUEST);
         }

--- a/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/plugins/OidcBaseClientValidatorTest.java
+++ b/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/plugins/OidcBaseClientValidatorTest.java
@@ -44,7 +44,8 @@ public class OidcBaseClientValidatorTest {
         redirectUris.add(new JsonPrimitive(redirectUri1));
         redirectUris.add(new JsonPrimitive(redirectUri2));
         client = new OidcBaseClient(clientId, clientSecret, redirectUris, clientName, componentId, true);
-        publicClient = new OidcBaseClient(clientId, null, redirectUris, clientName, componentId, true);
+        publicClient = new OidcBaseClient(clientId, clientSecret, redirectUris, clientName, componentId, true);
+        publicClient.setPublicClient(true);
     }
 
     @Test


### PR DESCRIPTION
Updates the BCL URI checking code to use `isPublicClient()` instead of `isConfidential()` to check if the client is public and therefore disallowed from using an HTTP endpoint.

Fixes #21372