### PR TITLE
JAX-B: Remove Moxy as it's only needed for as a test dependency.

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2567,11 +2567,6 @@
       <version>3.0.2</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.persistence</groupId>
-      <artifactId>org.eclipse.persistence.moxy</artifactId>
-      <version>4.0.0-M3</version>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse</groupId>
       <artifactId>yasson</artifactId>
       <version>2.0.1</version>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -509,7 +509,6 @@ org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:2.7.10
 org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:3.0.2
 org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.10
 org.eclipse.persistence:org.eclipse.persistence.jpa:3.0.2
-org.eclipse.persistence:org.eclipse.persistence.moxy:4.0.0-M3
 org.eclipse:yasson:2.0.1
 org.eclipse:yasson:3.0.0
 org.ehcache:ehcache:3.8.1


### PR DESCRIPTION
This pull request removes eclipse link moxy from cnf/oss_dependencies.maven since it's only needed for test purposes. 