### PR TITLE
Issue #20428: Don't throw UnsupportedOperationException

### DIFF
--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/osgi/webapp/WebApp31.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/osgi/webapp/WebApp31.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -149,7 +149,7 @@ public class WebApp31 extends com.ibm.ws.webcontainer.osgi.webapp.WebApp
     
     @Override
     public String getVirtualServerName() {
-        if (withinContextInitOfProgAddListener) {
+        if (withinContextInitOfProgAddListener && (WebContainer.getServletContainerSpecLevel() < WebContainer.SPEC_LEVEL_60)) {
             throw new UnsupportedOperationException(MessageFormat.format(
             		servlet31NLS.getString("Unsupported.op.from.servlet.context.listener.31"),
             		new Object[] {"getVirtualServerName", lastProgAddListenerInitialized, getApplicationName()}));  // 130165, PI41941            
@@ -182,7 +182,7 @@ public class WebApp31 extends com.ibm.ws.webcontainer.osgi.webapp.WebApp
      */
     @Override
     public ClassLoader getClassLoader() {
-        if (withinContextInitOfProgAddListener) {
+        if (withinContextInitOfProgAddListener && (WebContainer.getServletContainerSpecLevel() < WebContainer.SPEC_LEVEL_60)) {
             throw new UnsupportedOperationException(MessageFormat.format(
                     servlet31NLS.getString("Unsupported.op.from.servlet.context.listener.31"),
                     new Object[] {"getClassLoader", lastProgAddListenerInitialized, getApplicationName()}));  // 130165, PI41941
@@ -192,7 +192,7 @@ public class WebApp31 extends com.ibm.ws.webcontainer.osgi.webapp.WebApp
     
     @Override
     public int getEffectiveMajorVersion() throws UnsupportedOperationException {
-        if (withinContextInitOfProgAddListener) {
+        if (withinContextInitOfProgAddListener && (WebContainer.getServletContainerSpecLevel() < WebContainer.SPEC_LEVEL_60)) {
             throw new UnsupportedOperationException(MessageFormat.format(
                     servlet31NLS.getString("Unsupported.op.from.servlet.context.listener.31"),
                     new Object[] {"getEffectiveMajorVersion", lastProgAddListenerInitialized, getApplicationName()}));  // 130165, PI41941
@@ -202,7 +202,7 @@ public class WebApp31 extends com.ibm.ws.webcontainer.osgi.webapp.WebApp
 
     @Override
     public int getEffectiveMinorVersion() throws UnsupportedOperationException {
-        if (withinContextInitOfProgAddListener) {
+        if (withinContextInitOfProgAddListener && (WebContainer.getServletContainerSpecLevel() < WebContainer.SPEC_LEVEL_60)) {
             throw new UnsupportedOperationException(MessageFormat.format(
                     servlet31NLS.getString("Unsupported.op.from.servlet.context.listener.31"),
                     new Object[] {"getEffectiveMinorVersion", lastProgAddListenerInitialized, getApplicationName()}));  // 130165, PI41941

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/FATSuite.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/FATSuite.java
@@ -37,6 +37,7 @@ import com.ibm.ws.webcontainer.servlet31.fat.tests.UpgradeWriteListenerHttpUnit;
 import com.ibm.ws.webcontainer.servlet31.fat.tests.VHServerHttpUnit;
 import com.ibm.ws.webcontainer.servlet31.fat.tests.WCServerHttpUnit;
 import com.ibm.ws.webcontainer.servlet31.fat.tests.WCServerTest;
+import com.ibm.ws.webcontainer.servlet31.fat.tests.WCServletContextUnsupportedOperationExceptionTest;
 
 import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
@@ -67,7 +68,8 @@ import componenttest.topology.impl.JavaInfo;
                 CDIServletFilterListenerDynamicTest.class,
                 CDIServletFilterListenerTest.class,
                 FormLoginReadListenerTest.class,
-                NBMultiReadTest.class
+                NBMultiReadTest.class,
+                WCServletContextUnsupportedOperationExceptionTest.class
 })
 public class FATSuite {
 

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/WCServerTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/WCServerTest.java
@@ -68,7 +68,6 @@ public class WCServerTest extends LoggingTest {
     private static final String TEST_SERVLET_31_JAR_NAME = "TestServlet31";
     private static final String TEST_METADATA_COMPLETE_JAR_NAME = "TestMetadataComplete";
     private static final String TEST_METADATA_COMPLETE_EXCLUDED_FRAGMENT_JAR_NAME = "TestMetadataCompleteExcludedFragment";
-    private static final String TEST_PROGRAMATIC_LISTENER_ADDITION_JAR_NAME = "TestProgrammaticListenerAddition";
     private static final String SINGLETON_STORE_JAR_NAME = "SingletonStore";
     private static final String TEST_SERVLET_31_APP_NAME = "TestServlet31";
     private static final String TEST_METADATA_COMPLETE_APP_NAME = "TestMetadataComplete";
@@ -76,7 +75,6 @@ public class WCServerTest extends LoggingTest {
     private static final String SESSION_ID_LISTENER_APP_NAME = "SessionIdListener";
     private static final String SERVLET_CONTEXT_ADD_LISTENER_APP_NAME = "ServletContextAddListener";
     private static final String SERVLET_CONTEXT_CREATE_LISTENER_APP_NAME = "ServletContextCreateListener";
-    private static final String TEST_PROGRAMATIC_LISTENER_ADDITION_APP_NAME = "TestProgrammaticListenerAddition";
     private static final String TEST_SERVLET_MAPPING_APP_NAME = "TestServletMapping";
     private static final String TEST_SERVLET_MAPPING_ANNO_APP_NAME = "TestServletMappingAnno";
 
@@ -99,9 +97,7 @@ public class WCServerTest extends LoggingTest {
                                                                                    "com.ibm.ws.webcontainer.servlet_31_fat.testmetadatacompleteexcludedfragment.jar.servlets");
         TestMetadataCompleteExcludeJar = (JavaArchive) ShrinkHelper.addDirectory(TestMetadataCompleteExcludeJar,
                                                                                  "test-applications/TestMetadataCompleteExcludedFragment.jar/resources");
-        JavaArchive TestProgrammaticListenerJar = ShrinkHelper.buildJavaArchive(TEST_PROGRAMATIC_LISTENER_ADDITION_JAR_NAME + ".jar",
-                                                                                "com.ibm.ws.webcontainer.servlet_31_fat.testprogrammaticlisteneraddition.jar.listeners");
-        TestProgrammaticListenerJar = (JavaArchive) ShrinkHelper.addDirectory(TestProgrammaticListenerJar, "test-applications/TestProgrammaticListenerAddition.jar/resources");
+
         JavaArchive SingletonStoreJar = ShrinkHelper.buildJavaArchive(SINGLETON_STORE_JAR_NAME + ".jar",
                                                                       "com.ibm.ws.webcontainer.servlet_31_fat.singletonstore.jar.teststorage");
         // Build the war apps and add the dependencies
@@ -129,8 +125,6 @@ public class WCServerTest extends LoggingTest {
                                                                                   "com.ibm.ws.webcontainer.servlet_31_fat.servletcontextcreatelistener.war.listeners");
         ServletContextCreateListenerApp = ServletContextCreateListenerApp.addAsLibraries(TestServlet31Jar);
 
-        WebArchive TestProgrammaticListenerApp = ShrinkHelper.buildDefaultApp(TEST_PROGRAMATIC_LISTENER_ADDITION_APP_NAME + ".war");
-        TestProgrammaticListenerApp = TestProgrammaticListenerApp.addAsLibraries(TestServlet31Jar, TestProgrammaticListenerJar);
         WebArchive TestServletMappingApp = ShrinkHelper.buildDefaultApp(TEST_SERVLET_MAPPING_APP_NAME + ".war",
                                                                         "com.ibm.ws.webcontainer.servlet_31_fat.testservletmapping.war.servlets");
         TestServletMappingApp = (WebArchive) ShrinkHelper.addDirectory(TestServletMappingApp, "test-applications/TestServletMapping.war/resources");
@@ -160,11 +154,6 @@ public class WCServerTest extends LoggingTest {
             if (appInstalled.isEmpty())
                 ShrinkHelper.exportDropinAppToServer(SHARED_SERVER.getLibertyServer(), ServletContextAddListenerApp);
 
-            appInstalled = SHARED_SERVER.getLibertyServer().getInstalledAppNames(TEST_PROGRAMATIC_LISTENER_ADDITION_APP_NAME);
-            LOG.info("addAppToServer : " + TEST_PROGRAMATIC_LISTENER_ADDITION_APP_NAME + " already installed : " + !appInstalled.isEmpty());
-            if (appInstalled.isEmpty())
-                ShrinkHelper.exportDropinAppToServer(SHARED_SERVER.getLibertyServer(), TestProgrammaticListenerApp);
-
             appInstalled = SHARED_SERVER.getLibertyServer().getInstalledAppNames(SERVLET_CONTEXT_CREATE_LISTENER_APP_NAME);
             LOG.info("addAppToServer : " + SERVLET_CONTEXT_CREATE_LISTENER_APP_NAME + " already installed : " + !appInstalled.isEmpty());
             if (appInstalled.isEmpty())
@@ -191,7 +180,6 @@ public class WCServerTest extends LoggingTest {
         SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* " + TEST_SERVLET_31_APP_NAME);
         SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* " + SESSION_ID_ADD_LISTENER_APP_NAME);
         SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* " + SERVLET_CONTEXT_ADD_LISTENER_APP_NAME);
-        SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* " + TEST_PROGRAMATIC_LISTENER_ADDITION_APP_NAME);
         SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* " + SERVLET_CONTEXT_CREATE_LISTENER_APP_NAME);
         SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* " + SESSION_ID_LISTENER_APP_NAME);
         SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* " + TEST_METADATA_COMPLETE_APP_NAME);
@@ -450,35 +438,6 @@ public class WCServerTest extends LoggingTest {
 
         // application should be initialized with the above request, now check the logs for the proper output.
         Assert.assertNotNull(SHARED_SERVER.getLibertyServer().findStringsInLogs("SRVE8015E:.*ThisListenerDoesNotExist"));
-    }
-
-    /**
-     * This test case will use a ServletContainerInitializer to add a ServletContextListener in a
-     * programmatic way. Then in the ServletContextListener contextInitialized method calls a method
-     * on the ServletContext.
-     *
-     * This method should throw an UnsupportedOperationException according to the Servlet 3.1 ServletContext API.
-     *
-     * Check to ensure that this message is thrown and the NLS message is resolved correctly.
-     *
-     * @throws Exception
-     */
-    @Test
-    public void test_ProgrammaticListenerAddition() throws Exception {
-
-        // Drive a request to the SimpleTestServlet to initialize the application
-        this.verifyResponse("/TestProgrammaticListenerAddition/SimpleTestServlet", "Hello World");
-
-        // Ensure that the proper exception was output
-        LibertyServer server = SHARED_SERVER.getLibertyServer();
-
-        server.resetLogMarks();
-
-        // PI41941: Changed the message. Wait for the full message.
-        String logMessage = server
-                        .waitForStringInLog("SRVE9002E:.*\\(Operation: getVirtualServerName \\| Listener: com.ibm.ws.webcontainer.servlet_31_fat.testprogrammaticlisteneraddition.jar.listeners.MyProgrammaticServletContextListener \\| Application: TestProgrammaticListenerAddition\\)");
-        Assert.assertNotNull("The correct message was not logged.", logMessage);
-
     }
 
     /**

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/WCServletContextUnsupportedOperationExceptionTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/WCServletContextUnsupportedOperationExceptionTest.java
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.webcontainer.servlet31.fat.tests;
+
+import static componenttest.annotation.SkipForRepeat.EE10_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
+
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+import junit.framework.Assert;
+
+/**
+ * Tests to ensure that an UnsupportedOperationException is thrown when certain methods
+ * are invoked on the ServletContext using the following Servlet features: servlet-3.1, servlet-4.0,
+ * servlet-5.0 and that the exception is not thrown for the servlet-6.0 feature.
+ */
+@RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
+public class WCServletContextUnsupportedOperationExceptionTest {
+    private static final String TEST_PROGRAMATIC_LISTENER_ADDITION_JAR_NAME = "TestProgrammaticListenerAddition";
+    private static final String TEST_PROGRAMATIC_LISTENER_ADDITION_APP_NAME = "TestProgrammaticListenerAddition";
+
+    @Server("servlet31_ServletContext_UnsupportedOperationExceptionr")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        JavaArchive TestProgrammaticListenerJar = ShrinkHelper.buildJavaArchive(TEST_PROGRAMATIC_LISTENER_ADDITION_JAR_NAME + ".jar",
+                                                                                "com.ibm.ws.webcontainer.servlet_31_fat.testprogrammaticlisteneraddition.jar.listeners");
+        TestProgrammaticListenerJar = (JavaArchive) ShrinkHelper.addDirectory(TestProgrammaticListenerJar, "test-applications/TestProgrammaticListenerAddition.jar/resources");
+
+        WebArchive TestProgrammaticListenerApp = ShrinkHelper.buildDefaultApp(TEST_PROGRAMATIC_LISTENER_ADDITION_APP_NAME + ".war");
+        TestProgrammaticListenerApp = TestProgrammaticListenerApp.addAsLibraries(TestProgrammaticListenerJar);
+
+        ShrinkHelper.exportDropinAppToServer(server, TestProgrammaticListenerApp);
+
+        server.startServer(WCServletContextUnsupportedOperationExceptionTest.class.getSimpleName() + ".log");
+    }
+
+    @AfterClass
+    public static void testCleanup() throws Exception {
+        // Stop the server
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    /**
+     * This test case will use a ServletContainerInitializer to add a ServletContextListener in a
+     * programmatic way. Then the ServletContextListener contextInitialized method calls methods
+     * on the ServletContext.
+     *
+     * These methods should throw an UnsupportedOperationException according to the Servlet 3.1 ServletContext API.
+     *
+     * The following features will be tests: servlet-3.1, servlet-4.0, and servlet-5.0.
+     *
+     * Check to ensure that the correct message is thrown and the NLS message is resolved correctly.
+     *
+     * @throws Exception
+     */
+    @Test
+    @SkipForRepeat(EE10_FEATURES)
+    public void test_ProgrammaticListenerAddition_Throws_UnsupportedOperationException() throws Exception {
+        // PI41941: Changed the message. Wait for the full message.
+        String logMessage = server
+                        .waitForStringInLog("SRVE9002E:.*\\(Operation: getEffectiveMajorVersion \\| Listener: com.ibm.ws.webcontainer.servlet_31_fat.testprogrammaticlisteneraddition.jar.listeners.MyProgrammaticServletContextListener \\| Application: TestProgrammaticListenerAddition\\)");
+        Assert.assertNotNull("The correct message was not logged for getEffectiveMajorVersion.", logMessage);
+
+        logMessage = server
+                        .waitForStringInLog("SRVE9002E:.*\\(Operation: getEffectiveMinorVersion \\| Listener: com.ibm.ws.webcontainer.servlet_31_fat.testprogrammaticlisteneraddition.jar.listeners.MyProgrammaticServletContextListener \\| Application: TestProgrammaticListenerAddition\\)");
+        Assert.assertNotNull("The correct message was not logged for getEffectiveMinorVersion.", logMessage);
+
+        logMessage = server
+                        .waitForStringInLog("SRVE8011E:.*\\(Operation: getDefaultSessionTrackingModes \\| Listener: com.ibm.ws.webcontainer.servlet_31_fat.testprogrammaticlisteneraddition.jar.listeners.MyProgrammaticServletContextListener \\| Application: TestProgrammaticListenerAddition\\)");
+        Assert.assertNotNull("The correct message was not logged for getDefaultSessionTrackingModes.", logMessage);
+
+        logMessage = server
+                        .waitForStringInLog("SRVE8011E:.*\\(Operation: getEffectiveSessionTrackingModes \\| Listener: com.ibm.ws.webcontainer.servlet_31_fat.testprogrammaticlisteneraddition.jar.listeners.MyProgrammaticServletContextListener \\| Application: TestProgrammaticListenerAddition\\)");
+        Assert.assertNotNull("The correct message was not logged for getEffectiveSessionTrackingModes.", logMessage);
+
+        logMessage = server
+                        .waitForStringInLog("SRVE8011E:.*\\(Operation: getJspConfigDescriptor \\| Listener: com.ibm.ws.webcontainer.servlet_31_fat.testprogrammaticlisteneraddition.jar.listeners.MyProgrammaticServletContextListener \\| Application: TestProgrammaticListenerAddition\\)");
+        Assert.assertNotNull("The correct message was not logged for getJspConfigDescriptor.", logMessage);
+
+        logMessage = server
+                        .waitForStringInLog("SRVE9002E:.*\\(Operation: getClassLoader \\| Listener: com.ibm.ws.webcontainer.servlet_31_fat.testprogrammaticlisteneraddition.jar.listeners.MyProgrammaticServletContextListener \\| Application: TestProgrammaticListenerAddition\\)");
+        Assert.assertNotNull("The correct message was not logged for getClassLoader.", logMessage);
+
+        logMessage = server
+                        .waitForStringInLog("SRVE9002E:.*\\(Operation: getVirtualServerName \\| Listener: com.ibm.ws.webcontainer.servlet_31_fat.testprogrammaticlisteneraddition.jar.listeners.MyProgrammaticServletContextListener \\| Application: TestProgrammaticListenerAddition\\)");
+        Assert.assertNotNull("The correct message was not logged for getVirtualServerName.", logMessage);
+
+    }
+
+    /**
+     * This test case will use a ServletContainerInitializer to add a ServletContextListener in a
+     * programmatic way. Then the ServletContextListener contextInitialized method calls methods
+     * on the ServletContext.
+     *
+     * These methods should not throw an UnsupportedOperationException in the servlet-6.0 and later features.
+     *
+     * @throws Exception
+     */
+    @Test
+    @SkipForRepeat({ NO_MODIFICATION, EE8_FEATURES, EE9_FEATURES })
+    public void test_ProgrammaticListenerAddition_No_UnsupportedOperationException() throws Exception {
+
+        String logMessage = server
+                        .waitForStringInLog("UnsupportedOperationException was not thrown.");
+        Assert.assertNotNull("An UnsupportedOperationException was thrown and should not have been.", logMessage);
+    }
+}

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/publish/servers/servlet31_ServletContext_UnsupportedOperationExceptionr/.gitignore
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/publish/servers/servlet31_ServletContext_UnsupportedOperationExceptionr/.gitignore
@@ -1,0 +1,2 @@
+/apps
+/dropins

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/publish/servers/servlet31_ServletContext_UnsupportedOperationExceptionr/bootstrap.properties
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/publish/servers/servlet31_ServletContext_UnsupportedOperationExceptionr/bootstrap.properties
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+osgi.console=7777
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.webcontainer*=all:com.ibm.wsspi.webcontainer*=all:HttpTransport=all:HTTPChannel=all:TCPChannel=all:GenericBNF=all:ChannelFramework=all
+com.ibm.ws.logging.max.file.size=20
+com.ibm.ws.logging.max.files=10
+com.ibm.ws.logging.trace.format=BASIC
+com.ibm.ws.classloading.tcclLockWaitTimeMillis=60000

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/publish/servers/servlet31_ServletContext_UnsupportedOperationExceptionr/server.xml
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/publish/servers/servlet31_ServletContext_UnsupportedOperationExceptionr/server.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Server for testing the ServletContext methods that throw a UnsupportedOperationException">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>servlet-3.1</feature>
+        <feature>jsp-2.3</feature>
+    </featureManager>
+
+</server>

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/TestProgrammaticListenerAddition.jar/src/com/ibm/ws/webcontainer/servlet_31_fat/testprogrammaticlisteneraddition/jar/listeners/MyProgrammaticServletContextListener.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/TestProgrammaticListenerAddition.jar/src/com/ibm/ws/webcontainer/servlet_31_fat/testprogrammaticlisteneraddition/jar/listeners/MyProgrammaticServletContextListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,20 +38,105 @@ public class MyProgrammaticServletContextListener implements ServletContextListe
      * (non-Javadoc)
      *
      * @see javax.servlet.ServletContextListener#contextInitialized(javax.servlet.ServletContextEvent)
+     *
+     * Test the following methods:
+     *
+     * getEffectiveMajorVersion
+     * getEffectiveMinorVersion
+     * getDefaultSessionTrackingModes
+     * getEffectiveSessionTrackingModes
+     * getJspConfigDescriptor
+     * getClassLoader
+     * getVirtualServerName
+     *
+     * There are four methods that now throw an UnsupportedOperationException in servlet-3.1 that
+     * did not previously:
+     *
+     * getEffectiveMajorVersion
+     * getEffectiveMinorVersion
+     * getClassLoader
+     * getVirtualServerName
+     *
+     * The other methods we are testing just to be complete!
+     *
+     * The following methods are new to servlet-4.0 and will be tested in the Servlet 4.0 FAT bucket:
+     * getSessionTimeout
+     * getRequestCharacterEncoding
+     * getResponseCharacterEncoding
+     *
      */
     @Override
     public void contextInitialized(ServletContextEvent sce) {
+        boolean getEffectiveMajorVersionExceptionThrown = false;
+        boolean getEffectiveMinorVersionExceptionThrown = false;
+        boolean getDefaultSessionTrackingModesExceptionThrown = false;
+        boolean getEffectiveSessionTrackingModesExceptionThrown = false;
+        boolean getJspConfigDescriptorExceptionThrown = false;
+        boolean getClassLoaderExceptionThrown = false;
+        boolean getVirtualServerNameExceptionThrown = false;
+
         ServletContext context = sce.getServletContext();
 
-        // Since this test is running in the context for servlet-3.1 + we expect an UnsupportedOperationException
-        // to be thrown for the follow method call. The exception is caught and logged.
         try {
-            String virtualServerName = context.getVirtualServerName();
-            context.log("VirtualServerName: " + virtualServerName);
-        } catch (Exception e) {
-            context.log(e.getMessage());
+            context.log("effectiveMajorVersion: " + context.getEffectiveMajorVersion());
+        } catch (UnsupportedOperationException uoe) {
+            getEffectiveMajorVersionExceptionThrown = true;
+            context.log(uoe.getMessage());
         }
 
-    }
+        try {
+            context.log("effectiveMinorVersion: " + context.getEffectiveMinorVersion());
+        } catch (UnsupportedOperationException uoe) {
+            getEffectiveMinorVersionExceptionThrown = true;
+            context.log(uoe.getMessage());
+        }
 
+        try {
+            context.log("defaultSessionTrackingModes: " + context.getDefaultSessionTrackingModes());
+        } catch (UnsupportedOperationException uoe) {
+            getDefaultSessionTrackingModesExceptionThrown = true;
+            context.log(uoe.getMessage());
+        }
+
+        try {
+            context.log("effectiveSessionTrackingModes: " + context.getEffectiveSessionTrackingModes());
+        } catch (UnsupportedOperationException uoe) {
+            getEffectiveSessionTrackingModesExceptionThrown = true;
+            context.log(uoe.getMessage());
+        }
+
+        try {
+            context.log("jspConfigDescriptor: " + context.getJspConfigDescriptor());
+        } catch (UnsupportedOperationException uoe) {
+            getJspConfigDescriptorExceptionThrown = true;
+            context.log(uoe.getMessage());
+        }
+
+        try {
+            context.log("getClassLoader: " + context.getClassLoader());
+        } catch (UnsupportedOperationException uoe) {
+            getClassLoaderExceptionThrown = true;
+            context.log(uoe.getMessage());
+        }
+
+        try {
+            context.log("getVirtualServerName: " + context.getVirtualServerName());
+        } catch (UnsupportedOperationException uoe) {
+            getVirtualServerNameExceptionThrown = true;
+            context.log(uoe.getMessage());
+        }
+
+        context.log("getEffectiveMajorVersionExceptionThrown: " + getEffectiveMajorVersionExceptionThrown + " getEffectiveMinorVersionExceptionThrown: "
+                    + getEffectiveMinorVersionExceptionThrown +
+                    " getDefaultSessionTrackingModesExceptionThrown: " + getDefaultSessionTrackingModesExceptionThrown + " getEffectiveSessionTrackingModesExceptionThrown: "
+                    + getEffectiveSessionTrackingModesExceptionThrown +
+                    " getJspConfigDescriptorExceptionThrown: " + getJspConfigDescriptorExceptionThrown + " getClassLoaderExceptionThrown: " + getClassLoaderExceptionThrown
+                    + " getVirtualServerNameExceptionThrown: " + getVirtualServerNameExceptionThrown);
+
+        if (!getEffectiveMajorVersionExceptionThrown && !getEffectiveMinorVersionExceptionThrown && !getDefaultSessionTrackingModesExceptionThrown &&
+            !getEffectiveSessionTrackingModesExceptionThrown && !getJspConfigDescriptorExceptionThrown && !getClassLoaderExceptionThrown &&
+            !getVirtualServerNameExceptionThrown) {
+            context.log("UnsupportedOperationException was not thrown.");
+        }
+    }
 }

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/webapp/WebApp40.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/webapp/WebApp40.java
@@ -164,7 +164,7 @@ public class WebApp40 extends com.ibm.ws.webcontainer31.osgi.webapp.WebApp31 imp
      */
     @Override
     public int getSessionTimeout() {
-        if (withinContextInitOfProgAddListener) {
+        if (withinContextInitOfProgAddListener && (WebContainer.getServletContainerSpecLevel() < WebContainer.SPEC_LEVEL_60)) {
             throw new UnsupportedOperationException(MessageFormat.format(
                                                                          nls.getString("Unsupported.op.from.servlet.context.listener"),
                                                                          new Object[] { "getSessionTimeout", lastProgAddListenerInitialized, getApplicationName() })); // PI41941
@@ -226,7 +226,7 @@ public class WebApp40 extends com.ibm.ws.webcontainer31.osgi.webapp.WebApp31 imp
     @Override
     public String getRequestCharacterEncoding() {
 
-        if (withinContextInitOfProgAddListener) {
+        if (withinContextInitOfProgAddListener && (WebContainer.getServletContainerSpecLevel() < WebContainer.SPEC_LEVEL_60)) {
             throw new UnsupportedOperationException(MessageFormat.format(
                                                                          nls.getString("Unsupported.op.from.servlet.context.listener"),
                                                                          new Object[] { "getRequestCharacterEncoding", lastProgAddListenerInitialized, getApplicationName() }));
@@ -271,7 +271,7 @@ public class WebApp40 extends com.ibm.ws.webcontainer31.osgi.webapp.WebApp31 imp
      */
     @Override
     public String getResponseCharacterEncoding() {
-        if (withinContextInitOfProgAddListener) {
+        if (withinContextInitOfProgAddListener && (WebContainer.getServletContainerSpecLevel() < WebContainer.SPEC_LEVEL_60)) {
             throw new UnsupportedOperationException(MessageFormat.format(
                                                                          nls.getString("Unsupported.op.from.servlet.context.listener"),
                                                                          new Object[] { "getResponseCharacterEncoding", lastProgAddListenerInitialized, getApplicationName() }));

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/.classpath
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/.classpath
@@ -22,6 +22,7 @@
     <classpathentry kind="src" path="test-applications/TestPushBuilderAPI.war/src"/>
     <classpathentry kind="src" path="test-applications/DeferServletRequestListenerDestroyOnErrorTest.war/src"/>
     <classpathentry kind="src" path="test-applications/TestX590EncodedCert.war/src"/>
+    <classpathentry kind="src" path="test-applications/TestProgrammaticListenerAddition.jar/src"/>
     <classpathentry kind="con" path="aQute.bnd.classpath.container"/>
     <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
     <classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/bnd.bnd
@@ -33,7 +33,8 @@ src: \
     test-applications/TestPushBuilderAPI.war/src,\
     test-applications/ResponseHeadersTest.war/src,\
     test-applications/DeferServletRequestListenerDestroyOnErrorTest.war/src,\
-    test-applications/TestX590EncodedCert.war/src
+    test-applications/TestX590EncodedCert.war/src,\
+    test-applications/TestProgrammaticListenerAddition.jar/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/FATSuite.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/FATSuite.java
@@ -38,6 +38,7 @@ import com.ibm.ws.fat.wc.tests.WCServerTest;
 import com.ibm.ws.fat.wc.tests.WCServletClarificationTest;
 import com.ibm.ws.fat.wc.tests.WCServletContainerInitializerExceptionTest;
 import com.ibm.ws.fat.wc.tests.WCServletContainerInitializerFilterServletNameMappingTest;
+import com.ibm.ws.fat.wc.tests.WCServletContextUnsupportedOperationExceptionTest;
 import com.ibm.ws.fat.wc.tests.WCServletPathForDefaultMappingDefault;
 import com.ibm.ws.fat.wc.tests.WCServletPathForDefaultMappingFalse;
 import com.ibm.ws.fat.wc.tests.WCTestEncodedX590;
@@ -91,7 +92,8 @@ import componenttest.topology.impl.JavaInfo;
                 WCResponseHeadersTest.class,
                 WCServerMiscTest.class,
                 WCServerPropertyTest.class,
-                WCTestEncodedX590.class
+                WCTestEncodedX590.class,
+                WCServletContextUnsupportedOperationExceptionTest.class
 })
 
 public class FATSuite {

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCServletContextUnsupportedOperationExceptionTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCServletContextUnsupportedOperationExceptionTest.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.fat.wc.tests;
+
+import static componenttest.annotation.SkipForRepeat.EE10_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
+
+import java.util.logging.Logger;
+
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+import junit.framework.Assert;
+
+/**
+ * Tests to ensure that an UnsupportedOperationException is thrown when certain methods
+ * are invoked on the ServletContext.
+ */
+@RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
+public class WCServletContextUnsupportedOperationExceptionTest {
+
+    private static final Logger LOG = Logger.getLogger(WCServletContextUnsupportedOperationExceptionTest.class.getName());
+    private static final String TEST_PROGRAMATIC_LISTENER_ADDITION_JAR_NAME = "TestProgrammaticListenerAddition";
+    private static final String TEST_PROGRAMATIC_LISTENER_ADDITION_APP_NAME = "TestProgrammaticListenerAddition";
+
+    @Server("servlet40_ServletContext_UnsupportedOperationExceptionr")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        LOG.info("Setup : add TestServlet40 to the server if not already present.");
+
+        JavaArchive testProgrammaticListenerJar = ShrinkHelper.buildJavaArchive(TEST_PROGRAMATIC_LISTENER_ADDITION_JAR_NAME + ".jar",
+                                                                                "com.ibm.ws.webcontainer.servlet_40_fat.testprogrammaticlisteneraddition.jar.listeners");
+
+        WebArchive testProgrammaticListenerApp = ShrinkHelper.buildDefaultApp(TEST_PROGRAMATIC_LISTENER_ADDITION_APP_NAME + ".war");
+        testProgrammaticListenerApp = testProgrammaticListenerApp.addAsLibraries(testProgrammaticListenerJar);
+
+        ShrinkHelper.exportDropinAppToServer(server, testProgrammaticListenerApp);
+
+        server.startServer(WCServletContextUnsupportedOperationExceptionTest.class.getSimpleName() + ".log");
+        LOG.info("Setup : complete, ready for Tests");
+    }
+
+    @AfterClass
+    public static void testCleanup() throws Exception {
+        LOG.info("testCleanUp : stop server");
+
+        // Stop the server
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    /**
+     * This test case will use a ServletContainerInitializer to add a ServletContextListener in a
+     * programmatic way. Then in the ServletContextListener contextInitialized method calls methods
+     * on the ServletContext.
+     *
+     * These methods should throw an UnsupportedOperationException according to the Servlet 4.0 ServletContext API.
+     *
+     * @throws Exception
+     */
+    @Test
+    @SkipForRepeat(EE10_FEATURES)
+    public void test_ProgrammaticListenerAddition_Throws_UnsupportedOperationException() throws Exception {
+        // Ensure that the proper exception was output
+        String logMessage = server.waitForStringInLog("SRVE8011E:.*\\(Operation: getSessionTimeout \\| Listener: com.ibm.ws.webcontainer.servlet_40_fat.testprogrammaticlisteneraddition.jar.listeners.MyProgrammaticServletContextListener \\| Application: TestProgrammaticListenerAddition\\)");
+        Assert.assertNotNull("The correct message was not logged for getDefaultSessionTrackingModes.", logMessage);
+
+        logMessage = server.waitForStringInLog("SRVE8011E:.*\\(Operation: getRequestCharacterEncoding \\| Listener: com.ibm.ws.webcontainer.servlet_40_fat.testprogrammaticlisteneraddition.jar.listeners.MyProgrammaticServletContextListener \\| Application: TestProgrammaticListenerAddition\\)");
+        Assert.assertNotNull("The correct message was not logged for getDefaultSessionTrackingModes.", logMessage);
+
+        logMessage = server.waitForStringInLog("SRVE8011E:.*\\(Operation: getResponseCharacterEncoding \\| Listener: com.ibm.ws.webcontainer.servlet_40_fat.testprogrammaticlisteneraddition.jar.listeners.MyProgrammaticServletContextListener \\| Application: TestProgrammaticListenerAddition\\)");
+        Assert.assertNotNull("The correct message was not logged for getDefaultSessionTrackingModes.", logMessage);
+    }
+
+    /**
+     * This test case will use a ServletContainerInitializer to add a ServletContextListener in a
+     * programmatic way. Then in the ServletContextListener contextInitialized method calls methods
+     * on the ServletContext.
+     *
+     * These methods should not throw an UnsupportedOperationException in the Servlet 6.0 and later Specifications.
+     *
+     * @throws Exception
+     */
+    @Test
+    @SkipForRepeat({ NO_MODIFICATION, EE8_FEATURES, EE9_FEATURES })
+    public void test_ProgrammaticListenerAddition_No_UnsupportedOperationException() throws Exception {
+        String logMessage = server.waitForStringInLog("UnsupportedOperationException was not thrown.");
+        Assert.assertNotNull("An UnsupportedOperationException was thrown and should not have been.", logMessage);
+    }
+}

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet40_ServletContext_UnsupportedOperationExceptionr/.gitignore
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet40_ServletContext_UnsupportedOperationExceptionr/.gitignore
@@ -1,0 +1,2 @@
+/apps
+/dropins

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet40_ServletContext_UnsupportedOperationExceptionr/bootstrap.properties
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet40_ServletContext_UnsupportedOperationExceptionr/bootstrap.properties
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+osgi.console=7777
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.webcontainer*=all:com.ibm.wsspi.webcontainer*=all:HttpTransport=all:HTTPChannel=all:TCPChannel=all:GenericBNF=all:ChannelFramework=all
+com.ibm.ws.logging.max.file.size=20
+com.ibm.ws.logging.max.files=10
+com.ibm.ws.logging.trace.format=BASIC
+com.ibm.ws.classloading.tcclLockWaitTimeMillis=60000

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet40_ServletContext_UnsupportedOperationExceptionr/server.xml
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet40_ServletContext_UnsupportedOperationExceptionr/server.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Server for testing the ServletContext methods that throw a UnsupportedOperationException">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>servlet-4.0</feature>
+        <feature>jsp-2.3</feature>
+    </featureManager>
+
+</server>

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestProgrammaticListenerAddition.jar/resources/META-INF/services/javax.servlet.ServletContainerInitializer
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestProgrammaticListenerAddition.jar/resources/META-INF/services/javax.servlet.ServletContainerInitializer
@@ -1,0 +1,11 @@
+#/*******************************************************************************
+# * Copyright (c) 2022 IBM Corporation and others.
+# * All rights reserved. This program and the accompanying materials
+# * are made available under the terms of the Eclipse Public License v1.0
+# * which accompanies this distribution, and is available at
+# * http://www.eclipse.org/legal/epl-v10.html
+# *
+# * Contributors:
+# *     IBM Corporation - initial API and implementation
+# *******************************************************************************/
+com.ibm.ws.webcontainer.servlet_40_fat.testprogrammaticlisteneraddition.jar.listeners.MyServletContainerInitializer

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestProgrammaticListenerAddition.jar/src/com/ibm/ws/webcontainer/servlet_40_fat/testprogrammaticlisteneraddition/jar/listeners/MyProgrammaticServletContextListener.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestProgrammaticListenerAddition.jar/src/com/ibm/ws/webcontainer/servlet_40_fat/testprogrammaticlisteneraddition/jar/listeners/MyProgrammaticServletContextListener.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.webcontainer.servlet_40_fat.testprogrammaticlisteneraddition.jar.listeners;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+/**
+ * This ServletContextListener was added by MyServletContainerInitializer. The point of this ServletContextListener
+ * is to call a method on the ServletContext and ensure that we get an UnsupportedOperationException when expected.
+ *
+ * There are some methods on the ServletContext that throw the UnsupportedOperationException when a listener is added
+ * in a programmatic way.
+ */
+public class MyProgrammaticServletContextListener implements ServletContextListener {
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.servlet.ServletContextListener#contextDestroyed(javax.servlet.ServletContextEvent)
+     */
+    @Override
+    public void contextDestroyed(ServletContextEvent sce) {
+        // do nothing
+
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.servlet.ServletContextListener#contextInitialized(javax.servlet.ServletContextEvent)
+     *
+     * Test the following methods:
+     *
+     * getSessionTimeout
+     * getRequestCharacterEncoding
+     * getResponseCharacterEncoding
+     *
+     */
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        boolean getSessionTimeoutExceptionThrown = false;
+        boolean getRequestCharacterEncodingExceptionThrown = false;
+        boolean getResponseCharacterEncodingExceptionThrown = false;
+
+        ServletContext context = sce.getServletContext();
+
+        try {
+            context.log("getSessionTimeout: " + context.getSessionTimeout());
+        } catch (UnsupportedOperationException uoe) {
+            getSessionTimeoutExceptionThrown = true;
+            context.log(uoe.getMessage());
+        }
+
+        try {
+            context.log("getRequestCharacterEncoding: " + context.getRequestCharacterEncoding());
+        } catch (UnsupportedOperationException uoe) {
+            getRequestCharacterEncodingExceptionThrown = true;
+            context.log(uoe.getMessage());
+        }
+
+        try {
+            context.log("getResponseCharacterEncoding: " + context.getResponseCharacterEncoding());
+        } catch (UnsupportedOperationException uoe) {
+            getResponseCharacterEncodingExceptionThrown = true;
+            context.log(uoe.getMessage());
+        }
+
+        context.log("getSessionTimeoutExceptionThrown: " + getSessionTimeoutExceptionThrown + " getRequestCharacterEncodingExceptionThrown: "
+                    + getRequestCharacterEncodingExceptionThrown +
+                    " getResponseCharacterEncodingExceptionThrown: " + getResponseCharacterEncodingExceptionThrown);
+
+        if (!getSessionTimeoutExceptionThrown && !getRequestCharacterEncodingExceptionThrown && !getResponseCharacterEncodingExceptionThrown) {
+            context.log("UnsupportedOperationException was not thrown.");
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestProgrammaticListenerAddition.jar/src/com/ibm/ws/webcontainer/servlet_40_fat/testprogrammaticlisteneraddition/jar/listeners/MyServletContainerInitializer.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestProgrammaticListenerAddition.jar/src/com/ibm/ws/webcontainer/servlet_40_fat/testprogrammaticlisteneraddition/jar/listeners/MyServletContainerInitializer.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.webcontainer.servlet_40_fat.testprogrammaticlisteneraddition.jar.listeners;
+
+import java.util.Set;
+
+import javax.servlet.ServletContainerInitializer;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+
+/**
+ * Test ServletContainerInitializer to add a ServletContextListener in a programmatic way.
+ */
+public class MyServletContainerInitializer implements ServletContainerInitializer {
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.servlet.ServletContainerInitializer#onStartup(java.util.Set, javax.servlet.ServletContext)
+     */
+    @Override
+    public void onStartup(Set<Class<?>> arg0, ServletContext sc) throws ServletException {
+        // Lets add a ServletContextListener in a programmatic way and then call one of the methods that should throw
+        // an UnsupportedOperationException in the ServletContextListener.
+        sc.addListener(MyProgrammaticServletContextListener.class);
+    }
+
+}

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebApp.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebApp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2021 IBM Corporation and others.
+ * Copyright (c) 1997, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -6317,7 +6317,7 @@ public abstract class WebApp extends BaseContainer implements ServletContext, IS
 
     @Override
     public Set<SessionTrackingMode> getDefaultSessionTrackingModes() {
-        if (withinContextInitOfProgAddListener) {
+        if (withinContextInitOfProgAddListener && (com.ibm.ws.webcontainer.osgi.WebContainer.getServletContainerSpecLevel() < com.ibm.ws.webcontainer.osgi.WebContainer.SPEC_LEVEL_60)) {
             throw new UnsupportedOperationException(MessageFormat.format(
                     nls.getString("Unsupported.op.from.servlet.context.listener"),
                     new Object[] {"getDefaultSessionTrackingModes", lastProgAddListenerInitialized, getApplicationName()}));  // PI41941
@@ -6327,7 +6327,7 @@ public abstract class WebApp extends BaseContainer implements ServletContext, IS
 
     @Override
     public Set<SessionTrackingMode> getEffectiveSessionTrackingModes() {
-        if (withinContextInitOfProgAddListener) {
+        if (withinContextInitOfProgAddListener && (com.ibm.ws.webcontainer.osgi.WebContainer.getServletContainerSpecLevel() < com.ibm.ws.webcontainer.osgi.WebContainer.SPEC_LEVEL_60)) {
             throw new UnsupportedOperationException(MessageFormat.format(
                     nls.getString("Unsupported.op.from.servlet.context.listener"),
                     new Object[] {"getEffectiveSessionTrackingModes", lastProgAddListenerInitialized, getApplicationName()}));  // PI41941
@@ -6620,7 +6620,7 @@ public abstract class WebApp extends BaseContainer implements ServletContext, IS
 
     @Override
     public JspConfigDescriptor getJspConfigDescriptor() {
-        if (withinContextInitOfProgAddListener) {
+        if (withinContextInitOfProgAddListener && (com.ibm.ws.webcontainer.osgi.WebContainer.getServletContainerSpecLevel() < com.ibm.ws.webcontainer.osgi.WebContainer.SPEC_LEVEL_60)) {
             throw new UnsupportedOperationException(MessageFormat.format(
                     nls.getString("Unsupported.op.from.servlet.context.listener"),
                     new Object[] {"getJspConfigDescriptor", lastProgAddListenerInitialized, getApplicationName()}));  // PI41941


### PR DESCRIPTION
fixes #20428

I needed to add the JSP feature to the new test server since we get an NPE during EE10 executions: https://github.com/OpenLiberty/open-liberty/issues/21820