### PR TITLE
init userinfo subsystem

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcClientUtilTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcClientUtilTest.java
@@ -42,6 +42,7 @@ import com.ibm.ws.security.common.http.HttpUtils;
 import com.ibm.ws.security.openidconnect.common.Constants;
 import com.ibm.ws.security.test.common.CommonTestClass;
 
+import io.openliberty.security.oidcclientcore.http.HttpConstants;
 import io.openliberty.security.oidcclientcore.http.OidcClientHttpUtil;
 import test.common.SharedOutputManager;
 
@@ -171,31 +172,6 @@ public class OidcClientUtilTest extends CommonTestClass {
 
     /**
      * Test method for
-     * {@link com.ibm.ws.security.openidconnect.clients.common.OidcClientUtil#getFromEndpoint(java.lang.String, java.util.List, java.lang.String, java.lang.String, java.lang.String)}.
-     */
-    @Test
-    public void testGetFromEndpoint() {
-        OidcClientUtil oicu = new OidcClientUtil();
-        try {
-            final HttpGet getMethod = new HttpGet("http://localhost:8010/oidc/someEndPoint");
-
-            createHttpClientExpectations(true);
-
-            List<NameValuePair> params = new ArrayList<NameValuePair>();
-            oicu.oidcHttpUtil = oidcHttpUtil;
-            oicu.httpUtils = mockHttpUtils;
-            Map<String, Object> result = oicu.getFromEndpoint("http://localhost:8010/oidc/someEndPoint", params, "baUsername", "baPassword", access_token_content, sslSocketFactory, false, false);
-            HttpResponse responseCode = (HttpResponse) result.get(ClientConstants.RESPONSEMAP_CODE);
-            assertNotNull("Expect to see valid response code", responseCode);
-            HttpGet getMethod2 = (HttpGet) result.get(ClientConstants.RESPONSEMAP_METHOD);
-            assertEquals("HttpGet method ", getMethod.getMethod(), getMethod2.getMethod());
-        } catch (Throwable t) {
-            outputMgr.failWithThrowable(testName.getMethodName(), t);
-        }
-    }
-
-    /**
-     * Test method for
      * {@link com.ibm.ws.security.openidconnect.clients.common.OidcClientUtil#getUserinfo(java.lang.String, java.lang.String)}.
      */
     @Test
@@ -206,9 +182,22 @@ public class OidcClientUtilTest extends CommonTestClass {
             oicu.oidcHttpUtil = oidcHttpUtil;
             oicu.httpUtils = mockHttpUtils;
             final Map<String, Object> postResponseMap = new HashMap<String, Object>();
-            postResponseMap.put(token_type, "bearer");
+            postResponseMap.put(HttpConstants.RESPONSEMAP_CODE, mockHttpResponse);
+            postResponseMap.put(HttpConstants.RESPONSEMAP_METHOD, mockHttpGet);
 
-            createHttpClientExpectations(false);
+            mock.checking(new Expectations() {
+                {
+                    one(oidcHttpUtil).getFromEndpoint(with(any(String.class)),
+                            with(any(List.class)),
+                            with(any(String.class)),
+                            with(any(String.class)),
+                            with(any(String.class)),
+                            with(any(SSLSocketFactory.class)),
+                            with(any(Boolean.class)),
+                            with(any(Boolean.class)));
+                    will(returnValue(postResponseMap));
+                }
+            });
 
             Map<String, Object> userInfoResponse = oicu.getUserinfo(userInfoEndpoint, access_token_content, sslSocketFactory, false, false);
             assertNotNull("Expected to get an instance of userInfo map", userInfoResponse);
@@ -251,7 +240,6 @@ public class OidcClientUtilTest extends CommonTestClass {
                             with(any(String.class)), // strClientSecret,
                             with(any(String.class)), // (String) null,
                             with(any(SSLSocketFactory.class)), // sslContext,
-                            with(any(List.class)), // commonHeaders
                             with(any(Boolean.class)), //isHostnameVerification
                             with(any(String.class)),
                             with(any(Boolean.class))); // use jvm props
@@ -296,7 +284,6 @@ public class OidcClientUtilTest extends CommonTestClass {
                             with(any(String.class)), // strClientSecret,
                             with(any(String.class)), // (String) null,
                             with(any(SSLSocketFactory.class)), // sslContext,
-                            with(any(List.class)), // commonHeaders
                             with(any(Boolean.class)), //isHostnameVerification
                             with(any(String.class)),
                             with(any(Boolean.class)));

--- a/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
+++ b/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
@@ -31,7 +31,8 @@ Export-Package: \
 	io.openliberty.security.oidcclientcore.storage, \
 	io.openliberty.security.oidcclientcore.utils, \
 	io.openliberty.security.oidcclientcore.http, \
-	io.openliberty.security.oidcclientcore.token
+	io.openliberty.security.oidcclientcore.token, \
+	io.openliberty.security.oidcclientcore.userinfo
 
 -buildpath: \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/UserInfoEndpointNotHttpsException.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/UserInfoEndpointNotHttpsException.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oidcclientcore.exceptions;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+public class UserInfoEndpointNotHttpsException extends Exception {
+
+    public static final TraceComponent tc = Tr.register(UserInfoEndpointNotHttpsException.class);
+
+    private static final long serialVersionUID = 1L;
+
+    private final String userInfoEndpoint;
+
+    public UserInfoEndpointNotHttpsException(String userInfoEndpoint) {
+        this.userInfoEndpoint = userInfoEndpoint;
+    }
+
+    public String getUserInfoEndpoint() {
+        return userInfoEndpoint;
+    }
+
+}

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/UserInfoResponseException.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/UserInfoResponseException.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oidcclientcore.exceptions;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+public class UserInfoResponseException extends Exception {
+
+    public static final TraceComponent tc = Tr.register(UserInfoResponseException.class);
+
+    private static final long serialVersionUID = 1L;
+
+    public UserInfoResponseException(Exception e) {
+        super(e);
+    }
+
+}

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/UserInfoResponseNot200Exception.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/UserInfoResponseNot200Exception.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oidcclientcore.exceptions;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+public class UserInfoResponseNot200Exception extends Exception {
+
+    public static final TraceComponent tc = Tr.register(UserInfoResponseNot200Exception.class);
+
+    private static final long serialVersionUID = 1L;
+
+    private final String userInfoEndpoint;
+    private final String statusCode;
+    private final String responseStr;
+
+    public UserInfoResponseNot200Exception(String userInfoEndpoint, String statusCode, String responseStr) {
+        this.userInfoEndpoint = userInfoEndpoint;
+        this.statusCode = statusCode;
+        this.responseStr = responseStr;
+    }
+
+    public String getUserInfoEndpoint() {
+        return userInfoEndpoint;
+    }
+
+    public String getStatusCode() {
+        return statusCode;
+    }
+
+    public String responseStr() {
+        return responseStr;
+    }
+
+}

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/UserInfoResponseNot200Exception.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/UserInfoResponseNot200Exception.java
@@ -37,7 +37,7 @@ public class UserInfoResponseNot200Exception extends Exception {
         return statusCode;
     }
 
-    public String responseStr() {
+    public String getResponseStr() {
         return responseStr;
     }
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/http/HttpConstants.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/http/HttpConstants.java
@@ -12,9 +12,18 @@ package io.openliberty.security.oidcclientcore.http;
 
 public interface HttpConstants {
 
+    public final static String HTTP_SCHEME = "http:";
+    public final static String HTTPS_SCHEME = "https:";
+
     public final static String AUTHORIZATION = "Authorization";
     public final static String BASIC = "Basic ";
     public final static String BEARER = "Bearer ";
+
+    public final static String UTF_8 = "UTF-8";
+
+    public static final String ACCEPT = "Accept";
+    public static final String APPLICATION_JSON = "application/json";
+    public static final String APPLICATION_JWT = "application/jwt";
 
     public final static String METHOD_BASIC = "basic";
     public final static String METHOD_POST = "post";

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenConstants.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenConstants.java
@@ -20,9 +20,6 @@ public class TokenConstants {
     public static final String GRANT_TYPE = "grant_type";
     public static final String REDIRECT_URI = "redirect_uri";
 
-    public static final String ACCEPT = "Accept";
-    public static final String APPLICATION_JSON = "application/json";
-
     public static final String RESOURCE = "resource";
     public static final String METHOD_BASIC = "basic";
     public static final String METHOD_POST = "post";

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenRequestor.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenRequestor.java
@@ -30,8 +30,6 @@ import io.openliberty.security.oidcclientcore.http.OidcClientHttpUtil;
 
 public class TokenRequestor {
 
-    private static final List<NameValuePair> commonHeaders;
-
     private final String tokenEndpoint;
     private final String clientId;
     @Sensitive
@@ -49,11 +47,6 @@ public class TokenRequestor {
     private final boolean useSystemPropertiesForHttpClientConnections;
 
     OidcClientHttpUtil oidcClientHttpUtil = OidcClientHttpUtil.getInstance();
-
-    static {
-        commonHeaders = new ArrayList<NameValuePair>();
-        commonHeaders.add(new BasicNameValuePair(TokenConstants.ACCEPT, TokenConstants.APPLICATION_JSON));
-    }
 
     private TokenRequestor(Builder builder) {
         this.tokenEndpoint = builder.tokenEndpoint;
@@ -117,7 +110,6 @@ public class TokenRequestor {
                                                  clientSecret,
                                                  null,
                                                  sslSocketFactory,
-                                                 commonHeaders,
                                                  isHostnameVerification,
                                                  authMethod,
                                                  useSystemPropertiesForHttpClientConnections);

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/userinfo/UserInfoRequestor.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/userinfo/UserInfoRequestor.java
@@ -1,0 +1,162 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oidcclientcore.userinfo;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.net.ssl.SSLSocketFactory;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpException;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.util.EntityUtils;
+
+import com.ibm.json.java.JSONObject;
+
+import io.openliberty.security.oidcclientcore.exceptions.UserInfoEndpointNotHttpsException;
+import io.openliberty.security.oidcclientcore.exceptions.UserInfoResponseException;
+import io.openliberty.security.oidcclientcore.exceptions.UserInfoResponseNot200Exception;
+import io.openliberty.security.oidcclientcore.http.HttpConstants;
+import io.openliberty.security.oidcclientcore.http.OidcClientHttpUtil;
+
+public class UserInfoRequestor {
+
+    private final String userInfoEndpoint;
+    private final String accessToken;
+    private final SSLSocketFactory sslSocketFactory;
+
+    private final List<NameValuePair> params;
+    private final boolean hostnameVerification;
+    private final boolean useSystemPropertiesForHttpClientConnections;
+
+    OidcClientHttpUtil oidcClientHttpUtil = OidcClientHttpUtil.getInstance();
+
+    private UserInfoRequestor(Builder builder) {
+        this.userInfoEndpoint = builder.userInfoEndpoint;
+        this.accessToken = builder.accessToken;
+        this.sslSocketFactory = builder.sslSocketFactory;
+
+        this.hostnameVerification = builder.hostnameVerification;
+        this.useSystemPropertiesForHttpClientConnections = builder.useSystemPropertiesForHttpClientConnections;
+
+        this.params = new ArrayList<NameValuePair>();
+    }
+
+    public UserInfoResponse requestUserInfo() throws Exception {
+        if (!userInfoEndpoint.toLowerCase().startsWith(HttpConstants.HTTPS_SCHEME)) {
+            throw new UserInfoEndpointNotHttpsException(userInfoEndpoint);
+        }
+
+        int statusCode = 0;
+        JSONObject claims = null;
+        try {
+            Map<String, Object> resultMap = getFromUserInfoEndpoint();
+            HttpResponse response = (HttpResponse) resultMap.get(HttpConstants.RESPONSEMAP_CODE);
+            if (response == null) {
+                throw new Exception("HttpResponse from getUserinfo is null");
+            }
+            claims = extractClaimsFromResponse(response);
+            statusCode = getStatusCodeFromResponse(response);
+        } catch (Exception e) {
+            throw new UserInfoResponseException(e);
+        }
+
+        if (statusCode != 200) {
+            throw new UserInfoResponseNot200Exception(userInfoEndpoint, Integer.toString(statusCode), claims.toString());
+        }
+
+        return new UserInfoResponse(claims);
+    }
+
+    private int getStatusCodeFromResponse(HttpResponse response) {
+        return response.getStatusLine().getStatusCode();
+    }
+
+    private JSONObject extractClaimsFromResponse(HttpResponse response) throws Exception {
+        HttpEntity entity = response.getEntity();
+        String jresponse = null;
+        if (entity != null) {
+            jresponse = EntityUtils.toString(entity);
+        }
+        if (jresponse == null || jresponse.isEmpty()) {
+            return null;
+        }
+        String contentType = getContentType(entity);
+        if (contentType == null) {
+            return null;
+        }
+        JSONObject claims = null;
+        if (contentType.contains(HttpConstants.APPLICATION_JSON)) {
+            claims = extractClaimsFromJsonResponse(jresponse);
+        } else if (contentType.contains(HttpConstants.APPLICATION_JWT)) {
+            // TODO: handle jwt (jws and jwe) response type
+        }
+        return claims;
+    }
+
+    private JSONObject extractClaimsFromJsonResponse(String jresponse) throws IOException {
+        return JSONObject.parse(jresponse);
+    }
+
+    private String getContentType(HttpEntity entity) {
+        Header contentTypeHeader = entity.getContentType();
+        if (contentTypeHeader != null) {
+            return contentTypeHeader.getValue();
+        }
+        return null;
+    }
+
+    private Map<String, Object> getFromUserInfoEndpoint() throws HttpException, IOException {
+        return oidcClientHttpUtil.getFromEndpoint(userInfoEndpoint,
+                                                  params,
+                                                  null,
+                                                  null,
+                                                  accessToken,
+                                                  sslSocketFactory,
+                                                  hostnameVerification,
+                                                  useSystemPropertiesForHttpClientConnections);
+    }
+
+    public static class Builder {
+
+        private final String userInfoEndpoint;
+        private final String accessToken;
+        private final SSLSocketFactory sslSocketFactory;
+
+        private boolean hostnameVerification = false;
+        private boolean useSystemPropertiesForHttpClientConnections = false;
+
+        public Builder(String userInfoEndpoint, String accessToken, SSLSocketFactory sslSocketFactory) {
+            this.userInfoEndpoint = userInfoEndpoint;
+            this.accessToken = accessToken;
+            this.sslSocketFactory = sslSocketFactory;
+        }
+
+        public Builder hostnameVerification(boolean hostnameVerification) {
+            this.hostnameVerification = hostnameVerification;
+            return this;
+        }
+
+        public Builder useSystemPropertiesForHttpClientConnections(boolean useSystemPropertiesForHttpClientConnections) {
+            this.useSystemPropertiesForHttpClientConnections = useSystemPropertiesForHttpClientConnections;
+            return this;
+        }
+
+        public UserInfoRequestor build() {
+            return new UserInfoRequestor(this);
+        }
+    }
+}

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/userinfo/UserInfoResponse.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/userinfo/UserInfoResponse.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oidcclientcore.userinfo;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import com.ibm.json.java.JSONObject;
+
+public class UserInfoResponse {
+
+    private final JSONObject rawResponse;
+    private Map<String, String> responseAsMap;
+
+    public UserInfoResponse(JSONObject responseStr) {
+        rawResponse = responseStr;
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, String> asMap() {
+        if (responseAsMap != null) {
+            return responseAsMap;
+        }
+        if (rawResponse == null) {
+            return null;
+        }
+        Map<String, String> map = new HashMap<>();
+        Set<String> keys = rawResponse.keySet();
+        for (String key : keys) {
+            map.put(key, rawResponse.get(key).toString());
+        }
+        responseAsMap = new HashMap<>(map);
+        return map;
+    }
+
+    public JSONObject asJSON() {
+        return rawResponse;
+    }
+
+    public String serialize() {
+        try {
+            return rawResponse.serialize();
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+}

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/userinfo/UserInfoResponse.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/userinfo/UserInfoResponse.java
@@ -20,24 +20,24 @@ import com.ibm.json.java.JSONObject;
 public class UserInfoResponse {
 
     private final JSONObject rawResponse;
-    private Map<String, String> responseAsMap;
+    private Map<String, Object> responseAsMap;
 
     public UserInfoResponse(JSONObject responseStr) {
         rawResponse = responseStr;
     }
 
     @SuppressWarnings("unchecked")
-    public Map<String, String> asMap() {
+    public Map<String, Object> asMap() {
         if (responseAsMap != null) {
             return responseAsMap;
         }
         if (rawResponse == null) {
             return null;
         }
-        Map<String, String> map = new HashMap<>();
+        Map<String, Object> map = new HashMap<>();
         Set<String> keys = rawResponse.keySet();
         for (String key : keys) {
-            map.put(key, rawResponse.get(key).toString());
+            map.put(key, rawResponse.get(key));
         }
         responseAsMap = new HashMap<>(map);
         return map;

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/userinfo/package-info.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/userinfo/package-info.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+@TraceOptions(traceGroup = TraceConstants.TRACE_GROUP, messageBundle = TraceConstants.MESSAGE_BUNDLE)
+package io.openliberty.security.oidcclientcore.userinfo;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;
+
+import io.openliberty.security.oidcclientcore.TraceConstants;

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/http/OidcClientHttpUtilTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/http/OidcClientHttpUtilTest.java
@@ -37,6 +37,7 @@ import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
@@ -241,9 +242,8 @@ public class OidcClientHttpUtilTest {
             String baUsername = "testuser";
             String baPassword = "testuserpwd";
             String accessToken = "accesstokenstringabcdef";
-            List<NameValuePair> commonHeaders = new ArrayList<NameValuePair>();
 
-            Map<String, Object> map = moichu.postToEndpoint(url, params, baUsername, baPassword, accessToken, sslSocketFactory, commonHeaders, false, authMethod, false);
+            Map<String, Object> map = moichu.postToEndpoint(url, params, baUsername, baPassword, accessToken, sslSocketFactory, false, authMethod, false);
             HttpResponse myRes = (HttpResponse) map.get(HttpConstants.RESPONSEMAP_CODE);
             assertEquals("Did not get baclk HttepResponse " + httpResponse + " but " + myRes,
                     httpResponse, myRes);
@@ -276,9 +276,8 @@ public class OidcClientHttpUtilTest {
             String baUsername = "testuser";
             String baPassword = "testuserpwd";
             String accessToken = "accesstokenstringabcdef";
-            List<NameValuePair> commonHeaders = new ArrayList<NameValuePair>();
 
-            Map<String, Object> map = mockClientUtil.postToEndpoint(url, params, baUsername, baPassword, accessToken, sslSocketFactory, commonHeaders, false, authMethod, false);
+            Map<String, Object> map = mockClientUtil.postToEndpoint(url, params, baUsername, baPassword, accessToken, sslSocketFactory, false, authMethod, false);
             fail("Expected an IOException when executing the post, but no exception was thrown. Got map: " + map);
         } catch (IOException e) {
             String message = e.getMessage();
@@ -312,9 +311,8 @@ public class OidcClientHttpUtilTest {
             String baUsername = "testuser";
             String baPassword = "testuserpwd";
             String accessToken = "accesstokenstringabcdef";
-            List<NameValuePair> commonHeaders = new ArrayList<NameValuePair>();
 
-            Map<String, Object> map = mockClientUtil.postToEndpoint(url, params, baUsername, baPassword, accessToken, sslSocketFactory, commonHeaders, false, authMethod, false);
+            Map<String, Object> map = mockClientUtil.postToEndpoint(url, params, baUsername, baPassword, accessToken, sslSocketFactory, false, authMethod, false);
             fail("Expected an IOException when executing the POST, but no exception was thrown. Got map: " + map);
         } catch (IOException e) {
             String message = e.getMessage();
@@ -351,9 +349,8 @@ public class OidcClientHttpUtilTest {
             String baUsername = "testuser";
             String baPassword = "testuserpwd";
             String accessToken = "accesstokenstringabcdef";
-            List<NameValuePair> commonHeaders = new ArrayList<NameValuePair>();
 
-            Map<String, Object> map = mockClientUtil.postToEndpoint(url, params, baUsername, baPassword, accessToken, sslSocketFactory, commonHeaders, false, authMethod, false);
+            Map<String, Object> map = mockClientUtil.postToEndpoint(url, params, baUsername, baPassword, accessToken, sslSocketFactory, false, authMethod, false);
             fail("Expected to receive a response from the endpoint resulting in an IOException, but no exception was thrown. Got map: " + map);
         } catch (IOException e) {
             String message = e.getMessage();
@@ -392,9 +389,8 @@ public class OidcClientHttpUtilTest {
             String baUsername = "testuser";
             String baPassword = "testuserpwd";
             String accessToken = "accesstokenstringabcdef";
-            List<NameValuePair> commonHeaders = new ArrayList<NameValuePair>();
 
-            Map<String, Object> map = mockClientUtil.postToEndpoint(url, params, baUsername, baPassword, accessToken, sslSocketFactory, commonHeaders, false, authMethod, false);
+            Map<String, Object> map = mockClientUtil.postToEndpoint(url, params, baUsername, baPassword, accessToken, sslSocketFactory, false, authMethod, false);
             fail("Expected to receive an error response from the endpoint resulting in an IOException, but no exception was thrown. Got map: " + map);
         } catch (IOException e) {
             String message = e.getMessage();
@@ -423,6 +419,36 @@ public class OidcClientHttpUtilTest {
         int port = 80;
         String url = "http://hostname/oidc/endpoint";
         assertEquals(port, OidcClientHttpUtil.getTokenEndPointPort(url));
+    }
+
+    @Test
+    public void testGetFromEndpoint() {
+        final String methodName = "testGetFromEndpoint";
+        try {
+            String url = "http://localhost:8010/oidc/someEndPoint";
+            String baUsername = "baUsername";
+            String baPassword = "baPassword";
+            String accessToken = "qOuZdH6Anmxclul5d71AXoDbFVmRG2dPnHn9moaw";
+            List<NameValuePair> params = new ArrayList<NameValuePair>();
+
+            mock.checking(new Expectations() {
+                {
+                    one(httpClient).execute(with(any(HttpUriRequest.class)));
+                    will(returnValue(httpResponse));
+                }
+            });
+
+            Map<String, Object> result = moichu.getFromEndpoint(url, params, baUsername, baPassword, accessToken, sslSocketFactory, false, false);
+
+            HttpResponse responseCode = (HttpResponse) result.get(HttpConstants.RESPONSEMAP_CODE);
+            assertNotNull("Expect to see valid response code", responseCode);
+
+            HttpGet getMethod = new HttpGet(url);
+            HttpGet getMethod2 = (HttpGet) result.get(HttpConstants.RESPONSEMAP_METHOD);
+            assertEquals("HttpGet method ", getMethod.getMethod(), getMethod2.getMethod());
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(methodName, t);
+        }
     }
 
     class MockInputStream extends InputStream {
@@ -470,6 +496,11 @@ public class OidcClientHttpUtilTest {
         @Override
         public HttpClient createHTTPClient(SSLSocketFactory sslSocketFactory, String url, boolean b, String baUser, String baPassword, boolean useJvmProps) {
             //return new mockDefaultHttpClient();
+            return httpClient;
+        }
+
+        @Override
+        public HttpClient createHttpClient(SSLSocketFactory sslSocketFactory, String url, boolean isHostnameVerification, boolean useSystemPropertiesForHttpClientConnections, BasicCredentialsProvider credentialsProvider) {
             return httpClient;
         }
     }

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/token/TokenRequestorTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/token/TokenRequestorTest.java
@@ -52,13 +52,9 @@ public class TokenRequestorTest extends CommonTestClass {
     private static final String idToken = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwOi8vaGFybW9uaWM6ODAxMS9vYXV0aDIvZW5kcG9pbnQvT0F1dGhDb25maWdTYW1wbGUvdG9rZW4iLCJpYXQiOjEzODczODM5NTMsInN1YiI6InRlc3R1c2VyIiwiZXhwIjoxMzg3Mzg3NTUzLCJhdWQiOiJjbGllbnQwMSJ9.ottD3eYa6qrnItRpL_Q9UaKumAyo14LnlvwnyF3Kojk";
     private static final String tokenResponseEntity = "{\"access_token\":\"" + accessToken + "\",\"token_type\":\"" + tokenType + "\",\"expires_in\":" + expiresIn + ",\"scope\":\"" + scope + "\",\"refresh_token\":\"" + refreshToken + "\",\"id_token\":\"" + idToken + "\"}";
 
-    private static final List<NameValuePair> commonHeaders;
     private static final Map<String, Object> postResponseMap;
 
     static {
-        commonHeaders = new ArrayList<NameValuePair>();
-        commonHeaders.add(new BasicNameValuePair(TokenConstants.ACCEPT, TokenConstants.APPLICATION_JSON));
-
         postResponseMap = new HashMap<String, Object>();
         postResponseMap.put(TokenConstants.ACCESS_TOKEN, accessToken);
         postResponseMap.put(TokenConstants.TOKEN_TYPE, tokenType);
@@ -104,7 +100,7 @@ public class TokenRequestorTest extends CommonTestClass {
 
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, params, clientId, clientSecret, null, null, commonHeaders, false, TokenConstants.METHOD_BASIC, false);
+                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, params, clientId, clientSecret, null, null, false, TokenConstants.METHOD_BASIC, false);
                 will(returnValue(postResponseMap));
                 one(oidcClientHttpUtil).extractEntityFromTokenResponse(postResponseMap);
                 will(returnValue(tokenResponseEntity));
@@ -125,7 +121,7 @@ public class TokenRequestorTest extends CommonTestClass {
 
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).postToEndpoint(tokenEndpointSecure, params, clientId, clientSecret, null, sslSocketFactory, commonHeaders, false,
+                one(oidcClientHttpUtil).postToEndpoint(tokenEndpointSecure, params, clientId, clientSecret, null, sslSocketFactory, false,
                                                        TokenConstants.METHOD_BASIC, false);
                 will(returnValue(postResponseMap));
                 one(oidcClientHttpUtil).extractEntityFromTokenResponse(postResponseMap);
@@ -147,7 +143,7 @@ public class TokenRequestorTest extends CommonTestClass {
 
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, params, clientId, clientSecret, null, null, commonHeaders, true, TokenConstants.METHOD_BASIC, false);
+                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, params, clientId, clientSecret, null, null, true, TokenConstants.METHOD_BASIC, false);
                 will(returnValue(postResponseMap));
                 one(oidcClientHttpUtil).extractEntityFromTokenResponse(postResponseMap);
                 will(returnValue(tokenResponseEntity));
@@ -171,7 +167,7 @@ public class TokenRequestorTest extends CommonTestClass {
 
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, params, clientId, clientSecret, null, null, commonHeaders, false, TokenConstants.METHOD_POST, false);
+                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, params, clientId, clientSecret, null, null, false, TokenConstants.METHOD_POST, false);
                 will(returnValue(postResponseMap));
                 one(oidcClientHttpUtil).extractEntityFromTokenResponse(postResponseMap);
                 will(returnValue(tokenResponseEntity));
@@ -199,7 +195,7 @@ public class TokenRequestorTest extends CommonTestClass {
 
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, params, clientId, clientSecret, null, null, commonHeaders, false, TokenConstants.METHOD_BASIC, false);
+                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, params, clientId, clientSecret, null, null, false, TokenConstants.METHOD_BASIC, false);
                 will(returnValue(postResponseMap));
                 one(oidcClientHttpUtil).extractEntityFromTokenResponse(postResponseMap);
                 will(returnValue(tokenResponseEntity));
@@ -221,7 +217,7 @@ public class TokenRequestorTest extends CommonTestClass {
 
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, params, clientId, clientSecret, null, null, commonHeaders, false, TokenConstants.METHOD_BASIC, true);
+                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, params, clientId, clientSecret, null, null, false, TokenConstants.METHOD_BASIC, true);
                 will(returnValue(postResponseMap));
                 one(oidcClientHttpUtil).extractEntityFromTokenResponse(postResponseMap);
                 will(returnValue(tokenResponseEntity));
@@ -251,8 +247,7 @@ public class TokenRequestorTest extends CommonTestClass {
 
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).postToEndpoint(tokenEndpointSecure, params, clientId, clientSecret, null, sslSocketFactory, commonHeaders, true,
-                                                       TokenConstants.METHOD_POST, true);
+                one(oidcClientHttpUtil).postToEndpoint(tokenEndpointSecure, params, clientId, clientSecret, null, sslSocketFactory, true, TokenConstants.METHOD_POST, true);
                 will(returnValue(postResponseMap));
                 one(oidcClientHttpUtil).extractEntityFromTokenResponse(postResponseMap);
                 will(returnValue(tokenResponseEntity));

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/userinfo/UserInfoRequestorTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/userinfo/UserInfoRequestorTest.java
@@ -1,0 +1,297 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oidcclientcore.userinfo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.net.ssl.SSLSocketFactory;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.entity.BasicHttpEntity;
+import org.jmock.Expectations;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import io.openliberty.security.oidcclientcore.exceptions.UserInfoEndpointNotHttpsException;
+import io.openliberty.security.oidcclientcore.exceptions.UserInfoResponseException;
+import io.openliberty.security.oidcclientcore.exceptions.UserInfoResponseNot200Exception;
+import io.openliberty.security.oidcclientcore.http.HttpConstants;
+import io.openliberty.security.oidcclientcore.http.OidcClientHttpUtil;
+import test.common.SharedOutputManager;
+
+public class UserInfoRequestorTest extends CommonTestClass {
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+
+    private static final String userInfoEndpoint = "https://some-domain.com/path/userinfo";
+    private static final String accessToken = "qOuZdH6Anmxclul5d71AXoDbFVmRG2dPnHn9moaw";
+
+    private static final String sub = "testsub";
+    private static final String iss = "https://superfoo";
+    private static final String name = "testname";
+
+    private static final String userInfoJSONResponseEntity = "{\"sub\":\"" + sub + "\",\"iss\":\"" + iss + "\",\"name\":\"" + name + "\"}";
+
+    private final OidcClientHttpUtil oidcClientHttpUtil = mockery.mock(OidcClientHttpUtil.class);
+    private final SSLSocketFactory sslSocketFactory = mockery.mock(SSLSocketFactory.class);
+    private final HttpResponse httpResponse = mockery.mock(HttpResponse.class);
+    private final HttpGet httpGet = mockery.mock(HttpGet.class);
+    private final StatusLine statusLine = mockery.mock(StatusLine.class);
+
+    private List<NameValuePair> params;
+    private Map<String, Object> userInfoResponseMap;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void setUp() {
+        params = new ArrayList<NameValuePair>();
+
+        userInfoResponseMap = new HashMap<String, Object>();
+        userInfoResponseMap.put(HttpConstants.RESPONSEMAP_CODE, httpResponse);
+        userInfoResponseMap.put(HttpConstants.RESPONSEMAP_METHOD, httpGet);
+    }
+
+    @After
+    public void tearDown() {
+        outputMgr.resetStreams();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    @Test
+    public void test_requestUserInfo() throws Exception {
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(userInfoEndpoint, accessToken, sslSocketFactory).build();
+        userInfoRequestor.oidcClientHttpUtil = oidcClientHttpUtil;
+
+        BasicHttpEntity httpEntity = createBasicHttpEntity(userInfoJSONResponseEntity, HttpConstants.APPLICATION_JSON);
+        mockery.checking(new Expectations() {
+            {
+                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, sslSocketFactory, false, false);
+                will(returnValue(userInfoResponseMap));
+                one(httpResponse).getEntity();
+                will(returnValue(httpEntity));
+                one(httpResponse).getStatusLine();
+                will(returnValue(statusLine));
+                one(statusLine).getStatusCode();
+                will(returnValue(200));
+            }
+        });
+
+        UserInfoResponse userInfoResponse = userInfoRequestor.requestUserInfo();
+
+        verifyUserInfoResponse(userInfoResponse);
+    }
+
+    public void test_requestUserInfo_withHostnameVerification() throws Exception {
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(userInfoEndpoint, accessToken, sslSocketFactory).hostnameVerification(true).build();
+        userInfoRequestor.oidcClientHttpUtil = oidcClientHttpUtil;
+
+        BasicHttpEntity httpEntity = createBasicHttpEntity(userInfoJSONResponseEntity, HttpConstants.APPLICATION_JSON);
+        mockery.checking(new Expectations() {
+            {
+                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, sslSocketFactory, true, false);
+                will(returnValue(userInfoResponseMap));
+                one(httpResponse).getEntity();
+                will(returnValue(httpEntity));
+                one(httpResponse).getStatusLine();
+                will(returnValue(statusLine));
+                one(statusLine).getStatusCode();
+                will(returnValue(200));
+            }
+        });
+
+        UserInfoResponse userInfoResponse = userInfoRequestor.requestUserInfo();
+
+        verifyUserInfoResponse(userInfoResponse);
+    }
+
+    public void test_requestUserInfo_useSystemPropertiesForHttpClientConnections() throws Exception {
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(userInfoEndpoint, accessToken, sslSocketFactory).useSystemPropertiesForHttpClientConnections(true).build();
+        userInfoRequestor.oidcClientHttpUtil = oidcClientHttpUtil;
+
+        BasicHttpEntity httpEntity = createBasicHttpEntity(userInfoJSONResponseEntity, HttpConstants.APPLICATION_JSON);
+        mockery.checking(new Expectations() {
+            {
+                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, sslSocketFactory, false, true);
+                will(returnValue(userInfoResponseMap));
+                one(httpResponse).getEntity();
+                will(returnValue(httpEntity));
+                one(httpResponse).getStatusLine();
+                will(returnValue(statusLine));
+                one(statusLine).getStatusCode();
+                will(returnValue(200));
+            }
+        });
+
+        UserInfoResponse userInfoResponse = userInfoRequestor.requestUserInfo();
+
+        verifyUserInfoResponse(userInfoResponse);
+    }
+
+    public void test_requestUserInfo_withHostnameVerificationAndUseSystemPropertiesForHttpClientConnections() throws Exception {
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(userInfoEndpoint, accessToken, sslSocketFactory).hostnameVerification(true).useSystemPropertiesForHttpClientConnections(true).build();
+        userInfoRequestor.oidcClientHttpUtil = oidcClientHttpUtil;
+
+        BasicHttpEntity httpEntity = createBasicHttpEntity(userInfoJSONResponseEntity, HttpConstants.APPLICATION_JSON);
+        mockery.checking(new Expectations() {
+            {
+                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, sslSocketFactory, true, true);
+                will(returnValue(userInfoResponseMap));
+                one(httpResponse).getEntity();
+                will(returnValue(httpEntity));
+                one(httpResponse).getStatusLine();
+                will(returnValue(statusLine));
+                one(statusLine).getStatusCode();
+                will(returnValue(200));
+            }
+        });
+
+        UserInfoResponse userInfoResponse = userInfoRequestor.requestUserInfo();
+
+        verifyUserInfoResponse(userInfoResponse);
+    }
+
+    @Test(expected = UserInfoEndpointNotHttpsException.class)
+    public void test_requestUserInfo_urlNotHTTPS() throws Exception {
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder("http://superfoo", accessToken, sslSocketFactory).build();
+
+        userInfoRequestor.requestUserInfo();
+    }
+
+    @Test(expected = UserInfoResponseException.class)
+    public void test_requestUserInfo_httpResponseIsNull() throws Exception {
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(userInfoEndpoint, accessToken, sslSocketFactory).build();
+        userInfoRequestor.oidcClientHttpUtil = oidcClientHttpUtil;
+
+        userInfoResponseMap.put(HttpConstants.RESPONSEMAP_CODE, null);
+        mockery.checking(new Expectations() {
+            {
+                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, sslSocketFactory, false, false);
+                will(returnValue(userInfoResponseMap));
+            }
+        });
+
+        userInfoRequestor.requestUserInfo();
+    }
+
+    @Test(expected = UserInfoResponseException.class)
+    public void test_requestUserInfo_responseHasMalformedJSON() throws Exception {
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(userInfoEndpoint, accessToken, sslSocketFactory).build();
+        userInfoRequestor.oidcClientHttpUtil = oidcClientHttpUtil;
+
+        BasicHttpEntity httpEntity = createBasicHttpEntity("notJSON", HttpConstants.APPLICATION_JSON);
+        mockery.checking(new Expectations() {
+            {
+                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, sslSocketFactory, false, false);
+                will(returnValue(userInfoResponseMap));
+                one(httpResponse).getEntity();
+                will(returnValue(httpEntity));
+                one(httpResponse).getStatusLine();
+                will(returnValue(statusLine));
+                one(statusLine).getStatusCode();
+                will(returnValue(200));
+            }
+        });
+
+        userInfoRequestor.requestUserInfo();
+    }
+
+    @Test(expected = UserInfoResponseNot200Exception.class)
+    public void test_requestUserInfo_responseStatusCodeNot200() throws Exception {
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(userInfoEndpoint, accessToken, sslSocketFactory).build();
+        userInfoRequestor.oidcClientHttpUtil = oidcClientHttpUtil;
+
+        BasicHttpEntity httpEntity = createBasicHttpEntity(userInfoJSONResponseEntity, HttpConstants.APPLICATION_JSON);
+        mockery.checking(new Expectations() {
+            {
+                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, sslSocketFactory, false, false);
+                will(returnValue(userInfoResponseMap));
+                one(httpResponse).getEntity();
+                will(returnValue(httpEntity));
+                one(httpResponse).getStatusLine();
+                will(returnValue(statusLine));
+                one(statusLine).getStatusCode();
+                will(returnValue(500));
+            }
+        });
+
+        userInfoRequestor.requestUserInfo();
+    }
+
+    @Test
+    public void test_requestUserInfo_contentTypeUnknown() throws Exception {
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(userInfoEndpoint, accessToken, sslSocketFactory).build();
+        userInfoRequestor.oidcClientHttpUtil = oidcClientHttpUtil;
+
+        BasicHttpEntity httpEntity = createBasicHttpEntity(userInfoJSONResponseEntity, "unknownContentType");
+        mockery.checking(new Expectations() {
+            {
+                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, sslSocketFactory, false, false);
+                will(returnValue(userInfoResponseMap));
+                one(httpResponse).getEntity();
+                will(returnValue(httpEntity));
+                one(httpResponse).getStatusLine();
+                will(returnValue(statusLine));
+                one(statusLine).getStatusCode();
+                will(returnValue(200));
+            }
+        });
+
+        UserInfoResponse userInfoResponse = userInfoRequestor.requestUserInfo();
+
+        assertNull(userInfoResponse.asMap());
+    }
+
+    private BasicHttpEntity createBasicHttpEntity(String string, String contentType) {
+        BasicHttpEntity entity = createBasicHttpEntity(string);
+        entity.setContentType(contentType);
+        return entity;
+    }
+
+    private BasicHttpEntity createBasicHttpEntity(String string) {
+        InputStream input = new ByteArrayInputStream(string.getBytes());
+        BasicHttpEntity entity = new BasicHttpEntity();
+        entity.setContent(input);
+        return entity;
+    }
+
+    private void verifyUserInfoResponse(UserInfoResponse userInfoResponse) {
+        Map<String, String> claims = userInfoResponse.asMap();
+        assertEquals("Expected sub claim to be " + claims.get("sub") + ", but was " + sub + ".", claims.get("sub"), sub);
+        assertEquals("Expected iss claim to be " + claims.get("iss") + ", but was " + iss + ".", claims.get("iss"), iss);
+        assertEquals("Expected name claim to be " + claims.get("name") + ", but was " + name + ".", claims.get("name"), name);
+    }
+
+}

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/userinfo/UserInfoRequestorTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/userinfo/UserInfoRequestorTest.java
@@ -288,7 +288,7 @@ public class UserInfoRequestorTest extends CommonTestClass {
     }
 
     private void verifyUserInfoResponse(UserInfoResponse userInfoResponse) {
-        Map<String, String> claims = userInfoResponse.asMap();
+        Map<String, Object> claims = userInfoResponse.asMap();
         assertEquals("Expected sub claim to be " + claims.get("sub") + ", but was " + sub + ".", claims.get("sub"), sub);
         assertEquals("Expected iss claim to be " + claims.get("iss") + ", but was " + iss + ".", claims.get("iss"), iss);
         assertEquals("Expected name claim to be " + claims.get("name") + ", but was " + name + ".", claims.get("name"), name);

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/userinfo/UserInfoRequestorTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/userinfo/UserInfoRequestorTest.java
@@ -271,7 +271,7 @@ public class UserInfoRequestorTest extends CommonTestClass {
 
         UserInfoResponse userInfoResponse = userInfoRequestor.requestUserInfo();
 
-        assertNull(userInfoResponse.asMap());
+        assertNull("Expected UserInfoResponse map to be null since we don't know how to process the content type.", userInfoResponse.asMap());
     }
 
     private BasicHttpEntity createBasicHttpEntity(String string, String contentType) {


### PR DESCRIPTION
for #21172 

init `oidcclientcore.userinfo` subsystem
- creates a new `UserInfoRequestor` class to send requests to the op's userinfo endpoint from the rp/client
- move `getFromEndpoint` method from `OidcClientUtil` to `OidcClientHttpUtil` so it share the same class as `postToEndpoint` for consistency
- move `commonHeaders` to `OidcClientHttpUtil` to help reduce the number of params required to call these methods