### PR TITLE
Added repeat test rule to the timeout test class

### DIFF
--- a/dev/io.openliberty.checkpoint_fat/publish/servers/timeoutServer/server.xml
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/timeoutServer/server.xml
@@ -16,6 +16,6 @@
       <feature>mpFaultTolerance-3.0</feature>
       <feature>checkpoint-1.0</feature>
     </featureManager>
-    <variable name="timeout" defaultValue="true"/>
+    <variable id="timeout" name="timeout" defaultValue="true"/>
     <webApplication id="testingApp" location="testingApp.war" name="testingApp"/>
 </server>


### PR DESCRIPTION
Updated MPFaultToleranceTimeoutTest class to repeat tests with both Java 8 and Java 9, also added id to timeout system variable such that it may be fetch by id

