### PR TITLE
OIDC back-channel logout: Do not remove tokens for non-BCL clients

### DIFF
--- a/dev/com.ibm.ws.security.fat.common.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/CommonTests/BasicBCLTests.java
+++ b/dev/com.ibm.ws.security.fat.common.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/CommonTests/BasicBCLTests.java
@@ -888,9 +888,11 @@ public class BasicBCLTests extends BackChannelLogoutCommonTests {
         // logout expectations - just make sure we landed on the end_session/logout page - always with a good status code
         invokeLogout(webClient, updatedTestSettings, initLogoutWithHttpFailureExpectations(finalAppWithoutPostRedirect, client), response);
 
-        // Test uses the standard backchannelLogoutUri - so end_session with bcl steps should be performed - set expected states accordingly
+        // Access and refresh tokens should not be cleaned up since the BCL endpoint is not considered valid
         AfterLogoutStates states = new AfterLogoutStates(Constants.usesInvalidBCLEndpoint, updatedTestSettings.getFlowType(), logoutMethodTested, sessionLogoutEndpoint, updatedTestSettings.getRsTokenType());
-        //states.setIsRefreshTokenValid(true);
+        if (!currentRepeatAction.contains(Constants.END_SESSION)) {
+            states.setIsRefreshTokenValid(true);
+        }
 
         // Make sure that all cookies and tokens have been cleaned up
         validateLogoutResult(webClient, updatedTestSettings, tokens, states);
@@ -926,9 +928,11 @@ public class BasicBCLTests extends BackChannelLogoutCommonTests {
         // logout expectations - just make sure we landed on the end_session/logout page - always with a good status code
         invokeLogout(webClient, updatedTestSettings, initLogoutWithHttpFailureExpectations(finalAppWithoutPostRedirect, client), response);
 
-        // Test uses the standard backchannelLogoutUri - so end_session with bcl steps should be performed - set expected states accordingly
+        // Access and refresh tokens should not be cleaned up since the BCL endpoint is not considered valid
         AfterLogoutStates states = new AfterLogoutStates(Constants.usesInvalidBCLEndpoint, updatedTestSettings.getFlowType(), logoutMethodTested, sessionLogoutEndpoint, updatedTestSettings.getRsTokenType());
-        //states.setIsRefreshTokenValid(true);
+        if (!currentRepeatAction.contains(Constants.END_SESSION)) {
+            states.setIsRefreshTokenValid(true);
+        }
 
         // Make sure that all cookies and tokens have been cleaned up
         validateLogoutResult(webClient, updatedTestSettings, tokens, states);
@@ -989,9 +993,11 @@ public class BasicBCLTests extends BackChannelLogoutCommonTests {
         // logout expectations - just make sure we landed on the end_session/logout page - always with a good status code
         invokeLogout(webClient, updatedTestSettings, initLogoutWithHttpFailureExpectations(finalAppWithoutPostRedirect, client), response);
 
-        // Test uses the standard backchannelLogoutUri - so end_session with bcl steps should be performed - set expected states accordingly
+        // Access and refresh tokens should not be cleaned up since the BCL endpoint is not considered valid
         AfterLogoutStates states = new AfterLogoutStates(Constants.usesInvalidBCLEndpoint, updatedTestSettings.getFlowType(), logoutMethodTested, sessionLogoutEndpoint, updatedTestSettings.getRsTokenType());
-        //states.setIsRefreshTokenValid(true);
+        if (!currentRepeatAction.contains(Constants.END_SESSION)) {
+            states.setIsRefreshTokenValid(true);
+        }
 
         // Make sure that all cookies and tokens have been cleaned up
         validateLogoutResult(webClient, updatedTestSettings, tokens, states);
@@ -1026,9 +1032,11 @@ public class BasicBCLTests extends BackChannelLogoutCommonTests {
         // logout expectations - just make sure we landed on the end_session/logout page - always with a good status code
         invokeLogout(webClient, updatedTestSettings, initLogoutWithHttpFailureExpectations(finalAppWithoutPostRedirect, client), response);
 
-        // Test uses the standard backchannelLogoutUri - so end_session with bcl steps should be performed - set expected states accordingly
+        // Access and refresh tokens should not be cleaned up since the BCL endpoint is not considered valid
         AfterLogoutStates states = new AfterLogoutStates(Constants.usesInvalidBCLEndpoint, updatedTestSettings.getFlowType(), logoutMethodTested, sessionLogoutEndpoint, updatedTestSettings.getRsTokenType());
-        //states.setIsRefreshTokenValid(true);
+        if (!currentRepeatAction.contains(Constants.END_SESSION)) {
+            states.setIsRefreshTokenValid(true);
+        }
 
         // Make sure that all cookies and tokens have been cleaned up
         validateLogoutResult(webClient, updatedTestSettings, tokens, states);

--- a/dev/com.ibm.ws.security.fat.common.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/CommonTests/BasicBCLTests.java
+++ b/dev/com.ibm.ws.security.fat.common.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/CommonTests/BasicBCLTests.java
@@ -891,7 +891,13 @@ public class BasicBCLTests extends BackChannelLogoutCommonTests {
         // Access and refresh tokens should not be cleaned up since the BCL endpoint is not considered valid
         AfterLogoutStates states = new AfterLogoutStates(Constants.usesInvalidBCLEndpoint, updatedTestSettings.getFlowType(), logoutMethodTested, sessionLogoutEndpoint, updatedTestSettings.getRsTokenType());
         if (!currentRepeatAction.contains(Constants.END_SESSION)) {
+            // The end_session flow, however, will still clean up the refresh token
             states.setIsRefreshTokenValid(true);
+        }
+        if (!currentRepeatAction.contains("Social")) {
+            // oidcLogin clients for the social login feature don't support token propagation, so access tokens will not be considered valid by those clients.
+            // All other clients should still consider the access token valid.
+            states.setIsAccessTokenValid(true);
         }
 
         // Make sure that all cookies and tokens have been cleaned up
@@ -931,7 +937,13 @@ public class BasicBCLTests extends BackChannelLogoutCommonTests {
         // Access and refresh tokens should not be cleaned up since the BCL endpoint is not considered valid
         AfterLogoutStates states = new AfterLogoutStates(Constants.usesInvalidBCLEndpoint, updatedTestSettings.getFlowType(), logoutMethodTested, sessionLogoutEndpoint, updatedTestSettings.getRsTokenType());
         if (!currentRepeatAction.contains(Constants.END_SESSION)) {
+            // The end_session flow, however, will still clean up the refresh token
             states.setIsRefreshTokenValid(true);
+        }
+        if (!currentRepeatAction.contains("Social")) {
+            // oidcLogin clients for the social login feature don't support token propagation, so access tokens will not be considered valid by those clients.
+            // All other clients should still consider the access token valid.
+            states.setIsAccessTokenValid(true);
         }
 
         // Make sure that all cookies and tokens have been cleaned up
@@ -996,7 +1008,13 @@ public class BasicBCLTests extends BackChannelLogoutCommonTests {
         // Access and refresh tokens should not be cleaned up since the BCL endpoint is not considered valid
         AfterLogoutStates states = new AfterLogoutStates(Constants.usesInvalidBCLEndpoint, updatedTestSettings.getFlowType(), logoutMethodTested, sessionLogoutEndpoint, updatedTestSettings.getRsTokenType());
         if (!currentRepeatAction.contains(Constants.END_SESSION)) {
+            // The end_session flow, however, will still clean up the refresh token
             states.setIsRefreshTokenValid(true);
+        }
+        if (!currentRepeatAction.contains("Social")) {
+            // oidcLogin clients for the social login feature don't support token propagation, so access tokens will not be considered valid by those clients.
+            // All other clients should still consider the access token valid.
+            states.setIsAccessTokenValid(true);
         }
 
         // Make sure that all cookies and tokens have been cleaned up
@@ -1035,7 +1053,13 @@ public class BasicBCLTests extends BackChannelLogoutCommonTests {
         // Access and refresh tokens should not be cleaned up since the BCL endpoint is not considered valid
         AfterLogoutStates states = new AfterLogoutStates(Constants.usesInvalidBCLEndpoint, updatedTestSettings.getFlowType(), logoutMethodTested, sessionLogoutEndpoint, updatedTestSettings.getRsTokenType());
         if (!currentRepeatAction.contains(Constants.END_SESSION)) {
+            // The end_session flow, however, will still clean up the refresh token
             states.setIsRefreshTokenValid(true);
+        }
+        if (!currentRepeatAction.contains("Social")) {
+            // oidcLogin clients for the social login feature don't support token propagation, so access tokens will not be considered valid by those clients.
+            // All other clients should still consider the access token valid.
+            states.setIsAccessTokenValid(true);
         }
 
         // Make sure that all cookies and tokens have been cleaned up

--- a/dev/com.ibm.ws.security.fat.common.backchannelLogout/publish/files/serversettings/oidcClient_configTests.xml
+++ b/dev/com.ibm.ws.security.fat.common.backchannelLogout/publish/files/serversettings/oidcClient_configTests.xml
@@ -556,6 +556,8 @@
 		authorizationEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_true/authorize"
 		tokenEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_true/token"
 		authFilterRef="bcl_httpPublicClient_httpsRequired_true_withSecret_filter"
+		validationMethod="introspect"
+		validationEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_true/introspect"
 	>
 	</openidConnectClient>
 
@@ -573,6 +575,8 @@
 		authorizationEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_true/authorize"
 		tokenEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_true/token"
 		authFilterRef="bcl_httpPublicClient_httpsRequired_true_withoutSecret_filter"
+		validationMethod="introspect"
+		validationEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_true/introspect"
 	>
 	</openidConnectClient>
 		
@@ -609,6 +613,8 @@
 		authorizationEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_false/authorize"
 		tokenEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_false/token"
 		authFilterRef="bcl_httpPublicClient_httpsRequired_false_withSecret_filter"
+		validationMethod="introspect"
+		validationEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_false/introspect"
 	>
 	</openidConnectClient>
 
@@ -626,6 +632,8 @@
 		authorizationEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_false/authorize"
 		tokenEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_false/token"
 		authFilterRef="bcl_httpPublicClient_httpsRequired_false_withoutSecret_filter"
+		validationMethod="introspect"
+		validationEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_http_httpsRequired_false/introspect"
 	>
 	</openidConnectClient>
 		

--- a/dev/com.ibm.ws.security.fat.common.backchannelLogout/publish/files/serversettings/oidcProvider_configTests.xml
+++ b/dev/com.ibm.ws.security.fat.common.backchannelLogout/publish/files/serversettings/oidcProvider_configTests.xml
@@ -604,6 +604,7 @@
 				redirect="https://localhost:${bvt.prop.security_2_HTTP_default.secure}/oidcclient/redirect/bcl_http_publicClient_httpsRequired_true_withSecret,
 					https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ibm/api/social-login/redirect/bcl_http_publicClient_httpsRequired_true_withSecret"
 				scope="ALL_SCOPES"
+				introspectTokens="true"
 				enabled="true"
 			>
 			</client>
@@ -615,6 +616,7 @@
 				redirect="https://localhost:${bvt.prop.security_2_HTTP_default.secure}/oidcclient/redirect/bcl_http_publicClient_httpsRequired_true_withoutSecret,
 					https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ibm/api/social-login/redirect/bcl_http_publicClient_httpsRequired_true_withoutSecret"
 				scope="ALL_SCOPES"
+				introspectTokens="true"
 				enabled="true"
 			>
 			</client>
@@ -661,6 +663,7 @@
 				redirect="https://localhost:${bvt.prop.security_2_HTTP_default.secure}/oidcclient/redirect/bcl_http_publicClient_httpsRequired_false_withSecret,
 					https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ibm/api/social-login/redirect/bcl_http_publicClient_httpsRequired_false_withSecret"
 				scope="ALL_SCOPES"
+				introspectTokens="true"
 				enabled="true"
 			>
 			</client>
@@ -672,6 +675,7 @@
 				redirect="https://localhost:${bvt.prop.security_2_HTTP_default.secure}/oidcclient/redirect/bcl_http_publicClient_httpsRequired_false_withoutSecret,
 					https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ibm/api/social-login/redirect/bcl_http_publicClient_httpsRequired_false_withoutSecret"
 				scope="ALL_SCOPES"
+				introspectTokens="true"
 				enabled="true"
 			>
 			</client>

--- a/dev/com.ibm.ws.security.openidconnect.server/test/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutRequestHelperTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/test/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutRequestHelperTest.java
@@ -10,19 +10,13 @@
  *******************************************************************************/
 package io.openliberty.security.openidconnect.backchannellogout;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import javax.servlet.http.HttpServletRequest;
 
-import org.jmock.Expectations;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
-import com.ibm.ws.security.oauth20.plugins.OidcBaseClient;
 import com.ibm.ws.security.test.common.CommonTestClass;
 import com.ibm.ws.webcontainer.security.openidconnect.OidcServerConfig;
 
@@ -34,7 +28,6 @@ public class BackchannelLogoutRequestHelperTest extends CommonTestClass {
 
     private final HttpServletRequest request = mockery.mock(HttpServletRequest.class);
     private final OidcServerConfig oidcServerConfig = mockery.mock(OidcServerConfig.class);
-    private final OidcBaseClient client = mockery.mock(OidcBaseClient.class);
 
     private BackchannelLogoutRequestHelper helper;
 
@@ -59,69 +52,6 @@ public class BackchannelLogoutRequestHelperTest extends CommonTestClass {
     public static void tearDownAfterClass() throws Exception {
         outputMgr.dumpStreams();
         outputMgr.restoreStreams();
-    }
-
-    @Test
-    public void test_isValidClientForBackchannelLogout_noLogoutUri() {
-        mockery.checking(new Expectations() {
-            {
-                one(client).getBackchannelLogoutUri();
-                will(returnValue(null));
-            }
-        });
-        assertFalse("Client without a back-channel logout URI should not be considered valid for BCL.", helper.isValidClientForBackchannelLogout(client));
-    }
-
-    @Test
-    public void test_isValidClientForBackchannelLogout_logoutUriNotHttp() {
-        mockery.checking(new Expectations() {
-            {
-                one(client).getBackchannelLogoutUri();
-                will(returnValue("scp://localhost"));
-                allowing(client).getClientId();
-                will(returnValue("myOidcClient"));
-            }
-        });
-        assertFalse("Client with non-HTTP back-channel logout URI should not be considered valid for BCL.", helper.isValidClientForBackchannelLogout(client));
-    }
-
-    @Test
-    public void test_isValidClientForBackchannelLogout_httpPublicClient() {
-        mockery.checking(new Expectations() {
-            {
-                one(client).getBackchannelLogoutUri();
-                will(returnValue("http://localhost"));
-                one(client).isPublicClient();
-                will(returnValue(true));
-                allowing(client).getClientId();
-                will(returnValue("myOidcClient"));
-            }
-        });
-        assertFalse("Public client with HTTP back-channel logout URI should not be considered valid for BCL.", helper.isValidClientForBackchannelLogout(client));
-    }
-
-    @Test
-    public void test_isValidClientForBackchannelLogout_httpConfidentialClient() {
-        mockery.checking(new Expectations() {
-            {
-                one(client).getBackchannelLogoutUri();
-                will(returnValue("http://localhost"));
-                one(client).isPublicClient();
-                will(returnValue(false));
-            }
-        });
-        assertTrue("Confidential client with HTTP back-channel logout URI should be considered valid for BCL.", helper.isValidClientForBackchannelLogout(client));
-    }
-
-    @Test
-    public void test_isValidClientForBackchannelLogout_httpsUri() {
-        mockery.checking(new Expectations() {
-            {
-                one(client).getBackchannelLogoutUri();
-                will(returnValue("https://localhost"));
-            }
-        });
-        assertTrue("HTTPS back-channel logout URI should be considered valid for BCL.", helper.isValidClientForBackchannelLogout(client));
     }
 
 }


### PR DESCRIPTION
Fix the OIDC code to only go through with removing cached tokens for clients that are logging out if those clients have back-channel logout enabled.

Fixes #21878 