### PR TITLE
Skip Concurrency TCK InheritedAPITests

### DIFF
--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncher.java
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncher.java
@@ -186,6 +186,10 @@ public class ConcurrentTckLauncher {
             specExcludes.add("ee.jakarta.tck.concurrent.spec.signature");
         }
 
+        //FIXME This test class fails because of the following issue: https://github.com/jakartaee/concurrency/issues/261
+        //      This test is fixed in service release 3.0.2 and can be re-enabled when released
+        specExcludes.add("ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi.InheritedAPITests");
+
         apiPackage.setExclude(new ArrayList<String>(apiExcludes));
         specPackage.setExclude(new ArrayList<String>(specExcludes));
 


### PR DESCRIPTION
Need to skip InheritedAPITests because of a defect in the TCK where a singleton EJB was annotated with `@Stateless` which causes conflicting counts. 
See: https://github.com/jakartaee/concurrency/issues/261