### PR TITLE
Failover tests timeout increase

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/web/FailoverTimersTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/web/FailoverTimersTestServlet.java
@@ -44,7 +44,7 @@ public class FailoverTimersTestServlet extends FATServlet {
     /**
      * Maximum number of nanoseconds to wait for a task to finish.
      */
-    private static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
+    private static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(4);
 
     /**
      * List of timers that will intentionally fail on this server.


### PR DESCRIPTION
Double timeout for failover tests due to hitting timeout on iSeries builds
