### PR TITLE
Handle timer running during server shutdown

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/fat/src/com/ibm/ws/concurrent/persistent/fat/failovertimers/FailoverTimersTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/fat/src/com/ibm/ws/concurrent/persistent/fat/failovertimers/FailoverTimersTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -165,13 +165,17 @@ public class FailoverTimersTest extends FATServletClient {
             if (serverA.isStarted())
                 serverA.stopServer("CWWKC1503W",
                                    "DSRA0302E", // can happen if timer tries to run while the server stops
-                                   "DSRA0304E" // can happen if timer tries to run while the server stops
+                                   "DSRA0304E", // can happen if timer tries to run while the server stops
+                                   "DSRA0230E", // Attempt to perform operation XAResource.end is not allowed because transaction state is TRANSACTION_FAIL
+                                   "J2CA0027E" // Attempt to perform operation XAResource.end is not allowed because transaction state is TRANSACTION_FAIL
                 );
         } finally {
             if (serverB.isStarted())
                 serverB.stopServer("CWWKC1503W",
                                    "DSRA0302E", // can happen if timer tries to run while the server stops
-                                   "DSRA0304E" // can happen if timer tries to run while the server stops
+                                   "DSRA0304E", // can happen if timer tries to run while the server stops
+                                   "DSRA0230E", // Attempt to perform operation XAResource.end is not allowed because transaction state is TRANSACTION_FAIL
+                                   "J2CA0027E" // Attempt to perform operation XAResource.end is not allowed because transaction state is TRANSACTION_FAIL
                 );
         }
     }
@@ -392,7 +396,9 @@ public class FailoverTimersTest extends FATServletClient {
         LibertyServer serverToStop = SERVER_A_NAME.equals(serverName) ? serverA : serverB;
         serverToStop.stopServer("CWWKC1503W",
                                 "DSRA0302E", // can happen if timer tries to run while the server stops
-                                "DSRA0304E" // can happen if timer tries to run while the server stops
+                                "DSRA0304E", // can happen if timer tries to run while the server stops
+                                "DSRA0230E", // Attempt to perform operation XAResource.end is not allowed because transaction state is TRANSACTION_FAIL
+                                "J2CA0027E" // Attempt to perform operation XAResource.end is not allowed because transaction state is TRANSACTION_FAIL
         );
 
         String nameOfServerForFailover = serverToStop == serverA ? SERVER_B_NAME : SERVER_A_NAME;
@@ -403,7 +409,9 @@ public class FailoverTimersTest extends FATServletClient {
 
         serverForFailover.stopServer("CWWKC1503W",
                                      "DSRA0302E", // can happen if timer tries to run while the server stops
-                                     "DSRA0304E" // can happen if timer tries to run while the server stops
+                                     "DSRA0304E", // can happen if timer tries to run while the server stops
+                                     "DSRA0230E", // Attempt to perform operation XAResource.end is not allowed because transaction state is TRANSACTION_FAIL
+                                     "J2CA0027E" // Attempt to perform operation XAResource.end is not allowed because transaction state is TRANSACTION_FAIL
         );
     }
 }


### PR DESCRIPTION
Expands on issue #16988

It is possible that the server is further along in the shutdown process when this automatic timer tries to run. 
In this case the transaction would be marked as failed, instead of rollback. 

```
java.lang.Exception: Errors/warnings were found in server com.ibm.ws.concurrent.persistent.fat.failovertimers.serverB logs:
 <br>[2/5/22, 9:02:14:178 PST] 0000002b com.ibm.ws.rsadapter.impl.WSRdbXaResourceImpl                E DSRA0230E: Attempt to perform operation XAResource.end() is not allowed because transaction state is TRANSACTION_FAIL.
 <br>[2/5/22, 9:02:14:316 PST] 0000002b com.ibm.ejs.j2c.XATransactionWrapper                         E J2CA0027E: An exception occurred while invoking end on an XA Resource Adapter from DataSource dataSource[DefaultDataSource], within transaction ID {XidImpl: formatId(57415344), gtrid_length(36), bqual_length(54),
 <br>[2/5/22, 9:02:14:420 PST] 0000002b com.ibm.ejs.j2c.XATransactionWrapper                         E J2CA0027E: An exception occurred while invoking rollback on an XA Resource Adapter from DataSource dataSource[DefaultDataSource], within transaction ID {XidImpl: formatId(57415344), gtrid_length(36), bqual_length(54),
```

This is expected and the test needs to be updated to handle this. 


