### PR TITLE
Issue #21817: Use jar for classpath on zos

### DIFF
--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -294,7 +294,10 @@
 		<echo message="test.bucket.path including junit: ${toString:test.bucket.path}" />
 
 		<iff>
-			<istrue value="${is.windows.platform}" />
+			<or>
+				<istrue value="${is.windows.platform}" />
+				<istrue value="${is.zos.platform}" />
+			</or>
 			<then>
 				<echo>generating classpath jar file.</echo>
 				<property name="classpath.jar.name" value="${basedir}/build/lib/cp.jar" />


### PR DESCRIPTION
Use jar for classpath so _fat tests from open-liberty can run on z/OS systems using JAVA 11.