### PR TITLE
disallow Java 19 methods on persistent executor

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
@@ -431,6 +431,13 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
         return updateCount;
     }
 
+    @Trivial
+    public void close() {
+        // Section 3.1.6.1 of the Concurrency Utilities spec requires IllegalStateException
+        // for ManagedExecutorService and ManagedScheduledExecutorService
+        throw new IllegalStateException(new UnsupportedOperationException("close"));
+    }
+
     public <U> CompletableFuture<U> completedFuture(U value) {
         // Concurrency 3.0 reactive operations cannot be used on
         // persistent executor implementation that spans multiple servers

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/TaskStatusImpl.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/TaskStatusImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014,2019 IBM Corporation and others.
+ * Copyright (c) 2014,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -174,6 +174,14 @@ public class TaskStatusImpl<T> implements TaskStatus<T>, TimerStatus<T> {
                    && Arrays.equals(resultBytes, other.resultBytes);
         }
         return false;
+    }
+
+    /**
+     * Unimplemented because persistent executor futures (TaskStatus) are only usable by persistent EJB timers
+     * and not directly by applications.
+     */
+    Throwable exceptionNow() {
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -371,6 +379,14 @@ public class TaskStatusImpl<T> implements TaskStatus<T>, TimerStatus<T> {
             throw new IllegalStateException(Tr.formatMessage(tc, "CWWKC1550.status.unavailable.until.ended", "isDone"));
         else
             return true;
+    }
+
+    /**
+     * Unimplemented because persistent executor futures (TaskStatus) are only usable by persistent EJB timers
+     * and not directly by applications.
+     */
+    T resultNow() {
+        throw new UnsupportedOperationException();
     }
 
     /**


### PR DESCRIPTION
With the persistent executor only being used internally for persistent EJB timers, there is no reason to provide working implementations of the new Java 19 methods.  But we also don't want the default implementations doing things that might not be correct in case persistent EJB timers or other function ever starts using them.  The most straightforward option is to force them to raise errors.  We can do this for all of the new methods except for getState, which cannot compile against Java 11 due to its return type.  For that one, we will need to rely on the default implementation hopefully doing the right thing in some cases and indirectly causing an exception to be raised when it doesn't.