### PR TITLE
Disable Hibernate/OpenJPA testing in JPA Query FAT

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA21Hibernate.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA21Hibernate.java
@@ -45,6 +45,7 @@ public class RepeatWithJPA21Hibernate extends EE7FeatureReplacementAction {
 
     @Override
     public boolean isEnabled() {
+        // Disable testing against Hibernate for time constraints
         if (!Boolean.getBoolean("jpa.enable.repeat.hibernate"))
             return false;
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA21OpenJPA.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA21OpenJPA.java
@@ -42,4 +42,13 @@ public class RepeatWithJPA21OpenJPA extends EE7FeatureReplacementAction {
     public String getID() {
         return ID;
     }
+
+    @Override
+    public boolean isEnabled() {
+        // Disable testing against OpenJPA for time constraints
+        if (!Boolean.getBoolean("jpa.enable.repeat.openjpa"))
+            return false;
+
+        return super.isEnabled();
+    }
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA22Hibernate.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA22Hibernate.java
@@ -42,4 +42,13 @@ public class RepeatWithJPA22Hibernate extends EE8FeatureReplacementAction {
     public String getID() {
         return ID;
     }
+
+    @Override
+    public boolean isEnabled() {
+        // Disable testing against Hibernate for time constraints
+        if (!Boolean.getBoolean("jpa.enable.repeat.hibernate"))
+            return false;
+
+        return super.isEnabled();
+    }
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA22OpenJPA.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA22OpenJPA.java
@@ -42,4 +42,13 @@ public class RepeatWithJPA22OpenJPA extends EE8FeatureReplacementAction {
     public String getID() {
         return ID;
     }
+
+    @Override
+    public boolean isEnabled() {
+        // Disable testing against OpenJPA for time constraints
+        if (!Boolean.getBoolean("jpa.enable.repeat.openjpa"))
+            return false;
+
+        return super.isEnabled();
+    }
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA30Hibernate.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA30Hibernate.java
@@ -44,4 +44,13 @@ public class RepeatWithJPA30Hibernate extends JakartaEE9Action {
 //    public String getID() {
 //        return ID;
 //    }
+
+    @Override
+    public boolean isEnabled() {
+        // Disable testing against Hibernate for time constraints
+        if (!Boolean.getBoolean("jpa.enable.repeat.hibernate"))
+            return false;
+
+        return super.isEnabled();
+    }
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/FATSuite.java
@@ -68,7 +68,7 @@ public class FATSuite extends AbstractFATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests
-                    .with(new RepeatWithJPA31());
-//                    .andWith(new RepeatWithJPA31Hibernate());
+                    .with(new RepeatWithJPA31())
+                    .andWith(new RepeatWithJPA31Hibernate());
 
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA31Hibernate.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/RepeatWithJPA31Hibernate.java
@@ -38,4 +38,13 @@ public class RepeatWithJPA31Hibernate extends JakartaEE10Action {
         FATSuite.repeatPhase = "hibernate31-cfg.xml";
         FATSuite.provider = JPAPersistenceProvider.HIBERNATE;
     }
+
+    @Override
+    public boolean isEnabled() {
+        // Disable testing against Hibernate for time constraints
+        if (!Boolean.getBoolean("jpa.enable.repeat.hibernate"))
+            return false;
+
+        return super.isEnabled();
+    }
 }


### PR DESCRIPTION
The JPA FAT `com.ibm.ws.jpa.tests.spec10.query_jpa_2.2_fat` has been hitting the 3 hour limit on FULL FAT runs and creating build breaks as the FAT timesout. It's not entirely necessary that these Query tests run against Hibernate/OpenJPA, so we are moving them to manual testing.

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>

