### PR TITLE
Add keyStore and security config

### DIFF
--- a/dev/io.openliberty.microprofile.internal_fat/publish/servers/MPCompatibleServer/MP40andEE8.xml
+++ b/dev/io.openliberty.microprofile.internal_fat/publish/servers/MPCompatibleServer/MP40andEE8.xml
@@ -6,4 +6,7 @@
         <feature>microProfile-4.0</feature>
         <feature>jakartaee-8.0</feature>
     </featureManager>
+    
+    <keyStore id="defaultKeyStore" password="openliberty"/>
+    <quickStartSecurity userName="admin" userPassword="adminpwd"/>
 </server>

--- a/dev/io.openliberty.microprofile5.internal_fat/publish/servers/MP5CompatibleServer/MP50andEE8.xml
+++ b/dev/io.openliberty.microprofile5.internal_fat/publish/servers/MP5CompatibleServer/MP50andEE8.xml
@@ -6,4 +6,7 @@
         <feature>microProfile-5.0</feature>
         <feature>jakartaee-8.0</feature>
     </featureManager>
+    
+    <keyStore id="defaultKeyStore" password="openliberty"/>
+    <quickStartSecurity userName="admin" userPassword="adminpwd"/>
 </server>

--- a/dev/io.openliberty.microprofile5.internal_fat/publish/servers/MP5CompatibleServer/MP50andEE9.xml
+++ b/dev/io.openliberty.microprofile5.internal_fat/publish/servers/MP5CompatibleServer/MP50andEE9.xml
@@ -6,4 +6,7 @@
         <feature>microProfile-5.0</feature>
         <feature>jakartaee-9.1</feature>
     </featureManager>
+    
+    <keyStore id="defaultKeyStore" password="openliberty"/>
+    <quickStartSecurity userName="admin" userPassword="adminpwd"/>
 </server>


### PR DESCRIPTION
A follow on from https://github.com/OpenLiberty/open-liberty/pull/21965 which aims to avoid an intermittent error message which causes a build break

```
testMP40andEE8:java.lang.Exception: 2021-01-20-19:48:45:353 Errors/warnings were found in server MPCompatibleServer logs:
<br>[1/20/21 19:48:37:501 GMT] 0000002a ibm.ws.transport.iiop.security.AbstractCsiv2SubsystemFactory E CWWKS9582E: The [defaultSSLConfig] sslRef attributes required by the orb element with the defaultOrb id have not been resolved within 10 seconds. As a result, the applications will not start. Ensure that you have included a keyStore element and that Secure Sockets Layer (SSL) is configured correctly. If the sslRef is defaultSSLConfig, then add a keyStore element with the id defaultKeyStore and a password.
```

#build