### PR TITLE
Deliver Social Client Backchannel Logout tests plus some test updates

### DIFF
--- a/dev/com.ibm.ws.security.fat.common.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/CommonTests/BackChannelLogoutCommonTests.java
+++ b/dev/com.ibm.ws.security.fat.common.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/CommonTests/BackChannelLogoutCommonTests.java
@@ -484,12 +484,7 @@ public class BackChannelLogoutCommonTests extends CommonTest {
             // set expectations for refresh token no longer valid
             refreshTokenExpectations = vData.addSuccessStatusCodes(null, Constants.INVOKE_REFRESH_ENDPOINT);
             refreshTokenExpectations = vData.addResponseStatusExpectation(refreshTokenExpectations, Constants.INVOKE_REFRESH_ENDPOINT, Constants.BAD_REQUEST_STATUS);
-            if (settings.getClientID().toLowerCase().contains("publicclient")) {
-                refreshTokenExpectations = vData.addExpectation(refreshTokenExpectations, Constants.INVOKE_REFRESH_ENDPOINT, Constants.RESPONSE_FULL, Constants.STRING_MATCHES, "Did not receive error message trying to refresh token", null, ".*" + Constants.ERROR_RESPONSE_DESCRIPTION + ".*" + MessageConstants.CWWKS1406E_INTROSPECT_INVALID_CREDENTIAL);
-            } else {
-                refreshTokenExpectations = vData.addExpectation(refreshTokenExpectations, Constants.INVOKE_REFRESH_ENDPOINT, Constants.RESPONSE_FULL, Constants.STRING_MATCHES, "Did not receive error message trying to refresh token", null, ".*" + Constants.ERROR_RESPONSE_DESCRIPTION + ".*" + MessageConstants.CWOAU0029E_TOKEN_NOT_IN_CACHE);
-
-            }
+            refreshTokenExpectations = vData.addExpectation(refreshTokenExpectations, Constants.INVOKE_REFRESH_ENDPOINT, Constants.RESPONSE_FULL, Constants.STRING_MATCHES, "Did not receive error message trying to refresh token", null, ".*" + Constants.ERROR_RESPONSE_DESCRIPTION + ".*" + MessageConstants.CWOAU0029E_TOKEN_NOT_IN_CACHE);
         }
         invokeGenericForm_refreshToken(_testName, getAndSaveWebClient(true), settings, tokenKeeper.getRefreshToken(), refreshTokenExpectations);
 
@@ -641,6 +636,16 @@ public class BackChannelLogoutCommonTests extends CommonTest {
         } else {
             expectations = vData.addExpectation(expectations, Constants.LOGOUT, Constants.RESPONSE_COOKIE, Constants.STRING_CONTAINS, "Cookie \"" + Constants.opCookieName + "\" was NOT found in the response and should have been.", null, Constants.opCookieName);
         }
+        return expectations;
+    }
+
+    public List<validationData> initLogoutWithHttpFailureExpectations(String logoutPage, String client) throws Exception {
+
+        String logoutStep = ((logoutMethodTested.equals(Constants.SAML) ? Constants.PROCESS_LOGOUT_PROPAGATE_YES : Constants.LOGOUT));
+
+        List<validationData> expectations = initLogoutExpectations(logoutPage);
+        expectations = validationTools.addMessageExpectation(testOPServer, expectations, logoutStep, Constants.TRACE_LOG, Constants.STRING_MATCHES, "Trace log did not contain message indicating that the back channel logout uri could not be invoked.", client + ".*" + MessageConstants.CWWKS2300E_HTTP_WITH_PUBLIC_CLIENT);
+
         return expectations;
     }
 

