### PR TITLE
Fix NPE when executorSrvc gets nulled out on shutdown

### DIFF
--- a/dev/com.ibm.ws.webserver.plugin.runtime/src/com/ibm/ws/webserver/plugin/runtime/listeners/GeneratePluginConfigListener.java
+++ b/dev/com.ibm.ws.webserver.plugin.runtime/src/com/ibm/ws/webserver/plugin/runtime/listeners/GeneratePluginConfigListener.java
@@ -273,7 +273,8 @@ public class GeneratePluginConfigListener implements RuntimeUpdateListener, Appl
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(this, tc, "submitGeneratePluginTask : FrameworkState.isStopping() = " + FrameworkState.isStopping());
 
-        if (!FrameworkState.isStopping() && gpc != null && executorSrvc != null) {
+        ExecutorService currentExecutor = executorSrvc;
+        if (!FrameworkState.isStopping() && gpc != null && currentExecutor != null) {
             Runnable generatePluginTask = new Runnable() {
                 @Override
                 public void run() {
@@ -292,14 +293,14 @@ public class GeneratePluginConfigListener implements RuntimeUpdateListener, Appl
                 CheckpointHook restoreHook = new CheckpointHook() {
                     @Override
                     public void restore() {
-                        executorSrvc.submit(generatePluginTask);
+                        currentExecutor.submit(generatePluginTask);
                     }
                 };
                 if (!checkpoint.addMultiThreadedHook(restoreHook)) {
-                    executorSrvc.submit(generatePluginTask);
+                    currentExecutor.submit(generatePluginTask);
                 }
             } else {
-                executorSrvc.submit(generatePluginTask);
+                currentExecutor.submit(generatePluginTask);
             }
         }
 


### PR DESCRIPTION
If the server is shutdown while we are submitting the
task to generate the plugin XML file an NPE is possible.

The fix is to assign the local variable to do the null check
and call to the executor