### PR TITLE
Fix SpnegoFat - JwtSsoFeature test

### DIFF
--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/BasicAuthTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/BasicAuthTest.java
@@ -120,6 +120,7 @@ public class BasicAuthTest extends ApacheKDCCommonTest {
     @Test
     public void testSpnegoSuccessful_withJwtSsoFeature() throws Exception {
         preTestCheck();
+        setDefaultSpnegoServerConfig();
         ServerConfiguration newServerConfig = myServer.getServerConfiguration();
         newServerConfig.getFeatureManager().getFeatures().remove("servlet-3.1");
         newServerConfig.getFeatureManager().getFeatures().add("jwtSso-1.0");


### PR DESCRIPTION
On rare occasion `testSpnegoSuccessful_withJwtSsoFeature` would get ran as the first test and would fail because the SPNEGO config was not set. The test assumed SPNEGO config was already set from other test cases being run first normally.

Fix is simple to call `setDefaultSpnegoServerConfig();` at the beginning of the test to ensure the SPNEGO config has been set in the Liberty server config