### PR TITLE
Fix performance regression when using XLXP with the new CXF level.

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/jaxb/JAXBUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/jaxb/JAXBUtils.java
@@ -1134,8 +1134,7 @@ public final class JAXBUtils {
              || className.contains("eclipse"))) {
             //eclipse moxy accepts sun package CharacterEscapeHandler 
             return ".internal";
-        } else if (className.contains("com.sun.xml.bind")
-                   || className.startsWith("com.ibm.xml")) { //Liberty change) {
+        } else if (className.contains("com.sun.xml.bind")) {
             return "";
         }
         return null;
@@ -1193,6 +1192,10 @@ public final class JAXBUtils {
     private static Object createEscapeHandler(Class<?> cls, String simpleClassName) {
         try {
             //Liberty change begin
+            if (cls.getName().startsWith("com.ibm.xml")) {
+                // Do not use escape handlers with XLXP
+                return null;
+            }
             String packageName;
             //Jakarta EE 9
             if (isEE9OrHigher) {

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.3.2/src/org/apache/cxf/jaxb/JAXBDataBinding.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.3.2/src/org/apache/cxf/jaxb/JAXBDataBinding.java
@@ -953,7 +953,9 @@ public class JAXBDataBinding extends AbstractInterceptorProvidingDataBinding
             m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.FALSE);
             m.setListener(marshallerListener);
             if (!noEscape) {
-                JAXBUtils.setEscapeHandler(m, escapeHandler);
+                if (escapeHandler != null) {
+                    JAXBUtils.setEscapeHandler(m, escapeHandler);
+                }
             } else if (noEscapeHandler != null) {
                 JAXBUtils.setEscapeHandler(m, noEscapeHandler);
             }


### PR DESCRIPTION
- Do not use escape handlers when using XLXP.  CXF 2.6 didn't have escape handlers, and XLXP shouldn't require them.
