### PR TITLE
Additional log mark reset for ACME fat

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeConfigVariationsTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeConfigVariationsTest.java
@@ -204,6 +204,8 @@ public class AcmeConfigVariationsTest {
 			configuration.getFeatureManager().getFeatures().remove("acmeCA-2.0");
 			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, useAcmeURIs(), DOMAINS_1);
 			AcmeFatUtils.waitAcmeFeatureUninstall(server);
+			
+			AcmeFatUtils.resetMarksInLogs(server); // reset marks in case the cert checker woke up during the server update.
 
 			long timeElapsed = System.currentTimeMillis();
 


### PR DESCRIPTION
Add an additional log mark reset so we don't pick up an old Cert Checker wake up and run in `AcmeConfigVariationsTest`.

For RTC 291261