### PR TITLE
Add 'fileMkdir' to FileUtils.

### DIFF
--- a/dev/com.ibm.ws.artifact.overlay/resources/com/ibm/ws/artifact/overlay/internal/resources/ArtifactOverlayMessages.nlsprops
+++ b/dev/com.ibm.ws.artifact.overlay/resources/com/ibm/ws/artifact/overlay/internal/resources/ArtifactOverlayMessages.nlsprops
@@ -48,6 +48,6 @@ overlay.cache.not.directory.explanation=The Liberty file system is not consisten
 overlay.cache.not.directory.useraction=Restart the server with the '--clean' option.
 
 # # A file path.
-overlay.exists.as.directory=CWWKM0306E: The {0} overlay file exists and is a directory.
-overlay.exists.as.directory.explanation=The Liberty file system is not consistent with the overlay configuration.  This can occur because the server was restarted with changes to the overlay configuration.
-overlay.exists.as.directory.useraction=Restart the server with the '--clean' option.
+overlay.exists.not.directory=CWWKM0306E: The {0} overlay file exists but is not a directory.
+overlay.exists.not.directory.explanation=The Liberty file system is not consistent with the overlay configuration.  This can occur because the server was restarted with changes to the overlay configuration.
+overlay.exists.not.directory.useraction=Restart the server with the '--clean' option.

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/CpuInfo.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/CpuInfo.java
@@ -74,6 +74,9 @@ public class CpuInfo {
     private static final long INTERVAL = 10; // in minutes
     private static Collection<AvailableProcessorsListener> listeners = Collections.synchronizedCollection(new HashSet<AvailableProcessorsListener>());
 
+    // TODO: 'JavaInfo.vendor()' is deprecated.
+    //       See the assignment of 'nsFactor', below.
+    @SuppressWarnings({ "deprecation" })
     private CpuInfo() {
         activeTask = new IntervalTask();
         executor.scheduleAtFixedRate(activeTask, INTERVAL, INTERVAL, TimeUnit.MINUTES);
@@ -90,6 +93,13 @@ public class CpuInfo {
         } else {
             AVAILABLE_PROCESSORS.set(fileSystemAvailableProcessors);
         }
+
+        // TODO: 
+        // According to the deprecation comment on 'JavaInfo.vendor(), a test
+        // of the actual capability should be made instead of relying on the
+        // vendor information.  That is, something about the java environment
+        // should be checked to tell that the java vendor is IBM, instead of
+        // this access to vendor.
 
         int nsFactor = 1;
         // adjust for J9 cpuUsage units change from hundred-nanoseconds to nanoseconds in Java8sr5

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/wsspi/kernel/service/utils/FileUtils.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/wsspi/kernel/service/utils/FileUtils.java
@@ -290,6 +290,27 @@ public class FileUtils {
     }
 
     /**
+     * Calls {@link File#mkdir()} on the specified <code>target</code> from
+     * within a {@link PrivilegedAction}.
+     *
+     * @param target The tarket to make a directory for
+     * @return <code>true</code> if this succeeded.
+     */
+    public static boolean fileMkDir(final File target) {
+        Object token = ThreadIdentityManager.runAsServer();
+        try {
+            return AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+                @Override
+                public Boolean run() {
+                    return target.mkdir();
+                }
+            });
+        } finally {
+            ThreadIdentityManager.reset(token);
+        }
+    }
+
+    /**
      * Delete file
      *
      * @parm file or empty directory to delete


### PR DESCRIPTION
Retry of merge.

Add 'fileMkdir' to FileUtils.
Mask deprecation warning in CpuInfo.
Correct overlay directory validation logic in DirectoryBasedOverlayContainerImpl.
Correct 'overlay.exists.as.directory' to 'overlay.exists.not.directory' in ArtifactOverlayMessages.


