### PR TITLE
Modify FAT to test usernames with special characters

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/SecurityContextEJBTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/SecurityContextEJBTest.java
@@ -153,7 +153,7 @@ public class SecurityContextEJBTest extends JavaEESecTestBase {
 
         String queryString = "/securitycontextejbinwar/SimpleEJBInServlet?testInstance=ejb02&testMethod=employee";
 
-        String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, "user99", "user99pwd",
+        String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, "user\\ |1$", "specialCharUserPwd",
                                                           HttpServletResponse.SC_OK);
         verifySecurityContextResponse(response, "getCallerPrincipal()=" + "user", "isCallerInRole(Employee)=true");
 

--- a/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.ejb.fat/server.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.ejb.fat/server.xml
@@ -31,8 +31,11 @@
 		</group>
 		<user name="user6" password="user6pwd" /> 
 		<user name="user98" password="user98pwd" /> 
-		<user name="user99" password="user99pwd" />              		
+		<user name="user99" password="user99pwd" />       
+		<user name="user\ |1$" password="specialCharUserPwd" />       		
 	</basicRegistry>
+	
+	<authentication id="Basic" cacheEnabled="false" />
 	
     <keyStore id="defaultKeyStore" password="{xor}EzY9Oi0rJg==" /> <!-- pwd: Liberty, expires 1/4/2099 -->
 
@@ -41,6 +44,7 @@
 			<security-role name="Employee">
 				<group name="group1" />
 			    <user name="user99" />
+				<user name="user\ |1$" />
 				<run-as userid="user99"/>
 			</security-role>	
 			<security-role name="Manager">

--- a/dev/com.ibm.ws.security.token.ltpa/test/com/ibm/ws/security/token/ltpa/internal/LTPAToken2FactoryTest.java
+++ b/dev/com.ibm.ws.security.token.ltpa/test/com/ibm/ws/security/token/ltpa/internal/LTPAToken2FactoryTest.java
@@ -167,11 +167,12 @@ public class LTPAToken2FactoryTest {
         byte[] tokenBytes = token.getBytes();
         Token validatedToken = tokenFactory.validateTokenBytes(tokenBytes);
         assertNotNull("There must be a validated token.", validatedToken);
+        assertTrue("Token is invalid.", validatedToken.isValid());
     }
 
     private Map<String, Object> createBasicLTPA2TokenData() {
         Map<String, Object> tokenData = new HashMap<String, Object>();
-        tokenData.put("unique_id", "user:BasicRealm/user1");
+        tokenData.put("unique_id", "user:BasicRealm/u\\ser |1$");
         return tokenData;
     }
 }


### PR DESCRIPTION
Modified existing unit and FAT tests to ensure they test white-space characters and other special characters in the user field.

For Issue: https://github.com/OpenLiberty/open-liberty/issues/21916