### PR TITLE
Remove info logging from CXF 3.4 overlays

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/jaxb/JAXBUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/jaxb/JAXBUtils.java
@@ -627,17 +627,7 @@ public final class JAXBUtils {
 
     public static Object setNamespaceMapper(Bus bus, final Map<String, String> nspref,
                                             Marshaller marshaller) throws PropertyException {
-        LOG.info("****@TTJJ className of mapper is: " + marshaller.getClass() + " nspref stands for " + nspref);
         ClassLoaderService classLoaderService = bus.getExtension(ClassLoaderService.class);
-//        if(marshaller.getClass().getName().startsWith("com.ibm")) {
-//            try {
-//                Object mapper = classLoaderService.createNamespaceWrapperInstance(marshaller.getClass(), nspref);  
-//            } catch (NoClassDefFound) {
-//                if(NoClassDefFoundError e) {
-//                    // do nothing since XLXP has messed with the way this property gets read. 
-//                }
-//            }
-//        }
         Object mapper = classLoaderService.createNamespaceWrapperInstance(marshaller.getClass(), nspref);
         if (mapper != null) {
             if ((marshaller.getClass().getName().contains("com.sun") && marshaller.getClass().getName().contains(".internal."))) {

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/Soap12FaultOutInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/Soap12FaultOutInterceptor.java
@@ -67,7 +67,7 @@ public class Soap12FaultOutInterceptor extends AbstractSoapInterceptor {
             super(Phase.MARSHAL);
         }
         public void handleMessage(@Sensitive SoapMessage message) throws Fault { //Liberty Change
-            LOG.info(getClass() + (String) message.get(Message.CONTENT_TYPE));
+            LOG.finest(getClass() + (String) message.get(Message.CONTENT_TYPE));
 
             XMLStreamWriter writer = message.getContent(XMLStreamWriter.class);
             Fault f = (Fault)message.getContent(Exception.class);

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/HTTPConduit.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/HTTPConduit.java
@@ -1903,7 +1903,7 @@ public abstract class HTTPConduit
                     || !newUri.getHost().equals(lastUri.getHost())) {
                     String msg = "Different HTTP Scheme or Host Redirect detected on Conduit '"
                         + conduitName + "' on '" + newURL + "'";
-                    LOG.log(Level.INFO, msg);
+                    LOG.log(Level.FINEST, msg);
                     throw new IOException(msg);
                 }
             }
@@ -1911,7 +1911,7 @@ public abstract class HTTPConduit
             String allowedRedirectURI = (String)message.getContextualProperty(AUTO_REDIRECT_ALLOWED_URI);
             if (allowedRedirectURI != null && !newURL.startsWith(allowedRedirectURI)) {
                 String msg = "Forbidden Redirect URI " + newURL + "detected on Conduit '" + conduitName;
-                LOG.log(Level.INFO, msg);
+                LOG.log(Level.FINEST, msg);
                 throw new IOException(msg);
             }
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2/src/org/apache/cxf/wsdl/service/factory/ReflectionServiceFactoryBean.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2/src/org/apache/cxf/wsdl/service/factory/ReflectionServiceFactoryBean.java
@@ -388,7 +388,7 @@ public class ReflectionServiceFactoryBean extends org.apache.cxf.service.factory
 
         // Liberty Change Start
         if (LOG.isLoggable(Level.FINE)) {
-            LOG.info("Creating Service " + getServiceQName() + " from WSDL: " + url);
+            LOG.fine("Creating Service " + getServiceQName() + " from WSDL: " + url);
         }
         //Liberty Change End
         populateFromClass = false;
@@ -434,8 +434,8 @@ public class ReflectionServiceFactoryBean extends org.apache.cxf.service.factory
             throw new ServiceConstructionException(new Message("NO_WSDL_PROVIDED", LOG,
                                                                getServiceClass().getName()));
         }
-        if (LOG.isLoggable(Level.INFO)) {
-            LOG.info("Creating Service " + getServiceQName() + " from class " + getServiceClass().getName());
+        if (LOG.isLoggable(Level.FINE)) {
+            LOG.fine("Creating Service " + getServiceQName() + " from class " + getServiceClass().getName());
         }
         populateFromClass = true;
 


### PR DESCRIPTION
This PR cleans up the use of LOG.info in CXF to clean up message.log print outs. 