### PR TITLE
Update tests to remove skip for repeat for ee9

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2021 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -79,7 +79,10 @@ tested.features: \
   managedBeans-2.0,\
   pages-3.0,\
   xmlBinding-3.0,\
-  xmlWS-3.0
+  xmlWS-3.0,\
+  mpmetrics-4.0,\
+  microprofile-5.0,\
+  jakartaee-9.1
 
 -buildpath: \
   com.ibm.websphere.javaee.annotation.1.2,\

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/ExceptionMappingWithOTTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/ExceptionMappingWithOTTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,6 +32,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.topology.impl.LibertyServer;
 
 /*
@@ -41,7 +42,7 @@ import componenttest.topology.impl.LibertyServer;
  * the MP OT mapper.
  */
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // MP Open Tracing doesn't support EE9 until MP 5
+@SkipForRepeat(JakartaEE10Action.ID) // MP Open Tracing doesn't support EE10 until MP 6
 public class ExceptionMappingWithOTTest {
 
     @Server("com.ibm.ws.jaxrs.fat.exceptionMappingWithOT")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -81,5 +81,6 @@ public class FATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
                     .andWith(FeatureReplacementAction.EE8_FEATURES().withID("JAXRS-2.1"))
-                    .andWith(new JakartaEE9Action().alwaysAddFeature("jsonb-2.0").removeFeature("mpMetrics-2.3"));
+                    .andWith(new JakartaEE9Action().alwaysAddFeature("jsonb-2.0").removeFeature("mpMetrics-2.3").addFeature("mpMetrics-4.0")
+                             .removeFeature("microProfile-1.3").addFeature("microProfile-5.0"));
 }

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/RestMetricsTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/RestMetricsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -42,7 +42,7 @@ import com.ibm.ws.jaxrs.fat.restmetrics.MetricsUnmappedUncheckedException;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
@@ -109,9 +109,9 @@ public class RestMetricsTest {
                       server.waitForStringInLog("CWWKF0011I"));
 
         // wait for LTPA key to be available to avoid CWWKS4000E
