### PR TITLE
Fix test bug

### DIFF
--- a/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/JavaeeFeatureTests15.java
+++ b/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/JavaeeFeatureTests15.java
@@ -58,7 +58,7 @@ public class JavaeeFeatureTests15 extends AbstractSpringTests {
     public void modifyServerConfiguration(ServerConfiguration config) {
         ORB orb = config.getOrb();
         orb.setId("defaultOrb");
-        orb.setOrbSSLInitTimeout("30");
+        orb.setOrbSSLInitTimeout("45");
 
         List<KeyStore> keystores = config.getKeyStores();
         keystores.clear();

--- a/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/JavaeeFeatureTests20.java
+++ b/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/JavaeeFeatureTests20.java
@@ -45,7 +45,7 @@ public class JavaeeFeatureTests20 extends AbstractSpringTests {
     public void modifyServerConfiguration(ServerConfiguration config) {
         ORB orb = config.getOrb();
         orb.setId("defaultOrb");
-        orb.setOrbSSLInitTimeout("30");
+        orb.setOrbSSLInitTimeout("45");
 
         List<KeyStore> keystores = config.getKeyStores();
         keystores.clear();


### PR DESCRIPTION
Fix bug in SpringBoot JavaEE tests where ORB SSL initialization exceeds 30 seconds, causing applications not to start. 

RTC 291351.