### PR TITLE
Bnd and Eclipse updates from recent changes

### DIFF
--- a/dev/io.openliberty.jakarta.servlet.jsp.tags.3.0.internal/bnd.bnd
+++ b/dev/io.openliberty.jakarta.servlet.jsp.tags.3.0.internal/bnd.bnd
@@ -11,6 +11,11 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
+javac.source: 11
+javac.target: 11
+
+Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
+
 Bundle-SymbolicName: io.openliberty.jakarta.servlet.jsp.tags.3.0.internal
 Bundle-Description: TLDs for the Jakarta Standard Tag Library; Version 3.0.0
 

--- a/dev/io.openliberty.jstl.2.0.facade/.project
+++ b/dev/io.openliberty.jstl.2.0.facade/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>io.openliberty.jstl.facade</name>
+	<name>io.openliberty.jstl.2.0.facade</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/dev/io.openliberty.pages.3.1.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.pages.3.1.internal_fat/bnd.bnd
@@ -11,13 +11,16 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
+javac.source: 11
+javac.target: 11
+
 src: \
     fat/src
 
 fat.project: true
 
 -buildpath: \
-    io.openliberty.jakarta.pages.3.0;version=latest,\
+    io.openliberty.jakarta.pages.3.1;version=latest,\
     io.openliberty.jakarta.cdi.4.0;version=latest,\
     io.openliberty.jakarta.servlet.6.0;version=latest,\
     io.openliberty.jakarta.expressionLanguage.5.0;version=latest,\

--- a/dev/io.openliberty.security.oidcclientcore.internal/.classpath
+++ b/dev/io.openliberty.security.oidcclientcore.internal/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="test"/>
+	<classpathentry kind="src" path="test" output="bin_test"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>


### PR DESCRIPTION
- Fix to have an output of bin_test for test source dir
- Fix .project file to be accurate
- Mark javac source and target to be 11 for tags and pages component. The pages fat will fail currently with Java 8 builds without this fix.