### PR TITLE
com.ibm.ws.ui_rest_fat test problem

### DIFF
--- a/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/CatalogPersistenceTest.java
+++ b/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/CatalogPersistenceTest.java
@@ -135,7 +135,7 @@ public class CatalogPersistenceTest extends CommonRESTTest implements APIConstan
      */
     @Test
     public void catalogLoadNoErrorTest() throws Exception {
-        restartWithNewPersistedCatalog("simpleCatalog.json");
+        ignoreErrorAndRestartWithNewPersistedCatalog("simpleCatalog.json");
 
         // Confirm the catalog JSON contents
         response = get(url, adminUser, adminPassword, 200);
@@ -164,7 +164,7 @@ public class CatalogPersistenceTest extends CommonRESTTest implements APIConstan
      */
     @Test
     public void catalogLoadJSONWrongFieldTest() throws Exception {
-        restartWithNewPersistedCatalog("simpleTool.json");
+        ignoreErrorAndRestartWithNewPersistedCatalog("simpleTool.json");
 
         // Confirm catalog contents
         response = get(url, adminUser, adminPassword, 200);
@@ -283,7 +283,7 @@ public class CatalogPersistenceTest extends CommonRESTTest implements APIConstan
         assertSize(bookmarks, 2); // The default (openliberty.io) + newly added
 
         // restart server
-        stopServerAndValidate(server);
+        ignoreErrorAndStopServerWithValidate();
         startServerAndValidate(server);
 
         // Get the (now persisted)

--- a/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/FeatureToolServiceTest.java
+++ b/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/FeatureToolServiceTest.java
@@ -132,6 +132,16 @@ public class FeatureToolServiceTest extends CommonRESTTest implements APIConstan
             }
         }
 
+        if (FATSuite.server.fileExistsInLibertyServerRoot("server-original.xml")){
+            FATSuite.server.deleteFileFromLibertyServerRoot("server.xml");
+            FATSuite.server.renameLibertyServerRootFile("server-original.xml", "server.xml");
+            if (FATSuite.server.fileExistsInLibertyServerRoot("server-original.xml")) {
+                Log.info(c, method.getMethodName(), "WARNING: The original server.xml file couldn't be restored. It would cause other testsuites to fail.");
+            } else {
+                Log.info(c, method.getMethodName(), "The original server.xml was successfully restored.");
+            }
+        }
+
         removeCoreFeatureL10N(BASIC_AUTOFEATURE_L10N);
         for (String feature : coreFeatures)
             removeCoreFeature(feature);
@@ -864,9 +874,6 @@ public class FeatureToolServiceTest extends CommonRESTTest implements APIConstan
         findFeatureTool(featureTools, "scopedprodextn%3Acom.ibm.websphere.appserver.prodextn1-1.0-1.0.0",
                         "scopedprodextn:com.ibm.websphere.appserver.prodextn1-1.0", "1.0.0",
                         "Prod Extn 1 Tool Display Name", null);
-
-        ignoreErrorAndStopServerWithValidate();
-        FATSuite.server.renameLibertyServerRootFile("server-original.xml", "server.xml");
     }
 
     /**


### PR DESCRIPTION
Fix test in
- FeatureToolServiceTest to delete the current server.xml before restoring the original server.xml to see whether that would fix the problem on Windows machine not restoring the original server.xml
- CatalogPersistenceTest to fix problem when running tests in different order than written