### PR TITLE
EJBClient Fat remove short timed exit from client server

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.remote.client_fat/publish/clients/com.ibm.ws.ejbcontainer.remote.client.fat.clientInjection/bootstrap.properties
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client_fat/publish/clients/com.ibm.ws.ejbcontainer.remote.client.fat.clientInjection/bootstrap.properties
@@ -9,7 +9,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../../servers/testports.properties
-com.ibm.ws.timedexit.timetolive=120000
 #bvt.prop.IIOP=28090
 #bvt.prop.IIOP.secure=28100
 #bvt.prop.IIOP.client=28091


### PR DESCRIPTION
Bucket has a really short timedexit set which is unnecessary 