### PR TITLE
Add support for Virtual Threads

### DIFF
--- a/dev/com.ibm.ws.threading/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.threading/resources/OSGI-INF/l10n/metatype.properties
@@ -25,3 +25,6 @@ core.threads.desc=Baseline or minimum number of threads to associate with the ex
 
 max.threads=Maximum threads
 max.threads.desc=Maximum number of threads that can be associated with the executor. If greater than 0, maxThreads can be a minimum of 4, and should be at least as large as coreThreads; if maxThreads is set less than coreThreads, Liberty will reduce coreThreads to the maxThreads value.  If the value of maxThreads is less than or equal to 0, the maximum number of threads is unbounded, which lets the Liberty kernel decide how many threads to associate with the executor without having a defined upper boundary.
+
+virtual=Virtual Threads
+virtual.desc=Whether to use Virtual Threads rather than Platform Threads. Requires Java 19 with preview features enabled.

--- a/dev/com.ibm.ws.threading/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.threading/resources/OSGI-INF/metatype/metatype.xml
@@ -5,11 +5,11 @@
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
-   
+
     Contributors:
         IBM Corporation - initial API and implementation
  -->
-<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.1.0" 
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.1.0"
                    xmlns:ibm="http://www.ibm.com/xmlns/appservers/osgi/metatype/v1.0.0"
                    localization="OSGI-INF/l10n/metatype">
 
@@ -17,11 +17,12 @@
         <AD name="%name"         description="%name.desc"         id="name"        required="false" type="String"  default="Default Executor" />
         <AD name="%max.threads"  description="%max.threads.desc"  id="maxThreads"  required="false" type="Integer" default="-1" />
         <AD name="%core.threads" description="%core.threads.desc" id="coreThreads" required="false" type="Integer" default="-1" />
+        <AD name="%virtual"      description="%virtual.desc"      id="virtual"     required="false" type="Boolean" default="false" ibm:beta="true"/>
     </OCD>
 
     <!-- Designate pid="com.ibm.ws.threading" --> <!-- factoryPid="com.ibm.ws.threading" -->
     <Designate pid="com.ibm.ws.threading">
         <Object ocdref="com.ibm.ws.threading.metatype" />
     </Designate>
-  
+
 </metatype:MetaData>

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
@@ -43,6 +43,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.service.util.AvailableProcessorsListener;
 import com.ibm.ws.kernel.service.util.CpuInfo;
+import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.ws.threading.ThreadQuiesce;
 import com.ibm.wsspi.threading.ExecutorServiceTaskInterceptor;
 import com.ibm.wsspi.threading.WSExecutorService;
@@ -216,7 +217,10 @@ public final class ExecutorServiceImpl implements WSExecutorService, ThreadQuies
         if (threadPool != null) {
             ((BoundedBuffer<Runnable>) threadPool.getQueue()).removeFromAvailableProcessors();
         }
