### PR TITLE
Make mpConfig-3.0 compatible with EE10

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.mpCompatible-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.mpCompatible-6.0.feature
@@ -1,0 +1,8 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.mpCompatible-6.0
+visibility=private
+singleton=true
+-features=com.ibm.websphere.appserver.eeCompatible-10.0; ibm.tolerates:="9.0"
+kind=beta
+edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.config-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.config-3.0.feature
@@ -1,8 +1,8 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.org.eclipse.microprofile.config-3.0
 singleton=true
--features=io.openliberty.mpCompatible-5.0, \
-  io.openliberty.jakarta.cdi-3.0
+-features=io.openliberty.mpCompatible-5.0; ibm.tolerates:="6.0", \
+  io.openliberty.jakarta.cdi-3.0; ibm.tolerates:="4.0"
 -bundles=io.openliberty.org.eclipse.microprofile.config.3.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.config:microprofile-config-api:3.0.1"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpConfig-3.0/io.openliberty.mpConfig-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpConfig-3.0/io.openliberty.mpConfig-3.0.feature
@@ -13,11 +13,11 @@ IBM-ShortName: mpConfig-3.0
 Subsystem-Name: MicroProfile Config 3.0
 -features=com.ibm.websphere.appserver.appmanager-1.0, \
   com.ibm.websphere.appserver.containerServices-1.0, \
-  io.openliberty.jakarta.annotation-2.0, \
+  io.openliberty.jakarta.annotation-2.0; ibm.tolerates:="2.1", \
   io.openliberty.org.eclipse.microprofile.config-3.0, \
   com.ibm.websphere.appserver.internal.slf4j-1.7, \
-  io.openliberty.mpCompatible-5.0, \
-  io.openliberty.jakarta.cdi-3.0
+  io.openliberty.mpCompatible-5.0; ibm.tolerates:="6.0", \
+  io.openliberty.jakarta.cdi-3.0; ibm.tolerates:="4.0"
 -bundles=io.openliberty.io.smallrye.config.jakarta, \
  io.openliberty.io.smallrye.common.jakarta, \
  io.openliberty.microprofile.config.internal.common, \

--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPContextPropActions.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPContextPropActions.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.FeatureSet;
 import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatActions;
 import componenttest.rules.repeater.RepeatTests;
 
 public class MPContextPropActions {
@@ -34,7 +35,7 @@ public class MPContextPropActions {
     }
 
     public static RepeatTests repeat(String server, FeatureSet firstVersion, FeatureSet... otherVersions) {
-        return MicroProfileActions.repeat(server, TestMode.LITE, ALL, firstVersion, otherVersions);
+        return RepeatActions.repeat(server, TestMode.LITE, ALL, firstVersion, otherVersions);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.config.1.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat/bnd.bnd
@@ -42,10 +42,12 @@ tested.features: mpConfig-1.1,\
                  cdi-1.2,\
                  cdi-2.0,\
                  cdi-3.0,\
+                 cdi-4.0,\
                  localconnector-1.0,\
                  servlet-3.1,\
                  servlet-4.0,\
-                 servlet-5.0
+                 servlet-5.0,\
+                 servlet-6.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\

--- a/dev/com.ibm.ws.microprofile.config.1.1_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/BasicConfigTests.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/BasicConfigTests.java
@@ -34,6 +34,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -76,9 +77,14 @@ public class BasicConfigTests extends FATServletClient {
     public static final String CUSTOM_SOURCES_APP_NAME = "customSources";
     public static final String TYPES_APP_NAME = "types";
 
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP50, MicroProfileActions.MP12, MicroProfileActions.MP13, MicroProfileActions.MP14,
+    @ClassRule
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP60,
+                                                             MicroProfileActions.MP12,
+                                                             MicroProfileActions.MP13,
+                                                             MicroProfileActions.MP14,
                                                              MicroProfileActions.MP33,
-                                                             MicroProfileActions.MP41);
+                                                             MicroProfileActions.MP41,
+                                                             MicroProfileActions.MP50);
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.microprofile.config.1.1_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/ClassLoadersTest.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/ClassLoadersTest.java
@@ -47,7 +47,7 @@ public class ClassLoadersTest extends FATServletClient {
     public static final String APP_NAME = "classLoaders";
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP50, MicroProfileActions.MP14, MicroProfileActions.MP41);
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP60, MicroProfileActions.MP14, MicroProfileActions.MP41);
 
     @Server(SERVER_NAME)
     @TestServlet(servlet = ClassLoadersTestServlet.class, contextRoot = APP_NAME)

--- a/dev/com.ibm.ws.microprofile.config.1.1_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/DefaultSourcesTest.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/DefaultSourcesTest.java
@@ -52,7 +52,7 @@ public class DefaultSourcesTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP50, MicroProfileActions.MP33, MicroProfileActions.MP41);
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP60, MicroProfileActions.MP33, MicroProfileActions.MP41);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.microprofile.config.1.1_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/OrdinalsForDefaultsTest.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/OrdinalsForDefaultsTest.java
@@ -50,7 +50,7 @@ public class OrdinalsForDefaultsTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP50, MicroProfileActions.MP20, MicroProfileActions.MP41);
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP60, MicroProfileActions.MP20, MicroProfileActions.MP41);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.microprofile.config.1.1_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/SharedLibTest.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/SharedLibTest.java
@@ -50,7 +50,7 @@ public class SharedLibTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP50, MicroProfileActions.MP20, MicroProfileActions.MP41);
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP60, MicroProfileActions.MP20, MicroProfileActions.MP41);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.microprofile.config.1.1_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/SimultaneousRequestsTest.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/SimultaneousRequestsTest.java
@@ -52,7 +52,7 @@ public class SimultaneousRequestsTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP50, MicroProfileActions.MP33, MicroProfileActions.MP41);
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP60, MicroProfileActions.MP33, MicroProfileActions.MP41);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.microprofile.config.1.1_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/StressTest.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/StressTest.java
@@ -49,7 +49,7 @@ public class StressTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP50, MicroProfileActions.MP14, MicroProfileActions.MP41);
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP60, MicroProfileActions.MP14, MicroProfileActions.MP41);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.microprofile.config.1.1_fat/test-applications/cdiConfig.jar/src/com/ibm/ws/microprofile/appConfig/cdi/web/FieldTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat/test-applications/cdiConfig.jar/src/com/ibm/ws/microprofile/appConfig/cdi/web/FieldTestServlet.java
@@ -79,7 +79,10 @@ public class FieldTestServlet extends AbstractBeanServlet {
     }
 
     @Test
-    @SkipForRepeat({ MicroProfileActions.MP40_ID, MicroProfileActions.MP41_ID }) // TODO: The intended behaviour for this is not defined in the MP Config spec. It may be covered by the answer to this: https://github.com/eclipse/microprofile-config/issues/608
+    @SkipForRepeat({ MicroProfileActions.MP40_ID,
+                     MicroProfileActions.MP41_ID,
+                     MicroProfileActions.MP50_ID,
+                     MicroProfileActions.MP60_ID }) // TODO: The intended behaviour for this is not defined in the MP Config spec. It may be covered by the answer to this: https://github.com/eclipse/microprofile-config/issues/608
     public void testNullWithDefault() throws Exception {
         test("NULL_WITH_DEFAULT_KEY", "null");
     }

--- a/dev/com.ibm.ws.microprofile.config.1.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat/bnd.bnd
@@ -27,9 +27,11 @@ tested.features: mpConfig-1.2,\
                  cdi-1.2,\
                  cdi-2.0,\
                  cdi-3.0,\
+                 cdi-4.0,\
                  servlet-3.1,\
                  servlet-4.0,\
                  servlet-5.0,\
+                 servlet-6.0,\
                  localconnector-1.0
 
 -buildpath: \

--- a/dev/com.ibm.ws.microprofile.config.1.2_fat/fat/src/com/ibm/ws/microprofile/config12/test/Config12ConverterTests.java
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat/fat/src/com/ibm/ws/microprofile/config12/test/Config12ConverterTests.java
@@ -50,7 +50,7 @@ public class Config12ConverterTests extends FATServletClient {
     public static final String APP_NAME = "converterApp";
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP50, MicroProfileActions.MP41, MicroProfileActions.MP13);
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP60, MicroProfileActions.MP41, MicroProfileActions.MP13);
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat/bnd.bnd
@@ -32,9 +32,11 @@ tested.features: mpConfig-1.3,\
                  cdi-1.2,\
                  cdi-2.0,\
                  cdi-3.0,\
