### PR TITLE
Create internal xmlbinding 4.0 feature

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.connectors-2.1.internal.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.connectors-2.1.internal.feature
@@ -11,7 +11,7 @@ IBM-API-Package: \
   jakarta.resource.spi.work; type="spec"
 -features=com.ibm.websphere.appserver.connectionManagement-1.0, \
   com.ibm.websphere.appserver.appmanager-1.0, \
-  io.openliberty.xmlBinding-4.0, \
+  io.openliberty.xmlBinding.internal-4.0, \
   com.ibm.websphere.appserver.dynamicBundle-1.0, \
   com.ibm.websphere.appserver.classloading-1.0, \
   com.ibm.websphere.appserver.contextService-1.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlBinding.internal-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlBinding.internal-4.0.feature
@@ -1,0 +1,15 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.xmlBinding.internal-4.0
+singleton=true
+IBM-App-ForceRestart: uninstall, \
+ install
+IBM-Process-Types: client, \
+ server
+-features=io.openliberty.jakarta.xmlBinding-4.0, \
+  com.ibm.websphere.appserver.eeCompatible-10.0, \
+  com.ibm.websphere.appserver.classloading-1.0
+-bundles=\
+  io.openliberty.xmlBinding.4.0.internal.tools
+kind=beta
+edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appAuthentication-3.0/io.openliberty.appAuthentication-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appAuthentication-3.0/io.openliberty.appAuthentication-3.0.feature
@@ -12,7 +12,7 @@ WLP-AlsoKnownAs: jaspic-3.0
 IBM-SPI-Package: \
   com.ibm.wsspi.security.jaspi; type="ibm-spi"
 Subsystem-Name: Jakarta Authentication 3.0
--features=io.openliberty.xmlBinding-4.0, \
+-features=io.openliberty.xmlBinding.internal-4.0, \
   io.openliberty.appSecurity-5.0, \
   io.openliberty.jakarta.authentication-3.0, \
   com.ibm.websphere.appserver.servlet-6.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/persistenceContainer-3.1/io.openliberty.persistenceContainer-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/persistenceContainer-3.1/io.openliberty.persistenceContainer-3.1.feature
@@ -14,7 +14,7 @@ IBM-API-Package: jakarta.persistence; type="spec", \
 IBM-App-ForceRestart: uninstall, \
  install
 -features=com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:="4.3", \
-  io.openliberty.xmlBinding-4.0, \
+  io.openliberty.xmlBinding.internal-4.0, \
   io.openliberty.jakarta.annotation-2.1; apiJar=false, \
   com.ibm.websphere.appserver.eeCompatible-10.0, \
   com.ibm.websphere.appserver.classloading-1.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlBinding-4.0/io.openliberty.xmlBinding-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlBinding-4.0/io.openliberty.xmlBinding-4.0.feature
@@ -16,11 +16,13 @@ IBM-ShortName: xmlBinding-4.0
 IBM-Process-Types: client, \
  server
 Subsystem-Name: Jakarta XML Binding 4.0
--features=io.openliberty.jakarta.xmlBinding-4.0, \
-  com.ibm.websphere.appserver.eeCompatible-10.0, \
-  com.ibm.websphere.appserver.classloading-1.0
--bundles=\
-  io.openliberty.xmlBinding.4.0.internal.tools
+-features=io.openliberty.xmlBinding.internal-4.0, \
+  com.ibm.websphere.appserver.eeCompatible-10.0
+# These jars are used for the xmlBinding scripts below.
+-jars=\
+ io.openliberty.xmlBinding.3.0.internal.tools, \
+ io.openliberty.jakarta.xmlBinding.3.0; location:="dev/api/spec/", \
+ io.openliberty.jakarta.activation.2.0; location:="dev/api/spec/"
 -files=\
  bin/xmlBinding/xjc.bat, \
  bin/xmlBinding/tools/ws-schemagen.jar, \


### PR DESCRIPTION
- Create internal version of xmlBinding-4.0 that can be used by other features to just get the runtime without exposing the API or the XMLBinding tools
- Update features to use the XMLBinding 4.0 internal feature when it is only used internally by the feature to read XML deployment descriptors. This will allow for the web profile features to not expose the XML Binding APIs.
- Update xmlBinding-4.0 feature so that the tools will work when doing a minify since the tools depend on XMLBinding 3.0 versions of the jars.