### PR TITLE
Jakarta Security: Fix OIDC feature manifests for proper bundles

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.openidConnectClient1.0.internal.ee-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.openidConnectClient1.0.internal.ee-6.0.feature
@@ -8,6 +8,7 @@ visibility = private
   com.ibm.websphere.appserver.javax.cdi-1.0; apiJar=false; ibm.tolerates:="1.2,2.0"
 -bundles=\
   com.ibm.ws.security.openidconnect.client, \
-  com.ibm.ws.security.openidconnect.clients.common
+  com.ibm.ws.security.openidconnect.clients.common, \
+  io.openliberty.security.oidcclientcore.internal
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.openidConnectServer1.0.internal.ee-10.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.openidConnectServer1.0.internal.ee-10.0.feature
@@ -8,6 +8,7 @@ visibility = private
 -bundles=\
   io.openliberty.security.common.internal, \
   io.openliberty.security.openidconnect.internal.clients.common, \
-  io.openliberty.security.openidconnect.internal.server
+  io.openliberty.security.openidconnect.internal.server, \
+  io.openliberty.security.oidcclientcore.internal.jakarta
 kind=noship
 edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.openidConnectServer1.0.internal.ee-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.openidConnectServer1.0.internal.ee-6.0.feature
@@ -9,6 +9,7 @@ visibility = private
 -bundles=\
   com.ibm.ws.security.common, \
   com.ibm.ws.security.openidconnect.clients.common, \
-  com.ibm.ws.security.openidconnect.server
+  com.ibm.ws.security.openidconnect.server, \
+  io.openliberty.security.oidcclientcore.internal
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.openidConnectServer1.0.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.openidConnectServer1.0.internal.ee-9.0.feature
@@ -8,6 +8,7 @@ visibility = private
 -bundles=\
   io.openliberty.security.common.internal, \
   io.openliberty.security.openidconnect.internal.clients.common, \
-  io.openliberty.security.openidconnect.internal.server
+  io.openliberty.security.openidconnect.internal.server, \
+  io.openliberty.security.oidcclientcore.internal.jakarta
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.socialLogin1.0.internal.ee-10.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.socialLogin1.0.internal.ee-10.0.feature
@@ -6,6 +6,7 @@ visibility = private
   io.openliberty.jsonp-2.1
 -bundles=\
   io.openliberty.security.social.internal,\
-  io.openliberty.security.openidconnect.internal.clients.common
+  io.openliberty.security.openidconnect.internal.clients.common,\
+  io.openliberty.security.oidcclientcore.internal.jakarta
 kind=noship
 edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.socialLogin1.0.internal.ee-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.socialLogin1.0.internal.ee-6.0.feature
@@ -7,6 +7,7 @@ visibility = private
   com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1, 4.0"
 -bundles=\
   com.ibm.ws.security.social,\
-  com.ibm.ws.security.openidconnect.clients.common
+  com.ibm.ws.security.openidconnect.clients.common,\
+  io.openliberty.security.oidcclientcore.internal
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.socialLogin1.0.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.socialLogin1.0.internal.ee-9.0.feature
@@ -6,6 +6,7 @@ visibility = private
   io.openliberty.jsonp-2.0
 -bundles=\
   io.openliberty.security.social.internal,\
-  io.openliberty.security.openidconnect.internal.clients.common
+  io.openliberty.security.openidconnect.internal.clients.common,\
+  io.openliberty.security.oidcclientcore.internal.jakarta
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/openidConnectClient-1.0/com.ibm.websphere.appserver.openidConnectClient-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/openidConnectClient-1.0/com.ibm.websphere.appserver.openidConnectClient-1.0.feature
@@ -26,8 +26,7 @@ Subsystem-Name: OpenID Connect Client 1.0
   com.ibm.ws.security.common.jsonwebkey, \
   com.ibm.ws.com.google.gson.2.2.4, \
   com.ibm.ws.org.jose4j, \
-  com.ibm.ws.org.json.simple.1.1.1, \
-  io.openliberty.security.oidcclientcore.internal
+  com.ibm.ws.org.json.simple.1.1.1
 -jars=\
   com.ibm.websphere.appserver.api.oidc; location:=dev/api/ibm/
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.oidc_1.0-javadoc.zip


### PR DESCRIPTION
Updates the EE6, EE9, and EE10 private features for OIDC server, OIDC client, and social login to include the appropriate reference to the new `io.openliberty.security.oidcclientcore.internal` project. The EE6 versions will reference `io.openliberty.security.oidcclientcore.internal` while the EE9 and EE10 will reference the `io.openliberty.security.oidcclientcore.internal.jakarta` bundle.