### PR TITLE
Change CWWKL0060W to unsupported usage error

### DIFF
--- a/dev/com.ibm.ws.classloading.bells/resources/com/ibm/ws/classloading/bells/internal/resources/BellConfigurationMessages.nlsprops
+++ b/dev/com.ibm.ws.classloading.bells/resources/com/ibm/ws/classloading/bells/internal/resources/BellConfigurationMessages.nlsprops
@@ -87,16 +87,9 @@ bell.spi.visibility.enabled.explanation=To prevent applications and resources fr
 bell.spi.visibility.enabled.useraction=Disable SPI visibility in the BELL configuration whenever the BELL must reference a library through a class loader that is shared with applications that reference the same library. Otherwise, no action is required.
 
 # BETA
-bell.spi.visibility.disabled.libref.global=CWWKL0060W: BELL SPI visibility is not enabled for the Liberty global shared library.
-bell.spi.visibility.disabled.libref.global.explanation=BELL SPI visibility is not supported for the Liberty global shared library.
+bell.spi.visibility.disabled.libref.global=CWWKL0060E: BELL SPI visibility is not supported for the Liberty global shared library.
+bell.spi.visibility.disabled.libref.global.explanation=BELL SPI visibility cannot be enabled for the Liberty global shared library.
 bell.spi.visibility.disabled.libref.global.useraction=Modify the BELL configuration to reference a library other than the Liberty global shared library.
-
-# BETA: NOT IMPLEMENTED
-# {0} - application identifier
-# {1} - library identifier
-#bell.spi.visible.share.common.libref=CWWKL0061W: The {0} application and BELL share a common library reference, but do not reference the {1} library through a common class loader because the BELL is enabled for SPI visibility.
-#bell.spi.visible.share.common.libref.explanation=To prevent applications and resources from seeing SPI packages, the BELL references the library through a unique class loader that is not shared with the application.
-#bell.spi.visible.share.common.libref.useraction=Disable SPI visibility in the BELL configuration whenever the application and BELL must share a common library class loader. Otherwise, no action is required.
 
 # BETA
 # {0} - the name of the implementation class

--- a/dev/com.ibm.ws.classloading.bells_fat/fat/src/com/ibm/ws/classloading/BellSpiVisibilityTest.java
+++ b/dev/com.ibm.ws.classloading.bells_fat/fat/src/com/ibm/ws/classloading/BellSpiVisibilityTest.java
@@ -149,7 +149,7 @@ public class BellSpiVisibilityTest {
                 assertNotNull("The server should report bell spi visibility is enabled for library 'testSpiVisible', but did not.",
                         server.waitForStringInLog(".*CWWKL0059I: .*testSpiVisible"));
 
-                assertNotNull("The server should load the META-INF service in the 'testSpiVisible' library referenced by the BELL, but did not.",
+                assertNotNull("The server should register the META-INF service in the 'testSpiVisible' library referenced by the BELL, but did not.",
                         server.waitForStringInLog(".*CWWKL0050I: .*testSpiVisible.*SpiVisible"));
 
                 assertNotNull("SPI should be visible to the BELL service when spi visibility is enabled, but is not",
@@ -165,7 +165,7 @@ public class BellSpiVisibilityTest {
                 assertNull("The server should not report bell spi visibility is enabled for library 'testSpiVisible', but did.",
                         server.waitForStringInLog(".*CWWKL0059I: .*testSpiVisible", TimeOut));
 
-                assertNotNull("The server should load the META-INF service in the 'testSpiVisible' library referenced by the BELL, but did not.",
+                assertNotNull("The server should register the META-INF service in the 'testSpiVisible' library referenced by the BELL, but did not.",
                         server.waitForStringInLog(".*CWWKL0050I: .*testSpiVisible.*SpiVisible"));
 
                 assertNull("IBM-SPI packages should not be visible to the BELL service, but are.",
@@ -211,7 +211,7 @@ public class BellSpiVisibilityTest {
             assertNull("The server should not report bell spi visibility is enabled for library 'testNoSpiVisible', but did.",
                     server.waitForStringInLog(".*CWWKL0059I: .*testNoSpiVisible"));
 
-            assertNotNull("The server should load the META-INF service in the 'testNoSpiVisible' library, but did not.",
+            assertNotNull("The server should register the META-INF service in the 'testNoSpiVisible' library, but did not.",
                     server.waitForStringInLog(".*CWWKL0050I: .*testNoSpiVisible.*SpiVisible"));
 
             assertNotNull("IBM-SPI packages should not be visible to the BELL service, but are.",
@@ -319,10 +319,10 @@ public class BellSpiVisibilityTest {
 
             if (runAsBetaEdition) {
                 assertNotNull("The server should disable bell spi visibility for the global shared library, but did not",
-                        server.waitForStringInLog(".*CWWKL0060W: .*global "));
+                        server.waitForStringInLog(".*CWWKL0060E: .*global "));
             } else {
                 assertNull("The server should not disable bell spi visibility for the global shared library, but did",
-                        server.waitForStringInLog(".*CWWKL0060W: .*global", 10));
+                        server.waitForStringInLog(".*CWWKL0060E: .*global", 10));
 
                 assertNull("The server should not enable bell spi visibility for any shared library, but did",
                            server.waitForStringInLog(".*CWWKL0059I: ", 10));


### PR DESCRIPTION
Modify message CWWKL0060W to indicate that it is an unsupported usage **error** for a BELL configuration to reference the liberty global shared library and also enable SPI visibility. 

This PR also removes beta message CWWKL0061W as we are not going to implement/release the corresponding feature runtime function.