+                 cdi-4.0,\
                  servlet-3.1,\
                  servlet-4.0, \
                  servlet-5.0, \
+                 servlet-6.0, \
                  localconnector-1.0
 
 -buildpath: \

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat/fat/src/com/ibm/ws/microprofile/config13/test/ConfigOrdinalServerXMLTest.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat/fat/src/com/ibm/ws/microprofile/config13/test/ConfigOrdinalServerXMLTest.java
@@ -73,7 +73,7 @@ public class ConfigOrdinalServerXMLTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP50, MicroProfileActions.MP41, MicroProfileActions.MP20);
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP60, MicroProfileActions.MP41, MicroProfileActions.MP20);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat/fat/src/com/ibm/ws/microprofile/config13/test/ServerXMLTest.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat/fat/src/com/ibm/ws/microprofile/config13/test/ServerXMLTest.java
@@ -65,7 +65,7 @@ public class ServerXMLTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP50, MicroProfileActions.MP41, MicroProfileActions.MP14);
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP60, MicroProfileActions.MP41, MicroProfileActions.MP14);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat/fat/src/com/ibm/ws/microprofile/config13/test/VariableServerXMLTest.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat/fat/src/com/ibm/ws/microprofile/config13/test/VariableServerXMLTest.java
@@ -65,7 +65,7 @@ public class VariableServerXMLTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP50, MicroProfileActions.MP41, MicroProfileActions.MP20);
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP60, MicroProfileActions.MP41, MicroProfileActions.MP20);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.microprofile.config.1.4_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.4_fat/bnd.bnd
@@ -23,9 +23,11 @@ tested.features: mpConfig-1.4,\
                  cdi-1.2,\
                  cdi-2.0,\
                  cdi-3.0,\
+                 cdi-4.0,\
                  servlet-3.1,\
                  servlet-4.0, \
                  servlet-5.0, \
+                 servlet-6.0, \
                  localconnector-1.0
 
 -buildpath: \

--- a/dev/com.ibm.ws.microprofile.config.1.4_fat/fat/src/com/ibm/ws/microprofile/config14/test/Config14Tests.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4_fat/fat/src/com/ibm/ws/microprofile/config14/test/Config14Tests.java
@@ -40,7 +40,7 @@ public class Config14Tests extends FATServletClient {
     public static final String SERVER_NAME = "Config14Server";
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP50, MicroProfileActions.MP33, MicroProfileActions.LATEST);
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP60, MicroProfileActions.MP33, MicroProfileActions.LATEST);
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.microprofile.faulttolerance_repeat_tests/src/com/ibm/ws/microprofile/faulttolerance/fat/repeat/RepeatFaultTolerance.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_repeat_tests/src/com/ibm/ws/microprofile/faulttolerance/fat/repeat/RepeatFaultTolerance.java
@@ -17,6 +17,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.FeatureSet;
 import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatActions;
 import componenttest.rules.repeater.RepeatTests;
 
 /**
@@ -58,7 +59,7 @@ public class RepeatFaultTolerance {
      * @return a RepeatTests instance
      */
     public static RepeatTests repeat(String server, TestMode otherFeatureSetsTestMode, FeatureSet firstFeatureSet, FeatureSet... otherFeatureSets) {
-        return MicroProfileActions.repeat(server, otherFeatureSetsTestMode, ALL, firstFeatureSet, otherFeatureSets);
+        return RepeatActions.repeat(server, otherFeatureSetsTestMode, ALL, firstFeatureSet, otherFeatureSets);
     }
 
     /**
@@ -68,7 +69,7 @@ public class RepeatFaultTolerance {
      * @return the new action
      */
     public static FeatureReplacementAction ft11metrics20Features(String server) {
-        return MicroProfileActions.forFeatureSet(ALL, MP21_METRICS20, server, TestMode.LITE);
+        return RepeatActions.forFeatureSet(ALL, MP21_METRICS20, server, TestMode.LITE);
     }
 
     /**

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
@@ -209,6 +209,22 @@ public class MicroProfileActions extends RepeatActions {
                                                           "mpOpenTracing-3.0",
                                                           "mpRestClient-3.0" };
 
+    private static final String[] MP60_FEATURES_ARRAY = { /* "microProfile-6.0", */
+                                                          "servlet-6.0",
+                                                          "cdi-4.0",
+                                                          "restfulWS-3.1",
+                                                          "restfulWSClient-3.1",
+                                                          "jsonb-3.0",
+                                                          "jsonp-2.1",
+                                                          "mpConfig-3.0",
+                                                          "mpFaultTolerance-4.0",
+                                                          "mpHealth-4.0",
+                                                          /* "mpJwt-2.1", */
+                                                          "mpOpenAPI-3.1",
+                                                          /* "mpMetrics-5.0", */
+                                                          "mpTelemetry-1.0",
+                                                          "mpRestClient-3.0" };
+
     private static final Set<String> MP10_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MP10_FEATURES_ARRAY)));
     private static final Set<String> MP12_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MP12_FEATURES_ARRAY)));
     private static final Set<String> MP13_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MP13_FEATURES_ARRAY)));
@@ -222,6 +238,7 @@ public class MicroProfileActions extends RepeatActions {
     private static final Set<String> MP40_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MP40_FEATURES_ARRAY)));
     private static final Set<String> MP41_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MP41_FEATURES_ARRAY)));
     private static final Set<String> MP50_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MP50_FEATURES_ARRAY)));
+    private static final Set<String> MP60_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MP60_FEATURES_ARRAY)));
 
     //The FeatureSet IDs. Since these will be used as the RepeatAction IDs, they can also be used in annotations such as @SkipForRepeat
     public static final String MP10_ID = EE7FeatureReplacementAction.ID + "_MicroProfile_10";
@@ -237,6 +254,7 @@ public class MicroProfileActions extends RepeatActions {
     public static final String MP40_ID = EE8FeatureReplacementAction.ID + "_MicroProfile_40";
     public static final String MP41_ID = EE8FeatureReplacementAction.ID + "_MicroProfile_41";
     public static final String MP50_ID = JakartaEE9Action.ID + "_MicroProfile_50";
+    public static final String MP60_ID = JakartaEE10Action.ID + "_MicroProfile_60";
 
     //The MicroProfile FeatureSets
     public static final FeatureSet MP10 = new FeatureSet(MP10_ID, MP10_FEATURE_SET, EEVersion.EE7);
@@ -252,12 +270,13 @@ public class MicroProfileActions extends RepeatActions {
     public static final FeatureSet MP40 = new FeatureSet(MP40_ID, MP40_FEATURE_SET, EEVersion.EE8);
     public static final FeatureSet MP41 = new FeatureSet(MP41_ID, MP41_FEATURE_SET, EEVersion.EE8);
     public static final FeatureSet MP50 = new FeatureSet(MP50_ID, MP50_FEATURE_SET, EEVersion.EE9);
+    public static final FeatureSet MP60 = new FeatureSet(MP60_ID, MP60_FEATURE_SET, EEVersion.EE10);
 
     //The FeatureSet for the latest MicrotProfile version
     public static final FeatureSet LATEST = MP41;
 
     //All MicroProfile FeatureSets
-    private static final FeatureSet[] ALL_SETS_ARRAY = { MP10, MP12, MP13, MP14, MP20, MP21, MP22, MP30, MP32, MP33, MP40, MP41, MP50 };
+    private static final FeatureSet[] ALL_SETS_ARRAY = { MP10, MP12, MP13, MP14, MP20, MP21, MP22, MP30, MP32, MP33, MP40, MP41, MP50, MP60 };
     public static final Set<FeatureSet> ALL = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(ALL_SETS_ARRAY)));
 
     private static final String[] STANDALONE8_FEATURES_ARRAY = { "mpContextPropagation-1.0",
@@ -269,13 +288,7 @@ public class MicroProfileActions extends RepeatActions {
                                                                  "mpReactiveStreams-1.0" };
 
     private static final String[] STANDALONE9_FEATURES_ARRAY = { "mpContextPropagation-1.3",
-                                                                 "mpGraphQL-2.0",
-                                                                 "mpTelemetry-1.0",
-                                                                 "mpOpenAPI-3.1" };//,
-//                                                                 "mpLRA-2.0",
-//                                                                 "mpLRACoordinator-2.0",
-//                                                                 "mpReactiveMessaging-3.0",
-//                                                                 "mpReactiveStreams-2.0" };
+                                                                 "mpGraphQL-2.0" };
 
     private static final Set<String> STANDALONE8_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(STANDALONE8_FEATURES_ARRAY)));
     private static final Set<String> STANDALONE9_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(STANDALONE9_FEATURES_ARRAY)));
