### PR TITLE
Update mpRestClient-3.0 to tolerate MP 6 and EE 10

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.rest.client-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.rest.client-3.0.feature
@@ -2,10 +2,10 @@
 symbolicName=io.openliberty.org.eclipse.microprofile.rest.client-3.0
 singleton=true
 -features=\
-  io.openliberty.jakarta.annotation-2.0, \
-  io.openliberty.mpCompatible-5.0, \
-  io.openliberty.jakarta.cdi-3.0, \
-  io.openliberty.jakarta.restfulWS-3.0, \
+  io.openliberty.jakarta.annotation-2.0; ibm.tolerates:="2.1", \
+  io.openliberty.mpCompatible-5.0; ibm.tolerates:="6.0", \
+  io.openliberty.jakarta.cdi-3.0; ibm.tolerates:="4.0", \
+  io.openliberty.jakarta.restfulWS-3.0; ibm.tolerates:="3.1", \
   io.openliberty.org.eclipse.microprofile.config-3.0
 -bundles=io.openliberty.org.eclipse.microprofile.rest.client.3.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.rest.client:microprofile-rest-client-api:3.0"
 kind=ga

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/bnd.bnd
@@ -33,7 +33,8 @@ src: \
 fat.project: true
 
 tested.features=mpRestClient-1.2,jdbc-4.2,appSecurity-3.0,mpRestClient-1.3,mpRestClient-1.4,mpRestClient-2.0,mpRestClient-3.0,\
