### PR TITLE
AdminCenter and its tools: change locale selection based on the browser language settings

### DIFF
--- a/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/jsShared/bidiConfig.jsp
+++ b/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/jsShared/bidiConfig.jsp
@@ -1,5 +1,5 @@
 <%--
-    Copyright (c) 2014 IBM Corporation and others.
+    Copyright (c) 2014, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -34,16 +34,7 @@
     response.setHeader("X-Content-Type-Options", "nosniff");	
     response.setHeader("X-Frame-Options", "SAMEORIGIN");
    
-    // TODO: In newer browsers, the lang could have a variant which is not handled by dojo. ex. zh-hant-tw
-    // So, construct a "normal" lang-country from the locale
-    // TODO: for some reason, getVariant() is returning the country so for now ...
-    String userLocale = request.getLocale().getLanguage().toLowerCase();
-    if (request.getLocale().getVariant().length() > 0) {
-        userLocale += "-" + request.getLocale().getVariant().toLowerCase();
-    } else if (request.getLocale().getCountry().length() > 0) {
-        userLocale += "-" + request.getLocale().getCountry().toLowerCase();
-    }
-    String dojoConfigString = "locale: '" + userLocale + "'";
+    String dojoConfigString = "";
     
     String localAddress = request.getLocalAddr();
     // ipv6 addresses must be enclosed with square brackets in URLs
@@ -107,10 +98,6 @@
 <%                
             }
         }
-        if (hasBidi.length() > 0){
-            dojoConfigString = dojoConfigString + ", " + hasBidi;
-        }
-                    
     } catch (MalformedURLException e) {
         // just default to no bidi
         //e.printStackTrace();

--- a/dev/com.ibm.ws.ui.tool.explore/bnd.bnd
+++ b/dev/com.ibm.ws.ui.tool.explore/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -30,6 +30,7 @@ Include-Resource: \
   ${if;${driver;gradle};jsShared/utils/toolData.js=build/jsShared/utils/toolData.js}, \
   ${if;${driver;gradle};jsShared/utils/userConfig.js=build/jsShared/utils/userConfig.js}, \
   ${if;${driver;gradle};jsShared/utils/apiMsgUtils.js=build/jsShared/utils/apiMsgUtils.js}, \
+  ${if;${driver;gradle};jsShared/utils/globalization.js=build/jsShared/utils/globalization.js}, \
   WEB-INF=resources/WEB-INF, \
   images=resources/WEB-CONTENT/images, \
   index.jsp=resources/WEB-CONTENT/index.jsp, \

--- a/dev/com.ibm.ws.ui.tool.explore/import.xml
+++ b/dev/com.ibm.ws.ui.tool.explore/import.xml
@@ -59,6 +59,7 @@
         	<include name="apiMsgUtils.js" />
         	<include name="toolData.js" />
         	<include name="userConfig.js" />
+          <include name="globalization.js" />
         </fileset>
     </copy>
     <copy-one-font-file font-file="IBMPlexSans/IBMPlexSans-Bold.woff" font-target-dir="lib/fonts" />

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/index.jsp
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/index.jsp
@@ -1,5 +1,5 @@
 <%--
-    Copyright (c) 2014 IBM Corporation and others.
+    Copyright (c) 2014, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -29,7 +29,34 @@
 <script>svg4everybody(); // run it now or whenever you are ready</script>
 
 <%@ include file="jsShared/bidiConfig.jsp"%>
-<script src="dojo/dojo.js" data-dojo-config="<%=dojoConfigString%>"></script>
+<script src="jsShared/utils/globalization.js"></script>
+<script type="text/javascript">
+  var languageLocale = globalization.getLanguageCode(); // globalization.getLanguageCode();
+</script>
+<%
+    if (hasBidi.length() == 0) {
+%>
+<script type="text/javascript">
+      var dojoConfig = {
+        locale: languageLocale
+      };
+</script>
+<%
+    } else {
+%>
+<script type="text/javascript">
+      var dojoConfig = {
+        locale: languageLocale,
+        has: {
+          'adminCenter-bidi': true,
+          'dojo-bidi': true
+        }
+      };
+</script>
+<%
+    }
+%>
+<script src="dojo/dojo.js"></script>
 
 <script type="text/javascript">
   // On IE and old versions of FF (like 17), location.origin doesn't exist so create it. Consider something like 'Modernizer' instead.
@@ -44,7 +71,7 @@
       breadcrumbImg = "images/breadcrumb-dashboard-S.png";
     }
     document.getElementById("explore_tab_title").innerHTML = i18n.EXPLORE;
