### PR TITLE
Change workarea for application containers to the application ID, if available.

### DIFF
--- a/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/ear/internal/EARDeployedAppInfoFactoryImpl.java
+++ b/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/ear/internal/EARDeployedAppInfoFactoryImpl.java
@@ -26,6 +26,7 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.app.manager.ApplicationManager;
+import com.ibm.ws.app.manager.internal.ApplicationUtils;
 import com.ibm.ws.app.manager.module.AbstractDeployedAppInfoFactory;
 import com.ibm.ws.app.manager.module.DeployedAppInfo;
 import com.ibm.ws.app.manager.module.DeployedAppInfoFactory;
@@ -221,10 +222,8 @@ public class EARDeployedAppInfoFactoryImpl extends AbstractDeployedAppInfoFactor
         String appPath = appInfo.getLocation();
 
         Tr.debug(_tc, "Create deployed application:" +
-                      " ID [ " + appId + " ]" +
-                      " PID [ " + appPid + " ]" +
-                      " Name [ " + appName + " ]" +
-                      " Location [ " + appPath + " ]");
+                      " ID [ " + appId + " ]" + " PID [ " + appPid + " ]" +
+                      " Name [ " + appName + " ]" + " Location [ " + appPath + " ]");
 
         File appFile = new File(appPath);
 
