### PR TITLE
Stop using CXFActivator and expose the bus-extensions

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.3.clientcontainer/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.2.3.clientcontainer/bnd.bnd
@@ -14,8 +14,6 @@
 
 bVersion=1.0
 
-Bundle-Activator: org.apache.cxf.bus.osgi.CXFActivator
-
 # in cxf-rt-frontend-jaxws-3.2 bundle, we exposed: 
 # META-INF/services/javax.xml.ws.spi.Provider = com.ibm.ws.jaxws.client.LibertyProviderImpl
 # so we need make com.ibm.ws.jaxws.client;thread-context=true

--- a/dev/com.ibm.ws.jaxws.2.3.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.2.3.common/bnd.bnd
@@ -17,8 +17,6 @@ bVersion=1.0
 
 exportVer=2.3
 
-Bundle-Activator: org.apache.cxf.bus.osgi.CXFActivator
-
 # in cxf-rt-frontend-jaxws-3.2 bundle, we exposed:
 # META-INF/services/javax.xml.ws.spi.Provider = com.ibm.ws.jaxws.client.LibertyProviderImpl
 # so we need make com.ibm.ws.jaxws.client;thread-context=true

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/bnd.bnd
@@ -12,9 +12,17 @@
 
 -sub: *.bnd
 
-
-
 cxfVersion=3.4.3
+
+app-resources= \
+  META-INF/cxf/bus-extensions.txt
+
+Service-Component: \
+  com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap_3_2.ResourceProvider; \
+    implementation:=com.ibm.wsspi.classloading.ResourceProvider; \
+    provide:=com.ibm.wsspi.classloading.ResourceProvider; \
+    configuration-policy:=optional; \
+    properties:="resources=${app-resources}"
 
 -includeresource: \
    @${repo;org.apache.cxf:cxf-rt-bindings-soap;${cxfVersion};EXACT}!/!META-INF/*,\

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.xml.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.xml.3.2/bnd.bnd
@@ -12,9 +12,17 @@
 
 -sub: *.bnd
 
-
-
 instrument.classesIncludes: org/apache/cxf/*.class
+
+app-resources= \
+  META-INF/cxf/bus-extensions.txt
+
+Service-Component: \
+  com.ibm.ws.org.apache.cxf.cxf.rt.bindings.xml_3_2.ResourceProvider; \
+    implementation:=com.ibm.wsspi.classloading.ResourceProvider; \
+    provide:=com.ibm.wsspi.classloading.ResourceProvider; \
+    configuration-policy:=optional; \
+    properties:="resources=${app-resources}"
 
 cxfVersion=3.4.3
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.3.2/bnd.bnd
@@ -12,8 +12,17 @@
 
 -sub: *.bnd
 
-
 cxfVersion=3.4.3
+
+app-resources= \
+  META-INF/cxf/bus-extensions.txt
+
+Service-Component: \
+  com.ibm.ws.org.apache.cxf.cxf.rt.databindings.jaxb_3_2.ResourceProvider; \
+    implementation:=com.ibm.wsspi.classloading.ResourceProvider; \
+    provide:=com.ibm.wsspi.classloading.ResourceProvider; \
+    configuration-policy:=optional; \
+    properties:="resources=${app-resources}"
 
 -includeresource: \
    @${repo;org.apache.cxf:cxf-rt-databinding-jaxb;${cxfVersion};EXACT}!/*-INF/*, \

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.features.logging.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.features.logging.3.2/bnd.bnd
@@ -12,6 +12,16 @@
 
 CXFVersion=3.4.3
 
+app-resources= \
+  META-INF/cxf/bus-extensions.txt
+
+Service-Component: \
+  com.ibm.ws.org.apache.cxf.cxf.rt.features.logging_3_2.ResourceProvider; \
+    implementation:=com.ibm.wsspi.classloading.ResourceProvider; \
+    provide:=com.ibm.wsspi.classloading.ResourceProvider; \
+    configuration-policy:=optional; \
+    properties:="resources=${app-resources}"
+
 -includeresource: \
    @${repo;org.apache.cxf:cxf-rt-features-logging;${CXFVersion};EXACT}!/!*-INF/*,\
    META-INF/cxf=resources/META-INF/cxf

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.features.logging.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.features.logging.3.2/bnd.overrides
@@ -36,6 +36,7 @@ Import-Package: \
   !org.apache.cxf.transport.https, \
   !org.osgi.service.blueprint.*, \
   !javax.xml.ws.*, \
+  com.ibm.wsspi.classloading, \
   org.apache.cxf.*, \
   org.osgi.*, \
   org.slf4j.*, \

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.3.2/bnd.overrides
@@ -45,7 +45,8 @@ Export-Package: \
   org.apache.cxf.jaxws30.*;version=${cxfVersion}
 
 app-resources= \
-  META-INF/services/javax.xml.ws.spi.Provider
+  META-INF/services/javax.xml.ws.spi.Provider | \
+  META-INF/cxf/bus-extensions.txt
 
 # however this bundle symbolic name is com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.3.2, and this ds config need
 # the name not contains "-".

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.simple.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.simple.3.2/bnd.bnd
@@ -12,9 +12,17 @@
 
 -sub: *.bnd
 
-
-
 cxfVersion=3.4.3
+
+app-resources= \
+  META-INF/cxf/bus-extensions.txt
+
+Service-Component: \
+  com.ibm.ws.org.apache.cxf.cxf.rt.frontend.simple_3_2.ResourceProvider; \
+    implementation:=com.ibm.wsspi.classloading.ResourceProvider; \
+    provide:=com.ibm.wsspi.classloading.ResourceProvider; \
+    configuration-policy:=optional; \
+    properties:="resources=${app-resources}"
 
 -includeresource: \
    @${repo;org.apache.cxf:cxf-rt-frontend-simple;${cxfVersion};EXACT}!/!*-INF/*, \

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.management.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.management.3.2/bnd.bnd
@@ -12,9 +12,17 @@
 
 -sub: *.bnd
 
-
-
 cxfVersion=3.4.3
+
+app-resources= \
+  META-INF/cxf/bus-extensions.txt
+
+Service-Component: \
+  com.ibm.ws.org.apache.cxf.cxf.rt.management_3_2.ResourceProvider; \
+    implementation:=com.ibm.wsspi.classloading.ResourceProvider; \
+    provide:=com.ibm.wsspi.classloading.ResourceProvider; \
+    configuration-policy:=optional; \
+    properties:="resources=${app-resources}"
 
 -includeresource: \
    @${repo;org.apache.cxf:cxf-rt-management;${cxfVersion};EXACT}!/!*-INF/*, \

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.addr.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.addr.3.2/bnd.bnd
@@ -12,8 +12,17 @@
 
 -sub: *.bnd
 
-
 cxfVersion=3.4.3
+
+app-resources= \
+  META-INF/cxf/bus-extensions.txt
+
+Service-Component: \
+  com.ibm.ws.org.apache.cxf.cxf.rt.ws.addr_3_2.ResourceProvider; \
+    implementation:=com.ibm.wsspi.classloading.ResourceProvider; \
+    provide:=com.ibm.wsspi.classloading.ResourceProvider; \
+    configuration-policy:=optional; \
+    properties:="resources=${app-resources}"
 
 -includeresource: \
    @${repo;org.apache.cxf:cxf-rt-ws-addr;${cxfVersion};EXACT}!/!*-INF/*,\

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2/bnd.bnd
@@ -12,11 +12,20 @@
 
 -sub: *.bnd
 
-
 instrument.disabled: true
 instrument.ffdc: false
 
 cxfVersion=3.4.3
+
+app-resources= \
+  META-INF/cxf/bus-extensions.txt
+
+Service-Component: \
+  com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy_3_2.ResourceProvider; \
+    implementation:=com.ibm.wsspi.classloading.ResourceProvider; \
+    provide:=com.ibm.wsspi.classloading.ResourceProvider; \
+    configuration-policy:=optional; \
+    properties:="resources=${app-resources}"
 
 -includeresource: \
    @${repo;org.apache.cxf:cxf-rt-ws-policy;${cxfVersion};EXACT}!/!*-INF/*, \

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2/bnd.bnd
@@ -17,6 +17,16 @@ instrument.classesIncludes: org/cxf/apache/**/*.class
 instrument.ffdc: false
 cxfVersion=3.4.3
 
