### PR TITLE
PR for Issue 21159: Nonce/request URL storage and OP discovery enhancements

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.op/bootstrap.properties
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.op/bootstrap.properties
@@ -12,6 +12,8 @@
 bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
+OpenIdConnect=all:\
+OPENIDCONNECT=all:\
 com.ibm.ws.security.oauth*=all=enabled:\
 com.ibm.ws.security.openidconnect*=all=enabled:\
 com.ibm.ws.security.jwt*=all=enabled:\

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rp/bootstrap.properties
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rp/bootstrap.properties
@@ -12,6 +12,8 @@
 bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
+OpenIdConnect=all:\
+OPENIDCONNECT=all:\
 com.ibm.ws.security.oauth*=all=enabled:\
 com.ibm.ws.security.openidconnect*=all=enabled:\
 com.ibm.ws.security.jwt*=all=enabled:\

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rpd/bootstrap.properties
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rpd/bootstrap.properties
@@ -12,6 +12,8 @@
 bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
+OpenIdConnect=all:\
+OPENIDCONNECT=all:\
 com.ibm.ws.security.oauth*=all=enabled:\
 com.ibm.ws.security.openidconnect*=all=enabled:\
 com.ibm.ws.security.jwt*=all=enabled:\

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rpd2/bootstrap.properties
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rpd2/bootstrap.properties
@@ -12,6 +12,8 @@
 bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
