### PR TITLE
MP Fault Tolerance 1.x: Fix timeout cancellation race condition 

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.1.0/src/com/ibm/ws/microprofile/faulttolerance/executor/impl/TimeoutImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.1.0/src/com/ibm/ws/microprofile/faulttolerance/executor/impl/TimeoutImpl.java
@@ -172,7 +172,7 @@ public class TimeoutImpl {
         try {
             debugRelativeTime("Stop!");
             this.stopped = true;
-            if (this.future != null && !this.future.isDone()) {
+            if (this.future != null && !this.future.isDone() && timedout == false) {
                 debugRelativeTime("Cancelling");
                 this.future.cancel(true);
             }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.1.0/src/com/ibm/ws/microprofile/faulttolerance/executor/impl/package-info.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.1.0/src/com/ibm/ws/microprofile/faulttolerance/executor/impl/package-info.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ *
+ */
+@TraceOptions(traceGroup = "FAULTTOLERANCE", messageBundle = "com.ibm.ws.microprofile.faulttolerance.resources.FaultTolerance")
+package com.ibm.ws.microprofile.faulttolerance.executor.impl;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;


### PR DESCRIPTION
Don't attempt to cancel the timeout task if we've already timed out.

There's a lock shared between stop() and timeout(), but if the timeout
has fired, the timeout future is not complete at the point where
timeout() releases the lock. This gives stop() a chance to run and
attempt to cancel the future. Doing this can result in an
InterruptedException which causes and FFDC to be emitted by the policy
executor.

By checking the value of timedout, we can avoid trying to cancel the
timeout task if the timeout has already fired and interrupted our
thread.

Also add a package to the FT trace group

Fixes RTC291085
Fixes #21937