### PR TITLE
com.ibm.ws.ui_rest_fat: Add call to ignore expected error in CatalogPersistenceTest

### DIFF
--- a/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/CatalogPersistenceTest.java
+++ b/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/CatalogPersistenceTest.java
@@ -81,7 +81,16 @@ public class CatalogPersistenceTest extends CommonRESTTest implements APIConstan
      */
     @AfterClass
     public static void tearDownClass() throws Exception {
-        server.restartServer();
+        stopServerWithExpectedErrors();
+        server.startServer();
+    }
+
+    private static void stopServerWithExpectedErrors() throws Exception {
+        server.stopServer(
+            "CWWKX1002E:.*",
+            "CWWKX1003E:.*",
+            "CWWKX1009E:.*",
+            "CWWKX1010E:.*");
     }
 
     /**
@@ -109,10 +118,7 @@ public class CatalogPersistenceTest extends CommonRESTTest implements APIConstan
     }
 
     private void ignoreErrorAndStopServerWithValidate() throws Exception {
-        server.stopServer("CWWKX1010E:.*", 
-                            "CWWKX1003E:.*",
-                            "CWWKX1002E:.*",
-                            "CWWKX1009E:.*");
+        stopServerWithExpectedErrors();
         assertFalse("FAIL: Server is not stopped.",
                     server.isStarted());
     }


### PR DESCRIPTION
The tests in CatalogPersistenceTest were running in a different order as written. As a result, the last test ran before tearing down was an error scenario with an invalid server.xml. The tear down method needs to include errors to be ignored when stopping the server.
