### PR TITLE
Fix EJB FAT synchronization issue

### DIFF
--- a/dev/io.openliberty.ejbcontainer.checkpoint_fat/test-applications/CheckpointEJB.jar/src/io/openliberty/ejbcontainer/fat/checkpoint/ejb/CheckpointStatistics.java
+++ b/dev/io.openliberty.ejbcontainer.checkpoint_fat/test-applications/CheckpointEJB.jar/src/io/openliberty/ejbcontainer/fat/checkpoint/ejb/CheckpointStatistics.java
@@ -12,6 +12,7 @@
 package io.openliberty.ejbcontainer.fat.checkpoint.ejb;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -26,7 +27,7 @@ public class CheckpointStatistics {
     private static final long PRELOAD_WAIT_TIME = 60;
     private static final TimeUnit PRELOAD_WAIT_UNITS = TimeUnit.SECONDS;
 
-    private static List<String> ClassStaticInitList = new ArrayList<String>();
+    private static List<String> ClassStaticInitList = Collections.synchronizedList(new ArrayList<String>());
     private static Map<String, Integer> InstanceCountMap = new ConcurrentHashMap<String, Integer>();
     private static Map<String, Integer> PostConstructCountMap = new ConcurrentHashMap<String, Integer>();
     private static Map<String, CountDownLatch> PreloadLatchMap = new ConcurrentHashMap<String, CountDownLatch>();


### PR DESCRIPTION
EJB FAT is using an ArrayList that may be updated on concurrent threads; adding synchronization
when accessing the list.
