### PR TITLE
Add the BELL REST endpoint demo to the BELLs FAT

### DIFF
--- a/dev/com.ibm.ws.classloading.bells_fat/.classpath
+++ b/dev/com.ibm.ws.classloading.bells_fat/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
+        <classpathentry kind="src" path="test-applications/testRestEndpoint.jar/src"/>
 	<classpathentry kind="src" path="test-applications/testProperties.jar/src"/>
 	<classpathentry kind="src" path="test-applications/SpiVisibility.war/src"/>	
 	<classpathentry kind="src" path="test-applications/testSpiVisible.jar/src"/>

--- a/dev/com.ibm.ws.classloading.bells_fat/bnd.bnd
+++ b/dev/com.ibm.ws.classloading.bells_fat/bnd.bnd
@@ -15,6 +15,7 @@ bVersion=1.0
 
 src: \
 	fat/src, \
+	test-applications/testRestEndpoint.jar/src, \
 	test-applications/testProperties.jar/src, \
 	test-applications/SpiVisibility.war/src, \
 	test-applications/testSpiVisible.jar/src, \
@@ -39,6 +40,7 @@ tested.features: \
 -buildpath: \
 	com.ibm.websphere.appserver.spi.restHandler;version=latest, \
 	com.ibm.websphere.javaee.annotation.1.1;version=latest, \
+	com.ibm.websphere.javaee.jsonp.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest, \
 	com.ibm.websphere.org.osgi.core;version=latest, \
 	com.ibm.websphere.org.osgi.service.component;version=latest, \

