### PR TITLE
Remove hidden character in Bells FAT

### DIFF
--- a/dev/com.ibm.ws.classloading.bells_fat/test-applications/testSpiTypeVisible.jar/src/com/ibm/ws/test/SpiTypeVisibleRESTHandlerImpl.java
+++ b/dev/com.ibm.ws.classloading.bells_fat/test-applications/testSpiTypeVisible.jar/src/com/ibm/ws/test/SpiTypeVisibleRESTHandlerImpl.java
@@ -27,7 +27,7 @@ public class SpiTypeVisibleRESTHandlerImpl implements TestInterface2, RESTHandle
     }
 
     @Override
-    public void handleRequest​(RESTRequest request, RESTResponse response) {
+    public void handleRequest(RESTRequest request, RESTResponse response) {
         System.out.println("SpiTypeVisibilityRESTHandlerImpl.handleRequest: hello");
     }
 


### PR DESCRIPTION
Method name in a FAT class has a hidden character at the end which Eclipse
interprets as part of the method name and thus does not recognize as an
override of a method from parent.  Removed the hidden character.
