### PR TITLE
Fix transaction TCK for EE10

### DIFF
--- a/dev/com.ibm.ws.transaction.cdi/src/com/ibm/tx/jta/cdi/AbstractTransactionContext.java
+++ b/dev/com.ibm.ws.transaction.cdi/src/com/ibm/tx/jta/cdi/AbstractTransactionContext.java
@@ -48,14 +48,14 @@ public abstract class AbstractTransactionContext implements AlterableContext, Tr
 
     private static final TraceComponent tc = Tr.register(AbstractTransactionContext.class, TranConstants.TRACE_GROUP, TranConstants.NLS_FILE);
 
-    private static InitializedQualifier initializedQualifier = initializedQualifier = new InitializedQualifier() {
+    private static InitializedQualifier initializedQualifier = new InitializedQualifier() {
         @Override
         public Class value() {
             return TransactionScoped.class;
         }
     };
 
-    private static DestroyedQualifier destroyedQualifier = destroyedQualifier = new DestroyedQualifier() {
+    private static DestroyedQualifier destroyedQualifier = new DestroyedQualifier() {
         @Override
         public Class value() {
             return TransactionScoped.class;
@@ -212,7 +212,7 @@ public abstract class AbstractTransactionContext implements AlterableContext, Tr
         }
 
         //Fire any observers
-        beanManager.fireEvent("Destroying transaction context", destroyedQualifier);
+        fireEvent(beanManager, "Destroying transaction context", destroyedQualifier);
 
         if (tc.isEntryEnabled())
             Tr.exit(tc, "destroy");


### PR DESCRIPTION
- PR #20378 fixed the initialize path, but did not fix the destroy path. This PR updates the destroy path to be correct.
- Also updates the Annotation structure to remove additional static classes that appear to not be needed.  According to the comments they could be remove in Java 8 and that is the minimum required level of Liberty now.

#build