### PR TITLE
Clear logs mark in logging JSON FAT

### DIFF
--- a/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/JSONEventsTest.java
+++ b/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/JSONEventsTest.java
@@ -52,6 +52,9 @@ public abstract class JSONEventsTest {
 
         ArrayList<String> messageKeysOptionalList = new ArrayList<String>(Arrays.asList("ibm_className", "ibm_methodName"));
 
+        // Reset the log marks, so the log mark is at the start of the log file, since this test checks for the server
+        // started message (CWWKF0011I), it will find the string in the log file, if the tests are not run in order.
+        getServer().resetLogMarks();
         String line = getServer().waitForStringInLog("\\{.*\"ibm_messageId\":\"CWWKF0011I\".*\\}", getLogFile());
         assertNotNull("Cannot find \"ibm_messageId\":\"CWWKF0011I\" from messages.log", line);
         checkJsonMessage(line, messageKeysMandatoryList, messageKeysOptionalList);


### PR DESCRIPTION
- Clears the log marks for the checkMessages test case in the logging JSON FAT, so it can find the required server started string in the logs, if the test cases are ran out of order, in some SOE environments.