### PR TITLE
Repeat EE10 or EE9 only in lite mode based on Java level

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/FATSuite.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/FATSuite.java
@@ -24,9 +24,10 @@ import org.junit.runners.Suite.SuiteClasses;
 import com.ibm.websphere.simplicity.Machine;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
@@ -45,9 +46,20 @@ import componenttest.topology.utils.HttpUtils;
 public class FATSuite {
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification() // run all tests as-is (e.g. EE8 features)
-                    .andWith(new JakartaEE9Action()) // run all tests again with EE9 features+packages
-                    .andWith(FeatureReplacementAction.EE10_FEATURES());
+    public static RepeatTests r;
+
+    static {
+        // EE10 require Java 11.  If we only specify EE10 for lite mode it will cause no tests to run which causes an error.
+        // If we are running on Java 8 have EE9 be the lite mode test to run.
+        if (JavaInfo.JAVA_VERSION >= 11) {
+            r = RepeatTests.with(new EmptyAction().fullFATOnly()) // run all tests as-is (e.g. EE8 features)
+                            .andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly()) // run all tests again with EE9 features+packages
+                            .andWith(FeatureReplacementAction.EE10_FEATURES());
+        } else {
+            r = RepeatTests.with(new EmptyAction().fullFATOnly()) // run all tests as-is (e.g. EE8 features)
+                            .andWith(FeatureReplacementAction.EE9_FEATURES()); // run all tests again with EE9 features+packages
+        }
+    }
 
     @BeforeClass
     public static void beforeSuite() throws Exception {

--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/FATSuite.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/FATSuite.java
@@ -22,9 +22,10 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import componenttest.topology.utils.HttpUtils;
@@ -35,10 +36,22 @@ import componenttest.topology.utils.HttpUtils;
                 SessionCacheErrorPathsTest.class
 })
 public class FATSuite {
+
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification() // run all tests as-is (e.g. EE8 features)
-                    .andWith(new JakartaEE9Action()) // run all tests again with EE9 features+packages
-                    .andWith(FeatureReplacementAction.EE10_FEATURES());
+    public static RepeatTests r;
+
+    static {
+        // EE10 require Java 11.  If we only specify EE10 for lite mode it will cause no tests to run which causes an error.
+        // If we are running on Java 8 have EE9 be the lite mode test to run.
+        if (JavaInfo.JAVA_VERSION >= 11) {
+            r = RepeatTests.with(new EmptyAction().fullFATOnly()) // run all tests as-is (e.g. EE8 features)
+                            .andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly()) // run all tests again with EE9 features+packages
+                            .andWith(FeatureReplacementAction.EE10_FEATURES());
+        } else {
+            r = RepeatTests.with(new EmptyAction().fullFATOnly()) // run all tests as-is (e.g. EE8 features)
+                            .andWith(FeatureReplacementAction.EE9_FEATURES()); // run all tests again with EE9 features+packages
+        }
+    }
 
     public static String run(LibertyServer server, String path, String testMethod, List<String> session) throws Exception {
         HttpURLConnection con = HttpUtils.getHttpConnection(server, path + '?' + FATServletClient.TEST_METHOD + '=' + testMethod);


### PR DESCRIPTION
for #21200

1) Currently these buckets were executing the three Repeats all in lite mode. Updating to only execute the latest feature set in lite mode and the other repeats will execute in full mode.
2) A check is added to only repeat EE10 in lite mode on Java 11+ as Java 11+ is required for EE10, if not Java 11+ then the EE9 feature set will be executed.