### PR TITLE
Fix to multiple protocols with the IBM JDK

### DIFF
--- a/dev/com.ibm.ws.channel.ssl/src/com/ibm/ws/channel/ssl/internal/SSLLinkConfig.java
+++ b/dev/com.ibm.ws.channel.ssl/src/com/ibm/ws/channel/ssl/internal/SSLLinkConfig.java
@@ -96,7 +96,7 @@ public class SSLLinkConfig {
             }
             // Found the security level.
             ciphers = Constants.adjustSupportedCiphersToSecurityLevel(
-                                                                      sslEngine.getEnabledCipherSuites(), securityLevel);
+                                                                      sslEngine.getSupportedCipherSuites(), securityLevel);
         } else {
             // Found enabled cipher suites. Now we need to put them in the right kind of object.
             if (ciphersObject instanceof String) {

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/SSLConfigManager.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/SSLConfigManager.java
@@ -1395,7 +1395,7 @@ public class SSLConfigManager {
                 if (securityLevel == null)
                     securityLevel = "HIGH";
 
-                ciphers = adjustSupportedCiphersToSecurityLevel(socket.getEnabledCipherSuites(), securityLevel);
+                ciphers = adjustSupportedCiphersToSecurityLevel(socket.getSupportedCipherSuites(), securityLevel);
 
             }
         } catch (Exception e) {

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/provider/AbstractJSSEProvider.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/provider/AbstractJSSEProvider.java
@@ -630,8 +630,9 @@ public abstract class AbstractJSSEProvider implements JSSEProvider {
         } else {
             String[] protocols = protocolVal.split(",");
             if (protocols.length > 1)
-                protocolVal = protocols[0];
+                protocolVal = defaultProtocol;
         }
+
         final String protocol = protocolVal;
 
         try {


### PR DESCRIPTION
Change to get instance with the default protocol and use the supported ciphers list.