### PR TITLE
Remove javax.transaction.xa package from transaction API bundles

### DIFF
--- a/dev/com.ibm.websphere.javaee.transaction.1.1/bnd.bnd
+++ b/dev/com.ibm.websphere.javaee.transaction.1.1/bnd.bnd
@@ -12,7 +12,7 @@
 #*******************************************************************************
 
 -include= ~../cnf/resources/bnd/bundle.props
-bVersion=1.0
+bVersion=2.0
 
 Bundle-SymbolicName: com.ibm.websphere.javaee.transaction.1.1; singleton:=true
 

--- a/dev/com.ibm.websphere.javaee.transaction.1.1/bnd.bnd
+++ b/dev/com.ibm.websphere.javaee.transaction.1.1/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -17,20 +17,23 @@ bVersion=1.0
 Bundle-SymbolicName: com.ibm.websphere.javaee.transaction.1.1; singleton:=true
 
 Export-Package: \
-	javax.transaction,\
-	javax.transaction.xa
+	javax.transaction;version="1.1",\
+	javax.transaction.xa;version="1.1"
+
+Import-Package: \
+	!javax.transaction.xa, \
+	*
 
 -includeresource: \
-  @${repo;org.apache.geronimo.specs:geronimo-jta_1.1_spec;1.1.1}!/META-INF/NOTICE
+  @${repo;org.apache.geronimo.specs:geronimo-jta_1.1_spec;1.1.1}!/!(META-INF/maven/*|javax/transaction/xa/*.*)
 
 # this pulls in the partial javax.transaction and javax.transaction.xa packages from the jre
 # and lets us export them.
 Require-Bundle: system.bundle
 
-
 instrument.disabled: true
 
 publish.wlp.jar.suffix: dev/api/spec
 
--buildpath: \
-	org.apache.geronimo.specs:geronimo-jta_1.1_spec;version=1.1.1
+-maven-dependencies: \
+   dep1;groupId=org.apache.geronimo.specs;artifactId=geronimo-jta_1.1_spec;version=1.1.1;scope=runtime

--- a/dev/com.ibm.websphere.javaee.transaction.1.2/bnd.bnd
+++ b/dev/com.ibm.websphere.javaee.transaction.1.2/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -16,8 +16,15 @@ bVersion=1.0
 Bundle-SymbolicName: com.ibm.websphere.javaee.transaction.1.2; singleton:=true
 
 Export-Package: \
-	javax.transaction,\
-	javax.transaction.xa
+	javax.transaction;version="1.2",\
+	javax.transaction.xa;version="1.2"
+
+Import-Package: \
+	!javax.transaction.xa, \
+	*
+
+-includeresource: \
+  @${repo;javax.transaction:javax.transaction-api;1.2}!/!(META-INF/maven/*|javax/transaction/xa/*.*)
 
 # this pulls in the partial javax.transaction and javax.transaction.xa packages from the jre
 # and lets us export them.
@@ -27,5 +34,5 @@ instrument.disabled: true
 
 publish.wlp.jar.suffix: dev/api/spec
 
--buildpath: \
-	javax.transaction:javax.transaction-api;version=1.2
+-maven-dependencies: \
+   dep1;groupId=javax.transaction;artifactId=javax.transaction-api;version=1.2;scope=runtime

--- a/dev/com.ibm.websphere.javaee.transaction.1.2/bnd.bnd
+++ b/dev/com.ibm.websphere.javaee.transaction.1.2/bnd.bnd
@@ -11,7 +11,7 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
-bVersion=1.0
+bVersion=2.0
 
 Bundle-SymbolicName: com.ibm.websphere.javaee.transaction.1.2; singleton:=true
 

--- a/dev/com.ibm.ws.transaction.core_fat.misc/publish/files/features/utdecorator-1.0.mf
+++ b/dev/com.ibm.ws.transaction.core_fat.misc/publish/files/features/utdecorator-1.0.mf
@@ -3,7 +3,7 @@ IBM-Test-Feature: true
 Subsystem-SymbolicName: utdecorator-1.0; visibility:=public
 Subsystem-Version: 1.0.0
 Subsystem-Content: com.ibm.ws.transaction.fat.utdecorator; version="[1,1.1)"; location:="lib/com.ibm.ws.transaction.fat.utdecorator_1.0.jar",
- com.ibm.websphere.javaee.transaction.1.2; version="[1,1.1)"; location:="dev/api/spec/,lib/", 
+ com.ibm.websphere.javaee.transaction.1.2; version="[2.0,2.1)"; location:="dev/api/spec/,lib/", 
  com.ibm.ws.tx.embeddable;  version="[1,1.2)", 
 Subsystem-Type: osgi.subsystem.feature
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.transaction.test.util/publish/features/txtest-1.0.mf
+++ b/dev/com.ibm.ws.transaction.test.util/publish/features/txtest-1.0.mf
@@ -3,7 +3,7 @@ IBM-Test-Feature: true
 Subsystem-SymbolicName: txtest-1.0; visibility:=public
 Subsystem-Version: 1.0.0
 Subsystem-Content: com.ibm.ws.transaction.test.util; version="[1,1.1)"; location:="lib/com.ibm.ws.transaction.test.util.jar",
- com.ibm.websphere.javaee.transaction.1.2; version="[1,1.1)"; location:="dev/api/spec/,lib/", 
+ com.ibm.websphere.javaee.transaction.1.2; version="[2.0,2.1)"; location:="dev/api/spec/,lib/", 
  com.ibm.ws.tx.embeddable;  version="[1,1.2)"
 Subsystem-Type: osgi.subsystem.feature
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.transaction.test.util/publish/features/txtest-2.0.mf
+++ b/dev/com.ibm.ws.transaction.test.util/publish/features/txtest-2.0.mf
@@ -3,7 +3,7 @@ IBM-Test-Feature: true
 Subsystem-SymbolicName: txtest-2.0; visibility:=public
 Subsystem-Version: 1.0.0
 Subsystem-Content: com.ibm.ws.transaction.test.util.jakarta; version="[1,1.1)"; location:="lib/com.ibm.ws.transaction.test.util.jakarta.jar",
- io.openliberty.jakarta.transaction.2.0; version="[1,1.1)"; location:="dev/api/spec/,lib/", 
+ io.openliberty.jakarta.transaction.2.0; version="[2.0,2.1)"; location:="dev/api/spec/,lib/", 
  com.ibm.ws.tx.embeddable.jakarta;  version="[1,1.2)" 
 Subsystem-Type: osgi.subsystem.feature
 IBM-Feature-Version: 2

--- a/dev/io.openliberty.jakarta.transaction.2.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.transaction.2.0/bnd.bnd
@@ -11,7 +11,7 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
-bVersion=1.0
+bVersion=2.0
 
 Bundle-SymbolicName: io.openliberty.jakarta.transaction.2.0; singleton:=true
 

--- a/dev/io.openliberty.jakarta.transaction.2.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.transaction.2.0/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2023 IBM Corporation and others.
+# Copyright (c) 2020, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -16,10 +16,14 @@ bVersion=1.0
 Bundle-SymbolicName: io.openliberty.jakarta.transaction.2.0; singleton:=true
 
 Export-Package: \
-	jakarta.transaction,\
+	jakarta.transaction;version="2.0.1",\
 	javax.transaction.xa;version="1.2"
 
-# Pull in the partial javax.transaction.xa package from the jre re-export them.
+Import-Package: \
+	!javax.transaction.xa, \
+	*
+
+# this pulls in the javax.transaction.xa package from the jre
 Require-Bundle: system.bundle
 
 instrument.disabled: true
@@ -27,10 +31,7 @@ instrument.disabled: true
 publish.wlp.jar.suffix: dev/api/spec
 
 -includeresource: \
-  @${repo;jakarta.transaction:jakarta.transaction-api;2.0.1;EXACT}!/!(META-INF/maven/*|module-info.class)
+  @${repo;jakarta.transaction:jakarta.transaction-api;2.0.1;EXACT}!/!(META-INF/maven/*|module-info.class|javax/transaction/xa/*.*)
 
--buildpath: \
-  jakarta.transaction:jakarta.transaction-api;version=2.0.1;strategy=exact
-
-# If building with gradle include the javax.transaction.xa to the generated jar to maintain previous behavior.
--buildpath.extra: ${if;${driver;gradle};javax.transaction:javax.transaction-api\\;version=1.2}
+-maven-dependencies: \
+   dep1;groupId=jakarta.transaction;artifactId=jakarta.transaction-api;version=2.0.1;scope=runtime


### PR DESCRIPTION
- javax.transaction.xa is provided in the JDK and does not need to be in the transaction API bundles.  Having it there causes compile failures with Java 11 in Eclipse and will do the same for customers as well.

#build