+OpenIdConnect=all:\
+OPENIDCONNECT=all:\
 com.ibm.ws.security.oauth*=all=enabled:\
 com.ibm.ws.security.openidconnect*=all=enabled:\
 com.ibm.ws.security.jwt*=all=enabled:\

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
@@ -911,7 +911,7 @@ public class OidcClientConfigImpl implements OidcClientConfig {
             SSLSocketFactory sslSocketFactory = getSSLSocketFactory(discoveryUrl, sslConfigurationName, sslSupportRef.getService());
             if (isRunningBetaMode()) {
                 DiscoveryHandler discoveryHandler = new DiscoveryHandler(sslSocketFactory);
-                jsonString = discoveryHandler.fetchDiscoveryData(discoveryUrl, hostNameVerificationEnabled, useSystemPropertiesForHttpClientConnections);
+                jsonString = discoveryHandler.fetchDiscoveryDataString(discoveryUrl, hostNameVerificationEnabled, useSystemPropertiesForHttpClientConnections);
             } else {
                 jsonString = fetchDiscoveryData(discoveryUrl, sslSocketFactory);
             }

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/web/OidcRedirectServlet.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/web/OidcRedirectServlet.java
@@ -37,6 +37,7 @@ import com.ibm.ws.security.openidconnect.clients.common.OidcUtil;
 import com.ibm.ws.security.openidconnect.common.Constants;
 import com.ibm.ws.webcontainer.security.openidconnect.OidcClient;
 
+import io.openliberty.security.oidcclientcore.storage.OidcClientStorageConstants;
 import io.openliberty.security.oidcclientcore.utils.Utils;
 
 /**
@@ -122,7 +123,7 @@ public class OidcRedirectServlet extends HttpServlet {
         //  when OIDCClientAuthenticatorUtil.doClientSideRedirect initially redirected the browser,
         //  this cookie was set to hold the original URL.
         //  Now it's time to get it back.
-        String cookieName = ClientConstants.WAS_REQ_URL_OIDC + Utils.getStrHashCode(state);
+        String cookieName = OidcClientStorageConstants.WAS_REQ_URL_OIDC + Utils.getStrHashCode(state);
         String requestUrl = OidcClientUtil.getReferrerURLCookieHandler().getReferrerURLFromCookies(request, cookieName);
         // 240540
         //CookieHelper.clearCookie(request, response, cookieName, cookies); //clear the WAS_REQ_URL_OIDC cookie

--- a/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/web/OidcRedirectServletTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/web/OidcRedirectServletTest.java
@@ -38,7 +38,6 @@ import com.ibm.oauth.core.api.error.oauth20.OAuth20Exception;
 import com.ibm.ws.security.openidconnect.client.Cache;
 import com.ibm.ws.security.openidconnect.client.internal.OidcClientConfigImpl;
 import com.ibm.ws.security.openidconnect.client.internal.OidcClientImpl;
-import com.ibm.ws.security.openidconnect.clients.common.ClientConstants;
 import com.ibm.ws.security.openidconnect.clients.common.OidcClientUtil;
 import com.ibm.ws.security.openidconnect.clients.common.OidcUtil;
 import com.ibm.ws.security.openidconnect.common.Constants;
@@ -47,6 +46,7 @@ import com.ibm.ws.webcontainer.security.SSOCookieHelperImpl;
 import com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl;
 import com.ibm.ws.webcontainer.security.WebAppSecurityConfig;
 
+import io.openliberty.security.oidcclientcore.storage.OidcClientStorageConstants;
 import io.openliberty.security.oidcclientcore.utils.Utils;
 import test.common.SharedOutputManager;
 
@@ -469,7 +469,7 @@ public class OidcRedirectServletTest {
                     allowing(cache).put(OidcUtil.encode(OIDC_STATE), table);
                     will(returnValue(new StringBuffer("https://austin.ibm.com:8020/a/b")));//
                     allowing(req).getCookies();
-                    will(returnValue(new Cookie[] { new Cookie(ClientConstants.WAS_REQ_URL_OIDC + Utils.getStrHashCode(OIDC_STATE), MODIFIED_REQUEST_URL) }));
+                    will(returnValue(new Cookie[] { new Cookie(OidcClientStorageConstants.WAS_REQ_URL_OIDC + Utils.getStrHashCode(OIDC_STATE), MODIFIED_REQUEST_URL) }));
                     one(resp).sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
                     allowing(webAppSecurityConfig).getWASReqURLRedirectDomainNames();
                     will(returnValue(wasReqURLRedirectDomainNames));
@@ -520,7 +520,7 @@ public class OidcRedirectServletTest {
                     will(returnValue(new StringBuffer("https://austin.ibm.com:8020/a/b")));//
 
                     allowing(req).getCookies();
-                    will(returnValue(new Cookie[] { new Cookie(ClientConstants.WAS_REQ_URL_OIDC + Utils.getStrHashCode(OIDC_STATE_SHORT), REQUEST_URL) }));
+                    will(returnValue(new Cookie[] { new Cookie(OidcClientStorageConstants.WAS_REQ_URL_OIDC + Utils.getStrHashCode(OIDC_STATE_SHORT), REQUEST_URL) }));
                     allowing(req).getRequestURI();
                     will(returnValue(REQUEST_URL));
                     allowing(resp).addCookie(with(any(Cookie.class)));
@@ -553,7 +553,7 @@ public class OidcRedirectServletTest {
         mock.checking(new Expectations() {
             {
                 allowing(req).getCookies();
-                will(returnValue(new Cookie[] { new Cookie(ClientConstants.WAS_REQ_URL_OIDC + Utils.getStrHashCode(OIDC_STATE), REQUEST_URL) }));
+                will(returnValue(new Cookie[] { new Cookie(OidcClientStorageConstants.WAS_REQ_URL_OIDC + Utils.getStrHashCode(OIDC_STATE), REQUEST_URL) }));
             }
         });
     }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/ClientConstants.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/ClientConstants.java
@@ -54,9 +54,7 @@ public class ClientConstants {
     public static final String IMPLICIT = Constants.IMPLICIT; // "implicit"
     public final static String AUTHORIZATION_CODE = "authorization_code";
     public static final String STATE = Constants.STATE; // "state";
-    public static final String WAS_REQ_URL_OIDC = "WASReqURLOidc";
     public static final String WAS_OIDC_CODE = "WASOidcCode";
-    public static final String WAS_OIDC_NONCE = "WASOidcNonce";
     public static final String WAS_OIDC_SESSION = "WASOidcSession";
 
     public final static String RESPONSEMAP_CODE = "RESPONSEMAP_CODE";

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtil.java
@@ -49,8 +49,8 @@ public class OIDCClientAuthenticatorUtil {
     SSLSupport sslSupport = null;
     private Jose4jUtil jose4jUtil = null;
     private static int badStateCount = 0;
-    public static final String[] OIDC_COOKIES = { OidcClientStorageConstants.WAS_OIDC_STATE_KEY, ClientConstants.WAS_REQ_URL_OIDC,
-            ClientConstants.WAS_OIDC_CODE, ClientConstants.WAS_OIDC_NONCE };
+    public static final String[] OIDC_COOKIES = { OidcClientStorageConstants.WAS_OIDC_STATE_KEY, OidcClientStorageConstants.WAS_REQ_URL_OIDC,
+            ClientConstants.WAS_OIDC_CODE, OidcClientStorageConstants.WAS_OIDC_NONCE };
 
     public OIDCClientAuthenticatorUtil() {
     }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/RedirectionProcessor.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/RedirectionProcessor.java
@@ -23,6 +23,7 @@ import com.ibm.ws.security.common.web.WebUtils;
 import com.ibm.ws.security.openidconnect.common.Constants;
 import com.ibm.ws.webcontainer.security.CookieHelper;
 
+import io.openliberty.security.oidcclientcore.storage.OidcClientStorageConstants;
 import io.openliberty.security.oidcclientcore.utils.Utils;
 
 /**
@@ -135,7 +136,7 @@ public class RedirectionProcessor {
     }
 
     private String getOriginalRequestUrl(String state) {
-        String cookieName = ClientConstants.WAS_REQ_URL_OIDC + Utils.getStrHashCode(state);
+        String cookieName = OidcClientStorageConstants.WAS_REQ_URL_OIDC + Utils.getStrHashCode(state);
         Cookie[] cookies = request.getCookies();
         String requestUrl = CookieHelper.getCookieValue(cookies, cookieName);
         OidcClientUtil.invalidateReferrerURLCookie(request, response, cookieName);

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcAuthorizationRequestTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcAuthorizationRequestTest.java
@@ -51,8 +51,6 @@ public class OidcAuthorizationRequestTest {
         }
     };
 
-    private static final String TEST_URL = "http://harmonic.austin.ibm.com:8010/formlogin/SimpleServlet";
-
     private final String authorizationEndpointUrl = "https://localhost:8020/oidc/op/authorize";
     private final String scope = "openid";
     private final String responseType = "code";
@@ -516,64 +514,8 @@ public class OidcAuthorizationRequestTest {
         }
     }
 
-    @Test
-    public void test_getReqUrlNull() {
-        try {
-            createReqUrlExpectations(null);
-            String strUrl = oidcAuthzReq.getReqURL();
-
-            assertEquals("The URL must not contain a query string.", TEST_URL, strUrl);
-        } catch (Throwable t) {
-            outputMgr.failWithThrowable(testName.getMethodName(), t);
-        }
-    }
-
-    @Test
-    public void test_getReqUrlQuery() {
-        try {
-            final String query = "response_type=code";
-            createReqUrlExpectations(query);
-            String strUrl = oidcAuthzReq.getReqURL();
-            String expect = TEST_URL + "?" + query;
-
-            assertEquals("The URL must contain the query string.", expect, strUrl);
-        } catch (Throwable t) {
-            outputMgr.failWithThrowable(testName.getMethodName(), t);
-        }
-    }
-
-    @Test
-    public void test_getReqUrlQuery_withSpecialCharacters() {
-        try {
-            String value = "code>\"><script>alert(100)</script>";
-            final String query = "response_type=" + value;
-            createReqUrlExpectations(query);
-            String strUrl = oidcAuthzReq.getReqURL();
-            String expect = TEST_URL + "?response_type=" + value;
-
-            assertEquals("The URL must contain the unencoded query string.", expect, strUrl);
-        } catch (Throwable t) {
-            outputMgr.failWithThrowable(testName.getMethodName(), t);
-        }
-    }
-
     private AuthorizationRequestParameters createDefaultAuthorizationRequestParameters() {
         return new AuthorizationRequestParameters(authorizationEndpointUrl, scope, responseType, clientId, redirectUri, state);
-    }
-
-    private void createReqUrlExpectations(final String queryString) {
-        mock.checking(new Expectations() {
-            {
-                allowing(request).getScheme();
-                will(returnValue("https"));
-                one(request).getServerPort();
-                will(returnValue(8020));
-                one(request).getRequestURL();
-                will(returnValue(new StringBuffer(TEST_URL)));
-                one(request).getQueryString();
-                will(returnValue(queryString));
-            }
-        });
     }
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
+++ b/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
@@ -43,10 +43,12 @@ Export-Package: \
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
 	com.ibm.ws.webcontainer;version=latest,\
 	com.ibm.ws.webcontainer.security;version=latest,\
-	com.ibm.ws.org.apache.commons.lang3;version=latest, \
+	com.ibm.ws.org.apache.commons.lang3;version=latest,\
 	com.ibm.ws.ssl;version=latest,\
 	com.ibm.ws.webcontainer;version=latest,\
-	com.ibm.ws.common.encoder;version=latest
+	com.ibm.ws.common.encoder;version=latest,\
+	com.ibm.ws.kernel.service;version=latest,\
+	com.ibm.websphere.org.osgi.core;version=latest
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file,\

--- a/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
+++ b/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
@@ -29,7 +29,7 @@ URL_NOT_HTTPS=CWWKS2402E: The {0} endpoint URL that is configured for the {1} Op
 URL_NOT_HTTPS.explanation=The endpoint URL must use the HTTPS protocol to ensure that requests are secure.
 URL_NOT_HTTPS.useraction=Update the endpoint URL to use the HTTPS protocol.
 
-DISCOVERY_EXCEPTION=CWWKS2403E: The {0} OpenID Connect client encountered an error while discovering metadata for the OpenID Connect provider from the [{1}] URL. {2}
+DISCOVERY_EXCEPTION=CWWKS2403E: The {0} OpenID Connect client encountered the following error during discovery of metadata for the OpenID Connect provider from the [{1}] URL: {2}
 DISCOVERY_EXCEPTION.explanation=The OpenID Connect client configuration might be missing information, or the client encountered an error while communicating with the OpenID Connect provider.
 DISCOVERY_EXCEPTION.useraction=See the error in the message for more information.
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
+++ b/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
@@ -29,10 +29,18 @@ URL_NOT_HTTPS=CWWKS2402E: The {0} endpoint URL that is configured for the {1} Op
 URL_NOT_HTTPS.explanation=The endpoint URL must use the HTTPS protocol to ensure that requests are secure.
 URL_NOT_HTTPS.useraction=Update the endpoint URL to use the HTTPS protocol.
 
-DISCOVERY_EXCEPTION=CWWKS2403E: The {0} OpenID Connect client encountered an error while discovering metadata for the OpenID Connect provider. {1}
+DISCOVERY_EXCEPTION=CWWKS2403E: The {0} OpenID Connect client encountered an error while discovering metadata for the OpenID Connect provider from the [{1}] URL. {2}
 DISCOVERY_EXCEPTION.explanation=The OpenID Connect client configuration might be missing information, or the client encountered an error while communicating with the OpenID Connect provider.
 DISCOVERY_EXCEPTION.useraction=See the error in the message for more information.
 
 OIDC_CLIENT_MISSING_PROVIDER_URI=CWWKS2404E: The providerURI attribute for the {0} OpenID Connect client is null or empty, and there is no metadata available for the OpenID Connect provider.
 OIDC_CLIENT_MISSING_PROVIDER_URI.explanation=The OpenID Connect client must discover metadata for the OpenID Connect provider, but the client does not have a providerURI attribute or provider metadata configured.
 OIDC_CLIENT_MISSING_PROVIDER_URI.useraction=Specify a value for the providerURI attribute in the OpenID Connect client configuration, or specify OpenID Connect provider metadata in the client configuration.
+
+DISCOVERY_METADATA_MISSING_VALUE=CWWKS2405E: The OpenID Connect provider metadata is missing the required [{0}] property.
+DISCOVERY_METADATA_MISSING_VALUE.explanation=The property that is specified in the message must be present in the OpenID Connect provider metadata, but it is missing.
+DISCOVERY_METADATA_MISSING_VALUE.useraction=Verify that the providerURI attribute for the OpenID Connect client is set to the correct discovery URL for the OpenID Connect provider.
+
+ERROR_BUILDING_AUTHORIZATION_ENDPOINT_URL=CWWKS2406E: The {0} OpenID Connect client cannot redirect the user to the authorization endpoint because the client cannot determine the authorization endpoint URL. {1}
+ERROR_BUILDING_AUTHORIZATION_ENDPOINT_URL.explanation=The authorization endpoint URL in the OpenID Connect client configuration might be malformed or missing, or the OpenID Connect client failed to obtain the authorization endpoint URL from the OpenID Connect provider.
+ERROR_BUILDING_AUTHORIZATION_ENDPOINT_URL.useraction=See the error in the message for more information. Verify that the OpenID Connect client configuration is complete and accurate.

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationRequest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationRequest.java
@@ -60,9 +60,19 @@ public abstract class AuthorizationRequest {
 
     protected abstract String createStateValueForStorage(String state);
 
+    protected abstract String createNonceValueForStorage(String nonce, String state);
+
+    protected abstract ProviderAuthenticationResult redirectToAuthorizationEndpoint(String state, String redirectUrl);
+
     protected StorageProperties getStateStorageProperties() {
         StorageProperties props = new StorageProperties();
         props.setStorageLifetimeSeconds(OidcClientStorageConstants.DEFAULT_STATE_STORAGE_LIFETIME_SECONDS);
+        return props;
+    }
+
+    protected StorageProperties getOriginalRequestUrlStorageProperties() {
+        StorageProperties props = new StorageProperties();
+        props.setStorageLifetimeSeconds(OidcClientStorageConstants.DEFAULT_REQ_URL_STORAGE_LIFETIME_SECONDS);
         return props;
     }
 
@@ -73,6 +83,19 @@ public abstract class AuthorizationRequest {
         storage.store(storageName, storageValue, stateStorageProperties);
     }
 
+    protected void storeNonceValue(String nonce, String state) {
+        String storageName = OidcStorageUtils.getStorageKey(OidcClientStorageConstants.WAS_OIDC_NONCE, clientId, state);
+        String storageValue = createNonceValueForStorage(nonce, state);
+        storage.store(storageName, storageValue);
+    }
+
+    protected void storeOriginalRequestUrl(String state) {
+        String storageName = OidcClientStorageConstants.WAS_REQ_URL_OIDC + Utils.getStrHashCode(state);
+        String storageValue = requestUtils.getRequestUrl(request);
+        StorageProperties reqUrlStorageProperties = getOriginalRequestUrlStorageProperties();
+        storage.store(storageName, storageValue, reqUrlStorageProperties);
+    }
+
     void createSessionIfNecessary() {
         if (shouldCreateSession()) {
             try {
@@ -81,11 +104,6 @@ public abstract class AuthorizationRequest {
                 // ignore it. Session exists
             }
         }
-    }
-
-    protected ProviderAuthenticationResult redirectToAuthorizationEndpoint(String state, String redirectUrl) {
-        // TODO
-        return null;
     }
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationRequestParameters.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationRequestParameters.java
@@ -34,6 +34,7 @@ public class AuthorizationRequestParameters {
     public static final String NONCE = "nonce";
     public static final String PROMPT = "prompt";
     public static final String ACR_VALUES = "acr_values";
+    public static final String DISPLAY = "display";
 
     private final String authorizationEndpointUrl;
     private final String scope;

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationRequestUtils.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationRequestUtils.java
@@ -12,6 +12,8 @@ package io.openliberty.security.oidcclientcore.authentication;
 
 import javax.servlet.http.HttpServletRequest;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.security.common.crypto.HashUtils;
@@ -21,8 +23,13 @@ import io.openliberty.security.oidcclientcore.utils.Utils;
 
 public class AuthorizationRequestUtils {
 
-    String generateStateValue(HttpServletRequest request) {
-        String strRandom = RandomUtils.getRandomAlphaNumeric(9);
+    public static final TraceComponent tc = Tr.register(AuthorizationRequestUtils.class);
+
+    public static final int STATE_LENGTH = 9;
+    public static final int NONCE_LENGTH = 20;
+
+    public String generateStateValue(HttpServletRequest request) {
+        String strRandom = RandomUtils.getRandomAlphaNumeric(STATE_LENGTH);
         String timestamp = Utils.getTimeStamp();
         String state = timestamp + strRandom;
         if (request != null && !request.getMethod().equalsIgnoreCase("GET") && request.getParameter("oidc_client") != null) {
@@ -38,6 +45,53 @@ public class AuthorizationRequestUtils {
         String newValue = state + clientSecret; // state already has a timestamp in it
         String value = HashUtils.digest(newValue);
         return timestamp + value;
+    }
+
+    public String generateNonceValue() {
+        return RandomUtils.getRandomAlphaNumeric(NONCE_LENGTH);
+    }
+
+    public String getRequestUrl(HttpServletRequest request) {
+        // due to some longstanding webcontainer strangeness, we have to do some extra things for certain behind-proxy cases to get the right port.
+        boolean rewritePort = false;
+        Integer realPort = null;
+        if (request.getScheme().toLowerCase().contains("https")) {
+            realPort = new com.ibm.ws.security.common.web.WebUtils().getRedirectPortFromRequest(request);
+        }
+        int port = request.getServerPort();
+        if (realPort != null && realPort.intValue() != port) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "serverport = " + port + "real port is " + realPort.toString() + ", url will be rewritten to use real port");
+            }
+            rewritePort = true;
+        }
+
+        StringBuffer requestURL = request.getRequestURL();
+        if (rewritePort) {
+            requestURL = rewritePortInRequestUrl(request, realPort);
+        }
+        requestURL = appendQueryString(request, requestURL);
+        return requestURL.toString();
+    }
+
+    StringBuffer rewritePortInRequestUrl(HttpServletRequest request, int realPort) {
+        StringBuffer requestURL = new StringBuffer();
+        requestURL.append(request.getScheme());
+        requestURL.append("://");
+        requestURL.append(request.getServerName());
+        requestURL.append(":");
+        requestURL.append(realPort);
+        requestURL.append(request.getRequestURI());
+        return requestURL;
+    }
+
+    StringBuffer appendQueryString(HttpServletRequest request, StringBuffer requestURL) {
+        String queryString = request.getQueryString();
+        if (queryString != null) {
+            requestURL.append("?");
+            requestURL.append(queryString);
+        }
+        return requestURL;
     }
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/discovery/DiscoveryHandler.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/discovery/DiscoveryHandler.java
@@ -12,10 +12,12 @@ package io.openliberty.security.oidcclientcore.discovery;
 
 import javax.net.ssl.SSLSocketFactory;
 
-//import com.ibm.json.java.JSONObject;
+import com.ibm.json.java.JSONObject;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.security.common.http.HttpUtils;
+
+import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
 
 public class DiscoveryHandler {
 
@@ -29,7 +31,16 @@ public class DiscoveryHandler {
         this.httpUtils = new HttpUtils();
     }
 
-    public String fetchDiscoveryData(String discoveryUrl, boolean hostNameVerificationEnabled, boolean useSystemProperties) throws Exception {
+    public JSONObject fetchDiscoveryDataJson(String discoveryUri, String clientId) throws OidcDiscoveryException {
+        try {
+            String jsonString = fetchDiscoveryDataString(discoveryUri, true, false);
+            return JSONObject.parse(jsonString);
+        } catch (Exception e) {
+            throw new OidcDiscoveryException(clientId, discoveryUri, e.getMessage());
+        }
+    }
+
+    public String fetchDiscoveryDataString(String discoveryUrl, boolean hostNameVerificationEnabled, boolean useSystemProperties) throws Exception {
         return httpUtils.getHttpJsonRequest(sslSocketFactory, discoveryUrl, hostNameVerificationEnabled, useSystemProperties);
     }
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/discovery/OidcDiscoveryConstants.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/discovery/OidcDiscoveryConstants.java
@@ -10,12 +10,10 @@
  *******************************************************************************/
 package io.openliberty.security.oidcclientcore.discovery;
 
-/**
- *
- */
-public class TraceConstants {
+public class OidcDiscoveryConstants {
 
-    public static final String TRACE_GROUP = "OpenIdConnect";
-    public static final String MESSAGE_BUNDLE = "io.openliberty.security.oidcclientcore.internal.resources.OidcClientCoreMessages";
+    public static final String METADATA_KEY_AUTHORIZATION_ENDPOINT = "authorization_endpoint";
+
+    public static final String WELL_KNOWN_SUFFIX = ".well-known/openid-configuration";
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/OidcDiscoveryException.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/OidcDiscoveryException.java
@@ -19,8 +19,8 @@ public class OidcDiscoveryException extends Exception {
 
     private static final long serialVersionUID = 1L;
 
-    public OidcDiscoveryException(String clientId, String nlsMessage) {
-        super(Tr.formatMessage(tc, "DISCOVERY_EXCEPTION", clientId, nlsMessage));
+    public OidcDiscoveryException(String clientId, String discoveryUrl, String exceptionMessage) {
+        super(Tr.formatMessage(tc, "DISCOVERY_EXCEPTION", clientId, discoveryUrl, exceptionMessage));
     }
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/CookieBasedStorage.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/CookieBasedStorage.java
@@ -47,6 +47,10 @@ public class CookieBasedStorage implements Storage {
     @Override
     public void store(String name, @Sensitive String value, StorageProperties properties) {
         Cookie c = referrerURLCookieHandler.createCookie(name, value, request);
+        String domainName = webSsoUtils.getSsoDomain(request);
+        if (domainName != null && !domainName.isEmpty()) {
+            c.setDomain(domainName);
+        }
         if (properties != null) {
             setAdditionalCookieProperties(c, (CookieStorageProperties) properties);
         }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/OidcClientStorageConstants.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/OidcClientStorageConstants.java
@@ -13,7 +13,10 @@ package io.openliberty.security.oidcclientcore.storage;
 public class OidcClientStorageConstants {
 
     public static final String WAS_OIDC_STATE_KEY = "WASOidcState";
+    public static final String WAS_OIDC_NONCE = "WASOidcNonce";
+    public static final String WAS_REQ_URL_OIDC = "WASReqURLOidc";
 
     public static final int DEFAULT_STATE_STORAGE_LIFETIME_SECONDS = 420;
+    public static final int DEFAULT_REQ_URL_STORAGE_LIFETIME_SECONDS = DEFAULT_STATE_STORAGE_LIFETIME_SECONDS;
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/OidcStorageUtils.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/OidcStorageUtils.java
@@ -18,42 +18,24 @@ import io.openliberty.security.oidcclientcore.utils.Utils;
 
 public class OidcStorageUtils {
 
-    @Sensitive
     @Trivial
-    public static String createStateStorageValue(String state, String clientSecret) {
+    public static String createStateStorageValue(String state, @Sensitive String clientSecret) {
         String newValue = state + clientSecret; // state already has a timestamp in it
         String hashedStateValue = HashUtils.digest(newValue);
         String timestamp = state.substring(0, Utils.TIMESTAMP_LENGTH);
         return timestamp + hashedStateValue;
     }
 
+    public static String createNonceStorageValue(String nonceValue, String state, @Sensitive String clientSecret) {
+        return HashUtils.digest(nonceValue + state + clientSecret);
+    }
+
     @Sensitive
     @Trivial
-    public static String getCookieName(String prefix, String configId, String state) {
+    public static String getStorageKey(String prefix, String configId, String state) {
         String newValue = state + configId;
         String newName = Utils.getStrHashCode(newValue);
         return prefix + newName;
     }
-
-//    public void createAndAddCookie(String cookieName, String cookieValue, int cookieLifetime, boolean isHttpsRequired) {
-//        Cookie c = webSsoUtils.createCookie(cookieName, cookieValue, cookieLifetime, request);
-//        boolean isHttpsRequest = request.getScheme().toLowerCase().contains("https");
-//        if (isHttpsRequired && isHttpsRequest) {
-//            c.setSecure(true);
-//        }
-//        response.addCookie(c);
-//    }
-
-//    @Trivial
-//    public static void createNonceCookie(HttpServletRequest request, HttpServletResponse response, String nonceValue, String state, ConvergedClientConfig clientConfig) {
-//        String cookieName = getCookieName(ClientConstants.WAS_OIDC_NONCE, clientConfig, state);
-//        String cookieValue = createNonceCookieValue(nonceValue, state, clientConfig);
-//        Cookie cookie = OidcClientUtil.createCookie(cookieName, cookieValue, request);
-//        response.addCookie(cookie);
-//    }
-//
-//    public static String createNonceCookieValue(String nonceValue, String state, String clientSecret) {
-//        return HashUtils.digest(nonceValue + state + clientSecret);
-//    }
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/authentication/AuthorizationRequestUtilsTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/authentication/AuthorizationRequestUtilsTest.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oidcclientcore.authentication;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.jmock.Expectations;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import test.common.SharedOutputManager;
+
+public class AuthorizationRequestUtilsTest extends CommonTestClass {
+
+    protected static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+
+    private final HttpServletRequest request = mockery.mock(HttpServletRequest.class);
+
+    private final String testUrl = "http://localhost:8010/formlogin/SimpleServlet";
+
+    private AuthorizationRequestUtils requestUtils;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void setUp() {
+        requestUtils = new AuthorizationRequestUtils();
+    }
+
+    @After
+    public void tearDown() {
+        outputMgr.resetStreams();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    @Test
+    public void test_getRequestUrl_noQueryString() {
+        try {
+            createReqUrlExpectations(null);
+            String strUrl = requestUtils.getRequestUrl(request);
+
+            assertEquals("The URL must not contain a query string.", testUrl, strUrl);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_getRequestUrl_withQueryString() {
+        try {
+            final String query = "response_type=code";
+            createReqUrlExpectations(query);
+            String strUrl = requestUtils.getRequestUrl(request);
+            String expect = testUrl + "?" + query;
+
+            assertEquals("The URL must contain the query string.", expect, strUrl);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_getRequestUrl_queryWithSpecialCharacters() {
+        try {
+            String value = "code>\"><script>alert(100)</script>";
+            final String query = "response_type=" + value;
+            createReqUrlExpectations(query);
+            String strUrl = requestUtils.getRequestUrl(request);
+            String expect = testUrl + "?response_type=" + value;
+
+            assertEquals("The URL must contain the unencoded query string.", expect, strUrl);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    private void createReqUrlExpectations(final String queryString) {
+        mockery.checking(new Expectations() {
+            {
+                allowing(request).getScheme();
+                will(returnValue("https"));
+                one(request).getServerPort();
+                will(returnValue(8020));
+                one(request).getRequestURL();
+                will(returnValue(new StringBuffer(testUrl)));
+                one(request).getQueryString();
+                will(returnValue(queryString));
+            }
+        });
+    }
+
+}

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/storage/OidcStorageUtilsTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/storage/OidcStorageUtilsTest.java
@@ -19,6 +19,7 @@ import org.junit.rules.TestName;
 import com.ibm.ws.security.common.crypto.HashUtils;
 import com.ibm.ws.security.common.random.RandomUtils;
 
+import io.openliberty.security.oidcclientcore.authentication.AuthorizationRequestUtils;
 import io.openliberty.security.oidcclientcore.utils.Utils;
 import test.common.SharedOutputManager;
 
@@ -29,12 +30,12 @@ public class OidcStorageUtilsTest {
     @Rule
     public TestName testName = new TestName();
 
-    String strRandom = RandomUtils.getRandomAlphaNumeric(9);
+    String strRandom = RandomUtils.getRandomAlphaNumeric(AuthorizationRequestUtils.STATE_LENGTH);
     String timestamp = Utils.getTimeStamp();
     String state = timestamp + strRandom;
 
     @Test
-    public void testCreateStateCookieValue() {
+    public void test_createStateStorageValue() {
         String cookieValue = OidcStorageUtils.createStateStorageValue(state, "secret");
         String timestamp = state.substring(0, Utils.TIMESTAMP_LENGTH);
         String newValue = state + "secret";
@@ -44,12 +45,12 @@ public class OidcStorageUtilsTest {
     }
 
     @Test
-    public void testGetCookieName() {
-        String cookieName = OidcStorageUtils.getCookieName("WASOidc", "client01", state);
+    public void test_getStorageKey() {
+        String storageKey = OidcStorageUtils.getStorageKey("WASOidc", "client01", state);
         String newValue = state + "client01";
         String newName = Utils.getStrHashCode(newValue);
-        String expectedCookieName = "WASOidc" + newName;
-        assertEquals(expectedCookieName, cookieName);
+        String expectedStorageKey = "WASOidc" + newName;
+        assertEquals(expectedStorageKey, storageKey);
     }
 
 }


### PR DESCRIPTION
- Update authentication dialog to use storage subsystem for nonce and original request URL values
- Jakarta authentication dialog discovery enhancements:
    - Adds a caching mechanism for OP metadata to avoid sending discovery requests too often
    - Adds the bulk of the remaining code to perform OP discovery
- Added code to Jakarta authentication dialog to redirect to the authorization endpoint with all appropriate request parameters included
    - Includes required parameters (scope, response type, client ID, redirect URI, and state)
    - Includes optional parameters depending on the OIDC client config (nonce, prompt, response mode, display, extra parameters)

For #21159