### PR TITLE
Create .project for telemetry_fat

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/.project
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.microprofile.telemetry.1.0.internal_fat</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>


### PR DESCRIPTION
.project was missing for `io.openliberty.microprofile.telemetry.1.0.internal_fat`