### PR TITLE
Updating jca tests to not run EE10 features on Java 8

### DIFF
--- a/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/FATSuite.java
@@ -25,6 +25,7 @@ import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
@@ -47,11 +48,24 @@ public class FATSuite {
      * EE10 will run in full and lite mode.
      */
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly())
-                    // need widen option to handle jar file within a jar file.
-                    .andWith(new JakartaEE9Action().fullFATOnly().withWiden())
-                    // need widen option to handle jar file within a jar file.
-                    .andWith(new JakartaEE10Action().withWiden());
+    public static RepeatTests repeat;
+
+    static {
+        // EE10 requires Java 11.  If we only specify EE10 for lite mode it will cause no tests to run which causes an error.
+        // If we are running on Java 8 have EE9 be the lite mode test to run.
+        if (JavaInfo.JAVA_VERSION >= 11) {
+            repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
+                            // need widen option to handle jar file within a jar file.
+                            .andWith(new JakartaEE9Action().fullFATOnly().withWiden())
+                            // need widen option to handle jar file within a jar file.
+                            .andWith(new JakartaEE10Action().withWiden());
+        } else {
+            repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
+                            // need widen option to handle jar file within a jar file.
+                            .andWith(new JakartaEE9Action().withWiden());
+        }
+
+    }
 
     public static LibertyServer getServer() {
         if (JakartaEE9Action.isActive() || JakartaEE10Action.isActive()) {

--- a/dev/com.ibm.ws.jca_fat_configprops/fat/src/com/ibm/ws/jca/fat/configprops/FATSuite.java
+++ b/dev/com.ibm.ws.jca_fat_configprops/fat/src/com/ibm/ws/jca/fat/configprops/FATSuite.java
@@ -18,18 +18,31 @@ import org.junit.runners.Suite.SuiteClasses;
 import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.JavaInfo;
 
 @RunWith(Suite.class)
 @SuiteClasses(JCAConfigPropsTest.class)
 public class FATSuite {
 
     /*
-     * EE7 will run with full fat only.
-     * EE9 will run with full fat only.
-     * EE10 will run in lite and full mode.
+     * EE7 will run in full mode only.
+     * EE9 will run in full mode only.
+     * EE10 will run in full and lite mode.
      */
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly())
-                    .andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly())
-                    .andWith(FeatureReplacementAction.EE10_FEATURES());
+    public static RepeatTests repeat;
+
+    static {
+        // EE10 requires Java 11.  If we only specify EE10 for lite mode it will cause no tests to run which causes an error.
+        // If we are running on Java 8 have EE9 be the lite mode test to run.
+        if (JavaInfo.JAVA_VERSION >= 11) {
+            repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
+                            .andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly())
+                            .andWith(FeatureReplacementAction.EE10_FEATURES());
+        } else {
+            repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
+                            .andWith(FeatureReplacementAction.EE9_FEATURES());
+        }
+
+    }
 }


### PR DESCRIPTION
Fixing issue with no tests run on Java 8 when the EE10 repeat action is the only repeat action running lite mode tests.
