### PR TITLE
Update the Microprofile Rest Client TCK FAT projects

### DIFF
--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/bnd.bnd
@@ -17,6 +17,9 @@ src: \
 
 fat.project: true
 
+# These features get added programatically
+tested.features: \
+  mpconfig-2.0
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/fat/src/org/eclipse/microprofile/graphql/tck/GraphQLTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/fat/src/org/eclipse/microprofile/graphql/tck/GraphQLTckPackageTest.java
@@ -46,10 +46,15 @@ public class GraphQLTckPackageTest {
     @Server("FATServer")
     public static LibertyServer server;
 
+    @BeforeClass
+    public static void setUp() throws Exception {
+        server.startServer();
+    }
+
     @AfterClass
     public static void tearDown() throws Exception {
         if (server != null) {
-            server.postStopServerArchive(); // must explicitly collect since arquillian is starting/stopping the server
+            server.stopServer("CWNEN0047W", "CWNEN0049W", "CWWKZ0014W");
         }
     }
 

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/bnd.bnd
@@ -17,6 +17,12 @@ src: \
 
 fat.project: true
 
+# These features get added programatically
+tested.features: \
+  servlet-4.0, \
+  cdi-2.0, \
+  jsonp-1.1, \
+  jaxrsclient-2.1
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -11,24 +11,24 @@
 package org.eclipse.microprofile.rest.client.tck;
 
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.HashSet;
+import com.ibm.websphere.simplicity.log.Log;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Map;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.utils.MvnUtils;
 
 /**
@@ -39,18 +39,32 @@ import componenttest.topology.utils.MvnUtils;
 public class RestClientTckPackageTest {
 
     @ClassRule
-    public static RepeatTests r = 
+    public static RepeatTests r =
         RepeatTests.withoutModification()
                    .andWith(FeatureReplacementAction.EE8_FEATURES());
 
     @Server("FATServer")
     public static LibertyServer server;
 
+    @BeforeClass
+    public static void setUp() throws Exception {
+    	String javaVersion = System.getProperty("java.version");
+    	Log.info(RestClientTckPackageTest.class, "setup", "javaVersion: " + javaVersion);
+    	System.out.println("java.version = " + javaVersion);
+    	if (javaVersion.startsWith("1.8")) {
+    		Path cwd = Paths.get(".");
+    		Log.info(RestClientTckPackageTest.class, "setup", "cwd = " +  cwd.toAbsolutePath());
+    		Path java8File = Paths.get("publish/tckRunner/tck/tck-suite.xml-java8");
+    	    Path tckSuiteFile = Paths.get("publish/tckRunner/tck/tck-suite.xml");
+    	    Files.copy(java8File, tckSuiteFile, StandardCopyOption.REPLACE_EXISTING);
+    	}
+        server.startServer();
+    }
+
     @AfterClass
     public static void tearDown() throws Exception {
         if (server != null) {
-            server.postStopServerArchive(); // must explicitly collect since arquillian is starting/stopping the server
-//            server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWWKZ0002E");
+            server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWWKZ0002E");
         }
     }
 

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/servers/FATServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/servers/FATServer/server.xml
@@ -1,9 +1,9 @@
 <!--Copyright (c) 2018 IBM Corporation and others. All rights reserved.
-    This program and the accompanying materials are made available under the 
-    terms of the Eclipse Public License v1.0 which accompanies this distribution, 
-    and is available at 
-        http://www.eclipse.org/legal/epl-v10.html 
-    Contributors: 
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v1.0 which accompanies this distribution,
+    and is available at
+        http://www.eclipse.org/legal/epl-v10.html
+    Contributors:
         IBM Corporation - initial API and implementation
 -->
 <server>
@@ -20,6 +20,6 @@
     <include location="../fatTestPorts.xml" />
 
     <!--Java2 security-->
-    <!-- <javaPermission className="java.security.AllPermission"  name="*" actions="*" /> -->
+    <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 
 </server>

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -11,21 +11,21 @@
 package org.eclipse.microprofile.rest.client.tck;
 
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.HashSet;
+import com.ibm.websphere.simplicity.log.Log;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Map;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.utils.MvnUtils;
 
 /**
@@ -38,11 +38,25 @@ public class RestClientTckPackageTest {
     @Server("FATServer")
     public static LibertyServer server;
 
+    @BeforeClass
+    public static void setUp() throws Exception {
+    	String javaVersion = System.getProperty("java.version");
+    	Log.info(RestClientTckPackageTest.class, "setup", "javaVersion: " + javaVersion);
+    	System.out.println("java.version = " + javaVersion);
+    	if (javaVersion.startsWith("1.8")) {
+    		Path cwd = Paths.get(".");
+    		Log.info(RestClientTckPackageTest.class, "setup", "cwd = " +  cwd.toAbsolutePath());
+    		Path java8File = Paths.get("publish/tckRunner/tck/tck-suite.xml-java8");
+    	    Path tckSuiteFile = Paths.get("publish/tckRunner/tck/tck-suite.xml");
+    	    Files.copy(java8File, tckSuiteFile, StandardCopyOption.REPLACE_EXISTING);
+    	}
+        server.startServer();
+    }
+
     @AfterClass
     public static void tearDown() throws Exception {
         if (server != null) {
-            server.postStopServerArchive(); // must explicitly collect since arquillian is starting/stopping the server
-//            server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWWKZ0002E");
+            server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWWKZ0002E");
         }
     }
 

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/servers/FATServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/servers/FATServer/server.xml
@@ -1,9 +1,9 @@
 <!--Copyright (c) 2019 IBM Corporation and others. All rights reserved.
-    This program and the accompanying materials are made available under the 
-    terms of the Eclipse Public License v1.0 which accompanies this distribution, 
-    and is available at 
-        http://www.eclipse.org/legal/epl-v10.html 
-    Contributors: 
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v1.0 which accompanies this distribution,
+    and is available at
+        http://www.eclipse.org/legal/epl-v10.html
+    Contributors:
         IBM Corporation - initial API and implementation
 -->
 <server>
@@ -18,5 +18,8 @@
     </featureManager>
 
     <include location="../fatTestPorts.xml" />
+
+    <!--Java2 security-->
+    <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 
 </server>

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -11,21 +11,21 @@
 package org.eclipse.microprofile.rest.client.tck;
 
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.HashSet;
+import com.ibm.websphere.simplicity.log.Log;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Map;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.utils.MvnUtils;
 
 /**
@@ -38,11 +38,25 @@ public class RestClientTckPackageTest {
     @Server("FATServer")
     public static LibertyServer server;
 
+    @BeforeClass
+    public static void setUp() throws Exception {
+    	String javaVersion = System.getProperty("java.version");
+    	Log.info(RestClientTckPackageTest.class, "setup", "javaVersion: " + javaVersion);
+    	System.out.println("java.version = " + javaVersion);
+    	if (javaVersion.startsWith("1.8")) {
+    		Path cwd = Paths.get(".");
+    		Log.info(RestClientTckPackageTest.class, "setup", "cwd = " +  cwd.toAbsolutePath());
+    		Path java8File = Paths.get("publish/tckRunner/tck/tck-suite.xml-java8");
+    	    Path tckSuiteFile = Paths.get("publish/tckRunner/tck/tck-suite.xml");
+    	    Files.copy(java8File, tckSuiteFile, StandardCopyOption.REPLACE_EXISTING);
+    	}
+        server.startServer();
+    }
+
     @AfterClass
     public static void tearDown() throws Exception {
         if (server != null) {
-            server.postStopServerArchive(); // must explicitly collect since arquillian is starting/stopping the server
-//            server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWWKZ0002E");
+            server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWWKZ0002E", "CWNEN0047W", "CWNEN0049W");
         }
     }
 

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/servers/FATServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/servers/FATServer/server.xml
@@ -1,9 +1,9 @@
 <!--Copyright (c) 2019 IBM Corporation and others. All rights reserved.
-    This program and the accompanying materials are made available under the 
-    terms of the Eclipse Public License v1.0 which accompanies this distribution, 
-    and is available at 
-        http://www.eclipse.org/legal/epl-v10.html 
-    Contributors: 
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v1.0 which accompanies this distribution,
+    and is available at
+        http://www.eclipse.org/legal/epl-v10.html
+    Contributors:
         IBM Corporation - initial API and implementation
 -->
 <server>
@@ -18,5 +18,8 @@
     </featureManager>
 
     <include location="../fatTestPorts.xml" />
+
+    <!--Java2 security-->
+    <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 
 </server>

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -11,21 +11,21 @@
 package org.eclipse.microprofile.rest.client.tck;
 
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.HashSet;
+import com.ibm.websphere.simplicity.log.Log;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Map;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.utils.MvnUtils;
 
 /**
@@ -38,11 +38,25 @@ public class RestClientTckPackageTest {
     @Server("FATServer")
     public static LibertyServer server;
 
+    @BeforeClass
+    public static void setUp() throws Exception {
+    	String javaVersion = System.getProperty("java.version");
+    	Log.info(RestClientTckPackageTest.class, "setup", "javaVersion: " + javaVersion);
+    	System.out.println("java.version = " + javaVersion);
+    	if (javaVersion.startsWith("1.8")) {
+    		Path cwd = Paths.get(".");
+    		Log.info(RestClientTckPackageTest.class, "setup", "cwd = " +  cwd.toAbsolutePath());
+    		Path java8File = Paths.get("publish/tckRunner/tck/tck-suite.xml-java8");
+    	    Path tckSuiteFile = Paths.get("publish/tckRunner/tck/tck-suite.xml");
+    	    Files.copy(java8File, tckSuiteFile, StandardCopyOption.REPLACE_EXISTING);
+    	}
+        server.startServer();
+    }
+
     @AfterClass
     public static void tearDown() throws Exception {
         if (server != null) {
-            server.postStopServerArchive(); // must explicitly collect since arquillian is starting/stopping the server
-//            server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWWKZ0002E");
+            server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWWKZ0002E", "CWNEN0047W", "CWNEN0049W");
         }
     }
 

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/servers/FATServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/servers/FATServer/server.xml
@@ -1,9 +1,9 @@
 <!--Copyright (c) 2020 IBM Corporation and others. All rights reserved.
-    This program and the accompanying materials are made available under the 
-    terms of the Eclipse Public License v1.0 which accompanies this distribution, 
-    and is available at 
-        http://www.eclipse.org/legal/epl-v10.html 
-    Contributors: 
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v1.0 which accompanies this distribution,
+    and is available at
+        http://www.eclipse.org/legal/epl-v10.html
+    Contributors:
         IBM Corporation - initial API and implementation
 -->
 <server>
@@ -19,5 +19,8 @@
     </featureManager>
 
     <include location="../fatTestPorts.xml" />
+
+    <!--Java2 security-->
+    <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 
 </server>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -10,23 +10,22 @@
  *******************************************************************************/
 package org.eclipse.microprofile.rest.client.tck;
 
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.Map;
-import java.util.HashMap;
-import java.util.HashSet;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.ibm.websphere.simplicity.log.Log;
+
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.utils.MvnUtils;
 
 /**
@@ -39,16 +38,25 @@ public class RestClientTckPackageTest {
     @Server("FATServer")
     public static LibertyServer server;
 
-//    @BeforeClass
-//    public static void setUp() throws Exception {
-//        server.startServer();
-//    }
-//
+    @BeforeClass
+    public static void setUp() throws Exception {
+    	String javaVersion = System.getProperty("java.version");
+    	Log.info(RestClientTckPackageTest.class, "setup", "javaVersion: " + javaVersion);
+    	System.out.println("java.version = " + javaVersion);
+    	if (javaVersion.startsWith("1.8")) {
+    		Path cwd = Paths.get(".");
+    		Log.info(RestClientTckPackageTest.class, "setup", "cwd = " +  cwd.toAbsolutePath());
+    		Path java8File = Paths.get("publish/tckRunner/tck/tck-suite.xml-java8");
+    	    Path tckSuiteFile = Paths.get("publish/tckRunner/tck/tck-suite.xml");
+    	    Files.copy(java8File, tckSuiteFile, StandardCopyOption.REPLACE_EXISTING);
+    	}
+        server.startServer();
+    }
+
     @AfterClass
     public static void tearDown() throws Exception {
         if (server != null) {
-            server.postStopServerArchive(); // must explicitly collect since arquillian is starting/stopping the server
-//            server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWWKZ0002E");
+            server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWWKZ0002E");
         }
     }
 


### PR DESCRIPTION
Update the Microprofile Rest Client TCK FAT projects to have the FAT test harness manage the lifecycle of the Liberty server instead of Maven.

We are seeing issues in our builds with Liberty servers taking too long to start on slower hardware. By having the test harness manage the lifecycle of the Liberty server instead of Maven we should mitigate the impact of the build break, but it doesn't solve the underlying problem of the kernel sometimes taking > 30s to start up (especially on our slower Windows hardware).