### PR TITLE
policy executor java 19 methods

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskFuture.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskFuture.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2021 IBM Corporation and others.
+ * Copyright (c) 2017,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,8 @@ import java.util.concurrent.TimeUnit;
  * @param <T> type of the result.
  */
 public interface PolicyTaskFuture<T> extends Future<T> {
+    // State name constants match the spelling from java.util.concurrent.Future.State
+
     /**
      * The await operation has timed out.
      */
@@ -47,12 +49,12 @@ public interface PolicyTaskFuture<T> extends Future<T> {
     /**
      * Tasks has begun a cancel request.
      */
-    public static final int CANCELING = 4;
+    public static final int CANCELLING = 4;
 
     /**
      * Task has been canceled.
      */
-    public static final int CANCELED = 5;
+    public static final int CANCELLED = 5;
 
     /**
      * Task has completed its execution with an error.
@@ -62,7 +64,7 @@ public interface PolicyTaskFuture<T> extends Future<T> {
     /**
      * Task has completed successfully.
      */
-    public static final int SUCCESSFUL = 7;
+    public static final int SUCCESS = 7;
 
     /**
      * Await completion of the future. Completion could be successful, exceptional, or by cancellation.

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2021 IBM Corporation and others.
+ * Copyright (c) 2017,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -94,12 +94,12 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
      * Represents the state of the future, and allows for waiters. Initial state is PRESUBMIT.
      * State transitions in one direction only:
      * PRESUBMIT --> ABORTED
-     * PRESUBMIT --> CANCELED
+     * PRESUBMIT --> CANCELLED
      * PRESUBMIT --> SUBMITTED --> ABORTED,
-     * PRESUBMIT --> SUBMITTED --> CANCELED,
-     * PRESUBMIT --> SUBMITTED --> RUNNING --> CANCELING --> CANCELED,
+     * PRESUBMIT --> SUBMITTED --> CANCELLED,
+     * PRESUBMIT --> SUBMITTED --> RUNNING --> CANCELLING --> CANCELLED,
      * PRESUBMIT --> SUBMITTED --> RUNNING --> FAILED,
-     * PRESUBMIT --> SUBMITTED --> RUNNING --> SUCCESSFUL.
+     * PRESUBMIT --> SUBMITTED --> RUNNING --> SUCCESS.
      * Always set the result before updating the state, so that get() operations that await state can rely on the result being available.
      */
     private final State state = new State();
@@ -195,7 +195,7 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                         if (f.callback != null)
                             f.callback.raiseAbortedException(x);
                         throw new RejectedExecutionException(x);
-                    } else if (s == CANCELED || s == CANCELING)
+                    } else if (s == CANCELLED || s == CANCELLING)
                         canceled = true;
                 }
                 if (canceled)
@@ -257,7 +257,7 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
 
     /**
      * Awaitable state. Specifically, allows awaiting the transition from PRESUBMIT/SUBMITTED/RUNNING
-     * to an ABORTED/CANCELING/CANCELED/FAILED/SUCCESSFUL state.
+     * to an ABORTED/CANCELLING/CANCELLED/FAILED/SUCCESS state.
      */
     @Trivial
     private static class State extends AbstractQueuedSynchronizer {
@@ -515,11 +515,11 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                             System.nanoTime() - nsAcceptBegin, //
                             nsStartBy - nsAcceptBegin));
 
