### PR TITLE
xmlBinding-3.0: Change javax.xml.catalog to optional import 

### DIFF
--- a/dev/io.openliberty.xmlBinding.3.0.internal.tools/bnd.bnd
+++ b/dev/io.openliberty.xmlBinding.3.0.internal.tools/bnd.bnd
@@ -53,6 +53,7 @@ Import-Package: \
   javax.xml.datatype.*, \
   javax.xml.validation.*, \
   javax.xml.xpath.*, \
+  javax.xml.catalog.*; resolution:=optional, \
   org.xml.sax.*, \
   !com.sun.xml.internal.bind.v2, \
   !com.sun.xml.bind.v2, \


### PR DESCRIPTION
Since the javax.xml.catalog APIs are only available on Oracle JDKs greater than 9, the `javax.xml.catalog` APIs won't always be available for the feature to import.