### PR TITLE
Remove obsolete comments and suppresswarnings from CpuInfo.

### DIFF
--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/CpuInfo.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/CpuInfo.java
@@ -75,9 +75,6 @@ public class CpuInfo {
     private static final long INTERVAL = 10; // in minutes
     private static Collection<AvailableProcessorsListener> listeners = Collections.synchronizedCollection(new HashSet<AvailableProcessorsListener>());
 
-    // TODO: 'JavaInfo.vendor()' is deprecated.
-    //       See the assignment of 'nsFactor', below.
-    @SuppressWarnings({ "deprecation" })
     private CpuInfo() {
         activeTask = new IntervalTask();
         executor.scheduleAtFixedRate(activeTask, INTERVAL, INTERVAL, TimeUnit.MINUTES);
@@ -94,13 +91,6 @@ public class CpuInfo {
         } else {
             AVAILABLE_PROCESSORS.set(fileSystemAvailableProcessors);
         }
-
-        // TODO: 
-        // According to the deprecation comment on 'JavaInfo.vendor(), a test
-        // of the actual capability should be made instead of relying on the
-        // vendor information.  That is, something about the java environment
-        // should be checked to tell that the java vendor is IBM, instead of
-        // this access to vendor.
 
         int nsFactor = 1;
         // Adjust for J9 cpuUsage units change from hundred-nanoseconds to nanoseconds in IBM Java8sr5


### PR DESCRIPTION
Updates made to add comments to CpuInfo by pull request #21559 are made obsolete by the preceding pull request #21482.  Those comments should have been removed during the merge, but were not.