-        if (result.compareAndSet(state, CANCELED))
+        if (result.compareAndSet(state, CANCELLED))
             try {
                 if (executor.queue.remove(this)) {
                     nsRunEnd = nsQueueEnd = System.nanoTime();
-                    state.releaseShared(CANCELED);
+                    state.releaseShared(CANCELLED);
                     executor.maxQueueSizeConstraint.release();
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                         Tr.debug(this, tc, "canceled from queue");
@@ -527,13 +527,13 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                         callback.onCancel(task, this, false);
                 } else if (state.get() == PRESUBMIT) {
                     nsRunEnd = nsQueueEnd = nsAcceptEnd = System.nanoTime();
-                    state.releaseShared(CANCELED);
+                    state.releaseShared(CANCELLED);
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                         Tr.debug(this, tc, "canceled during pre-submit");
                     if (callback != null)
                         callback.onCancel(task, this, false);
                 } else if (interruptIfRunning) {
-                    state.releaseShared(CANCELING);
+                    state.releaseShared(CANCELLING);
                     Thread t = thread;
                     try {
                         if (t != null) {
@@ -542,12 +542,12 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                             AccessController.doPrivileged(new InterruptAction(t));
                         }
                     } finally {
-                        state.releaseShared(CANCELED);
+                        state.releaseShared(CANCELLED);
                         if (callback != null)
                             callback.onCancel(task, this, true);
                     }
                 } else {
-                    state.releaseShared(CANCELED);
+                    state.releaseShared(CANCELLED);
                     if (callback != null)
                         callback.onCancel(task, this, true);
                 }
@@ -570,11 +570,33 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
         }
     }
 
