### PR TITLE
Fix Admin Center Explore tool error dialog text layout problem

### DIFF
--- a/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/cssShared/dialog.css
+++ b/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/cssShared/dialog.css
@@ -181,6 +181,7 @@ svg.yesNoDescriptionIcon {
 .confirmDescriptionText {
     display: inline-block;
     box-sizing: border-box; 
+    word-break: break-word;
 }
 
 .confirmOkButton {


### PR DESCRIPTION
When the error dialog includes a continuous long string of text without a breaking character in it (eg. hyphen), the text will overflow the content box in the dialog. To fix this problem, add css to break long continuous text in the dialog to avoid overflow.

Without the fix:

![image](https://user-images.githubusercontent.com/25039033/185240529-547cbd70-e045-4cd4-be2e-20a0a95108b7.png)


With the fix:

![image](https://user-images.githubusercontent.com/25039033/185240462-1a7acdcb-69cd-4e00-af90-116e7347914b.png)
