### PR TITLE
Fix obtaining the refresh_token for the bcl uri omitted tests

### DIFF
--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/common-classes/src/web/BaseServlet.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/common-classes/src/web/BaseServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -43,6 +43,7 @@ import com.ibm.wsspi.security.oauth20.token.WSOAuth20Token ;
 public abstract class BaseServlet extends HttpServlet {
     private static final long serialVersionUID = 1L;
     private String servletName;
+    protected String newLine = System.getProperty("line.separator");
 
     BaseServlet(String servletName) {
         this.servletName = servletName;
@@ -54,7 +55,7 @@ public abstract class BaseServlet extends HttpServlet {
 
     @Override
     protected void service(HttpServletRequest req, HttpServletResponse res)
-                    throws ServletException, IOException {
+            throws ServletException, IOException {
         if ("CUSTOM".equalsIgnoreCase(req.getMethod()))
             doCustom(req, res);
         else
@@ -63,32 +64,32 @@ public abstract class BaseServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp)
-                    throws ServletException, IOException {
+            throws ServletException, IOException {
         handleRequest("GET", req, resp);
     }
 
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp)
-                    throws ServletException, IOException {
+            throws ServletException, IOException {
         handleRequest("POST", req, resp);
     }
 
     private void doCustom(HttpServletRequest req, HttpServletResponse resp)
-                    throws ServletException, IOException {
+            throws ServletException, IOException {
         handleRequest("CUSTOM", req, resp);
     }
 
     /**
      * Common logic to handle any of the various requests this servlet supports.
      * The actual business logic can be customized by overriding performTask.
-     * 
+     *
      * @param req
      * @param resp
      * @throws ServletException
      * @throws IOException
      */
     protected void handleRequest(String type, HttpServletRequest req, HttpServletResponse resp)
-                    throws ServletException, IOException {
+            throws ServletException, IOException {
         PrintWriter writer = resp.getWriter();
         writer.println("ServletName: " + servletName);
         writer.println("Request type: " + type);
@@ -107,7 +108,7 @@ public abstract class BaseServlet extends HttpServlet {
 
     /**
      * Default action for the servlet if not overridden.
-     * 
+     *
      * @param req
      * @param resp
      * @param writer
@@ -115,16 +116,17 @@ public abstract class BaseServlet extends HttpServlet {
      * @throws IOException
      */
     protected void performTask(String type,
-    						   HttpServletRequest req,
-                               HttpServletResponse resp, StringBuffer sb)
-                    throws ServletException, IOException {
+            HttpServletRequest req,
+            HttpServletResponse resp, StringBuffer sb)
+            throws ServletException, IOException {
         printProgrammaticApiValues(type, req, sb);
     }
 
     /**
      * Gets the SSO token from the subject.
-     * 
-     * @param subject {@code null} is not supported.
+     *
+     * @param subject
+     *            {@code null} is not supported.
      * @return
      */
     private SingleSignonToken getSSOToken(Subject subject) {
@@ -139,174 +141,175 @@ public abstract class BaseServlet extends HttpServlet {
 
     /**
      * Print the various programmatic API values we care about.
-     * 
+     *
      * @param req
      * @param writer
      */
-	protected void printProgrammaticApiValues(String type,
-			HttpServletRequest req, StringBuffer sb) {
-	           
+    protected void printProgrammaticApiValues(String type,
+            HttpServletRequest req, StringBuffer sb) {
+
         Enumeration headerNames = req.getHeaderNames();
         while (headerNames.hasMoreElements()) {
             String key = (String) headerNames.nextElement();
             String value = req.getHeader(key);
-            writeLine(sb, "Header key: " + key + " with value: " + value);        }
+            writeLine(sb, "Header key: " + key + " with value: " + value);
+        }
 
-		// print all the parms even it is "POST"
-		Enumeration e = req.getParameterNames();
-		if (e.hasMoreElements()) {
-			writeLine(sb, "All Parameters");
-			while (e.hasMoreElements()) {
-				String name = (String) e.nextElement();
-				writeLine(
-						sb,
-						"Param: " + name + " with value: "
-								+ req.getParameter(name));
-			}
-		}
-		if (type.equals("POST")) {
+        // print all the parms even it is "POST"
+        Enumeration e = req.getParameterNames();
+        if (e.hasMoreElements()) {
+            writeLine(sb, "All Parameters");
+            while (e.hasMoreElements()) {
+                String name = (String) e.nextElement();
+                writeLine(
+                        sb,
+                        "Param: " + name + " with value: "
+                                + req.getParameter(name));
+            }
+        }
+        if (type.equals("POST")) {
 
-			try {
-				Collection<Part> myParts = req.getParts();
-				writeLine(sb, "All Parameters");
-				for (Iterator<Part> myIt = myParts.iterator(); myIt.hasNext();) {
-					Part p = myIt.next();
-					InputStream inst = p.getInputStream();
-					StringBuilder inputStringBuilder = new StringBuilder();
-					BufferedReader bufferedReader = new BufferedReader(
-							new InputStreamReader(inst, "UTF-8"));
-					String line = bufferedReader.readLine();
-					Boolean firstOneDone = false;
-					while (line != null) {
-						if (firstOneDone) {
-							inputStringBuilder.append('\n');
-							firstOneDone = true;
-						}
-						inputStringBuilder.append(line);
-						line = bufferedReader.readLine();
-					}
-					writeLine(sb, "Param: " + p.getName() + " with value: "
-							+ inputStringBuilder.toString());
-				}
-			} catch (Exception exc) {
-				writeLine(sb, "Exception occurred: " + exc.toString());
+            try {
+                Collection<Part> myParts = req.getParts();
+                writeLine(sb, "All Parameters");
+                for (Iterator<Part> myIt = myParts.iterator(); myIt.hasNext();) {
+                    Part p = myIt.next();
+                    InputStream inst = p.getInputStream();
+                    StringBuilder inputStringBuilder = new StringBuilder();
+                    BufferedReader bufferedReader = new BufferedReader(
+                            new InputStreamReader(inst, "UTF-8"));
+                    String line = bufferedReader.readLine();
+                    Boolean firstOneDone = false;
+                    while (line != null) {
+                        if (firstOneDone) {
+                            inputStringBuilder.append(newLine);
+                            firstOneDone = true;
+                        }
+                        inputStringBuilder.append(line);
+                        line = bufferedReader.readLine();
+                    }
+                    writeLine(sb, "Param: " + p.getName() + " with value: "
+                            + inputStringBuilder.toString());
+                }
+            } catch (Exception exc) {
+                writeLine(sb, "Exception occurred: " + exc.toString());
 
-			}
-		}
-		writeLine(sb, "getAuthType: " + req.getAuthType());
-		writeLine(sb, "getRemoteUser: " + req.getRemoteUser());
-		writeLine(sb, "getUserPrincipal: " + req.getUserPrincipal());
+            }
+        }
+        writeLine(sb, "getAuthType: " + req.getAuthType());
+        writeLine(sb, "getRemoteUser: " + req.getRemoteUser());
+        writeLine(sb, "getUserPrincipal: " + req.getUserPrincipal());
 
-		if (req.getUserPrincipal() != null) {
-			writeLine(sb, "getUserPrincipal().getName(): "
-					+ req.getUserPrincipal().getName());
-		}
-		writeLine(sb, "isUserInRole(Employee): " + req.isUserInRole("Employee"));
-		writeLine(sb, "isUserInRole(Manager): " + req.isUserInRole("Manager"));
-		String role = req.getParameter("role");
-		if (role == null) {
-			writeLine(sb,
-					"You can customize the isUserInRole call with the follow paramter: ?role=name");
-		}
-		writeLine(sb, "isUserInRole(" + role + "): " + req.isUserInRole(role));
+        if (req.getUserPrincipal() != null) {
+            writeLine(sb, "getUserPrincipal().getName(): "
+                    + req.getUserPrincipal().getName());
+        }
+        writeLine(sb, "isUserInRole(Employee): " + req.isUserInRole("Employee"));
+        writeLine(sb, "isUserInRole(Manager): " + req.isUserInRole("Manager"));
+        String role = req.getParameter("role");
+        if (role == null) {
+            writeLine(sb,
+                    "You can customize the isUserInRole call with the follow paramter: ?role=name");
+        }
+        writeLine(sb, "isUserInRole(" + role + "): " + req.isUserInRole(role));
 
-		Cookie[] cookies = req.getCookies();
-		writeLine(sb, "Getting cookies");
-		if (cookies != null && cookies.length > 0) {
-			for (int i = 0; i < cookies.length; i++) {
-				writeLine(sb, "cookie: " + cookies[i].getName() + " value: "
-						+ cookies[i].getValue());
-			}
-		}
-		writeLine(sb, "getRequestURL: " + req.getRequestURL().toString());
+        Cookie[] cookies = req.getCookies();
+        writeLine(sb, "Getting cookies");
+        if (cookies != null && cookies.length > 0) {
+            for (int i = 0; i < cookies.length; i++) {
+                writeLine(sb, "cookie: " + cookies[i].getName() + " value: "
+                        + cookies[i].getValue());
+            }
+        }
+        writeLine(sb, "getRequestURL: " + req.getRequestURL().toString());
 
-		try {
-			// Get the CallerSubject
-			Subject callerSubject = WSSubject.getCallerSubject();
-			writeLine(sb, "MY callerSubject: \n" + callerSubject);
-			writeLine(sb, "break 1");
+        try {
+            // Get the CallerSubject
+            Subject callerSubject = WSSubject.getCallerSubject();
+            writeLine(sb, "MY callerSubject: " + newLine + callerSubject);
+            writeLine(sb, "break 1");
 
-			// Get the public credential from the CallerSubject
-			if (callerSubject != null) {
-				WSCredential callerCredential = callerSubject
-						.getPublicCredentials(WSCredential.class).iterator()
-						.next();
-				if (callerCredential != null) {
-					writeLine(sb, "callerCredential One: " + callerCredential);
-				} else {
-					writeLine(sb, "callerCredential Two: null");
-				}
-				// WSOAuth20Token callerToken =
-				// callerSubject.getPrivateCredentials(com.ibm.wsspi.security.oauth20.token.WSOAuth20Token.class).iterator().next()
-				// ;
-				Set<WSOAuth20Token> callerToken = callerSubject
-						.getPrivateCredentials(com.ibm.wsspi.security.oauth20.token.WSOAuth20Token.class);
-				writeLine(
-						sb,
-						"priv cred: "
-								+ callerSubject
-										.getPrivateCredentials(
-												com.ibm.wsspi.security.oauth20.token.WSOAuth20Token.class)
-										.toString());
-				writeLine(
-						sb,
-						"priv cred size: "
-								+ callerSubject
-										.getPrivateCredentials(
-												com.ibm.wsspi.security.oauth20.token.WSOAuth20Token.class)
-										.size());
-				writeLine(sb, "default priv cred: "
-						+ callerSubject.getPrivateCredentials().toString());
-				writeLine(sb, "default priv cred size: "
-						+ callerSubject.getPrivateCredentials().size());
-				if (callerToken != null) {
-					writeLine(sb, "callerToken One: " + callerToken);
-				} else {
-					writeLine(sb, "callerToken Two: null");
-				}
-			} else {
-				writeLine(sb, "callerCredential Three: null");
-				writeLine(sb, "callerToken Three: null");
-			}
-			writeLine(sb, "break 2");
+            // Get the public credential from the CallerSubject
+            if (callerSubject != null) {
+                WSCredential callerCredential = callerSubject
+                        .getPublicCredentials(WSCredential.class).iterator()
+                        .next();
+                if (callerCredential != null) {
+                    writeLine(sb, "callerCredential One: " + callerCredential);
+                } else {
+                    writeLine(sb, "callerCredential Two: null");
+                }
+                // WSOAuth20Token callerToken =
+                // callerSubject.getPrivateCredentials(com.ibm.wsspi.security.oauth20.token.WSOAuth20Token.class).iterator().next()
+                // ;
+                Set<WSOAuth20Token> callerToken = callerSubject
+                        .getPrivateCredentials(com.ibm.wsspi.security.oauth20.token.WSOAuth20Token.class);
+                writeLine(
+                        sb,
+                        "priv cred: "
+                                + callerSubject
+                                        .getPrivateCredentials(
+                                                com.ibm.wsspi.security.oauth20.token.WSOAuth20Token.class)
+                                        .toString());
+                writeLine(
+                        sb,
+                        "priv cred size: "
+                                + callerSubject
+                                        .getPrivateCredentials(
+                                                com.ibm.wsspi.security.oauth20.token.WSOAuth20Token.class)
+                                        .size());
+                writeLine(sb, "default priv cred: "
+                        + callerSubject.getPrivateCredentials().toString());
+                writeLine(sb, "default priv cred size: "
+                        + callerSubject.getPrivateCredentials().size());
+                if (callerToken != null) {
+                    writeLine(sb, "callerToken One: " + callerToken);
+                } else {
+                    writeLine(sb, "callerToken Two: null");
+                }
+            } else {
+                writeLine(sb, "callerCredential Three: null");
+                writeLine(sb, "callerToken Three: null");
+            }
+            writeLine(sb, "break 2");
 
-			// getInvocationSubject for RunAs tests
-			Subject runAsSubject = WSSubject.getRunAsSubject();
-			writeLine(sb, "RunAs subject: " + runAsSubject);
+            // getInvocationSubject for RunAs tests
+            Subject runAsSubject = WSSubject.getRunAsSubject();
+            writeLine(sb, "RunAs subject: " + runAsSubject);
 
-			// Check for cache key for hashtable login test. Will return null
-			// otherwise
-			String customCacheKey = null;
-			if (callerSubject != null) {
-				String[] properties = { AttributeNameConstants.WSCREDENTIAL_CACHE_KEY };
-				SubjectHelper subjectHelper = new SubjectHelper();
-				Hashtable<String, ?> customProperties = subjectHelper
-						.getHashtableFromSubject(callerSubject, properties);
-				if (customProperties != null) {
-					customCacheKey = (String) customProperties
-							.get(AttributeNameConstants.WSCREDENTIAL_CACHE_KEY);
-				}
-				if (customCacheKey == null) {
-					SingleSignonToken ssoToken = getSSOToken(callerSubject);
-					if (ssoToken != null) {
-						String[] attrs = ssoToken
-								.getAttributes(AttributeNameConstants.WSCREDENTIAL_CACHE_KEY);
-						if (attrs != null && attrs.length > 0) {
-							customCacheKey = attrs[0];
-						}
-					}
-				}
-			}
-			writeLine(sb, "customCacheKey: " + customCacheKey);
+            // Check for cache key for hashtable login test. Will return null
+            // otherwise
+            String customCacheKey = null;
+            if (callerSubject != null) {
+                String[] properties = { AttributeNameConstants.WSCREDENTIAL_CACHE_KEY };
+                SubjectHelper subjectHelper = new SubjectHelper();
+                Hashtable<String, ?> customProperties = subjectHelper
+                        .getHashtableFromSubject(callerSubject, properties);
+                if (customProperties != null) {
+                    customCacheKey = (String) customProperties
+                            .get(AttributeNameConstants.WSCREDENTIAL_CACHE_KEY);
+                }
+                if (customCacheKey == null) {
+                    SingleSignonToken ssoToken = getSSOToken(callerSubject);
+                    if (ssoToken != null) {
+                        String[] attrs = ssoToken
+                                .getAttributes(AttributeNameConstants.WSCREDENTIAL_CACHE_KEY);
+                        if (attrs != null && attrs.length > 0) {
+                            customCacheKey = attrs[0];
+                        }
+                    }
+                }
+            }
+            writeLine(sb, "customCacheKey: " + customCacheKey);
 
-		} catch (NoClassDefFoundError ne) {
-			// For OSGI App testing (EBA file), we expect this exception for all
-			// packages that are not public
-			writeLine(sb, "NoClassDefFoundError for SubjectManager: " + ne);
-		} catch (Throwable t) {
-			t.printStackTrace();
-		}
-	}
+        } catch (NoClassDefFoundError ne) {
+            // For OSGI App testing (EBA file), we expect this exception for all
+            // packages that are not public
+            writeLine(sb, "NoClassDefFoundError for SubjectManager: " + ne);
+        } catch (Throwable t) {
+            t.printStackTrace();
+        }
+    }
 
     /**
      * "Writes" the msg out to the client. This actually appends the msg
@@ -314,12 +317,14 @@ public abstract class BaseServlet extends HttpServlet {
      * because if too much data is written to the PrintWriter before the
      * logic is done, a flush() may get called and lock out changes to the
      * response.
-     * 
-     * @param sb Running StringBuffer
-     * @param msg Message to write
+     *
+     * @param sb
+     *            Running StringBuffer
+     * @param msg
+     *            Message to write
      */
     void writeLine(StringBuffer sb, String msg) {
-        sb.append(msg + "\n");
+        sb.append(msg + newLine);
     }
 
 }

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonValidationTools.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonValidationTools.java
@@ -1017,7 +1017,7 @@ public class CommonValidationTools {
                             String[] splitLine = part1.split(",");
                             if (splitLine != null) {
                                 if (splitLine[0] != null) {
-                                    String token = splitLine[0].replace("with value:", "").trim();
+                                    String token = splitLine[0].replace("with value:", "").trim().replace("}+$", "");
                                     Log.info(thisClass, thisMethod, "token: " + token);
                                     printJWTToken(token);
                                     return token;


### PR DESCRIPTION
Disable BasicBCLTests_omittedBackchannelLogoutUri_withIdTokenHint and BasicBCLTests_omittedBackchannelLogoutUri_withoutIdTokenHint until https://github.com/OpenLiberty/open-liberty/issues/21878 is resolved.