### PR TITLE
Delay creation of LibertyProxyInvocationHandler until first invoke

### DIFF
--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/bnd.bnd
@@ -100,7 +100,8 @@ Include-Resource:\
   com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
   javax.activation:activation;version=1.1,\
   com.ibm.websphere.appserver.api.basics,\
-  com.ibm.ws.kernel.service
+  com.ibm.ws.kernel.service,\
+  com.ibm.ws.kernel.boot.core;version=latest
 
 -testpath: \
   ../build.sharedResources/lib/junit/old/junit.jar;version=file,\

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/ot/LibertyProxyInvocationHandlerCheckpoint.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/ot/LibertyProxyInvocationHandlerCheckpoint.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.jboss.resteasy.microprofile.client.ot;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
+
+import javax.enterprise.inject.spi.BeanManager;
+
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+
+import io.openliberty.checkpoint.spi.CheckpointHook;
+
+/**
+ * A handler only used if we are doing a checkpoint
+ */
+public class LibertyProxyInvocationHandlerCheckpoint implements InvocationHandler, CheckpointHook{
+    final AtomicReference<LibertyProxyInvocationHandler> delegate = new AtomicReference<>();
+
+    final LibertyRestClientBuilderImpl libertyBuilder;
+    final ResteasyClientBuilder resteasyClientBuilder;
+    final Class<?> aClass;
+    final ClassLoader classLoader;
+    final BeanManager beanManager;
+    final Map<Method, List<InterceptorInvoker>> interceptorInvokers;
+    LibertyProxyInvocationHandlerCheckpoint(final LibertyRestClientBuilderImpl libertyBuilder, final ResteasyClientBuilder resteasyClientBuilder, final Class<?> aClass, final ClassLoader classLoader, final BeanManager beanManager, final Map<Method, List<InterceptorInvoker>> interceptorInvokers) {
+        this.libertyBuilder = libertyBuilder;
+        this.resteasyClientBuilder = resteasyClientBuilder;
+        this.aClass = aClass;
+        this.classLoader = classLoader;
+        this.beanManager = beanManager;
+        this.interceptorInvokers = interceptorInvokers;
+    }
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        return delegate.updateAndGet(new UnaryOperator<LibertyProxyInvocationHandler>() {
+            @Override
+            public LibertyProxyInvocationHandler apply(LibertyProxyInvocationHandler t) {
+                if (t != null) {
+                    return t;
+                }
+                return libertyBuilder.createLibertyProxyInvocationHandler(resteasyClientBuilder, aClass, classLoader, beanManager, interceptorInvokers);
+            }
+        }).invoke(proxy, method, args);
+    }
+
+}


### PR DESCRIPTION
Creating the LibertyProxyInvocationHandler first requires building
the ResteasyClient.  That requires access to the JVM security
stack that is not available before the checkpoint. This change
delays creating the LibertyProxyInvocationHandler (and therefore
the ResteasyClient) until the rest client instance is first invoked
by application code. If nothing invokes the rest client object
before the checkpoint then that allows for the JVM security stack
to be avoided until the restore side.

This approach still has a issue that the rest client cannot be
configured with respect to the URI used to connect to for invoking
the rest client on the restore side.
