### PR TITLE
Update mpTelemetry-1.0 for MP 6 compatibility

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.telemetry-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.telemetry-1.0.feature
@@ -2,7 +2,7 @@
 symbolicName=io.openliberty.org.eclipse.microprofile.telemetry-1.0
 visibility=private
 singleton=true
--features=io.openliberty.mpCompatible-5.0
+-features=io.openliberty.mpCompatible-6.0; ibm.tolerates:="5.0"
 -bundles=io.openliberty.io.opentelemetry; location:="dev/api/stable/,lib/"
 kind=beta
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpTelemetry-1.0/io.openliberty.mpTelemetry-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpTelemetry-1.0/io.openliberty.mpTelemetry-1.0.feature
@@ -12,11 +12,11 @@ IBM-API-Package: \
   io.opentelemetry.api;type="stable",\
   io.opentelemetry.api.trace;type="stable"
 -features=\
-  io.openliberty.jakarta.annotation-2.0, \
-  io.openliberty.restfulWS-3.0, \
+  io.openliberty.jakarta.annotation-2.1; ibm.tolerates:="2.0", \
+  io.openliberty.restfulWS-3.1; ibm.tolerates:="3.0", \
   io.openliberty.mpConfig-3.0, \
-  io.openliberty.cdi-3.0, \
-  io.openliberty.mpCompatible-5.0,\
+  io.openliberty.cdi-4.0; ibm.tolerates:="3.0", \
+  io.openliberty.mpCompatible-6.0; ibm.tolerates:="5.0",\
   com.ibm.websphere.appserver.injection-2.0, \
   io.openliberty.org.eclipse.microprofile.telemetry-1.0
 -bundles=\

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/suite/FATSuite.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/suite/FATSuite.java
@@ -10,12 +10,16 @@
  *******************************************************************************/
 package io.openliberty.microprofile.telemetry.internal.suite;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.containers.TestContainerSuite;
 import componenttest.custom.junit.runner.AlwaysPassesTest;
+import componenttest.rules.repeater.FeatureSet;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatTests;
 import io.openliberty.microprofile.telemetry.internal.tests.AutoInstrumentationTest;
 
 @RunWith(Suite.class)
@@ -28,4 +32,10 @@ import io.openliberty.microprofile.telemetry.internal.tests.AutoInstrumentationT
  * Purpose: This suite collects and runs all known good test suites.
  */
 public class FATSuite extends TestContainerSuite {
+
+    private static final FeatureSet MP50_MPTELEMETRY = MicroProfileActions.MP50.addFeature("mpTelemetry-1.0").build(MicroProfileActions.MP50_ID + "_MPTELEMETRY");
+
+    @ClassRule
+    public static final RepeatTests r = MicroProfileActions.repeat(null, MicroProfileActions.MP60, MP50_MPTELEMETRY);
+
 }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/testServer1/server.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/testServer1/server.xml
@@ -5,6 +5,7 @@
     <featureManager>
         <feature>mpTelemetry-1.0</feature>
         <feature>timedexit-1.0</feature>
+        <feature>restfulWS-3.0</feature> <!-- need an EE feature to repeat on EE9 and EE10 -->
     </featureManager>
 
     <include location="../fatTestPorts.xml" />

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/bnd.bnd
@@ -41,7 +41,10 @@ Service-Component: \
         configuration-policy:=optional; \
 	properties:="resources=${app-resources}" 
 
+# Tolerate CDI 3.0 + 4.0
 Import-Package: \
+	jakarta.enterprise.context;version="[3.0.0,5.0.0)", \
+	jakarta.enterprise.inject;version="[3.0.0,5.0.0)", \
 	*
 
 Export-Package: \
@@ -61,6 +64,7 @@ Private-Package: \
     com.ibm.ws.cdi.interfaces.jakarta;version=latest,\
     com.ibm.ws.injection;version=latest,\
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+    com.ibm.ws.logging;version=latest, \
     io.openliberty.io.opentelemetry.internal;version=latest, \
     io.openliberty.io.opentelemetry;version=latest,\
     io.openliberty.org.eclipse.microprofile.config.3.0

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/.classpath
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/.project
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.microprofile.telemetry.1.0.internal_fat</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/.settings/bndtools.core.prefs
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/bnd.bnd
@@ -16,7 +16,10 @@ src: \
 	
 fat.project: true
 
-tested.features: mpTelemetry-1.0
+tested.features:\
+  mpTelemetry-1.0,\
+  restfulws-3.0,\
+  servlet-6.0
 
 -buildpath: \
 	io.openliberty.jakarta.servlet.5.0;version=latest,\

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/build.gradle
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/build.gradle
@@ -9,9 +9,4 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-dependencies {
-  requiredLibs 'org.json:json:20080701'
-} 
-
-addRequiredLibraries.dependsOn copyTestContainers
 addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
@@ -10,16 +10,24 @@
  *******************************************************************************/
 package io.openliberty.microprofile.telemetry.internal_fat;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import componenttest.custom.junit.runner.AlwaysPassesTest;
+import componenttest.rules.repeater.FeatureSet;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
                 Telemetry10.class
 })
 public class FATSuite {
+
+    private static final FeatureSet MP50_MPTELEMETRY = MicroProfileActions.MP50.addFeature("mpTelemetry-1.0").build(MicroProfileActions.MP50_ID + "_MPTELEMETRY");
+
+    @ClassRule
+    public static final RepeatTests r = MicroProfileActions.repeat(null, MicroProfileActions.MP60, MP50_MPTELEMETRY);
 
 }

--- a/dev/io.openliberty.microprofile.telemetry_git_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry_git_fat_tck/bnd.bnd
@@ -16,6 +16,11 @@ src: \
 
 fat.project: true
 
-tested.features: mpTelemetry-1.0
+tested.features:\
+  concurrent-2.0,\
+  jsonp-2.0,\
+  mpTelemetry-1.0,\
+  restfulws-3.0,\
+  restfulwsclient-3.0
 
 -buildpath: \


### PR DESCRIPTION
mpTelemetry-1.0 will be part of MP 6.

It's currently still compatible with EE 9, but that will be changed before release to require EE 10.

For #21968