### PR TITLE
Update ManagedCompletableFuture tests for Java 19

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
@@ -2887,9 +2887,9 @@ public class MPConcurrentTestServlet extends FATServlet {
     public void testNoNewMethods() throws Exception {
         int methodCount = CompletableFuture.class.getMethods().length;
         assertTrue("Methods have been added to CompletableFuture which need to be properly implemented on wrapper class ManagedCompletableFuture. " +
-                   "Expected 127 (Java 12) 117 (Java 9+) or 104 (Java 8). Found " + methodCount,
+                   "Expected 130 (Java 19) 127 (Java 12) 117 (Java 9) or 104 (Java 8). Found " + methodCount,
                    // WARNING: do not update these values unless you have properly implemented (or added code to reject) the new methods on ManagedCompletableFuture!
-                   methodCount == 127 || methodCount == 117 || methodCount == 104);
+                   methodCount == 130 || methodCount == 127 || methodCount == 117 || methodCount == 104);
     }
 
     /**


### PR DESCRIPTION
Confirmed that Java 19 did add 3 new methods to CompletableFutures so this test will need to be updated to reflect that. 