### PR TITLE
Remove mpOpenAPI-3.1 from compatible features to avoid clash

### DIFF
--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/JakartaEE9Test.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/JakartaEE9Test.java
@@ -49,6 +49,7 @@ public class JakartaEE9Test extends FATServletClient {
         compatFeatures.remove("jsonpContainer-2.0");
         compatFeatures.remove("passwordUtilities-1.1");
         compatFeatures.remove("persistenceContainer-3.0");
+        compatFeatures.remove("mpOpenAPI-3.1");
 
         // remove client features
         compatFeatures.remove("jakartaeeClient-9.1");


### PR DESCRIPTION
The Jakarta EE 9 feature compatibility test should only use mpOpenAPI-3.0 and NOT mpOpenAPI-3.1