@@ -299,6 +312,7 @@ public class MicroProfileActions extends RepeatActions {
     public static RepeatTests repeatAll(String server) {
         Set<FeatureSet> others = new HashSet<>(ALL);
         others.remove(LATEST);
+        others.remove(MP60); //Not yet ready
         return repeat(server, TestMode.FULL, ALL, LATEST, others);
     }
 
@@ -312,6 +326,7 @@ public class MicroProfileActions extends RepeatActions {
         Set<FeatureSet> others = new HashSet<>(ALL);
         others.remove(LATEST);
         others.remove(MP10); //Does not contain mpConfig
+        others.remove(MP60); //Not yet ready
         return repeat(server, TestMode.FULL, ALL, LATEST, others);
     }
 

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/RepeatActions.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/RepeatActions.java
@@ -19,7 +19,17 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 public class RepeatActions {
 
     public static enum EEVersion {
-        EE6, EE7, EE8, EE9, EE10
+        EE6(8), EE7(8), EE8(8), EE9(8), EE10(11);
+
+        private EEVersion(int minJavaLevel) {
+            this.minJavaLevel = minJavaLevel;
+        }
+
+        private final int minJavaLevel;
+
+        public int getMinJavaLevel() {
+            return minJavaLevel;
+        }
     }
 
     /**

--- a/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10FeatureCompatibilityTest.java
+++ b/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10FeatureCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021,2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,9 @@
  *******************************************************************************/
 package io.openliberty.jakartaee10.internal.tests;
 
+import static org.junit.Assert.assertThat;
+
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -21,11 +22,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
-import java.util.Scanner;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
 
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -50,11 +52,9 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.EE7FeatureReplacementAction;
 import componenttest.rules.repeater.EE8FeatureReplacementAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.FeatureSet;
 import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.MicroProfileActions;
-import componenttest.rules.repeater.RepeatActions.EEVersion;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
@@ -77,13 +77,11 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
 
     private static final Class<?> c = EE10FeatureCompatibilityTest.class;
 
-    static final Set<String> features = new HashSet<>();
+    static Set<String> allFeatures = new HashSet<>();
 
-    static final Set<String> nonEE10JavaEEFeatures = new HashSet<>();
+    static Set<String> compatibleFeatures = new HashSet<>();
 
-    static final Set<String> nonEE10MicroProfileFeatures = new HashSet<>();
-
-    static final Set<String> incompatibleValueAddFeatures = new HashSet<>();
+    static Set<String> incompatibleFeatures = new HashSet<>();
 
     static final String serverName = "jakartaee10.fat";
     static final FeatureResolver resolver = new FeatureResolverImpl();
@@ -92,114 +90,80 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
     @Server("jakartaee10.fat")
     public static LibertyServer server;
 
-    static {
-        nonEE10JavaEEFeatures.addAll(EE7FeatureReplacementAction.EE7_FEATURE_SET);
-        nonEE10JavaEEFeatures.addAll(EE8FeatureReplacementAction.EE8_FEATURE_SET);
-
-        // appSecurity-1.0 is superceded by appSecurity-2.0 so it isn't in one of the replacement
-        // feature lists.  jaxb and jaxws 2.3 are EE related, but are noship features currently.
-        // jsp-2.2 is a EE6 feature that is included with open liberty.
-        // websocket-1.0 is a special case.  Part of EE7, but 1.1 is used by liberty.
-        nonEE10JavaEEFeatures.add("appSecurity-1.0");
-        nonEE10JavaEEFeatures.add("jsp-2.2");
-        nonEE10JavaEEFeatures.add("websocket-1.0");
-
-        // Remove test features that are in the FeatureReplacementActions
-        nonEE10JavaEEFeatures.remove("componenttest-1.0");
-        nonEE10JavaEEFeatures.remove("componenttest-2.0");
-        nonEE10JavaEEFeatures.remove("txtest-1.0");
-        nonEE10JavaEEFeatures.remove("txtest-2.0");
-        nonEE10JavaEEFeatures.remove("ejbTest-1.0");
-        nonEE10JavaEEFeatures.remove("ejbTest-2.0");
-
-        for (FeatureSet mpFeatureSet : MicroProfileActions.ALL) {
-            if (mpFeatureSet.getEEVersion() != EEVersion.EE10) {
-                nonEE10MicroProfileFeatures.addAll(mpFeatureSet.getFeatures());
-            }
-        }
-
-        // MP standalone features
-        for (FeatureSet mpFeatureSet : MicroProfileActions.STANDALONE_ALL) {
-            if (mpFeatureSet.getEEVersion() != EEVersion.EE10) {
-                nonEE10MicroProfileFeatures.addAll(mpFeatureSet.getFeatures());
-            }
-        }
-
-        // Add EE9 features that are not part of EE10
-        for (String feature : JakartaEE9Action.EE9_FEATURE_SET) {
-            if (!JakartaEE10Action.EE10_FEATURE_SET.contains(feature)) {
-                nonEE10JavaEEFeatures.add(feature);
-            }
-        }
-
-        incompatibleValueAddFeatures.add("openid-2.0"); // stabilized
-        incompatibleValueAddFeatures.add("openapi-3.1"); // depends on mpOpenAPI
-        incompatibleValueAddFeatures.add("opentracing-1.0"); // opentracing depends on mpConfig
-        incompatibleValueAddFeatures.add("opentracing-1.1");
-        incompatibleValueAddFeatures.add("opentracing-1.2");
-        incompatibleValueAddFeatures.add("opentracing-1.3");
-        incompatibleValueAddFeatures.add("opentracing-2.0");
-        incompatibleValueAddFeatures.add("sipServlet-1.1"); // purposely not supporting EE 10
-        incompatibleValueAddFeatures.add("springBoot-1.5"); // springBoot 3.0 will support EE 9 and possibly 10
-        incompatibleValueAddFeatures.add("springBoot-2.0");
-
-        // temporarily add jwtSso-1.0 until mpJWT 2.1 is added or mpJWT 2.0 is designated as compatible with EE10.
-        incompatibleValueAddFeatures.add("jwtSso-1.0");
-    }
-
     static Set<String> getAllCompatibleFeatures() {
-        Set<String> compatFeatures = new HashSet<>();
+        Set<String> allFeatures = new HashSet<>();
         try {
-            File featureDir = new File(Bootstrap.getInstance().getValue("libertyInstallPath") + "/lib/features/");
-            // If there was a problem building projects before this test runs, "lib/features" won't exist
-            if (featureDir != null && featureDir.exists()) {
-                for (File feature : featureDir.listFiles()) {
-                    if (feature.getName().startsWith("io.openliberty.") ||
-                        feature.getName().startsWith("com.ibm.")) {
-                        String shortName = EE10FeatureCompatibilityTest.parseShortName(feature);
-                        if (shortName != null) {
-                            compatFeatures.add(shortName);
-                        }
-                    }
-                }
-            }
+            File installRoot = new File(Bootstrap.getInstance().getValue("libertyInstallPath"));
+            allFeatures.addAll(FeatureUtilities.getFeaturesFromServer(installRoot));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        compatFeatures.removeAll(EE10FeatureCompatibilityTest.nonEE10JavaEEFeatures);
-        compatFeatures.removeAll(EE10FeatureCompatibilityTest.nonEE10MicroProfileFeatures);
-        compatFeatures.removeAll(EE10FeatureCompatibilityTest.incompatibleValueAddFeatures);
+        return getCompatibleFeatures(allFeatures);
+    }
 
-        return compatFeatures;
+    private static Set<String> getCompatibleFeatures(Set<String> allFeatures) {
+        Set<String> compatibleFeatures = new HashSet<>();
+
+        // By default, features are assumed to be compatible
+        compatibleFeatures.addAll(allFeatures);
+
+        // Non-ee10 features are not compatible
+        compatibleFeatures.removeAll(FeatureUtilities.allEeFeatures());
+        compatibleFeatures.addAll(JakartaEE10Action.EE10_FEATURE_SET);
+
+        // MP features are only compatible if they're in MP versions which work with EE10
+        compatibleFeatures.removeAll(FeatureUtilities.allMpFeatures());
+        // Add only the MP 6.0 features which we've made compatible
+        compatibleFeatures.add("mpConfig-3.0");
+        // TODO: switch to adding all of them when ready
+        //compatibleFeatures.addAll(FeatureUtilities.compatibleMpFeatures(EEVersion.EE10));
+
+        // Value-add features which aren't compatible
+        compatibleFeatures.remove("openid-2.0"); // stabilized
+        compatibleFeatures.remove("openapi-3.1"); // depends on mpOpenAPI
+        compatibleFeatures.remove("opentracing-1.0"); // opentracing depends on mpConfig
+        compatibleFeatures.remove("opentracing-1.1");
+        compatibleFeatures.remove("opentracing-1.2");
+        compatibleFeatures.remove("opentracing-1.3");
+        compatibleFeatures.remove("opentracing-2.0");
+        compatibleFeatures.remove("sipServlet-1.1"); // purposely not supporting EE 10
+        compatibleFeatures.remove("springBoot-1.5"); // springBoot 3.0 will support EE 9 and maybe EE10
+        compatibleFeatures.remove("springBoot-2.0");
+
+        // temporarily add jwtSso-1.0 until mpJWT 2.1 is added or mpJWT 2.0 is designated as compatible with EE10.
+        compatibleFeatures.remove("jwtSso-1.0");
+
+        // Test features may or may not be compatible, we don't want to assert either way
+        compatibleFeatures.removeAll(FeatureUtilities.allTestFeatures());
+
+        return compatibleFeatures;
+    }
+
+    public static Set<String> getIncompatibleFeatures(Set<String> allFeatures, Set<String> compatibleFeatures) {
+        Set<String> incompatibleFeatures = new HashSet<>();
+
+        // Logically, incompatible features are all those that aren't compatible...
+        incompatibleFeatures.addAll(allFeatures);
+        incompatibleFeatures.removeAll(compatibleFeatures);
+
+        // TODO: We're working on getting MP60 to be EE10 compatible, so don't assert that it isn't
+        incompatibleFeatures.removeAll(MicroProfileActions.MP60.getFeatures());
+
+        // Test features may or may not be compatible, we don't want to assert either way
+        incompatibleFeatures.removeAll(FeatureUtilities.allTestFeatures());
+
+        return incompatibleFeatures;
     }
 
     @BeforeClass
     public static void setUp() throws Exception {
-        File featureDir = new File(server.getInstallRoot() + "/lib/features/");
-        // If there was a problem building projects before this test runs, "lib/features" won't exist
-        if (featureDir != null && featureDir.exists()) {
-            for (File feature : featureDir.listFiles()) {
-                if (feature.getName().startsWith("io.openliberty.") ||
-                    feature.getName().startsWith("com.ibm.")) {
-                    String shortName = parseShortName(feature);
-                    if (shortName != null) {
-                        features.add(shortName);
-                    }
-                }
-            }
-        }
+        allFeatures = FeatureUtilities.getFeaturesFromServer(new File(server.getInstallRoot()));
+        compatibleFeatures = getCompatibleFeatures(allFeatures);
+        incompatibleFeatures = getIncompatibleFeatures(allFeatures, compatibleFeatures);
 
-        // The features set should contain all of the incompatible features.  If it doesn't
-        // something was removed or there is a typo.
-        for (String feature : nonEE10JavaEEFeatures) {
-            Assert.assertTrue(feature + " was not in the all features list", features.contains(feature));
-        }
-        for (String feature : nonEE10MicroProfileFeatures) {
-            Assert.assertTrue(feature + " was not in the all features list", features.contains(feature));
-        }
-        for (String feature : incompatibleValueAddFeatures) {
-            Assert.assertTrue(feature + " was not in the all features list", features.contains(feature));
-        }
+        // Check for typos, every feature we've declared as being compatible or non-compatible should exist
+        Stream.concat(incompatibleFeatures.stream(), compatibleFeatures.stream())
+                        .forEach(feature -> assertThat(allFeatures, Matchers.hasItem(feature)));
 
         File lib = new File(server.getInstallRoot(), "lib");
 
@@ -212,48 +176,12 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
         repository.init();
     }
 
-    static String parseShortName(File feature) throws IOException {
-        // Only scan *.mf files
-        if (feature.isDirectory() || !feature.getName().endsWith(".mf"))
-            return null;
-
-        Scanner scanner = new Scanner(feature);
-        try {
-            String shortName = null;
-            while (scanner.hasNextLine()) {
-                String line = scanner.nextLine();
-                if (line.startsWith("IBM-ShortName:")) {
-                    shortName = line.substring("IBM-ShortName:".length()).trim();
-                } else if (line.contains("IBM-Test-Feature:") && line.contains("true")) {
-                    Log.info(c, "parseShortName", "Skipping test feature: " + feature.getName());
-                    return null;
-                } else if (line.startsWith("Subsystem-SymbolicName:") && !line.contains("visibility:=public")) {
-                    Log.info(c, "parseShortName", "Skipping non-public feature: " + feature.getName());
-                    return null;
-                } else if (line.startsWith("IBM-ProductID") && !line.contains("io.openliberty")) {
-                    Log.info(c, "parseShortName", "Skipping non Open Liberty feature: " + feature.getName());
-                    return null;
-                }
-            }
-            // some test feature files do not have a short name and do not have IBM-Test-Feature set.
-            // We do not want those ones.
-            if (shortName != null) {
-                return shortName;
-            }
-        } finally {
-            scanner.close();
-        }
-        return null;
-    }
-
     @Test
     public void testEE10FeatureConflictsEE8() throws Exception {
         Set<String> ee8Features = new HashSet<>();
         ee8Features.addAll(EE8FeatureReplacementAction.EE8_FEATURE_SET);
         // remove test features from the list
-        ee8Features.remove("componenttest-1.0");
-        ee8Features.remove("txtest-1.0");
-        ee8Features.remove("ejbTest-1.0");
+        ee8Features.removeAll(FeatureUtilities.allTestFeatures());
 
         // j2eeManagement-1.1 was removed in Jakarta EE 9 so there is no replacement
         ee8Features.remove("j2eeManagement-1.1");
@@ -272,9 +200,7 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
         Set<String> ee7Features = new HashSet<>();
         ee7Features.addAll(EE7FeatureReplacementAction.EE7_FEATURE_SET);
         // remove test features from the list
-        ee7Features.remove("componenttest-1.0");
-        ee7Features.remove("txtest-1.0");
-        ee7Features.remove("ejbTest-1.0");
+        ee7Features.removeAll(FeatureUtilities.allTestFeatures());
 
         // j2eeManagement-1.1 was removed in Jakarta EE 9 so there is no replacement
         ee7Features.remove("j2eeManagement-1.1");
@@ -321,15 +247,41 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
         }
     }
 
+    /**
+     * Test expected compatibility of the jsonp-2.1 feature (picked as an example of an EE10 feature)
+     * <p>
+     * For jsonp-2.0 and jsonp-2.1, check that it's incompatible and that io.openliberty.jsonp is listed as a conflict
+     * <p>
+     * Otherwise:
+     * <ul>
+     * <li>Check that it's compatible with all features in {@link #compatibleFeatures}
+     * <li>Check that it's incompatible with all features in {@link #incompatibleFeatures} and that eeCompatible is listed as a conflict
+     * </ul>
+     *
+     * @throws Exception
+     */
     @Test
     public void testJsonP21Feature() throws Exception {
         Map<String, String> specialEE10Conflicts = new HashMap<>();
         specialEE10Conflicts.put("jsonp-2.0", "io.openliberty.jsonp");
         // jsonp-2.1 will conflict with itself
         specialEE10Conflicts.put("jsonp-2.1", "io.openliberty.jsonp");
-        testCompatibility("jsonp-2.1", features, specialEE10Conflicts);
+        testCompatibility("jsonp-2.1", allFeatures, specialEE10Conflicts);
     }
 
+    /**
+     * Test expected compatibility of the servlet-6.0 feature
+     * <p>
+     * For servlet-x.x features, check that it's incompatible and that com.ibm.websphere.appserver.servlet is listed as a conflict
+     * <p>
+     * Otherwise:
+     * <ul>
+     * <li>Check that it's compatible with all features in {@link #compatibleFeatures}
+     * <li>Check that it's incompatible with all features in {@link #incompatibleFeatures} and that eeCompatible is listed as a conflict
+     * </ul>
+     *
+     * @throws Exception
+     */
     @Test
     public void testServlet60Feature() throws Exception {
         Map<String, String> specialEE10Conflicts = new HashMap<>();
@@ -338,7 +290,7 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
         specialEE10Conflicts.put("servlet-4.0", "com.ibm.websphere.appserver.servlet");
         specialEE10Conflicts.put("servlet-3.1", "com.ibm.websphere.appserver.servlet");
 
-        testCompatibility("servlet-6.0", features, specialEE10Conflicts);
+        testCompatibility("servlet-6.0", allFeatures, specialEE10Conflicts);
     }
 
     /**
@@ -352,7 +304,7 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
     //@Test
     @Mode(TestMode.FULL)
     public void testJakarta10ConvenienceFeature() throws Exception {
-        Set<String> featureSet = new HashSet<>(features);
+        Set<String> featureSet = new HashSet<>(allFeatures);
         // opentracing-1.3 and jakartaee-10.0 take over an hour to run on power linux system.
         // For now excluding opentracing-1.3 in order to not go past the 3 hour limit for a
         // Full FAT to run.
@@ -436,7 +388,11 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
         while ((feature = featureQueue.poll()) != null) {
             Log.info(c, "checkFeatures", "start testing: " + feature);
             featuresToTest.set(1, feature);
-            boolean expectToConflict = nonEE10JavaEEFeatures.contains(feature) || nonEE10MicroProfileFeatures.contains(feature) || incompatibleValueAddFeatures.contains(feature);
+            if (!compatibleFeatures.contains(feature) && !incompatibleFeatures.contains(feature)) {
+                // Don't test this feature
+                continue;
+            }
+            boolean expectToConflict = incompatibleFeatures.contains(feature);
             Result result = resolver.resolveFeatures(repository, Collections.<ProvisioningFeatureDefinition> emptySet(), featuresToTest, Collections.<String> emptySet(), false);
             Log.info(c, "checkFeatures", "finished testing: " + feature);
             Map<String, Collection<Chain>> conflicts = result.getConflicts();
@@ -474,8 +430,8 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
         ee10FeaturesThatEnableSsl.add("connectorsInboundSecurity-2.0");
         ee10FeaturesThatEnableSsl.add("messagingSecurity-3.0");
 
-        for (String feature : features) {
-            if (nonEE10JavaEEFeatures.contains(feature) || nonEE10MicroProfileFeatures.contains(feature) || incompatibleValueAddFeatures.contains(feature)) {
+        for (String feature : allFeatures) {
+            if (!compatibleFeatures.contains(feature)) {
                 continue;
             }
             Set<String> featuresToTest;

--- a/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10FeatureCompatibilityTest.java
+++ b/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10FeatureCompatibilityTest.java
@@ -427,7 +427,6 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
 
         Set<String> ee10FeaturesThatEnableSsl = new HashSet<>();
         ee10FeaturesThatEnableSsl.add("appSecurity-5.0");
-        ee10FeaturesThatEnableSsl.add("connectorsInboundSecurity-2.0");
         ee10FeaturesThatEnableSsl.add("messagingSecurity-3.0");
 
         for (String feature : compatibleFeatures) {

--- a/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10FeatureCompatibilityTest.java
+++ b/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10FeatureCompatibilityTest.java
@@ -430,10 +430,7 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
         ee10FeaturesThatEnableSsl.add("connectorsInboundSecurity-2.0");
         ee10FeaturesThatEnableSsl.add("messagingSecurity-3.0");
 
-        for (String feature : allFeatures) {
-            if (!compatibleFeatures.contains(feature)) {
-                continue;
-            }
+        for (String feature : compatibleFeatures) {
             Set<String> featuresToTest;
             if (ee10FeaturesThatEnableSsl.contains(feature)) {
                 featuresToTest = Collections.singleton(feature);

--- a/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/FeatureUtilities.java
+++ b/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/FeatureUtilities.java
@@ -1,0 +1,166 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.jakartaee10.internal.tests;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.rules.repeater.EE7FeatureReplacementAction;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
+import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatActions.EEVersion;
+
+/**
+ *
+ */
+public class FeatureUtilities {
+
+    private static final Class<?> c = FeatureUtilities.class;
+
+    /**
+     * Returns the set of all public Java/Jakarta EE feature short names
+     *
+     * @return the set of short names
+     */
+    public static Set<String> allEeFeatures() {
+        Set<String> features = new HashSet<>();
+        features.addAll(EE7FeatureReplacementAction.EE7_FEATURE_SET);
+        features.addAll(EE8FeatureReplacementAction.EE8_FEATURE_SET);
+        features.addAll(JakartaEE9Action.EE9_FEATURE_SET);
+        features.addAll(JakartaEE10Action.EE10_FEATURE_SET);
+
+        // EE-related features which aren't in one of the feature sets
+        features.add("appSecurity-1.0");
+        features.add("jsp-2.2");
+        features.add("websocket-1.0");
+
+        return features;
+    }
+
+    /**
+     * Returns the set of all public MicroProfile feature short names
+     *
+     * @return the set of short names
+     */
+    public static Set<String> allMpFeatures() {
+        return Stream.concat(MicroProfileActions.ALL.stream(),
+                             MicroProfileActions.STANDALONE_ALL.stream())
+                        .flatMap(s -> s.getFeatures().stream())
+                        .collect(Collectors.toSet());
+    }
+
+    /**
+     * Returns the set of public MicroProfile features which are compatible with a given Java/Jakarta EE version
+     *
+     * @param eeVersion the EE version
+     * @return the set of compatible MP feature short names
+     */
+    public static Set<String> compatibleMpFeatures(EEVersion eeVersion) {
+        return Stream.concat(MicroProfileActions.ALL.stream(),
+                             MicroProfileActions.STANDALONE_ALL.stream())
+                        .filter(s -> s.getEEVersion() == eeVersion)
+                        .flatMap(s -> s.getFeatures().stream())
+                        .collect(Collectors.toSet());
+    }
+
+    /**
+     * Returns the set of public test features
+     *
+     * @return the set of short names of public test features
+     */
+    public static Set<String> allTestFeatures() {
+        Set<String> testFeatures = new HashSet<>();
+        testFeatures.add("componenttest-1.0");
+        testFeatures.add("componenttest-2.0");
+        testFeatures.add("txtest-1.0");
+        testFeatures.add("txtest-2.0");
+        testFeatures.add("ejbTest-1.0");
+        testFeatures.add("ejbTest-2.0");
+        testFeatures.add("enterpriseBeansTest-2.0");
+        return testFeatures;
+    }
+
+    /**
+     * Get the set of public feature short names by reading the feature files from a liberty install
+     *
+     * @param libertyInstallRoot the wlp directory containing the liberty install
+     * @return the list of public short names
+     */
+    public static Set<String> getFeaturesFromServer(File libertyInstallRoot) {
+        try {
+            File featureDir = new File(libertyInstallRoot, "lib/features");
+            Set<String> features = new HashSet<>();
+            // If there was a problem building projects before this test runs, "lib/features" won't exist
+            if (featureDir != null && featureDir.exists()) {
+                for (File feature : featureDir.listFiles()) {
+                    if (feature.getName().startsWith("io.openliberty.") ||
+                        feature.getName().startsWith("com.ibm.")) {
+                        String shortName = parseShortName(feature);
+                        if (shortName != null) {
+                            features.add(shortName);
+                        }
+                    }
+                }
+            }
+            return features;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Get the short name from a feature file
+     *
+     * @param feature the feature file
+     * @return the short name, or {@code null} if it could not be found
+     * @throws IOException if there is a problem reading the feature file
+     */
+    private static String parseShortName(File feature) throws IOException {
+        // Only scan *.mf files
+        if (feature.isDirectory() || !feature.getName().endsWith(".mf"))
+            return null;
+
+        try (Scanner scanner = new Scanner(feature)) {
+            String shortName = null;
+            while (scanner.hasNextLine()) {
+                String line = scanner.nextLine();
+                if (line.startsWith("IBM-ShortName:")) {
+                    shortName = line.substring("IBM-ShortName:".length()).trim();
+                } else if (line.contains("IBM-Test-Feature:") && line.contains("true")) {
+                    Log.info(c, "parseShortName", "Skipping test feature: " + feature.getName());
+                    return null;
+                } else if (line.startsWith("Subsystem-SymbolicName:") && !line.contains("visibility:=public")) {
+                    Log.info(c, "parseShortName", "Skipping non-public feature: " + feature.getName());
+                    return null;
+                } else if (line.startsWith("IBM-ProductID") && !line.contains("io.openliberty")) {
+                    Log.info(c, "parseShortName", "Skipping non Open Liberty feature: " + feature.getName());
+                    return null;
+                }
+            }
+            // some test feature files do not have a short name and do not have IBM-Test-Feature set.
+            // We do not want those ones.
+            if (shortName != null) {
+                return shortName;
+            }
+        }
+        return null;
+    }
+
+}

--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9FeatureCompatibilityTest.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9FeatureCompatibilityTest.java
@@ -418,10 +418,7 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
         ee9FeaturesThatEnableSsl.add("connectorsInboundSecurity-2.0");
         ee9FeaturesThatEnableSsl.add("messagingSecurity-3.0");
 
-        for (String feature : allFeatures) {
-            if (!compatibleFeatures.contains(feature)) {
-                continue;
-            }
+        for (String feature : compatibleFeatures) {
             Set<String> featuresToTest;
             if (ee9FeaturesThatEnableSsl.contains(feature)) {
                 featuresToTest = Collections.singleton(feature);

--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9FeatureCompatibilityTest.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9FeatureCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021,2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,9 @@
  *******************************************************************************/
 package io.openliberty.jakartaee9.internal.tests;
 
+import static org.junit.Assert.assertThat;
+
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -21,11 +22,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
-import java.util.Scanner;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
 
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -50,7 +52,6 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.EE7FeatureReplacementAction;
 import componenttest.rules.repeater.EE8FeatureReplacementAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.FeatureSet;
 import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.MicroProfileActions;
@@ -77,13 +78,11 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
 
     private static final Class<?> c = EE9FeatureCompatibilityTest.class;
 
-    static final Set<String> features = new HashSet<>();
+    static Set<String> allFeatures = new HashSet<>();
 
-    static final Set<String> nonEE9JavaEEFeatures = new HashSet<>();
+    static Set<String> compatibleFeatures = new HashSet<>();
 
-    static final Set<String> nonEE9MicroProfileFeatures = new HashSet<>();
-
-    static final Set<String> incompatibleValueAddFeatures = new HashSet<>();
+    static Set<String> incompatibleFeatures = new HashSet<>();
 
     static final String serverName = "jakartaee9.fat";
     static final FeatureResolver resolver = new FeatureResolverImpl();
@@ -92,114 +91,74 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
     @Server("jakartaee9.fat")
     public static LibertyServer server;
 
-    static {
-        nonEE9JavaEEFeatures.addAll(EE7FeatureReplacementAction.EE7_FEATURE_SET);
-        nonEE9JavaEEFeatures.addAll(EE8FeatureReplacementAction.EE8_FEATURE_SET);
-
-        // appSecurity-1.0 is superceded by appSecurity-2.0 so it isn't in one of the replacement
-        // feature lists.  jaxb and jaxws 2.3 are EE related, but are noship features currently.
-        // jsp-2.2 is a EE6 feature that is included with open liberty.
-        // websocket-1.0 is a special case.  Part of EE7, but 1.1 is used by liberty.
-        nonEE9JavaEEFeatures.add("appSecurity-1.0");
-        nonEE9JavaEEFeatures.add("jsp-2.2");
-        nonEE9JavaEEFeatures.add("websocket-1.0");
-
-        // Remove test features that are in the FeatureReplacementActions
-        nonEE9JavaEEFeatures.remove("componenttest-1.0");
-        nonEE9JavaEEFeatures.remove("componenttest-2.0");
-        nonEE9JavaEEFeatures.remove("txtest-1.0");
-        nonEE9JavaEEFeatures.remove("txtest-2.0");
-        nonEE9JavaEEFeatures.remove("ejbTest-1.0");
-        nonEE9JavaEEFeatures.remove("ejbTest-2.0");
-
-        for (FeatureSet mpFeatureSet : MicroProfileActions.ALL) {
-            if (mpFeatureSet.getEEVersion() != EEVersion.EE9) {
-                nonEE9MicroProfileFeatures.addAll(mpFeatureSet.getFeatures());
-            }
-        }
-
-        // MP standalone features
-        for (FeatureSet mpFeatureSet : MicroProfileActions.STANDALONE_ALL) {
-            if (mpFeatureSet.getEEVersion() != EEVersion.EE9) {
-                nonEE9MicroProfileFeatures.addAll(mpFeatureSet.getFeatures());
-            }
-        }
-
-        // Add EE10 features that are not part of EE9
-        for (String feature : JakartaEE10Action.EE10_FEATURE_SET) {
-            if (!JakartaEE9Action.EE9_FEATURE_SET.contains(feature)) {
-                nonEE9JavaEEFeatures.add(feature);
-            }
-        }
-
-        incompatibleValueAddFeatures.add("openid-2.0"); // stabilized
-        incompatibleValueAddFeatures.add("openapi-3.1"); // depends on mpOpenAPI
-        incompatibleValueAddFeatures.add("opentracing-1.0"); // opentracing depends on mpConfig
-        incompatibleValueAddFeatures.add("opentracing-1.1");
-        incompatibleValueAddFeatures.add("opentracing-1.2");
-        incompatibleValueAddFeatures.add("opentracing-1.3");
-        incompatibleValueAddFeatures.add("opentracing-2.0");
-        incompatibleValueAddFeatures.add("sipServlet-1.1"); // purposely not supporting EE 9
-        incompatibleValueAddFeatures.add("springBoot-1.5"); // springBoot 3.0 will support EE 9
-        incompatibleValueAddFeatures.add("springBoot-2.0");
-    }
-
     static Set<String> getAllCompatibleFeatures() {
-        Set<String> compatFeatures = new HashSet<>();
+        Set<String> allFeatures = new HashSet<>();
         try {
-            File featureDir = new File(Bootstrap.getInstance().getValue("libertyInstallPath") + "/lib/features/");
-            // If there was a problem building projects before this test runs, "lib/features" won't exist
-            if (featureDir != null && featureDir.exists()) {
-                for (File feature : featureDir.listFiles()) {
-                    if (feature.getName().startsWith("io.openliberty.") ||
-                        feature.getName().startsWith("com.ibm.")) {
-                        String shortName = EE9FeatureCompatibilityTest.parseShortName(feature);
-                        if (shortName != null) {
-                            compatFeatures.add(shortName);
-                        }
-                    }
-                }
-            }
+            File installRoot = new File(Bootstrap.getInstance().getValue("libertyInstallPath"));
+            allFeatures.addAll(FeatureUtilities.getFeaturesFromServer(installRoot));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        compatFeatures.removeAll(EE9FeatureCompatibilityTest.nonEE9JavaEEFeatures);
-        compatFeatures.removeAll(EE9FeatureCompatibilityTest.nonEE9MicroProfileFeatures);
-        compatFeatures.removeAll(EE9FeatureCompatibilityTest.incompatibleValueAddFeatures);
+        return getCompatibleFeatures(allFeatures);
+    }
 
-        // when concurrent-3.0 moves to EE10 only you can remove this line since it won't be in the Set any longer.
-        compatFeatures.remove("concurrent-3.0");
+    private static Set<String> getCompatibleFeatures(Set<String> allFeatures) {
+        Set<String> compatibleFeatures = new HashSet<>();
 
-        return compatFeatures;
+        // By default, features are assumed to be compatible
+        compatibleFeatures.addAll(allFeatures);
+
+        // Non-ee9 features are not compatible
+        compatibleFeatures.removeAll(FeatureUtilities.allEeFeatures());
+        compatibleFeatures.addAll(JakartaEE9Action.EE9_FEATURE_SET);
+
+        // MP features are only compatible if they're in MP versions which work with EE9
+        compatibleFeatures.removeAll(FeatureUtilities.allMpFeatures());
+        compatibleFeatures.addAll(FeatureUtilities.compatibleMpFeatures(EEVersion.EE9));
+
+        // Value-add features which aren't compatible
+        compatibleFeatures.remove("openid-2.0"); // stabilized
+        compatibleFeatures.remove("openapi-3.1"); // depends on mpOpenAPI
+        compatibleFeatures.remove("opentracing-1.0"); // opentracing depends on mpConfig
+        compatibleFeatures.remove("opentracing-1.1");
+        compatibleFeatures.remove("opentracing-1.2");
+        compatibleFeatures.remove("opentracing-1.3");
+        compatibleFeatures.remove("opentracing-2.0");
+        compatibleFeatures.remove("sipServlet-1.1"); // purposely not supporting EE 9
+        compatibleFeatures.remove("springBoot-1.5"); // springBoot 3.0 will support EE 9
+        compatibleFeatures.remove("springBoot-2.0");
+
+        // Test features may or may not be compatible, we don't want to assert either way
+        compatibleFeatures.removeAll(FeatureUtilities.allTestFeatures());
+
+        return compatibleFeatures;
+    }
+
+    public static Set<String> getIncompatibleFeatures(Set<String> allFeatures, Set<String> compatibleFeatures) {
+        Set<String> incompatibleFeatures = new HashSet<>();
+
+        // Logically, incompatible features are all those that aren't compatible...
+        incompatibleFeatures.addAll(allFeatures);
+        incompatibleFeatures.removeAll(compatibleFeatures);
+
+        // ...but there are a few in-development features which are maybe compatible
+        incompatibleFeatures.removeAll(MicroProfileActions.MP60.getFeatures());
+
+        // Test features may or may not be compatible, we don't want to assert either way
+        incompatibleFeatures.removeAll(FeatureUtilities.allTestFeatures());
+
+        return incompatibleFeatures;
     }
 
     @BeforeClass
     public static void setUp() throws Exception {
-        File featureDir = new File(server.getInstallRoot() + "/lib/features/");
-        // If there was a problem building projects before this test runs, "lib/features" won't exist
-        if (featureDir != null && featureDir.exists()) {
-            for (File feature : featureDir.listFiles()) {
-                if (feature.getName().startsWith("io.openliberty.") ||
-                    feature.getName().startsWith("com.ibm.")) {
-                    String shortName = parseShortName(feature);
-                    if (shortName != null) {
-                        features.add(shortName);
-                    }
-                }
-            }
-        }
+        allFeatures = FeatureUtilities.getFeaturesFromServer(new File(server.getInstallRoot()));
+        compatibleFeatures = getCompatibleFeatures(allFeatures);
+        incompatibleFeatures = getIncompatibleFeatures(allFeatures, compatibleFeatures);
 
-        // The features set should contain all of the incompatible features.  If it doesn't
-        // something was removed or there is a typo.
-        for (String feature : nonEE9JavaEEFeatures) {
-            Assert.assertTrue(feature + " was not in the all features list", features.contains(feature));
-        }
-        for (String feature : nonEE9MicroProfileFeatures) {
-            Assert.assertTrue(feature + " was not in the all features list", features.contains(feature));
-        }
-        for (String feature : incompatibleValueAddFeatures) {
-            Assert.assertTrue(feature + " was not in the all features list", features.contains(feature));
-        }
+        // Check for typos, every feature we've declared as being compatible or non-compatible should exist
+        Stream.concat(incompatibleFeatures.stream(), compatibleFeatures.stream())
+                        .forEach(feature -> assertThat(allFeatures, Matchers.hasItem(feature)));
 
         File lib = new File(server.getInstallRoot(), "lib");
 
@@ -212,48 +171,12 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
         repository.init();
     }
 
-    static String parseShortName(File feature) throws IOException {
-        // Only scan *.mf files
-        if (feature.isDirectory() || !feature.getName().endsWith(".mf"))
-            return null;
-
-        Scanner scanner = new Scanner(feature);
-        try {
-            String shortName = null;
-            while (scanner.hasNextLine()) {
-                String line = scanner.nextLine();
-                if (line.startsWith("IBM-ShortName:")) {
-                    shortName = line.substring("IBM-ShortName:".length()).trim();
-                } else if (line.contains("IBM-Test-Feature:") && line.contains("true")) {
-                    Log.info(c, "parseShortName", "Skipping test feature: " + feature.getName());
-                    return null;
-                } else if (line.startsWith("Subsystem-SymbolicName:") && !line.contains("visibility:=public")) {
-                    Log.info(c, "parseShortName", "Skipping non-public feature: " + feature.getName());
-                    return null;
-                } else if (line.startsWith("IBM-ProductID") && !line.contains("io.openliberty")) {
-                    Log.info(c, "parseShortName", "Skipping non Open Liberty feature: " + feature.getName());
-                    return null;
-                }
-            }
-            // some test feature files do not have a short name and do not have IBM-Test-Feature set.
-            // We do not want those ones.
-            if (shortName != null) {
-                return shortName;
-            }
-        } finally {
-            scanner.close();
-        }
-        return null;
-    }
-
     @Test
     public void testEE9FeatureConflictsEE8() throws Exception {
         Set<String> ee8Features = new HashSet<>();
         ee8Features.addAll(EE8FeatureReplacementAction.EE8_FEATURE_SET);
         // remove test features from the list
-        ee8Features.remove("componenttest-1.0");
-        ee8Features.remove("txtest-1.0");
-        ee8Features.remove("ejbTest-1.0");
+        ee8Features.removeAll(FeatureUtilities.allTestFeatures());
 
         // j2eeManagement-1.1 was removed in Jakarta EE 9 so there is no replacement
         ee8Features.remove("j2eeManagement-1.1");
@@ -269,9 +192,7 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
         Set<String> ee7Features = new HashSet<>();
         ee7Features.addAll(EE7FeatureReplacementAction.EE7_FEATURE_SET);
         // remove test features from the list
-        ee7Features.remove("componenttest-1.0");
-        ee7Features.remove("txtest-1.0");
-        ee7Features.remove("ejbTest-1.0");
+        ee7Features.removeAll(FeatureUtilities.allTestFeatures());
 
         // j2eeManagement-1.1 was removed in Jakarta EE 9 so there is no replacement
         ee7Features.remove("j2eeManagement-1.1");
@@ -315,15 +236,41 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
         }
     }
 
+    /**
+     * Test expected compatibility of the jsonp-2.0 feature (picked as an example of an EE9 feature)
+     * <p>
+     * For jsonp-2.0 and jsonp-2.1, check that it's incompatible and that io.openliberty.jsonp is listed as a conflict
+     * <p>
+     * Otherwise:
+     * <ul>
+     * <li>Check that it's compatible with all features in {@link #compatibleFeatures}
+     * <li>Check that it's incompatible with all features in {@link #incompatibleFeatures} and that eeCompatible is listed as a conflict
+     * </ul>
+     *
+     * @throws Exception
+     */
     @Test
     public void testJsonP20Feature() throws Exception {
         Map<String, String> specialEE9Conflicts = new HashMap<>();
         // jsonp-2.0 will conflict with itself
         specialEE9Conflicts.put("jsonp-2.0", "io.openliberty.jsonp");
         specialEE9Conflicts.put("jsonp-2.1", "io.openliberty.jsonp");
-        testCompatibility("jsonp-2.0", features, specialEE9Conflicts);
+        testCompatibility("jsonp-2.0", allFeatures, specialEE9Conflicts);
     }
 
+    /**
+     * Test expected compatibility of the servlet-5.0 feature
+     * <p>
+     * For servlet-x.x features, check that it's incompatible and that com.ibm.websphere.appserver.servlet is listed as a conflict
+     * <p>
+     * Otherwise:
+     * <ul>
+     * <li>Check that it's compatible with all features in {@link #compatibleFeatures}
+     * <li>Check that it's incompatible with all features in {@link #incompatibleFeatures} and that eeCompatible is listed as a conflict
+     * </ul>
+     *
+     * @throws Exception
+     */
     @Test
     public void testServlet50Feature() throws Exception {
         Map<String, String> specialEE9Conflicts = new HashMap<>();
@@ -332,7 +279,7 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
         specialEE9Conflicts.put("servlet-4.0", "com.ibm.websphere.appserver.servlet");
         specialEE9Conflicts.put("servlet-3.1", "com.ibm.websphere.appserver.servlet");
 
-        testCompatibility("servlet-5.0", features, specialEE9Conflicts);
+        testCompatibility("servlet-5.0", allFeatures, specialEE9Conflicts);
     }
 
     /**
@@ -346,7 +293,7 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
     //@Test
     @Mode(TestMode.FULL)
     public void testJakarta91ConvenienceFeature() throws Exception {
-        Set<String> featureSet = new HashSet<>(features);
+        Set<String> featureSet = new HashSet<>(allFeatures);
         // opentracing-1.3 and jakartaee-9.1 take over an hour to run on power linux system.
         // For now excluding opentracing-1.3 in order to not go past the 3 hour limit for a
         // Full FAT to run.
@@ -429,7 +376,11 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
         while ((feature = featureQueue.poll()) != null) {
             Log.info(c, "checkFeatures", "start testing: " + feature);
             featuresToTest.set(1, feature);
-            boolean expectToConflict = nonEE9JavaEEFeatures.contains(feature) || nonEE9MicroProfileFeatures.contains(feature) || incompatibleValueAddFeatures.contains(feature);
+            if (!compatibleFeatures.contains(feature) && !incompatibleFeatures.contains(feature)) {
+                // Don't test this feature
+                continue;
+            }
+            boolean expectToConflict = incompatibleFeatures.contains(feature);
             Result result = resolver.resolveFeatures(repository, Collections.<ProvisioningFeatureDefinition> emptySet(), featuresToTest, Collections.<String> emptySet(), false);
             Log.info(c, "checkFeatures", "finished testing: " + feature);
             Map<String, Collection<Chain>> conflicts = result.getConflicts();
@@ -467,8 +418,8 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
         ee9FeaturesThatEnableSsl.add("connectorsInboundSecurity-2.0");
         ee9FeaturesThatEnableSsl.add("messagingSecurity-3.0");
 
-        for (String feature : features) {
-            if (nonEE9JavaEEFeatures.contains(feature) || nonEE9MicroProfileFeatures.contains(feature) || incompatibleValueAddFeatures.contains(feature)) {
+        for (String feature : allFeatures) {
+            if (!compatibleFeatures.contains(feature)) {
                 continue;
             }
             Set<String> featuresToTest;

--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/FeatureUtilities.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/FeatureUtilities.java
@@ -1,0 +1,166 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.jakartaee9.internal.tests;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.rules.repeater.EE7FeatureReplacementAction;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
+import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatActions.EEVersion;
+
+/**
+ *
+ */
+public class FeatureUtilities {
+
+    private static final Class<?> c = FeatureUtilities.class;
+
+    /**
+     * Returns the set of all public Java/Jakarta EE feature short names
+     *
+     * @return the set of short names
+     */
+    public static Set<String> allEeFeatures() {
+        Set<String> features = new HashSet<>();
+        features.addAll(EE7FeatureReplacementAction.EE7_FEATURE_SET);
+        features.addAll(EE8FeatureReplacementAction.EE8_FEATURE_SET);
+        features.addAll(JakartaEE9Action.EE9_FEATURE_SET);
+        features.addAll(JakartaEE10Action.EE10_FEATURE_SET);
+
+        // EE-related features which aren't in one of the feature sets
+        features.add("appSecurity-1.0");
+        features.add("jsp-2.2");
+        features.add("websocket-1.0");
+
+        return features;
+    }
+
+    /**
+     * Returns the set of all public MicroProfile feature short names
+     *
+     * @return the set of short names
+     */
+    public static Set<String> allMpFeatures() {
+        return Stream.concat(MicroProfileActions.ALL.stream(),
+                             MicroProfileActions.STANDALONE_ALL.stream())
+                        .flatMap(s -> s.getFeatures().stream())
+                        .collect(Collectors.toSet());
+    }
+
+    /**
+     * Returns the set of public MicroProfile features which are compatible with a given Java/Jakarta EE version
+     *
+     * @param eeVersion the EE version
+     * @return the set of compatible MP feature short names
+     */
+    public static Set<String> compatibleMpFeatures(EEVersion eeVersion) {
+        return Stream.concat(MicroProfileActions.ALL.stream(),
+                             MicroProfileActions.STANDALONE_ALL.stream())
+                        .filter(s -> s.getEEVersion() == eeVersion)
+                        .flatMap(s -> s.getFeatures().stream())
+                        .collect(Collectors.toSet());
+    }
+
+    /**
+     * Returns the set of public test features
+     *
+     * @return the set of short names of public test features
+     */
+    public static Set<String> allTestFeatures() {
+        Set<String> testFeatures = new HashSet<>();
+        testFeatures.add("componenttest-1.0");
+        testFeatures.add("componenttest-2.0");
+        testFeatures.add("txtest-1.0");
+        testFeatures.add("txtest-2.0");
+        testFeatures.add("ejbTest-1.0");
+        testFeatures.add("ejbTest-2.0");
+        testFeatures.add("enterpriseBeansTest-2.0");
+        return testFeatures;
+    }
+
+    /**
+     * Get the set of public feature short names by reading the feature files from a liberty install
+     *
+     * @param libertyInstallRoot the wlp directory containing the liberty install
+     * @return the list of public short names
+     */
+    public static Set<String> getFeaturesFromServer(File libertyInstallRoot) {
+        try {
+            File featureDir = new File(libertyInstallRoot, "lib/features");
+            Set<String> features = new HashSet<>();
+            // If there was a problem building projects before this test runs, "lib/features" won't exist
+            if (featureDir != null && featureDir.exists()) {
+                for (File feature : featureDir.listFiles()) {
+                    if (feature.getName().startsWith("io.openliberty.") ||
+                        feature.getName().startsWith("com.ibm.")) {
+                        String shortName = parseShortName(feature);
+                        if (shortName != null) {
+                            features.add(shortName);
+                        }
+                    }
+                }
+            }
+            return features;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Get the short name from a feature file
+     *
+     * @param feature the feature file
+     * @return the short name, or {@code null} if it could not be found
+     * @throws IOException if there is a problem reading the feature file
+     */
+    private static String parseShortName(File feature) throws IOException {
+        // Only scan *.mf files
+        if (feature.isDirectory() || !feature.getName().endsWith(".mf"))
+            return null;
+
+        try (Scanner scanner = new Scanner(feature)) {
+            String shortName = null;
+            while (scanner.hasNextLine()) {
+                String line = scanner.nextLine();
+                if (line.startsWith("IBM-ShortName:")) {
+                    shortName = line.substring("IBM-ShortName:".length()).trim();
+                } else if (line.contains("IBM-Test-Feature:") && line.contains("true")) {
+                    Log.info(c, "parseShortName", "Skipping test feature: " + feature.getName());
+                    return null;
+                } else if (line.startsWith("Subsystem-SymbolicName:") && !line.contains("visibility:=public")) {
+                    Log.info(c, "parseShortName", "Skipping non-public feature: " + feature.getName());
+                    return null;
+                } else if (line.startsWith("IBM-ProductID") && !line.contains("io.openliberty")) {
+                    Log.info(c, "parseShortName", "Skipping non Open Liberty feature: " + feature.getName());
+                    return null;
+                }
+            }
+            // some test feature files do not have a short name and do not have IBM-Test-Feature set.
+            // We do not want those ones.
+            if (shortName != null) {
+                return shortName;
+            }
+        }
+        return null;
+    }
+
+}


### PR DESCRIPTION
This PR includes some prerequisite work:
* Creating the `mpCompatible-6.0` feature
* Adding an MP60 feature set to MicroProfileActions
* Re-factoring the EE compatibility tests to make it easier to express that we don't yet want to assert the compatibility of the new MP60 features against EE9 or EE10

For #21968