### PR TITLE
Fix JPA FAT framework build

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.eclipselink.query_jpa_2.1_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink.query_jpa_2.1_fat/build.gradle
@@ -21,17 +21,16 @@ dependencies {
 task addJPAFATTools (type: Copy) {
   mustRunAfter jar
   from configurations.jpaFatTools
-  include "**/com.ibm.ws.jpa_testframework*.jar"
+  include "**/com.ibm.ws.jpa_testframework.jar"
   into new File(autoFvtDir, 'lib')
-  rename 'com.ibm.ws.jpa_testframework-(.*).jar', 'com.ibm.ws.jpa_testframework.jar'
 }
 
 task copyFAT {
-    dependsOn ':com.ibm.ws.jpa.tests.eclipselink.query_fat.common:build'
-    copy {
-      from project(':com.ibm.ws.jpa.tests.eclipselink.query_fat.common').file('fat/src/com/ibm/ws/jpa/tests/eclipselink/query/tests')
-      into new File('fat/src/com/ibm/ws/jpa/tests/eclipselink/query/tests')
-    }
+  dependsOn ':com.ibm.ws.jpa.tests.eclipselink.query_fat.common:build'
+  copy {
+    from project(':com.ibm.ws.jpa.tests.eclipselink.query_fat.common').file('fat/src/com/ibm/ws/jpa/tests/eclipselink/query/tests')
+    into new File('fat/src/com/ibm/ws/jpa/tests/eclipselink/query/tests')
+  }
 }
 
 task copyCommonFiles {

--- a/dev/com.ibm.ws.jpa.tests.jpa_31_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.jpa_31_fat/build.gradle
@@ -29,9 +29,8 @@ dependencies {
 task addJPAFATTools (type: Copy) {
   mustRunAfter jar
   from configurations.jpaFatTools
-  include "**/com.ibm.ws.jpa_testframework*.jar"
+  include "**/com.ibm.ws.jpa_testframework.jar"
   into new File(autoFvtDir, 'lib')
-  rename 'com.ibm.ws.jpa_testframework-(.*).jar', 'com.ibm.ws.jpa_testframework.jar'
 }
 
 task addhibernateJPA31(type: Copy) {


### PR DESCRIPTION
JPA FAT `com.ibm.ws.jpa.tests.eclipselink.query_jpa_2.1_fat` is failing with exception:
```
[ERROR   ] SRVE9990E: The class jpahelper.databasemanagement.DatabaseManagementServlet has a @WebServlet annotation but does not implement the javax.servlet.http.HttpServlet interface.
```

The build.gradle `addJPAFATTools` is a unique implementation that requires a specific testframework bundle name. The fix should change `addJPAFATTools` to follow the same implementation the rest of the FATs do. The FAT `com.ibm.ws.jpa.tests.jpa_31_fat` also doesn't follow the same conventions the other FATs use.

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>