### PR TITLE
Add debug information for MpHealth Semeru JDK CDI TCK failure

### DIFF
--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat_tck/publish/servers/Health31TCKServer/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat_tck/publish/servers/Health31TCKServer/bootstrap.properties
@@ -9,4 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:HEALTH=all:io.openliberty.microprofile.health31*=all:com.ibm.ws.webcontainer.extension.*=all
+com.ibm.ws.logging.trace.specification=*=info:HEALTH=all:io.openliberty.microprofile.health31*=all:com.ibm.ws.webcontainer.extension.*=all:JCDI=all:com.ibm.ws.webbeans*=all:org.apache.webbeans*=all:org.jboss.weld*=all:com.ibm.ws.cdi*=all

--- a/dev/io.openliberty.microprofile.health.4.0.internal_fat_tck/publish/servers/Health40TCKServer/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.health.4.0.internal_fat_tck/publish/servers/Health40TCKServer/bootstrap.properties
@@ -9,4 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:HEALTH=all:io.openliberty.microprofile.health31*=all:com.ibm.ws.webcontainer.extension.*=all
+com.ibm.ws.logging.trace.specification=*=info:HEALTH=all:io.openliberty.microprofile.health31*=all:com.ibm.ws.webcontainer.extension.*=all:JCDI=all:com.ibm.ws.webbeans*=all:org.apache.webbeans*=all:org.jboss.weld*=all:com.ibm.ws.cdi*=all


### PR DESCRIPTION
- Enables CDI debug trace to gather more information on MpHealth 3.1/4.0 TCK failing on Semeru JDK 17.