### PR TITLE
Skip Repeat for certain redundant RequestTiming FATs

### DIFF
--- a/dev/com.ibm.ws.request.timing.hung_fat/fat/src/com/ibm/ws/request/timing/hung/fat/FATSuite.java
+++ b/dev/com.ibm.ws.request.timing.hung_fat/fat/src/com/ibm/ws/request/timing/hung/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,6 +27,9 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
     // Using the RepeatTests @ClassRule in FATSuite will cause all tests in the FAT to be run twice.
     // First without any modifications, then again with all features in all server.xml's upgraded to their EE8/EE9 equivalents.
+    // Some corner case tests are skipped for repeating, as its not necessary to repeat these tests using the newer features, since
+    // some basic functionality test cases that use common code are already being repeated.
+    // Ensure, the corner case scenario test cases are skipped for repeat, when adding another RepeatAction below, to save build and test time.
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification().andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly()).andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly());
 }

--- a/dev/com.ibm.ws.request.timing.hung_fat/fat/src/com/ibm/ws/request/timing/hung/fat/HungRequestEnableThreadDumps.java
+++ b/dev/com.ibm.ws.request.timing.hung_fat/fat/src/com/ibm/ws/request/timing/hung/fat/HungRequestEnableThreadDumps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.request.timing.hung.fat;
 
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
@@ -31,6 +33,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -80,6 +83,7 @@ public class HungRequestEnableThreadDumps {
      * Tests when the boolean "enableThreadDumps" attribute is not specified, the thread dumps should be created when the hung request is detected.
      */
     @Test
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testEnableThreadDumpsNotSpecified() throws Exception {
         CommonTasks.writeLogMsg(Level.INFO, "***** Begining testEnableThreadDumpsNotSpecified! *****");
 
@@ -125,6 +129,7 @@ public class HungRequestEnableThreadDumps {
      */
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testDynamicThreadDumpsDisable() throws Exception {
         CommonTasks.writeLogMsg(Level.INFO, "***** Begining testDynamicThreadDumpsDisable! *****");
 
@@ -205,6 +210,7 @@ public class HungRequestEnableThreadDumps {
      * The sub-element configuration should override the root element configuration, hence when a hung request is detected, thread dumps will be created.
      */
     @Test
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testGlobalThreadDumpsDisableLocalThreadDumpsEnable() throws Exception {
         CommonTasks.writeLogMsg(Level.INFO, "***** Begining testGlobalThreadDumpsDisableLocalThreadDumpsEnable! *****");
 
@@ -251,6 +257,7 @@ public class HungRequestEnableThreadDumps {
      * The default configuration will be used ("enableThreadDumps=true"), where thread dumps will be created.
      */
     @Test
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testInvalidEnableThreadDumpsAttributeValue() throws Exception {
         CommonTasks.writeLogMsg(Level.INFO, "***** Begining testInvalidEnableThreadDumpsAttributeValue! *****");
 

--- a/dev/com.ibm.ws.request.timing.hung_fat/fat/src/com/ibm/ws/request/timing/hung/fat/HungRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing.hung_fat/fat/src/com/ibm/ws/request/timing/hung/fat/HungRequestTiming.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.request.timing.hung.fat;
 
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -44,6 +46,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -137,6 +140,7 @@ public class HungRequestTiming {
     }
 
     @Test
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testHungRequestIntrospector() throws Exception {
         final String METHOD_NAME = "testHungRequestIntrospector";
 
@@ -339,6 +343,7 @@ public class HungRequestTiming {
 
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testHungRequestDynamicDisable() throws Exception {
         // Disabling thread dumps, so server stops gracefully, instead of waiting for all thread dumps to be generated.
         CommonTasks.writeLogMsg(Level.INFO, "Setting hung threshold as 2s, with thread dumps disabled");
@@ -401,6 +406,7 @@ public class HungRequestTiming {
 
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testSequentialHungMultipleRequests() throws Exception {
         CommonTasks.writeLogMsg(Level.INFO, "Setting hung threshold as 2s");
         server.setServerConfigurationFile("server_hungRequestThreshold2.xml");

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/FATSuite.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,6 +27,9 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
     // Using the RepeatTests @ClassRule in FATSuite will cause all tests in the FAT to be run twice.
     // First without any modifications, then again with all features in all server.xml's upgraded to their EE8/EE9 equivalents.
+    // Some corner case tests are skipped for repeating, as its not necessary to repeat these tests using the newer features, since
+    // some basic functionality test cases that use common code are already being repeated.
+    // Ensure, the corner case scenario test cases are skipped for repeat, when adding another RepeatAction below, to save build and test time.
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification().andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly()).andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly());
 }

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.request.timing.fat;
 
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -36,6 +38,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -227,6 +230,7 @@ public class SlowRequestTiming {
     }
 
     @Test
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testSlowReqTimingTurnOff() throws Exception {
         server.setServerConfigurationFile("server_slowRequestThreshold0.xml");
         server.waitForStringInLog("CWWKG0017I");
@@ -374,6 +378,7 @@ public class SlowRequestTiming {
 //    }
 
     @Test
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testSlowReqSampleRateZero() throws Exception {
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> Updating server with configuration : sampleRate=0");
         server.setServerConfigurationFile("server_sampleRate0.xml");
@@ -403,6 +408,7 @@ public class SlowRequestTiming {
 
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testDynamicEnableWithNoContextInfo() throws Exception {
         //Step 1 - Remove Request Timing feature
         CommonTasks.writeLogMsg(Level.INFO, "-----> Updating server configuration to REMOVE Request Timing feature..");
@@ -452,6 +458,7 @@ public class SlowRequestTiming {
 
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testDynamicDisableWithNoContextInfo() throws Exception {
         //Step 1 -  Update server configuration - ContextInfo = false , Threshold = 2s
         CommonTasks.writeLogMsg(Level.INFO, "---> Updating server with ContextInfo = false");
@@ -626,6 +633,7 @@ public class SlowRequestTiming {
 
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testSlowReqSampleRateOdd() throws Exception {
         //Step 1 - Update server configuration - sampleRate=3, Threshold = "3s"
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> Updating server with configuration : sampleRate=3");
@@ -661,6 +669,7 @@ public class SlowRequestTiming {
 
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testSlowReqSampleRateEven() throws Exception {
         //Step 1 - Update server configuration - sampleRate=2, Threshold = "3s"
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> Updating server with configuration : sampleRate=2");
@@ -698,6 +707,7 @@ public class SlowRequestTiming {
 
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testSlowReqSampleRateNegative() throws Exception {
         //Step 1 - Update server configuration - sampleRate=-2, Threshold = "3s"
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> Updating server with configuration : sampleRate=-2");
@@ -716,6 +726,7 @@ public class SlowRequestTiming {
 
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testSlowReqSampleRateDynamicUpdate() throws Exception {
         //Step 1 - Update server configuration - sampleRate=2, Threshold = "3s"
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> Updating server with configuration : sampleRate=2");
@@ -757,6 +768,7 @@ public class SlowRequestTiming {
 
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testSlowReqSampleRateDynamicEnable() throws Exception {
         //Step 1 - Update server configuration - Enable Request Timing
         CommonTasks.writeLogMsg(Level.INFO, "**** Starting server with default Request Timing configuration");
@@ -796,6 +808,7 @@ public class SlowRequestTiming {
 
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testSlowReqSampleRateDynamicDisable() throws Exception {
         //Step 1 - Update server configuration - sampleRate=2, Threshold = "3s"
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> Updating server with configuration : sampleRate=2");

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/TimingRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/TimingRequestTiming.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.request.timing.fat;
 
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -36,6 +38,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -153,6 +156,7 @@ public class TimingRequestTiming {
      * </requestTiming>
      */
     @Test
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testDynamicTimingEnableDisable() throws Exception {
         //Set to default Configuration of Request Timing feature
         server.setServerConfigurationFile("server_original.xml");
@@ -222,6 +226,7 @@ public class TimingRequestTiming {
      * Verify that an exact match on context info over-rides global defaults.
      */
     @Test
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testContextInfoExactMatchOverrideDefault() throws Exception {
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration thresholds for - <global - slow : 5s , hung : 10s> <timing - Slow : 120s , hung : 120s>");
         server.setServerConfigurationFile("contextInfoPattern/server_timing_1.xml");
@@ -266,6 +271,7 @@ public class TimingRequestTiming {
      * Verify that a wild-card match on context info over-rides global defaults.
      */
     @Test
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testContextInfoWildCardMatchOverrideDefault() throws Exception {
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration thresholds for - <global - slow : 5s , hung : 10s> <timing - Slow : 120s , hung : 120s>");
         server.setServerConfigurationFile("contextInfoPattern/server_timing_3.xml");
@@ -317,6 +323,7 @@ public class TimingRequestTiming {
      */
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testTimingGlobalConfig() throws Exception {
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration thresholds for  <global : slow : 3s , hung : 6s><timing - Slow : 10s , hung : 12s>");
         server.setServerConfigurationFile("server_timing_global.xml");
@@ -356,6 +363,7 @@ public class TimingRequestTiming {
      */
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testTimingLocalConfigOnly() throws Exception {
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration thresholds for  <global : defaults ><timing - Slow : 3s , hung : 5s>");
         server.setServerConfigurationFile("server_timing_localOnly.xml");
@@ -399,6 +407,7 @@ public class TimingRequestTiming {
      */
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testTimingGlobalConfigNotSpecified() throws Exception {
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration thresholds for  <global : defaults ><timing - Slow : 3s , hung : 5s>");
         server.setServerConfigurationFile("server_timing_NoGlobal.xml");
@@ -440,6 +449,7 @@ public class TimingRequestTiming {
      */
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testTimingLocalNegativeSlowThreshold() throws Exception {
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration thresholds for  <global : slow : 9s , hung : 20s ><timing - Slow : -1 , hung : 3s>");
         server.setServerConfigurationFile("server_timing_local_NoSlowReq.xml");
@@ -475,6 +485,7 @@ public class TimingRequestTiming {
      */
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testTimingLocalInheritsGlobalConfig() throws Exception {
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration thresholds for  <global : slow : 2s , hung : 4s ><timing>");
         server.setServerConfigurationFile("server_timing_local_inherits.xml");
@@ -512,6 +523,7 @@ public class TimingRequestTiming {
      */
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testTimingLocalGlobalNoConfig() throws Exception {
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration thresholds for - <global -default> <timing - default>");
         server.setServerConfigurationFile("server_timing_local_global_noConfig.xml");
@@ -541,6 +553,7 @@ public class TimingRequestTiming {
      */
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testTimingLocalDisableSlowHungRequest() throws Exception {
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration thresholds for - <global : slow : 1s , hung : 2s ><timing - slow : 0 , hung : 0>");
         server.setServerConfigurationFile("server_timing_NoSlowHungReqs.xml");
@@ -569,6 +582,7 @@ public class TimingRequestTiming {
      */
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testTimingGlobalConfigFollowsLocal() throws Exception {
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration thresholds for - <global : slow : 3s , hung : 6s ><timing - slow : 2s , hung : 9m>");
         server.setServerConfigurationFile("server_timing_global_follows_local.xml");
@@ -660,6 +674,7 @@ public class TimingRequestTiming {
      */
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testTimingContextInfoConflict() throws Exception {
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration ctx info conflict");
         server.setServerConfigurationFile("server_timing_ctxinfo_conflict.xml");
@@ -688,6 +703,7 @@ public class TimingRequestTiming {
      */
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testTimingContextInfoNoConflict() throws Exception {
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration ctx info no conflict");
         server.setServerConfigurationFile("server_timing_ctxinfo_no_conflict.xml");
@@ -704,6 +720,7 @@ public class TimingRequestTiming {
      */
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testContextInfoWildCardNoMatch() throws Exception {
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration thresholds for - <global - slow : 120s , hung : 120s> <timing - Slow : 5s , hung : 10s>");
         server.setServerConfigurationFile("contextInfoPattern/server_timing_5.xml");
@@ -748,6 +765,7 @@ public class TimingRequestTiming {
      */
     @Test
     @Mode(TestMode.FULL)
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testContextInfoExactMatchDisableDefault() throws Exception {
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration thresholds for - <global - slow : 5s , hung : 10s> <timing - Slow : 120s , hung : 120s>");
         server.setServerConfigurationFile("contextInfoPattern/server_timing_7.xml");


### PR DESCRIPTION
fixes #21868
- Skips certain RequestTiming FATs in `com.ibm.ws.request.timing_fat` and `com.ibm.ws.request.timing.hung_fat` projects, to reduce the test run time in SOE builds, preventing timeout errors.
- The tests that were skipped are basically corner test scenarios that rarely happen, the basic core functionality tests are repeated.