-        threadPool = new ThreadPoolExecutor(coreThreads, maxThreads, 0, TimeUnit.MILLISECONDS, workQueue, threadFactory != null ? threadFactory : new ThreadFactoryImpl(poolName, threadGroupName), rejectedExecutionHandler);
+
+        boolean virtual = ProductInfo.getBetaEdition() && (Boolean)componentConfig.get("virtual");
+
+        threadPool = new ThreadPoolExecutor(coreThreads, maxThreads, 0, TimeUnit.MILLISECONDS, workQueue, threadFactory != null ? threadFactory : ThreadFactoryBuilder.create(poolName, threadGroupName, virtual), rejectedExecutionHandler);
 
         threadPoolController = new ThreadPoolController(this, threadPool);
 

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ScheduledExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ScheduledExecutorImpl.java
@@ -38,7 +38,7 @@ public final class ScheduledExecutorImpl extends ScheduledThreadPoolExecutor {
     }
 
     public ScheduledExecutorImpl() {
-        super(1, new ThreadFactoryImpl("Scheduled Executor", threadGroupName));
+        super(1, ThreadFactoryBuilder.create("Scheduled Executor", threadGroupName, false));
     }
 
     @Override

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ThreadFactoryBuilder.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ThreadFactoryBuilder.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+ package com.ibm.ws.threading.internal;
+
+ import java.util.concurrent.ThreadFactory;
+
+ import com.ibm.websphere.ras.Tr;
+ import com.ibm.websphere.ras.TraceComponent;
+ import com.ibm.websphere.ras.annotation.Trivial;
+
+ /**
+  * The default thread factory to use when one is not specified.
+  */
+public final class ThreadFactoryBuilder {
+  private final static TraceComponent tc = Tr.register(ThreadFactoryBuilder.class);
+
+  private static final boolean virtualThreadsSupported = VirtualThreadFactoryImpl.isSupported();
+
+  public static ThreadFactory create(String name, String tgName, boolean virtual) {
+    if (virtualThreadsSupported && virtual) {
+      return new VirtualThreadFactoryImpl(name);
+    } else {
+      return new ThreadFactoryImpl(name, tgName);
+    }
+  }
+}

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/VirtualThreadFactory.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/VirtualThreadFactory.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.threading.internal;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
+
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
+/**
+ * The default thread factory to use when one is not specified.
+ */
+final class VirtualThreadFactoryImpl implements ThreadFactory {
+  private final static TraceComponent tc = Tr.register(VirtualThreadFactoryImpl.class);
+  private final AtomicInteger createdThreadCount = new AtomicInteger();
+
+  /**
+   * The name of the executor associated with this factory.
+   */
+  private final String executorName;
+
+  /**
+   * The context class loader to associate with newly created threads.
+   */
+  private final ClassLoader contextClassLoader;
+
+  private  static MethodHandle name;
+  private  static MethodHandle unstarted;
+  private  static MethodHandle ofVirtual;
+
+  private Object builder;
+
+  private static Class<?> builderClass;
+
+  static {
+    doInit();
+  }
+
+  @FFDCIgnore(Exception.class)
+  private static void doInit() {
+    try {
+        builderClass = Class.forName("java.lang.Thread$Builder$OfVirtual");
+
+        MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+        name = lookup.findVirtual(builderClass, "name", MethodType.methodType(builderClass, String.class));
+        unstarted = lookup.findVirtual(builderClass, "unstarted", MethodType.methodType(Thread.class, Runnable.class));
+
+        ofVirtual = lookup.findStatic(Thread.class, "ofVirtual", MethodType.methodType(builderClass));
+    } catch (Exception e) {
+    }
+  }
+
+  /**
+   * Create a thread factory that creates threads associated with a
+   * named thread group.
+   *
+   * @param executorName the name of the owning executor that serves as
+   * @param threadGroupName the name of the thread group to create
+   */
+  @FFDCIgnore({RuntimeException.class, Error.class, Throwable.class})
+  VirtualThreadFactoryImpl(final String executorName) {
+      this.executorName = executorName;
+      this.contextClassLoader = Thread.currentThread().getContextClassLoader();
+
+      try {
+        builder = ofVirtual.invoke();
+      } catch (RuntimeException re) {
+        throw (RuntimeException)re;
+      } catch (Error e) {
+        throw (Error)e;
+      } catch (Throwable t) {
+        // do nothing since the called method doesn't throw checked exceptions
+      }
+  }
+
+  /**
+   * Create a new thread.
+   *
+   * @param runnable the task to run
+   */
+  @Override
+  public synchronized Thread newThread(final Runnable runnable) {
+    try {
+      int threadId = createdThreadCount.incrementAndGet();
+      final String threadName = executorName + "-thread-" + threadId;
+      name.invoke(builder, threadName);
+      Thread thread  = (Thread) unstarted.invoke(builder, runnable);
+      thread.setContextClassLoader(contextClassLoader);
+      return thread;
+    } catch (RuntimeException re) {
+      throw (RuntimeException)re;
+    } catch (Error e) {
+      throw (Error)e;
+    } catch (Throwable t) {
+      // do nothing since the called method doesn't throw checked exceptions
+      return null;
+    }
+  }
+
+  @FFDCIgnore(UnsupportedOperationException.class)
+  public static boolean isSupported() {
+    try {
+      return builderClass != null && ofVirtual.invoke() != null;
+    } catch (UnsupportedOperationException e) {
+      // This is a normal situation if preview features are not enabled so ignore
+    } catch (Throwable t) {
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
Adds preview support for virtual threads. Since Open Liberty does not compile
with Java 19 the interaction with virtual threads will use MethodHandles.

This code will only take effect if the following conditions are true:

1. A beta of Open Liberty is used
2. The configuration <executor virtual="true" /> is set in server.xml
3. Preview features of Java 19 is enabled