@@ -239,7 +238,6 @@ public class EARDeployedAppInfoFactoryImpl extends AbstractDeployedAppInfoFactor
             Tr.info(_tc, "info.directory.app", appName, appPath);
 
         } else if (applicationManager.getExpandApps()) {
-
             try {
                 prepareExpansion(appName);
 
@@ -272,10 +270,7 @@ public class EARDeployedAppInfoFactoryImpl extends AbstractDeployedAppInfoFactor
                 NonPersistentCache initialCache = appContainer.adapt(NonPersistentCache.class);
                 ApplicationInfoForContainer appContainerInfo = (ApplicationInfoForContainer) initialCache.getFromCache(ApplicationInfoForContainer.class);
 
-                // Tr.info(_tc, "Initial 'useJandex' [ " +
-                //     ((appContainerInfo == null) ? "unavailable" : appContainerInfo.getUseJandex()) + " ]");
-
-                String cacheId = ( (appId == null) ? appPid : appId );                
+                String cacheId = ApplicationUtils.getCacheId(appId, appPid);
                 originalAppContainer = appContainer;
                 appContainer = deployedAppServices.setupContainer(cacheId, expandedFile);
 

--- a/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/ear/internal/EARDeployedAppInfoFactoryImpl.java
+++ b/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/ear/internal/EARDeployedAppInfoFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -220,14 +220,12 @@ public class EARDeployedAppInfoFactoryImpl extends AbstractDeployedAppInfoFactor
         String appName = appInfo.getName();
         String appPath = appInfo.getLocation();
 
-        Tr.info(_tc, "Create deployed application:" +
-                     " ID [ " + appId + " ]" +
-                     " PID [ " + appPid + " ]" +
-                     " Name [ " + appName + " ]" +
-                     " Location [ " + appPath + " ]");
+        Tr.debug(_tc, "Create deployed application:" +
+                      " ID [ " + appId + " ]" +
+                      " PID [ " + appPid + " ]" +
+                      " Name [ " + appName + " ]" +
+                      " Location [ " + appPath + " ]");
 
-        String cacheId = ( ( appId == null ) ? appPid : appId );
-        
         File appFile = new File(appPath);
 
         Container appContainer = appInfo.getContainer();
@@ -277,6 +275,7 @@ public class EARDeployedAppInfoFactoryImpl extends AbstractDeployedAppInfoFactor
                 // Tr.info(_tc, "Initial 'useJandex' [ " +
                 //     ((appContainerInfo == null) ? "unavailable" : appContainerInfo.getUseJandex()) + " ]");
 
+                String cacheId = ( (appId == null) ? appPid : appId );                
                 originalAppContainer = appContainer;
                 appContainer = deployedAppServices.setupContainer(cacheId, expandedFile);
 

--- a/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/war/internal/WARDeployedAppInfoFactoryImpl.java
+++ b/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/war/internal/WARDeployedAppInfoFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -104,14 +104,12 @@ public class WARDeployedAppInfoFactoryImpl extends AbstractDeployedAppInfoFactor
         String warName = appInfo.getName();
         String warPath = appInfo.getLocation();
 
-        Tr.info(tc, "Create deployed application:" +
-                    " ID [ " + warId + " ]" +
-                    " PID [ " + warPid + " ]" +
-                    " Name [ " + warName + " ]" +
-                    " Location [ " + warPath + " ]");
+        Tr.debug(tc, "Create deployed application:" +
+                     " ID [ " + warId + " ]" +
+                     " PID [ " + warPid + " ]" +
+                     " Name [ " + warName + " ]" +
+                     " Location [ " + warPath + " ]");
 
-        String cacheId = ( ( warId == null ) ? warPid : warId );
-        
         File warFile = new File(warPath);
 
         BinaryType appType = getApplicationType(warFile, warPath);
@@ -154,6 +152,7 @@ public class WARDeployedAppInfoFactoryImpl extends AbstractDeployedAppInfoFactor
                 // Tr.info(tc, "Initial 'useJandex' [ " +
                 //     ((appContainerInfo == null) ? "unavailable" : appContainerInfo.getUseJandex()) + " ]");
 
+                String cacheId = ( (warId == null) ? warPid : warId );                
                 Container expandedContainer = deployedAppServices.setupContainer(cacheId, expandedFile);
                 appInfo.setContainer(expandedContainer);
 

--- a/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/war/internal/WARDeployedAppInfoFactoryImpl.java
+++ b/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/war/internal/WARDeployedAppInfoFactoryImpl.java
@@ -23,6 +23,7 @@ import com.ibm.ws.app.manager.module.AbstractDeployedAppInfoFactory;
 import com.ibm.ws.app.manager.module.DeployedAppInfo;
 import com.ibm.ws.app.manager.module.DeployedAppInfoFactory;
 import com.ibm.ws.app.manager.module.DeployedAppServices;
+import com.ibm.ws.app.manager.internal.ApplicationUtils;
 import com.ibm.ws.app.manager.module.internal.ModuleHandler;
 import com.ibm.ws.container.service.app.deploy.extended.ApplicationInfoForContainer;
 import com.ibm.wsspi.adaptable.module.Container;
@@ -72,8 +73,7 @@ public class WARDeployedAppInfoFactoryImpl extends AbstractDeployedAppInfoFactor
         return deployedAppServices.getLocationAdmin().resolveResource(applicationManager.getExpandLocation() + appName + ".war/");
     }
 
-    protected void expand(
-                          String name, File collapsedFile,
+    protected void expand(String name, File collapsedFile,
                           WsResource expandedResource, File expandedFile) throws IOException {
 
         String collapsedPath = collapsedFile.getAbsolutePath();
@@ -93,7 +93,6 @@ public class WARDeployedAppInfoFactoryImpl extends AbstractDeployedAppInfoFactor
         expandedResource.create();
 
         ZipUtils.unzip(collapsedFile, expandedFile, ZipUtils.IS_NOT_EAR, collapsedFile.lastModified()); // throws IOException
-
     }
 
     @Override
@@ -105,20 +104,19 @@ public class WARDeployedAppInfoFactoryImpl extends AbstractDeployedAppInfoFactor
         String warPath = appInfo.getLocation();
 
         Tr.debug(tc, "Create deployed application:" +
-                     " ID [ " + warId + " ]" +
-                     " PID [ " + warPid + " ]" +
-                     " Name [ " + warName + " ]" +
-                     " Location [ " + warPath + " ]");
+                     " ID [ " + warId + " ]" + " PID [ " + warPid + " ]" +
+                     " Name [ " + warName + " ]" + " Location [ " + warPath + " ]");
 
         File warFile = new File(warPath);
 
         BinaryType appType = getApplicationType(warFile, warPath);
         if (appType == BinaryType.LOOSE) {
             Tr.info(tc, "info.loose.app", warName, warPath);
+
         } else if (appType == BinaryType.DIRECTORY) {
             Tr.info(tc, "info.directory.app", warName, warPath);
-        } else if (applicationManager.getExpandApps()) {
 
+        } else if (applicationManager.getExpandApps()) {
             try {
                 prepareExpansion(warName);
 
@@ -147,12 +145,10 @@ public class WARDeployedAppInfoFactoryImpl extends AbstractDeployedAppInfoFactor
 
                 // Part 1: Retrieve the container info from the initial container.
                 NonPersistentCache initialCache = appInfo.getContainer().adapt(NonPersistentCache.class);
-                ApplicationInfoForContainer appContainerInfo = (ApplicationInfoForContainer) initialCache.getFromCache(ApplicationInfoForContainer.class);
+                ApplicationInfoForContainer appContainerInfo = (ApplicationInfoForContainer)
+                    initialCache.getFromCache(ApplicationInfoForContainer.class);
 
-                // Tr.info(tc, "Initial 'useJandex' [ " +
-                //     ((appContainerInfo == null) ? "unavailable" : appContainerInfo.getUseJandex()) + " ]");
-
-                String cacheId = ( (warId == null) ? warPid : warId );                
+                String cacheId = ApplicationUtils.getCacheId(warId, warPid);
                 Container expandedContainer = deployedAppServices.setupContainer(cacheId, expandedFile);
                 appInfo.setContainer(expandedContainer);
 

--- a/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/ApplicationUtils.java
+++ b/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/ApplicationUtils.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.app.manager.internal;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
+/**
+ * Application configuration utilities.
+ *
+ * Element: application, ejbApplication, webApplication
+ *
+ * Relevant attributes:
+ *
+ * id string [not-required] [unique] [null]
+ * "A unique configuration ID."
+ *
+ * location string [required] [not-unique]
+ * "The location of the application. Specified as an absolute path or as a path relative to the server-level 'apps' directory."
+ *
+ * name string [not-required] [unique] [simple name of the application file]
+ * "The name of the application."
+ *
+ * type string [not-required] [not-unique] [extension of the application file]
+ * "The type of the application."
+ */
+public class ApplicationUtils {
+    // Encode samples:
+
+    // Value [ a ] [ a ]
+    // Value [ a a ] [ a+a ]
+    // Value [ a+b ] [ a%2Bb ]
+    // Value [ a\b ] [ a%5Cb ]
+    // Value [ a/b ] [ a%2Fb ]
+    // Value [ a a/b b ] [ a+a%2Fb+b ]
+    // Value [ a a\b b ] [ a+a%5Cb+b ]
+
+    public static final String UTF_8_ENCODING_NAME = "UTF-8";
+
+    /**
+     * URL encode a value, per {@link URLEncoder#encode(String, String)}.
+     *
+     * This currently intended for generating safe file names for
+     * applications, starting with the application ID or PID.
+     *
+     * @param value The value which is to be encoded.
+     *
+     * @return The encoded value.
+     */
+    @FFDCIgnore(UnsupportedEncodingException.class)
+    public static final String urlEncode(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        try {
+            return URLEncoder.encode(value, UTF_8_ENCODING_NAME); // throws UnsupportedEncodingException
+        } catch (UnsupportedEncodingException e) {
+            // This should never occur.
+            throw new IllegalArgumentException("Unable to use UTF-8 encoding [ " + UTF_8_ENCODING_NAME + " ]", e);
+        }
+    }
+
+    /**
+     * Decode a URL encoded value, per {@link URLEncoder#decode(String, String)}.
+     *
+     * This currently intended for recovering cache ID values from
+     * file names.
+     *
+     * @param e_value The encoded value.
+     *
+     * @return The decoded value.
+     */
+    @FFDCIgnore(UnsupportedEncodingException.class)
+    public static final String urlDecode(String e_value) {
+        if (e_value == null) {
+            return null;
+        }
+
+        try {
+            return URLDecoder.decode(e_value, UTF_8_ENCODING_NAME); // throws UnsupportedEncodingException
+        } catch (UnsupportedEncodingException e) {
+            // This should never occur.
+            throw new IllegalArgumentException("Unable to use UTF-8 encoding [ " + UTF_8_ENCODING_NAME + " ]", e);
+        }
+    }
+
+    /**
+     * Generate a cache ID given an application ID and and application PID.
+     *
+     * The ID may be null, in which case the PID is used.
+     *
+     * The resulting value is URL encoded. This ensures that the generated
+     * value is safe for use as a file name.
+     *
+     * Encoding is technically unnecessary on unix systems. However, embedding
+     * special characters can cause problems for scripts. Also, encoding in
+     * all cases ensures that unix and windows systems have the same cache
+     * IDs.
+     *
+     * @param appId  The ID of the application.
+     * @param appPid The PID of the application.
+     *
+     * @return The encoded cache ID of the application.
+     */
+    public static String getCacheId(String appId, String appPid) {
+        return urlEncode((appId == null) ? appPid : appId);
+    }
+}

--- a/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/ApplicationStateMachineImpl.java
+++ b/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/ApplicationStateMachineImpl.java
@@ -42,6 +42,7 @@ import com.ibm.ws.app.manager.internal.ApplicationConfig;
 import com.ibm.ws.app.manager.internal.ApplicationConfigurator;
 import com.ibm.ws.app.manager.internal.ApplicationDependency;
 import com.ibm.ws.app.manager.internal.ApplicationInstallInfo;
+import com.ibm.ws.app.manager.internal.ApplicationUtils;
 import com.ibm.ws.app.manager.internal.FutureCollectionCompletionListener;
 import com.ibm.ws.app.manager.internal.monitor.ApplicationMonitor;
 import com.ibm.ws.app.manager.internal.monitor.ApplicationMonitorConfig;
@@ -601,15 +602,16 @@ class ApplicationStateMachineImpl extends ApplicationStateMachine implements App
             }
         }
 
+        @Deprecated
         @Override
         public Container setupContainer(String pid, File locationFile) {
             return setupContainer(null, pid, locationFile);
         }
-        
+
         @Override
         public Container setupContainer(String configId, String pid, File locationFile) {
-            String cacheId = ( (configId == null) ? pid : configId );
-            
+            String cacheId = ApplicationUtils.getCacheId(configId,  pid);
+
             File cacheDir = new File(getCacheDir(), cacheId);
             if (!FileUtils.ensureDirExists(cacheDir)) {
                 if (_tc.isEventEnabled()) {

--- a/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/ApplicationStateMachineImpl.java
+++ b/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/ApplicationStateMachineImpl.java
@@ -603,7 +603,15 @@ class ApplicationStateMachineImpl extends ApplicationStateMachine implements App
 
         @Override
         public Container setupContainer(String pid, File locationFile) {
-            File cacheDir = new File(getCacheDir(), pid);
+            return setupContainer(null, pid, locationFile);
+        }
+        
+        @Override
+        public Container setupContainer(String configId, String pid, File locationFile) {
+            String cacheId = ( (configId == null) ? pid : configId );
+            Tr.event(_tc, asmLabel() + "Workarea cache ID {0}", cacheId);
+            
+            File cacheDir = new File(getCacheDir(), cacheId);
             if (!FileUtils.ensureDirExists(cacheDir)) {
                 if (_tc.isEventEnabled()) {
                     Tr.event(_tc, asmLabel() + "Could not create directory at {0}.", cacheDir.getAbsolutePath());
@@ -616,7 +624,7 @@ class ApplicationStateMachineImpl extends ApplicationStateMachine implements App
                 return null;
             }
 
-            File cacheDirAdapt = new File(getCacheAdaptDir(), pid);
+            File cacheDirAdapt = new File(getCacheAdaptDir(), cacheId);
             if (!FileUtils.ensureDirExists(cacheDirAdapt)) {
                 if (_tc.isEventEnabled()) {
                     Tr.event(_tc, asmLabel() + "Could not create directory at {0}.", cacheDirAdapt.getAbsolutePath());
@@ -624,7 +632,7 @@ class ApplicationStateMachineImpl extends ApplicationStateMachine implements App
                 return null;
             }
 
-            File cacheDirOverlay = new File(getCacheOverlayDir(), pid);
+            File cacheDirOverlay = new File(getCacheOverlayDir(), cacheId);
             if (!FileUtils.ensureDirExists(cacheDirOverlay)) {
                 if (_tc.isEventEnabled()) {
                     Tr.event(_tc, asmLabel() + "Could not create directory at {0}.", cacheDirOverlay.getAbsolutePath());
@@ -1321,13 +1329,14 @@ class ApplicationStateMachineImpl extends ApplicationStateMachine implements App
                         synchronized (_stateLock) {
                             resolveFileCallback = new ResolveFileCallback();
                             ApplicationConfig appConfig = _appConfig.get();
+                            String configId = (String) appConfig.getConfigProperty("id");
                             String configPid = appConfig.getConfigPid();
                             String location = appConfig.getLocation();
                             if (isLocationAURL(location)) {
-                                resolveFileAction = new DownloadFileAction(_locAdmin, configPid, location, resolveFileCallback, _handler);
+                                resolveFileAction = new DownloadFileAction(_locAdmin, configId, configPid, location, resolveFileCallback, _handler);
                             } else {
                                 ApplicationMonitorConfig appMonitorConfig = _appMonitor.getConfig();
-                                resolveFileAction = new ResolveFileAction(_ctx, appMonitorConfig.getPollingRate(), appMonitorConfig.getUpdateTrigger(), _locAdmin, appConfig.getName(), configPid, location, resolveFileCallback, _handler);
+                                resolveFileAction = new ResolveFileAction(_ctx, appMonitorConfig.getPollingRate(), appMonitorConfig.getUpdateTrigger(), _locAdmin, appConfig.getName(), configId, configPid, location, resolveFileCallback, _handler);
                                 _rfa.set((ResolveFileAction) resolveFileAction);
                             }
                             _currentAction.set(resolveFileAction);

--- a/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/ApplicationStateMachineImpl.java
+++ b/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/ApplicationStateMachineImpl.java
@@ -609,7 +609,6 @@ class ApplicationStateMachineImpl extends ApplicationStateMachine implements App
         @Override
         public Container setupContainer(String configId, String pid, File locationFile) {
             String cacheId = ( (configId == null) ? pid : configId );
-            Tr.event(_tc, asmLabel() + "Workarea cache ID {0}", cacheId);
             
             File cacheDir = new File(getCacheDir(), cacheId);
             if (!FileUtils.ensureDirExists(cacheDir)) {

--- a/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/DownloadFileAction.java
+++ b/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/DownloadFileAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -101,7 +101,7 @@ class DownloadFileAction implements Runnable, Action {
             output = new BufferedOutputStream(new FileOutputStream(downloadedFile));
 
             input = urlConection.getInputStream();
-            buf = new byte[32 * 1024]; //you can change the 1024 to a different size value
+            buf = new byte[1024]; //you can change the 1024 to a different size value
             while (_active.get() && (byteRead = input.read(buf)) != -1) {
                 output.write(buf, 0, byteRead);
             }

--- a/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/ResolveFileAction.java
+++ b/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/ResolveFileAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,12 +35,10 @@ import com.ibm.wsspi.kernel.filemonitor.FileMonitor;
 import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
 import com.ibm.wsspi.kernel.service.utils.FrameworkState;
 
-/**
- *
- */
 class ResolveFileAction implements Action, FileMonitor {
     private static final TraceComponent _tc = Tr.register(ResolveFileAction.class);
     private final WsLocationAdmin _locAdmin;
+    private final String _configId;
     private final String _configPid;
     private final String _location;
     private final AtomicReference<ResourceCallback> _callback = new AtomicReference<ResourceCallback>();
@@ -54,16 +52,11 @@ class ResolveFileAction implements Action, FileMonitor {
     private final AtomicReference<ApplicationHandler<?>> _handler;
     private final ReentrantLock lock;
 
-    /**
-     * @param _locAdmin
-     * @param string
-     * @param fm
-     * @param callback
-     */
     public ResolveFileAction(BundleContext ctx, long pollRate, UpdateTrigger trigger,
-                             WsLocationAdmin locAdmin, String name, String configPid, String location,
+                             WsLocationAdmin locAdmin, String name, String configId, String configPid, String location,
                              ResourceCallback callback, AtomicReference<ApplicationHandler<?>> handler) {
         _locAdmin = locAdmin;
+        _configId = configId;
         _configPid = configPid;
         _location = location;
         _callback.set(callback);
@@ -97,7 +90,7 @@ class ResolveFileAction implements Action, FileMonitor {
             _file.set(f);
             ResourceCallback callback = _callback.get();
             if (callback != null) {
-                _container.set(callback.setupContainer(_configPid, f));
+                _container.set(callback.setupContainer(_configId, _configPid, f));
 
                 if (_container.get() != null) {
                     if (!complete) {

--- a/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/ResourceCallback.java
+++ b/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/ResourceCallback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,5 +27,8 @@ interface ResourceCallback {
 
     void failedCompletion(Throwable t);
 
+    @Deprecated
     Container setupContainer(String _servicePid, File downloadedFile);
+    
+    Container setupContainer(String _configId, String _servicePid, File downloadedFile);
 }

--- a/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/FATSuite.java
+++ b/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/FATSuite.java
@@ -17,10 +17,10 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({
                 FATTest.class,
-                AutoExtractTest.class,
-                AppOrderTests.class,
-                DropinsTests.class,
-                AppPrereqTest.class
+                // AutoExtractTest.class,
+                // AppOrderTests.class,
+                // DropinsTests.class,
+                // AppPrereqTest.class
 })
 public class FATSuite {
 

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/admin/internal/ConfigurationAdminImpl.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/admin/internal/ConfigurationAdminImpl.java
@@ -28,9 +28,7 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 /**
  * Implementation of ConfigurationAdmin.
  * Provides APIs to managed Configurations such as providing APIs to create new
- * configuration
- * and get or list existing configurations.
- *
+ * configuration and get or list existing configurations.
  */
 class ConfigurationAdminImpl implements ConfigurationAdmin {
     private static final TraceComponent tc = Tr.register(ConfigurationAdminImpl.class, ConfigAdminConstants.TR_GROUP, ConfigAdminConstants.NLS_PROPS);

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/admin/internal/ConfigurationStore.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/admin/internal/ConfigurationStore.java
@@ -13,21 +13,17 @@ package com.ibm.ws.config.admin.internal;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
-import org.osgi.framework.Filter;
 import org.osgi.service.cm.ConfigurationAdmin;
 
 import com.ibm.websphere.ras.Tr;
@@ -43,244 +39,707 @@ import com.ibm.ws.config.admin.internal.ConfigurationStorageHelper.ConfigStorage
  * identified by their pid. Persistence details are in the constructor, saveConfiguration, and
  * deleteConfiguration and can be factored out separately if required.
  */
-class ConfigurationStore implements Runnable {
-    private static final TraceComponent tc = Tr.register(ConfigurationStore.class, ConfigAdminConstants.TR_GROUP, ConfigAdminConstants.NLS_PROPS);
+// @formatter:off
+class ConfigurationStore {
+    private static final TraceComponent tc =
+        Tr.register(ConfigurationStore.class,
+                    ConfigAdminConstants.TR_GROUP, ConfigAdminConstants.NLS_PROPS);
 
-    private final ConfigAdminServiceFactory caFactory;
-
-    private final Map<String, ExtendedConfigurationImpl> configurations;
-
-    /** A counter for PID names to avoid collisions - the instance of this class should be synchronized before modifying this field */
-    private long configCount = 0;
-
-    private final File persistentConfig;
-
-    private final Lock saveMonitor = new ReentrantLock();
-    private volatile Future<?> saveTask = null;
-    private boolean shutdown = false;
-    private final ReentrantReadWriteLock storeMonitor = new ReentrantReadWriteLock();
-
-    public ConfigurationStore(ConfigAdminServiceFactory configAdminServiceFactory, BundleContext bc) {
-        this.caFactory = configAdminServiceFactory;
-        this.persistentConfig = bc.getDataFile(ConfigAdminConstants.CONFIG_PERSISTENT);
-        this.configurations = loadConfigurationDatas(this.persistentConfig);
-
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-            Tr.debug(tc, "config store pids are [" + configurations.keySet() + "]");
-    }
-
-    private final void readLock() {
-        storeMonitor.readLock().lock();
-    }
-
-    private final void readUnlock() {
-        storeMonitor.readLock().unlock();
-    }
-
-    public final void writeLock() {
-        if (storeMonitor.getReadHoldCount() > 0) {
-            // this is not supported and will cause deadlock if allowed to proceed.
-            // fail fast instead of deadlocking
-            throw new IllegalMonitorStateException("Requesting upgrade to write lock.");
-        }
-        storeMonitor.writeLock().lock();
-    }
-
-    public final void writeUnlock() {
-        storeMonitor.writeLock().unlock();
-    }
-
-    public void removeConfiguration(final String pid) {
-        writeLock();
-        try {
-            configurations.remove(pid);
-        } finally {
-            writeUnlock();
-        }
-        save();
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-            Tr.debug(tc, "removed configuration pid = " + pid + ", remaining pids are [" + configurations.keySet() + "]");
-    }
-
-    public ExtendedConfigurationImpl getConfiguration(String pid, String location) {
-        readLock();
-        ExtendedConfigurationImpl config;
-        try {
-            config = configurations.get(pid);
-        } finally {
-            readUnlock();
-        }
-        if (config != null) {
-            return config;
-        }
-        writeLock();
-        try {
-            config = configurations.get(pid);
-            if (config == null) {
-                config = new ExtendedConfigurationImpl(caFactory, location, null, pid, null, null, null);
-                configurations.put(pid, config);
-            }
-        } finally {
-            writeUnlock();
-        }
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-            Tr.debug(tc, "added config " + config);
-        return config;
-    }
-
-    public ExtendedConfiguration createFactoryConfiguration(String factoryPid, String location) {
-        ExtendedConfigurationImpl config;
-        writeLock();
-        try {
-            String pid;
-            do {
-                pid = factoryPid + "_" + configCount++;
-            } while (configurations.containsKey(pid));
-            config = new ExtendedConfigurationImpl(caFactory, location, factoryPid, pid, null, null, null);
-            configurations.put(pid, config);
-        } finally {
-            writeUnlock();
-        }
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-            Tr.debug(tc, "added created factory config " + config);
-        return config;
-    }
-
-    public ExtendedConfigurationImpl findConfiguration(String pid) {
-        readLock();
-        try {
-            return configurations.get(pid);
-        } finally {
-            readUnlock();
-        }
-    }
-
-    /*
-     * This method can return deleted configurations
+    /**
+     * Factory method: Create a configuration store, with the store initial contents
+     * read from the bundle specific {@link ConfigAdminConstants#CONFIG_PERSISTENT}
+     * data file.
+     *
+     * @param caFactory The service factory for the store.
+     * @param bc The context supplying the configuration persistence file.
      */
-    public ExtendedConfigurationImpl[] getFactoryConfigurations(String factoryPid) {
-        readLock();
-        try {
-            List<ExtendedConfigurationImpl> resultList = new ArrayList<ExtendedConfigurationImpl>();
-            for (ExtendedConfigurationImpl config : configurations.values()) {
-                //bypassing the check to see if configuration was deleted
-                String otherFactoryPid = config.getFactoryPid(false);
-                if (otherFactoryPid != null && otherFactoryPid.equals(factoryPid))
-                    resultList.add(config);
-            }
-            return resultList.toArray(new ExtendedConfigurationImpl[resultList.size()]);
-        } finally {
-            readUnlock();
-        }
-    }
-
-    public ExtendedConfiguration[] listConfigurations(Filter filter) {
-        List<ExtendedConfigurationImpl> resultList = new ArrayList<>();
-        readLock();
-        try {
-            resultList.addAll(configurations.values());
-        } finally {
-            readUnlock();
-        }
-        for (Iterator<ExtendedConfigurationImpl> it = resultList.iterator(); it.hasNext();) {
-            ExtendedConfigurationImpl config = it.next();
-            if (!config.matchesFilter(filter)) {
-                it.remove();
-            }
-        }
-        int size = resultList.size();
-        return size == 0 ? null : (ExtendedConfigurationImpl[]) resultList.toArray(new ExtendedConfigurationImpl[size]);
-    }
-
-    public void unbindConfigurations(Bundle bundle) {
-        Collection<ExtendedConfigurationImpl> currentConfigs;
-        readLock();
-        try {
-            currentConfigs = new ArrayList<>(configurations.values());
-        } finally {
-            readUnlock();
-        }
-        for (ExtendedConfigurationImpl config : currentConfigs) {
-            config.unbind(bundle);
-        }
-    }
-
-    void saveConfigurationDatas(boolean shutdown) throws IOException {
-        Future<?> currentSaveTask;
-        saveMonitor.lock();
-        try {
-            currentSaveTask = saveTask;
-            saveTask = null;
-            this.shutdown = shutdown;
-        } finally {
-            saveMonitor.unlock();
-        }
-        if (currentSaveTask == null) {
-            return;
-        }
-        readLock();
-        try {
-            ConfigurationStorageHelper.store(persistentConfig, configurations.values());
-            if (shutdown && currentSaveTask != null) {
-                currentSaveTask.cancel(false);
-            }
-
-        } finally {
-            readUnlock();
-        }
-    }
-
-    private Map<String, ExtendedConfigurationImpl> loadConfigurationDatas(File configDatas) {
-        if (configDatas.isFile()) {
-            ConfigStorageConsumer<String, ExtendedConfigurationImpl> consumer = new ConfigStorageConsumer<String, ExtendedConfigurationImpl>() {
-                @Override
-                public ExtendedConfigurationImpl consumeConfigData(String location, Set<String> uniqueVars, Set<ConfigID> references, ConfigurationDictionary dict) {
-                    String pid = (String) dict.get(Constants.SERVICE_PID);
-                    String factoryPid = (String) dict.get(ConfigurationAdmin.SERVICE_FACTORYPID);
-                    return new ExtendedConfigurationImpl(caFactory, location, factoryPid, pid, dict, references, uniqueVars);
-                }
-
-                @Override
-                public String getKey(ExtendedConfigurationImpl configuration) {
-                    return configuration.getPid(false);
-                }
-            };
-            try {
-                return ConfigurationStorageHelper.load(configDatas, consumer);
-            } catch (IOException e) {
-                // auto FFDC is fine
-                return new HashMap<>();
-            }
-        }
-        return new HashMap<>();
+    public ConfigurationStore(ConfigAdminServiceFactory caFactory, BundleContext bc) {
+        this( caFactory, bc.getDataFile(ConfigAdminConstants.CONFIG_PERSISTENT) );
     }
 
     /**
+     * Factory method: Create a configuration store with the store contents read
+     * from the specified configuration persistence file.
      *
+     * A failure to read the specified configuration will result in an empty
+     * initial store.  If the configuration file does not exist, no error occurs.
+     * If the configuration file does exist, an exception occurs.  FFDC handles
+     * this exception, and processing continues with no data read.
+     *
+     * @param caFactory The service factory for the store.
+     * @param persistentConfig The configuration persistence file from which to
+     *     read the initial configurations.
      */
-    void save() {
-        if (saveTask != null) {
-            return;
-        }
-        saveMonitor.lock();
+    public ConfigurationStore(ConfigAdminServiceFactory caFactory, File persistentConfig) {
+        this.caFactory = caFactory;
+        this.persistentConfig = persistentConfig;
+        this.configurations = load(persistentConfig);
+    }
+
+    /**
+     * Service factory provided to configurations created by this store.
+     *
+     * Also used to schedule configuration saves.  See {@link #save()}.
+     */
+    private final ConfigAdminServiceFactory caFactory;
+
+    /**
+     * Create a new extended configuration instance.
+     *
+     * The new configuration has null attributes.
+     *
+     * @param location The location of the new configuration.
+     * @param factoryPid The factory PID of the new configuration.  Null for singletons.
+     * @param pid The PID of the new configuration.
+     *
+     * @return The new configuration instance.
+     */
+    private ExtendedConfigurationImpl createConfiguration(String location, String factoryPid, String pid) {
+        return new ExtendedConfigurationImpl(caFactory, location, factoryPid, pid, null, null, null);
+    }
+
+    /**
+     * Create a new extended configuration instance.
+     *
+     * This factory method is used to marshall deserialized configuration data.
+     * See {@link #load(File)}.
+     *
+     * The table of attributes is expected to contain a PID, and to possibly
+     * contain a factory PID.  See {@link Constants#SERVICE_PID} and
+     * {@link ConfigurationAdmin#SERVICE_FACTORYPID}.
+     *
+     * @param location The location of the new configuration.
+     * @param uniqueVariables The variables used by the configuration.
+     * @param references The references within the configuration.
+     * @param properties The table of attributes of the configuration.
+     *
+     * @return The new configuration.
+     */
+    public ExtendedConfigurationImpl createConfiguration(
+        String location,
+        Set<String> uniqueVariables,
+        Set<ConfigID> references,
+        ConfigurationDictionary properties) {
+
+        String pid = (String) properties.get(Constants.SERVICE_PID);
+        String factoryPid = (String) properties.get(ConfigurationAdmin.SERVICE_FACTORYPID);
+        return new ExtendedConfigurationImpl(caFactory, location, factoryPid, pid, properties, references, uniqueVariables);
+    }
+
+    /**
+     * Table of current configurations. Keys are PIDs. Values are
+     * configurations.
+     *
+     * The configurations are initially read from data file
+     * {@link ConfigAdminConstants#CONFIG_PERSISTENT}.
+     */
+    private final Map<String, ExtendedConfigurationImpl> configurations;
+
+    /**
+     * Monitor used to guard access to the configurations collection.
+     */
+    private final ReentrantReadWriteLock configurationsLock = new ReentrantReadWriteLock();
+
+    private final void readLock() {
+        configurationsLock.readLock().lock();
+    }
+
+    private final void readUnlock() {
+        configurationsLock.readLock().unlock();
+    }
+
+    /**
+     * Perform an operation on the configurations.  Allow concurrent reads.
+     *
+     * @param processor The processor used to operate on the configurations.
+     *
+     * @return The return value from the processor.  Usually, either, one of
+     *     the configurations, or null.
+     */
+    private final ExtendedConfigurationImpl excludeWrites(
+        Function<Map<String, ExtendedConfigurationImpl>, ExtendedConfigurationImpl> processor) {
+
+        readLock();
         try {
-            if (shutdown) {
-                return;
-            }
-            if (saveTask == null) {
-                saveTask = caFactory.updateQueue.addScheduled(this);
-            }
+            return processor.apply(configurations);
         } finally {
-            saveMonitor.unlock();
+            readUnlock();
         }
     }
 
-    @Override
-    public void run() {
+    /**
+     * Obtain the current configurations.  Read these in a thread safe
+     * manner.  The returned collection is independent of the underlying
+     * storage.
+     *
+     * @return A list of the current configurations.
+     */
+    private final List<ExtendedConfigurationImpl> getConfigurations() {
+        // Unfortunately, there is no convenient way to use 'excludeWrites'.
+        readLock();
         try {
-            saveConfigurationDatas(false);
-        } catch (IOException e) {
-            // Auto-FFDC is fine here
+            return new ArrayList<>(configurations.values());
+        } finally {
+            readUnlock();
         }
+    }
+
+    public final void writeLock() {
+        if (configurationsLock.getReadHoldCount() > 0) {
+            // This is not allowed, as it would cause deadlock.
+            // Fail fast instead of deadlocking.
+            throw new IllegalMonitorStateException("Requesting upgrade to write lock.");
+        }
+        configurationsLock.writeLock().lock();
+    }
+
+    public final void writeUnlock() {
+        configurationsLock.writeLock().unlock();
+    }
+
+    /**
+     * Perform an operation on the configurations.  Allow no concurrent access.
+     * (The operation is expected to sometimes update the configurations.)
+     *
+     * @param The processor used to operate on the configurations.
+     *
+     * @return The return value from the processor.  Usually, one of the configurations,
+     *     which may be a newly created configuration, or null.
+     */
+    private final ExtendedConfigurationImpl excludeAll(
+        Function<Map<String, ExtendedConfigurationImpl>, ExtendedConfigurationImpl> processor) {
+
+        writeLock();
+        try {
+            return processor.apply(configurations);
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    /**
+     * File used as a persistent store of the configurations.
+     */
+    private final File persistentConfig;
+
+    /**
+     * Monitor used when saving the configurations.
+     *
+     * Used to guard access to {@link #saveTask} and {@link #shutdown}.
+     *
+     * Saves are performed asynchronously: When performing a save, the
+     * base save operation is performed through the update queue.
+     *
+     * Multiple concurrent saves are collapsed: A save which is requested
+     * while another save is pending is ignored.  This is safe, since, the
+     * save is performed with a read lock on the configurations.  The
+     * duplicate save would rewrite the same configurations.
+     *
+     * During shutdown, any scheduled save is performed immediately, and
+     * future saves are disallowed.
+     */
+    private final Object saveMonitor = new Object();
+
+    /**
+     * Scheduled save task. Set when saving the configuration. Used to
+     * avoid multiple saves: A concurrent save request returns immediately.
+     *
+     * The save task is accessed using double-locking, and must be volatile.
+     * See {@link #save()}.
+     */
+    private volatile Future<?> saveTask;
+
+    /**
+     * State parameter: Used to prevent new saves when shutting down services.
+     *
+     * Accessed using double-locking, and must be volatile.  See {@link #save()}.
+     */
+    private volatile boolean shutdown;
+
+    /**
+     * Simple integer counter type. Used for generating reference PIDs
+     * for configuration elements.
+     */
+    public static class Counter {
+        private int value;
+
+        public Counter() {
+            this.value = 0;
+        }
+
+        public int increment() {
+            return value++;
+        }
+    }
+
+    /**
+     * A counter for PID names to avoid collisions.
+     *
+     * The map is not thread safe: Access must be externally synchronized.
+     *
+     * Keys are factory PIDs. Values are counters, which are used to generate
+     * reference PIDs for configuration elements.
+     *
+     * Counters are
+     */
+    private final Map<String, Counter> configCount = new HashMap<>();
+
+    /**
+     * Generate a new count for a given factory PID.
+     *
+     * This operation is not thread safe: The caller,
+     * {@link #createFactoryConfiguration(String, String)}, ensures
+     * safety by including the invocation in a region that is guarded
+     * by the configurations write lock.
+     *
+     * Each factory PID has its own counter.  That enables the configuration
+     * admin to continue its main processing loops, which aggregate the
+     * processing of configurations by factory PID, and which iterate across
+     * the factory PIDs in an indeterminate order.
+     *
+     * The processing per factory PID orders the configuration data by sequence
+     * number.  That ensures that minimally changed configurations obtain the
+     * same PIDs for the same configuration elements.
+     *
+     * @param factoryPid The factory PID for which to generate a new count.
+     *
+     * @return The new count for the specified factory PID.
+     */
+    private long getCount(String factoryPid) {
+        Counter counter = configCount.computeIfAbsent(factoryPid, (String useFactoryPid) -> new Counter());
+        return counter.increment();
+    }
+
+    /**
+     * Generate a new PID for a given factory PID.
+     *
+     * PIDs are generated using a a factory PID specific counter.
+     *
+     * The generated PID is guaranteed to be unique relative to the
+     * current stored configurations. New PIDs are generated sequentially
+     * until a unique PID is generated.
+     *
+     * This operation is not thread safe: The caller,
+     * {@link #createFactoryConfiguration(String, String)}, ensures
+     * safety by including the invocation in a region that is guarded
+     * by the configurations write lock.
+     *
+     * @param factoryPid The factory PID for which to generate a new PID.
+     *
+     * @return The new PID.
+     */
+    private String generatePid(String factoryPid) {
+        String pid;
+        do {
+            pid = factoryPid + "_" + getCount(factoryPid);
+        } while (configurations.containsKey(pid));
+        return pid;
+    }
+
+    //
+
+    /**
+     * Remove a specified configuration.  After removing the configuration, save it back to
+     * the configuration store.
+     *
+     * In operation, this method removes the element, then schedules a save of the configuration.
+     *
+     * A save is scheduled even if no configuration was actually removed.
+     *
+     * No new save is scheduled if a save is already pending.
+     *
+     * @param pid The PID of the element which is to be removed.
+     */
+    public void removeConfiguration(String pid) {
+        ExtendedConfigurationImpl removedConfiguration =
+            excludeAll( (useConfigurations) -> useConfigurations.remove(pid) );
+        if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+            Tr.debug(tc, "Removed [ " + pid + " ] [ " + removedConfiguration + " ]");
+        }
+        save();
+    }
+
+    /**
+     * Retrieve or create a configuration having the specified ID.
+     *
+     * A new configuration is created with just a PID and a location.
+     *
+     * @param pid The PID of the configuration which is to be retrieved.
+     * @param location The location of the new configuration.
+     *
+     * @return The configuration which was retrieved or created.
+     */
+    public ExtendedConfigurationImpl getConfiguration(String pid, String location) {
+        // This uses a form of double-locking:
+        //
+        // First, attempt to retrieve the target configuration within a read lock.
+        //
+        // Second, attempt again to retrieve the target configuration within a write
+        // lock.  If the second attempted retrieval fails, only then create a new
+        // configuration.
+
+        ExtendedConfigurationImpl configuration =
+            excludeWrites((useConfigurations) -> useConfigurations.get(pid));
+        if ( configuration != null ) {
+            if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+                Tr.debug(tc, "Retrieved [ " + pid + " ] [ " + configuration + " ]");
+            }
+            return configuration;
+        }
+
+        // Note that this does a second 'get'!
+        configuration = excludeAll( (useConfigurations) ->
+            useConfigurations.computeIfAbsent(pid, (usePid) -> createConfiguration(location, null, usePid)) );
+
+        if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+            Tr.debug(tc, "Added [ " + pid + " ] " + configuration);
+        }
+        return configuration;
+    }
+
+    /**
+     * Create and store a new factory element using the supplied factory PID.
+     *
+     * Generate a new PID for the new element.
+     *
+     * The new element is created with null attributes.
+     *
+     * @param factoryPid The factory PID of the new element.
+     * @param location The location of the new element.
+     *
+     * @return The new factory element.
+     */
+    public ExtendedConfiguration createFactoryConfiguration(String factoryPid, String location) {
+        ExtendedConfigurationImpl factoryConfiguration = excludeAll( (useConfigurations) -> {
+            String pid = generatePid(factoryPid);
+            ExtendedConfigurationImpl configuration = createConfiguration(location, factoryPid, pid);
+            useConfigurations.put(pid, configuration);
+            return configuration;
+        } );
+
+        if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+            Tr.debug(tc, "New factory [ " + factoryPid + " ]" + " [ " + location + " ]" +
+                                    " [ " + factoryConfiguration.getPid() + " ]" +
+                                    " [ " + factoryConfiguration + " ]");
+        }
+        return factoryConfiguration;
+    }
+
+    /**
+     * Retrieve the configuration which has the specified PID.
+     *
+     * @param pid The PID of the configuration which is to be retrieved.
+     *
+     * @return The configuration matching the specified PID.  Null if no
+     *     stored configuration matches the PID.
+     */
+    public ExtendedConfigurationImpl findConfiguration(String pid) {
+        return excludeWrites( (useConfigurations) -> useConfigurations.get(pid) );
+    }
+
+    /**
+     * Answer the configurations which have the specified factory PID.
+     *
+     * The results include deleted configurations.
+     *
+     * @param factoryPid The factory PID of the configurations which
+     *     are to be retrieved.
+     *
+     * @return The configurations which have the specified factory PID.
+     */
+    public ExtendedConfigurationImpl[] getFactoryConfigurations(String factoryPid) {
+        List<ExtendedConfigurationImpl> factoryConfigurations = new ArrayList<ExtendedConfigurationImpl>();
+
+        excludeWrites( useConfigurations -> {
+            for ( ExtendedConfigurationImpl configuration : useConfigurations.values() ) {
+                // 'false' means don't fail if the configuration was deleted.
+                String otherFactoryPid = configuration.getFactoryPid(false);
+                if ( (otherFactoryPid != null) && otherFactoryPid.equals(factoryPid) ) {
+                    factoryConfigurations.add(configuration);
+                }
+            }
+            return null; // block return
+        } );
+
+        return factoryConfigurations.toArray(new ExtendedConfigurationImpl[factoryConfigurations.size()]);
+    }
+
+    /**
+     * Answer the configurations which match a specified selection filter.
+     *
+     * @param selector A condition {@link Filter} which selects the
+     *     configurations which are to be retrieved.
+     *
+     * @return The configurations which match the specified selection filter.
+     *     Answer null if no configurations match the selection filter.
+     */
+    public ExtendedConfiguration[] listConfigurations(Filter selector) {
+        List<ExtendedConfigurationImpl> selectedConfigurations = new ArrayList<>();
+        excludeWrites( (useConfigurations) -> {
+            selectedConfigurations.addAll(configurations.values());
+            return null;
+        } );
+
+        // Note: The filter is a selection filter.  Keep configurations
+        // which match the filter.  Remove configurations which do not match
+        // the filter.
+        selectedConfigurations.removeIf((configuration) -> !configuration.matchesFilter(selector));
+
+        int size = selectedConfigurations.size();
+        if ( size == 0 ) {
+            return null;
+        } else {
+            return selectedConfigurations.toArray(new ExtendedConfigurationImpl[size]);
+        }
+    }
+
+    /**
+     * Conditionally unbind (invoke {@link ExtendedConfigurationImpl#unbind(Bundle)})
+     * all of the configurations.
+     *
+     * Do nothing to configurations which are not bound to the specified bundle.
+     *
+     * @param bundle The bundle from which to unbind the configurations.
+     */
+    public void unbindConfigurations(Bundle bundle) {
+        for ( ExtendedConfigurationImpl configuration : getConfigurations() ) {
+            configuration.unbind(bundle);
+        }
+    }
+
+    //
+
+    /**
+     * Second half of the persistence API. Schedule a new save of the configuration.
+     *
+     * Immediately return if a save is already scheduled.
+     */
+    void save() {
+        // Safe: Double locking.
+        if ( (saveTask != null) || shutdown ) {
+            return;
+        }
+
+        synchronized( saveMonitor ) {
+            // 'shutdown' can only be set just before
+            // performing an immediate save.  That will
+            // consume any pending save task.
+            //
+            // This code will only be reached with 'shutdown' set
+            // if the cancel following the shutdown save is not
+            // processed before the save is scheduled.  Normally,
+            // the cancel will prevent the save from being attempted.
+
+            if ( (saveTask != null) || shutdown ) {
+                return;
+            }
+
+            // This is thread safe.  The scheduled save runs in
+            // an independent thread which will block on the save
+            // monitor within 'doSave'.  The assignment to 'saveTask'
+            // must complete before the save monitor is released
+            // and allowing 'saveTask' to be retrieved.
+
+            saveTask = caFactory.updateQueue.addScheduled( () -> {
+                try {
+                    doSave();
+                } catch ( IOException e ) {
+                    // Auto-FFDC is fine here
+                }
+            } );
+        }
+    }
+
+    /**
+     * Immediately perform any pending save.
+     *
+     * This is only invoked with shutdown requested from
+     * {@link com.ibm.ws.config.admin.internal.ConfigAdminServiceFactory#closeServices}.
+     *
+     * @param shutdown Control parameter: Disable (or enable) future
+     *                 save requests. Do not interrupt any already
+     *                 started save.
+     *
+     * @throws IOException Thrown if the save fails.
+     */
+    @Deprecated
+    void saveConfigurationDatas(boolean shutdown) throws IOException {
+        doSave(shutdown); // throws IOException
+    }
+
+    /**
+     * Conditionally perform a save.  Conditionally, set the
+     * shutdown flag.
+     *
+     * If a save task which was scheduled is still pending,
+     * then clear it and proceed to store the configuration.
+     *
+     * After storing the configuration, if shutdown was set,
+     * cancel the save task.  That is done because the save
+     * was performed immediately, not as scheduled by the update
+     * queue.
+     *
+     * @param shutdown Control parameter: Disable (or enable) future
+     *                 save requests. Do not interrupt any already
+     *                 started save.
+     *
+     * @throws IOException Thrown if the save fails.
+     */
+    private void doSave(boolean setShutdown) throws IOException {
+        Future<?> saveTask;
+        if ( (saveTask = pullSaveTask(setShutdown)) != null ) {
+            if ( setShutdown ) {
+                // Help the update queue to shutdown: Cancel the
+                // pending save, which would obtain a null save
+                // task and subsequently do nothing.
+                saveTask.cancel(false);
+            }
+            store(); // throws IOException
+        }
+    }
+
+    /**
+     * Basic operation: Store the active configuration to the configuration file.
+     *
+     * @throws IOException Thrown if the store failed.
+     */
+    private void store() throws IOException {
+        excludeWrites( (useConfigurations) -> {
+            ConfigurationStorageHelper.store(persistentConfig, useConfigurations.values());
+            // throws IOException
+            return null;
+        } );
+    }
+
+    private static final boolean DO_SET_SHUTDOWN = true;
+
+    /**
+     * Retrieve and set the save task to null as an atomic operation.
+     *
+     * Retrieval of the save task is performed when the save task eventually
+     * runs.
+     *
+     * The shutdown flag, once set, will never be cleared.  Invoking this
+     * with 'setShutdown' set to false has no affect on the shutdown flag.
+     *
+     * @param setShutdown Control parameter: Used to set the shutdown flag.
+     *
+     * @return The current save task.
+     */
+    private Future<?> pullSaveTask(boolean setShutdown) {
+        Future<?> saveTask;
+        synchronized(saveMonitor) {
+            // Consume the save task reference, and return it.
+            // Normally, the save task only serves to collapse
+            // concurrent saves. Returning the task allows it to
+            // be cancelled, which is done to speed up shutdown
+            // processing.
+            saveTask = this.saveTask;
+            this.saveTask = null;
+
+            // Prevent any saves from being scheduled.
+            // For thread safety, this must be done within
+            // the save monitor.
+            if ( setShutdown ) {
+                this.shutdown = true;
+            }
+        }
+        return saveTask;
+    }
+
+    /**
+     * Half of the configuration store persistence API. Marshal configurations
+     * from the specified configuration file into a table keyed by persistence ID.
+     *
+     * Answer an empty collection if the configuration file does not exist (or
+     * if it exists but is not a simple file.)
+     *
+     * Answer an empty collection if an IO exception occurs while reading the
+     * configuration file. The exception is processed by FFDC but is otherwise
+     * ignored.
+     *
+     * Note: No synchronization is provided for this initial load: A load currently
+     * only occurs while creating a new configuration store.
+     *
+     * @param configurationFile A configuration file from which to read configurations.
+     *
+     * @return Configurations read from the configuration file.
+     */
+    private Map<String, ExtendedConfigurationImpl> load(File configurationFile) {
+        String loadCase;
+
+        Map<String, ExtendedConfigurationImpl> loaded;
+        if ( !configurationFile.isFile() ) {
+            // Either, the configuration file does not exist, or is not a normal file.
+
+            // TODO: This might be better with distinct 'exists' and 'isFile' tests:
+            //       We probably care if the configuration file exists but is not a
+            //       normal file.  On the other hand, that should never happen.
+
+            loaded = new HashMap<>();
+            loadCase = "Unloadable file";
+
+        } else {
+            // Helper which marshals de-serialized configuration data.
+            //
+            // The marshalled data is an extended configuration instance.
+            //
+            // The marshalled data contains, in particular the factory PID and PID of
+            // previously serialized data.
+
+            ConfigStorageConsumer<String, ExtendedConfigurationImpl> consumer =
+                new ConfigStorageConsumer<String, ExtendedConfigurationImpl>() {
+                    /**
+                     * Implementer API: Marshal configuration data by creating a configuration.
+                     *
+                     * @param location The location of the configuration.
+                     * @param uniqueVariables The unique variables of the configuration.
+                     * @param references The references within the configuration.
+                     * @param properties The attributes of the configuration.
+                     *
+                     * @return The new configuration.
+                     */
+                    @Override
+                    public ExtendedConfigurationImpl consumeConfigData(String location, Set<String> uniqueVariables, Set<ConfigID> references, ConfigurationDictionary properties) {
+                        return createConfiguration(location, uniqueVariables, references, properties);
+                    }
+
+                    /**
+                     * Answer the key value from a configuration.
+                     *
+                     * This implementation answers the PID of the configuration.
+                     * The PID is answered regardless of whether the configuration
+                     * has been deleted.  See {@link ExtendedConfigurationImpl#getPid(boolean)}
+                     *
+                     * @param configuration The configuration from which to retrieve the key.
+                     *
+                     * @return The key value of the configuration.
+                     */
+                    @Override
+                    public String getKey(ExtendedConfigurationImpl configuration) {
+                        return configuration.getPid(false);
+                    }
+            };
+
+            // Create a table of configurations loaded from the specified configuration
+            // file.
+
+            try {
+                loaded = ConfigurationStorageHelper.load(configurationFile, consumer);
+                loadCase = "Loaded file";
+
+            } catch (IOException e) {
+                // FFDC, but continue.  Do not use the partially loaded configuration.
+                loaded = new HashMap<>(); // AutoFFDC
+                loadCase = "Load failure [ " + e + " ]";
+            }
+        }
+
+        if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+            Tr.debug(tc, "Loaded PIDS [ " + loaded.keySet() + " ]" +
+                                    " [ " + configurationFile.getAbsolutePath() + " ]" +
+                                    " ( " + loadCase + " )");
+        }
+        return loaded;
     }
 }

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/admin/internal/ManagedServiceFactoryTracker.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/admin/internal/ManagedServiceFactoryTracker.java
@@ -47,9 +47,9 @@ class ManagedServiceFactoryTracker extends ServiceTracker<ManagedServiceFactory,
 
     /**
      * Constructor for ManagedServiceFactoryTracker.
-     * 
+     *
      * @param bc
-     *            - bundle context
+     *               - bundle context
      */
     public ManagedServiceFactoryTracker(ConfigAdminServiceFactory casf, BundleContext bc) {
         super(bc, ManagedServiceFactory.class.getName(), null);
@@ -59,9 +59,9 @@ class ManagedServiceFactoryTracker extends ServiceTracker<ManagedServiceFactory,
     /**
      * Processes registered ManagedServiceFactory and updates each with their own
      * configuration properties.
-     * 
+     *
      * @param reference
-     *            - ServiceReference for MangedServiceFactory
+     *                      - ServiceReference for MangedServiceFactory
      */
     @Override
     public ManagedServiceFactory addingService(ServiceReference<ManagedServiceFactory> reference) {
@@ -124,7 +124,7 @@ class ManagedServiceFactoryTracker extends ServiceTracker<ManagedServiceFactory,
     /**
      * MangedServiceFactory service removed. Process removal and unget service
      * from its context.
-     * 
+     *
      * @param reference
      * @param service
      */
@@ -246,7 +246,7 @@ class ManagedServiceFactoryTracker extends ServiceTracker<ManagedServiceFactory,
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                         Tr.debug(tc,
                                  "asyncDelete(): Exception thrown while trying to update ManagedServiceFactory.  Exception = "
-                                                 + t.toString());
+                                     + t.toString());
                     }
                     FFDCFilter.processException(t, ME,
                                                 "asyncDelete()",
@@ -257,6 +257,9 @@ class ManagedServiceFactoryTracker extends ServiceTracker<ManagedServiceFactory,
     }
 
     private Future<?> asyncUpdated(final ManagedServiceFactory service, final String factoryPid, final String pid, final Dictionary<String, ?> properties) {
+        String message = "Updating factory PID [ " + factoryPid + " ] PID [ " + pid + " ]";
+        (new Throwable(message)).printStackTrace(System.out);
+
         return caFactory.updateQueue.add(factoryPid, new Runnable() {
             @Override
             public void run() {
@@ -269,7 +272,7 @@ class ManagedServiceFactoryTracker extends ServiceTracker<ManagedServiceFactory,
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                         Tr.debug(tc,
                                  "asyncUpdated(): Exception thrown while trying to update ManagedServiceFactory.  Exception = "
-                                                 + t.toString());
+                                     + t.toString());
                     }
                     FFDCFilter.processException(t, ME,
                                                 "asyncUpdated()",

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigRetriever.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigRetriever.java
@@ -13,9 +13,10 @@ package com.ibm.ws.config.xml.internal;
 import java.io.IOException;
 import java.util.List;
 
+import javax.security.auth.login.Configuration;
+
 import org.osgi.framework.Constants;
 import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 
 import com.ibm.websphere.config.ConfigRetrieverException;
@@ -28,9 +29,6 @@ import com.ibm.ws.config.admin.SystemConfigSupport;
 import com.ibm.ws.config.xml.internal.variables.ConfigVariableRegistry;
 import com.ibm.wsspi.kernel.service.utils.FilterUtils;
 
-/**
- *
- */
 class ConfigRetriever {
 
     private static final TraceComponent tc = Tr.register(ConfigRetriever.class, XMLConfigConstants.TR_GROUP, XMLConfigConstants.NLS_PROPS);
@@ -91,14 +89,14 @@ class ConfigRetriever {
 
                 config = (ExtendedConfiguration) getConfiguration(pid, factoryFilter);
                 config.setInOverridesFile(true);
-                // This really needs to move somewhere else. ConfigRetriever should not have a variable registry
+                // This really needs to move somewhere else.
+                // ConfigRetriever should not have a variable registry
                 for (String variable : config.getUniqueVariables()) {
                     variableRegistry.addVariableInUse(variable);
                 }
                 if (configId.getId() != null) {
                     caSupport.registerConfiguration(configId, config);
                 }
-
             }
             return config;
         } catch (ConfigRetrieverException ex) {
@@ -188,19 +186,10 @@ class ConfigRetriever {
         }
     }
 
-    /**
-     * @return
-     * @throws InvalidSyntaxException
-     */
     ExtendedConfiguration[] listAllConfigurations() throws InvalidSyntaxException, IOException {
         return (ExtendedConfiguration[]) configAdmin.listConfigurations(null);
     }
 
-    /**
-     * @param configElement
-     * @return
-     * @throws ConfigRetrieverException
-     */
     ExtendedConfiguration[] findConfigurations(ConfigID configID) throws ConfigRetrieverException {
         String filter = getConfigurationFilter(configID);
         try {
@@ -214,11 +203,6 @@ class ConfigRetriever {
         }
     }
 
-    /**
-     * @param configID
-     * @return
-     * @throws ConfigRetrieverException
-     */
     public ExtendedConfiguration[] findAllNestedConfigurations(ConfigID configID) throws ConfigRetrieverException {
         String filter = ("(| " +
                          "(" + XMLConfigConstants.CFG_CONFIG_INSTANCE_ID + "=*//" + configID.getPid() + "[*)" +

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/DeploymentTest.java~
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/DeploymentTest.java~
@@ -136,14 +136,11 @@ public class DeploymentTest {
 
         assertRest();
         assertOpenApiDoc();
-        // Changed by issue 22058, pull request 22025.
-        // Previously, the cache location would incorrectly change between
-        // server restarts, even when the application did not change between
-        // restarts.
-        // See also the comment on 'getConfig', in this class.  The cache
-        // location is stable because an ID assigned within the application
-        // configuration.
-        assertCache(ear, CacheUsed.CACHE_USED, CacheWritten.CACHE_NOT_WRITTEN);
+        // Slightly odd behaviour - the app manager expands the .ear so the .war file is
+        // available on disk
+        // However, when the .ear is redeployed, the .ear is re-expanded and the
+        // location is different
+        assertCache(ear, CacheUsed.CACHE_NOT_USED, CacheWritten.CACHE_WRITTEN);
     }
 
     @Test
@@ -268,10 +265,6 @@ public class DeploymentTest {
     private Application getConfig(Archive<?> archive) {
         Application appConfig = new Application();
         appConfig.setLocation(archive.getName());
-        // This ID assignment is necessary for the workarea cache
-        // location for the application to be stable between server
-        // restarts.  See method 'testEar' within this class for
-        // more information.
         appConfig.setId(getName(archive));
         if (archive instanceof WebArchive) {
             appConfig.setType("war");


### PR DESCRIPTION
This is a proof of concept.  I've verified that the configuration ID is null if not explicitly assigned, and found the assignment point (in ApplicationStateMachineImpl; see the PR for details), and assign the configuration ID if it is available instead of the service PID as the workarea folder for the application cache folder.

In addition to the primary change, there is a step which re-assigns the application container to the expanded application folder which was also updated (two code locations).
