### PR TITLE
Issue #22303: On z/OS running Java 11 a FFDC with caused by AttachNotSupportedException occurs when feature localConnector-1.0  is specified.

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -713,7 +713,12 @@ serverEnvAndJVMOptions()
 
   # Avoids HeadlessException on all platforms and Liberty JVMs appearing as applications and stealing focus on Mac.
   # Declare allowAttachSelf=true so that the VM will permit a late self attach if localConnector-1.0 is enabled
-  JVM_OPTIONS_QUOTED="-Djava.awt.headless=true -Djdk.attach.allowAttachSelf=true"
+  # need -Dcom.ibm.tools.attach.enable=yes for java 11 on z/OS
+  if [ "${uname}" = OS/390 ]; then
+    JVM_OPTIONS_QUOTED="-Djava.awt.headless=true -Djdk.attach.allowAttachSelf=true -Dcom.ibm.tools.attach.enable=yes"
+  else
+    JVM_OPTIONS_QUOTED="-Djava.awt.headless=true -Djdk.attach.allowAttachSelf=true"
+  fi
   SERVER_JVM_OPTIONS_QUOTED=${JVM_OPTIONS_QUOTED}
 
   rc=0


### PR DESCRIPTION
When running on z/OS with Java 11, a FFDC with java.lang.reflect.InvocationTargetException caused by com.sun.tools.attach.AttachNotSupportedException is seen when starting a server that requests the localConnector-1.0 feature.

fixes #22303 