+app-resources= \
+  META-INF/cxf/bus-extensions.txt
+
+Service-Component: \
+  com.ibm.ws.org.apache.cxf.cxf.rt.wsdl_3_2.ResourceProvider; \
+    implementation:=com.ibm.wsspi.classloading.ResourceProvider; \
+    provide:=com.ibm.wsspi.classloading.ResourceProvider; \
+    configuration-policy:=optional; \
+    properties:="resources=${app-resources}"
+
 -includeresource: \
    @${repo;org.apache.cxf:cxf-rt-wsdl;${cxfVersion};EXACT}!/!*-INF/*, \
    META-INF/cxf=resources/META-INF/cxf, \

--- a/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/bnd.bnd
@@ -12,6 +12,15 @@
 
 -sub: *.bnd
 
+app-resources= \
+  META-INF/cxf/bus-extensions.txt
+
+Service-Component: \
+  com.ibm.ws.org.apache.cxf.rt.ws.security_3_4_1.ResourceProvider; \
+    implementation:=com.ibm.wsspi.classloading.ResourceProvider; \
+    provide:=com.ibm.wsspi.classloading.ResourceProvider; \
+    configuration-policy:=optional; \
+    properties:="resources=${app-resources}"
 
 -includeresource: \
     @${repo;org.apache.cxf:cxf-rt-ws-security;3.4.1;EXACT}!/!META-INF/maven/*, \

--- a/dev/com.ibm.ws.wssecurity.3.4.1/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/bnd.bnd
@@ -11,9 +11,18 @@
 -include= ~../cnf/resources/bnd/bundle.props
 
 -sub: *.bnd
-
           
 bVersion=1.0
+
+app-resources= \
+  META-INF/cxf/bus-extensions.txt
+
+Service-Component: \
+  com.ibm.ws.wssecurity_3_4_1.ResourceProvider; \
+    implementation:=com.ibm.wsspi.classloading.ResourceProvider; \
+    provide:=com.ibm.wsspi.classloading.ResourceProvider; \
+    configuration-policy:=optional; \
+    properties:="resources=${app-resources}"
 
 Bundle-ActivationPolicy: lazy
 


### PR DESCRIPTION
- CXFActivator enables a lot of extra functions we do not want.  This causes us to try to load things with OSGi instead of the normal bus-extensions route.  This leads to Java 2 security failures.
