### PR TITLE
com.ibm.ws.ui_rest.fat test problems

### DIFF
--- a/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/ToolboxAPIv1Test.java
+++ b/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/ToolboxAPIv1Test.java
@@ -12,9 +12,6 @@ package com.ibm.ws.ui.fat.rest.v1;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-
-import java.beans.Transient;
-
 import static org.junit.Assert.assertFalse;
 
 import javax.json.JsonArray;

--- a/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/ToolboxAPIv1Test.java
+++ b/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/ToolboxAPIv1Test.java
@@ -12,6 +12,9 @@ package com.ibm.ws.ui.fat.rest.v1;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import java.beans.Transient;
+
 import static org.junit.Assert.assertFalse;
 
 import javax.json.JsonArray;
@@ -1304,6 +1307,11 @@ public class ToolboxAPIv1Test extends CommonRESTTest implements APIConstants {
      * 3. Confirm Simple+Clock no longer exists in the Toolbox
      *
      * @throws Exception
+     *
+     * Note: if this test happens to be run as the first test in the testsuite, it would
+     * fail with 409 when doing the POST with reader credential. This is likely caused by
+     * some timing issue. To work around the problem, perform a get on both admin and reader
+     * credentials to force both toolboxes to be loaded.
      */
     @Test
     public void catalogRemoveCausesToolboxRemove_reader() throws Exception {
@@ -1317,7 +1325,14 @@ public class ToolboxAPIv1Test extends CommonRESTTest implements APIConstants {
         final String catalogURL = API_V1_CATALOG;
         final String toolURL = API_V1_TOOLBOX + "/toolEntries/" + bookmark.getId();
 
+        // make sure the toolboxes for admin and reader are loaded
+        get(toolURL, adminUser, adminPassword, 404);
+        get(toolURL, readerUser, readerPassword, 404);
+
         post(catalogURL + "/bookmarks", adminUser, adminPassword, bookmarkString, 201);
+        // confirm that the bookmark (New York Times) is not in either toolbox
+        get(toolURL, adminUser, adminPassword, 404);
+        get(toolURL, readerUser, readerPassword, 404);
 
         ToolEntry newToolEntry = new ToolEntry(bookmark.getId(), bookmark.getType());
         String newToolEntryString = newToolEntry.toString().substring(10);

--- a/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/ToolboxPersistenceTest.java
+++ b/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/ToolboxPersistenceTest.java
@@ -118,7 +118,17 @@ public class ToolboxPersistenceTest extends CommonRESTTest implements APIConstan
      */
     @AfterClass
     public static void tearDownClass() throws Exception {
-        FATSuite.server.restartServer();
+        stopServerWithExpectedErrors();
+        FATSuite.server.startServer();
+    }
+
+    private static void stopServerWithExpectedErrors() throws Exception {
+        FATSuite.server.stopServer(
+            "CWWKX1010E:.*",
+            "CWWKX1031E:.*",
+            "CWWKX1009E:.*",
+            "CWWKX1030E:.*"
+        );
     }
 
     /**
@@ -184,12 +194,7 @@ public class ToolboxPersistenceTest extends CommonRESTTest implements APIConstan
     @Override
     protected void stopServerAndValidate(LibertyServer server) throws Exception {
         Log.info(c, method.getMethodName(), "Using stopServerAndValidate with errors to ignore");
-        server.stopServer(
-            "CWWKX1010E:.*",
-            "CWWKX1031E:.*",
-            "CWWKX1009E:.*",
-            "CWWKX1030E:.*"
-        );
+        stopServerWithExpectedErrors();
         assertFalse("FAIL: Server is not stopped.",
                     server.isStarted());
     }


### PR DESCRIPTION
Fixing test problem when tests in ToolboxPersistenceTest and ToolboxAPIv1Test are run in different order than written.