### PR TITLE
Fix app validation logic for started servers

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/ServerXMLBindingTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/ServerXMLBindingTest.java
@@ -78,9 +78,6 @@ public class ServerXMLBindingTest extends FATServletClient {
         //lookupServerXMLBindings
         FATServletClient.runTest(server, servlet, "lookupServerXMLBindings");
 
-        //remove app
-        server.removeAllInstalledAppsForValidation();
-
         if (server != null && server.isStarted()) {
             server.stopServer("CNTR0338W");
         }
@@ -100,9 +97,6 @@ public class ServerXMLBindingTest extends FATServletClient {
 
         //lookupServerXMLBindings
         FATServletClient.runTest(server, servlet, "lookupServerXMLBindings");
-
-        //remove app
-        server.removeAllInstalledAppsForValidation();
 
         if (server != null && server.isStarted()) {
             server.stopServer("CNTR0338W");

--- a/dev/com.ibm.ws.jpa.tests.ormdiagnostics_3.0_fat/fat/src/com/ibm/ws/jpa/ormdiagnostics/tests/TestExample_EAR.java
+++ b/dev/com.ibm.ws.jpa.tests.ormdiagnostics_3.0_fat/fat/src/com/ibm/ws/jpa/ormdiagnostics/tests/TestExample_EAR.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.jpa.ormdiagnostics.tests;
 
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.DISABLE_VALIDATION;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -106,7 +108,7 @@ public class TestExample_EAR extends JPAFATServletClient {
         app.addAsLibrary(jpa_libJar);
         ShrinkHelper.addDirectory(app, RESOURCE_ROOT + "resources/ear");
 
-        ShrinkHelper.exportAppToServer(server, app);
+        ShrinkHelper.exportAppToServer(server, app, DISABLE_VALIDATION);
 
         Application appRecord = new Application();
         appRecord.setLocation(appName + "_EAR.ear");

--- a/dev/com.ibm.ws.jpa.tests.ormdiagnostics_3.0_fat/fat/src/com/ibm/ws/jpa/ormdiagnostics/tests/TestExample_WAR.java
+++ b/dev/com.ibm.ws.jpa.tests.ormdiagnostics_3.0_fat/fat/src/com/ibm/ws/jpa/ormdiagnostics/tests/TestExample_WAR.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.jpa.ormdiagnostics.tests;
 
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.DISABLE_VALIDATION;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -94,7 +96,7 @@ public class TestExample_WAR extends JPAFATServletClient {
         webApp.addAsLibrary(ejbJar);
         ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + "resources/war");
 
-        ShrinkHelper.exportAppToServer(server, webApp);
+        ShrinkHelper.exportAppToServer(server, webApp, DISABLE_VALIDATION);
 
         Application appRecord = new Application();
         appRecord.setLocation(appName + "_WAR.war");

--- a/dev/com.ibm.ws.jpa.tests.ormdiagnostics_fat/fat/src/com/ibm/ws/jpa/ormdiagnostics/tests/TestExample_EAR.java
+++ b/dev/com.ibm.ws.jpa.tests.ormdiagnostics_fat/fat/src/com/ibm/ws/jpa/ormdiagnostics/tests/TestExample_EAR.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.jpa.ormdiagnostics.tests;
 
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.DISABLE_VALIDATION;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -106,7 +108,7 @@ public class TestExample_EAR extends JPAFATServletClient {
         app.addAsLibrary(jpa_libJar);
         ShrinkHelper.addDirectory(app, RESOURCE_ROOT + "resources/ear");
 
-        ShrinkHelper.exportAppToServer(server, app);
+        ShrinkHelper.exportAppToServer(server, app, DISABLE_VALIDATION);
 
         Application appRecord = new Application();
         appRecord.setLocation(appName + "_EAR.ear");

--- a/dev/com.ibm.ws.jpa.tests.ormdiagnostics_fat/fat/src/com/ibm/ws/jpa/ormdiagnostics/tests/TestExample_WAR.java
+++ b/dev/com.ibm.ws.jpa.tests.ormdiagnostics_fat/fat/src/com/ibm/ws/jpa/ormdiagnostics/tests/TestExample_WAR.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.jpa.ormdiagnostics.tests;
 
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.DISABLE_VALIDATION;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -94,7 +96,7 @@ public class TestExample_WAR extends JPAFATServletClient {
         webApp.addAsLibrary(ejbJar);
         ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + "resources/war");
 
-        ShrinkHelper.exportAppToServer(server, webApp);
+        ShrinkHelper.exportAppToServer(server, webApp, DISABLE_VALIDATION);
 
         Application appRecord = new Application();
         appRecord.setLocation(appName + "_WAR.war");

--- a/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/JSF23CDIGeneralTests.java
+++ b/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/JSF23CDIGeneralTests.java
@@ -42,6 +42,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlTableCell;
 import com.gargoylesoftware.htmlunit.html.HtmlTableRow;
 import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.jsf23.fat.JSFUtils;
 
@@ -388,7 +389,7 @@ public class JSF23CDIGeneralTests {
             assertTrue(testELResolutionImplicitObjectsPage.asText().contains("HttpSession isNew: true"));
             // Additional Requirement (See section 5.6.3)
             assertTrue(testELResolutionImplicitObjectsPage.asText().contains("ExternalContext getApplicationContextPath: /ELImplicitObjectsViaCDI"));
-            
+
         }
     }
 
@@ -448,7 +449,8 @@ public class JSF23CDIGeneralTests {
         // Use the ELImplicitObjectsViaCDIErrorAppServer.xml server configuration file.
         server.setMarkToEndOfLog();
         server.saveServerConfiguration();
-        ShrinkHelper.defaultApp(server, appName, "com.ibm.ws.jsf23.fat.elimplicit.cdi.error.beans");
+        DeployOptions[] options = new DeployOptions[] { DeployOptions.DISABLE_VALIDATION };
+        ShrinkHelper.defaultApp(server, appName, options, "com.ibm.ws.jsf23.fat.elimplicit.cdi.error.beans");
         server.setServerConfigurationFile("ELImplicitObjectsViaCDIErrorAppServer.xml");
 
         // Make sure the application doesn't start
@@ -475,8 +477,7 @@ public class JSF23CDIGeneralTests {
         // Ensure that the server configuration has completed before uninstalling the application
         server.waitForConfigUpdateInLogUsingMark(null);
 
-        // Now uninstall the application and archive the logs.
-        server.removeInstalledAppForValidation(appName.substring(0, appName.length() - 4));
+        // Now archive the logs.
         server.postStopServerArchive();
     }
 

--- a/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/JSF23FaceletVDLTests.java
+++ b/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/JSF23FaceletVDLTests.java
@@ -26,6 +26,7 @@ import org.junit.runner.RunWith;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.jsf23.fat.JSFUtils;
 
@@ -176,8 +177,10 @@ public class JSF23FaceletVDLTests {
 
         server.setMarkToEndOfLog();
         server.saveServerConfiguration();
-        ShrinkHelper.defaultApp(server, appName);
+        DeployOptions[] options = new DeployOptions[] { DeployOptions.DISABLE_VALIDATION };
+        ShrinkHelper.defaultApp(server, appName, options);
         server.setServerConfigurationFile(contextRoot + ".xml");
+        server.addInstalledAppForValidation(contextRoot);
 
         // Ensure the application was installed successfully.
         assertNotNull("The application " + appName + " did not appear to have been installed.",
@@ -234,7 +237,7 @@ public class JSF23FaceletVDLTests {
         // restore the original server configuration and uninstall the application
         server.restoreServerConfiguration();
 
-        // Ensure that the server configuration has completed before uninstalling the application
+        // Ensure that the server configuration has completed and that the app then stops
         server.waitForConfigUpdateInLogUsingMark(null);
 
         server.removeInstalledAppForValidation(contextRoot);

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/utils/JSFApplication.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/utils/JSFApplication.java
@@ -109,6 +109,7 @@ public class JSFApplication implements TestRule {
                 server.addInstalledAppForValidation(appName);
                 Log.info(c, description.getMethodName(), "STARTED MOJARRA TEST");
                 base.evaluate();
+                server.removeDropinsApplications(mojarraApp.getName());
                 server.removeInstalledAppForValidation(appName);
             }
 
@@ -117,6 +118,7 @@ public class JSFApplication implements TestRule {
                 server.addInstalledAppForValidation(appName);
                 Log.info(c, description.getMethodName(), "STARTED MYFACES TEST");
                 base.evaluate();
+                server.removeDropinsApplications(myfacesApp.getName());
                 server.removeInstalledAppForValidation(appName);
             }
         }

--- a/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/RealFlushTest.java
+++ b/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/RealFlushTest.java
@@ -15,7 +15,6 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -326,8 +325,8 @@ public class RealFlushTest {
     @AfterClass
     public static void completeTest() throws Exception {
         if (server != null && server.isStarted()) {
-            server.removeAllInstalledAppsForValidation();
             server.stopServer("CWWKW1001W");
+            server.removeAllInstalledAppsForValidation();
         }
     }
 }

--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/ApplicationProcessorTest.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/ApplicationProcessorTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.openapi.fat;
 
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.DISABLE_VALIDATION;
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
@@ -371,8 +372,8 @@ public class ApplicationProcessorTest extends FATServletClient {
         WebArchive test2 = ShrinkWrap.create(WebArchive.class, "test2.war")
             .addPackage(JAXRSApp.class.getPackage());
 
-        ShrinkHelper.exportAppToServer(server, test1, SERVER_ONLY);
-        ShrinkHelper.exportAppToServer(server, test2, SERVER_ONLY);
+        ShrinkHelper.exportAppToServer(server, test1, SERVER_ONLY, DISABLE_VALIDATION);
+        ShrinkHelper.exportAppToServer(server, test2, SERVER_ONLY, DISABLE_VALIDATION);
 
         // Deploy both in the same server.xml update and ensure they start
         server.setMarkToEndOfLog(server.getDefaultLogFile());
@@ -382,8 +383,8 @@ public class ApplicationProcessorTest extends FATServletClient {
         config.addApplication("test2", "${server.config.dir}/apps/test2.war", "war");
         server.updateServerConfiguration(config);
 
-        server.waitForStringInLogUsingMark("CWWKZ0001I.*test1");
-        server.waitForStringInLogUsingMark("CWWKZ0001I.*test2");
+        server.addInstalledAppForValidation("test1");
+        server.addInstalledAppForValidation("test2");
 
         // Check there were no errors or warnings emitted during startup
         List<String> errorsAndWarnings = server.findStringsInLogsUsingMark("[EW] .*\\d{4}[EW]:",

--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/utils/OpenAPITestUtil.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/utils/OpenAPITestUtil.java
@@ -183,7 +183,7 @@ public class OpenAPITestUtil {
         if (waitForAppProcessor) {
             waitForApplicationProcessorAddedEvent(server, name);
         }
-        server.validateAppLoaded(name);
+        server.addInstalledAppForValidation(name);
         return app;
     }
 

--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/utils/OpenAPITestUtil.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/utils/OpenAPITestUtil.java
@@ -154,8 +154,7 @@ public class OpenAPITestUtil {
             server.updateServerConfiguration(config);
             server.waitForConfigUpdateInLogUsingMark(null);
             waitForApplicationProcessorRemovedEvent(server, appName);
-            assertNotNull("FAIL: App didn't report is has been stopped.",
-                server.waitForStringInLogUsingMark("CWWKZ0009I.*" + appName));
+            server.removeInstalledAppForValidation(appName);
         } catch (Exception e) {
             fail("FAIL: Could not remove the application " + appName);
         }

--- a/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleRealmTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleRealmTest.java
@@ -109,6 +109,7 @@ public class EJBModuleRealmTest extends JavaEESecTestBase {
     }
 
     protected static void startServer(String config, String appName, String appName2) throws Exception {
+        myServer.removeAllInstalledAppsForValidation(); // We're changing configuration, so clear the list of apps expected to start
         myServer.setServerConfigurationFile(config);
         myServer.addInstalledAppForValidation(appName);
         myServer.addInstalledAppForValidation(appName2);
@@ -194,8 +195,6 @@ public class EJBModuleRealmTest extends JavaEESecTestBase {
         httpclient.getConnectionManager().shutdown();
         setupConnection();
 
-        myServer.removeInstalledAppForValidation(EJB_REALM_APP_NAME);
-        myServer.removeInstalledAppForValidation(EJB_REALM2_APP_NAME);
         Log.info(logClass, getCurrentTestName(), "-----Exiting " + getCurrentTestName());
     }
 
@@ -277,8 +276,6 @@ public class EJBModuleRealmTest extends JavaEESecTestBase {
         httpclient.getConnectionManager().shutdown();
         setupConnection();
 
-        myServer.removeInstalledAppForValidation(EJB_REALM_APP_NAME);
-        myServer.removeInstalledAppForValidation(EJB_REALM2_APP_NAME);
         Log.info(logClass, getCurrentTestName(), "-----Exiting " + getCurrentTestName());
     }
 

--- a/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleDBRunAsTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleDBRunAsTest.java
@@ -62,8 +62,8 @@ public class MultipleModuleDBRunAsTest extends JavaEESecTestBase {
     protected static String XML_DB_NAME = "multipleModuleRunAsDB.xml";
     protected static String APP_NAME = "multipleModuleRunAs";
     protected static String EAR_NAME = APP_NAME + ".ear";
-    protected static String APP_DB_NAME = "multipleDB";
-    protected static String WAR_DB_NAME = APP_DB_NAME + ".war";
+    protected static String APP_DB_NAME = "MultipleDBServlet";
+    protected static String WAR_DB_NAME = "multipleDB.war";
     protected static String APP1_SERVLET = "/" + MODULE1_ROOT + "/MultipleISFormRunAsServlet";
     protected static String APP2_SERVLET = "/" + MODULE2_ROOT + "/MultipleISCustomFormRunAsServlet";
 

--- a/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalLoginTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalLoginTest.java
@@ -130,6 +130,7 @@ public class MultipleModuleGlobalLoginTest extends JavaEESecTestBase {
         ldapServer = new LocalLdapServer();
         ldapServer.start();
 
+        myServer.removeAllInstalledAppsForValidation(); // Ensure there's no expected installed apps from a previous repeat
         myServer.setServerConfigurationFile(XML_BASE_NAME);
         myServer.startServer(true);
         urlBase = "http://" + myServer.getHostname() + ":" + myServer.getHttpDefaultPort();
@@ -202,14 +203,14 @@ public class MultipleModuleGlobalLoginTest extends JavaEESecTestBase {
 
         myServer.setServerConfigurationFile(XML_FORM_NAME);
         myServer.addInstalledAppForValidation(APP_NAME);
-        myServer.addInstalledAppForValidation(GLOBAL_LOGIN_WAR);
+        myServer.addInstalledAppForValidation(GLOBAL_LOGIN_ROOT);
 
         runMultipulModuleFormScenario();
 
         myServer.setMarkToEndOfLog();
         myServer.setServerConfigurationFile(XML_BASE_NAME);
         myServer.removeInstalledAppForValidation(APP_NAME);
-        myServer.removeInstalledAppForValidation(GLOBAL_LOGIN_WAR);
+        myServer.removeInstalledAppForValidation(GLOBAL_LOGIN_ROOT);
         Log.info(logClass, getCurrentTestName(), "-----Exiting " + getCurrentTestName());
     }
 
@@ -251,14 +252,14 @@ public class MultipleModuleGlobalLoginTest extends JavaEESecTestBase {
 
         myServer.setServerConfigurationFile(XML_NO_ROOT_CONTEXT_NAME);
         myServer.addInstalledAppForValidation(APP_NAME);
-        myServer.addInstalledAppForValidation(GLOBAL_LOGIN_WAR);
+        myServer.addInstalledAppForValidation(GLOBAL_LOGIN_ROOT);
 
         runMultipulModuleFormScenario();
 
         myServer.setMarkToEndOfLog();
         myServer.setServerConfigurationFile(XML_BASE_NAME);
         myServer.removeInstalledAppForValidation(APP_NAME);
-        myServer.removeInstalledAppForValidation(GLOBAL_LOGIN_WAR);
+        myServer.removeInstalledAppForValidation(GLOBAL_LOGIN_ROOT);
         Log.info(logClass, getCurrentTestName(), "-----Exiting " + getCurrentTestName());
     }
 

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleTestProtectedServlet.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleTestProtectedServlet.java
@@ -60,9 +60,9 @@ public class EJBModuleTestProtectedServlet extends JavaEESecTestBase {
     protected static String EJB_REALM2_WAR_NAME = "AnnotatedEjbinWarServletLdapRealm2.war";
     protected static String EJB_REALM2_WAR_PATH = "/AnnotatedEjbinWarServletLdapRealm2/";
     protected static String EJB_EAR_NAME = "securityejbinwar2.ear";
-    protected static String EJB_APP_NAME = EJB_EAR_NAME;
+    protected static String EJB_APP_NAME = "securityejbinwar2";
     protected static String EJB_EAR_REALM_NAME = "securityejbinwarrealm.ear";
-    protected static String EJB_REALM_APP_NAME = EJB_EAR_REALM_NAME;
+    protected static String EJB_REALM_APP_NAME = "securityejbinwarrealm";
     protected static String XML_NAME = "ejbprotectedserver.xml";
     protected static String XML_REALM_NAME = "ejbprotectedrealmserver.xml";
     protected static String JASPIC_RUN_AS_XML_NAME = "ejbprotectedCustomISRunAsserver.xml";

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat_helper/JavaEESecTestBase.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat_helper/JavaEESecTestBase.java
@@ -19,7 +19,9 @@ import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
+import java.util.HashSet;
 import java.util.List;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
@@ -115,7 +117,7 @@ public class JavaEESecTestBase {
      * Process the response from an http invocation, such as validating
      * the status code, extracting the response entity...
      *
-     * @param response the HttpResponse
+     * @param response           the HttpResponse
      * @param expectedStatusCode
      * @return The response entity text, or null if request failed
      * @throws IOException
@@ -295,10 +297,10 @@ public class JavaEESecTestBase {
      * Send HttpClient get request to the given URL, ensure that the user is redirected to the form login page
      * and that the JASPI provider was or was not called, as expected.
      *
-     * @param httpclient HttpClient object to execute request
-     * @param url URL for request, should be protected and redirect to form login page
+     * @param httpclient   HttpClient object to execute request
+     * @param url          URL for request, should be protected and redirect to form login page
      * @param providerName Name of JASPI provider that should authenticate the request, null if JASPI not enabled for request
-     * @param formTitle Name of Login form (defaults to Form Login Page if not specified)
+     * @param formTitle    Name of Login form (defaults to Form Login Page if not specified)
      * @throws Exception
      */
     public void getFormLoginPage(HttpClient httpclient, String url, String providerName) throws Exception {
@@ -341,10 +343,10 @@ public class JavaEESecTestBase {
      * This propety let httpclient disable following the redirect automatically.
      *
      * @param httpclient HttpClient object to execute request
-     * @param url URL for request, should be protected and redirect to form login page
-     * @param redirect true if redirect is used to go to the login page, otherwise, use forward.
-     * @param formUrl Url of login page. this value is used when redirect is set as true.
-     * @param formTitle Name of Login form.
+     * @param url        URL for request, should be protected and redirect to form login page
+     * @param redirect   true if redirect is used to go to the login page, otherwise, use forward.
+     * @param formUrl    Url of login page. this value is used when redirect is set as true.
+     * @param formTitle  Name of Login form.
      * @throws Exception
      */
 
@@ -397,11 +399,11 @@ public class JavaEESecTestBase {
      * This propety let httpclient disable following the redirect automatically.
      *
      * @param httpclient HttpClient object to execute request
-     * @param url URL for request, should be protected and redirect to form login page
-     * @param params post parameters.
-     * @param redirect true if redirect is used to go to the login page, otherwise, use forward.
-     * @param formUrl Url of login page. this value is used when redirect is set as true.
-     * @param formTitle Name of Login form.
+     * @param url        URL for request, should be protected and redirect to form login page
+     * @param params     post parameters.
+     * @param redirect   true if redirect is used to go to the login page, otherwise, use forward.
+     * @param formUrl    Url of login page. this value is used when redirect is set as true.
+     * @param formTitle  Name of Login form.
      * @throws Exception
      */
 
@@ -451,9 +453,9 @@ public class JavaEESecTestBase {
      * Post HttpClient request to execute a form login on the given page, using the given username and password
      *
      * @param httpclient HttpClient object to execute login
-     * @param url URL for login page
-     * @param username User name
-     * @param password User password
+     * @param url        URL for login page
+     * @param username   User name
+     * @param password   User password
      * @return URL of page redirected to after the login
      * @throws Exception
      */
@@ -869,11 +871,7 @@ public class JavaEESecTestBase {
             Log.info(logClass, "setServerConfiguration", "setServerConfigurationFile to : " + serverXML);
             server.setMarkToEndOfLog();
             server.setServerConfigurationFile("/" + serverXML);
-            if (appNames != null) {
-                for (String appName : appNames) {
-                    server.addInstalledAppForValidation(appName);
-                }
-            }
+            server.waitForConfigUpdateInLogUsingMark(new HashSet<>(Arrays.asList(appNames)));
             serverConfigurationFile = serverXML;
         }
     }
@@ -886,7 +884,7 @@ public class JavaEESecTestBase {
 
     /**
      * Assert that the regular expression string is present or NOT present in the server's logs.
-     * 
+     *
      * @param regexp The regular expression string to search for.
      * @throws Exception If there was an error checking the log or trace files.
      */
@@ -896,8 +894,8 @@ public class JavaEESecTestBase {
 
     /**
      * Assert that the regular expression string is present or NOT present in the server's logs.
-     * 
-     * @param regexp The regular expression string to search for.
+     *
+     * @param regexp    The regular expression string to search for.
      * @param isPresent If true, check that the string is present. If false, check that it is NOT present.
      * @throws Exception If there was an error checking the log or trace files.
      */
@@ -912,7 +910,7 @@ public class JavaEESecTestBase {
 
     /**
      * Assert that the regular expression string is present in the server's logs or trace
-     * 
+     *
      * @param regexp The regular expression string to search for.
      * @throws Exception If there was an error checking the log or trace files.
      */
@@ -922,8 +920,8 @@ public class JavaEESecTestBase {
 
     /**
      * Assert that the regular expression string is present or NOT present in the server's logs or trace.
-     * 
-     * @param regexp The regular expression string to search for.
+     *
+     * @param regexp    The regular expression string to search for.
      * @param isPresent If true, check that the string is present. If false, check that it is NOT present.
      * @throws Exception If there was an error checking the log or trace files.
      */

--- a/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/ReplayCookieTests.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/ReplayCookieTests.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package com.ibm.ws.security.jwtsso.fat;
 
-import static org.junit.Assert.assertNotNull;
-
 import java.io.File;
 import java.io.StringReader;
 import java.net.MalformedURLException;
@@ -300,11 +298,11 @@ public class ReplayCookieTests extends CommonSecurityFat {
     @Test
     public void test_obtainLtpa_reconfigureToUseJwtSso_reaccessResourceWithLtpaCookie() throws Exception {
 
-        expandAndUpdateServerConfiguration(server, "server_noFeature.xml", true, "formlogin", "testmarker");
+        expandAndUpdateServerConfiguration(server, "server_noFeature.xml", true, JwtFatConstants.APP_FORMLOGIN, JwtFatConstants.APP_TESTMARKER);
 
         Cookie ltpaCookie = actions.logInAndObtainLtpaCookie(_testName, protectedUrl, defaultUser, defaultPassword);
 
-        expandAndUpdateServerConfiguration(server, DEFAULT_CONFIG, true, APP_NAME_JWT_BUILDER, "formlogin", "testmarker");
+        expandAndUpdateServerConfiguration(server, DEFAULT_CONFIG, true, APP_NAME_JWT_BUILDER, JwtFatConstants.APP_FORMLOGIN, JwtFatConstants.APP_TESTMARKER);
 
         // Access the protected again using a new conversation with the LTPA cookie included
         String currentAction = TestActions.ACTION_INVOKE_PROTECTED_RESOURCE;
@@ -330,11 +328,11 @@ public class ReplayCookieTests extends CommonSecurityFat {
     @Test
     public void test_obtainLtpa_reconfigureToUseJwtSso_reaccessResourceWithLtpaCookie_useLtpaIfJwtAbsent() throws Exception {
 
-        expandAndUpdateServerConfiguration(server, "server_noFeature.xml", true, "formlogin", "testmarker");
+        expandAndUpdateServerConfiguration(server, "server_noFeature.xml", true, JwtFatConstants.APP_FORMLOGIN, JwtFatConstants.APP_TESTMARKER);
 
         Cookie ltpaCookie = actions.logInAndObtainLtpaCookie(_testName, protectedUrl, defaultUser, defaultPassword);
 
-        expandAndUpdateServerConfiguration(server, "server_useLtpaIfJwtAbsent_true.xml", true, "formlogin", "testmarker");
+        expandAndUpdateServerConfiguration(server, "server_useLtpaIfJwtAbsent_true.xml", true, JwtFatConstants.APP_FORMLOGIN, JwtFatConstants.APP_TESTMARKER);
 
         // Access the protected again using a new conversation with the LTPA cookie included
         String currentAction = TestActions.ACTION_INVOKE_PROTECTED_RESOURCE;
@@ -350,8 +348,6 @@ public class ReplayCookieTests extends CommonSecurityFat {
 
         Page response = actions.invokeUrlWithCookie(_testName, protectedUrl, ltpaCookie);
         validationUtils.validateResult(response, currentAction, expectations);
-        
-        //expandAndUpdateServerConfiguration(server, DEFAULT_CONFIG, false, APP_NAME_JWT_BUILDER, "formlogin", "testmarker");
     }
 
     /**
@@ -367,7 +363,7 @@ public class ReplayCookieTests extends CommonSecurityFat {
 
         Cookie jwtCookie = actions.logInAndObtainJwtCookie(_testName, protectedUrl, defaultUser, defaultPassword);
 
-        expandAndUpdateServerConfiguration(server, "server_noFeature.xml", true, "formlogin", "testmarker");
+        expandAndUpdateServerConfiguration(server, "server_noFeature.xml", true, JwtFatConstants.APP_FORMLOGIN, JwtFatConstants.APP_TESTMARKER);
 
         // Access the protected again using a new conversation with the JWT SSO cookie included
         String currentAction = TestActions.ACTION_INVOKE_PROTECTED_RESOURCE;
@@ -377,8 +373,6 @@ public class ReplayCookieTests extends CommonSecurityFat {
 
         Page response = actions.invokeUrlWithCookie(_testName, protectedUrl, jwtCookie);
         validationUtils.validateResult(response, currentAction, expectations);
-        
-        //expandAndUpdateServerConfiguration(server, DEFAULT_CONFIG, true, APP_NAME_JWT_BUILDER, "formlogin", "testmarker");
     }
 
     /**
@@ -413,8 +407,6 @@ public class ReplayCookieTests extends CommonSecurityFat {
         validationUtils.validateResult(response, currentAction, expectations);
 
         actions.destroyWebClient(webClient);
-        
-        //expandAndUpdateServerConfiguration(server, DEFAULT_CONFIG, false, APP_NAME_JWT_BUILDER);
     }
 
     /**

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/WCServerTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/WCServerTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.webcontainer.servlet31.fat.tests;
 
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.DISABLE_VALIDATION;
 import static componenttest.annotation.SkipForRepeat.EE10_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
@@ -177,12 +178,12 @@ public class WCServerTest extends LoggingTest {
             appInstalled = SHARED_SERVER.getLibertyServer().getInstalledAppNames(TEST_SERVLET_MAPPING_APP_NAME);
             LOG.info("addAppToServer : " + TEST_SERVLET_MAPPING_APP_NAME + " already installed : " + !appInstalled.isEmpty());
             if (appInstalled.isEmpty())
-                ShrinkHelper.exportAppToServer(SHARED_SERVER.getLibertyServer(), TestServletMappingApp);
+                ShrinkHelper.exportAppToServer(SHARED_SERVER.getLibertyServer(), TestServletMappingApp, DISABLE_VALIDATION);
 
             appInstalled = SHARED_SERVER.getLibertyServer().getInstalledAppNames(TEST_SERVLET_MAPPING_ANNO_APP_NAME);
             LOG.info("addAppToServer : " + TEST_SERVLET_MAPPING_ANNO_APP_NAME + " already installed : " + !appInstalled.isEmpty());
             if (appInstalled.isEmpty())
-                ShrinkHelper.exportAppToServer(SHARED_SERVER.getLibertyServer(), TestServletMappingAnnoApp);
+                ShrinkHelper.exportAppToServer(SHARED_SERVER.getLibertyServer(), TestServletMappingAnnoApp, DISABLE_VALIDATION);
         }
 
         SHARED_SERVER.startIfNotStarted();

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCResponseHeadersTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCResponseHeadersTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.websphere.simplicity.config.HttpEndpoint;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.log.Log;
@@ -1230,7 +1231,8 @@ public class WCResponseHeadersTest {
         Header expectedHeader = null;
 
         // Build and deploy the application that we need for this test
-        ShrinkHelper.defaultApp(server, APP_NAME_SECURE_APP + ".war", "samesite.security.servlet");
+        DeployOptions[] options = new DeployOptions[] { DeployOptions.DISABLE_VALIDATION };
+        ShrinkHelper.defaultApp(server, APP_NAME_SECURE_APP + ".war", options, "samesite.security.servlet");
 
         // Use the necessary server.xml for this test.
         ServerConfiguration configuration = server.getServerConfiguration();
@@ -1371,8 +1373,6 @@ public class WCResponseHeadersTest {
 
                 assertTrue("Response did not contain expected response: " + expectedResponse,
                            content.equals(expectedResponse));
-            } finally {
-                server.removeInstalledAppForValidation(APP_NAME_SECURE_APP);
             }
         }
 

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/ShrinkHelper.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/ShrinkHelper.java
@@ -145,6 +145,9 @@ public class ShrinkHelper {
      * Writes an application to a a file in the 'publish/servers/<server_name>/apps/' directory
      * with the file name returned by a.getName(), which should include the
      * file type extension (.ear, .war, .jar, .rar, etc)
+     * <p>
+     * Note that if you're deploying to a running server, this method will wait for the application to start before returning unless you pass the
+     * {@link DeployOptions#DISABLE_VALIDATION DISABLE_VALIDATION} option.
      *
      * @param server  The server to publish the application to
      * @param a       The archive to export as a file

--- a/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/SecureTest.java
+++ b/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/SecureTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package io.openliberty.wsoc.tests;
 
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.DISABLE_VALIDATION;
+
 import java.io.File;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -83,7 +85,7 @@ public class SecureTest {
             Set<String> appInstalled = LS.getInstalledAppNames(SECURE_WAR_NAME);
             LOG.info("addAppToServer : " + SECURE_WAR_NAME + " already installed : " + !appInstalled.isEmpty());
             if (appInstalled.isEmpty())
-                ShrinkHelper.exportDropinAppToServer(LS, SecureApp);
+                ShrinkHelper.exportDropinAppToServer(LS, SecureApp, DISABLE_VALIDATION);
         }
 
         LS.saveServerConfiguration();


### PR DESCRIPTION
The previous logic was broken:

When the first app (e.g. named `appOne`) is deployed, the `startApplicationMessages` counter is incremented and it waits for one message matching `CWWKZ0001I:.*appOne`

When the second app (e.g. named `appTwo`) is deployed, the `startApplicationMessages` counter is incremented and it waits for *two* messages matching `CWWKZ0001I:.*appTwo`

It'll never get two messages so it will always wait for the full timeout, log an error and then continue.

Instead, this change means we will look for messages indicating that the application has either started or stopped and assumes that the most recent message represents the application's current state.

If there are no started or stopped messages, the application is assumed to be stopped.

In addition, I've changed the code to throw an exception if the app fails to start or stop. This ensures that we get error messages as early as possible if something goes wrong during app deployment and that the test always fails if this check times out.

Fixes #21887
Hopefully also helps with RTC291366
Hopefully also reduces runtimes for a bunch of buckets