-        //TODO: make sure to remove this check when MP 5.0 is available - where MP Metrics supports EE9
-        //      metrics loads LTPA, so when we use MP Metrics in MP 5, we'll need to verify that LTPA is started
-        if (!JakartaEE9Action.isActive()) {
+        //TODO: make sure to remove this check when MP 6.0 is available - where MP Metrics supports EE10
+        //      metrics loads LTPA, so when we use MP Metrics in MP 6, we'll need to verify that LTPA is started
+        if (!JakartaEE10Action.isActive()) {
             assertNotNull("CWWKS4105I.* not received on server",
                       server.waitForStringInLog("CWWKS4105I.*"));
         }
@@ -121,7 +121,7 @@ public class RestMetricsTest {
     public static void tearDown() throws Exception {
         if (server != null) {
             server.stopServer("MetricsUnmappedUncheckedException", "MetricsUnmappedCheckedException",
-                              "Fault: Unmapped Checked","SRVE0777E", "SRVE0315E");
+                              "Fault: Unmapped Checked","SRVE0777E", "SRVE0315E", "CWPMI2005W");
         }
     }
 
@@ -198,7 +198,7 @@ public class RestMetricsTest {
         boolean allow404 = true;
         ArrayList<String> metricsList = getMetricsStrings(200, METRICS_URL_STRING, allow404);
 
-        // getMetricsStrings() doesn't run for EE9 so metricsList will be null in that case
+        // getMetricsStrings() doesn't run for EE10 so metricsList will be null in that case
         if ((metricsList != null) && (metricsList.contains("abortTest"))) {
             fail("The /restmetrics/rest/restmetrics/abortTest method should not have run following the ContainerRequestFilter abort so no metrics information should be collected." + metricsList.toString());
         }
@@ -644,8 +644,8 @@ public class RestMetricsTest {
     }
 
     private ArrayList<String> getMetricsStrings(int expectedRc, String metricString, boolean allow404) {
-        //TODO: remove this check when MP 5.0 is available - where MP Metrics supports EE9:
-        if (JakartaEE9Action.isActive()) {
+        //TODO: remove this check when MP 6.0 is available - where MP Metrics supports EE10:
+        if (JakartaEE10Action.isActive()) {
             return null;
         }
 
@@ -699,8 +699,8 @@ public class RestMetricsTest {
 
 
     private float checkMetrics(ArrayList<String> lines, int index) {
-        //TODO: remove this check when MP 5.0 is available - where MP Metrics supports EE9:
-        if (JakartaEE9Action.isActive()) {
+        //TODO: remove this check when MP 6.0 is available - where MP Metrics supports EE10:
+        if (JakartaEE10Action.isActive()) {
             return -1.0f;
         }
 

--- a/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 IBM Corporation and others.
+ * Copyright (c) 2011, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,7 +22,6 @@ import com.ibm.ws.jca.fat.regr.InboundSecurityTest;
 import com.ibm.ws.jca.fat.regr.InboundSecurityTestRapid;
 
 import componenttest.rules.repeater.EmptyAction;
-import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
@@ -46,7 +45,7 @@ public class FATSuite {
      */
     @ClassRule
     public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly())
-                    .andWith(FeatureReplacementAction.EE9_FEATURES());
+                    .andWith(new JakartaEE9Action().withWiden()); // need widen option to handle jar file within a jar file.
 
     public static LibertyServer getServer() {
         if (JakartaEE9Action.isActive()) {

--- a/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/JCATest.java
+++ b/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/JCATest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011,2020 IBM Corporation and others.
+ * Copyright (c) 2011,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,6 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jca.fat.app;
-
-import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 
 import java.io.File;
 
@@ -31,7 +29,6 @@ import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.ws.jca.fat.FATSuite;
 
 import componenttest.annotation.AllowedFFDC;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
@@ -137,7 +134,6 @@ public class JCATest extends FATServletClient {
     }
 
     @Test
-    @SkipForRepeat(EE9_FEATURES) //Transformer does not seem to transform jars inside of jars
     public void testLoginModuleInJarInJarInRar() throws Exception {
         runTest();
     }

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/.classpath
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/.classpath
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
-	<classpathentry kind="src" path="test-applications/backchannelLogoutTestApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE10Action.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE10Action.java
@@ -41,6 +41,7 @@ public class JakartaEE10Action extends FeatureReplacementAction {
     private static final String TRANSFORMER_RULES_APPEND_ROOT = System.getProperty("user.dir") + "/publish/rules/";
     private static final Map<String, String> DEFAULT_TRANSFORMATION_RULES = new HashMap();
     private static final Map<String, String> TRANSFORMATION_RULES_APPEND = new HashMap();
+    private static boolean WIDEN = false;
 
     static {
         // Fill the default transformation rules for the transformer
@@ -262,6 +263,16 @@ public class JakartaEE10Action extends FeatureReplacementAction {
         return this;
     }
 
+    /**
+     * The widen option in the transformer enables the transformer to handle things like jars
+     * inside of other jars or zips inside of other zips. These are not the usual setup of
+     * of bundles and applications, so it is only enabled by an argument to the transformer.
+     */
+    public JakartaEE10Action withWiden() {
+        WIDEN = true;
+        return this;
+    }
+
     @Override
     public void setup() throws Exception {
         // Ensure all shared servers are stopped and applications are cleaned
@@ -320,6 +331,6 @@ public class JakartaEE10Action extends FeatureReplacementAction {
      * @param newAppPath The application path of the transformed file (or <code>null<code>)
      */
     public static void transformApp(Path appPath, Path newAppPath) {
-        JakartaEE9Action.transformApp(appPath, newAppPath, DEFAULT_TRANSFORMATION_RULES, TRANSFORMATION_RULES_APPEND);
+        JakartaEE9Action.transformApp(appPath, newAppPath, DEFAULT_TRANSFORMATION_RULES, TRANSFORMATION_RULES_APPEND, WIDEN);
     }
 }

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE9Action.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE9Action.java
@@ -52,6 +52,7 @@ public class JakartaEE9Action extends FeatureReplacementAction {
     static final String TRANSFORMER_RULES_ROOT = System.getProperty("user.dir") + "/autoFVT-templates/";
     private static final Map<String, String> DEFAULT_TRANSFORMATION_RULES = new HashMap();
     private static final Map<String, String> TRANSFORMATION_RULES_APPEND = new HashMap();
+    private static boolean WIDEN = false;
 
     static {
         // Fill the default transformation rules for the transformer
@@ -272,6 +273,16 @@ public class JakartaEE9Action extends FeatureReplacementAction {
         return this;
     }
 
+    /**
+     * The widen option in the transformer enables the transformer to handle things like jars
+     * inside of other jars or zips inside of other zips. These are not the usual setup of
+     * of bundles and applications, so it is only enabled by an argument to the transformer.
+     */
+    public JakartaEE9Action withWiden() {
+        WIDEN = true;
+        return this;
+    }
+
     //
 
     @Override
@@ -332,11 +343,11 @@ public class JakartaEE9Action extends FeatureReplacementAction {
      * @param newAppPath The application path of the transformed file (or <code>null<code>)
      */
     public static void transformApp(Path appPath, Path newAppPath) {
-        transformApp(appPath, newAppPath, DEFAULT_TRANSFORMATION_RULES, TRANSFORMATION_RULES_APPEND);
+        transformApp(appPath, newAppPath, DEFAULT_TRANSFORMATION_RULES, TRANSFORMATION_RULES_APPEND, WIDEN);
     }
 
     protected static void transformApp(Path appPath, Path newAppPath, Map<String, String> defaultTransformationRules,
-                                       Map<String, String> transformationRulesAppend) {
+                                       Map<String, String> transformationRulesAppend, boolean widen) {
         final String m = "transformApp";
         Log.info(c, m, "Transforming app: " + appPath);
 
@@ -405,7 +416,7 @@ public class JakartaEE9Action extends FeatureReplacementAction {
 
         try {
             // Invoke the jakarta transformer
-            String[] args = new String[15 + transformationRulesAppend.size() * 2];
+            String[] args = new String[(widen ? 16 : 15) + transformationRulesAppend.size() * 2];
 
             args[0] = appPath.toAbsolutePath().toString(); // input
             args[1] = outputPath.toAbsolutePath().toString(); // output
@@ -426,6 +437,10 @@ public class JakartaEE9Action extends FeatureReplacementAction {
             args[12] = defaultTransformationRules.get("-td");
             args[13] = "-tf"; // text updates
             args[14] = defaultTransformationRules.get("-tf");
+            // The widen option handles jars inside of jars.
+            if (widen) {
+                args[15] = "-w";
+            }
 
             // Go through the additions
             if (transformationRulesAppend.size() > 0) {
@@ -435,7 +450,7 @@ public class JakartaEE9Action extends FeatureReplacementAction {
                     additions[index++] = addition.getKey();
                     additions[index++] = addition.getValue();
                 }
-                System.arraycopy(additions, 0, args, 15, transformationRulesAppend.size() * 2);
+                System.arraycopy(additions, 0, args, widen ? 16 : 15, transformationRulesAppend.size() * 2);
             }
 
             Log.info(c, m, "Initializing transformer with args: " + Arrays.toString(args));


### PR DESCRIPTION
- Update jaxrs tests to do repeat for EE9 with MP 5.0, but then also update to skip for repeat for EE10 until MP 6.0 support is added.
- Update RestMetrics test to ignore new message for mpMetrics 3.0 and 4.0 when dealing with an unchecked exception as the test expects.
- Update JCATest to use the widen option with the transformer to handle jar within a jar file which the transformer doesn't do by default.
- Remove non existent source directory for com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout