### PR TITLE
update com.ibm.ws.jaxrs.2.1.client_fat tests to include OS/400 when checking if the test is running on z/OS or not

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/test-applications/jaxrs21bookstore/src/com/ibm/ws/jaxrs21/fat/JAXRS21bookstore/CXFRxInvokerTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/test-applications/jaxrs21bookstore/src/com/ibm/ws/jaxrs21/fat/JAXRS21bookstore/CXFRxInvokerTestServlet.java
@@ -60,7 +60,7 @@ public class CXFRxInvokerTestServlet extends HttpServlet {
 
     private static final boolean isZOS() {
         String osName = System.getProperty("os.name");
-        if (osName.contains("OS/390") || osName.contains("z/OS") || osName.contains("zOS")) {
+        if (osName.toLowerCase().contains("os/") || osName.toLowerCase().contains("z/os") || osName.toLowerCase().contains("zos")) {
             return true;
         }
         return false;

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/test-applications/jaxrs21bookstore/src/com/ibm/ws/jaxrs21/fat/JAXRS21bookstore/CompletionStageRxInvokerTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/test-applications/jaxrs21bookstore/src/com/ibm/ws/jaxrs21/fat/JAXRS21bookstore/CompletionStageRxInvokerTestServlet.java
@@ -52,7 +52,7 @@ public class CompletionStageRxInvokerTestServlet extends HttpServlet {
 
     private static final boolean isZOS() {
         String osName = System.getProperty("os.name");
-        if (osName.contains("OS/390") || osName.contains("z/OS") || osName.contains("zOS")) {
+        if (osName.toLowerCase().contains("os/") || osName.toLowerCase().contains("z/os") || osName.toLowerCase().contains("zos")) {
             return true;
         }
         return false;

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/test-applications/jaxrs21bookstore/src/com/ibm/ws/jaxrs21/fat/JAXRS21bookstore/JerseyRxInvokerTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/test-applications/jaxrs21bookstore/src/com/ibm/ws/jaxrs21/fat/JAXRS21bookstore/JerseyRxInvokerTestServlet.java
@@ -60,7 +60,7 @@ public class JerseyRxInvokerTestServlet extends HttpServlet {
 
     private static final boolean isZOS() {
         String osName = System.getProperty("os.name");
-        if (osName.contains("OS/390") || osName.contains("z/OS") || osName.contains("zOS")) {
+        if (osName.toLowerCase().contains("os/") || osName.toLowerCase().contains("z/os") || osName.toLowerCase().contains("zos")) {
             return true;
         }
         return false;


### PR DESCRIPTION
Tests are currently failing when running on the `OS/400` platform because they are not being treated as running on z/OS.

**Test**:
`com.ibm.ws.jaxrs21.client.fat.test.JAXRS21ClientCXFRxInvokerTest.testObservableRxInvoker_getCbConnectionTimeout`

**Results**
```
testObservableRxInvoker_getCbConnectionTimeout:junit.framework.AssertionFailedError: 2022-04-17-01:55:34:892 Real response is throwable and the expected response is one of [Timeout as expected]
at com.ibm.ws.jaxrs21.client.fat.test.JAXRS21AbstractTest.runTestOnServer(JAXRS21AbstractTest.java:84)
at com.ibm.ws.jaxrs21.client.fat.test.JAXRS21ClientCXFRxInvokerTest.testObservableRxInvoker_getCbConnectionTimeout(JAXRS21ClientCXFRxInvokerTest.java:218)
at componenttest.custom.junit.runner.FATRunner$1.evaluate(FATRunner.java:199)
at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:320)
at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:173)
at componenttest.rules.repeater.RepeatTests$CompositeRepeatTestActionStatement.evaluate(RepeatTests.java:143)
```

**server logs:**
```
[7/10/22 19:55:36:506 EDT] 00000078 SystemOut                                                    O testObservableRxInvoker_getCbConnectionTimeout with TIMEOUT 5000 observableRxInvoker.get elapsed time 0
[7/10/22 19:55:36:525 EDT] 000000c1 xf.rt.transports.http.3.2:1.0.67.cl220820220706-1900(id=88)] W HTTP Response code appears to be corrupted
[7/10/22 19:55:36:527 EDT] 000000c1 g.apache.cxf.cxf.core.3.2:1.0.67.cl220820220706-1900(id=87)] W Interceptor for {[http://localhost:23/blah}WebClient](http://localhost:23/blah%7DWebClient) has thrown exception, unwinding now
org.apache.cxf.interceptor.Fault: Could not send Message.
at org.apache.cxf.interceptor.MessageSenderInterceptor$MessageSenderEndingInterceptor.handleMessage(MessageSenderInterceptor.java:67)
at org.apache.cxf.phase.PhaseInterceptorChain.doIntercept(PhaseInterceptorChain.java:308)
at org.apache.cxf.jaxrs.client.AbstractClient.doRunInterceptorChain(AbstractClient.java:704)
at org.apache.cxf.jaxrs.client.WebClient.doChainedInvocation(WebClient.java:1086)
at org.apache.cxf.jaxrs.client.WebClient.doInvoke(WebClient.java:932)
at org.apache.cxf.jaxrs.client.WebClient.doInvoke(WebClient.java:901)
at org.apache.cxf.jaxrs.client.WebClient.invoke(WebClient.java:461)
at org.apache.cxf.jaxrs.client.SyncInvokerImpl.method(SyncInvokerImpl.java:135)
at org.apache.cxf.jaxrs.rx2.client.ObservableRxInvokerImpl.lambda$method$2(ObservableRxInvokerImpl.java:162)
at org.apache.cxf.jaxrs.rx2.client.ObservableRxInvokerImpl$$Lambda$65/0x35b54c88.get(Unknown Source)
at org.apache.cxf.jaxrs.rx2.client.ObservableRxInvokerImpl$1.subscribe(ObservableRxInvokerImpl.java:175)
at io.reactivex.internal.operators.observable.ObservableCreate.subscribeActual(ObservableCreate.java:40)
at io.reactivex.Observable.subscribe(Observable.java:12090)
at io.reactivex.internal.operators.observable.ObservableSubscribeOn$SubscribeTask.run(ObservableSubscribeOn.java:96)
at io.reactivex.Scheduler$DisposeTask.run(Scheduler.java:578)
at io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:66)
at io.reactivex.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:57)
at java.util.concurrent.FutureTask.run(FutureTask.java:277)
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:191)
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1160)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
at java.lang.Thread.run(Thread.java:825)
Caused by: java.io.IOException: IOException invoking http://localhost:23/blah: Invalid Http response
at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:83)
at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:57)
at java.lang.reflect.Constructor.newInstance(Constructor.java:437)
at org.apache.cxf.transport.http.HTTPConduit$WrappedOutputStream.mapException(HTTPConduit.java:1458)
at org.apache.cxf.transport.http.HTTPConduit$WrappedOutputStream.close(HTTPConduit.java:1441)
at org.apache.cxf.io.AbstractWrappedOutputStream.close(AbstractWrappedOutputStream.java:77)
at org.apache.cxf.transport.AbstractConduit.close(AbstractConduit.java:56)
at org.apache.cxf.transport.http.HTTPConduit.close(HTTPConduit.java:691)
at org.apache.cxf.interceptor.MessageSenderInterceptor$MessageSenderEndingInterceptor.handleMessage(MessageSenderInterceptor.java:63)
... 22 more
Caused by: java.io.IOException: Invalid Http response
at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:83)
at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:57)
at java.lang.reflect.Constructor.newInstance(Constructor.java:437)
at sun.net.[www.protocol.http.HttpURLConnection$10.run(HttpURLConnection.java:1962)](http://www.protocol.http.httpurlconnection%2410.run%28httpurlconnection.java:1962)/)
at sun.net.[www.protocol.http.HttpURLConnection$10.run(HttpURLConnection.java:1957)](http://www.protocol.http.httpurlconnection%2410.run%28httpurlconnection.java:1957)/)
at java.security.AccessController.doPrivileged(AccessController.java:738)
at sun.net.[www.protocol.http.HttpURLConnection.getChainedException(HttpURLConnection.java:1956)](http://www.protocol.http.httpurlconnection.getchainedexception%28httpurlconnection.java:1956)/)
at sun.net.[www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1526)](http://www.protocol.http.httpurlconnection.getinputstream0%28httpurlconnection.java:1526)/)
at sun.net.[www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1510)](http://www.protocol.http.httpurlconnection.getinputstream%28httpurlconnection.java:1510)/)
at org.apache.cxf.transport.http.URLConnectionHTTPConduit$URLConnectionWrappedOutputStream.getInputStream(URLConnectionHTTPConduit.java:399)
at org.apache.cxf.transport.http.HTTPConduit$WrappedOutputStream.handleResponseInternal(HTTPConduit.java:1749)
at org.apache.cxf.transport.http.HTTPConduit$WrappedOutputStream.handleResponse(HTTPConduit.java:1632)
at org.apache.cxf.transport.http.HTTPConduit$WrappedOutputStream.close(HTTPConduit.java:1424)
... 26 more
Caused by: java.io.IOException: Invalid Http response
at sun.net.[www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1624)](http://www.protocol.http.httpurlconnection.getinputstream0%28httpurlconnection.java:1624)/)
at sun.net.[www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1510)](http://www.protocol.http.httpurlconnection.getinputstream%28httpurlconnection.java:1510)/)
at java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:491)
at org.apache.cxf.transport.http.URLConnectionHTTPConduit$URLConnectionWrappedOutputStream$2.run(URLConnectionHTTPConduit.java:424)
at org.apache.cxf.transport.http.URLConnectionHTTPConduit$URLConnectionWrappedOutputStream$2.run(URLConnectionHTTPConduit.java:420)
at java.security.AccessController.doPrivileged(AccessController.java:738)
at org.apache.cxf.transport.http.URLConnectionHTTPConduit$URLConnectionWrappedOutputStream.getResponseCode(URLConnectionHTTPConduit.java:420)
at org.apache.cxf.transport.http.HTTPConduit$WrappedOutputStream.doProcessResponseCode(HTTPConduit.java:1659)
at org.apache.cxf.transport.http.HTTPConduit$WrappedOutputStream.handleResponseInternal(HTTPConduit.java:1687)
... 28 more

[7/10/22 19:55:36:530 EDT] 000000c1 SystemErr                                                    R javax.ws.rs.ProcessingException: java.lang.IllegalArgumentException: Illegal status value : -1
[7/10/22 19:55:36:531 EDT] 000000c1 SystemErr                                                    R at org.apache.cxf.jaxrs.client.WebClient.handleResponse(WebClient.java:1194)
[7/10/22 19:55:36:534 EDT] 000000c1 SystemErr                                                    R at org.apache.cxf.jaxrs.client.WebClient.doResponse(WebClient.java:1161)
[7/10/22 19:55:36:535 EDT] 000000c1 SystemErr                                                    R at org.apache.cxf.jaxrs.client.WebClient.doChainedInvocation(WebClient.java:1087)
[7/10/22 19:55:36:536 EDT] 000000c1 SystemErr                                                    R at org.apache.cxf.jaxrs.client.WebClient.doInvoke(WebClient.java:932)
[7/10/22 19:55:36:537 EDT] 000000c1 SystemErr                                                    R at org.apache.cxf.jaxrs.client.WebClient.doInvoke(WebClient.java:901)
[7/10/22 19:55:36:538 EDT] 000000c1 SystemErr                                                    R at org.apache.cxf.jaxrs.client.WebClient.invoke(WebClient.java:461)
[7/10/22 19:55:36:540 EDT] 000000c1 SystemErr                                                    R at org.apache.cxf.jaxrs.client.SyncInvokerImpl.method(SyncInvokerImpl.java:135)
[7/10/22 19:55:36:542 EDT] 000000c1 SystemErr                                                    R at org.apache.cxf.jaxrs.rx2.client.ObservableRxInvokerImpl.lambda$method$2(ObservableRxInvokerImpl.java:162)
[7/10/22 19:55:36:544 EDT] 000000c1 SystemErr                                                    R at org.apache.cxf.jaxrs.rx2.client.ObservableRxInvokerImpl$$Lambda$65/0x35b54c88.get(Unknown Source)
[7/10/22 19:55:36:545 EDT] 000000c1 SystemErr                                                    R at org.apache.cxf.jaxrs.rx2.client.ObservableRxInvokerImpl$1.subscribe(ObservableRxInvokerImpl.java:175)
[7/10/22 19:55:36:547 EDT] 000000c1 SystemErr                                                    R at io.reactivex.internal.operators.observable.ObservableCreate.subscribeActual(ObservableCreate.java:40)
[7/10/22 19:55:36:549 EDT] 000000c1 SystemErr                                                    R at io.reactivex.Observable.subscribe(Observable.java:12090)
[7/10/22 19:55:36:551 EDT] 000000c1 SystemErr                                                    R at io.reactivex.internal.operators.observable.ObservableSubscribeOn$SubscribeTask.run(ObservableSubscribeOn.java:96)
[7/10/22 19:55:36:552 EDT] 000000c1 SystemErr                                                    R at io.reactivex.Scheduler$DisposeTask.run(Scheduler.java:578)
[7/10/22 19:55:36:554 EDT] 000000c1 SystemErr                                                    R at io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:66)
[7/10/22 19:55:36:555 EDT] 000000c1 SystemErr                                                    R at io.reactivex.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:57)
[7/10/22 19:55:36:557 EDT] 000000c1 SystemErr                                                    R at java.util.concurrent.FutureTask.run(FutureTask.java:277)
[7/10/22 19:55:36:559 EDT] 000000c1 SystemErr                                                    R at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:191)
[7/10/22 19:55:36:560 EDT] 000000c1 SystemErr                                                    R at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
[7/10/22 19:55:36:562 EDT] 000000c1 SystemErr                                                    R at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1160)
[7/10/22 19:55:36:564 EDT] 000000c1 SystemErr                                                    R at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[7/10/22 19:55:36:566 EDT] 000000c1 SystemErr                                                    R at java.lang.Thread.run(Thread.java:825)
[7/10/22 19:55:36:567 EDT] 000000c1 SystemErr                                                    R Caused by:
[7/10/22 19:55:36:568 EDT] 000000c1 SystemErr                                                    R java.lang.IllegalArgumentException: Illegal status value : -1
[7/10/22 19:55:36:569 EDT] 000000c1 SystemErr                                                    R at org.apache.cxf.jaxrs.impl.ResponseBuilderImpl.validateStatusCode(ResponseBuilderImpl.java:95)
[7/10/22 19:55:36:571 EDT] 000000c1 SystemErr                                                    R at org.apache.cxf.jaxrs.impl.ResponseBuilderImpl.status(ResponseBuilderImpl.java:79)
[7/10/22 19:55:36:573 EDT] 000000c1 SystemErr                                                    R at org.apache.cxf.jaxrs.utils.JAXRSUtils.toResponseBuilder(JAXRSUtils.java:1990)
[7/10/22 19:55:36:575 EDT] 000000c1 SystemErr                                                    R at org.apache.cxf.jaxrs.client.AbstractClient.setResponseBuilder(AbstractClient.java:434)
[7/10/22 19:55:36:576 EDT] 000000c1 SystemErr                                                    R at org.apache.cxf.jaxrs.client.WebClient.handleResponse(WebClient.java:1169)
[7/10/22 19:55:36:578 EDT] 000000c1 SystemErr                                                    R ... 21 more
[7/10/22 19:55:36:578 EDT] 00000078 SystemOut                                                    O testObservableRxInvoker_getCbConnectionTimeout with TIMEOUT 5000 OnError elapsed2 time 72
```