### PR TITLE
Create webBundle.internal feature that doesn't expose servlet 6.0 for EE10 for liberty product features to use.

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webBundle.internal-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webBundle.internal-1.0.feature
@@ -1,0 +1,17 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+
+symbolicName = io.openliberty.webBundle.internal-1.0
+WLP-DisableAllFeatures-OnConflict: false
+visibility = private
+
+-bundles= \
+ com.ibm.ws.eba.wab.integrator
+
+-features=io.openliberty.servlet.api-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0", \
+  io.openliberty.webBundle.internal.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"
+
+Subsystem-Name: OSGi Application
+
+edition=core
+kind=ga
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webBundle.internal.servlet-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webBundle.internal.servlet-3.1.feature
@@ -1,0 +1,23 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+
+symbolicName = io.openliberty.webBundle.internal.servlet-3.1
+singleton=true
+WLP-DisableAllFeatures-OnConflict: false
+visibility = private
+
+-features=io.openliberty.servlet.api-3.1, \
+  com.ibm.websphere.appserver.servlet-3.1
+
+-bundles= com.ibm.ws.app.manager.wab; start-phase:=APPLICATION_EARLY
+
+-jars= \
+ com.ibm.websphere.appserver.spi.wab.configure; location:=dev/spi/ibm/
+
+-files= \
+ dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.wab.configure_1.0-javadoc.zip
+
+IBM-SPI-Package: com.ibm.wsspi.wab.configure
+
+edition=core
+kind=ga
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webBundle.internal.servlet-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webBundle.internal.servlet-4.0.feature
@@ -1,0 +1,23 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+
+symbolicName = io.openliberty.webBundle.internal.servlet-4.0
+singleton=true
+WLP-DisableAllFeatures-OnConflict: false
+visibility = private
+
+-features=io.openliberty.servlet.api-4.0, \
+  com.ibm.websphere.appserver.servlet-4.0
+
+-bundles= com.ibm.ws.app.manager.wab; start-phase:=APPLICATION_EARLY
+
+-jars= \
+ com.ibm.websphere.appserver.spi.wab.configure; location:=dev/spi/ibm/
+
+-files= \
+ dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.wab.configure_1.0-javadoc.zip
+
+IBM-SPI-Package: com.ibm.wsspi.wab.configure
+
+edition=core
+kind=ga
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webBundle.internal.servlet-5.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webBundle.internal.servlet-5.0.feature
@@ -1,0 +1,22 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+
+symbolicName = io.openliberty.webBundle.internal.servlet-5.0
+singleton=true
+visibility = private
+
+-features=io.openliberty.servlet.api-5.0, \
+  com.ibm.websphere.appserver.servlet-5.0
+
+-bundles= com.ibm.ws.app.manager.wab.jakarta; start-phase:=APPLICATION_EARLY
+
+-jars= \
+ com.ibm.websphere.appserver.spi.wab.configure; location:=dev/spi/ibm/
+
+-files= \
+ dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.wab.configure_1.0-javadoc.zip
+
+IBM-SPI-Package: com.ibm.wsspi.wab.configure
+
+kind=ga
+edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webBundle.internal.servlet-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webBundle.internal.servlet-6.0.feature
@@ -1,0 +1,14 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+
+symbolicName = io.openliberty.webBundle.internal.servlet-6.0
+singleton=true
+visibility = private
+
+-features=io.openliberty.servlet.api-6.0, \
+  io.openliberty.servlet.internal-6.0
+
+-bundles= com.ibm.ws.app.manager.wab.jakarta; start-phase:=APPLICATION_EARLY
+
+kind=beta
+edition=core
+WLP-Activation-Type: parallel


### PR DESCRIPTION
- Support using the Liberty Arquillian plugin 2.1 to not depend on servlet
- Create webBundle-internal private feature so we do not expose the Servlet 6.0 API or webBundle SPI when using MP 6.0 / EE10.
