### PR TITLE
Run MP OpenAPI tests without servlet where possible

### DIFF
--- a/dev/com.ibm.ws.microprofile.openapi_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/bnd.bnd
@@ -33,7 +33,8 @@ tested.features=\
   jsonb-2.0,\
   jsonb-3.0,\
   restfulws-3.1,\
-  restfulwsclient-3.1
+  restfulwsclient-3.1,\
+  servlet-6.0
 
 -buildpath: \
     com.ibm.ws.microprofile.openapi;version=latest, \

--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/ApplicationProcessorServletTest.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/ApplicationProcessorServletTest.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.openapi.fat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+import com.ibm.ws.microprofile.openapi.fat.utils.OpenAPIConnection;
+import com.ibm.ws.microprofile.openapi.fat.utils.OpenAPITestUtil;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpUtils;
+
+/**
+ * ApplicationProcessor tests which require the servlet feature
+ */
+@RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
+public class ApplicationProcessorServletTest {
+
+    private static final Class<?> c = ApplicationProcessorServletTest.class;
+
+    private static final String SERVER_NAME = "ApplicationProcessorServletServer";
+
+    private static final String APP_NAME_3 = "simpleServlet";
+
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME,
+        MicroProfileActions.MP60, // mpOpenAPI-3.1, LITE
+        MicroProfileActions.MP50, // mpOpenAPI-3.0, FULL
+        MicroProfileActions.MP41, // mpOpenAPI-2.0, FULL
+        MicroProfileActions.MP33, // mpOpenAPI-1.1, FULL
+        MicroProfileActions.MP22);// mpOpenAPI-1.0, FULL
+
+    @BeforeClass
+    public static void setUpTest() throws Exception {
+        HttpUtils.trustAllCertificates();
+
+        DeployOptions[] opts = {
+            DeployOptions.SERVER_ONLY
+        };
+        ShrinkHelper.defaultApp(server, APP_NAME_3, opts, "app.web.servlet");
+
+        LibertyServer.setValidateApps(false);
+
+        // Change server ports to the default ones
+        OpenAPITestUtil.changeServerPorts(server, server.getHttpDefaultPort(), server.getHttpDefaultSecurePort());
+
+        server.startServer(c.getSimpleName() + ".log");
+        assertNotNull("Web application is not available at /openapi/",
+            server.waitForStringInLog("CWWKT0016I.*/openapi/")); // wait for /openapi/ endpoint to become available
+        assertNotNull("Web application is not available at /openapi/ui/",
+            server.waitForStringInLog("CWWKT0016I.*/openapi/ui/")); // wait for /openapi/ui/ endpoint to become
+                                                                    // available
+        assertNotNull("Server did not report that it has started",
+            server.waitForStringInLog("CWWKF0011I.*"));
+
+        assertNotNull("Http port not opened",
+            server.waitForStringInLog("CWWKO0219I.* defaultHttpEndpoint ")); // Wait for http port
+        assertNotNull("Https port not opened",
+            server.waitForStringInLog("CWWKO0219I.* defaultHttpEndpoint-ssl ")); // Wait for https port to open (this
+                                                                                 // can sometimes take a while)
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer("CWWKO1650E", "CWWKO1651W");
+    }
+
+    @Test
+    public void testApplicationProcessorWithServlet() throws Exception {
+
+        // With no apps deployed, ensure that the default empty OpenAPI documentation is
+        // created
+        String emptyDoc = OpenAPIConnection.openAPIDocsConnection(server, false).download();
+        JsonNode openapiNode = OpenAPITestUtil.readYamlTree(emptyDoc);
+        OpenAPITestUtil.checkServer(openapiNode,
+            OpenAPITestUtil.getServerURLs(server, server.getHttpDefaultPort(), server.getHttpDefaultSecurePort()));
+        OpenAPITestUtil.checkPaths(openapiNode, 0);
+
+        // Add an empty servlet app is deployed and ensure the default empty OpenAPI
+        // documentation is created
+        OpenAPITestUtil.setMarkToEndOfAllLogs(server);
+        OpenAPITestUtil.addApplication(server, APP_NAME_3);
+        String openapi = OpenAPIConnection.openAPIDocsConnection(server, false).download();
+        assertEquals("FAIL: Server with a single empty app should not change the default OpenAPI document.", emptyDoc,
+            openapi);
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/ApplicationProcessorTest.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/ApplicationProcessorTest.java
@@ -62,7 +62,6 @@ public class ApplicationProcessorTest extends FATServletClient {
     private static final Class<?> c = ApplicationProcessorTest.class;
     private static final String APP_NAME_1 = "appWithAnnotations";
     private static final String APP_NAME_2 = "appWithStaticDoc";
-    private static final String APP_NAME_3 = "simpleServlet";
     private static final String APP_NAME_4 = "staticDocWithServerObject";
     private static final String APP_NAME_5 = "staticDocWithoutServerObject";
     private static final String APP_NAME_6 = "openAPIEarWithServer";
@@ -94,7 +93,6 @@ public class ApplicationProcessorTest extends FATServletClient {
         };
         ShrinkHelper.defaultApp(server, APP_NAME_1, opts, "app.web.airlines.*");
         ShrinkHelper.defaultApp(server, APP_NAME_2, opts);
-        ShrinkHelper.defaultApp(server, APP_NAME_3, opts, "app.web.servlet");
         ShrinkHelper.defaultApp(server, APP_NAME_10, opts, "app.web.pure.jaxrs");
         ShrinkHelper.defaultApp(server, APP_NAME_11, opts, "app.web.complete.flow.*");
 
@@ -181,14 +179,6 @@ public class ApplicationProcessorTest extends FATServletClient {
         OpenAPITestUtil.checkServer(openapiNode,
             OpenAPITestUtil.getServerURLs(server, server.getHttpDefaultPort(), server.getHttpDefaultSecurePort()));
         OpenAPITestUtil.checkPaths(openapiNode, 0);
-
-        // Add an empty servlet app is deployed and ensure the default empty OpenAPI
-        // documentation is created
-        OpenAPITestUtil.setMarkToEndOfAllLogs(server);
-        OpenAPITestUtil.addApplication(server, APP_NAME_3);
-        openapi = OpenAPIConnection.openAPIDocsConnection(server, false).download();
-        assertEquals("FAIL: Server with a single empty app should not change the default OpenAPI document.", emptyDoc,
-            openapi);
 
         // Now add an app with OpenAPI artifacts and ensure it shows up
         OpenAPITestUtil.setMarkToEndOfAllLogs(server);

--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ import com.ibm.ws.microprofile.openapi.validation.fat.OpenAPIValidationTestTwo;
 @RunWith(Suite.class)
 @SuiteClasses({
     AnnotationProcessingTest.class,
+    ApplicationProcessorServletTest.class,
     ApplicationProcessorTest.class,
     ContentTypeTest.class,
     OpenAPIValidationTestOne.class,

--- a/dev/com.ibm.ws.microprofile.openapi_fat/publish/servers/ApplicationProcessorServletServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/publish/servers/ApplicationProcessorServletServer/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all=enabled:mpOpenAPI=debug=enabled

--- a/dev/com.ibm.ws.microprofile.openapi_fat/publish/servers/ApplicationProcessorServletServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/publish/servers/ApplicationProcessorServletServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2018 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -10,12 +10,16 @@
  -->
 <server>
 
-  <include location="../fatTestPorts.xml" />
+  <!-- Note that fatTestPorts.xml is not included because we control creation of all ports in fats -->
+  <include location="../fatTestCommon.xml" />
 
   <featureManager>
     <feature>componenttest-1.0</feature>
-    <feature>mpOpenAPI-2.0</feature>
-    <feature>jaxrs-2.1</feature> <!-- EE feature to ensure we get the expected EE version -->
+    <feature>ssl-1.0</feature>
+    <feature>mpOpenAPI-1.0</feature>
+    <feature>servlet-3.1</feature>
   </featureManager>
+
+  <keyStore id="defaultKeyStore" password="password" />
 
 </server>

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/FATSuite.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/FATSuite.java
@@ -18,6 +18,7 @@ import io.openliberty.microprofile.openapi20.fat.cache.CacheTest;
 import io.openliberty.microprofile.openapi20.fat.deployments.DeploymentTest;
 import io.openliberty.microprofile.openapi20.fat.deployments.MergeConfigTest;
 import io.openliberty.microprofile.openapi20.fat.deployments.MergeTest;
+import io.openliberty.microprofile.openapi20.fat.deployments.MergeWithServletTest;
 import io.openliberty.microprofile.openapi20.fat.shutdown.ShutdownTest;
 
 @RunWith(Suite.class)
@@ -27,6 +28,7 @@ import io.openliberty.microprofile.openapi20.fat.shutdown.ShutdownTest;
     DeploymentTest.class,
     MergeConfigTest.class,
     MergeTest.class,
+    MergeWithServletTest.class,
     ShutdownTest.class
 })
 public class FATSuite {}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeTest.java
@@ -199,47 +199,6 @@ public class MergeTest {
     }
 
     @Test
-    public void testNonJaxrsEarModule() throws Exception {
-        WebArchive war1 = ShrinkWrap.create(WebArchive.class, "test1.war")
-                                    .addClasses(DeploymentTestApp.class, DeploymentTestResource.class);
-
-        WebArchive war2 = ShrinkWrap.create(WebArchive.class, "test2.war")
-                                    .addClasses(TestServlet.class);
-
-        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "test.ear")
-                                          .addAsModules(war1, war2);
-
-        deployApp(ear);
-
-        String doc = OpenAPIConnection.openAPIDocsConnection(server, false).download();
-        JsonNode openapiNode = OpenAPITestUtil.readYamlTree(doc);
-        OpenAPITestUtil.checkPaths(openapiNode, 1, "/test");
-        assertServerContextRoot(openapiNode, "test1");
-    }
-
-    @Test
-    public void testNonJaxrsAppNotMerged() throws Exception {
-        WebArchive war1 = ShrinkWrap.create(WebArchive.class, "test1.war")
-                                    .addClasses(DeploymentTestApp.class, DeploymentTestResource.class);
-
-        WebArchive war2 = ShrinkWrap.create(WebArchive.class, "test2.war")
-                                    .addClasses(TestServlet.class);
-
-        deployApp(war1);
-        deployApp(war2);
-
-        assertRest("/test1/test");
-        assertRest("/test2/test");
-
-        // Check that war1 is documented and no merging is done, (no context root
-        // prepended to path)
-        String doc = OpenAPIConnection.openAPIDocsConnection(server, false).download();
-        JsonNode openapiNode = OpenAPITestUtil.readYamlTree(doc);
-        OpenAPITestUtil.checkPaths(openapiNode, 1, "/test");
-        assertServerContextRoot(openapiNode, "test1");
-    }
-
-    @Test
     public void testMergeClash() throws Exception {
         WebArchive war1 = ShrinkWrap.create(WebArchive.class, "test1.war")
                                     .addClasses(DeploymentTestApp.class, DeploymentTestResource.class)

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeWithServletTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeWithServletTest.java
@@ -1,0 +1,170 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.openapi20.fat.deployments;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.DISABLE_VALIDATION;
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpRequest;
+import io.openliberty.microprofile.openapi20.fat.deployments.test1.DeploymentTestApp;
+import io.openliberty.microprofile.openapi20.fat.deployments.test1.DeploymentTestResource;
+import io.openliberty.microprofile.openapi20.fat.utils.OpenAPIConnection;
+import io.openliberty.microprofile.openapi20.fat.utils.OpenAPITestUtil;
+
+/**
+ * Merge tests which require the servlet feature
+ */
+@RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
+public class MergeWithServletTest {
+
+    private static final String SERVER_NAME = "OpenAPIMergeWithServletTestServer";
+
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME,
+                                                             MicroProfileActions.MP60, // mpOpenAPI-3.1, FULL
+                                                             MicroProfileActions.MP50, // mpOpenAPI-3.0, FULL
+                                                             MicroProfileActions.MP41);// mpOpenAPI-2.0, FULL
+
+    private final List<String> deployedApps = new ArrayList<>();
+
+    @BeforeClass
+    public static void setupServer() throws Exception {
+        server.setAdditionalSystemProperties(
+                                             Collections.singletonMap("mp_openapi_extensions_liberty_merged_include", "all"));
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void shutdownServer() throws Exception {
+        server.stopServer("CWWKO1662W"); // Problems occurred while merging
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        server.setMarkToEndOfLog();
+        server.deleteAllDropinApplications();
+
+        List<String> failedToStop = new ArrayList<>();
+        for (String app : deployedApps) {
+            if (server.waitForStringInLogUsingMark("CWWKZ0009I:.*" + app) == null) {
+                failedToStop.add(app);
+            }
+        }
+
+        if (!failedToStop.isEmpty()) {
+            throw new AssertionError("The following apps failed to stop: " + failedToStop);
+        }
+    }
+
+    @Test
+    public void testNonJaxrsEarModule() throws Exception {
+        WebArchive war1 = ShrinkWrap.create(WebArchive.class, "test1.war")
+                                    .addClasses(DeploymentTestApp.class, DeploymentTestResource.class);
+
+        WebArchive war2 = ShrinkWrap.create(WebArchive.class, "test2.war")
+                                    .addClasses(TestServlet.class);
+
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "test.ear")
+                                          .addAsModules(war1, war2);
+
+        deployApp(ear);
+
+        String doc = OpenAPIConnection.openAPIDocsConnection(server, false).download();
+        JsonNode openapiNode = OpenAPITestUtil.readYamlTree(doc);
+        OpenAPITestUtil.checkPaths(openapiNode, 1, "/test");
+        assertServerContextRoot(openapiNode, "test1");
+    }
+
+    @Test
+    public void testNonJaxrsAppNotMerged() throws Exception {
+        WebArchive war1 = ShrinkWrap.create(WebArchive.class, "test1.war")
+                                    .addClasses(DeploymentTestApp.class, DeploymentTestResource.class);
+
+        WebArchive war2 = ShrinkWrap.create(WebArchive.class, "test2.war")
+                                    .addClasses(TestServlet.class);
+
+        deployApp(war1);
+        deployApp(war2);
+
+        assertRest("/test1/test");
+        assertRest("/test2/test");
+
+        // Check that war1 is documented and no merging is done, (no context root
+        // prepended to path)
+        String doc = OpenAPIConnection.openAPIDocsConnection(server, false).download();
+        JsonNode openapiNode = OpenAPITestUtil.readYamlTree(doc);
+        OpenAPITestUtil.checkPaths(openapiNode, 1, "/test");
+        assertServerContextRoot(openapiNode, "test1");
+    }
+
+    private void assertRest(String path) throws Exception {
+        String response = new HttpRequest(server, path).run(String.class);
+        assertEquals("Failed to call test resource at " + path, "OK", response);
+    }
+
+    private void assertServerContextRoot(JsonNode model,
+                                         String contextRoot) {
+        OpenAPITestUtil.checkServer(model,
+                                    OpenAPITestUtil.getServerURLs(server, server.getHttpDefaultPort(), -1, contextRoot));
+    }
+
+    private void deployApp(Archive<?> archive) throws Exception {
+        server.setMarkToEndOfLog();
+        server.setTraceMarkToEndOfDefaultTrace();
+        ShrinkHelper.exportDropinAppToServer(server, archive, SERVER_ONLY, DISABLE_VALIDATION);
+        assertNotNull(server.waitForStringInLogUsingMark("CWWKZ0001I:.*" + getName(archive)));
+        deployedApps.add(getName(archive));
+    }
+
+    private String getName(Archive<?> archive) {
+        return getName(archive.getName());
+    }
+
+    private String getName(String fileName) {
+        int lastDot = fileName.lastIndexOf('.');
+        if (lastDot != -1) {
+            fileName = fileName.substring(0, lastDot);
+        }
+        return fileName;
+    }
+
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/publish/servers/OpenAPIMergeWithServletTestServer/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/publish/servers/OpenAPIMergeWithServletTestServer/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info=enabled:mpOpenAPI=all=enabled

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/publish/servers/OpenAPIMergeWithServletTestServer/server.xml
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/publish/servers/OpenAPIMergeWithServletTestServer/server.xml
@@ -15,7 +15,7 @@
   <featureManager>
     <feature>componenttest-1.0</feature>
     <feature>mpOpenAPI-2.0</feature>
-    <feature>jaxrs-2.1</feature> <!-- EE feature to ensure we get the expected EE version -->
+    <feature>servlet-4.0</feature> <!-- EE feature to ensure we get the expected EE version -->
   </featureManager>
 
 </server>

--- a/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/publish/servers/FATServer/server.xml
+++ b/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/publish/servers/FATServer/server.xml
@@ -12,7 +12,6 @@
         <feature>restfulWS-3.1</feature>
         <feature>localConnector-1.0</feature>
         <feature>mpOpenAPI-3.1</feature>
-        <feature>servlet-6.0</feature>
         <feature>arquillian-support-jakarta-2.1</feature>
     </featureManager>
     <javaPermission className="java.security.AllPermission"/>

--- a/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -10,7 +10,7 @@
     <name>MicroProfile OpenAPI TCK Runner</name>
 
     <properties>
-        <microprofile.openapi.version>3.1-RC2</microprofile.openapi.version>
+        <microprofile.openapi.version>3.1-RC3</microprofile.openapi.version>
 
         <surefire.version>2.17</surefire.version> <!-- Any changes to the surefire version must be tested against ZOS-->
 

--- a/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
+++ b/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
@@ -25,6 +25,7 @@
             <property name="failSafeUndeployment">${tck_failSafeUndeployment}</property>
             <property name="appDeployTimeout">${tck_appDeployTimeout}</property>
             <property name="appUndeployTimeout">${tck_appUndeployTimeout}</property>
+            <property name="testProtocol">rest</property>
         </configuration>
     </container>
 </arquillian>


### PR DESCRIPTION
* Run 3.1 TCK without servlet
* Separate out FAT tests which require servlet

Fixes #22264