### PR TITLE
Fix test bug 291351

### DIFF
--- a/dev/com.ibm.ws.classloading.bells_fat/fat/src/com/ibm/ws/classloading/BellPropertiesTest.java
+++ b/dev/com.ibm.ws.classloading.bells_fat/fat/src/com/ibm/ws/classloading/BellPropertiesTest.java
@@ -113,7 +113,7 @@ public class BellPropertiesTest {
 
 
     /**
-     * Verify a service impl logged a messaging indicating the expected injection operation
+     * Verify a service impl logged a message indicating the expected injection operation
      * and property set.
      * @serviceName The simple name of a service impl class.
      * @injectOp The expected method used to inject properties into the service impl.
@@ -374,8 +374,8 @@ public class BellPropertiesTest {
         finally {
             if (propsInvalidServer.isStarted()) {
                 propsInvalidServer.stopServer(
-                        ".*CWWKG0014E:.*TIP_P0.*properties", // xml parse error on malformed property
-                        ".*CWWKF0009W:");                    // no features installed
+                        "CWWKG0014E: .*TIP_P0", // xml parse error on malformed property TIP_P0
+                        "CWWKF0009W");          // no features installed
             }
             removeSysProps(propsInvalidServer, sysProps);
          }


### PR DESCRIPTION
Fix BELL properties test `testPropertiesInvalid` for beta and non-beta editions. The regex argument `.*CWWKG0014E:.*TIP_P0.*properties` passed into stopServer() expects the term "properties" to appear in msg CWWKG0014E. The test verifies CWWKG0014E mentions the property name w/ the syntax error, which is in the `<properties/>` element. Strange that the error message no longer contains the element name ("properties").  I'll reduce the regex to `CWWKG0014E:.*TIP_P0`.