### PR TITLE
Switch groupid's of ibm ws rebundled jars for scanning

### DIFF
--- a/dev/build.depScanner/src/io/openliberty/depScanner/Module.java
+++ b/dev/build.depScanner/src/io/openliberty/depScanner/Module.java
@@ -128,4 +128,8 @@ public final class Module extends Jar implements Comparable<Module> {
     public String getModuleId() {
         return groupId + ":" + artifactId;
     }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
 }


### PR DESCRIPTION
More changes to recognize rebundled ibm ws jar's from upstream oss projects.
Changing to the correct groupid will flag these properly for scanning.