### PR TITLE
Add an INACTIVE CheckpointPhase

### DIFF
--- a/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/ApplicationConfigurator.java
+++ b/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/ApplicationConfigurator.java
@@ -418,17 +418,12 @@ public class ApplicationConfigurator implements ManagedServiceFactory, Introspec
     private volatile ScheduledExecutorService _scheduledExecutor;
     private volatile AppMonitorConfigurator _appMonitorConfigurator;
     private volatile ApplicationManager _applicationManager;
-    private final CheckpointPhase _checkpointPhase;
+    private final CheckpointPhase _checkpointPhase = CheckpointPhase.getPhase();
     private final List<Runnable> _restoreMessages = new CopyOnWriteArrayList<Runnable>();
 
     private static final Collection<String> SIMPLE_INITIAL_UPDATE_NOTIFICATIONS = Arrays.asList(new String[] { RuntimeUpdateNotification.FEATURE_UPDATES_COMPLETED,
                                                                                                                RuntimeUpdateNotification.CONFIG_UPDATES_DELIVERED,
                                                                                                                RuntimeUpdateNotification.ORB_STARTED });
-
-    @Activate
-    public ApplicationConfigurator(@Reference(cardinality = ReferenceCardinality.OPTIONAL) CheckpointPhase checkpointPhase) {
-        this._checkpointPhase = checkpointPhase;
-    }
 
     @Activate
     protected void activate(ComponentContext ctx) {
@@ -2082,7 +2077,7 @@ public class ApplicationConfigurator implements ManagedServiceFactory, Introspec
     }
 
     public void restoreMessage(Runnable message) {
-        if (_checkpointPhase != null) {
+        if (_checkpointPhase != CheckpointPhase.INACTIVE) {
             _restoreMessages.add(message);
         }
     }

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
@@ -80,6 +80,7 @@ import com.ibm.wsspi.kernel.service.utils.PathUtils;
 import io.openliberty.checkpoint.spi.CheckpointPhase;
 
 abstract class ContainerClassLoader extends LibertyLoader implements Keyed<ClassLoaderIdentity> {
+    static final CheckpointPhase checkpointPhase = CheckpointPhase.getPhase();
     static {
         ClassLoader.registerAsParallelCapable();
     }
@@ -612,8 +613,7 @@ abstract class ContainerClassLoader extends LibertyLoader implements Keyed<Class
             this.container = container;
             this.isRoot = container.isRoot();
             // If we are doing checkpoint, process the manifest file when the container is created.
-            CheckpointPhase phase = CheckpointPhase.getPhase();
-            if (phase != null && !phase.restored()) {
+            if (!checkpointPhase.restored()) {
                 getManifestMainAttributes();
             }
         }
@@ -811,8 +811,7 @@ abstract class ContainerClassLoader extends LibertyLoader implements Keyed<Class
             this.container = container;
             this.isRoot = container.isRoot();
             // If we are doing checkpoint, process the manifest file when the container is created.
-            CheckpointPhase phase = CheckpointPhase.getPhase();
-            if (phase != null && !phase.restored()) {
+            if (!checkpointPhase.restored()) {
                 getManifestMainAttributes();
             }
         }

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/LaunchArguments.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/LaunchArguments.java
@@ -280,7 +280,7 @@ public class LaunchArguments {
             throw new RuntimeException(e);
         }
 
-        if (checkpointPhase != null && CheckpointPhase.getPhase() == null) {
+        if (CheckpointPhase.getPhase() == CheckpointPhase.INACTIVE && checkpointPhase != null) {
             System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("error.invalidPhaseName"), checkpointPhase));
             System.out.println();
             return ReturnCode.BAD_ARGUMENT;

--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
@@ -592,17 +592,17 @@ public class FrameworkManager {
             if (fwk == null)
                 return null;
             fwk.init();
+            final CheckpointPhase phase = CheckpointPhase.getPhase();
+
+            // register the checkpoint phase as early as possible
+            final BundleContext fwkContext = fwk.getBundleContext();
+            final Dictionary<String, Object> phaseRegProps = new Hashtable<>();
+            phaseRegProps.put(CHECKPOINT_RESTORED_PROPERTY, Boolean.valueOf(phase.restored()));
+            phaseRegProps.put(CHECKPOINT_PROPERTY, phase);
+            final ServiceRegistration<CheckpointPhase> phaseReg = fwkContext.registerService(CheckpointPhase.class, phase, phaseRegProps);
             if (LaunchArguments.isBetaEdition()) {
-
-                final CheckpointPhase phase = CheckpointPhase.getPhase();
-                if (phase != null) {
-                    // register the checkpoint phase as early as possible
-                    final BundleContext fwkContext = fwk.getBundleContext();
-                    final Dictionary<String, Object> phaseRegProps = new Hashtable<>();
-                    phaseRegProps.put(CHECKPOINT_RESTORED_PROPERTY, Boolean.FALSE);
-                    phaseRegProps.put(CHECKPOINT_PROPERTY, phase);
-                    final ServiceRegistration<CheckpointPhase> phaseReg = fwkContext.registerService(CheckpointPhase.class, phase, phaseRegProps);
-
+                // only register the hooks if we are not the INACTIVE phase
+                if (phase != CheckpointPhase.INACTIVE) {
                     fwkContext.registerService(CheckpointHook.class, new CheckpointHook() {
                         Field restoredField = null;
 
@@ -620,6 +620,11 @@ public class FrameworkManager {
                         @Override
                         public void restore() {
                             try {
+                                // We use reflection here to set the restored state because we need this done
+                                // first and this hook is registered first and with the min ranking which
+                                // means it will be the first hook called on restore (and the last one called on checkpoint).
+                                // It is tempting to put this as a hook directly in the static hooks of the phase itself
+                                // but that would not be run as early as this hook on restore.
                                 restoredField.set(phase, Boolean.TRUE);
                             } catch (IllegalArgumentException | IllegalAccessException e) {
                                 throw new RuntimeException(e);
@@ -645,7 +650,7 @@ public class FrameworkManager {
                     // register the hooks from the CheckpointPhase that may be statically added
                     registerCheckpointPhaseStaticHooks(phase, fwkContext);
                 } else {
-                    // not a checkpoint launch; register the running condition now
+                    // not an active checkpoint launch; register the running condition now
                     registerRunningCondition(fwk);
                 }
             } else {

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
@@ -296,8 +296,7 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
      */
     private volatile boolean deactivated;
 
-    @Reference(cardinality = ReferenceCardinality.OPTIONAL)
-    private CheckpointPhase checkpointPhase;
+    private final CheckpointPhase checkpointPhase = CheckpointPhase.getPhase();
 
     private volatile LibertyBootRuntime libertyBoot;
 
@@ -1921,7 +1920,7 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
     private void checkIfCheckpointFeatureMissing(Collection<String> features) {
 
         //TODO remove beta check on feature release.
-        if (checkpointPhase != null && ProductInfo.getBetaEdition()) {
+        if (checkpointPhase != CheckpointPhase.INACTIVE && ProductInfo.getBetaEdition()) {
             if (!features.contains("checkpoint-1.0")) {
                 Tr.error(tc, "CHECKPOINT_REQUESTED_CHECKPOINT_FEATURE_MISSING");
 

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/CpuInfo.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/CpuInfo.java
@@ -80,7 +80,7 @@ public class CpuInfo {
         executor.scheduleAtFixedRate(activeTask, INTERVAL, INTERVAL, TimeUnit.MINUTES);
         cpuCount = new CPUCount();
         CheckpointPhase phase = CheckpointPhase.getPhase();
-        if (phase != null) {
+        if (phase != CheckpointPhase.INACTIVE) {
             phase.addMultiThreadedHook(activeTask);
         }
         int runtimeAvailableProcessors = Runtime.getRuntime().availableProcessors();

--- a/dev/com.ibm.ws.timedexit/src/com/ibm/ws/timedexit/internal/TimedExitComponent.java
+++ b/dev/com.ibm.ws.timedexit/src/com/ibm/ws/timedexit/internal/TimedExitComponent.java
@@ -38,7 +38,7 @@ public class TimedExitComponent implements org.osgi.framework.BundleActivator {
         try {
             Tr.audit(tc, "TE9900.timedexit.enabled");
 
-            if (context.getServiceReference(CheckpointPhase.class) != null) {
+            if (CheckpointPhase.getPhase() != CheckpointPhase.INACTIVE) {
                 context.registerService(CheckpointHook.class, new CheckpointHook() {
                     @Override
                     public void restore() {

--- a/dev/com.ibm.ws.transport.iiop/src/com/ibm/ws/transport/iiop/internal/ORBWrapperInternal.java
+++ b/dev/com.ibm.ws.transport.iiop/src/com/ibm/ws/transport/iiop/internal/ORBWrapperInternal.java
@@ -75,20 +75,17 @@ public class ORBWrapperInternal extends ServerPolicySourceImpl implements ORBRef
 
     private final transient ConcurrentServiceReferenceMap<String, AdapterActivatorOp> map = new ConcurrentServiceReferenceMap<>(KEY);
     
-    private CheckpointPhase checkpointPhase = null;
-    @Reference(cardinality = ReferenceCardinality.OPTIONAL)
-    protected void setCheckpoint(CheckpointPhase checkpointPhase) {
-    	this.checkpointPhase = checkpointPhase;
-    }
+    private final CheckpointPhase checkpointPhase = CheckpointPhase.getPhase();
+
     
     @Activate
     protected void activate(Map<String, Object> properties, ComponentContext cc) throws Exception {
         map.activate(cc);
         super.activate(properties, cc.getBundleContext());
         try {
-        	if (checkpointPhase != null) {
-        		Util.createValueHandler().getRunTimeCodeBase();
-        	}
+            if (checkpointPhase != CheckpointPhase.INACTIVE) {
+                Util.createValueHandler().getRunTimeCodeBase();
+            }
         } catch (Exception e) {
         }
         try {

--- a/dev/com.ibm.ws.webcontainer.servlet.3.0.factories/src/com/ibm/ws/webcontainer/osgi/webapp/internal/WebAppFactoryImpl.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.0.factories/src/com/ibm/ws/webcontainer/osgi/webapp/internal/WebAppFactoryImpl.java
@@ -10,10 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.webcontainer.osgi.webapp.internal;
 
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
 
 import com.ibm.websphere.csi.J2EENameFactory;
 import com.ibm.ws.container.service.metadata.MetaDataService;
@@ -23,23 +20,15 @@ import com.ibm.ws.webcontainer.osgi.webapp.WebAppConfiguration;
 import com.ibm.ws.webcontainer.osgi.webapp.WebAppFactory;
 import com.ibm.wsspi.injectionengine.ReferenceContext;
 
-import io.openliberty.checkpoint.spi.CheckpointPhase;
-
 
 @Component(service= WebAppFactory.class, property = { "service.vendor=IBM" })
 public class WebAppFactoryImpl implements WebAppFactory {
-	private final CheckpointPhase checkpointPhase;
-    @Activate
-    public WebAppFactoryImpl(@Reference(cardinality = ReferenceCardinality.OPTIONAL) CheckpointPhase checkpointPhase) {
-        this.checkpointPhase = checkpointPhase;
-    }
-
    /* (non-Javadoc)
     * @see com.ibm.ws.webcontainer.osgi.webapp.WebAppFactory#createWebApp(com.ibm.ws.webcontainer.osgi.webapp.WebAppConfiguration, java.lang.ClassLoader, com.ibm.wsspi.injectionengine.ReferenceContext, com.ibm.ws.container.service.metadata.MetaDataService, com.ibm.websphere.csi.J2EENameFactory)
     */
    @Override
    public WebApp createWebApp(WebAppConfiguration webAppConfig, ClassLoader moduleLoader, ReferenceContext referenceContext, MetaDataService metaDataService,
                               J2EENameFactory j2eeNameFactory, ManagedObjectService managedObjectService) {
-	   return new WebApp(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService, checkpointPhase);
+       return new WebApp(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService);
    }
 }

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1.factories/src/com/ibm/ws/webcontainer31/osgi/webapp/factory/WebAppFactoryImpl31.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1.factories/src/com/ibm/ws/webcontainer31/osgi/webapp/factory/WebAppFactoryImpl31.java
@@ -10,10 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.webcontainer31.osgi.webapp.factory;
 
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
 
 import com.ibm.websphere.csi.J2EENameFactory;
 import com.ibm.ws.container.service.metadata.MetaDataService;
@@ -24,19 +21,11 @@ import com.ibm.ws.webcontainer.osgi.webapp.WebAppFactory;
 import com.ibm.ws.webcontainer31.osgi.webapp.WebApp31;
 import com.ibm.wsspi.injectionengine.ReferenceContext;
 
-import io.openliberty.checkpoint.spi.CheckpointPhase;
-
 /**
  *
  */
 @Component(service = WebAppFactory.class, property = { "service.vendor=IBM" })
 public class WebAppFactoryImpl31 implements WebAppFactory {
-    private final CheckpointPhase checkpointPhase;
-
-    @Activate
-    public WebAppFactoryImpl31(@Reference(cardinality = ReferenceCardinality.OPTIONAL) CheckpointPhase checkpointPhase) {
-        this.checkpointPhase = checkpointPhase;
-    }
 
     /*
      * (non-Javadoc)
@@ -47,7 +36,7 @@ public class WebAppFactoryImpl31 implements WebAppFactory {
     @Override
     public WebApp createWebApp(WebAppConfiguration webAppConfig, ClassLoader moduleLoader, ReferenceContext referenceContext, MetaDataService metaDataService,
                                J2EENameFactory j2eeNameFactory, ManagedObjectService managedObjectService) {
-        return new WebApp31(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService, checkpointPhase);
+        return new WebApp31(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService);
     }
 
 }

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/osgi/webapp/WebApp31.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/osgi/webapp/WebApp31.java
@@ -12,7 +12,6 @@
 package com.ibm.ws.webcontainer31.osgi.webapp;
 
 
-import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.text.MessageFormat;
@@ -29,7 +28,6 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRegistration;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSessionAttributeListener;
 import javax.servlet.http.HttpSessionIdListener;
 import javax.servlet.http.HttpSessionListener;
@@ -40,7 +38,6 @@ import com.ibm.websphere.csi.J2EENameFactory;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.container.service.metadata.MetaDataService;
-import com.ibm.ws.http2.upgrade.H2UpgradeHandler;
 import com.ibm.ws.managedobject.ManagedObject;
 import com.ibm.ws.managedobject.ManagedObjectService;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
@@ -53,11 +50,8 @@ import com.ibm.ws.webcontainer31.osgi.listener.RegisterEventListenerProvider;
 import com.ibm.ws.webcontainer31.osgi.osgi.WebContainerConstants;
 import com.ibm.ws.webcontainer31.session.IHttpSessionContext31;
 import com.ibm.ws.webcontainer31.upgrade.H2HandlerImpl;
-import com.ibm.ws.webcontainer31.upgrade.H2UpgradeHandlerWrapper;
 import com.ibm.wsspi.injectionengine.InjectionException;
 import com.ibm.wsspi.injectionengine.ReferenceContext;
-
-import io.openliberty.checkpoint.spi.CheckpointPhase;
 
 
 /**
@@ -88,9 +82,8 @@ public class WebApp31 extends com.ibm.ws.webcontainer.osgi.webapp.WebApp
                   ReferenceContext referenceContext,
                   MetaDataService metaDataService,
                   J2EENameFactory j2eeNameFactory,
-                  ManagedObjectService managedObjectService,
-                  CheckpointPhase checkpointPhase) {
-        super(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService, checkpointPhase);
+                  ManagedObjectService managedObjectService) {
+        super(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService);
     }
 
     public <T extends HttpUpgradeHandler> T createHttpUpgradeHandler(Class<T> classToCreate) throws ServletException {

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/test/com/ibm/ws/webcontainer/webapp/MethodsForProgrammaticConfigurationOfServletsTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/test/com/ibm/ws/webcontainer/webapp/MethodsForProgrammaticConfigurationOfServletsTest.java
@@ -61,7 +61,7 @@ public class MethodsForProgrammaticConfigurationOfServletsTest {
         final J2EENameFactory jnf = context.mock(J2EENameFactory.class);
 
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null, null);
+        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null);
 
         webApp.withinContextInitOfProgAddListener = true;
 
@@ -83,7 +83,7 @@ public class MethodsForProgrammaticConfigurationOfServletsTest {
         final J2EENameFactory jnf = context.mock(J2EENameFactory.class);
 
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null, null);
+        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null);
 
         webApp.withinContextInitOfProgAddListener = true;
 
@@ -105,7 +105,7 @@ public class MethodsForProgrammaticConfigurationOfServletsTest {
         final J2EENameFactory jnf = context.mock(J2EENameFactory.class);
 
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null, null);
+        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null);
 
         webApp.withinContextInitOfProgAddListener = true;
 
@@ -127,7 +127,7 @@ public class MethodsForProgrammaticConfigurationOfServletsTest {
         final J2EENameFactory jnf = context.mock(J2EENameFactory.class);
 
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null, null);
+        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null);
 
         webApp.withinContextInitOfProgAddListener = true;
 
@@ -149,7 +149,7 @@ public class MethodsForProgrammaticConfigurationOfServletsTest {
         final J2EENameFactory jnf = context.mock(J2EENameFactory.class);
 
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null, null);
+        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null);
 
         webApp.withinContextInitOfProgAddListener = true;
 
@@ -171,7 +171,7 @@ public class MethodsForProgrammaticConfigurationOfServletsTest {
         final J2EENameFactory jnf = context.mock(J2EENameFactory.class);
 
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null, null);
+        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null);
 
         webApp.withinContextInitOfProgAddListener = true;
 
@@ -193,7 +193,7 @@ public class MethodsForProgrammaticConfigurationOfServletsTest {
         final J2EENameFactory jnf = context.mock(J2EENameFactory.class);
 
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null, null);
+        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null);
 
         webApp.withinContextInitOfProgAddListener = true;
 
@@ -215,7 +215,7 @@ public class MethodsForProgrammaticConfigurationOfServletsTest {
         final J2EENameFactory jnf = context.mock(J2EENameFactory.class);
 
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null, null);
+        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null);
 
         webApp.withinContextInitOfProgAddListener = true;
 
@@ -237,7 +237,7 @@ public class MethodsForProgrammaticConfigurationOfServletsTest {
         final J2EENameFactory jnf = context.mock(J2EENameFactory.class);
 
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null, null);
+        WebApp31 webApp = new WebApp31(webAppConfig, null, null, mds, jnf, null);
 
         webApp.withinContextInitOfProgAddListener = true;
 

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0.factories/src/com/ibm/ws/webcontainer40/osgi/webapp/factory/WebAppFactory40Impl.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0.factories/src/com/ibm/ws/webcontainer40/osgi/webapp/factory/WebAppFactory40Impl.java
@@ -10,10 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.webcontainer40.osgi.webapp.factory;
 
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
 
 import com.ibm.websphere.csi.J2EENameFactory;
 import com.ibm.ws.container.service.metadata.MetaDataService;
@@ -24,20 +21,11 @@ import com.ibm.ws.webcontainer.osgi.webapp.WebAppFactory;
 import com.ibm.ws.webcontainer40.osgi.webapp.WebApp40;
 import com.ibm.wsspi.injectionengine.ReferenceContext;
 
-import io.openliberty.checkpoint.spi.CheckpointPhase;
-
 /**
 *
 */
 @Component(service = WebAppFactory.class, property = { "service.vendor=IBM" })
 public class WebAppFactory40Impl implements WebAppFactory {
-    private final CheckpointPhase checkpointPhase;
-
-    @Activate
-    public WebAppFactory40Impl(@Reference(cardinality = ReferenceCardinality.OPTIONAL) CheckpointPhase checkpointPhase) {
-        this.checkpointPhase = checkpointPhase;
-    }
-
     /*
      * (non-Javadoc)
      *
@@ -47,6 +35,6 @@ public class WebAppFactory40Impl implements WebAppFactory {
     @Override
     public WebApp createWebApp(WebAppConfiguration webAppConfig, ClassLoader moduleLoader, ReferenceContext referenceContext, MetaDataService metaDataService,
                                J2EENameFactory j2eeNameFactory, ManagedObjectService managedObjectService) {
-        return new WebApp40(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService, checkpointPhase);
+        return new WebApp40(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService);
     }
 }

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/webapp/WebApp40.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/webapp/WebApp40.java
@@ -38,8 +38,6 @@ import com.ibm.wsspi.webcontainer.RequestProcessor;
 import com.ibm.wsspi.webcontainer.servlet.IServletConfig;
 import com.ibm.wsspi.webcontainer.util.EncodingUtils;
 
-import io.openliberty.checkpoint.spi.CheckpointPhase;
-
 public class WebApp40 extends com.ibm.ws.webcontainer31.osgi.webapp.WebApp31 implements ServletContext {
     private final static TraceComponent tc = Tr.register(WebApp40.class, WebContainerConstants.TR_GROUP, WebContainerConstants.NLS_PROPS);
     protected static final TraceNLS servlet40NLS = TraceNLS.getTraceNLS(WebApp40.class, "com.ibm.ws.webcontainer40.resources.Messages");
@@ -63,9 +61,8 @@ public class WebApp40 extends com.ibm.ws.webcontainer31.osgi.webapp.WebApp31 imp
                     ReferenceContext referenceContext,
                     MetaDataService metaDataService,
                     J2EENameFactory j2eeNameFactory,
-                    ManagedObjectService managedObjectService,
-                    CheckpointPhase checkpointPhase) {
-        super(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService, checkpointPhase);
+                    ManagedObjectService managedObjectService) {
+        super(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService);
     }
 
     /*

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/webapp/WebApp.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/webapp/WebApp.java
@@ -134,10 +134,9 @@ public class WebApp extends com.ibm.ws.webcontainer.webapp.WebApp implements Com
                 ReferenceContext referenceContext,
                 MetaDataService metaDataService,
                 J2EENameFactory j2eeNameFactory,
-                ManagedObjectService managedObjectService,
-                CheckpointPhase checkpointPhase)
+                ManagedObjectService managedObjectService)
   {
-    super(webAppConfig, null, checkpointPhase);
+    super(webAppConfig, null);
     this.webAppConfig = webAppConfig;
     this.moduleLoader = moduleLoader;
     this.referenceContext = referenceContext;

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebApp.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebApp.java
@@ -362,7 +362,7 @@ public abstract class WebApp extends BaseContainer implements ServletContext, IS
     
     private static Object[] OBJ_EMPTY = new Object[] {};
     private static Class<?>[] CLASS_EMPTY = new Class<?>[] {};
-    private final CheckpointPhase checkpointPhase;
+    private final CheckpointPhase checkpointPhase = CheckpointPhase.getPhase();
     
     // PK37608 Start
     static {
@@ -387,10 +387,9 @@ public abstract class WebApp extends BaseContainer implements ServletContext, IS
   public static final boolean DEFER_SERVLET_REQUEST_LISTENER_DESTROY_ON_ERROR = WCCustomProperties.DEFER_SERVLET_REQUEST_LISTENER_DESTROY_ON_ERROR;  //PI26908
   
     // PK37698 End
-    public WebApp(WebAppConfiguration webAppConfig, Container parent, CheckpointPhase checkpointPhase) {
+    public WebApp(WebAppConfiguration webAppConfig, Container parent) {
         super(webAppConfig.getId(), parent);
         this.config = webAppConfig;
-        this.checkpointPhase = checkpointPhase;
         // PK63920 Start
         if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE))
             logger.entering(CLASS_NAME, "<init> [ " + this + " ] with name -> [ " + name + " ] and parent [ " + parent + " ]");

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/WCCustomProperties.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/WCCustomProperties.java
@@ -698,7 +698,7 @@ public class WCCustomProperties {
         //End 8.0.0.4
         
         //Start Liberty
-        DEFER_SERVLET_LOAD = CheckpointPhase.getPhase() == null && Boolean.valueOf(customProps.getProperty("deferservletload")); //Liberty to override delayed load/init
+        DEFER_SERVLET_LOAD = CheckpointPhase.getPhase() == CheckpointPhase.INACTIVE && Boolean.valueOf(customProps.getProperty("deferservletload")); //Liberty to override delayed load/init
 
         
         

--- a/dev/com.ibm.ws.webcontainer/test/com/ibm/ws/webcontainer/webapp/SRTServletRequestTest.java
+++ b/dev/com.ibm.ws.webcontainer/test/com/ibm/ws/webcontainer/webapp/SRTServletRequestTest.java
@@ -202,7 +202,7 @@ public class SRTServletRequestTest {
         Hashtable bundleHeaders = new Hashtable(1);
         bundleHeaders.put("IBM-Authorization-Roles", "com.ibm.ws.management");
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp webApp = new WebApp(webAppConfig, null, null, mds, jnf, null, null);
+        WebApp webApp = new WebApp(webAppConfig, null, null, mds, jnf, null);
         webAppConfig.setWebApp(webApp);
         webAppConfig.setBundleHeaders(bundleHeaders);
         webApp.setCollaboratorHelper(new CollaboratorHelperImpl(webApp, null));
@@ -258,7 +258,7 @@ public class SRTServletRequestTest {
         Hashtable bundleHeaders = new Hashtable(1);
         bundleHeaders.put("IBM-Authorization-Roles", "default");
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp webApp = new WebApp(webAppConfig, null, null, mds, jnf, null, null);
+        WebApp webApp = new WebApp(webAppConfig, null, null, mds, jnf, null);
         webAppConfig.setWebApp(webApp);
         webAppConfig.setBundleHeaders(bundleHeaders);
         webApp.setCollaboratorHelper(new CollaboratorHelperImpl(webApp, null));
@@ -311,7 +311,7 @@ public class SRTServletRequestTest {
         Hashtable bundleHeaders = new Hashtable(1);
         bundleHeaders.put("IBM-Authorization-Roles", "com.ibm.ws.management");
         WebAppConfiguration webAppConfig = new WebAppConfiguration(null, "name");
-        WebApp webApp = new WebApp(webAppConfig, null, null, mds, jnf, null, null);
+        WebApp webApp = new WebApp(webAppConfig, null, null, mds, jnf, null);
         webAppConfig.setWebApp(webApp);
         webAppConfig.setBundleHeaders(bundleHeaders);
         webApp.setCollaboratorHelper(new CollaboratorHelperImpl(webApp, null));

--- a/dev/com.ibm.ws.webserver.plugin.runtime/src/com/ibm/ws/webserver/plugin/runtime/listeners/GeneratePluginConfigListener.java
+++ b/dev/com.ibm.ws.webserver.plugin.runtime/src/com/ibm/ws/webserver/plugin/runtime/listeners/GeneratePluginConfigListener.java
@@ -289,7 +289,7 @@ public class GeneratePluginConfigListener implements RuntimeUpdateListener, Appl
             };
 
             final CheckpointPhase checkpoint = CheckpointPhase.getPhase();
-            if (checkpoint != null) {
+            if (checkpoint != CheckpointPhase.INACTIVE) {
                 CheckpointHook restoreHook = new CheckpointHook() {
                     @Override
                     public void restore() {

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/FATServletClient.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/FATServletClient.java
@@ -184,6 +184,19 @@ public class FATServletClient {
      * @return test method name without the RepeatTests suffix.
      */
     public String getTestMethodSimpleName() {
+        return getTestMethodSimpleName(testName);
+    }
+
+    /**
+     * Returns the test method name without the RepeatTests suffix.
+     *
+     * For example, when using RepeatTests with EE7_FEATURES, the suffix _EE7_FEATURES is added
+     * to provide unique test names for junit reporting purposes. The simple test method name
+     * dose not include the suffix.
+     *
+     * @return test method name without the RepeatTests suffix.
+     */
+    public static String getTestMethodSimpleName(TestName testName) {
         String testMethodName = testName.getMethodName();
         String currentAction = RepeatTestFilter.getRepeatActionsAsString();
         if (currentAction != null && testMethodName.endsWith(currentAction)) {

--- a/dev/io.openliberty.checkpoint/src/io/openliberty/checkpoint/internal/CheckpointImpl.java
+++ b/dev/io.openliberty.checkpoint/src/io/openliberty/checkpoint/internal/CheckpointImpl.java
@@ -209,7 +209,8 @@ public class CheckpointImpl implements RuntimeUpdateListener, ServerReadyStatus 
     private static volatile CheckpointImpl INSTANCE = null;
 
     @Activate
-    public CheckpointImpl(ComponentContext cc, @Reference WsLocationAdmin locAdmin, @Reference CheckpointPhase phase) {
+    public CheckpointImpl(ComponentContext cc, @Reference WsLocationAdmin locAdmin,
+                          @Reference(target = CheckpointPhase.CHECKPOINT_ACTIVE_FILTER) CheckpointPhase phase) {
         this(cc, null, locAdmin, phase);
     }
 

--- a/dev/io.openliberty.checkpoint/src/io/openliberty/checkpoint/internal/CheckpointOSGiConsole.java
+++ b/dev/io.openliberty.checkpoint/src/io/openliberty/checkpoint/internal/CheckpointOSGiConsole.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package io.openliberty.checkpoint.internal;
 
+import static io.openliberty.checkpoint.spi.CheckpointPhase.CHECKPOINT_ACTIVE_FILTER;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -39,7 +41,7 @@ public class CheckpointOSGiConsole implements CheckpointHook {
     private final FrameworkWiring fwkWiring;
 
     @Activate
-    public CheckpointOSGiConsole(@Reference CheckpointPhase phase, BundleContext context) {
+    public CheckpointOSGiConsole(@Reference(target = CHECKPOINT_ACTIVE_FILTER) CheckpointPhase phase, BundleContext context) {
         Requirement consolePkg = new Requirement() {
 
             @Override

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/BasicServletTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/BasicServletTest.java
@@ -10,15 +10,13 @@
  *******************************************************************************/
 package io.openliberty.checkpoint.fat;
 
-import static io.openliberty.checkpoint.fat.FATSuite.getTestMethodName;
+import static io.openliberty.checkpoint.fat.FATSuite.getTestMethodNameOnly;
 import static org.junit.Assert.assertNotNull;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -39,8 +37,6 @@ import io.openliberty.checkpoint.spi.CheckpointPhase;
 @RunWith(FATRunner.class)
 @SkipIfCheckpointNotSupported
 public class BasicServletTest extends FATServletClient {
-    @Rule
-    public TestName testName = new TestName();
 
     public static final String APP_NAME = "app1";
 
@@ -66,7 +62,7 @@ public class BasicServletTest extends FATServletClient {
                                  assertNotNull("'CWWKZ0001I: Application app1 started' message not found in log.",
                                                server.waitForStringInLogUsingMark("CWWKZ0001I: Application app1 started", 0));
                              });
-        server.startServer(getTestMethodName(testName) + ".log");
+        server.startServer(getTestMethodNameOnly(testName) + ".log");
     }
 
     @After

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/CheckpointPhaseTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/CheckpointPhaseTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package io.openliberty.checkpoint.fat;
 
-import static io.openliberty.checkpoint.fat.FATSuite.getTestMethodName;
+import static io.openliberty.checkpoint.fat.FATSuite.getTestMethodNameOnly;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -126,7 +126,7 @@ public class CheckpointPhaseTest {
 
     @Before
     public void setConsoleLogName() {
-        server.setConsoleLogName(getTestMethodName(testName));
+        server.setConsoleLogName(getTestMethodNameOnly(testName));
     }
 
     @After

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/CheckpointSPITest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/CheckpointSPITest.java
@@ -11,6 +11,7 @@
 package io.openliberty.checkpoint.fat;
 
 import static io.openliberty.checkpoint.fat.FATSuite.getTestMethod;
+import static io.openliberty.checkpoint.fat.FATSuite.getTestMethodNameOnly;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -76,7 +77,7 @@ public class CheckpointSPITest {
 
     @Test
     public void testRestoreWithDefaults() throws Exception {
-        server.startServer(getTestMethod(TestMethod.class, testName) + ".log");
+        server.startServer(getTestMethodNameOnly(testName) + ".log");
         findLogMessage("No restore config", "TESTING - restore config: ", "pida=test1 pidb=test1", 0);
         findLogMessage("No RESTORED true found in restore", "TESTING - in restore method RESTORED", " - true -- true", 500);
         findLogMessage("Restore should have null running condition", "TESTING - restore running condition: ", "null", 500);
@@ -85,26 +86,26 @@ public class CheckpointSPITest {
 
     @Test
     public void testRestoreWithEnvSet() throws Exception {
-        server.startServer(getTestMethod(TestMethod.class, testName) + ".log");
+        server.startServer(getTestMethodNameOnly(testName) + ".log");
         findLogMessage("No restore config", "TESTING - modified config: pida=env2 pidb=env2", "", 0);
     }
 
     @Test
     public void testAddImmutableEnvKey() throws Exception {
-        server.startServer(getTestMethod(TestMethod.class, testName) + ".log");
+        server.startServer(getTestMethodNameOnly(testName) + ".log");
         findLogMessage("Unexpected value for mutable key", "TESTING - in restore envs -", " v1 - v2 - v3 - v4", 500);
     }
 
     @Test
     public void testRunningConditionLaunch() throws Exception {
-        server.startServer(getTestMethod(TestMethod.class, testName) + ".log");
+        server.startServer(getTestMethodNameOnly(testName) + ".log");
         findLogMessage("Activate should have non-null running condition", "TESTING - activate running condition: ", "io.openliberty.process.running null", 500);
     }
 
     @Test
     @ExpectedFFDC("io.openliberty.checkpoint.internal.criu.CheckpointFailedException")
     public void testFailedCheckpoint() throws Exception {
-        ProgramOutput output = server.startServer(getTestMethod(TestMethod.class, testName) + ".log");
+        ProgramOutput output = server.startServer(getTestMethodNameOnly(testName) + ".log");
         int retureCode = output.getReturnCode();
         assertEquals("Wrong return code for failed checkpoint.", 72, retureCode);
     }
@@ -112,7 +113,7 @@ public class CheckpointSPITest {
     @Test
     @ExpectedFFDC("io.openliberty.checkpoint.internal.criu.CheckpointFailedException")
     public void testFailedRestore() throws Exception {
-        server.startServer(getTestMethod(TestMethod.class, testName) + ".log");
+        server.startServer(getTestMethodNameOnly(testName) + ".log");
         ProgramOutput output = server.checkpointRestore();
         int retureCode = output.getReturnCode();
         assertEquals("Wrong return code for failed checkpoint.", 77, retureCode);
@@ -120,7 +121,7 @@ public class CheckpointSPITest {
 
     @Test
     public void testStaticHook() throws Exception {
-        server.startServer(getTestMethod(TestMethod.class, testName) + ".log");
+        server.startServer(getTestMethodNameOnly(testName) + ".log");
         findLogMessage("Static single prepare method", STATIC_SINGLE_RESTORE, "SUCCESS", 500);
         findLogMessage("Static single prepare method", STATIC_MULTI_RESTORE, "SUCCESS", 500);
     }

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FATSuite.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FATSuite.java
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package io.openliberty.checkpoint.fat;
 
+import static componenttest.topology.utils.FATServletClient.getTestMethodSimpleName;
+import static org.junit.Assert.fail;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -57,8 +60,16 @@ public class FATSuite extends TestContainerSuite {
         appFile.copyToDest(server.getFileFromLibertyServerRoot("dropins"));
     }
 
-    static String getTestMethodName(TestName testName) {
-        String testMethodSimpleName = testName.getMethodName();
+    /**
+     * Gets only the test method of the TestName without the class name
+     * and without the repeating rule name.
+     *
+     * @param testName
+     * @return the test method only
+     */
+    static String getTestMethodNameOnly(TestName testName) {
+        String testMethodSimpleName = getTestMethodSimpleName(testName);
+        // Sometimes the method name includes the class name; remove the class name.
         int dot = testMethodSimpleName.indexOf('.');
         if (dot != -1) {
             testMethodSimpleName = testMethodSimpleName.substring(dot + 1);
@@ -67,12 +78,13 @@ public class FATSuite extends TestContainerSuite {
     }
 
     static public <T extends Enum<T>> T getTestMethod(Class<T> type, TestName testName) {
-        String testMethodSimpleName = getTestMethodName(testName);
+        String simpleName = getTestMethodNameOnly(testName);
         try {
-            return Enum.valueOf(type, testMethodSimpleName);
+            return Enum.valueOf(type, simpleName);
         } catch (IllegalArgumentException e) {
-            Log.info(type, testName.getMethodName(), "No configuration enum: " + testName.getMethodName());
-            return Enum.valueOf(type, "unknown");
+            Log.info(type, simpleName, "No configuration enum: " + testName);
+            fail("Unknown test name: " + testName);
+            return null;
         }
     }
 

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/LocalEJBTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/LocalEJBTest.java
@@ -11,6 +11,7 @@
 package io.openliberty.checkpoint.fat;
 
 import static io.openliberty.checkpoint.fat.FATSuite.getTestMethod;
+import static io.openliberty.checkpoint.fat.FATSuite.getTestMethodNameOnly;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -96,7 +97,7 @@ public class LocalEJBTest extends FATServletClient {
                                      }
                                  }
                              });
-        server.startServer(getTestMethodSimpleName() + ".log");
+        server.startServer(getTestMethodNameOnly(testName) + ".log");
     }
 
     @Test

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/LogsVerificationTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/LogsVerificationTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package io.openliberty.checkpoint.fat;
 
-import static io.openliberty.checkpoint.fat.FATSuite.getTestMethodName;
+import static io.openliberty.checkpoint.fat.FATSuite.getTestMethodNameOnly;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -61,7 +61,7 @@ public class LogsVerificationTest {
     @Test
     public void testMessagesAndTraceLogsCreatedNewOnCheckpointRestore() throws Exception {
         server.setCheckpoint(CheckpointPhase.APPLICATIONS, false, null);
-        server.startServer(getTestMethodName(testName) + ".log");
+        server.startServer(getTestMethodNameOnly(testName) + ".log");
 
         server.checkpointRestore();
 
@@ -101,7 +101,7 @@ public class LogsVerificationTest {
         FATSuite.configureBootStrapProperties(server, properties);
 
         server.setCheckpoint(CheckpointPhase.APPLICATIONS, false, null);
-        server.startServer(getTestMethodName(testName) + ".log");
+        server.startServer(getTestMethodNameOnly(testName) + ".log");
 
         server.checkpointRestore();
 
@@ -137,7 +137,7 @@ public class LogsVerificationTest {
     @Test
     public void testRestoreWorksAfterMessagesLogIsDeleted() throws Exception {
         server.setCheckpoint(CheckpointPhase.APPLICATIONS, false, null);
-        server.startServer(getTestMethodName(testName) + ".log");
+        server.startServer(getTestMethodNameOnly(testName) + ".log");
         assertEquals("Expected checkpoint message not found", 1, server.findStringsInLogs("CWWKC0451I", server.getDefaultLogFile()).size());
 
         RemoteFile messagesLog = server.getDefaultLogFile();
@@ -154,7 +154,7 @@ public class LogsVerificationTest {
     @Test
     public void testVariableSourceDirUpdateDuringRestore() throws Exception {
         server.setCheckpoint(CheckpointPhase.APPLICATIONS, false, null);
-        server.startServer(getTestMethodName(testName) + ".log");
+        server.startServer(getTestMethodNameOnly(testName) + ".log");
 
         server.copyFileToLibertyServerRoot("varfiles/server.env");
 

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/TestSPIConfig/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/TestSPIConfig/bootstrap.properties
@@ -11,3 +11,4 @@
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
 io.openliberty.checkpoint.allowed.features=timedexit-1.0,componenttest-1.0,usr:test.checkpoint.config-1.0
+io.openliberty.checkpoint.debug=true

--- a/dev/io.openliberty.io.smallrye.config/src/io/openliberty/microprofile/config/internal/extension/OLSmallRyeConfigBuilder.java
+++ b/dev/io.openliberty.io.smallrye.config/src/io/openliberty/microprofile/config/internal/extension/OLSmallRyeConfigBuilder.java
@@ -61,7 +61,7 @@ public class OLSmallRyeConfigBuilder extends SmallRyeConfigBuilder {
         // Getting the phase non null implies that the server did a checkpoint.
         // Wrap all the config sources during the checkpoint to record the configuration values read during checkpoint by the application before doing a server restore.
         CheckpointPhase phase = CheckpointPhase.getPhase();
-        if (phase != null && !phase.restored()) {
+        if (!phase.restored()) {
             for (ListIterator<ConfigSource> iSources = defaultSources.listIterator(); iSources.hasNext();) {
                 ConfigSource source = iSources.next();
                 iSources.set(new ConfigSourceWrapper(source, phase));

--- a/dev/io.openliberty.io.smallrye.config/src/io/openliberty/microprofile/config/internal/extension/OLSmallRyeConfigExtension.java
+++ b/dev/io.openliberty.io.smallrye.config/src/io/openliberty/microprofile/config/internal/extension/OLSmallRyeConfigExtension.java
@@ -72,7 +72,7 @@ public class OLSmallRyeConfigExtension extends ConfigExtension implements Extens
      * @return Returns a closeable that is used to unpause recording of reads.
      */
     static UnpauseRecording pauseRecordingReads() {
-        if (phase == null || phase.restored() || !recordingPaused.get().compareAndSet(false, true)) {
+        if (phase.restored() || !recordingPaused.get().compareAndSet(false, true)) {
             return noOpCloseable;
         }
         return unpauseRecordingCloseable;
@@ -83,7 +83,7 @@ public class OLSmallRyeConfigExtension extends ConfigExtension implements Extens
      * @return Returns true if recording of config reads is enabled, otherwise false.
      */
     public static boolean isRecording() {
-        if (phase == null || phase.restored()) {
+        if (phase.restored()) {
             return false;
         }
         return !recordingPaused.get().get();

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal.factories/src/io/openliberty/webcontainer/servlet/internal/osgi/webapp/factory/WebAppFactory60Impl.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal.factories/src/io/openliberty/webcontainer/servlet/internal/osgi/webapp/factory/WebAppFactory60Impl.java
@@ -10,10 +10,7 @@
  *******************************************************************************/
 package io.openliberty.webcontainer.servlet.internal.osgi.webapp.factory;
 
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
 
 import com.ibm.websphere.csi.J2EENameFactory;
 import com.ibm.ws.container.service.metadata.MetaDataService;
@@ -24,19 +21,11 @@ import com.ibm.ws.webcontainer.osgi.webapp.WebAppFactory;
 import com.ibm.ws.webcontainer40.osgi.webapp.WebApp40;
 import com.ibm.wsspi.injectionengine.ReferenceContext;
 
-import io.openliberty.checkpoint.spi.CheckpointPhase;
-
 /**
 *
 */
 @Component(service = WebAppFactory.class, property = { "service.vendor=IBM" })
 public class WebAppFactory60Impl implements WebAppFactory {
-    private final CheckpointPhase checkpointPhase;
-
-    @Activate
-    public WebAppFactory60Impl(@Reference(cardinality = ReferenceCardinality.OPTIONAL) CheckpointPhase checkpointPhase) {
-        this.checkpointPhase = checkpointPhase;
-    }
 
     /*
      * (non-Javadoc)
@@ -47,6 +36,6 @@ public class WebAppFactory60Impl implements WebAppFactory {
     @Override
     public WebApp createWebApp(WebAppConfiguration webAppConfig, ClassLoader moduleLoader, ReferenceContext referenceContext, MetaDataService metaDataService,
                                J2EENameFactory j2eeNameFactory, ManagedObjectService managedObjectService) {
-        return new WebApp40(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService, checkpointPhase);
+        return new WebApp40(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService);
     }
 }


### PR DESCRIPTION
Add an INACTIVE CheckpointPhase
    
Change CheckpointPhase.getPhase to never return null.
If no checkpoint is being done then getPhase will return
the INACTIVE phase.  Always register the CheckpointPhase
service.  This service is internal so is not beta gaurded from
registration.
    
Updates to all places that checked for null instead of
the INACTIVE phase.