-  mpConfig-1.2,mpConfig-2.0,mpConfig-3.0,restfulWS-3.0,jsonb-2.0,enterpriseBeansLite-4.0,appSecurity-4.0,expressionLanguage-4.0
+  mpConfig-1.2,mpConfig-2.0,mpConfig-3.0,restfulWS-3.0,jsonb-2.0,jsonb-3.0,enterpriseBeansLite-4.0,appSecurity-4.0,expressionLanguage-4.0,\
+  restfulWSClient-3.1,jsonp-2.1,cdi-4.0,servlet-6.0,concurrent-3.0,restfulWS-3.1,expressionlanguage-5.0,appSecurity-5.0
 
 
 -buildpath: \

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/AsyncMethodTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/AsyncMethodTest.java
@@ -46,7 +46,8 @@ public class AsyncMethodTest extends FATServletClient {
                                                              MicroProfileActions.MP30, // 1.3
                                                              MicroProfileActions.MP33, // 1.4
                                                              MicroProfileActions.MP40, // 2.0
-                                                             MicroProfileActions.MP50); // 3.0
+                                                             MicroProfileActions.MP50, // 3.0
+                                                             MicroProfileActions.MP60);// 3.0+EE10
 
     private static final String appName = "asyncApp";
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicCdiTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicCdiTest.java
@@ -23,6 +23,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
@@ -43,7 +44,8 @@ public class BasicCdiTest extends FATServletClient {
                                                              MicroProfileActions.MP30, // 1.3
                                                              MicroProfileActions.MP33, // 1.4
                                                              MicroProfileActions.MP40, // 2.0
-                                                             MicroProfileActions.MP50); // 3.0
+                                                             MicroProfileActions.MP50, // 3.0
+                                                             MicroProfileActions.MP60);// 3.0+EE10
     /*
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
@@ -74,7 +76,7 @@ public class BasicCdiTest extends FATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         ShrinkHelper.defaultDropinApp(remoteAppServer, "basicRemoteApp", new DeployOptions[] {DeployOptions.OVERWRITE}, "remoteApp.basic");
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE9Action.isActive() | JakartaEE10Action.isActive()) {
             remoteAppServer.changeFeatures(Arrays.asList("componenttest-2.0", "restfulWS-3.0", "ssl-1.0", "jsonb-2.0"));
         }
         remoteAppServer.startServer();
@@ -82,6 +84,8 @@ public class BasicCdiTest extends FATServletClient {
         ShrinkHelper.defaultDropinApp(server, appName, "mpRestClient10.basicCdi");
         if (JakartaEE9Action.isActive()) {
             server.changeFeatures(Arrays.asList("componenttest-2.0", "mpRestClient-3.0", "mpConfig-3.0", "cdi-3.0", "jsonb-2.0"));
+        } else if (JakartaEE10Action.isActive()) {
+            server.changeFeatures(Arrays.asList("componenttest-2.0", "mpRestClient-3.0", "mpConfig-3.0", "cdi-4.0", "jsonb-3.0", "servlet-6.0"));
         }
         server.startServer();
     }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicEJBTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicEJBTest.java
@@ -23,6 +23,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
@@ -43,7 +44,8 @@ public class BasicEJBTest extends FATServletClient {
                                                              MicroProfileActions.MP30, // 1.3
                                                              MicroProfileActions.MP33, // 1.4
                                                              MicroProfileActions.MP40, // 2.0
-                                                             MicroProfileActions.MP50); // 3.0
+                                                             MicroProfileActions.MP50, // 3.0
+                                                             MicroProfileActions.MP60);// 3.0+EE10
 
     private static final String appName = "basicEJBClientApp";
 
@@ -65,7 +67,7 @@ public class BasicEJBTest extends FATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         ShrinkHelper.defaultDropinApp(remoteAppServer, "basicRemoteApp", new DeployOptions[] {DeployOptions.OVERWRITE}, "remoteApp.basic");
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE9Action.isActive() | JakartaEE10Action.isActive()) {
             remoteAppServer.changeFeatures(Arrays.asList("componenttest-2.0", "restfulWS-3.0", "ssl-1.0", "jsonb-2.0"));
         }
         remoteAppServer.startServer();
@@ -73,6 +75,8 @@ public class BasicEJBTest extends FATServletClient {
         ShrinkHelper.defaultDropinApp(server, appName, "mpRestClient10.basicEJB");
         if (JakartaEE9Action.isActive()) {
             server.changeFeatures(Arrays.asList("componenttest-2.0", "mpRestClient-3.0", "mpConfig-3.0", "cdi-3.0", "enterpriseBeansLite-4.0", "jsonb-2.0"));
+        } else if (JakartaEE10Action.isActive()) {
+            server.changeFeatures(Arrays.asList("componenttest-2.0", "mpRestClient-3.0", "mpConfig-3.0", "cdi-4.0", "enterpriseBeansLite-4.0", "jsonb-3.0", "servlet-6.0"));
         }
         server.startServer();
     }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicTest.java
@@ -23,6 +23,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
@@ -43,7 +44,8 @@ public class BasicTest extends FATServletClient {
                                                              MicroProfileActions.MP30, // 1.3
                                                              MicroProfileActions.MP33, // 1.4
                                                              MicroProfileActions.MP40, // 2.0
-                                                             MicroProfileActions.MP50.addFeature("jsonb-2.0").build(MicroProfileActions.MP50_ID)); // 3.0
+                                                             MicroProfileActions.MP50, // 3.0
+                                                             MicroProfileActions.MP60);// 3.0+EE10
 
     private static final String appName = "basicClientApp";
 
@@ -65,7 +67,7 @@ public class BasicTest extends FATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         ShrinkHelper.defaultDropinApp(remoteAppServer, "basicRemoteApp", new DeployOptions[] {DeployOptions.OVERWRITE}, "remoteApp.basic");
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE9Action.isActive() | JakartaEE10Action.isActive()) {
             remoteAppServer.changeFeatures(Arrays.asList("componenttest-2.0", "restfulWS-3.0", "ssl-1.0", "jsonb-2.0"));
         }
         remoteAppServer.startServer();
@@ -74,6 +76,8 @@ public class BasicTest extends FATServletClient {
         ShrinkHelper.defaultDropinApp(server, appName, "mpRestClient10.basic");
         if (JakartaEE9Action.isActive()) {
             server.changeFeatures(Arrays.asList("componenttest-2.0", "mpRestClient-3.0", "ssl-1.0", "jsonb-2.0"));
+        } else if (JakartaEE10Action.isActive()) {
+            server.changeFeatures(Arrays.asList("componenttest-2.0", "mpRestClient-3.0", "ssl-1.0", "jsonb-3.0", "servlet-6.0"));
         }
         server.startServer();
         server.waitForStringInLog("CWWKO0219I.*ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/CollectionsTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/CollectionsTest.java
@@ -25,6 +25,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
@@ -45,7 +46,8 @@ public class CollectionsTest extends FATServletClient {
                                                              MicroProfileActions.MP30, // 1.3
                                                              MicroProfileActions.MP33, // 1.4
                                                              MicroProfileActions.MP40, // 2.0
-                                                             MicroProfileActions.MP50); // 3.0
+                                                             MicroProfileActions.MP50, // 3.0
+                                                             MicroProfileActions.MP60);// 3.0+EE10
 
     private static final String appName = "collectionsApp";
     public static final String YASSON_IMPL = "publish/shared/resources/yasson/";
@@ -72,7 +74,7 @@ public class CollectionsTest extends FATServletClient {
         app.addAsLibraries(new File(YASSON_IMPL).listFiles());
         app.addAsLibraries(new File(JSONB_API).listFiles());
         ShrinkHelper.exportDropinAppToServer(remoteAppServer, app, new DeployOptions[] {DeployOptions.OVERWRITE});
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE9Action.isActive() | JakartaEE10Action.isActive()) {
             remoteAppServer.changeFeatures(Arrays.asList("componenttest-2.0", "restfulWS-3.0", "ssl-1.0", "jsonb-2.0"));
         }
         remoteAppServer.startServer();
@@ -81,6 +83,8 @@ public class CollectionsTest extends FATServletClient {
         ShrinkHelper.defaultDropinApp(server, appName, "mpRestClient10.collections");
         if (JakartaEE9Action.isActive()) {
             server.changeFeatures(Arrays.asList("componenttest-2.0", "mpRestClient-3.0", "ssl-1.0", "jsonb-2.0"));
+        } else if (JakartaEE10Action.isActive()) {
+            server.changeFeatures(Arrays.asList("componenttest-2.0", "mpRestClient-3.0", "ssl-1.0", "jsonb-3.0", "servlet-6.0"));
         }
         server.startServer();
         server.waitForStringInLog("CWWKO0219I.*ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HandleResponsesTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HandleResponsesTest.java
@@ -23,6 +23,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
@@ -43,7 +44,8 @@ public class HandleResponsesTest extends FATServletClient {
                                                              MicroProfileActions.MP30, // 1.3
                                                              MicroProfileActions.MP33, // 1.4
                                                              MicroProfileActions.MP40, // 2.0
-                                                             MicroProfileActions.MP50); // 3.0
+                                                             MicroProfileActions.MP50, // 3.0
+                                                             MicroProfileActions.MP60);// 3.0+EE10
 
     private static final String appName = "handleresponsesApp";
 
@@ -65,7 +67,7 @@ public class HandleResponsesTest extends FATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         ShrinkHelper.defaultDropinApp(remoteAppServer, "basicRemoteApp", new DeployOptions[] {DeployOptions.OVERWRITE}, "remoteApp.basic");
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE9Action.isActive() | JakartaEE10Action.isActive()) {
             remoteAppServer.changeFeatures(Arrays.asList("componenttest-2.0", "restfulWS-3.0", "ssl-1.0", "jsonb-2.0"));
         }
         remoteAppServer.startServer();
@@ -74,6 +76,8 @@ public class HandleResponsesTest extends FATServletClient {
         ShrinkHelper.defaultDropinApp(server, appName, "mpRestClient10.handleresponses");
         if (JakartaEE9Action.isActive()) {
             server.changeFeatures(Arrays.asList("componenttest-2.0", "mpRestClient-3.0", "ssl-1.0", "jsonb-2.0"));
+        } else if (JakartaEE10Action.isActive()) {
+            server.changeFeatures(Arrays.asList("componenttest-2.0", "mpRestClient-3.0", "ssl-1.0", "jsonb-3.0", "servlet-6.0"));
         }
         server.startServer();
         server.waitForStringInLog("CWWKO0219I.*ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HeaderPropagation12Test.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HeaderPropagation12Test.java
@@ -40,7 +40,8 @@ public class HeaderPropagation12Test extends FATServletClient {
                                                              MicroProfileActions.MP30, // 1.3
                                                              MicroProfileActions.MP33, // 1.4
                                                              MicroProfileActions.MP40, // 2.0
-                                                             MicroProfileActions.MP50); // 3.0
+                                                             MicroProfileActions.MP50, // 3.0
+                                                             MicroProfileActions.MP60);// 3.0+EE10
 
     @Server(SERVER_NAME)
     @TestServlet(servlet = HeaderPropagationTestServlet.class, contextRoot = appName)

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HeaderPropagationTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HeaderPropagationTest.java
@@ -41,7 +41,8 @@ public class HeaderPropagationTest extends FATServletClient {
                                                              MicroProfileActions.MP30, // 1.3
                                                              MicroProfileActions.MP33, // 1.4
                                                              MicroProfileActions.MP40, // 2.0
-                                                             MicroProfileActions.MP50); // 3.0
+                                                             MicroProfileActions.MP50, // 3.0
+                                                             MicroProfileActions.MP60);// 3.0+EE10
 
     private static final String appName = "headerPropagationApp";
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HostnameVerifierTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HostnameVerifierTest.java
@@ -41,7 +41,8 @@ public class HostnameVerifierTest extends FATServletClient {
                                                              MicroProfileActions.MP30, //mpRestClient-1.3
                                                              MicroProfileActions.MP33, // 1.4
                                                              MicroProfileActions.MP40, // 2.0
-                                                             MicroProfileActions.MP50); // 3.0
+                                                             MicroProfileActions.MP50, // 3.0
+                                                             MicroProfileActions.MP60);// 3.0+EE10
 
     private static final String appName = "hostnameVerifierApp";
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/JsonbContextTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/JsonbContextTest.java
@@ -23,6 +23,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
@@ -41,7 +42,8 @@ public class JsonbContextTest extends FATServletClient {
                                                              MicroProfileActions.MP30, // 1.3
                                                              MicroProfileActions.MP33, // 1.4
                                                              MicroProfileActions.MP40, // 2.0
-                                                             MicroProfileActions.MP50); // 3.0
+                                                             MicroProfileActions.MP50, // 3.0
+                                                             MicroProfileActions.MP60);// 3.0+EE10
 
     private static final String appName = "jsonbContextApp";
 
@@ -55,7 +57,7 @@ public class JsonbContextTest extends FATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         ShrinkHelper.defaultDropinApp(remoteAppServer, "basicRemoteApp", new DeployOptions[] {DeployOptions.OVERWRITE}, "remoteApp.basic");
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE9Action.isActive() | JakartaEE10Action.isActive()) {
             remoteAppServer.changeFeatures(Arrays.asList("componenttest-2.0", "restfulWS-3.0", "ssl-1.0", "jsonb-2.0"));
         }
         remoteAppServer.startServer();

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/MultiClientCdiTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/MultiClientCdiTest.java
@@ -40,7 +40,8 @@ public class MultiClientCdiTest extends FATServletClient {
                                                              MicroProfileActions.MP30, // 1.3
                                                              MicroProfileActions.MP33, // 1.4
                                                              MicroProfileActions.MP40, // 2.0
-                                                             MicroProfileActions.MP50); // 3.0
+                                                             MicroProfileActions.MP50, // 3.0
+                                                             MicroProfileActions.MP60);// 3.0+EE10
 
     private static final String appName = "multiClientCdiApp";
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/ProduceConsumeTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/ProduceConsumeTest.java
@@ -43,7 +43,8 @@ public class ProduceConsumeTest extends FATServletClient {
                                                              MicroProfileActions.MP30, // 1.3
                                                              MicroProfileActions.MP33, // 1.4
                                                              MicroProfileActions.MP40, // 2.0
-                                                             MicroProfileActions.MP50); // 3.0
+                                                             MicroProfileActions.MP50, // 3.0
+                                                             MicroProfileActions.MP60);// 3.0+EE10
 
     @Server(SERVER_NAME)
     @TestServlet(servlet = ProduceConsumeTestServlet.class, contextRoot = appName)

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/PropsTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/PropsTest.java
@@ -39,7 +39,8 @@ public class PropsTest extends FATServletClient {
                                                              MicroProfileActions.MP30, // 1.3
                                                              MicroProfileActions.MP33, // 1.4
                                                              MicroProfileActions.MP40, // 2.0
-                                                             MicroProfileActions.MP50); // 3.0
+                                                             MicroProfileActions.MP50, // 3.0
+                                                             MicroProfileActions.MP60);// 3.0+EE10
 
     private static final String appName = "propsApp";
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/SseTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/SseTest.java
@@ -20,6 +20,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
@@ -36,8 +37,9 @@ public class SseTest extends FATServletClient {
     @ClassRule
     public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, 
                                                              MicroProfileActions.MP40, //mpRestClient-2.0
-                                                             MicroProfileActions.MP50, // 3.0
-                                                             MicroProfileActions.MP60);// 3.0+EE10
+                                                             MicroProfileActions.MP50); // 3.0
+                                                             // TODO: MP60 currently causes Java 2 security errors
+                                                             // MicroProfileActions.MP60);// 3.0+EE10
     /*
      * We need two servers to clearly distinguish that the "client" server
      * only has the client features enabled - it includes mpRestClient-1.0

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/SseTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/SseTest.java
@@ -36,7 +36,8 @@ public class SseTest extends FATServletClient {
     @ClassRule
     public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, 
                                                              MicroProfileActions.MP40, //mpRestClient-2.0
-                                                             MicroProfileActions.MP50); // 3.0
+                                                             MicroProfileActions.MP50, // 3.0
+                                                             MicroProfileActions.MP60);// 3.0+EE10
     /*
      * We need two servers to clearly distinguish that the "client" server
      * only has the client features enabled - it includes mpRestClient-1.0

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.basic.cdi/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.basic.cdi/server.xml
@@ -4,6 +4,7 @@
     <feature>mpRestClient-1.0</feature>
     <feature>mpConfig-1.1</feature>
     <feature>cdi-1.2</feature>
+    <feature>servlet-3.1</feature>
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.headerPropagation/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.headerPropagation/server.xml
@@ -4,6 +4,7 @@
     <feature>jaxrs-2.0</feature>
     <feature>mpRestClient-1.0</feature>
     <feature>appSecurity-2.0</feature>
+    <feature>servlet-4.0</feature>
   </featureManager>
 
   <ssl id="defaultSSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" />

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.multi.client.cdi/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.multi.client.cdi/server.xml
@@ -4,6 +4,7 @@
     <feature>mpRestClient-1.0</feature>
     <feature>mpConfig-1.1</feature>
     <feature>cdi-1.2</feature>
+    <feature>servlet-3.1</feature>
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.props/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.props/server.xml
@@ -3,6 +3,7 @@
     <feature>componenttest-1.0</feature>
     <feature>mpRestClient-1.0</feature>
     <feature>jaxrs-2.0</feature>
+    <feature>servlet-3.1</feature>
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.async/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.async/server.xml
@@ -5,6 +5,7 @@
         <feature>mpRestClient-1.1</feature>
         <feature>jsonb-1.0</feature>
         <feature>concurrent-1.0</feature>
+        <feature>servlet-4.0</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.produceConsume/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.produceConsume/server.xml
@@ -3,6 +3,7 @@
     <feature>componenttest-1.0</feature>
     <feature>mpRestClient-1.1</feature>
     <feature>ssl-1.0</feature>
+    <feature>servlet-4.0</feature>
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient12.headerPropagation/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient12.headerPropagation/server.xml
@@ -6,6 +6,7 @@
     <feature>mpConfig-1.3</feature>
     <feature>cdi-2.0</feature>
     <feature>appSecurity-3.0</feature>
+    <feature>servlet-4.0</feature>
   </featureManager>
 
   <ssl id="defaultSSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" />

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient12.jsonbContext/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient12.jsonbContext/server.xml
@@ -5,6 +5,7 @@
     <feature>jsonb-1.0</feature>
     <feature>mpRestClient-1.2</feature>
     <feature>ssl-1.0</feature>
+    <feature>servlet-4.0</feature>
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient13.ssl/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient13.ssl/server.xml
@@ -5,6 +5,7 @@
     <feature>jsonb-1.0</feature>
     <feature>mpRestClient-1.3</feature>
     <feature>ssl-1.0</feature>
+    <feature>servlet-4.0</feature>
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient20.sse/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient20.sse/server.xml
@@ -4,6 +4,7 @@
     <feature>mpRestClient-2.0</feature>
     <feature>jaxrs-2.1</feature>
     <feature>jsonb-1.0</feature>
+    <feature>servlet-4.0</feature>
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/basicClientApp/src/mpRestClient10/basic/BasicClientTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/basicClientApp/src/mpRestClient10/basic/BasicClientTestServlet.java
@@ -134,7 +134,7 @@ public class BasicClientTestServlet extends FATServlet {
     }
 
     @Test
-    @SkipForRepeat(MicroProfileActions.MP50_ID) // timeout property not supported in Rest Client 3.0 - use timeout method instead
+    @SkipForRepeat({MicroProfileActions.MP50_ID, MicroProfileActions.MP60_ID}) // timeout property not supported in Rest Client 3.0 - use timeout method instead
     public void testReadTimeout(HttpServletRequest req, HttpServletResponse resp) throws Exception {
         try {
             builder.property("com.ibm.ws.jaxrs.client.receive.timeout", "5");

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/handleresponsesApp/src/mpRestClient10/handleresponses/ClientTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/handleresponsesApp/src/mpRestClient10/handleresponses/ClientTestServlet.java
@@ -81,7 +81,7 @@ public class ClientTestServlet extends FATServlet {
     }
 
     @Test
-    @SkipForRepeat(MP50_ID) // EE9's Response#readEntity behaves differently when there is no entity - see test below
+    @SkipForRepeat({MP50_ID, MP60_ID}) // EE9's Response#readEntity behaves differently when there is no entity - see test below
     public void testEmpty202Response(HttpServletRequest req, HttpServletResponse res) throws Exception {
 
         Response r = builder.build(HandleResponsesClient.class).batchWidget(new Widget("Markers", 150, 0.2));

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/headerPropagation12App/src/mpRestClient12/headerPropagation/HeaderPropagationTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/headerPropagation12App/src/mpRestClient12/headerPropagation/HeaderPropagationTestServlet.java
@@ -110,7 +110,7 @@ public class HeaderPropagationTestServlet extends FATServlet {
     }
 
     @Test
-    @SkipForRepeat(MicroProfileActions.MP50_ID) // @Context injection not supported in ClientHeaderFactory instances in RESTEasy
+    @SkipForRepeat({MicroProfileActions.MP50_ID, MicroProfileActions.MP60_ID}) // @Context injection not supported in ClientHeaderFactory instances in RESTEasy
     public void testSendCustomHeaderViaFactory(HttpServletRequest req, HttpServletResponse resp) throws Exception {
 
         String allHeaders = ClientBuilder.newClient()
@@ -129,7 +129,7 @@ public class HeaderPropagationTestServlet extends FATServlet {
     }
 
     @Test
-    @SkipForRepeat(MicroProfileActions.MP50_ID) // @Context injection not supported in ClientHeaderFactory instances in RESTEasy
+    @SkipForRepeat({MicroProfileActions.MP50_ID, MicroProfileActions.MP60_ID}) // @Context injection not supported in ClientHeaderFactory instances in RESTEasy
     public void testSendCustomHeaderViaCDIEnabledFactory(HttpServletRequest req, HttpServletResponse resp) throws Exception {
 
         String allHeaders = ClientBuilder.newClient()

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/propsApp/src/mpRestClient10/props/PropsTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/propsApp/src/mpRestClient10/props/PropsTestServlet.java
@@ -34,7 +34,7 @@ public class PropsTestServlet extends FATServlet {
     private final static Logger _log = Logger.getLogger(PropsTestServlet.class.getName());
 
     @Test
-    @SkipForRepeat(MicroProfileActions.MP50_ID) // EE9 does not support keep-alive property
+    @SkipForRepeat({MicroProfileActions.MP50_ID, MicroProfileActions.MP60_ID}) // EE9 does not support keep-alive property
     public void testKeepAliveProp(HttpServletRequest req, HttpServletResponse resp) throws Exception {
         final String m = "testKeepAliveProp";
         int port = req.getServerPort();

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/sseApp/src/mpRestClient20/sse/SseClientTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/sseApp/src/mpRestClient20/sse/SseClientTestServlet.java
@@ -115,7 +115,7 @@ public class SseClientTestServlet extends FATServlet {
     }
 
     @Test
-    @SkipForRepeat(MicroProfileActions.MP50_ID) // RESTEasy does not auto-detect media types - users must register custom MBR
+    @SkipForRepeat({MicroProfileActions.MP50_ID, MicroProfileActions.MP60_ID}) // RESTEasy does not auto-detect media types - users must register custom MBR
     public void testPublisherSomeObject(HttpServletRequest req, HttpServletResponse resp) throws Exception {
         try (SseClient client = builder.build(SseClient.class)) {
             GenericSubscriber<SomeObject> subscriber = new GenericSubscriber<>(7);

--- a/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/bnd.bnd
@@ -17,6 +17,18 @@ src: \
 
 fat.project: true
 
+tested.features:\
+  restfulwsclient-3.0,\
+  restfulwsclient-3.1,\
+  jsonb-2.0,\
+  jsonb-3.0,\
+  jsonp-2.0,\
+  jsonp-2.1,\
+  cdi-3.0,\
+  cdi-4.0,\
+  servlet-5.0,\
+  servlet-6.0
+
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/build.gradle
+++ b/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/build.gradle
@@ -42,3 +42,5 @@ addRequiredLibraries {
   dependsOn addWiremockAndJetty
   dependsOn addHttpcore
 }
+
+addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -14,15 +14,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-
-import java.util.HashMap;
 import java.util.Map;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -31,10 +27,11 @@ import com.ibm.websphere.simplicity.log.Log;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.custom.junit.runner.TestModeFilter;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.custom.junit.runner.TestModeFilter;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.utils.MvnUtils;
 
 /**
@@ -43,8 +40,15 @@ import componenttest.topology.utils.MvnUtils;
  */
 @RunWith(FATRunner.class)
 public class RestClientTckPackageTest {
+    
+    public static final String SERVER_NAME = "FATServer";
+    
+    @ClassRule
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, 
+                                                             MicroProfileActions.MP50, // 3.0
+                                                             MicroProfileActions.MP60);// 3.0+EE10
 
-    @Server("FATServer")
+    @Server(SERVER_NAME)
     public static LibertyServer server;
 
     @BeforeClass


### PR DESCRIPTION
mpRestClient-3.0 will be included in both MP 5 and MP 6.

For #21968 