-    document.documentElement.setAttribute("lang", dojo.locale);
+    document.documentElement.setAttribute("lang", languageLocale);
   });
 </script>
 <script>

--- a/dev/com.ibm.ws.ui.tool.javaBatch/bnd.bnd
+++ b/dev/com.ibm.ws.ui.tool.javaBatch/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ Include-Resource: \
   ${if;${driver;gradle};jsShared/bidiConfig.jsp=build/dojo/jsShared/bidiConfig.jsp}, \
   ${if;${driver;gradle};jsShared/utils/toolData.js=build/jsShared/utils/toolData.js}, \
   ${if;${driver;gradle};jsShared/utils/userConfig.js=build/jsShared/utils/userConfig.js}, \
+  ${if;${driver;gradle};jsShared/utils/userConfig.js=build/jsShared/utils/globalization.js}, \
   ${if;${driver;gradle};=lib/dojo-release}, \
   ${if;${driver;gradle};fonts=lib/fonts}, \
   WEB-INF=resources/WEB-INF, \

--- a/dev/com.ibm.ws.ui.tool.javaBatch/bnd.bnd
+++ b/dev/com.ibm.ws.ui.tool.javaBatch/bnd.bnd
@@ -26,7 +26,7 @@ Include-Resource: \
   ${if;${driver;gradle};jsShared/bidiConfig.jsp=build/dojo/jsShared/bidiConfig.jsp}, \
   ${if;${driver;gradle};jsShared/utils/toolData.js=build/jsShared/utils/toolData.js}, \
   ${if;${driver;gradle};jsShared/utils/userConfig.js=build/jsShared/utils/userConfig.js}, \
-  ${if;${driver;gradle};jsShared/utils/userConfig.js=build/jsShared/utils/globalization.js}, \
+  ${if;${driver;gradle};jsShared/utils/globalization.js=build/jsShared/utils/globalization.js}, \
   ${if;${driver;gradle};=lib/dojo-release}, \
   ${if;${driver;gradle};fonts=lib/fonts}, \
   WEB-INF=resources/WEB-INF, \

--- a/dev/com.ibm.ws.ui.tool.javaBatch/import.xml
+++ b/dev/com.ibm.ws.ui.tool.javaBatch/import.xml
@@ -37,6 +37,7 @@
 	        <fileset dir="${basedir}/../com.ibm.ws.ui.shared/resources/WEB-CONTENT/jsShared/utils">
 	            <include name="toolData.js" />
 	            <include name="userConfig.js" />
+				<include name="globalization.js" />
 	        </fileset>
 	    </copy>
       <copy-font-files font-name="IBMPlexSans" font-target-dir="lib/fonts" />

--- a/dev/com.ibm.ws.ui.tool.javaBatch/resources/WEB-CONTENT/index.jsp
+++ b/dev/com.ibm.ws.ui.tool.javaBatch/resources/WEB-CONTENT/index.jsp
@@ -1,5 +1,5 @@
 <%--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -33,10 +33,37 @@ response.setHeader("X-Frame-Options", "SAMEORIGIN");
 %>
 
 <%@ include file="jsShared/bidiConfig.jsp"%>
