### PR TITLE
Make failed login delay properties public

### DIFF
--- a/dev/com.ibm.ws.security.wim.core/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.wim.core/resources/OSGI-INF/l10n/metatype.properties
@@ -1,6 +1,6 @@
 
 ###############################################################################
-# Copyright (c) 2011 IBM Corporation and others.
+# Copyright (c) 2011,2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -140,6 +140,12 @@ pageCacheTimeOut.desc=Defines the maximum time that an entry, which added to the
 
 extendedProperty=Extended Property Mapping
 extendedProperty.desc=The extended properties for Person and Group.
+
+failedLoginDelayMin=Failed login delay minimum 
+failedLoginDelayMin.desc=The minimum delay for a failed login attempt. For example, 0s or 1000ms. The failed login delay adds a variable delay to requests where the login fails. To customize the maximum delay time, set the failedLoginDelayMax attribute.
+
+failedLoginDelayMax=Failed login delay maximum
+failedLoginDelayMax.desc=The maximum delay for a failed login attempt. For example, 5s or 5000ms. The failed login delay adds a variable delay to requests where the login fails. To disable the failed login delay, set the value to 0s. The delay is intended to mitigate user enumeration style attacks; therefore, disabling it is not recommended. To customize the minimum delay time, set the failedLoginDelayMin attribute.
 
 propertyName=Name of extended property
 propertyName.desc=Defines the name of the property extended for Person and Group.

--- a/dev/com.ibm.ws.security.wim.core/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.wim.core/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011,2021 IBM Corporation and others.
+    Copyright (c) 2011,2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -30,9 +30,8 @@
 		  
 		  <AD id="extendedProperty" name="%extendedProperty" description="%extendedProperty.desc"  type="String" ibm:flat="true" ibm:type="pid" ibm:reference="com.ibm.ws.security.wim.core.extendedProperty" required="false"  cardinality="2147483647"/>
 
-		  <!-- Review name, add supporting description and messages if made external -->
-		  <AD id="failedLoginDelayMin" name="internal" description="internal use only" required="false" type="String" ibm:type="duration" default="0s"/>	
-          <AD id="failedLoginDelayMax" name="internal" description="internal use only" required="false" type="String" ibm:type="duration" default="5s"/>
+		  <AD id="failedLoginDelayMin" name="%failedLoginDelayMin" description="%failedLoginDelayMin.desc" required="false" type="String" ibm:type="duration" default="0s"/>	
+		  <AD id="failedLoginDelayMax" name="%failedLoginDelayMax" description="%failedLoginDelayMax.desc" required="false" type="String" ibm:type="duration" default="5s"/>
 </OCD>
 
 <Designate factoryPid="com.ibm.ws.security.wim.core.config">


### PR DESCRIPTION
Make the login delay properties public. Tests already exist in com.ibm.ws.security.wim.registry.fat.