### PR TITLE
Remove warning since Liberty does not ship Woodstox

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/staxutils/StaxUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/staxutils/StaxUtils.java
@@ -331,7 +331,9 @@ public final class StaxUtils {
 
             if (!setRestrictionProperties(factory)) {
                 if (ALLOW_INSECURE_PARSER_VAL) {
-                    LOG.log(Level.WARNING, "INSECURE_PARSER_DETECTED", factory.getClass().getName());
+                    //Liberty change start:  Comment out warning since Liberty does not ship Woodstox
+                    // LOG.log(Level.WARNING, "INSECURE_PARSER_DETECTED", factory.getClass().getName());
+                    //Liberty change end
                 } else {
                     throw new RuntimeException("Cannot create a secure XMLInputFactory, "
                         + "you should either add woodstox or set " + ALLOW_INSECURE_PARSER


### PR DESCRIPTION
This change is to remove the following bogus warning message from Liberty log files.   It also matches an identical change made to the JAXRS 2.0 version of org.apache.cxf.staxutils.StaxUtils.