### PR TITLE
asynchronous repository methods

### DIFF
--- a/dev/io.openliberty.data.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.data.internal_fat/bnd.bnd
@@ -40,6 +40,7 @@ fat.project: true
   com.ibm.ws.tx.embeddable.jakarta;version=latest,\
   io.openliberty.jakarta.annotation.2.0,\
   io.openliberty.jakarta.cdi.3.0,\
+  io.openliberty.jakarta.concurrency.3.0,\
   io.openliberty.jakarta.interceptor.2.0,\
   io.openliberty.jakarta.persistence.3.0,\
   io.openliberty.jakarta.servlet.5.0;version=latest,\

--- a/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat/server.xml
+++ b/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat/server.xml
@@ -12,6 +12,7 @@
 
   <featureManager>
     <feature>componenttest-2.0</feature>
+    <feature>concurrent-3.0</feature> <!-- for @Asynchronous -->
     <feature>data-1.0</feature>
     <feature>jndi-1.0</feature>
     <feature>servlet-5.0</feature>

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -166,6 +166,14 @@ public class DataTestServlet extends FATServlet {
                                              .map(p -> p.firstName)
                                              .collect(Collectors.toList()));
 
+        CompletableFuture<Person> future = personnel.findBySsn(p4.ssn);
+
+        Person p = future.get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
+        assertNotNull(p);
+        assertEquals(p4.ssn, p.ssn);
+        assertEquals(p4.firstName, p.firstName);
+        assertEquals(p4.lastName, p.lastName);
+
         deleted = personnel.removeAll();
         assertEquals(Long.valueOf(10), deleted.get(TIMEOUT_MINUTES, TimeUnit.MINUTES));
     }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Personnel.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Personnel.java
@@ -13,12 +13,15 @@ package test.jakarta.data.web;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.stream.Collector;
 
 import jakarta.enterprise.concurrent.Asynchronous;
 
 import io.openliberty.data.Data;
 import io.openliberty.data.Delete;
 import io.openliberty.data.Limit;
+import io.openliberty.data.Paginated;
+import io.openliberty.data.Select;
 import io.openliberty.data.Update;
 import io.openliberty.data.Where;
 