-<script src="dojo/dojo.js" data-dojo-config="<%=dojoConfigString%>"></script>
+<script src="jsShared/utils/globalization.js"></script>
+<script type="text/javascript">
+  var languageLocale = globalization.getLanguageCode();
+</script>
+<%
+    if (hasBidi.length() == 0) {
+%>
+<script type="text/javascript">
+        var dojoConfig = {
+            locale: languageLocale
+        };
+</script>
+<%
+    } else {
+%>
+<script type="text/javascript">
+        var dojoConfig = {
+            locale: languageLocale,
+            has: {
+                'adminCenter-bidi': true,
+                'dojo-bidi': true
+            }
+        };
+</script>
+<%
+    }
+%>
+<script src="dojo/dojo.js"></script>
 <script>
   require([ "jsBatch/main" ], function(dashboard) {
-    document.documentElement.setAttribute("lang", dojo.locale);
+    document.documentElement.setAttribute("lang", languageLocale);
   });
 </script>
 <title>Java Batch Tool</title>

--- a/dev/com.ibm.ws.ui/resources/WEB-CONTENT/js/toolbox/views/toolbox.js
+++ b/dev/com.ibm.ws.ui/resources/WEB-CONTENT/js/toolbox/views/toolbox.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corporation and others.
+ * Copyright (c) 2016, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -283,10 +283,6 @@ define(["dojo/parser",
 
       // set translated tab text - Admin Center
       document.getElementById("toolbox_tab_title").innerHTML = i18nL.LIBERTY_HEADER_TITLE;
-
-      // set lang on the <html> tag
-      console.log("locale:" + kernel.locale);
-      document.documentElement.setAttribute("lang", kernel.locale);
 
       ready(function(){
 

--- a/dev/com.ibm.ws.ui/resources/WEB-CONTENT/login.jsp
+++ b/dev/com.ibm.ws.ui/resources/WEB-CONTENT/login.jsp
@@ -1,5 +1,5 @@
 <%--
-    Copyright (c) 2014 IBM Corporation and others.
+    Copyright (c) 2014, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -65,19 +65,19 @@
     response.setHeader("X-Content-Type-Options", "nosniff");	
     response.setHeader("X-Frame-Options", "SAMEORIGIN");
 
-    // TODO: In newer browsers, the lang could have a variant which is not handled by dojo. ex. zh-hant-tw
-    // So, construct a "normal" lang-country from the locale
-    // TODO: for some reason, getVariant() is returning the country so for now ...
-    String userLocale = request.getLocale().getLanguage().toLowerCase();
-    if (request.getLocale().getVariant().length() > 0) {
-        userLocale += "-" + request.getLocale().getVariant().toLowerCase();
-    } else if (request.getLocale().getCountry().length() > 0) {
-        userLocale += "-" + request.getLocale().getCountry().toLowerCase();
-    }
-    String dojoConfigString = "locale: '" + userLocale + "'";
+    String dojoConfigString = ""; // this is required otherwise it won't run
 %>
+  <script src="404/404.js"></script>
+  <script type="text/javascript">
+    var userLocale = getLanguageCode();
 
-  <script src="dojo/dojo.js" data-dojo-config="<%=dojoConfigString%>"></script>
+    var dojoConfig = {
+      locale: userLocale
+    };
+
+    document.documentElement.setAttribute("lang", userLocale);
+  </script>
+  <script src="dojo/dojo.js"></script>
   <script src="login/login-init.js"></script>
   <title id="loginTabTitle">Liberty Admin Center</title>
 </head>

--- a/dev/com.ibm.ws.ui/resources/WEB-CONTENT/login/login.js
+++ b/dev/com.ibm.ws.ui/resources/WEB-CONTENT/login/login.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -313,8 +313,6 @@ define(['dojo/dom','dojo/request/xhr','dojo/i18n!./nls/loginMessages', './hashCo
   }
 
   function initPage() {
-    // 1. Set page locale and override the English text accordingly.
-    document.documentElement.setAttribute("lang", kernel.locale);
     setLoginButtonText(dom);
     setTitleText(dom);
     setPlaceholders(dom);

--- a/dev/com.ibm.ws.ui/resources/WEB-CONTENT/toolbox.jsp
+++ b/dev/com.ibm.ws.ui/resources/WEB-CONTENT/toolbox.jsp
@@ -1,5 +1,5 @@
 <%--
-    Copyright (c) 2014 IBM Corporation and others.
+    Copyright (c) 2014, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -81,17 +81,7 @@
 
     String hasBidi = "";       // used to initialize dojo
     String userId = request.getRemoteUser();     // passed to widgets
-    // String userLocale = request.getLocale().toString().replace('_', '-').toLowerCase();
-    // TODO: In newer browsers, the lang could have a variant which is not handled by dojo. ex. zh-hant-tw
-    // So, construct a "normal" lang-country from the locale
-    // TODO: for some reason, getVariant() is returning the country so for now ...
-    String userLocale = request.getLocale().getLanguage().toLowerCase();
-    if (request.getLocale().getVariant().length() > 0) {
-        userLocale += "-" + request.getLocale().getVariant().toLowerCase();
-    } else if (request.getLocale().getCountry().length() > 0) {
-        userLocale += "-" + request.getLocale().getCountry().toLowerCase();
-    }
-    String dojoConfigString = "locale: '" + userLocale + "'";
+    String dojoConfigString = ""; // this is required otherwise it won't run
     
     String localAddress = request.getLocalAddr();
     // ipv6 addresses must be enclosed with square brackets in URLs
@@ -149,10 +139,6 @@ BIDI_PREFS_STRING = '<%=line%>';
 <%                
             }
         }
-        if (hasBidi.length() > 0){
-            dojoConfigString = dojoConfigString + ", " + hasBidi;
-        }
-                    
     } catch (MalformedURLException e) {
         // just default to no bidi
         //e.printStackTrace();
@@ -173,7 +159,36 @@ BIDI_PREFS_STRING = '<%=line%>';
     }
 %>
 
-<script src="dojo/dojo.js" data-dojo-config="<%=dojoConfigString%>"></script>
+<script src="404/404.js"></script>
+
+<script type="text/javascript">
+    var languageLocale = getLanguageCode(); // globalization.getLanguageCode();
+    document.documentElement.setAttribute("lang", languageLocale);
+</script>
+<%
+    if (hasBidi.length() == 0) {
+%>
+<script type="text/javascript">
+        var dojoConfig = {
+            locale: languageLocale
+        };
+</script>
+<%
+    } else {
+%>
+<script type="text/javascript">
+        var dojoConfig = {
+            locale: languageLocale,
+            has: {
+                'adminCenter-bidi': true,
+                'dojo-bidi': true
+            }
+        };
+</script>
+<%
+    }
+%>
+<script src="dojo/dojo.js"></script>
 <script>require(["js/loadToolbox"])</script>
 
  

--- a/dev/com.ibm.ws.ui/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.ui/resources/WEB-INF/web.xml
@@ -54,6 +54,7 @@
       <url-pattern>/login/*</url-pattern>
       <url-pattern>/login.jsp</url-pattern>
       <url-pattern>/fonts/IBMPlexSans-Regular.woff</url-pattern>
+      <url-pattern>/404/404.js</url-pattern>
       <http-method>GET</http-method>
     </web-resource-collection>
     <user-data-constraint id="UserDataConstraint_AdminCenter">


### PR DESCRIPTION
The current implementation of all dojo based AdminCenter codes does not look at the browser locale list to select the first supported locale in the list. Instead it uses English as the default locale if the first locale in the list is not supported. This PR changes the logic to select the first supported locale in the list. If none is supported, then it would default to English.

Example, if the browser has the following languages in the order listed:

Dutch (nl) - not supported
Portuguese (pt) - not supported unless it is pt-br
Chinsee (zh) - supported
English (en) - supported

With the current implementation, Dutch is set as the locale. Since it is not supported, it defaults to English.
With the code changes, Chinese would be the selected locale.