### PR TITLE
Update Jakarta Security 3.0 cookie storage behavior to be in line with spec

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcAuthorizationRequest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcAuthorizationRequest.java
@@ -114,6 +114,12 @@ public class OidcAuthorizationRequest extends AuthorizationRequest {
     }
 
     @Override
+    protected StorageProperties getNonceStorageProperties() {
+        CookieStorageProperties props = new CookieStorageProperties();
+        return props;
+    }
+
+    @Override
     protected StorageProperties getOriginalRequestUrlStorageProperties() {
         CookieStorageProperties props = new CookieStorageProperties();
         props.setStorageLifetimeSeconds((int) clientConfig.getAuthenticationTimeLimitInSeconds());

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationRequest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationRequest.java
@@ -70,6 +70,11 @@ public abstract class AuthorizationRequest {
         return props;
     }
 
+    protected StorageProperties getNonceStorageProperties() {
+        StorageProperties props = new StorageProperties();
+        return props;
+    }
+
     protected StorageProperties getOriginalRequestUrlStorageProperties() {
         StorageProperties props = new StorageProperties();
         props.setStorageLifetimeSeconds(OidcClientStorageConstants.DEFAULT_REQ_URL_STORAGE_LIFETIME_SECONDS);
@@ -86,7 +91,8 @@ public abstract class AuthorizationRequest {
     protected void storeNonceValue(String nonce, String state) {
         String storageName = OidcStorageUtils.getStorageKey(OidcClientStorageConstants.WAS_OIDC_NONCE, clientId, state);
         String storageValue = createNonceValueForStorage(nonce, state);
-        storage.store(storageName, storageValue);
+        StorageProperties nonceStorageProperties = getNonceStorageProperties();
+        storage.store(storageName, storageValue, nonceStorageProperties);
     }
 
     protected void storeOriginalRequestUrl(String state) {

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/CookieBasedStorage.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/CookieBasedStorage.java
@@ -83,6 +83,9 @@ public class CookieBasedStorage implements Storage {
         if (cookieProps.isSecureSet()) {
             cookie.setSecure(cookieProps.isSecure());
         }
+        if (cookieProps.isHttpOnlySet()) {
+            cookie.setHttpOnly(cookieProps.isHttpOnly());
+        }
         cookie.setMaxAge(cookieProps.getStorageLifetimeSeconds());
     }
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/CookieStorageProperties.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/CookieStorageProperties.java
@@ -18,6 +18,12 @@ public class CookieStorageProperties extends StorageProperties {
      */
     private Boolean isSecure = null;
 
+    /**
+     * Defined as a Boolean type so that we can determine if this property is specifically set by a caller. If the property isn't
+     * specifically set, we can defer to any existing logic that determines whether the HttpOnly flag should be set for the cookie.
+     */
+    private Boolean isHttpOnly = null;
+
     public void setSecure(boolean isSecure) {
         this.isSecure = isSecure;
     }
@@ -30,11 +36,24 @@ public class CookieStorageProperties extends StorageProperties {
         return isSecure;
     }
 
+    public void setHttpOnly(boolean isHttpOnly) {
+        this.isHttpOnly = isHttpOnly;
+    }
+
+    public boolean isHttpOnlySet() {
+        return isHttpOnly != null;
+    }
+
+    public boolean isHttpOnly() {
+        return isHttpOnly;
+    }
+
     @Override
     public String toString() {
         String result = "CookieStorageProperties:{";
         result += "storageLifetimeSeconds=" + storageLifetimeSeconds + ", ";
-        result += "isSecure=" + isSecure;
+        result += "isSecure=" + isSecure + ", ";
+        result += "isHttpOnly=" + isHttpOnly;
         result += "}";
         return result;
     }


### PR DESCRIPTION
Updates some of the cookie storage behavior to align with https://jakarta.ee/specifications/security/3.0/jakarta-security-spec-3.0.html#authentication-dialog, specifically:

> The State value, and also the Nonce value if requested, MUST be stored between requests so that these values can be validated when the OpenID Connect Provider later calls the supplied redirectURI. These values can either be stored serverside (in the HTTP Session) or clientside (as a Cookie). The value of the `OpenIdAuthenticationDefinition.useSession` attribute determines which one is used. In the case of storage through a Cookie, the Cookie must be defined as `HTTPonly` and must have the `Secure` flag set.