+    /**
+     * Java 19+ method that immediately returns the exception with which the task completes (not including cancellation)
+     * or otherwise raises IllegalStateException.
+     */
+    public Throwable exceptionNow() {
+        Throwable cause = null;
+        if (isDone()) {
+            int s = state.get();
+            if (s == ABORTED || s == FAILED) {
+                Throwable failure = (Throwable) result.get();
+                return failure;
+            } else if (s == CANCELLED || s == CANCELLING) {
+                cause = new CancellationException();
+            }
+        }
+
+        IllegalStateException x = new IllegalStateException(toString());
+        if (cause != null)
+            x.initCause(cause);
+        throw x;
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public T get() throws InterruptedException, ExecutionException {
         switch (await()) {
-            case SUCCESSFUL:
+            case SUCCESS:
                 return (T) result.get();
             case ABORTED:
                 if (callback != null)
@@ -582,8 +604,8 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                 throw new RejectedExecutionException((Throwable) result.get());
             case FAILED:
                 throw new ExecutionException((Throwable) result.get());
-            case CANCELED:
-            case CANCELING:
+            case CANCELLED:
+            case CANCELLING:
                 throw new CancellationException();
             case RUNNING: // only possible when get() is invoked from thread of execution and therefore blocks completion
             case PRESUBMIT: // only possible when get() is invoked from onStart, which runs on the submitter's thread and therefore blocks completion
@@ -599,7 +621,7 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
     @Override
     public T get(long time, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         switch (await(time, unit)) {
-            case SUCCESSFUL:
+            case SUCCESS:
                 return (T) result.get();
             case ABORTED:
                 if (callback != null)
@@ -607,8 +629,8 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                 throw new RejectedExecutionException((Throwable) result.get());
             case FAILED:
                 throw new ExecutionException((Throwable) result.get());
-            case CANCELED:
-            case CANCELING:
+            case CANCELLED:
+            case CANCELLING:
                 throw new CancellationException();
             case TIMEOUT:
                 throw new TimeoutException();
@@ -659,7 +681,7 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
     @Override
     public boolean isCancelled() {
         int s = state.get();
-        return s == CANCELED || s == CANCELING;
+        return s == CANCELLED || s == CANCELLING;
     }
 
     @Override
@@ -673,6 +695,32 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                                   System.nanoTime() - nsAcceptBegin, //
                                   nsStartBy - nsAcceptBegin))
                       || state.get() > RUNNING);
+    }
+
+    /**
+     * Java 19+ method that immediately returns the result or otherwise raises IllegalStateException.
+     */
+    public T resultNow() {
+        Throwable cause = null;
+        if (isDone()) {
+            int s = state.get();
+            if (s == SUCCESS) {
+                @SuppressWarnings("unchecked")
+                T successfulResult = (T) result.get();
+                return successfulResult;
+            } else if (s == CANCELLED || s == CANCELLING) {
+                cause = new CancellationException();
+            } else {
+                Object failure = result.get();
+                if (failure instanceof Throwable)
+                    cause = (Throwable) failure;
+            }
+        }
+
+        IllegalStateException x = new IllegalStateException(toString());
+        if (cause != null)
+            x.initCause(cause);
+        throw x;
     }
 
     /**
@@ -700,7 +748,7 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                 aborted = false;
             else {
                 callbackContext = callback.onStart(task, this);
-                aborted = state.get() == CANCELED;
+                aborted = state.get() == CANCELLED;
             }
 
             if (aborted)
@@ -717,13 +765,13 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                 nsRunEnd = System.nanoTime();
 
                 if (result.compareAndSet(state, t)) {
-                    state.releaseShared(SUCCESSFUL);
+                    state.releaseShared(SUCCESS);
                     if (latch != null)
                         latch.countDown(t);
-                } else if (Integer.valueOf(CANCELED).equals(result.get())) {
+                } else if (Integer.valueOf(CANCELLED).equals(result.get())) {
                     if (trace && tc.isDebugEnabled())
                         Tr.debug(this, tc, "canceled during/after run");
-                    // Prevent dirty read of state during onEnd before the canceling thread transitions the state to CANCELING/CANCELED
+                    // Prevent dirty read of state during onEnd before the canceling thread transitions the state to CANCELLING/CANCELLED
                     while (state.get() == RUNNING)
                         Thread.yield();
                 }
@@ -753,11 +801,18 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                 callback.onEnd(task, this, callbackContext, aborted, 0, x);
         } finally {
             thread = null;
-            // Prevent accidental interrupt of subsequent operations by awaiting the transition from CANCELING to CANCELED
-            while (state.get() == CANCELING)
+            // Prevent accidental interrupt of subsequent operations by awaiting the transition from CANCELLING to CANCELLED
+            while (state.get() == CANCELLING)
                 Thread.yield();
         }
     }
+
+    /**
+     * TODO Add a more efficient implementation of this method once Java 21 is the minimum level.
+     * This method of java.util.concurrent.Future was added in Java 19, but has a return type that
+     * makes it incompatible with prior versions of Java.
+     */
+    // Future.State state()
 
     /**
      * @throws InterruptedException if the task failed with InterruptedException.
@@ -778,7 +833,7 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
     /**
      * String representation for debug purposes.
      *
-     * @return output of the form: PolicyTaskFuture@12345678 for org.example.MyTask@23456789 SUCCESSFUL on MyPolicyExecutor: My Successful Task Result
+     * @return output of the form: PolicyTaskFuture@12345678 for org.example.MyTask@23456789 SUCCESS on MyPolicyExecutor: My Successful Task Result
      */
     @Trivial
     @Override
@@ -798,23 +853,23 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
             case ABORTED:
                 b.append("ABORTED");
                 break;
-            case CANCELING:
-                b.append("CANCELING");
+            case CANCELLING:
+                b.append("CANCELLING");
                 break;
-            case CANCELED:
-                b.append("CANCELED");
+            case CANCELLED:
+                b.append("CANCELLED");
                 break;
             case FAILED:
                 b.append("FAILED");
                 break;
-            case SUCCESSFUL:
-                b.append("SUCCESSFUL");
+            case SUCCESS:
+                b.append("SUCCESS");
                 break;
             default:
                 b.append(s); // should be unreachable
         }
         b.append(" on ").append(getIdentifier());
-        if (s == SUCCESSFUL || s == FAILED)
+        if (s == SUCCESS || s == FAILED)
             b.append(": ").append(result.get());
         return b.toString();
     }

