### PR TITLE
Cleanup leaked FAT servers after timeout

### DIFF
--- a/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -370,14 +370,29 @@
 				<!-- If the tests timeout, attempt to copy logs from zombie servers -->
 				<fileset dir="${basedir}/output" includes="*.mrk" id="markfiles" />
 				<foreach param="serverFile" in="markfiles">
-					<echo>Failure running ${test.bucket.name}, attempting to copy logs from servers that did not stop properly : ${serverFile}</echo>
-					<local name="serverDir"/>
+					<echo>Failure running ${test.bucket.name}, attempting to stop servers that did not stop properly : ${serverFile}</echo>
+					<local name="serverDir" />
 					<basename property="serverDir" file="${serverFile}" suffix=".mrk" />
+					<condition property="script.exec" value="cmd" else="sh">
+						<istrue value="${is.windows.platform}" />
+					</condition>
+					<condition property="script.cmd" value="/c server.bat" else="server">
+						<istrue value="${is.windows.platform}" />
+					</condition>
+
+					<echo>Executing ${libertyInstallPath}/bin/${script.exec} ${script.cmd} stop ${serverDir}</echo>
+					<exec failonerror="false" executable="${script.exec}" dir="${libertyInstallPath}/bin" timeout="300000">
+						<arg line="${script.cmd}" />
+						<arg line="stop" />
+						<arg line="${serverDir}" />
+					</exec>
+
+					<echo>Failure running ${test.bucket.name}, attempting to copy logs from servers that did not stop properly : ${serverFile}</echo>
 					<tstamp>
 						<format property="copyTime" pattern="dd-MM-yyyy-HH-mm-ss" />
 					</tstamp>
 
-					<copy failonerror="false" todir="${basedir}/output/servers/${serverDir}-${copyTime}">
+					<copy failonerror="false" todir="${basedir}/output/servers/${serverDir}-LEAKED-${copyTime}">
 						<fileset dir="${libertyInstallPath}/usr/servers/${serverDir}" />
 					</copy>
 				</foreach>

--- a/dev/com.ibm.ws.jmx_fat/override/autoFVT/src/ant/launch.xml
+++ b/dev/com.ibm.ws.jmx_fat/override/autoFVT/src/ant/launch.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017, 2021 IBM Corporation and others.
+    Copyright (c) 2017, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -556,14 +556,29 @@
 				<!-- If the tests timeout, attempt to copy logs from zombie servers -->
 				<fileset dir="${basedir}/output" includes="*.mrk" id="markfiles" />
 				<foreach param="serverFile" in="markfiles">
-					<echo>Failure running ${test.bucket.name}, attempting to copy logs from servers that did not stop properly : ${serverFile}</echo>
+					<echo>Failure running ${test.bucket.name}, attempting to stop servers that did not stop properly : ${serverFile}</echo>
 					<local name="serverDir" />
 					<basename property="serverDir" file="${serverFile}" suffix=".mrk" />
+					<condition property="script.exec" value="cmd" else="sh">
+						<istrue value="${is.windows.platform}" />
+					</condition>
+					<condition property="script.cmd" value="/c server.bat" else="server">
+						<istrue value="${is.windows.platform}" />
+					</condition>
+
+					<echo>Executing ${libertyInstallPath}/bin/${script.exec} ${script.cmd} stop ${serverDir}</echo>
+					<exec failonerror="false" executable="${script.exec}" dir="${libertyInstallPath}/bin" timeout="300000">
+						<arg line="${script.cmd}" />
+						<arg line="stop" />
+						<arg line="${serverDir}" />
+					</exec>
+
+					<echo>Failure running ${test.bucket.name}, attempting to copy logs from servers that did not stop properly : ${serverFile}</echo>
 					<tstamp>
 						<format property="copyTime" pattern="dd-MM-yyyy-HH-mm-ss" />
 					</tstamp>
 
-					<copy failonerror="false" todir="${basedir}/output/servers/${serverDir}-${copyTime}">
+					<copy failonerror="false" todir="${basedir}/output/servers/${serverDir}-LEAKED-${copyTime}">
 						<fileset dir="${libertyInstallPath}/usr/servers/${serverDir}" />
 					</copy>
 				</foreach>

