### PR TITLE
Added "overwrite" deployment option to ShrinkHelper methods in test a…

### DIFF
--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/BasicServletTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/BasicServletTest.java
@@ -14,7 +14,6 @@ import static io.openliberty.checkpoint.fat.FATSuite.getTestMethodName;
 import static org.junit.Assert.assertNotNull;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -23,6 +22,7 @@ import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import app1.TestServletA;
 import componenttest.annotation.Server;
@@ -53,7 +53,7 @@ public class BasicServletTest extends FATServletClient {
 
     @BeforeClass
     public static void copyAppToDropins() throws Exception {
-        ShrinkHelper.defaultApp(server, APP_NAME, "app1");
+        ShrinkHelper.defaultApp(server, APP_NAME, new DeployOptions[] { DeployOptions.OVERWRITE }, "app1");
         FATSuite.copyAppsAppToDropins(server, APP_NAME);
     }
 
@@ -72,11 +72,6 @@ public class BasicServletTest extends FATServletClient {
     @After
     public void tearDown() throws Exception {
         server.stopServer();
-    }
-
-    @AfterClass
-    public static void removeWebApp() throws Exception {
-        ShrinkHelper.cleanAllExportedArchives();
     }
 
 }

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/CheckpointPhaseTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/CheckpointPhaseTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertNotNull;
 import java.util.Set;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -27,6 +26,7 @@ import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 
 import componenttest.annotation.Server;
@@ -55,7 +55,7 @@ public class CheckpointPhaseTest {
 
     @BeforeClass
     public static void setUpClass() throws Exception {
-        ShrinkHelper.defaultApp(server, APP_NAME, "app2");
+        ShrinkHelper.defaultApp(server, APP_NAME, new DeployOptions[] { DeployOptions.OVERWRITE }, "app2");
         FATSuite.copyAppsAppToDropins(server, APP_NAME);
     }
 
@@ -132,11 +132,6 @@ public class CheckpointPhaseTest {
     @After
     public void tearDown() throws Exception {
         server.stopServer();
-    }
-
-    @AfterClass
-    public static void removeWebApp() throws Exception {
-        ShrinkHelper.cleanAllExportedArchives();
     }
 
 }

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/LogsVerificationTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/LogsVerificationTest.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -28,6 +27,7 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.RemoteFile;
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipIfCheckpointNotSupported;
@@ -54,7 +54,7 @@ public class LogsVerificationTest {
 
     @BeforeClass
     public static void setUpClass() throws Exception {
-        ShrinkHelper.defaultApp(server, APP_NAME, "app2");
+        ShrinkHelper.defaultApp(server, APP_NAME, new DeployOptions[] { DeployOptions.OVERWRITE }, "app2");
         FATSuite.copyAppsAppToDropins(server, APP_NAME);
     }
 
@@ -167,11 +167,6 @@ public class LogsVerificationTest {
     @After
     public void tearDown() throws Exception {
         server.stopServer();
-    }
-
-    @AfterClass
-    public static void removeWebApp() throws Exception {
-        ShrinkHelper.cleanAllExportedArchives();
     }
 
 }

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/MPFaultToleranceTimeoutTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/MPFaultToleranceTimeoutTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 
 import componenttest.annotation.Server;
@@ -37,7 +38,7 @@ public class MPFaultToleranceTimeoutTest {
 
     @BeforeClass
     public static void copyAppToDropins() throws Exception {
-        ShrinkHelper.defaultApp(server, APP_NAME, "timeoutTest");
+        ShrinkHelper.defaultApp(server, APP_NAME, new DeployOptions[] { DeployOptions.OVERWRITE }, "timeoutTest");
         FATSuite.copyAppsAppToDropins(server, APP_NAME);
     }
 

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/OSGiConsoleTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/OSGiConsoleTest.java
@@ -14,7 +14,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -23,6 +22,7 @@ import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 
 import componenttest.annotation.Server;
@@ -52,7 +52,7 @@ public class OSGiConsoleTest {
 
     @BeforeClass
     public static void setUpClass() throws Exception {
-        ShrinkHelper.defaultApp(server, APP_NAME, "app2");
+        ShrinkHelper.defaultApp(server, APP_NAME, new DeployOptions[] { DeployOptions.OVERWRITE }, "app2");
         FATSuite.copyAppsAppToDropins(server, APP_NAME);
     }
 
@@ -81,11 +81,6 @@ public class OSGiConsoleTest {
     @After
     public void tearDown() throws Exception {
         server.stopServer();
-    }
-
-    @AfterClass
-    public static void removeWebApp() throws Exception {
-        ShrinkHelper.cleanAllExportedArchives();
     }
 
 }

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/RESTclientTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/RESTclientTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 
 import componenttest.annotation.Server;
@@ -70,7 +71,7 @@ public class RESTclientTest {
                         .addClass(ServerApp.class)
                         .addClass(ServerEndpoint.class);
 
-        ShrinkHelper.exportAppToServer(server, webappWar);
+        ShrinkHelper.exportAppToServer(server, webappWar, DeployOptions.OVERWRITE);
     }
 
     @Test


### PR DESCRIPTION
…pplications

The DefaultApp and ExportToServer methods of the ShrinkHelper class include the overwrite option in the BasicServletTest, CheckpointPhaseTest, LogsVerificationTest, MPFaultToleranceTimeouTest, OSGiConsoleTest, and RESTclientTest classes. This ensures that the exported archive will be overwritten if it exists. This is necessary for running repeated tests with test classes that use the same application.