### PR TITLE
Issue 21160: Add EL support for redirectURI

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/test/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanismTest.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/test/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanismTest.java
@@ -116,8 +116,8 @@ public class OidcHttpAuthenticationMechanismTest {
                 will(returnValue(mppi));
                 one(mppi).get();
                 will(returnValue(mpp));
-                one(mpp).getAuthMechProperties(OidcHttpAuthenticationMechanism.class);
-                will(returnValue(props));
+//                one(mpp).getAuthMechProperties(OidcHttpAuthenticationMechanism.class);
+//                will(returnValue(props));
             }
         });
     }
@@ -182,7 +182,7 @@ public class OidcHttpAuthenticationMechanismTest {
         }
 
         @Override
-        protected Client getClient() {
+        protected Client getClient(HttpServletRequest request) {
             return client;
         }
 

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/JakartaSec30Constants.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/JakartaSec30Constants.java
@@ -19,4 +19,8 @@ public class JakartaSec30Constants extends JavaEESecConstants {
 
     public static final String OIDC_ANNOTATION = "oidc_annotation";
 
+    public static final String BASE_URL_VARIABLE = "baseURL";
+
+    public static final String BASE_URL_DEFAULT = "${" + BASE_URL_VARIABLE + "}/Callback";
+
 }


### PR DESCRIPTION
Fixes #21160

- Added `ELHelper` support for a composite expression, such as `${baseURL}/Callback`
- Constructed the baseURL from the HttpRequest, which required moving `OpenIdAuthenticationMechanismDefinitionWrapper` to being setup on every `validateRequest`.
- Set the `baseURL` variable whenever we evaluate the `redirectURL`
- Added redirectURL unit tests