--- a/dev/com.ibm.ws.kernel.boot_fat/override/autoFVT/src/ant/launch.xml
+++ b/dev/com.ibm.ws.kernel.boot_fat/override/autoFVT/src/ant/launch.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017, 2021 IBM Corporation and others.
+    Copyright (c) 2017, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -556,14 +556,29 @@
 				<!-- If the tests timeout, attempt to copy logs from zombie servers -->
 				<fileset dir="${basedir}/output" includes="*.mrk" id="markfiles" />
 				<foreach param="serverFile" in="markfiles">
-					<echo>Failure running ${test.bucket.name}, attempting to copy logs from servers that did not stop properly : ${serverFile}</echo>
+					<echo>Failure running ${test.bucket.name}, attempting to stop servers that did not stop properly : ${serverFile}</echo>
 					<local name="serverDir" />
 					<basename property="serverDir" file="${serverFile}" suffix=".mrk" />
+					<condition property="script.exec" value="cmd" else="sh">
+						<istrue value="${is.windows.platform}" />
+					</condition>
+					<condition property="script.cmd" value="/c server.bat" else="server">
+						<istrue value="${is.windows.platform}" />
+					</condition>
+
+					<echo>Executing ${libertyInstallPath}/bin/${script.exec} ${script.cmd} stop ${serverDir}</echo>
+					<exec failonerror="false" executable="${script.exec}" dir="${libertyInstallPath}/bin" timeout="300000">
+						<arg line="${script.cmd}" />
+						<arg line="stop" />
+						<arg line="${serverDir}" />
+					</exec>
+
+					<echo>Failure running ${test.bucket.name}, attempting to copy logs from servers that did not stop properly : ${serverFile}</echo>
 					<tstamp>
 						<format property="copyTime" pattern="dd-MM-yyyy-HH-mm-ss" />
 					</tstamp>
 
-					<copy failonerror="false" todir="${basedir}/output/servers/${serverDir}-${copyTime}">
+					<copy failonerror="false" todir="${basedir}/output/servers/${serverDir}-LEAKED-${copyTime}">
 						<fileset dir="${libertyInstallPath}/usr/servers/${serverDir}" />
 					</copy>
 				</foreach>

--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017, 2020 IBM Corporation and others.
+    Copyright (c) 2017, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -534,14 +534,29 @@
 				<!-- If the tests timeout, attempt to copy logs from zombie servers -->
 				<fileset dir="${basedir}/output" includes="*.mrk" id="markfiles" />
 				<foreach param="serverFile" in="markfiles">
-					<echo>Failure running ${test.bucket.name}, attempting to copy logs from servers that did not stop properly : ${serverFile}</echo>
+					<echo>Failure running ${test.bucket.name}, attempting to stop servers that did not stop properly : ${serverFile}</echo>
 					<local name="serverDir" />
 					<basename property="serverDir" file="${serverFile}" suffix=".mrk" />
+					<condition property="script.exec" value="cmd" else="sh">
+						<istrue value="${is.windows.platform}" />
+					</condition>
+					<condition property="script.cmd" value="/c server.bat" else="server">
+						<istrue value="${is.windows.platform}" />
+					</condition>
+
+					<echo>Executing ${libertyInstallPath}/bin/${script.exec} ${script.cmd} stop ${serverDir}</echo>
+					<exec failonerror="false" executable="${script.exec}" dir="${libertyInstallPath}/bin" timeout="300000">
+						<arg line="${script.cmd}" />
+						<arg line="stop" />
+						<arg line="${serverDir}" />
+					</exec>
+
+					<echo>Failure running ${test.bucket.name}, attempting to copy logs from servers that did not stop properly : ${serverFile}</echo>
 					<tstamp>
 						<format property="copyTime" pattern="dd-MM-yyyy-HH-mm-ss" />
 					</tstamp>
 
-					<copy failonerror="false" todir="${basedir}/output/servers/${serverDir}-${copyTime}">
+					<copy failonerror="false" todir="${basedir}/output/servers/${serverDir}-LEAKED-${copyTime}">
 						<fileset dir="${libertyInstallPath}/usr/servers/${serverDir}" />
 					</copy>
 				</foreach>


### PR DESCRIPTION
Execute server stop for each server still running after a FAT bucket times out.
