### PR TITLE
Clarify oracle URL property behavior

### DIFF
--- a/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/l10n/metatype.properties
@@ -1046,7 +1046,7 @@ updateCountForBatch=Update count for batch
 updateCountForBatch.desc=JDBC driver property: updateCountForBatch.
 URL=URL
 URL.desc=URL for connecting to the database.
-URL.oracle.desc=JDBC driver property: URL. URL for connecting to the database. If a URL is configured that contains values for other properties like serverName and driverType, then the values specified in the URL could override the values specified for those individual properties. Examples: jdbc:oracle:thin:@//localhost:1521/sample or jdbc:oracle:oci:@//localhost:1521/sample.
+URL.oracle.desc=JDBC driver property: URL. URL for connecting to the database. If a URL is configured, the Oracle JDBC driver ignores individual connection properties such as serverName and driverType. Oracle JDBC driver updates might impact this behavior. Examples: jdbc:oracle:thin:@//localhost:1521/sample or jdbc:oracle:oci:@//localhost:1521/sample.
 URL.sqlserver.desc=URL for connecting to the database. Example: jdbc:sqlserver://localhost:1433;databaseName=myDB.
 useBlockInsert=Use block insert
 useBlockInsert.desc=JDBC driver property: useBlockInsert.

--- a/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/l10n/metatype.properties
@@ -1046,7 +1046,7 @@ updateCountForBatch=Update count for batch
 updateCountForBatch.desc=JDBC driver property: updateCountForBatch.
 URL=URL
 URL.desc=URL for connecting to the database.
-URL.oracle.desc=URL for connecting to the database. Examples: jdbc:oracle:thin:@//localhost:1521/sample or jdbc:oracle:oci:@//localhost:1521/sample.
+URL.oracle.desc=JDBC driver property: URL. URL for connecting to the database. If a URL is configured that contains values for other properties like serverName and driverType, then the values specified in the URL could override the values specified for those individual properties. Examples: jdbc:oracle:thin:@//localhost:1521/sample or jdbc:oracle:oci:@//localhost:1521/sample.
 URL.sqlserver.desc=URL for connecting to the database. Example: jdbc:sqlserver://localhost:1433;databaseName=myDB.
 useBlockInsert=Use block insert
 useBlockInsert.desc=JDBC driver property: useBlockInsert.


### PR DESCRIPTION
Update metatype to clarify the expected behavior that configuring a URL should override the individual properties of `driverType`, `serverName`, `databaseName`, and `portNumber` based on the documented behavior of the Oracle JDBC driver.  See oracle's documentation here: https://javadoc.io/static/com.oracle.database.jdbc/ojdbc8/21.6.0.0.1/oracle/jdbc/datasource/OracleCommonDataSource.html#setURL-java.lang.String-
