### PR TITLE
New MicroProfile 6.0 features do not work with Java 8

### DIFF
--- a/dev/build.featureStart.mToZ_fat/publish/files/feature-java-levels.properties
+++ b/dev/build.featureStart.mToZ_fat/publish/files/feature-java-levels.properties
@@ -1,5 +1,10 @@
 mail-2.1=11
 messaging-3.1=11
+microProfile-6.0=11
+mpJwt-2.1=11
+mpMetrics-5.0=11
+mpOpenAPI-3.1=11
+mpTelemetry-1.0=11
 pages-3.1=11
 persistence-3.1=11
 persistenceContainer-3.1=11


### PR DESCRIPTION
Within the FeaturesStartTestMToZ test, set the minimum Java version to 11 for all new MP6 features
#build