--- a/dev/com.ibm.ws.classloading.bells_fat/fat/src/com/ibm/ws/classloading/BellRestEndpointTest.java
+++ b/dev/com.ibm.ws.classloading.bells_fat/fat/src/com/ibm/ws/classloading/BellRestEndpointTest.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.classloading;
+
+import static com.ibm.ws.classloading.TestUtils.BETA_EDITION_JVM_OPTION;
+import static com.ibm.ws.classloading.TestUtils.buildAndExportBellLibrary;
+import static com.ibm.ws.classloading.TestUtils.removeSysProps;
+import static com.ibm.ws.classloading.TestUtils.setSysProps;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
+import componenttest.topology.utils.HttpsRequest;
+
+/**
+ * Tests for {@link LibraryServiceExporter}.
+ */
+@SuppressWarnings("serial")
+public class BellRestEndpointTest {
+    private static final LibertyServer server = LibertyServerFactory.getLibertyServer("bell_restep_server");
+
+    @BeforeClass
+    public static void setup() throws Throwable {
+        buildAndExportBellLibrary(server, "testRestEndpoint.jar", "BellEndpoint", "BellEndpoint$1");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Throwable {
+        stopServer();
+    }
+
+    @Before
+    public void beforeTest() throws Throwable {
+        // nada
+    }
+
+    @After
+    public void afterTest() {
+        stopServer();
+    };
+
+    static void stopServer() {
+        if (server.isStarted()) {
+            try {
+                server.stopServer();
+            } catch (final Exception e) {
+                e.printStackTrace();
+            }
+        }
+    };
+
+    static final int TimeOut = 3000;
+
+    /**
+     * Ring the BELL.
+     */
+    @Test
+    public void testRingTheBellRestEndpoint() throws Exception
+    {
+        doTestRingTheBellRestEndpoint(server, Boolean.FALSE);
+    }
+
+    @Test
+    public void testRingTheBellEndpoint_BETA() throws Exception
+    {
+        doTestRingTheBellRestEndpoint(server, Boolean.TRUE); // beta-edition
+    }
+
+    void doTestRingTheBellRestEndpoint(LibertyServer server, Boolean runAsBetaEdition) throws Exception
+    {
+        Map<String,String> props = new HashMap<String,String>(3){};
+        props.put(BETA_EDITION_JVM_OPTION, runAsBetaEdition.toString());
+
+        try {
+            setSysProps(server, props);
+            server.startServer();
+
+            if (runAsBetaEdition) {
+                assertNotNull("The server should report BELL SPI Visibility and BELL Properties was invoked in beta images, but did not.",
+                        server.waitForStringInLog(".*BETA: BELL SPI Visibility and BELL Properties "));
+
+                assertNotNull("The server should report BELL SPI visibility is enabled for library 'testRestEndpoint', but did not.",
+                        server.waitForStringInLog(".*CWWKL0059I: .*testRestEndpoint"));
+
+                assertNotNull("The server should register the `RestEndpoint` impl in the 'testRestEndpoint' library referenced by the BELL, but did not.",
+                        server.waitForStringInLog(".*CWWKL0050I: .*testRestEndpoint.*RestEndpoint"));
+
+                assertNotNull("Wait for the SSL port to open",
+                        server.waitForStringInLog("CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests"));
+
+                // fyi: the allowInsecure() call in the request builder chain configures the SSL factory
+                try {
+                    new HttpsRequest(server, "/ibm/api/bellEP").allowInsecure().basicAuth("you", "yourPassword").run(String.class);
+                } catch (Exception ex) {
+                    System.out.println("FAILED TO HIT ENDPOINT https://localhost:<secPort>/ibm/api/bellEP " + ex);
+                    ex.printStackTrace(System.out);
+                }
+
+                assertNotNull("The server should log the call to BellEndpoint.handleRequest(), but did not.",
+                        server.waitForStringInLog("hello DOLLY"));
+            }
+            else {
+                assertNull("The server should not report BELL SPI Visibility and BELL Properties has been invoked in non-beta images, but did.",
+                        server.waitForStringInLog(".*BETA: BELL SPI Visibility and BELL Properties has been invoked by class", TimeOut));
+            }
+        } finally {
+            stopServer();
+            removeSysProps(server, props);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.classloading.bells_fat/fat/src/com/ibm/ws/classloading/FATSuite.java
+++ b/dev/com.ibm.ws.classloading.bells_fat/fat/src/com/ibm/ws/classloading/FATSuite.java
@@ -18,6 +18,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({
                BellFatTest.class,
                BellSpiVisibilityTest.class,
-               BellPropertiesTest.class
+               BellPropertiesTest.class,
+               BellRestEndpointTest.class
 })
 public class FATSuite {}

--- a/dev/com.ibm.ws.classloading.bells_fat/publish/servers/bell_restep_server/bootstrap.properties
+++ b/dev/com.ibm.ws.classloading.bells_fat/publish/servers/bell_restep_server/bootstrap.properties
@@ -1,0 +1,2 @@
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.classloading.bells.internal.Bell=debug

--- a/dev/com.ibm.ws.classloading.bells_fat/publish/servers/bell_restep_server/jvm.options
+++ b/dev/com.ibm.ws.classloading.bells_fat/publish/servers/bell_restep_server/jvm.options
@@ -1,0 +1,2 @@
+#-Dcom.ibm.ws.beta.edition=true
+#-Xshareclasses:none

--- a/dev/com.ibm.ws.classloading.bells_fat/publish/servers/bell_restep_server/server.xml
+++ b/dev/com.ibm.ws.classloading.bells_fat/publish/servers/bell_restep_server/server.xml
@@ -1,0 +1,39 @@
+<server>
+
+    <featureManager>
+        <feature>bells-1.0</feature>
+        <feature>restConnector-2.0</feature>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+
+    <include location="../fatTestPorts.xml"/>
+
+    <!-- Provide a BELL service that implements the RESTHander SPI interface.
+         Protected feature restHandler-1.0 enables the REST handler framework 
+         and exports the SPI; restHandler-1.0 is enabled by restConnector-2.0. --> 
+
+    <library id="testRestEndpoint">
+        <fileset dir="${server.output.dir}/sharedLib" includes="testRestEndpoint.jar" />
+    </library>
+
+    <bell libraryRef="testRestEndpoint"
+         service="com.ibm.wsspi.rest.handler.RESTHandler"
+         spiVisibility="true" >
+       <properties hello="DOLLY" />
+    </bell>
+
+    <!-- REST endpoint access requires secure transport (transportSecurity-1.0)
+         and a user mapped to the administrator role --> 
+
+    <keyStore id="defaultKeyStore" password="keystorePassword" />
+
+    <basicRegistry>
+        <user name="you" password="yourPassword" />
+        <group name="yourGroup" />
+    </basicRegistry>
+    <administrator-role>
+        <user>you</user>
+        <group>yourGroup</group>
+    </administrator-role>
+
+</server>

--- a/dev/com.ibm.ws.classloading.bells_fat/test-applications/testRestEndpoint.jar/resources/META-INF/services/com.ibm.wsspi.rest.handler.RESTHandler
+++ b/dev/com.ibm.ws.classloading.bells_fat/test-applications/testRestEndpoint.jar/resources/META-INF/services/com.ibm.wsspi.rest.handler.RESTHandler
@@ -1,0 +1,2 @@
+#com.ibm.wsspi.rest.handler.root=/bellEP
+com.ibm.ws.test.BellEndpoint

--- a/dev/com.ibm.ws.classloading.bells_fat/test-applications/testRestEndpoint.jar/src/com/ibm/ws/test/BellEndpoint.java
+++ b/dev/com.ibm.ws.classloading.bells_fat/test-applications/testRestEndpoint.jar/src/com/ibm/ws/test/BellEndpoint.java
@@ -1,0 +1,32 @@
+
+package com.ibm.ws.test;
+
+import java.util.Map;
+
+import com.ibm.wsspi.rest.handler.RESTHandler;
+import com.ibm.wsspi.rest.handler.RESTRequest;
+import com.ibm.wsspi.rest.handler.RESTResponse;
+
+/**
+ * Expose a REST endpoint using a BELL service that implements REST Handler SPI.
+ */
+public class BellEndpoint implements RESTHandler {
+
+    public BellEndpoint() {
+        System.out.println("BellEndpoint.<ctor>: new instance");
+    }
+
+    Map<String, String> bellProps = null;
+
+    // Required to receive configured properties
+    public void updateBell(Map<String,String> props) {
+        bellProps = props;
+        System.out.println("BellEndpoint.updateBell: injected props=" + bellProps);
+    }
+
+    @Override
+    public void handleRequest(RESTRequest request, RESTResponse response) {
+        System.out.println("BellEndpoint.handleRequest: hello " + bellProps.get("hello"));
+    }
+}
+


### PR DESCRIPTION
Create a test that provides a BELL service that implements a REST endpoint. The test deploys a server configuration and BELL artifacts useful for demonstrating BELL service development and BELLs feature (bells-1.0) capabilities 

