### PR TITLE
Add Apache httpcomponents to SAML/OpenSAML 2.6 feature

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.samlWeb2.0.internal.opensaml-2.6.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.samlWeb2.0.internal.opensaml-2.6.feature
@@ -11,6 +11,7 @@ singleton=true
   com.ibm.ws.security.saml.sso.2.0,\
   com.ibm.ws.org.opensaml.xmltooling.1.4.4, \
   com.ibm.ws.org.joda.time.1.6.2, \
-  com.ibm.ws.org.apache.commons.httpclient
+  com.ibm.ws.org.apache.commons.httpclient, \
+  com.ibm.ws.org.apache.httpcomponents
 kind=ga
 edition=core


### PR DESCRIPTION
Include `com.ibm.ws.org.apache.httpcomponents` in the bundles activated by the io.openliberty.samlWeb2.0.internal.opensaml-2.6.feature private feature.