### PR TITLE
Run Context Propagation 1.3 TCK without servlet

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019,2021 IBM Corporation and others.
+# Copyright (c) 2019,2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -21,5 +21,6 @@ tested.features=\
   concurrent-3.0,\
   cdi-3.0,\
   cdi-4.0,\
-  servlet-5.0,\
-  servlet-6.0
+  jsonp-2.1,\
+  restfulws-3.1,\
+  restfulwsclient-3.1

--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/servers/tckServerForMPContextPropagation13/server.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/servers/tckServerForMPContextPropagation13/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019,2021 IBM Corporation and others.
+    Copyright (c) 2019,2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  -->
 <server>
     <featureManager>
-        <feature>servlet-5.0</feature>
+        <feature>restfulWS-3.0</feature>
         <feature>componenttest-2.0</feature>
         <feature>localConnector-1.0</feature>
         <feature>cdi-3.0</feature>

--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
@@ -25,6 +25,7 @@
             <property name="failSafeUndeployment">${tck_failSafeUndeployment}</property>
             <property name="appDeployTimeout">${tck_appDeployTimeout}</property>
             <property name="appUndeployTimeout">${tck_appUndeployTimeout}</property>
+            <property name="testProtocol">rest</property>
         </configuration>
     </container>
 </arquillian>


### PR DESCRIPTION
Run without the servlet feature when running with EE10 features, use restfulWS-3.1 and the arquillian rest protocol instead.

Fixes #22279 