### PR TITLE
Java 19 methods on managed scheduled future

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat/publish/servers/concurrent.spec.fat/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat/publish/servers/concurrent.spec.fat/server.xml
@@ -1,3 +1,13 @@
+<!--
+    Copyright (c) 2017,2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
 <server>
   <featureManager>
     <feature>componenttest-1.0</feature>
@@ -32,7 +42,8 @@
     </contextService>
   </managedThreadFactory>
 
-  <!-- Test application needs these permissions to help verify thread context -->
+  <!-- Test application needs these permissions to access Java 19+ methods with reflection and help verify thread context -->
+  <javaPermission codebase="${server.config.dir}/dropins/concurrentSpec.war" className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
   <javaPermission codebase="${server.config.dir}/dropins/concurrentSpec.war" className="java.lang.RuntimePermission" name="getClassLoader"/>
   <javaPermission codebase="${server.config.dir}/dropins/concurrentSpec.war" className="java.lang.RuntimePermission" name="getContextClassLoader"/>
   <javaPermission codebase="${server.config.dir}/dropins/concurrentSpec.war" className="java.lang.RuntimePermission" name="modifyThread"/>

--- a/dev/com.ibm.ws.concurrent_fat/test-applications/concurrentSpec/src/fat/concurrent/spec/app/EEConcurrencyTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat/test-applications/concurrentSpec/src/fat/concurrent/spec/app/EEConcurrencyTestServlet.java
@@ -17,6 +17,10 @@ import static org.junit.Assert.fail;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -747,6 +751,156 @@ public class EEConcurrencyTestServlet extends FATServlet {
                 return null;
             }
         }).get(TIMEOUT * 5, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Test exceptionNow on a ScheduledFuture from a ManagedScheduledExecutorService.
+     */
+    @Test
+    public void testExceptionNowOnScheduledFuture() throws Exception {
+        ScheduledFuture<Integer> neverStartedFuture = mschedxsvcDefaultLookup.schedule(() -> 1910, 10, TimeUnit.DAYS);
+        final Method exceptionNow = neverStartedFuture.getClass().getMethod("exceptionNow");
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            exceptionNow.setAccessible(true);
+            return null;
+        });
+
+        // exceptionNow on cancelled scheduled future
+        assertEquals(true, neverStartedFuture.cancel(true));
+        try {
+            Object exception = exceptionNow.invoke(neverStartedFuture);
+            fail("Cancelled scheduled future should not have a task failure exception now: " + exception);
+        } catch (InvocationTargetException x) {
+            if (x.getCause() instanceof IllegalStateException
+                && x.getCause().getCause() instanceof CancellationException)
+                ; // pass
+            else
+                throw x;
+        }
+
+        // exceptionNow during taskSubmitted and taskStarting
+        LinkedBlockingQueue<Object> results = new LinkedBlockingQueue<Object>();
+        mschedxsvcDefaultLookup.schedule(ManagedExecutors.managedTask(() -> 1911, new ManagedTaskListener() {
+            @Override
+            public void taskAborted(Future<?> future, ManagedExecutorService executor, Object task, Throwable failure) {
+            }
+
+            @Override
+            public void taskDone(Future<?> future, ManagedExecutorService executor, Object task, Throwable failure) {
+            }
+
+            @Override
+            public void taskStarting(Future<?> future, ManagedExecutorService executor, Object task) {
+                try {
+                    results.add(exceptionNow.invoke(future));
+                } catch (InvocationTargetException x) {
+                    results.add(x.getCause());
+                } catch (Throwable x) {
+                    results.add(x);
+                }
+                future.cancel(false);
+            }
+
+            @Override
+            public void taskSubmitted(Future<?> future, ManagedExecutorService executor, Object task) {
+                try {
+                    results.add(exceptionNow.invoke(future));
+                } catch (InvocationTargetException x) {
+                    results.add(x.getCause());
+                } catch (Throwable x) {
+                    results.add(x);
+                }
+            }
+        }), 191, TimeUnit.MILLISECONDS);
+
+        Object result;
+        assertNotNull(result = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS)); // taskSubmitted
+        assertEquals(IllegalStateException.class, result.getClass());
+        assertNotNull(result = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS)); // taskStarting
+        assertEquals(IllegalStateException.class, result.getClass());
+        assertEquals(null, results.poll());
+
+        // exceptionNow during taskAborted (due to skip)
+        mschedxsvcDefaultLookup.schedule(ManagedExecutors.managedTask(() -> 1912, new ManagedTaskListener() {
+            @Override
+            public void taskAborted(Future<?> future, ManagedExecutorService executor, Object task, Throwable failure) {
+                try {
+                    results.add(exceptionNow.invoke(future));
+                } catch (InvocationTargetException x) {
+                    results.add(x.getCause());
+                } catch (Throwable x) {
+                    results.add(x);
+                }
+            }
+
+            @Override
+            public void taskDone(Future<?> future, ManagedExecutorService executor, Object task, Throwable failure) {
+            }
+
+            @Override
+            public void taskStarting(Future<?> future, ManagedExecutorService executor, Object task) {
+            }
+
+            @Override
+            public void taskSubmitted(Future<?> future, ManagedExecutorService executor, Object task) {
+            }
+        }), new Trigger() {
+            boolean firstTime = true;
+
+            @Override
+            public Date getNextRunTime(LastExecution lastExecution, Date taskScheduledTime) {
+                Date next = firstTime ? new Date() : null;
+                firstTime = false;
+                return next;
+            }
+
+            @Override
+            public boolean skipRun(LastExecution lastExecution, Date scheduledRunTime) {
+                return true;
+            }
+        });
+
+        assertNotNull(result = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS)); // taskAborted
+        assertEquals(IllegalStateException.class, result.getClass());
+        assertNotNull(((IllegalStateException) result).getCause());
+        assertEquals(SkippedException.class, ((IllegalStateException) result).getCause().getClass());
+
+        // exceptionNow on each execution of the task
+        AtomicInteger countdown = new AtomicInteger(1);
+        Runnable failOnSecondAttempt = () -> {
+            @SuppressWarnings("unused")
+            int i = 1 / countdown.getAndDecrement();
+        };
+        mschedxsvcDefaultLookup.scheduleAtFixedRate(ManagedExecutors.managedTask(failOnSecondAttempt, new ManagedTaskListener() {
+            @Override
+            public void taskAborted(Future<?> future, ManagedExecutorService executor, Object task, Throwable failure) {
+            }
+
+            @Override
+            public void taskDone(Future<?> future, ManagedExecutorService executor, Object task, Throwable failure) {
+                try {
+                    results.add(exceptionNow.invoke(future));
+                } catch (InvocationTargetException x) {
+                    results.add(x.getCause());
+                } catch (Throwable x) {
+                    results.add(x);
+                }
+            }
+
+            @Override
+            public void taskStarting(Future<?> future, ManagedExecutorService executor, Object task) {
+            }
+
+            @Override
+            public void taskSubmitted(Future<?> future, ManagedExecutorService executor, Object task) {
+            }
+        }), 14, 194, TimeUnit.MILLISECONDS);
+
+        assertNotNull(result = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS)); // taskDone #1
+        assertEquals(IllegalStateException.class, result.getClass());
+
+        assertNotNull(result = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS)); // taskDone #2
+        assertEquals(ArithmeticException.class, result.getClass());
     }
 
     /**
@@ -7610,6 +7764,165 @@ public class EEConcurrencyTestServlet extends FATServlet {
         int count = ((CounterTask) runnable).counter.get();
         if (count != 2)
             throw new Exception("Task should run exactly twice when resubmitted once. Instead: " + count);
+    }
+
+    /**
+     * Test resultNow on a ScheduledFuture from a ManagedScheduledExecutorService.
+     */
+    @Test
+    public void testResultNowOnScheduledFuture() throws Exception {
+        ScheduledFuture<Integer> neverStartedFuture = mschedxsvcDefaultLookup.schedule(() -> 1900, 19, TimeUnit.DAYS);
+        final Method resultNow = neverStartedFuture.getClass().getMethod("resultNow");
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            resultNow.setAccessible(true);
+            return null;
+        });
+
+        // resultNow on cancelled scheduled future
+        assertEquals(true, neverStartedFuture.cancel(true));
+        try {
+            Object result = resultNow.invoke(neverStartedFuture);
+            fail("Cancelled scheduled future should not have a result now: " + result);
+        } catch (InvocationTargetException x) {
+            if (x.getCause() instanceof IllegalStateException
+                && x.getCause().getCause() instanceof CancellationException)
+                ; // pass
+            else
+                throw x;
+        }
+
+        // resultNow during taskSubmitted and taskStarting
+        LinkedBlockingQueue<Object> results = new LinkedBlockingQueue<Object>();
+        mschedxsvcDefaultLookup.schedule(ManagedExecutors.managedTask(() -> 1901, new ManagedTaskListener() {
+            @Override
+            public void taskAborted(Future<?> future, ManagedExecutorService executor, Object task, Throwable failure) {
+            }
+
+            @Override
+            public void taskDone(Future<?> future, ManagedExecutorService executor, Object task, Throwable failure) {
+            }
+
+            @Override
+            public void taskStarting(Future<?> future, ManagedExecutorService executor, Object task) {
+                try {
+                    results.add(resultNow.invoke(future));
+                } catch (InvocationTargetException x) {
+                    results.add(x.getCause());
+                } catch (Throwable x) {
+                    results.add(x);
+                }
+                future.cancel(false);
+            }
+
+            @Override
+            public void taskSubmitted(Future<?> future, ManagedExecutorService executor, Object task) {
+                try {
+                    results.add(resultNow.invoke(future));
+                } catch (InvocationTargetException x) {
+                    results.add(x.getCause());
+                } catch (Throwable x) {
+                    results.add(x);
+                }
+            }
+        }), 191, TimeUnit.MILLISECONDS);
+
+        Object result;
+        assertNotNull(result = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS)); // taskSubmitted
+        assertEquals(IllegalStateException.class, result.getClass());
+        assertNotNull(result = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS)); // taskStarting
+        assertEquals(IllegalStateException.class, result.getClass());
+        assertEquals(null, results.poll());
+
+        // resultNow during taskAborted (due to skip)
+        mschedxsvcDefaultLookup.schedule(ManagedExecutors.managedTask(() -> 1902, new ManagedTaskListener() {
+            @Override
+            public void taskAborted(Future<?> future, ManagedExecutorService executor, Object task, Throwable failure) {
+                try {
+                    results.add(resultNow.invoke(future));
+                } catch (InvocationTargetException x) {
+                    results.add(x.getCause());
+                } catch (Throwable x) {
+                    results.add(x);
+                }
+            }
+
+            @Override
+            public void taskDone(Future<?> future, ManagedExecutorService executor, Object task, Throwable failure) {
+            }
+
+            @Override
+            public void taskStarting(Future<?> future, ManagedExecutorService executor, Object task) {
+            }
+
+            @Override
+            public void taskSubmitted(Future<?> future, ManagedExecutorService executor, Object task) {
+            }
+        }), new Trigger() {
+            boolean firstTime = true;
+
+            @Override
+            public Date getNextRunTime(LastExecution lastExecution, Date taskScheduledTime) {
+                Date next = firstTime ? new Date() : null;
+                firstTime = false;
+                return next;
+            }
+
+            @Override
+            public boolean skipRun(LastExecution lastExecution, Date scheduledRunTime) {
+                return true;
+            }
+        });
+
+        assertNotNull(result = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS)); // taskAborted
+        assertEquals(IllegalStateException.class, result.getClass());
+        assertNotNull(((IllegalStateException) result).getCause());
+        assertEquals(SkippedException.class, ((IllegalStateException) result).getCause().getClass());
+
+        // resultNow on each execution of the task
+        AtomicInteger countdown = new AtomicInteger(4);
+        Callable<Integer> failOnFourthAttempt = () -> {
+            return 1 / countdown.decrementAndGet();
+        };
+        mschedxsvcDefaultLookup.schedule(ManagedExecutors.managedTask(failOnFourthAttempt, new ManagedTaskListener() {
+            @Override
+            public void taskAborted(Future<?> future, ManagedExecutorService executor, Object task, Throwable failure) {
+            }
+
+            @Override
+            public void taskDone(Future<?> future, ManagedExecutorService executor, Object task, Throwable failure) {
+                try {
+                    results.add(resultNow.invoke(future));
+                } catch (InvocationTargetException x) {
+                    results.add(x.getCause());
+                } catch (Throwable x) {
+                    results.add(x);
+                }
+            }
+
+            @Override
+            public void taskStarting(Future<?> future, ManagedExecutorService executor, Object task) {
+            }
+
+            @Override
+            public void taskSubmitted(Future<?> future, ManagedExecutorService executor, Object task) {
+            }
+        }), new Trigger() {
+            @Override
+            public Date getNextRunTime(LastExecution lastExecution, Date taskScheduledTime) {
+                return new Date();
+            }
+
+            @Override
+            public boolean skipRun(LastExecution lastExecution, Date scheduledRunTime) {
+                return false;
+            }
+        });
+
+        assertEquals(Integer.valueOf(0), results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS)); // taskDone #1
+        assertEquals(Integer.valueOf(0), results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS)); // taskDone #2
+        assertEquals(Integer.valueOf(1), results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS)); // taskDone #3
+        assertNotNull(result = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS)); // taskDone #4
+        assertEquals(IllegalStateException.class, result.getClass());
     }
 
     /**

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
@@ -578,9 +578,10 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
         Throwable cause = null;
         if (isDone()) {
             int s = state.get();
-            if (s == ABORTED || s == FAILED) {
-                Throwable failure = (Throwable) result.get();
-                return failure;
+            if (s == FAILED) {
+                return (Throwable) result.get();
+            } else if (s == ABORTED) {
+                cause = (Throwable) result.get();
             } else if (s == CANCELLED || s == CANCELLING) {
                 cause = new CancellationException();
             }

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
@@ -1931,9 +1931,17 @@ public class PolicyExecutorServlet extends FATServlet {
         assertEquals(false, blocker.await(400, TimeUnit.MILLISECONDS));
 
         // Future.exceptionNow on task that times out and is aborted:
-        exception = (Throwable) exceptionNow.invoke(task4future);
-        if (!StartTimeoutException.class.equals(exception.getClass()))
-            throw exception;
+        try {
+            exception = (Throwable) exceptionNow.invoke(task4future);
+            if (exception == null)
+                throw new AssertionError("exceptionNow returned null for aborted task");
+            else
+                throw new AssertionError("exceptionNow returned value for aborted task").initCause(exception);
+        } catch (IllegalStateException x) {
+            if (!(x.getCause() instanceof StartTimeoutException))
+                throw x;
+            // pass
+        }
 
         // Future.exceptionNow on cancelled task:
         assertEquals(true, task3future.cancel(true));


### PR DESCRIPTION
Implement Java 19 methods on the scheduled future for managed scheduled executor tasks.
While adding this, I spotted a bug in the code that was added to policy executor futures and am fixing that as well.  In that case aborted tasks should not be returning a completed task failure exception because the tasks did not run and did not complete.  Instead, it should raise IllegalStateException to follow the exceptionNow JavaDoc.