### PR TITLE
Rest client FAT review comments

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/ProduceConsumeTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/ProduceConsumeTest.java
@@ -38,7 +38,8 @@ public class ProduceConsumeTest extends FATServletClient {
 
     @ClassRule
     public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, 
-                                                             MicroProfileActions.MP20, //mpRestClient-1.1
+                                                             MicroProfileActions.MP14, // 1.1 + EE7
+                                                             MicroProfileActions.MP20, // 1.1 + EE8
                                                              MicroProfileActions.MP22, // 1.2
                                                              MicroProfileActions.MP30, // 1.3
                                                              MicroProfileActions.MP33, // 1.4

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.headerPropagation/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.headerPropagation/server.xml
@@ -4,7 +4,7 @@
     <feature>jaxrs-2.0</feature>
     <feature>mpRestClient-1.0</feature>
     <feature>appSecurity-2.0</feature>
-    <feature>servlet-4.0</feature>
+    <feature>servlet-3.1</feature>
   </featureManager>
 
   <ssl id="defaultSSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" />

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.produceConsume/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.produceConsume/server.xml
@@ -3,7 +3,7 @@
     <feature>componenttest-1.0</feature>
     <feature>mpRestClient-1.1</feature>
     <feature>ssl-1.0</feature>
-    <feature>servlet-4.0</feature>
+    <feature>servlet-3.1</feature>
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>


### PR DESCRIPTION
Rest client FAT review comments for #22141

Although ProduceConsumeTest specified that it ran on MP20 which is based on EE8, it didn't have any EE features in the server.xml so it would actually have run on EE7. Now that it has servlet in the server.xml, update the test so that it runs with  mpRestClient-1.1 on both EE7 and EE8.

Fix the header.propagation server.xml to use servlet-3.1 to match the other EE7 features listed. This didn't cause a failure because the features in the server.xml will be overwritten by the repeat action in the test, but it's confusing to have a mismatch of features.