--- a/dev/com.ibm.ws.threading_policy_fat/fat/src/com/ibm/ws/threading/policy/PolicyExecutorTest.java
+++ b/dev/com.ibm.ws.threading_policy_fat/fat/src/com/ibm/ws/threading/policy/PolicyExecutorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -49,7 +49,9 @@ public class PolicyExecutorTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server1.stopServer("CWWKE1205E:.*PolicyExecutorProvider-testStartTimeout.*"); // some tests intentionally exceed the startTimeout
+        server1.stopServer("CWWKE1205E:.*PolicyExecutorProvider-testExceptionNow.*",
+                           "CWWKE1205E:.*PolicyExecutorProvider-testResultNow.*",
+                           "CWWKE1205E:.*PolicyExecutorProvider-testStartTimeout.*"); // some tests intentionally exceed the startTimeout
         server1.deleteFileFromLibertyInstallRoot("lib/features/policyExecutorUser-1.0.mf");
         server1.deleteFileFromLibertyInstallRoot("lib/test.policyexecutor.bundle_fat.jar");
     }

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2021 IBM Corporation and others.
+ * Copyright (c) 2017,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.Closeable;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -960,6 +963,63 @@ public class PolicyExecutorServlet extends FATServlet {
     }
 
     /**
+     * Use ExecutorService.close to shut down the executor and await completion of running tasks, if on Java 19 or above.
+     * Otherwise, use shutdown and awaitCompletion.
+     */
+    @Test
+    public void testClose() throws Exception {
+        PolicyExecutor executor = provider.create("testClose")
+                        .maxConcurrency(2);
+
+        CountDownLatch blocker = new CountDownLatch(1);
+        CountDownLatch twoTasksStarted = new CountDownLatch(2);
+        CountDownLatch thirdTaskStarted = new CountDownLatch(1);
+        CountDownLatch fourthTaskStarted = new CountDownLatch(1);
+
+        CountDownTask task1 = new CountDownTask(twoTasksStarted, blocker, TimeUnit.SECONDS.toNanos(2));
+        CountDownTask task2 = new CountDownTask(twoTasksStarted, blocker, TimeUnit.SECONDS.toNanos(2));
+        CountDownTask task3 = new CountDownTask(thirdTaskStarted, thirdTaskStarted, TIMEOUT_NS);
+        CountDownTask task4 = new CountDownTask(fourthTaskStarted, fourthTaskStarted, TIMEOUT_NS);
+
+        // Use up max concurrency by submitting 2 tasks
+        Future<Boolean> task1future = executor.submit(task1);
+        Future<Boolean> task2future = executor.submit(task2);
+
+        assertEquals(true, twoTasksStarted.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        // Third task should remain in the queue for 2 seconds or so
+        Future<Boolean> task3future = executor.submit(task3);
+
+        if (executor instanceof Closeable) {
+            // Java 19+
+            ((Closeable) executor).close();
+        } else {
+            // Java 18-
+            executor.shutdown();
+            assertEquals(true, executor.awaitTermination(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        }
+
+        assertEquals(true, task1future.isDone());
+        assertEquals(true, task2future.isDone());
+        assertEquals(true, task3future.isDone());
+
+        assertEquals(false, task1future.isCancelled());
+        assertEquals(false, task2future.isCancelled());
+        assertEquals(false, task3future.isCancelled());
+
+        assertEquals(Boolean.FALSE, task1future.get(1, TimeUnit.MILLISECONDS));
+        assertEquals(Boolean.FALSE, task2future.get(1, TimeUnit.MILLISECONDS));
+        assertEquals(Boolean.TRUE, task3future.get(1, TimeUnit.MILLISECONDS));
+
+        try {
+            Future<Boolean> task4future = executor.submit(task4);
+            fail("Should not be able to submit task after closing or shutting down the executor: " + task4future);
+        } catch (RejectedExecutionException x) {
+            // pass - the executor was closed or shut down.
+        }
+    }
+
+    /**
      * Use CompletionStageFactory to create CompletableFutures that run on a supplied executor.
      * A policy executor with constraints on max concurrency/queue size is used, which helps to
      * make it obvious that the CompletionStage is running or attempting to run on that executor
@@ -1801,6 +1861,95 @@ public class PolicyExecutorServlet extends FATServlet {
         executor.shutdown();
         assertTrue(executor.isShutdown());
         assertTrue(executor.awaitTermination(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+    }
+
+    /**
+     * Use Future.exceptionNow on futures for tasks that are:
+     *
+     * <li>successfully completed
+     * <li>exceptionally completed
+     * <li>running
+     * <li>aborted due to exceeding start timeout
+     * <li>cancelled
+     */
+    @Test
+    public void testExceptionNow() throws Throwable {
+        PolicyExecutor executor = provider.create("testExceptionNow")
+                        .maxConcurrency(1);
+
+        FactorialTask sucessfulTask = new FactorialTask(1, executor);
+        Future<Long> successfulTaskFuture = executor.submit(sucessfulTask);
+
+        FactorialTask failingTask = new FactorialTask(6, null); // causes NullPointerException when task runs
+        Future<Long> failingTaskFuture = executor.submit(failingTask);
+
+        // Use up maxConcurrency
+        CountDownLatch blocker = new CountDownLatch(1);
+        CountDownLatch task3started = new CountDownLatch(1);
+
+        CountDownTask task3 = new CountDownTask(task3started, blocker, TIMEOUT_NS * 2);
+        Future<Boolean> task3future = executor.submit(task3);
+
+        assertEquals(true, task3started.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        // Future.exceptionNow on task that completes successfully:
+        // successfulTask must have completed by now because task3 is using up max concurrency
+        Method exceptionNow = successfulTaskFuture.getClass().getMethod("exceptionNow");
+        try {
+            Throwable exception = (Throwable) exceptionNow.invoke(successfulTaskFuture);
+            if (exception == null)
+                throw new AssertionError("exceptionNow returned null for successfully completed task");
+            else
+                throw new AssertionError("exceptionNow returned value for successfully completed task").initCause(exception);
+        } catch (IllegalStateException x) {
+            // pass
+        }
+
+        // Future.exceptionNow on task that failed with an exception:
+        // failingTask must have completed by now because task3 is using up max concurrency
+        Throwable exception = (Throwable) exceptionNow.invoke(failingTaskFuture);
+        if (!NullPointerException.class.equals(exception.getClass()))
+            throw exception;
+
+        // Future.exceptionNow on running task:
+        try {
+            exception = (Throwable) exceptionNow.invoke(task3future);
+            if (exception == null)
+                throw new AssertionError("exceptionNow returned null for running task");
+            else
+                throw new AssertionError("exceptionNow returned value for running task").initCause(exception);
+        } catch (IllegalStateException x) {
+            // pass
+        }
+
+        // startTimeout is applied after submitting the blocker so that it doesn't ever stop the blocker task from starting
+        executor.startTimeout(300);
+
+        Future<Long> task4future = executor.submit(new FactorialTask(1, executor));
+
+        // Wait long enough to time out the queued task
+        assertEquals(false, blocker.await(400, TimeUnit.MILLISECONDS));
+
+        // Future.exceptionNow on task that times out and is aborted:
+        exception = (Throwable) exceptionNow.invoke(task4future);
+        if (!StartTimeoutException.class.equals(exception.getClass()))
+            throw exception;
+
+        // Future.exceptionNow on cancelled task:
+        assertEquals(true, task3future.cancel(true));
+        try {
+            exception = (Throwable) exceptionNow.invoke(task3future);
+            if (exception == null)
+                throw new AssertionError("exceptionNow returned null for cancelled task");
+            else
+                throw new AssertionError("exceptionNow returned value for cancelled task").initCause(exception);
+        } catch (IllegalStateException x) {
+            // pass
+        }
+
+        blocker.countDown();
+
+        assertEquals(Collections.EMPTY_LIST, executor.shutdownNow());
     }
 
     /**
@@ -5047,6 +5196,108 @@ public class PolicyExecutorServlet extends FATServlet {
         }
 
         assertTrue(executor.awaitTermination(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+    }
+
+    /**
+     * Use Future.resultNow on futures for tasks that are:
+     *
+     * <li>successfully completed
+     * <li>exceptionally completed
+     * <li>running
+     * <li>aborted due to exceeding start timeout
+     * <li>cancelled
+     */
+    @Test
+    public void testResultNow() throws Throwable {
+        PolicyExecutor executor = provider.create("testResultNow")
+                        .maxConcurrency(1);
+
+        FactorialTask sucessfulTask = new FactorialTask(1, executor);
+        Future<Long> successfulTaskFuture = executor.submit(sucessfulTask);
+
+        FactorialTask failingTask = new FactorialTask(6, null); // causes NullPointerException when task runs
+        Future<Long> failingTaskFuture = executor.submit(failingTask);
+
+        // Use up maxConcurrency
+        CountDownLatch blocker = new CountDownLatch(1);
+        CountDownLatch task3started = new CountDownLatch(1);
+
+        CountDownTask task3 = new CountDownTask(task3started, blocker, TIMEOUT_NS * 2);
+        Future<Boolean> task3future = executor.submit(task3);
+
+        assertEquals(true, task3started.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        // Future.resultNow on task that completes successfully:
+        // successfulTask must have completed by now because task3 is using up max concurrency
+        Method resultNow = successfulTaskFuture.getClass().getMethod("resultNow");
+        Object result = resultNow.invoke(successfulTaskFuture);
+        assertEquals(Long.valueOf(1), result);
+
+        // Future.resultNow on task that failed with an exception:
+        // failingTask must have completed by now because task3 is using up max concurrency
+        try {
+            result = resultNow.invoke(failingTaskFuture);
+            throw new AssertionError("resultNow returned " + result + " for failed task");
+        } catch (InvocationTargetException xx) { // Java reflection should not be wrapping IllegalStateException because it is a type of RuntimeException!
+            IllegalStateException x = (IllegalStateException) xx.getCause();
+            if (!(x.getCause() instanceof NullPointerException))
+                throw x;
+        } catch (IllegalStateException x) {
+            if (!(x.getCause() instanceof NullPointerException))
+                throw x;
+        }
+
+        // Future.resultNow on running task:
+        try {
+            result = resultNow.invoke(task3future);
+            throw new AssertionError("resultNow returned " + result + " for running task");
+        } catch (InvocationTargetException xx) { // Java reflection should not be wrapping IllegalStateException because it is a type of RuntimeException!
+            IllegalStateException x = (IllegalStateException) xx.getCause();
+            if (x.getCause() != null)
+                throw x;
+        } catch (IllegalStateException x) {
+            if (x.getCause() != null)
+                throw x;
+        }
+
+        // startTimeout is applied after submitting the blocker so that it doesn't ever stop the blocker task from starting
+        executor.startTimeout(300);
+
+        Future<Long> task4future = executor.submit(new FactorialTask(1, executor));
+
+        // Wait long enough to time out the queued task
+        assertEquals(false, blocker.await(400, TimeUnit.MILLISECONDS));
+
+        // Future.resultNow on task that times out and is aborted:
+        try {
+            result = resultNow.invoke(task4future);
+            throw new AssertionError("resultNow returned " + result + " for aborted task");
+        } catch (InvocationTargetException xx) { // Java reflection should not be wrapping IllegalStateException because it is a type of RuntimeException!
+            IllegalStateException x = (IllegalStateException) xx.getCause();
+            if (!(x.getCause() instanceof StartTimeoutException))
+                throw x;
+        } catch (IllegalStateException x) {
+            if (!(x.getCause() instanceof StartTimeoutException))
+                throw x;
+        }
+
+        // Future.resultNow on cancelled task:
+        assertEquals(true, task3future.cancel(true));
+        try {
+            result = resultNow.invoke(task3future);
+            throw new AssertionError("resultNow returned " + result + " for cancelled task");
+        } catch (InvocationTargetException xx) { // Java reflection should not be wrapping IllegalStateException because it is a type of RuntimeException!
+            IllegalStateException x = (IllegalStateException) xx.getCause();
+            if (!(x.getCause() instanceof CancellationException))
+                throw x;
+        } catch (IllegalStateException x) {
+            if (!(x.getCause() instanceof CancellationException))
+                throw x;
+        }
+
+        blocker.countDown();
+
+        assertEquals(Collections.EMPTY_LIST, executor.shutdownNow());
     }
 
     // Verify that tasks submitted via the execute and submit methods run on the caller thread when the queue is full


### PR DESCRIPTION
Provide implementations of resultNow and exceptionNow for policy executor futures.  Test these as well as the default implementation of policy executor close.