@@ -41,6 +44,17 @@ public interface Personnel {
     @Asynchronous
     @Limit(1) // indicates single result (rather than list) for the completion stage
     CompletableFuture<Person> findBySsn(long ssn);
+
+    @Asynchronous
+    @Select("firstName")
+    @Where("o.firstName LIKE CONCAT(?1, '%')")
+    @Paginated(3)
+    CompletableFuture<Long> namesThatStartWith(String beginningOfFirstName,
+                                               Collector<String, ?, Long> collector);
+
+    // An alternative to the above would be to make the Collector class a parameter
+    // of the Paginated annotation, although this would rule out easily accessing the
+    // various built-in collectors that are provided by Java's Collectors interface.
 
     @Asynchronous
     @Delete

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Personnel.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Personnel.java
@@ -18,6 +18,7 @@ import jakarta.enterprise.concurrent.Asynchronous;
 
 import io.openliberty.data.Data;
 import io.openliberty.data.Delete;
+import io.openliberty.data.Limit;
 import io.openliberty.data.Update;
 import io.openliberty.data.Where;
 
@@ -36,6 +37,10 @@ public interface Personnel {
 
     @Asynchronous
     CompletionStage<List<Person>> findByLastNameOrderByFirstName(String lastName);
+
+    @Asynchronous
+    @Limit(1) // indicates single result (rather than list) for the completion stage
+    CompletableFuture<Person> findBySsn(long ssn);
 
     @Asynchronous
     @Delete

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Personnel.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Personnel.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.web;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import jakarta.enterprise.concurrent.Asynchronous;
+
+import io.openliberty.data.Data;
+import io.openliberty.data.Delete;
+import io.openliberty.data.Update;
+import io.openliberty.data.Where;
+
+/**
+ * This is a second repository interface for the Person entity,
+ * where the focus is on returning CompletableFuture/CompletionStage
+ * and experimenting with how generated repository method implementations
+ * fit with asynchronous methods.
+ */
+@Data(Person.class) // TODO infer the entity class?
+public interface Personnel {
+    @Asynchronous
+    @Update("o.lastName = ?2")
+    @Where("o.lastName = ?1 AND o.ssn IN ?3")
+    CompletionStage<Long> changeSurnames(String oldSurname, String newSurname, List<Long> ssnList);
+
+    @Asynchronous
+    CompletionStage<List<Person>> findByLastNameOrderByFirstName(String lastName);
+
+    @Asynchronous
+    @Delete
+    CompletableFuture<Long> removeAll();
+
+    @Asynchronous
+    CompletableFuture<List<Person>> save(Person... p);
+}

--- a/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/Limit.java
+++ b/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/Limit.java
@@ -28,6 +28,20 @@ import java.lang.annotation.Target;
  * City[] findMostPopulousIn(String country);
  * </pre>
  *
+ * This annotation can also be used to indicate a single result for a
+ * {@link java.util.concurrent.CompletionStage CompletionStage} or
+ * {@link java.util.concurrent.CompletableFuture CompletableFuture}.<p>
+ *
+ * For example,<p>
+ *
+ * <pre>
+ * &#64;Asynchronous
+ * &#64;Limit(1)
+ * CompletableFuture&#60;City&#62; findByCityAndStateAndCountry(String cityName,
+ *                                                      String stateName,
+ *                                                      String countryName);
+ * </pre>
+ *
  * Do not combine on a method with {@link Paginated &#64;Paginated} or
  * {@link Pagination}, which limits results per page instead of per query.
  */

--- a/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/internal/QueryHandler.java
+++ b/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/internal/QueryHandler.java
@@ -29,6 +29,8 @@ import java.util.Vector;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Flow.Publisher;
+import java.util.function.BiConsumer;
+import java.util.stream.Collector;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -398,6 +400,7 @@ public class QueryHandler<T> implements InvocationHandler {
         Object returnValue;
         QueryType queryType;
         boolean requiresTransaction;
+        Collector<Object, Object, Object> collector = null;
         Pagination pagination = null;
         Sorts sorts = null;
 
@@ -441,10 +444,14 @@ public class QueryHandler<T> implements InvocationHandler {
         if (jpql == null)
             jpql = generateRepositoryQuery(method);
 
-        // Jakarta NoSQL allows the last 2 parameter positions to be used for Pagination and Sorts
-        for (paramCount = paramTypes.length; paramCount > 0 && paramCount > paramTypes.length - 2;) {
+        // Jakarta NoSQL allows the last 3 parameter positions to be used for Pagination, Sorts, and Consumer
+        // Collector is added here for experimentation.
+        for (paramCount = paramTypes.length; paramCount > 0 && paramCount > paramTypes.length - 3;) {
             Class<?> type = paramTypes[paramCount - 1];
-            if (Pagination.class.equals(type))
+            if (Collector.class.equals(type))
+                collector = (Collector<Object, Object, Object>) args[--paramCount];
+            // TODO Consumer
+            else if (Pagination.class.equals(type))
                 pagination = (Pagination) args[--paramCount];
             else if (Sort.class.equals(type))
                 sorts = Sorts.sorts().add((Sort) args[--paramCount]);
@@ -491,7 +498,9 @@ public class QueryHandler<T> implements InvocationHandler {
             if (paginated != null)
                 pagination = Pagination.page(1).size(paginated.value());
         }
-        if (pagination != null && Iterator.class.equals(returnType))
+        if (pagination != null && collector != null && (CompletableFuture.class.equals(returnType) || CompletionStage.class.equals(returnType)))
+            return runAndCollect(jpql, pagination, collector, method, paramCount, args);
+        else if (pagination != null && Iterator.class.equals(returnType))
             return new PaginatedIterator<T>(jpql, pagination, this, method, paramCount, args);
         else if (Page.class.equals(returnType))
             return new PageImpl<T>(jpql, pagination, this, method, paramCount, args);
@@ -587,19 +596,28 @@ public class QueryHandler<T> implements InvocationHandler {
 
                     List<?> results = query.getResultList();
 
-                    if (entityClass.equals(returnType))
+                    if (collector != null) {
+                        // Collector is more useful on the other path, when combined with pagination
+                        Object r = collector.supplier().get();
+                        BiConsumer<Object, Object> accumulator = collector.accumulator();
+                        for (Object item : results)
+                            accumulator.accept(r, item);
+                        returnValue = collector.finisher().apply(r);
+                        if (CompletableFuture.class.equals(returnType) || CompletionStage.class.equals(returnType))
+                            returnValue = CompletableFuture.completedFuture(returnValue);
+                    } else if (entityClass.equals(returnType)) {
                         returnValue = results.isEmpty() ? null : results.get(0);
-                    else if (returnType.isInstance(results))
+                    } else if (returnType.isInstance(results)) {
                         returnValue = results;
-                    else if (returnArrayType != null) {
+                    } else if (returnArrayType != null) {
                         Object r = Array.newInstance(returnArrayType, results.size());
                         int i = 0;
                         for (Object o : results)
                             Array.set(r, i++, o);
                         returnValue = r;
-                    } else if (Optional.class.equals(returnType))
+                    } else if (Optional.class.equals(returnType)) {
                         returnValue = results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
-                    else if (Collection.class.isAssignableFrom(returnType))
+                    } else if (Collection.class.isAssignableFrom(returnType)) {
                         try {
                             @SuppressWarnings("unchecked")
                             Constructor<? extends Collection<Object>> c = (Constructor<? extends Collection<Object>>) returnType.getConstructor();
@@ -609,7 +627,7 @@ public class QueryHandler<T> implements InvocationHandler {
                         } catch (NoSuchMethodException x) {
                             throw new UnsupportedOperationException(returnType + " lacks public zero parameter constructor.");
                         }
-                    else if (Stream.class.isAssignableFrom(returnType)) {
+                    } else if (Stream.class.isAssignableFrom(returnType)) {
                         Stream.Builder<Object> builder = Stream.builder();
                         for (Object result : results)
                             builder.accept(result);
@@ -683,6 +701,69 @@ public class QueryHandler<T> implements InvocationHandler {
             }
         }
         return returnValue;
+    }
+
+    /**
+     * This is an experiment with allowing a collector to perform reduction
+     * on the contents of each page as the page is read in. This avoids having
+     * all pages loaded at once and gives the application a completion stage
+     * with a final result that can be awaited, or to which dependent stages
+     * can be added to run once the final result is ready.
+     *
+     * @param jpql
+     * @param pagination
+     * @param collector
+     * @param method
+     * @param paramCount
+     * @param args
+     * @return completion stage that is already completed if only being used to
+     *         supply the result to an Asynchronous method. If the database supports
+     *         asynchronous patterns, it could be a not-yet-completedd completion stage
+     *         that is controlled by the database's async support.
+     */
+    private CompletableFuture<Object> runAndCollect(String jpql, Pagination pagination,
+                                                    Collector<Object, Object, Object> collector,
+                                                    Method method, int numParams, Object[] args) {
+
+        Object r = collector.supplier().get();
+        BiConsumer<Object, Object> accumulator = collector.accumulator();
+
+        // TODO it would be possible to process multiple pages in parallel if we wanted to and if the collector supports it
+        EntityManager em = punit.createEntityManager();
+        try {
+            @SuppressWarnings("unchecked")
+            TypedQuery<T> query = (TypedQuery<T>) em.createQuery(jpql, entityClass);
+            if (args != null) {
+                Parameter[] params = method.getParameters();
+                for (int i = 0; i < numParams; i++) {
+                    Param param = params[i].getAnnotation(Param.class);
+                    if (param == null)
+                        query.setParameter(i + 1, args[i]);
+                    else // named parameter
+                        query.setParameter(param.value(), args[i]);
+                }
+            }
+
+            List<T> page;
+            int maxResults;
+            do {
+                // TODO possible overflow with both of these. And what is the difference between getPageSize/getLimit?
+                query.setFirstResult((int) pagination.getSkip());
+                query.setMaxResults(maxResults = (int) pagination.getPageSize());
+                pagination = pagination.next();
+
+                page = query.getResultList();
+
+                for (Object item : page)
+                    accumulator.accept(r, item);
+
+                System.out.println("Processed page with " + page.size() + " results");
+            } while (pagination != null && page.size() == maxResults);
+        } finally {
+            em.close();
+        }
+
+        return CompletableFuture.completedFuture(collector.finisher().apply(r));
     }
 
     private static final Object toReturnValue(int i, Class<?> returnType) {

--- a/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/internal/cdi/BeanProducer.java
+++ b/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/internal/cdi/BeanProducer.java
@@ -10,26 +10,32 @@
  *******************************************************************************/
 package io.openliberty.data.internal.cdi;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Proxy;
 import java.util.Collections;
 import java.util.Set;
 
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.inject.spi.InterceptionFactory;
 import jakarta.enterprise.inject.spi.Producer;
+import jakarta.enterprise.inject.spi.configurator.AnnotatedMethodConfigurator;
 
 import io.openliberty.data.Data;
 import io.openliberty.data.internal.QueryHandler;
 
 public class BeanProducer<T> implements Producer<T> {
     private final Bean<T> bean;
+    private final BeanManager beanMgr;
     private final Class<?> entityClass;
     private final String keyAttribute;
 
-    public BeanProducer(Bean<T> bean, Class<?> entityClass, String keyAttribute) {
+    public BeanProducer(Bean<T> bean, BeanManager beanMgr, Class<?> entityClass, String keyAttribute) {
         System.out.println("Producer created for " + bean + ". Entity is " + entityClass);
         this.bean = bean;
+        this.beanMgr = beanMgr;
         this.entityClass = entityClass;
         this.keyAttribute = keyAttribute;
     }
@@ -50,6 +56,18 @@ public class BeanProducer<T> implements Producer<T> {
         Class<T> c = (Class<T>) bean.getBeanClass();
         System.out.println("Producer.produce for " + c + " with " + c.getAnnotation(Data.class));
 
-        return c.cast(Proxy.newProxyInstance(c.getClassLoader(), new Class<?>[] { c }, new QueryHandler<T>(bean, entityClass, keyAttribute)));
+        InterceptionFactory<T> interception = beanMgr.createInterceptionFactory(cc, c);
+
+        boolean intercept = false;
+        for (AnnotatedMethodConfigurator<? super T> method : beanMgr.createInterceptionFactory(cc, c).configure().methods())
+            for (Annotation anno : method.getAnnotated().getAnnotations())
+                if ("jakarta.enterprise.concurrent.Asynchronous".equals(anno.annotationType().getName())) {
+                    intercept = true;
+                    method.add(anno);
+                    System.out.println("Add " + anno + " for " + method.getAnnotated().getJavaMember());
+                }
+
+        T instance = c.cast(Proxy.newProxyInstance(c.getClassLoader(), new Class<?>[] { c }, new QueryHandler<T>(bean, entityClass, keyAttribute)));
+        return intercept ? interception.createInterceptedInstance(instance) : instance;
     }
 }

--- a/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/internal/cdi/BeanProducerFactory.java
+++ b/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/internal/cdi/BeanProducerFactory.java
@@ -11,16 +11,19 @@
 package io.openliberty.data.internal.cdi;
 
 import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.Producer;
 import jakarta.enterprise.inject.spi.ProducerFactory;
 
 import io.openliberty.data.Data;
 
 public class BeanProducerFactory<R> implements ProducerFactory<R> {
+    final BeanManager beanMgr;
     final Class<?> entityClass;
     final String keyAttribute;
 
-    BeanProducerFactory(Class<?> entityClass, String keyAttribute) {
+    BeanProducerFactory(BeanManager beanMgr, Class<?> entityClass, String keyAttribute) {
+        this.beanMgr = beanMgr;
         this.entityClass = entityClass;
         this.keyAttribute = keyAttribute;
     }
@@ -32,7 +35,7 @@ public class BeanProducerFactory<R> implements ProducerFactory<R> {
             System.out.println("createProducer null because " + bean + " has no @Data");
             return null;
         } else {
-            return new BeanProducer<T>(bean, entityClass, keyAttribute);
+            return new BeanProducer<T>(bean, beanMgr, entityClass, keyAttribute);
         }
     }
 }

--- a/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/internal/cdi/DataExtension.java
+++ b/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/internal/cdi/DataExtension.java
@@ -96,7 +96,7 @@ public class DataExtension implements Extension {
             entities.put(entityClass, keyAttribute);
 
             BeanAttributes<?> attrs = beanMgr.createBeanAttributes(beanType);
-            Bean<?> bean = beanMgr.createBean(attrs, beanInterface, new BeanProducerFactory<>(entityClass, keyAttribute));
+            Bean<?> bean = beanMgr.createBean(attrs, beanInterface, new BeanProducerFactory<>(beanMgr, entityClass, keyAttribute));
             beans.add(bean);
         }
 


### PR DESCRIPTION
The pull has some in-depth experimentation with asynchronous repository methods.
First, I figured out a way to get Concurrency's asynchronous annotation to be transferred to the bean that backs the mock repository method, after which all the repository method needs to do is declare that it returns CompletionStage or CompletableFuture as the Concurrency spec requires for asynchronous.  If a database has its own async programming model, then Concurrency Asynchronous won't even be needed an an incomplete stage can be returned instead. This helps fill in the gap when that option isn't available.
With the ability to return completion stages, we needed a way to identify at run time whether the completion stage represents a list or single result.  Reusing the value from Limit annotation worked well for that.
Finally, one of the things I've been wanting to experiment with is to combine with processing/reduction of pages inline so that there is no need to have all of the results read into memory at once.  Streams aren't an option because the entire stream needs to exist first.  However, the Collector mechanism from streams doesn't have this requirement.  I added the ability to specify a Collector parameter that would process pages as they are read in, with a completion stage returned to the application to await or chain dependent stages to the final result.