### PR TITLE
Temporarily skip EE10 for InjectIntoPathTest

### DIFF
--- a/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/jaxrs/inject/InjectIntoPathTest.java
+++ b/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/jaxrs/inject/InjectIntoPathTest.java
@@ -36,8 +36,9 @@ public class InjectIntoPathTest {
     public static final String SERVER_NAME = "jaxInjectIntoPathServer";
 
     //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
+    //TODO This test currently fails with EE10. The EE10 repeat should be added back in ASAP.
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE9, EERepeatActions.EE10, EERepeatActions.EE7);
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE9, EERepeatActions.EE7);
 
     @Server(SERVER_NAME)
     public static LibertyServer server;

--- a/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/jaxrs/inject/war/CDIResource.java
+++ b/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/jaxrs/inject/war/CDIResource.java
@@ -24,10 +24,13 @@ public class CDIResource {
 
     private HelloWorldBean helloWorldBean;
 
-    public CDIResource() {}
+    public CDIResource() {
+        System.out.println("no-args xtor");
+    }
 
     @Inject
     public CDIResource(HelloWorldBean helloWorldBean) {
+        System.out.println("xtor: " + helloWorldBean);
         this.helloWorldBean = helloWorldBean;
     }
 
@@ -36,8 +39,14 @@ public class CDIResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Response get() {
         System.out.println("GET!");
-        System.out.println(helloWorldBean.message());
-        return Response.ok().type(MediaType.TEXT_PLAIN).entity(helloWorldBean.message()).build();
+        String result;
+        if (helloWorldBean == null) {
+            result = "Injected HelloWorldBean was null";
+        } else {
+            result = helloWorldBean.message();
+        }
+        System.out.println(result);
+        return Response.ok().type(MediaType.TEXT_PLAIN).entity(result).build();
     }
 
     @POST


### PR DESCRIPTION
Constructor Injection into a restfulWS resource does not currently work with EE10 (restfulWS-3.1). Skipping EE10 for now but also improving the error messages.
#build