--- a/dev/com.ibm.ws.security.fat.common.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/utils/BackChannelLogout_RegisterClients.java
+++ b/dev/com.ibm.ws.security.fat.common.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/utils/BackChannelLogout_RegisterClients.java
@@ -84,6 +84,7 @@ public class BackChannelLogout_RegisterClients {
     private JSONObject setRegistrationBody(String clientId, String bcl, String postRedirect, String[] redirectOverride) {
 
         msgUtils.printMethodName("setRegistrationBody");
+        String defaultSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger";
 
         JSONObject prefix = new JSONObject();
 
@@ -96,8 +97,19 @@ public class BackChannelLogout_RegisterClients {
         // if public client, set the public flag and don't configure a secret
         if (clientId.toLowerCase().contains("public")) {
             prefix.put("publicClient", true);
+            if (clientId.toLowerCase().contains("withSecret")) {
+                prefix.put("client_secret", defaultSecret);
+            }
+            // otherwise omit the secret
         } else {
-            prefix.put("client_secret", "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger");
+            prefix.put("client_secret", defaultSecret);
+        }
+
+        // default config value for httpsRequired is true, so, only need to set the value when false
+        if (clientId.toLowerCase().contains("httpsRequired")) {
+            if (clientId.toLowerCase().contains("httpsRequired_false")) {
+                prefix.put("httpsRequired", "false");
+            }
         }
 
         // need to update this to allow a client without a bcl
@@ -256,9 +268,10 @@ public class BackChannelLogout_RegisterClients {
         registerClient("OidcConfigSample_checkDuplicateBCLCalls", "checkDupBcl_client1", clientHttpsRoot + "/backchannelLogoutTestApp/backChannelLogoutLogMsg/checkDupBcl_client1", null);
         registerClient("OidcConfigSample_checkDuplicateBCLCalls", "checkDupBcl_client2", clientHttpsRoot + "/backchannelLogoutTestApp/backChannelLogoutLogMsg/checkDupBcl_client2", null);
 
-        registerClient("OidcConfigSample_http", "bcl_http_confClient", clientHttpRoot + "/oidcclient/backchannel_logout/bcl_http_confClient", null);
+        registerClient("OidcConfigSample_http_httpsRequired_true", "bcl_http_confClient_httpsRequired_true", clientHttpRoot + "/oidcclient/backchannel_logout/bcl_http_confClient_httpsRequired_true", null);
+        registerClient("OidcConfigSample_http_httpsRequired_false", "bcl_http_confClient_httpsRequired_false", clientHttpRoot + "/oidcclient/backchannel_logout/bcl_http_confClient_httpsRequired_false", null);
         // We can't register a "bad" client - the public client test will test for the proper behavior in this case
-        //            registerClient("OidcConfigSample_http", "bcl_http_publicClient", clientHttpRoot + "/oidcclient/backchannel_logout/bcl_http_publicClient", null);
+        //            registerClient("OidcConfigSample_http_httpsRequired_true", "bcl_http_publicClient", clientHttpRoot + "/oidcclient/backchannel_logout/bcl_http_publicClient_httpsRequired_true_withSecret", null);
 
         registerClient("OidcConfigSample_idTokenCacheEnabledFalse", "idTokenCacheEnabledFalseClient-1", clientHttpsRoot + "/backchannelLogoutTestApp/backChannelLogoutLogMsg/idTokenCacheEnabledFalseClient-1", null);
         registerClient("OidcConfigSample_idTokenCacheEnabledFalse", "idTokenCacheEnabledFalseClient-2", clientHttpsRoot + "/backchannelLogoutTestApp/backChannelLogoutLogMsg/idTokenCacheEnabledFalseClient-2", null);

--- a/dev/com.ibm.ws.security.fat.common.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/utils/Constants.java
+++ b/dev/com.ibm.ws.security.fat.common.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/utils/Constants.java
@@ -44,5 +44,8 @@ public class Constants extends com.ibm.ws.security.oauth_oidc.fat.commonTest.Con
 
     public static final boolean usesValidBCLEndpoint = true;
     public static final boolean usesFakeBCLEndpoint = false;
+    public static final boolean usesInvalidBCLEndpoint = false;
+
+    public static final String SOCIAL = "SOCIAL";
 
 }

--- a/dev/com.ibm.ws.security.fat.common.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/utils/SkipIfSocialClient.java
+++ b/dev/com.ibm.ws.security.fat.common.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/utils/SkipIfSocialClient.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.backchannelLogout.fat.utils;
+
+import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.security.fat.common.utils.MySkipRule;
+
+public class SkipIfSocialClient extends MySkipRule {
+
+    protected static Class<?> thisClass = SkipIfSocialClient.class;
+    public static Boolean socialClient = false;
+
+    @Override
+    public Boolean callSpecificCheck() {
+        Log.info(thisClass, "callSpecificCheck", Boolean.toString(socialClient));
+        return socialClient;
+    }
+}

--- a/dev/com.ibm.ws.security.fat.common.backchannelLogout/publish/files/serversettings/client_configTests_filters.xml
+++ b/dev/com.ibm.ws.security.fat.common.backchannelLogout/publish/files/serversettings/client_configTests_filters.xml
@@ -172,16 +172,40 @@
 			urlPattern="/simple/checkDupBcl_client2" />
 	</authFilter>
 
-	<authFilter id="bcl_httpConfClient_filter">
+	<authFilter id="bcl_httpConfClient_httpsRequired_true_filter">
 		<requestUrl
 			matchType="contains" 
-			urlPattern="/simple/bcl_http_confClient" />
+			urlPattern="/simple/bcl_http_confClient_httpsRequired_true" />
 	</authFilter>
 
-	<authFilter id="bcl_httpPublicClient_filter">
+	<authFilter id="bcl_httpPublicClient_httpsRequired_true_withSecret_filter">
 		<requestUrl
 			matchType="contains" 
-			urlPattern="/simple/bcl_http_publicClient" />
+			urlPattern="/simple/bcl_http_publicClient_httpsRequired_true_withSecret" />
+	</authFilter>
+
+	<authFilter id="bcl_httpPublicClient_httpsRequired_true_withoutSecret_filter">
+		<requestUrl
+			matchType="contains" 
+			urlPattern="/simple/bcl_http_publicClient_httpsRequired_true_withoutSecret" />
+	</authFilter>
+
+	<authFilter id="bcl_httpConfClient_httpsRequired_false_filter">
+		<requestUrl
+			matchType="contains" 
+			urlPattern="/simple/bcl_http_confClient_httpsRequired_false" />
+	</authFilter>
+
+	<authFilter id="bcl_httpPublicClient_httpsRequired_false_withSecret_filter">
+		<requestUrl
+			matchType="contains" 
+			urlPattern="/simple/bcl_http_publicClient_httpsRequired_false_withSecret" />
+	</authFilter>
+
+	<authFilter id="bcl_httpPublicClient_httpsRequired_false_withoutSecret_filter">
+		<requestUrl
+			matchType="contains" 
+			urlPattern="/simple/bcl_http_publicClient_httpsRequired_false_withoutSecret" />
 	</authFilter>
 
 	<authFilter id="idTokenCacheEnabledFalseClient-1_filter">

--- a/dev/com.ibm.ws.security.fat.common.backchannelLogout/publish/files/serversettings/oidcClient_configTests.xml
+++ b/dev/com.ibm.ws.security.fat.common.backchannelLogout/publish/files/serversettings/oidcClient_configTests.xml
@@ -514,9 +514,9 @@
 	</openidConnectClient>
 
 	<openidConnectClient
-		id="bcl_http_confClient"
+		id="bcl_http_confClient_httpsRequired_true"
 		scope="openid profile"
-		clientId="bcl_http_confClient"
+		clientId="bcl_http_confClient_httpsRequired_true"
 		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
 		signatureAlgorithm="RS256"
 		trustStoreRef="trust_allSigAlg"
@@ -525,16 +525,17 @@
 		jwtAccessTokenRemoteValidation="require"
 		httpsRequired="false"
 		redirectToRPHostAndPort="https://localhost:${client2Port}"
-		authorizationEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http/authorize"
-		tokenEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http/token"
-		authFilterRef="bcl_httpConfClient_filter"
+		authorizationEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_true/authorize"
+		tokenEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_true/token"
+		authFilterRef="bcl_httpConfClient_httpsRequired_true_filter"
 	>
 	</openidConnectClient>
 
 	<openidConnectClient
-		id="bcl_http_publicClient"
+		id="bcl_http_publicClient_httpsRequired_true_withSecret"
 		scope="openid profile"
-		clientId="bcl_http_publicClient"
+		clientId="bcl_http_publicClient_httpsRequired_true_withSecret"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
 		signatureAlgorithm="RS256"
 		trustStoreRef="trust_allSigAlg"
 		trustAliasName="RS256"
@@ -542,9 +543,79 @@
 		jwtAccessTokenRemoteValidation="require"
 		httpsRequired="false"
 		redirectToRPHostAndPort="https://localhost:${client2Port}"
-		authorizationEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http/authorize"
-		tokenEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http/token"
-		authFilterRef="bcl_httpPublicClient_filter"
+		authorizationEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_true/authorize"
+		tokenEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_true/token"
+		authFilterRef="bcl_httpPublicClient_httpsRequired_true_withSecret_filter"
+	>
+	</openidConnectClient>
+
+	<openidConnectClient
+		id="bcl_http_publicClient_httpsRequired_true_withoutSecret"
+		scope="openid profile"
+		clientId="bcl_http_publicClient_httpsRequired_true_withoutSecret"
+		signatureAlgorithm="RS256"
+		trustStoreRef="trust_allSigAlg"
+		trustAliasName="RS256"
+		inboundPropagation="supported"
+		jwtAccessTokenRemoteValidation="require"
+		httpsRequired="false"
+		redirectToRPHostAndPort="https://localhost:${client2Port}"
+		authorizationEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_true/authorize"
+		tokenEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_true/token"
+		authFilterRef="bcl_httpPublicClient_httpsRequired_true_withoutSecret_filter"
+	>
+	</openidConnectClient>
+		
+	<openidConnectClient
+		id="bcl_http_confClient_httpsRequired_false"
+		scope="openid profile"
+		clientId="bcl_http_confClient_httpsRequired_false"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="RS256"
+		trustStoreRef="trust_allSigAlg"
+		trustAliasName="RS256"
+		inboundPropagation="supported"
+		jwtAccessTokenRemoteValidation="require"
+		httpsRequired="false"
+		redirectToRPHostAndPort="https://localhost:${client2Port}"
+		authorizationEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_false/authorize"
+		tokenEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_false/token"
+		authFilterRef="bcl_httpConfClient_httpsRequired_false_filter"
+	>
+	</openidConnectClient>
+
+	<openidConnectClient
+		id="bcl_http_publicClient_httpsRequired_false_withSecret"
+		scope="openid profile"
+		clientId="bcl_http_publicClient_httpsRequired_false_withSecret"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="RS256"
+		trustStoreRef="trust_allSigAlg"
+		trustAliasName="RS256"
+		inboundPropagation="supported"
+		jwtAccessTokenRemoteValidation="require"
+		httpsRequired="false"
+		redirectToRPHostAndPort="https://localhost:${client2Port}"
+		authorizationEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_false/authorize"
+		tokenEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_false/token"
+		authFilterRef="bcl_httpPublicClient_httpsRequired_false_withSecret_filter"
+	>
+	</openidConnectClient>
+
+	<openidConnectClient
+		id="bcl_http_publicClient_httpsRequired_false_withoutSecret"
+		scope="openid profile"
+		clientId="bcl_http_publicClient_httpsRequired_false_withoutSecret"
+		signatureAlgorithm="RS256"
+		trustStoreRef="trust_allSigAlg"
+		trustAliasName="RS256"
+		inboundPropagation="supported"
+		jwtAccessTokenRemoteValidation="require"
+		httpsRequired="false"
+		redirectToRPHostAndPort="https://localhost:${client2Port}"
+		authorizationEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_false/authorize"
+		tokenEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_false/token"
+		authFilterRef="bcl_httpPublicClient_httpsRequired_false_withoutSecret_filter"
 	>
 	</openidConnectClient>
 		

--- a/dev/com.ibm.ws.security.fat.common.backchannelLogout/publish/files/serversettings/oidcProvider_configTests.xml
+++ b/dev/com.ibm.ws.security.fat.common.backchannelLogout/publish/files/serversettings/oidcProvider_configTests.xml
@@ -538,40 +538,55 @@
 	</oauthProvider>
 	
 	<openidConnectProvider
-		id="OidcConfigSample_http"
+		id="OidcConfigSample_http_httpsRequired_true"
 		signatureAlgorithm="RS256"
 		keyAliasName="rs256"
 		keyStoreRef="key_allSigAlg"
 		tokenEndpointAuthMethodsSupported="client_secret_post, client_secret_basic, none"
 		allowPublicClients="true"
-		oauthProviderRef="OAuthConfigSample_http" />
+		oauthProviderRef="OAuthConfigSample_http_httpsRequired_true" />
 
 	<oauthProvider
-		id="OAuthConfigSample_http"
+		id="OAuthConfigSample_http_httpsRequired_true"
 		tokenFormat="${oidcTokenFormat}"
 		autoAuthorize="true"
+		httpsRequired="true"
 	>
-		<autoAuthorizeClient>bcl_http_confClient</autoAuthorizeClient>
-		<autoAuthorizeClient>bcl_http_publicClient</autoAuthorizeClient>
+		<autoAuthorizeClient>bcl_http_confClient_httpsRequired_true</autoAuthorizeClient>
+		<autoAuthorizeClient>bcl_http_publicClient_httpsRequired_true_withSecret</autoAuthorizeClient>
+		<autoAuthorizeClient>bcl_http_publicClient_httpsRequired_true_withoutSecret</autoAuthorizeClient>
 		
 		<localStore>
 			<client
-				name="bcl_http_confClient"
+				name="bcl_http_confClient_httpsRequired_true"
+				publicClient="false"
 				secret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
-				backchannelLogoutUri="http://localhost:${bvt.prop.security_2_HTTP_default}/${bclRoot}/bcl_http_confClient"
-				redirect="https://localhost:${bvt.prop.security_2_HTTP_default.secure}/oidcclient/redirect/bcl_http_confClient,
-					https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ibm/api/social-login/redirect/bcl_http_confClient"
+				backchannelLogoutUri="http://localhost:${bvt.prop.security_2_HTTP_default}/${bclRoot}/bcl_http_confClient_httpsRequired_true"
+				redirect="https://localhost:${bvt.prop.security_2_HTTP_default.secure}/oidcclient/redirect/bcl_http_confClient_httpsRequired_true,
+					https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ibm/api/social-login/redirect/bcl_http_confClient_httpsRequired_true"
 				scope="ALL_SCOPES"
 				enabled="true"
 			>
 			</client>
 			<client
-				name="bcl_http_publicClient"
+				name="bcl_http_publicClient_httpsRequired_true_withSecret"
+				publicClient="true"
+				secret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+				tokenEndpointAuthMethod="none"
+				backchannelLogoutUri="http://localhost:${bvt.prop.security_2_HTTP_default}/${bclRoot}/bcl_http_publicClient_httpsRequired_true_withSecret"
+				redirect="https://localhost:${bvt.prop.security_2_HTTP_default.secure}/oidcclient/redirect/bcl_http_publicClient_httpsRequired_true_withSecret,
+					https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ibm/api/social-login/redirect/bcl_http_publicClient_httpsRequired_true_withSecret"
+				scope="ALL_SCOPES"
+				enabled="true"
+			>
+			</client>
+			<client
+				name="bcl_http_publicClient_httpsRequired_true_withoutSecret"
 				publicClient="true"
 				tokenEndpointAuthMethod="none"
-				backchannelLogoutUri="http://localhost:${bvt.prop.security_2_HTTP_default}/${bclRoot}/bcl_http_publicClient"
-				redirect="https://localhost:${bvt.prop.security_2_HTTP_default.secure}/oidcclient/redirect/bcl_http_publicClient,
-					https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ibm/api/social-login/redirect/bcl_http_publicClient"
+				backchannelLogoutUri="http://localhost:${bvt.prop.security_2_HTTP_default}/${bclRoot}/bcl_http_publicClient_httpsRequired_true_withoutSecret"
+				redirect="https://localhost:${bvt.prop.security_2_HTTP_default.secure}/oidcclient/redirect/bcl_http_publicClient_httpsRequired_true_withoutSecret,
+					https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ibm/api/social-login/redirect/bcl_http_publicClient_httpsRequired_true_withoutSecret"
 				scope="ALL_SCOPES"
 				enabled="true"
 			>
@@ -579,7 +594,62 @@
 		</localStore>
 	</oauthProvider>
 		
+	<openidConnectProvider
+		id="OidcConfigSample_http_httpsRequired_false"
+		signatureAlgorithm="RS256"
+		keyAliasName="rs256"
+		keyStoreRef="key_allSigAlg"
+		tokenEndpointAuthMethodsSupported="client_secret_post, client_secret_basic, none"
+		allowPublicClients="true"
+		oauthProviderRef="OAuthConfigSample_http_httpsRequired_false" />
+
+	<oauthProvider
+		id="OAuthConfigSample_http_httpsRequired_false"
+		tokenFormat="${oidcTokenFormat}"
+		autoAuthorize="true"
+		httpsRequired="false"
+	>
+		<autoAuthorizeClient>bcl_http_confClient_httpsRequired_false</autoAuthorizeClient>
+		<autoAuthorizeClient>bcl_http_publicClient_httpsRequired_false_withSecret</autoAuthorizeClient>
+		<autoAuthorizeClient>bcl_http_publicClient_httpsRequired_false_withoutSecret</autoAuthorizeClient>
 		
+		<localStore>
+			<client
+				name="bcl_http_confClient_httpsRequired_false"
+				publicClient="false"
+				secret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+				backchannelLogoutUri="http://localhost:${bvt.prop.security_2_HTTP_default}/${bclRoot}/bcl_http_confClient_httpsRequired_false"
+				redirect="https://localhost:${bvt.prop.security_2_HTTP_default.secure}/oidcclient/redirect/bcl_http_confClient_httpsRequired_false,
+					https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ibm/api/social-login/redirect/bcl_http_confClient_httpsRequired_false"
+				scope="ALL_SCOPES"
+				enabled="true"
+			>
+			</client>
+			<client
+				name="bcl_http_publicClient_httpsRequired_false_withSecret"
+				publicClient="true"
+				secret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+				tokenEndpointAuthMethod="none"
+				backchannelLogoutUri="http://localhost:${bvt.prop.security_2_HTTP_default}/${bclRoot}/bcl_http_publicClient_httpsRequired_false_withSecret"
+				redirect="https://localhost:${bvt.prop.security_2_HTTP_default.secure}/oidcclient/redirect/bcl_http_publicClient_httpsRequired_false_withSecret,
+					https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ibm/api/social-login/redirect/bcl_http_publicClient_httpsRequired_false_withSecret"
+				scope="ALL_SCOPES"
+				enabled="true"
+			>
+			</client>
+			<client
+				name="bcl_http_publicClient_httpsRequired_false_withoutSecret"
+				publicClient="true"
+				tokenEndpointAuthMethod="none"
+				backchannelLogoutUri="http://localhost:${bvt.prop.security_2_HTTP_default}/${bclRoot}/bcl_http_publicClient_httpsRequired_false_withoutSecret"
+				redirect="https://localhost:${bvt.prop.security_2_HTTP_default.secure}/oidcclient/redirect/bcl_http_publicClient_httpsRequired_false_withoutSecret,
+					https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ibm/api/social-login/redirect/bcl_http_publicClient_httpsRequired_false_withoutSecret"
+				scope="ALL_SCOPES"
+				enabled="true"
+			>
+			</client>
+		</localStore>
+	</oauthProvider>		
 	<openidConnectProvider
 		id="OidcConfigSample_idTokenCacheEnabledFalse"
 		signatureAlgorithm="HS256"

--- a/dev/com.ibm.ws.security.fat.common.backchannelLogout/publish/files/serversettings/oidcProvider_configTests_notLocalStore.xml
+++ b/dev/com.ibm.ws.security.fat.common.backchannelLogout/publish/files/serversettings/oidcProvider_configTests_notLocalStore.xml
@@ -194,22 +194,44 @@
 	</oauthProvider>
 	
 	<openidConnectProvider
-		id="OidcConfigSample_http"
+		id="OidcConfigSample_http_httpsRequired_true"
 		signatureAlgorithm="RS256"
 		keyAliasName="rs256"
 		keyStoreRef="key_allSigAlg"
 		tokenEndpointAuthMethodsSupported="client_secret_post, client_secret_basic, none"
 		allowPublicClients="true"
-		oauthProviderRef="OAuthConfigSample_http" />
+		oauthProviderRef="OAuthConfigSample_http_httpsRequired_true" />
 
 	<oauthProvider
-		id="OAuthConfigSample_http"
+		id="OAuthConfigSample_http_httpsRequired_true"
 		tokenFormat="${oidcTokenFormat}"
 		autoAuthorize="true"
 	>
 		<customStore storeId="mongoDbStore" />
-		<autoAuthorizeClient>bcl_http_confClient</autoAuthorizeClient>
-		<autoAuthorizeClient>bcl_http_publicClient</autoAuthorizeClient>
+		<autoAuthorizeClient>bcl_http_confClient_httpsRequired_true</autoAuthorizeClient>
+		<autoAuthorizeClient>bcl_http_publicClient_httpsRequired_true_withSecret</autoAuthorizeClient>
+		<autoAuthorizeClient>bcl_http_publicClient_httpsRequired_true_withoutSecret</autoAuthorizeClient>
+		
+	</oauthProvider>
+		
+	<openidConnectProvider
+		id="OidcConfigSample_http_httpsRequired_false"
+		signatureAlgorithm="RS256"
+		keyAliasName="rs256"
+		keyStoreRef="key_allSigAlg"
+		tokenEndpointAuthMethodsSupported="client_secret_post, client_secret_basic, none"
+		allowPublicClients="true"
+		oauthProviderRef="OAuthConfigSample_http_httpsRequired_false" />
+
+	<oauthProvider
+		id="OAuthConfigSample_http_httpsRequired_false"
+		tokenFormat="${oidcTokenFormat}"
+		autoAuthorize="true"
+	>
+		<customStore storeId="mongoDbStore" />
+		<autoAuthorizeClient>bcl_http_confClient_httpsRequired_false</autoAuthorizeClient>
+		<autoAuthorizeClient>bcl_http_publicClient_httpsRequired_false_withSecret</autoAuthorizeClient>
+		<autoAuthorizeClient>bcl_http_publicClient_httpsRequired_false_withoutSecret</autoAuthorizeClient>
 		
 	</oauthProvider>
 		

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/TestServer.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/TestServer.java
@@ -169,15 +169,15 @@ public class TestServer extends ExternalResource {
     }
 
     public void setServerHttpPort(Integer port) {
-        this.serverHttpPort = port;
+        serverHttpPort = port;
     }
 
     public void setServerHttpsPort(Integer port) {
-        this.serverHttpsPort = port;
+        serverHttpsPort = port;
     }
 
     public Integer getServerHttpPort() {
-        return this.serverHttpPort;
+        return serverHttpPort;
     }
 
     public Integer getServerHttpsPort() {
@@ -198,11 +198,11 @@ public class TestServer extends ExternalResource {
     }
 
     public void setIgnoredServerExceptions(String[] ignoredExceptions) {
-        this.ignoredServerExceptions = ignoredExceptions.clone();
+        ignoredServerExceptions = ignoredExceptions.clone();
     }
 
     public String[] getIgnoredServerExceptions() {
-        return this.ignoredServerExceptions;
+        return ignoredServerExceptions;
     }
 
     public void setServerHostname(String hostname) {
@@ -336,6 +336,22 @@ public class TestServer extends ExternalResource {
         }
     }
 
+    /**
+     * Reset the log mark - used when the whole log needs to be scanned (not just what was logged since the last mark)
+     */
+    public void resetLogMarks() {
+        String methodName = "resetLogMarks";
+        if (!server.isStarted()) {
+            return;
+        }
+        try {
+            Log.info(thisClass, methodName, "re-setting marks for: " + server.getServerName());
+            server.resetLogMarks();// resets map to a new map - equating to resetting marks to the start of all files.
+        } catch (Exception e) {
+            Log.error(thisClass, methodName, e, "Failure re-setting the log mark.");
+        }
+    }
+
     public int getRetryTimeoutCount() {
         return retryTimeoutCount;
     }
@@ -351,9 +367,12 @@ public class TestServer extends ExternalResource {
     /**
      * Starts the current server using the server configuration file provided.
      *
-     * @param checkApps - List of apps to be validated as ready upon server start
-     * @param waitForMessages - List of regular expressions to be waited for upon server start
-     * @param reportViaJunit - boolean indicating whether failures should be reported via JUnit or if we should just
+     * @param checkApps
+     *            - List of apps to be validated as ready upon server start
+     * @param waitForMessages
+     *            - List of regular expressions to be waited for upon server start
+     * @param reportViaJunit
+     *            - boolean indicating whether failures should be reported via JUnit or if we should just
      *            log a message
      */
     public void startServer(String serverXml, String testName, List<String> checkApps, List<String> waitForMessages, boolean reportViaJunit, int[] requiredPorts) throws Exception {
@@ -547,7 +566,8 @@ public class TestServer extends ExternalResource {
      * JUnit.
      *
      * @param newServerXml
-     * @param testName - Test name that should be included in messages
+     * @param testName
+     *            - Test name that should be included in messages
      * @throws exception
      */
     public void reconfigServer(String newServerXml, String testName) throws Exception {
@@ -559,9 +579,12 @@ public class TestServer extends ExternalResource {
      * indicating that the server configuration was updated.
      *
      * @param newServerXml
-     * @param testName - Test name that should be included in messages
-     * @param waitForMessages - List of regular expressions to be waited for upon server update/restart
-     * @param reportViaJunit - boolean indicating whether failures should be reported via JUnit or if we should just
+     * @param testName
+     *            - Test name that should be included in messages
+     * @param waitForMessages
+     *            - List of regular expressions to be waited for upon server update/restart
+     * @param reportViaJunit
+     *            - boolean indicating whether failures should be reported via JUnit or if we should just
      *            log a message
      * @throws exception
      */
@@ -574,10 +597,14 @@ public class TestServer extends ExternalResource {
      * indicating that the server configuration was updated.
      *
      * @param newServerXml
-     * @param testName - Test name that should be included in messages
-     * @param waitForMessages - List of regular expressions to be waited for upon server update/restart
-     * @param restartServer - boolean indicating whether the server should be restarted
-     * @param reportViaJunit - boolean indicating whether failures should be reported via JUnit or if we should just
+     * @param testName
+     *            - Test name that should be included in messages
+     * @param waitForMessages
+     *            - List of regular expressions to be waited for upon server update/restart
+     * @param restartServer
+     *            - boolean indicating whether the server should be restarted
+     * @param reportViaJunit
+     *            - boolean indicating whether failures should be reported via JUnit or if we should just
      *            log a message
      * @throws exception
      */
@@ -662,10 +689,14 @@ public class TestServer extends ExternalResource {
      * Restarts the current server using the server configuration file provided.
      *
      * @param serverXml
-     * @param testName - Test name that should be included in messages
-     * @param checkApps - List of apps to be validated as ready upon server start
-     * @param waitForMessages - List of regular expressions to be waited for upon server start
-     * @param reportViaJunit - boolean indicating whether failures should be reported via JUnit or if we should just
+     * @param testName
+     *            - Test name that should be included in messages
+     * @param checkApps
+     *            - List of apps to be validated as ready upon server start
+     * @param waitForMessages
+     *            - List of regular expressions to be waited for upon server start
+     * @param reportViaJunit
+     *            - boolean indicating whether failures should be reported via JUnit or if we should just
      *            log a message
      * @throws exception
      */
@@ -766,10 +797,13 @@ public class TestServer extends ExternalResource {
      * Waits for the server to complete a configuration update. Also waits for all messages included in startMessages
      * to appear in the log.
      *
-     * @param testName - Test name that should be included in messages
-     * @param reportViaJunit - boolean indicating whether failures should be reported via JUnit or if we should just
+     * @param testName
+     *            - Test name that should be included in messages
+     * @param reportViaJunit
+     *            - boolean indicating whether failures should be reported via JUnit or if we should just
      *            log a message
-     * @param waitForMessages - List of regular expressions to be waited for
+     * @param waitForMessages
+     *            - List of regular expressions to be waited for
      * @throws Exception
      */
     public void waitForServer(String testName, List<String> waitForMessages, boolean reportViaJunit) throws Exception {
@@ -977,7 +1011,8 @@ public class TestServer extends ExternalResource {
      * Copy the specified server config file to server.xml. Make a copy of the server config in the testServers sub-directory for
      * debug use later.
      *
-     * @param copyFromFile - File to copy into the server's root directory as server.xml
+     * @param copyFromFile
+     *            - File to copy into the server's root directory as server.xml
      */
     public void copyNewServerConfig(String copyFromFile, String testName) throws Exception {
         String thisMethod = "copyNewServerConfig";
@@ -1056,8 +1091,10 @@ public class TestServer extends ExternalResource {
      * Builds and returns the absolute path to the specified file within the configs/ directory under the given
      * server's root directory.
      *
-     * @param theServer - The server instance containing the specified file
-     * @param fileName - Name of the file within the configs/ directory to build the path for
+     * @param theServer
+     *            - The server instance containing the specified file
+     * @param fileName
+     *            - Name of the file within the configs/ directory to build the path for
      * @return The absolute path to the specified file within the server's configs/ directory
      */
     public String buildFullServerConfigPath(LibertyServer theServer, String fileName) {
@@ -1093,8 +1130,10 @@ public class TestServer extends ExternalResource {
      * Searches and waits for message strings in the default log and reports success/failure of the search either via a
      * message and possibly JUnit reporting.
      *
-     * @param waitForMessages - List of regular expression strings to wait for in the default log
-     * @param reportViaJunit - boolean indicating whether failures should be reported via JUnit or if we should just
+     * @param waitForMessages
+     *            - List of regular expression strings to wait for in the default log
+     * @param reportViaJunit
+     *            - boolean indicating whether failures should be reported via JUnit or if we should just
      *            log a message
      */
     public void validateStartMessages(List<String> waitForMessages, boolean reportViaJunit) throws Exception {
@@ -1106,10 +1145,13 @@ public class TestServer extends ExternalResource {
      * message and possibly JUnit reporting. If expectedResult is false, the passed messages are expected NOT to be
      * found.
      *
-     * @param waitForMessages - List of regular expression strings to wait for in the default log
-     * @param reportViaJunit - boolean indicating whether failures should be reported via JUnit or if we should just
+     * @param waitForMessages
+     *            - List of regular expression strings to wait for in the default log
+     * @param reportViaJunit
+     *            - boolean indicating whether failures should be reported via JUnit or if we should just
      *            log a message
-     * @param expectedResult - If true, the messages specified are expected to be found. Otherwise, the passed messages
+     * @param expectedResult
+     *            - If true, the messages specified are expected to be found. Otherwise, the passed messages
      *            are expected NOT to be found.
      * @throws Exception
      */
@@ -1154,7 +1196,8 @@ public class TestServer extends ExternalResource {
     /**
      * Searches for a message string in the specified server log.
      *
-     * @param expected - a validationMsg type to search (contains the log to search and the string to search for)
+     * @param expected
+     *            - a validationMsg type to search (contains the log to search and the string to search for)
      * @throws Exception
      */
     public void validateWithServerLog(String checkType, String where, String errorMsg, String valueToCheck) throws Exception {
@@ -1196,9 +1239,12 @@ public class TestServer extends ExternalResource {
     /**
      * Searches for and returns the line containing message string in the specified server log.
      *
-     * @param valueToCheck - identified unique string to determine the line containing the string
-     * @param where - which log to search for
-     * @exception - throws error if no string is found
+     * @param valueToCheck
+     *            - identified unique string to determine the line containing the string
+     * @param where
+     *            - which log to search for
+     * @exception -
+     *                throws error if no string is found
      *
      * @return - returns the string of the line found within the specified server log
      *
@@ -1223,7 +1269,8 @@ public class TestServer extends ExternalResource {
     /**
      * Searches for passwords in the server logs.
      *
-     * @param expected - a validationMsg type to search (contains the log to search and the string to search for)
+     * @param expected
+     *            - a validationMsg type to search (contains the log to search and the string to search for)
      * @throws Exception
      */
     public int searchForPasswordsInLogs(String where) throws Exception {
@@ -1334,7 +1381,6 @@ public class TestServer extends ExternalResource {
         }
     }
 
-
     public void unInstallCallbackHandler(String callbackHandler, String feature) throws Exception {
         if (feature != null) {
             Log.info(thisClass, "unInstallCallbackHandler", "Un-Installing callback handler feature: " + feature);
@@ -1345,7 +1391,6 @@ public class TestServer extends ExternalResource {
             server.uninstallUserBundle(callbackHandler);
         }
     }
-
 
     /** TODO *************************************** Bootstrap utils *****************************************/
 

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonTest.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonTest.java
@@ -2705,7 +2705,11 @@ public class CommonTest extends com.ibm.ws.security.fat.common.CommonTest {
 
         List<endpointSettings> parms = eSettings.addEndpointSettings(null, "refresh_token", originalRefreshToken);
         parms = eSettings.addEndpointSettings(parms, "client_id", settings.getClientID());
-        parms = eSettings.addEndpointSettings(parms, "client_secret", settings.getClientSecret());
+        if (settings.getClientSecret() != null) {
+            parms = eSettings.addEndpointSettings(parms, "client_secret", settings.getClientSecret());
+        } else {
+            parms = eSettings.addEndpointSettings(parms, "client_secret", "null");
+        }
         parms = eSettings.addEndpointSettings(parms, "token_endpoint", settings.getTokenEndpt());
         parms = eSettings.addEndpointSettings(parms, "scope", settings.getScope());
         // parms = eSettings.addEndpointSettings(parms, "grant_type",

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/test-applications/oauthclient/resources/refresh.jsp
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/test-applications/oauthclient/resources/refresh.jsp
@@ -72,13 +72,16 @@ if (submit) {
 		connToken.setDoOutput(true);
 		OutputStreamWriter wrToken = new OutputStreamWriter(connToken.getOutputStream());
 		StringBuffer sb = new StringBuffer();
-		sb.append("client_id=" + clientId + 
-		         "&client_secret=" + clientSecret +
-		         "&grant_type=refresh_token" +
+		sb.append("client_id=" + clientId);
+		if (clientSecret != null && clientSecret.trim().length() > 0 && !clientSecret.equals("null")) {
+		    sb.append("&client_secret=" + clientSecret) ;
+		}
+		sb.append("&grant_type=refresh_token" +
 		         "&refresh_token=" + refreshToken);
 		if (scope != null && scope.trim().length() > 0) {
 			sb.append("&scope=" + scope);
 		} 
+		System.out.println("refresh.jsp parms: " + sb.toString());
 		wrToken.write(sb.toString());
 		wrToken.flush();
 		wrToken.close();

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/bnd.bnd
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/bnd.bnd
@@ -23,7 +23,7 @@ fat.project: true
 
 publish.wlp.jar.disabled: true
 
-tested.features:  jsp-2.2, servlet-3.1, osgiconsole-1.0, openidconnectserver-1.0, jsp-2.3, jaxrs-2.0, jaxrsclient-2.0, el-3.0
+tested.features:  restfulwsclient-3.0, transportsecurity-1.0, appsecurity-4.0, expressionlanguage-4.0, servlet-5.0, concurrent-2.0, restfulws-3.0, jsonp-2.0, cdi-3.0, pages-3.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.jsonp.1.0;version=latest,\
@@ -48,5 +48,6 @@ tested.features:  jsp-2.2, servlet-3.1, osgiconsole-1.0, openidconnectserver-1.0
 	org.glassfish:javax.json;version='1.0',\
 	com.ibm.json4j;version=latest,\
 	org.bitbucket.b_c.jose4j,\
+	com.ibm.ws.security.fat.common.social;version=latest,\
 	com.ibm.ws.security.jwt;version=latest
 

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/build.gradle
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/build.gradle
@@ -10,7 +10,9 @@
  *******************************************************************************/
 apply from: '../com.ibm.ws.security.fat.common.backchannelLogout/CommonBackchannelLogout.gradle'
 
-addRequiredLibraries.dependsOn copyGenericServer
+addRequiredLibraries.dependsOn copyGenericServer, copyGenericClient
+
+autoFVT.dependsOn ':com.ibm.ws.security.fat.common.social:assemble'
 
 autoFVT.doLast {
   
@@ -21,67 +23,19 @@ autoFVT.doLast {
     'com.ibm.ws.security.backchannelLogout_fat.social'
   ]
   servers.each { server ->
-    copy { 
-      from project(':com.ibm.ws.security.fat.common.backchannelLogout').file('publish/servers/' + server)
-      into new File(autoFvtDir, 'publish/servers/' + server)
-      include '**'
-    }
-    
-    copy { 
-      from project(':com.ibm.ws.security.fat.common.backchannelLogout').file('publish/files/serversettings/')
+  
+      copy { 
+      from new File(projectDir, 'publish/files/serversettings/')
       into new File(autoFvtDir, 'publish/servers/' + server + '/imports')
       include '*.xml'
     }
-    
-    copy { 
-      from new File(project(':com.ibm.ws.security.fat.common').buildDir, 'test-application/testmarker.war')
-      into new File(autoFvtDir, 'publish/servers/' + server + '/dropins')
-    }
 
-  	/* copy shared key/trust stores from the common security fat project */
-    copy { 
-     from project(':com.ibm.ws.security.fat.common').file('publish/shared/securityKeys')
-     into new File(autoFvtDir, 'publish/servers/' + server + '/')
-     include 'allAlgKeyStore.p12'
-     include 'allAlgTrustStore.p12'
-    }
-    
-    copy {
-      from new File(project(':com.ibm.ws.security.oauth.oidc_fat.common').projectDir, "/securitykeys")
-      into new File(autoFvtDir, 'publish/servers/' + server)
-      include 'commonBasicKeyStore.jks'
-      include 'commonTrustStore.jks'
-      include 'commonBadTrustStore.jks'
-    }
-    copy {
-      from new File(project(':com.ibm.ws.security.oauth.oidc_fat.common').projectDir, 'publish/files/serversettings/')
-      into new File(autoFvtDir, 'publish/servers/' + server + '/imports')
-      include 'oauthRoles_1.xml'
-    }  
-    
-    copy {
-      from project(':com.ibm.ws.security.fat.common.jwt').file('publish/shared/config')
-      into new File(autoFvtDir, 'publish/servers/' + server+ '/imports')
-      include 'signEncryptSSLSettings.xml'
-    }
-    
-    copy {
-      from project(':com.ibm.ws.security.fat.common.jwt').file('publish/shared/securityKeys')
-      into new File(autoFvtDir, 'publish/servers/' + server + '/')
-      include '*.pem'
-    }
-    
-    copy {
-      from new File(project(":com.ibm.ws.security.fat.common.backchannelLogout").buildDir, "test-application/backchannelLogoutTestApp.zip")
-      into new File(autoFvtDir, 'publish/servers/' + server + '/test-apps')
-      rename 'backchannelLogoutTestApp.zip', 'backchannelLogoutTestApp.war'
-    }
-
+    /* overwrite formlogin from oidc with the social version */
     copy {
       from new File(project(":com.ibm.ws.security.fat.common.social").buildDir, "test-application/formlogin.war")
       into new File(autoFvtDir, 'publish/servers/' + server + '/test-apps')
     }
-    
+   
   }
               
 }

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/BasicBCLTests.java
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/BasicBCLTests.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.security.backchannelLogout.fat;
+
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+import com.ibm.ws.security.backchannelLogout.fat.utils.Constants;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServerWrapper;
+
+/**
+ * This test class contains tests that validate the proper behavior in end-to-end end_session requests.
+ * These tests will focus on the proper logout/end_session behavior based on the OP and OAuth registered client
+ * configs.
+ **/
+
+@RunWith(FATRunner.class)
+@LibertyServerWrapper
+@Mode(TestMode.FULL)
+@AllowedFFDC({ "org.apache.http.NoHttpResponseException", "com.ibm.oauth.core.api.error.oauth20.OAuth20InvalidTokenException" })
+public class BasicBCLTests extends com.ibm.ws.security.backchannelLogout.fat.CommonTests.BasicBCLTests {
+
+    @ClassRule
+    public static RepeatTests repeat = createRepeats(Constants.SOCIAL);
+
+}

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/FATSuite.java
@@ -11,18 +11,24 @@
 
 package com.ibm.ws.security.backchannelLogout.fat;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
+import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
+
 import componenttest.custom.junit.runner.AlwaysPassesTest;
+import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
         AlwaysPassesTest.class,
         HttpMethodsTests.class,
         LogoutTokenValidationTests.class,
-        //  TODO      bclbasictests.class
+        BasicBCLTests.class
 
 })
 /**
@@ -35,10 +41,9 @@ public class FATSuite {
      *
      * This was done to increase coverage of EE9 while not adding a large amount of of test runtime.
      */
-    //    @ClassRule
-    //    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
-    //            .andWith(new JakartaEE9Action().fullFATOnly());
-    //    @ClassRule
-    //    public static RepeatTests repeat = RepeatTests.withoutModification(); // adding no modification for now to enable the updates to test case naming
+    @ClassRule
+    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
+            .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
+            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().alwaysAddFeature("servlet-5.0").fullFATOnly());
 
 }

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/gradle.properties
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/gradle.properties
@@ -14,3 +14,8 @@ srcServerName=com.ibm.ws.security.backchannelLogout_fat.op
 # to exclude the default server configs, omit <serverName>_copyServerConfigs and add 
 #  steps to the current project's build.gradle to populate the publish server's configs dir
 com.ibm.ws.security.backchannelLogout_fat.op_copyServerConfigs=true
+
+# these are the clients to create based on the basic backchannelLogout rp 
+clientNames=com.ibm.ws.security.backchannelLogout_fat.social
+srcClientName=com.ibm.ws.security.backchannelLogout_fat.rp
+com.ibm.ws.security.backchannelLogout_fat.rp_copyClientConfigs=false

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/publish/files/serversettings/socialClientFeatures.xml
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/publish/files/serversettings/socialClientFeatures.xml
@@ -1,0 +1,23 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+	<featureManager>
+        <feature>servlet-3.1</feature> <!-- required for EE9 repeat -->
+        <feature>ssl-1.0</feature>
+        <feature>jsp-2.3</feature>
+        <feature>appSecurity-2.0</feature>
+        <feature>socialLogin-1.0</feature>
+        <feature>jaxrs-2.0</feature>
+	</featureManager>
+
+</server>
+    

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/publish/files/serversettings/socialClient_configTests.xml
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/publish/files/serversettings/socialClient_configTests.xml
@@ -1,0 +1,655 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+ 
+ <!--  Lots of similar configs because we're using test apps for backchannel logout (so we can record/return the logout_token - when we share configs between tests, we can't rely on which bcl requests we'll get or their order  -->
+<server>
+
+	<oidcLogin
+		id="bcl_mainPath"
+		scope="profile email openid"
+		clientId="bcl_mainPath"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		sharedKey="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_mainPath/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_mainPath/token"
+		hostNameVerificationEnabled="false"
+		authFilterRef="bcl_mainPath_filter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="bcl_defaultBCLTimeout"
+		scope="profile email openid"
+		clientId="bcl_defaultBCLTimeout"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		sharedKey="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_defaultBCLTimeout/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_defaultBCLTimeout/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_defaultBCLTimeout/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="bcl_defaultBCLTimeout_filter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="bcl_otherDefaultBCLTimeout"
+		scope="profile email openid"
+		clientId="bcl_otherDefaultBCLTimeout"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_defaultBCLTimeout/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_defaultBCLTimeout/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_defaultBCLTimeout/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="bcl_otherDefaultBCLTimeout_filter"
+	>
+	</oidcLogin>
+
+
+
+	<oidcLogin
+		id="bcl_shortBCLTimeout"
+		scope="profile email openid"
+		clientId="bcl_shortBCLTimeout"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_shortBCLTimeout/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_shortBCLTimeout/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_shortBCLTimeout/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="bcl_shortBCLTimeout_filter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="bcl_otherShortBCLTimeout"
+		scope="profile email openid"
+		clientId="bcl_otherShortBCLTimeout"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_shortBCLTimeout/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_shortBCLTimeout/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_shortBCLTimeout/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="bcl_otherShortBCLTimeout_filter"
+	>
+	</oidcLogin>
+
+
+	<oidcLogin
+		id="bcl_invalidBCLUri"
+		scope="profile email openid"
+		clientId="bcl_invalidBCLUri"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_invalidBCL/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_invalidBCL/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_invalidBCL/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="bcl_invalidBCLUri_filter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="bcl_omittedBCLUri"
+		scope="profile email openid"
+		clientId="bcl_omittedBCLUri"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_invalidBCL/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_invalidBCL/token"
+ 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_invalidBCL/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="bcl_omittedBCLUri_filter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="bcl_returns400"
+		scope="profile email openid"
+		clientId="bcl_returns400"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_invalidBCL/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_invalidBCL/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_invalidBCL/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="bcl_returns400_filter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="bcl_returns501"
+		scope="profile email openid"
+		clientId="bcl_returns501"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_invalidBCL/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_invalidBCL/token"
+ 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_invalidBCL/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="bcl_returns501_filter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="bcl_logsMsg"
+		scope="profile email openid"
+		clientId="bcl_logsMsg"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_invalidBCL/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_invalidBCL/token"
+ 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_invalidBCL/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="bcl_logsMsg_filter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="loggerClient1-1"
+		scope="profile email openid"
+		clientId="loggerClient1-1"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger1/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger1/token"
+ 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger1/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="loggerClient1-1_filter"
+	>
+	</oidcLogin>
+				
+	<oidcLogin
+		id="loggerClient1-2"
+		scope="profile email openid"
+		clientId="loggerClient1-2"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger1/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger1/token"
+ 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger1/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="loggerClient1-2_filter"
+	>
+	</oidcLogin>
+				
+	<oidcLogin
+		id="loggerClient1-3"
+		scope="profile email openid"
+		clientId="loggerClient1-3"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger1/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger1/token"
+ 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger1/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="loggerClient1-3_filter"
+	>
+	</oidcLogin>
+				
+	<oidcLogin
+		id="loggerClient1-4"
+		scope="profile email openid"
+		clientId="loggerClient1-4"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger1/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger1/token"
+ 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger1/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="loggerClient1-4_filter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="loggerClient2-1"
+		scope="profile email openid"
+		clientId="loggerClient2-1"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger2/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger2/token"
+ 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger2/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="loggerClient2-1_filter"
+	>
+	</oidcLogin>
+				
+	<oidcLogin
+		id="loggerClient2-2"
+		scope="profile email openid"
+		clientId="loggerClient2-2"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger2/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger2/token"
+ 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger2/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="loggerClient2-2_filter"
+	>
+	</oidcLogin>
+				
+	<oidcLogin
+		id="loggerClient2-3"
+		scope="profile email openid"
+		clientId="loggerClient2-3"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger2/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger2/token"
+ 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger2/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="loggerClient2-3_filter"
+	>
+	</oidcLogin>
+				
+	<oidcLogin
+		id="loggerClient2-4"
+		scope="profile email openid"
+		clientId="loggerClient2-4"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger2/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger2/token"
+ 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger2/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="loggerClient2-4_filter"
+	>
+	</oidcLogin>
+	
+	<oidcLogin
+		id="loggerClient3-1"
+		scope="profile email openid"
+		clientId="loggerClient3-1"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger3/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger3/token"
+ 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger3/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="loggerClient3-1_filter"
+	>
+	</oidcLogin>
+				
+	<oidcLogin
+		id="loggerClient4-1"
+		scope="profile email openid"
+		clientId="loggerClient4-1"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger4/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger4/token"
+ 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_logger4/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="loggerClient4-1_filter"
+	>
+	</oidcLogin>
+	
+	<oidcLogin
+		id="useLogoutTokenForAccess_introspect"
+		scope="profile email openid"
+		clientId="useLogoutTokenForAccess"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		sharedKey="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_useLogoutTokenForAccess/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_useLogoutTokenForAccess/token"
+		hostNameVerificationEnabled="false"
+		authFilterRef="useLogoutTokenForAccess_introspect_filter"
+		accessTokenSupported="true"
+	>
+	</oidcLogin>
+	<oidcLogin
+		id="useLogoutTokenForAccess_userinfo"
+		scope="profile email openid"
+		clientId="useLogoutTokenForAccess"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		sharedKey="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_useLogoutTokenForAccess/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_useLogoutTokenForAccess/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_useLogoutTokenForAccess/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="useLogoutTokenForAccess_userinfo_filter"
+		accessTokenSupported="true"
+	>
+	</oidcLogin>
+				
+	<oidcLogin
+		id="bcl_client1"
+		scope="profile email openid"
+		clientId="bcl_client1"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		sharedKey="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_multiClientWithAndWithoutBCL/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_multiClientWithAndWithoutBCL/token"
+		hostNameVerificationEnabled="false"
+		authFilterRef="bcl_client1_filter"
+	>
+	</oidcLogin>
+	<oidcLogin
+		id="bcl_client2"
+		scope="profile email openid"
+		clientId="bcl_client2"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		sharedKey="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_multiClientWithAndWithoutBCL/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_multiClientWithAndWithoutBCL/token"
+		hostNameVerificationEnabled="false"
+		authFilterRef="bcl_client2_filter"
+	>
+	</oidcLogin>
+	<oidcLogin
+		id="nobcl_client1"
+		scope="profile email openid"
+		clientId="nobcl_client1"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		sharedKey="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_multiClientWithAndWithoutBCL/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_multiClientWithAndWithoutBCL/token"
+		hostNameVerificationEnabled="false"
+		authFilterRef="nobcl_client1_filter"
+	>
+	</oidcLogin>
+				
+	<oidcLogin
+		id="checkDupBcl_client1"
+		scope="profile email openid"
+		clientId="checkDupBcl_client1"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		sharedKey="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_checkDuplicateBCLCalls/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_checkDuplicateBCLCalls/token"
+		hostNameVerificationEnabled="false"
+		authFilterRef="checkDupBcl_client1_filter"
+	>
+	</oidcLogin>
+	<oidcLogin
+		id="checkDupBcl_client2"
+		scope="profile email openid"
+		clientId="checkDupBcl_client2"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		sharedKey="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_checkDuplicateBCLCalls/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_checkDuplicateBCLCalls/token"
+		hostNameVerificationEnabled="false"
+		authFilterRef="checkDupBcl_client2_filter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="bcl_http_confClient_httpsRequired_true"
+		scope="profile email openid"
+		clientId="bcl_http_confClient_httpsRequired_true"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="RS256"
+		trustStoreRef="trust_allSigAlg"
+		trustAliasName="RS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_true/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_true/token"
+		hostNameVerificationEnabled="false"
+		authFilterRef="bcl_httpConfClient_httpsRequired_true_filter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="bcl_http_publicClient_httpsRequired_true_withSecret"
+		scope="profile email openid"
+		clientId="bcl_http_publicClient_httpsRequired_true_withSecret"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="RS256"
+		trustStoreRef="trust_allSigAlg"
+		trustAliasName="RS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_true/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_true/token"
+		hostNameVerificationEnabled="false"
+		authFilterRef="bcl_httpPublicClient_httpsRequired_true_withSecret_filter"
+	>
+	</oidcLogin>
+	
+	<!-- client is invalid, so exclude -->	
+	<!--
+	<oidcLogin
+		id="bcl_http_publicClient_withoutSecret"
+		scope="profile email openid"
+		clientId="bcl_http_publicClient_withoutSecret"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="RS256"
+		trustStoreRef="trust_allSigAlg"
+		trustAliasName="RS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http/token"
+		hostNameVerificationEnabled="false"
+		authFilterRef="bcl_httpPublicClient_withoutSecret_filter"
+	>
+	</oidcLogin>
+	-->
+
+	<oidcLogin
+		id="bcl_http_confClient_httpsRequired_false"
+		scope="profile email openid"
+		clientId="bcl_http_confClient_httpsRequired_false"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="RS256"
+		trustStoreRef="trust_allSigAlg"
+		trustAliasName="RS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_false/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_false/token"
+		hostNameVerificationEnabled="false"
+		authFilterRef="bcl_httpConfClient_httpsRequired_false_filter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="bcl_http_publicClient_httpsRequired_false_withSecret"
+		scope="profile email openid"
+		clientId="bcl_http_publicClient_httpsRequired_false_withSecret"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="RS256"
+		trustStoreRef="trust_allSigAlg"
+		trustAliasName="RS256"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_false/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_false/token"
+		hostNameVerificationEnabled="false"
+		authFilterRef="bcl_httpPublicClient_httpsRequired_false_withSecret_filter"
+	>
+	</oidcLogin>
+	
+		
+	<oidcLogin
+		id="idTokenCacheEnabledFalseClient-1"
+		scope="profile email openid"
+		clientId="idTokenCacheEnabledFalseClient-1"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		sharedKey="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_idTokenCacheEnabledFalse/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_idTokenCacheEnabledFalse/token"
+		hostNameVerificationEnabled="false"
+		authFilterRef="idTokenCacheEnabledFalseClient-1_filter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="idTokenCacheEnabledFalseClient-2"
+		scope="profile email openid"
+		clientId="idTokenCacheEnabledFalseClient-2"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		sharedKey="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_idTokenCacheEnabledFalse/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_idTokenCacheEnabledFalse/token"
+		hostNameVerificationEnabled="false"
+		authFilterRef="idTokenCacheEnabledFalseClient-2_filter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="idTokenCacheEnabledFalseClient-3"
+		scope="profile email openid"
+		clientId="idTokenCacheEnabledFalseClient-3"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		sharedKey="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_idTokenCacheEnabledFalse/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_idTokenCacheEnabledFalse/token"
+		hostNameVerificationEnabled="false"
+		authFilterRef="idTokenCacheEnabledFalseClient-3_filter"
+	>
+	</oidcLogin>
+		
+	<oidcLogin
+		id="accessTokenCacheEnabledFalseClient-1"
+		scope="profile email openid"
+		clientId="accessTokenCacheEnabledFalseClient-1"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		sharedKey="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_accessTokenCacheEnabledFalse/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_accessTokenCacheEnabledFalse/token"
+		hostNameVerificationEnabled="false"
+		authFilterRef="accessTokenCacheEnabledFalseClient-1_filter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="accessTokenCacheEnabledFalseClient-2"
+		scope="profile email openid"
+		clientId="accessTokenCacheEnabledFalseClient-2"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		sharedKey="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_accessTokenCacheEnabledFalse/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_accessTokenCacheEnabledFalse/token"
+		hostNameVerificationEnabled="false"
+		authFilterRef="accessTokenCacheEnabledFalseClient-2_filter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="accessTokenCacheEnabledFalseClient-3"
+		scope="profile email openid"
+		clientId="accessTokenCacheEnabledFalseClient-3"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="HS256"
+		sharedKey="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		createSession="true"
+		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_accessTokenCacheEnabledFalse/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_accessTokenCacheEnabledFalse/token"
+		hostNameVerificationEnabled="false"
+		authFilterRef="accessTokenCacheEnabledFalseClient-3_filter"
+	>
+	</oidcLogin>
+				
+</server>

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/publish/files/serversettings/socialClient_httpMethods.xml
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/publish/files/serversettings/socialClient_httpMethods.xml
@@ -1,0 +1,27 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+	<oidcLogin 
+		id="client01" 
+		signatureAlgorithm="HS256"
+		clientId="client01" 
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/userinfo"
+		userInfoEndpointEnabled="true" 
+		issuer="testIssuer"
+		hostNameVerificationEnabled="false"
+		>
+	</oidcLogin>
+
+</server>

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/publish/files/serversettings/socialClient_logoutTokenValidation.xml
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/publish/files/serversettings/socialClient_logoutTokenValidation.xml
@@ -1,0 +1,252 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+	<oidcLogin
+		id="clientSignHS256"
+		clientId="clientSignHS256"
+		signatureAlgorithm="HS256"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_hs/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_hs/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_hs/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="myClientSignHS256AuthFilter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="clientSignHS384"
+		clientId="clientSignHS384"
+		signatureAlgorithm="${HS384}"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_hs/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_hs/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_hs/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="myClientSignHS384AuthFilter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="clientSignHS512"
+		clientId="clientSignHS512"
+		signatureAlgorithm="${HS512}"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_hs/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_hs/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_hs/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		authFilterRef="myClientSignHS512AuthFilter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="clientSignRS256"
+		clientId="clientSignRS256"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="RS256"
+		trustAliasName="RS256"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		sslRef="ssl_allSigAlg"
+		authFilterRef="myClientSignRS256AuthFilter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="clientSignRS384"
+		clientId="clientSignRS384"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="${RS384}"
+		trustAliasName="${RS384}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		sslRef="ssl_allSigAlg"
+		authFilterRef="myClientSignRS384AuthFilter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="clientSignRS512"
+		clientId="clientSignRS512"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="${RS512}"
+		trustAliasName="${RS512}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		sslRef="ssl_allSigAlg"
+		authFilterRef="myClientSignRS512AuthFilter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="clientSignES256"
+		clientId="clientSignES256"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="${ES256}"
+		trustAliasName="${ES256}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		sslRef="ssl_allSigAlg"
+		authFilterRef="myClientSignES256AuthFilter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="clientSignES384"
+		clientId="clientSignES384"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="${ES384}"
+		trustAliasName="${ES384}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		sslRef="ssl_allSigAlg"
+		authFilterRef="myClientSignES384AuthFilter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="clientSignES512"
+		clientId="clientSignES512"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="${ES512}"
+		trustAliasName="${ES512}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		sslRef="ssl_allSigAlg"
+		authFilterRef="myClientSignES512AuthFilter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="clientSignEncryptRS256"
+		clientId="clientSignEncryptRS256"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="RS256"
+		trustAliasName="RS256"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		keyManagementKeyAlias="${RS256_keyMgmtAlias}"
+		sslRef="ssl_allSigAlg"
+		authFilterRef="myClientSignEncryptRS256AuthFilter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="clientSignEncryptRS384"
+		clientId="clientSignEncryptRS384"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="${RS384}"
+		trustAliasName="${RS384}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		keyManagementKeyAlias="${RS384_keyMgmtAlias}"
+		sslRef="ssl_allSigAlg"
+		authFilterRef="myClientSignEncryptRS384AuthFilter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="clientSignEncryptRS512"
+		clientId="clientSignEncryptRS512"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="${RS512}"
+		trustAliasName="${RS512}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		keyManagementKeyAlias="${RS512_keyMgmtAlias}"
+		sslRef="ssl_allSigAlg"
+		authFilterRef="myClientSignEncryptRS512AuthFilter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="clientSignEncryptES256"
+		clientId="clientSignEncryptES256"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="${ES256}"
+		trustAliasName="${ES256}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		keyManagementKeyAlias="${ES256_keyMgmtAlias}"
+		sslRef="ssl_allSigAlg"
+		authFilterRef="myClientSignEncryptES256AuthFilter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="clientSignEncryptES384"
+		clientId="clientSignEncryptES384"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="${ES384}"
+		trustAliasName="${ES384}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		keyManagementKeyAlias="${ES384_keyMgmtAlias}"
+		sslRef="ssl_allSigAlg"
+		authFilterRef="myClientSignEncryptES384AuthFilter"
+	>
+	</oidcLogin>
+
+	<oidcLogin
+		id="clientSignEncryptES512"
+		clientId="clientSignEncryptES512"
+		clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+		signatureAlgorithm="${ES512}"
+		trustAliasName="${ES512}"
+		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/authorize"
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/token"
+		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_rs/userinfo"
+		userInfoEndpointEnabled="true"
+		hostNameVerificationEnabled="false"
+		keyManagementKeyAlias="${ES512_keyMgmtAlias}"
+		sslRef="ssl_allSigAlg"
+		authFilterRef="myClientSignEncryptES512AuthFilter"
+	>
+	</oidcLogin>
+</server>

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/publish/servers/com.ibm.ws.security.backchannelLogout_fat.social/bootstrap.properties
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/publish/servers/com.ibm.ws.security.backchannelLogout_fat.social/bootstrap.properties
@@ -18,6 +18,7 @@ io.openliberty.security*=all:\
 com.ibm.ws.security.oauth*=all=enabled:\
 com.ibm.ws.security.jwt*=all=enabled:\
 com.ibm.ws.security.common*=all=enabled:\
+com.ibm.ws.security.social*=all=enabled:\
 com.ibm.ws.webcontainer.security.*=all=enabled:\
 org.apache.http.client.*=all
 

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/publish/servers/com.ibm.ws.security.backchannelLogout_fat.social/configs/social_server_basicTests.xml
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/publish/servers/com.ibm.ws.security.backchannelLogout_fat.social/configs/social_server_basicTests.xml
@@ -1,0 +1,32 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+
+<server>
+
+	<include location="${server.config.dir}/imports/socialClientFeatures.xml" />
+
+	<include location="${server.config.dir}/imports/socialClient_configTests.xml" />
+	<include location="${server.config.dir}/imports/client_configTests_filters.xml" />
+
+	<include location="${server.config.dir}/imports/goodBasicRegistry.xml" />
+
+	<include location="${server.config.dir}/imports/goodSSLSettings.xml" />
+	<include location="${server.config.dir}/imports/signEncryptSSLSettings.xml" />
+
+	<include location="${server.config.dir}/imports/formlogin_1.xml" />
+	<include location="${server.config.dir}/imports/backchannelLogoutTestApp.xml" />
+	<include location="${server.config.dir}/imports/simpleLogoutTestApp.xml" />
+
+	<include location="${server.config.dir}/imports/rp_fatTestPorts.xml" />
+	
+	<include location="${server.config.dir}/imports/clientMisc.xml" />
+
+</server>

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/publish/servers/com.ibm.ws.security.backchannelLogout_fat.social/configs/social_server_basicTests_false.xml
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/publish/servers/com.ibm.ws.security.backchannelLogout_fat.social/configs/social_server_basicTests_false.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+        <httpSession
+                cookieHttpOnly="false"
+                cookieName="clientJSESSIONID"
+                securityIntegrationEnabled="false" />
+
+        <include location="${server.config.dir}/configs/social_server_basicTests.xml" />
+</server>
+

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/publish/servers/com.ibm.ws.security.backchannelLogout_fat.social/configs/social_server_basicTests_true.xml
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/publish/servers/com.ibm.ws.security.backchannelLogout_fat.social/configs/social_server_basicTests_true.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+        <httpSession 
+                cookieHttpOnly="false"
+                cookieName="clientJSESSIONID"
+                securityIntegrationEnabled="true" />
+
+        <include location="${server.config.dir}/configs/social_server_basicTests.xml" />
+</server>
+


### PR DESCRIPTION
Deliver Back channel logout tests using a social client.
Tests classes use common tests provided by com.ibm.ws.security.fat.common.backchannel.
Tests repeat to cover bcl behavior when the end_session and logout endpoints are invoked on the OP as well as use of a logout app on the RP which invokes req.logout() and then either end_session or logout on the OP.

For https://github.com/OpenLiberty/open-liberty/issues/20049