### PR TITLE
Create common SecuritySSLUtils class for SSO code to use

### DIFF
--- a/dev/com.ibm.ws.security.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.common/bnd.bnd
@@ -63,7 +63,8 @@ instrument.classesExcludes: com/ibm/ws/security/common/internal/resources/*.clas
     com.ibm.ws.security.authentication;version=latest, \
     com.ibm.json4j;version=latest, \
     com.ibm.ws.webcontainer.security;version=latest, \
-    com.ibm.ws.org.apache.httpcomponents;version=latest
+    com.ibm.ws.org.apache.httpcomponents;version=latest, \
+    com.ibm.ws.ssl;version=latest
 
 -testpath: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/ssl/NoSSLSocketFactoryException.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/ssl/NoSSLSocketFactoryException.java
@@ -1,0 +1,7 @@
+package com.ibm.ws.security.common.ssl;
+
+public class NoSSLSocketFactoryException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/ssl/SecuritySSLUtils.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/ssl/SecuritySSLUtils.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.common.ssl;
+
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSocketFactory;
+
+import com.ibm.wsspi.ssl.SSLSupport;
+
+public class SecuritySSLUtils {
+
+    public static SSLSocketFactory getSSLSocketFactory(SSLSupport sslSupport, String sslConfigurationName) throws SSLException, NoSSLSocketFactoryException {
+        SSLSocketFactory sslSocketFactory = null;
+        if (sslSupport != null) {
+            sslSocketFactory = sslSupport.getSSLSocketFactory(sslConfigurationName);
+        }
+        if (sslSocketFactory == null) {
+            throw new NoSSLSocketFactoryException();
+        }
+        return sslSocketFactory;
+    }
+
+}

--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/ssl/package-info.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/ssl/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+package com.ibm.ws.security.common.ssl;

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
@@ -62,6 +62,8 @@ import com.ibm.ws.security.common.crypto.HashUtils;
 import com.ibm.ws.security.common.http.HttpUtils;
 import com.ibm.ws.security.common.http.SocialLoginWrapperException;
 import com.ibm.ws.security.common.jwk.impl.JWKSet;
+import com.ibm.ws.security.common.ssl.NoSSLSocketFactoryException;
+import com.ibm.ws.security.common.ssl.SecuritySSLUtils;
 import com.ibm.ws.security.common.structures.SingleTableCache;
 import com.ibm.ws.security.jwt.config.ConsumerUtils;
 import com.ibm.ws.security.jwt.utils.JwtUtils;
@@ -1123,26 +1125,16 @@ public class OidcClientConfigImpl implements OidcClientConfig {
 
     }
 
-    @FFDCIgnore({ javax.net.ssl.SSLException.class })
+    @FFDCIgnore({ javax.net.ssl.SSLException.class, NoSSLSocketFactoryException.class })
     protected SSLSocketFactory getSSLSocketFactory(String requestUrl, String sslConfigurationName,
             SSLSupport sslSupport) throws SSLException {
         SSLSocketFactory sslSocketFactory = null;
-
         try {
-            if (sslSupport != null) {
-                sslSocketFactory = sslSupport.getSSLSocketFactory(sslConfigurationName);
-            }
-
+            sslSocketFactory = SecuritySSLUtils.getSSLSocketFactory(sslSupport, sslConfigurationName);
         } catch (javax.net.ssl.SSLException e) {
             throw new SSLException(e.getMessage());
-        }
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            Tr.debug(tc, "sslSocketFactory (" + ") get: " + sslSocketFactory);
-        }
-
-        if (sslSocketFactory == null) {
-            throw new SSLException(Tr.formatMessage(tc, "OIDC_CLIENT_HTTPS_WITH_SSLCONTEXT_NULL",
-                    new Object[] { "Null ssl socket factory", getId() }));
+        } catch (NoSSLSocketFactoryException e) {
+            throw new SSLException(Tr.formatMessage(tc, "OIDC_CLIENT_HTTPS_WITH_SSLCONTEXT_NULL", new Object[] { "Null ssl socket factory", getId() }));
         }
         return sslSocketFactory;
     }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
@@ -59,6 +59,8 @@ import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 import com.ibm.wsspi.security.token.AttributeNameConstants;
 import com.ibm.wsspi.ssl.SSLSupport;
 
+import io.openliberty.security.oidcclientcore.utils.Utils;
+
 public class Jose4jUtil {
 
     private static final TraceComponent tc = Tr.register(Jose4jUtil.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
@@ -205,7 +207,7 @@ public class Jose4jUtil {
         String iss = jwtClaims.getIssuer();
         String sub = jwtClaims.getSubject();
         String sid = jwtClaims.getClaimValue("sid", String.class);
-        String timestamp = OidcUtil.getTimeStamp();
+        String timestamp = Utils.getTimeStamp();
 
         OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp);
 

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/AuthorizationCodeHandler.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/AuthorizationCodeHandler.java
@@ -95,7 +95,6 @@ public class AuthorizationCodeHandler {
 
         SSLSocketFactory sslSocketFactory = null;
         try {
-            //sslSocketFactory = getSSLSocketFactory(clientConfig.getTokenEndpointUrl(), clientConfig.getSSLConfigurationName(), clientId);
             boolean throwExc = clientConfig.getTokenEndpointUrl() != null && clientConfig.getTokenEndpointUrl().startsWith("https");
             sslSocketFactory = new OidcClientHttpUtil().getSSLSocketFactory(clientConfig, sslSupport, throwExc, false);
         } catch (SSLException e) {

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientHttpUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientHttpUtil.java
@@ -34,6 +34,8 @@ import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.ws.common.encoder.Base64Coder;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.common.http.HttpUtils;
+import com.ibm.ws.security.common.ssl.NoSSLSocketFactoryException;
+import com.ibm.ws.security.common.ssl.SecuritySSLUtils;
 import com.ibm.ws.security.common.web.WebUtils;
 import com.ibm.wsspi.ssl.SSLSupport;
 import com.ibm.wsspi.webcontainer.util.ThreadContextHelper;
@@ -51,28 +53,21 @@ public class OidcClientHttpUtil {
         this.clientId = id;
     }
 
+    @FFDCIgnore(NoSSLSocketFactoryException.class)
     public SSLSocketFactory getSSLSocketFactory(ConvergedClientConfig config, SSLSupport sslSupport,
             boolean throwExceptionIfNull, boolean logErrorIfNull) throws com.ibm.websphere.ssl.SSLException {
         SSLSocketFactory sslSocketFactory = null;
-
         try {
-            if (sslSupport != null) {
-                sslSocketFactory = sslSupport.getSSLSocketFactory(config.getSSLConfigurationName());
-            }
+            sslSocketFactory = SecuritySSLUtils.getSSLSocketFactory(sslSupport, config.getSSLConfigurationName());
         } catch (javax.net.ssl.SSLException e) {
             throw new com.ibm.websphere.ssl.SSLException(e);
-        }
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            Tr.debug(tc, "sslSocketFactory (" + ") get: " + sslSocketFactory);
-        }
-
-        if (sslSocketFactory == null && throwExceptionIfNull) {
-            throw new com.ibm.websphere.ssl.SSLException(Tr.formatMessage(tc, "OIDC_CLIENT_HTTPS_WITH_SSLCONTEXT_NULL",
-                    new Object[] { "Null ssl socket factory", config.getClientId() }));
-
-        }
-        if (sslSocketFactory == null && logErrorIfNull) {
-            Tr.error(tc, "OIDC_CLIENT_HTTPS_WITH_SSLCONTEXT_NULL", new Object[] { "Null ssl socket factory", config.getClientId() });
+        } catch (NoSSLSocketFactoryException e) {
+            if (throwExceptionIfNull) {
+                throw new com.ibm.websphere.ssl.SSLException(Tr.formatMessage(tc, "OIDC_CLIENT_HTTPS_WITH_SSLCONTEXT_NULL", new Object[] { "Null ssl socket factory", config.getClientId() }));
+            }
+            if (logErrorIfNull) {
+                Tr.error(tc, "OIDC_CLIENT_HTTPS_WITH_SSLCONTEXT_NULL", new Object[] { "Null ssl socket factory", config.getClientId() });
+            }
         }
         return sslSocketFactory;
     }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcUtil.java
@@ -15,7 +15,6 @@ import java.net.URLEncoder;
 import java.security.Principal;
 import java.security.SecureRandom;
 import java.security.Security;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.Random;
 
@@ -207,22 +206,6 @@ public class OidcUtil {
         } else {
             return result;
         }
-    }
-
-    static String[] zeroFillers = new String[] {
-            "", "0", "00", "000", "0000", "00000", "000000"
-    };
-
-    public static String getTimeStamp() {
-        long lNumber = (new Date()).getTime();
-        return getTimeStamp(lNumber);
-    }
-
-    // for unit test
-    public static String getTimeStamp(long lNumber) {
-        String timeStamp = "" + lNumber;
-        int iIndex = TIMESTAMP_LENGTH - timeStamp.length(); // this is enough for 3000 years
-        return zeroFillers[iIndex] + timeStamp;
     }
 
     public static long convertNormalizedTimeStampToLong(String input) {

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcUtilTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcUtilTest.java
@@ -13,8 +13,6 @@ package com.ibm.ws.security.openidconnect.clients.common;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Date;
-
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -111,17 +109,6 @@ public class OidcUtilTest {
         assertEquals("param=value+of+param&param2&param3=value", OidcUtil.encodeQuery("param=value of param&param2&param3=value"));
         assertEquals("param=value+of+param&param2=%3Cscript%3Ealert%28300%29%3C%2Fscript%3E&param3=value",
                 OidcUtil.encodeQuery("param=value of param&param2=<script>alert(300)</script>&param3=value"));
-    }
-
-    @Test
-    public void testTimeStampInLong() {
-        Date date = new Date();
-        long lNumber = date.getTime();
-        String state = OidcUtil.getTimeStamp(lNumber) + OidcUtil.generateRandom(OidcUtil.RANDOM_LENGTH);
-        long lTmp = OidcUtil.convertNormalizedTimeStampToLong(state);
-        Date newDate = new Date(lTmp);
-        assertTrue("lNumber is " + lNumber + ", lTmp is " + lTmp + " are not equal", lNumber == lTmp);
-        assertTrue("date is " + date + "newDate is " + newDate + " are not equal", date.equals(newDate));
     }
 
     @Test


### PR DESCRIPTION
Creates `com.ibm.ws.security.common.ssl.SecuritySSLUtils` as a utility class for SSL-related methods. This initial drop adds a method to obtain an `SSLSocketFactory` instance.