### PR TITLE
Add javapermission and retry logic

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/MicroProfileTelemetryTestBase.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/MicroProfileTelemetryTestBase.java
@@ -94,7 +94,7 @@ public abstract class MicroProfileTelemetryTestBase {
         return APP_URL;
     }
 
-    protected String getSpansFromJaeger() {
+    protected String queryJaeger() {
         String method = "getSpans";
         String url = String.format(JAEGER_QUERY_URL, jaegerContainer.getHost(), String.valueOf(jaegerContainer.getMappedPort(JAEGER_UI_PORT)));
         String queryParams = String.format(JAEGER_QUERY_PARAMS, System.currentTimeMillis(), JAEGER_QUERY_LIMIT, OTEL_SERVICE_NAME_SYSTEM);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/testServer1/server.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/testServer1/server.xml
@@ -16,4 +16,6 @@
 
     <webApplication id="system" location="system.war" contextRoot="/"></webApplication>
     
+    <javaPermission className="java.util.PropertyPermission" name="*" actions="read" />
+    
 </server>


### PR DESCRIPTION
Fixes #22246

- Add `javapermission` in `server.xml`
- Add retry logic when querying Jaeger 