### PR TITLE
Update mpOpenAPI 3.1 for config validation

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.configValidationConfigSchema-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.configValidationConfigSchema-3.0.feature
@@ -3,7 +3,7 @@ symbolicName=io.openliberty.configValidationConfigSchema-3.0
 visibility=private
 IBM-Provision-Capability:\
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.restConnector-2.0))",\
-  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.mpOpenAPI-3.0))"
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.mpOpenAPI-3.0)(osgi.identity=io.openliberty.mpOpenAPI-3.1)))"
 IBM-Install-Policy: when-satisfied
 -bundles=\
  io.openliberty.rest.handler.config.openapi.2.0,\

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.configValidationValidatorSchema-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.configValidationValidatorSchema-3.0.feature
@@ -2,7 +2,7 @@
 symbolicName=io.openliberty.configValidationValidatorSchema-3.0
 visibility=private
 IBM-Provision-Capability:\
-  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.mpOpenAPI-3.0))",\
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.mpOpenAPI-3.0)(osgi.identity=io.openliberty.mpOpenAPI-3.1)))",\
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.configValidationJDBC-1.0)(osgi.identity=com.ibm.websphere.appserver.configValidationJCA-1.0)(osgi.identity=com.ibm.websphere.appserver.configValidationCloudant-1.0)))"
 IBM-Install-Policy: when-satisfied
 -bundles=\

--- a/dev/com.ibm.ws.rest.handler.config_fat/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.config_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2021 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -38,16 +38,21 @@ fat.project: true
     com.ibm.websphere.org.eclipse.microprofile.openapi.1.0;version=latest
 
 tested.features: componenttest-2.0,\
+                 connectors-2.1,\
                  messagingserver-3.0,\
                  messaging-3.0,\
+                 messaging-3.1,\
                  enterprisebeanslite-4.0,\
                  messagingclient-3.0,\
+                 mpOpenApi-3.1,\
                  mpOpenApi-3.0,\
                  mpOpenApi-2.0,\
                  mpOpenApi-1.1,\
                  servlet-4.0,\
                  servlet-5.0,\
+                 servlet-6.0,\
                  mpConfig-2.0,\
                  jsonp-1.1,\
                  jaxrsclient-2.1,\
-                 jaxrs-2.1
+                 jaxrs-2.1,\
+                 restfulws-3.1

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -42,6 +42,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -1199,7 +1200,8 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertNotNull(stack.get(1));
         assertNotNull(stack.get(2));
         assertNotNull(err, cause = failure.getJsonObject("cause"));
-        assertEquals(err, JakartaEE9Action.isActive() ? "jakarta.resource.ResourceException" : "javax.resource.ResourceException", cause.getString("class"));
+        assertEquals(err, JakartaEE9Action.isActive() || JakartaEE10Action.isActive() ? "jakarta.resource.ResourceException" : "javax.resource.ResourceException",
+                     cause.getString("class"));
         assertNotNull(err, message = cause.getString("message"));
         assertTrue(err, message.startsWith("J2CA8011E") && message.contains("1:05:30"));
         assertNotNull(err, stack = cause.getJsonArray("stack"));
@@ -1321,7 +1323,7 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertNotNull(err, j = j.getJsonObject("info"));
         assertEquals(err, "IBM", j.getString("jmsProviderName"));
         assertEquals(err, "1.0", j.getString("jmsProviderVersion"));
-        assertEquals(err, JakartaEE9Action.isActive() ? "3.0" : "2.0", j.getString("jmsProviderSpecVersion"));
+        assertEquals(err, getExpectedJmsProviderSpecVersion(), j.getString("jmsProviderSpecVersion"));
         assertEquals(err, "clientID", j.getString("clientID"));
     }
 
@@ -1342,7 +1344,7 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertNotNull(err, j = j.getJsonObject("info"));
         assertEquals(err, "IBM", j.getString("jmsProviderName"));
         assertEquals(err, "1.0", j.getString("jmsProviderVersion"));
-        assertEquals(err, JakartaEE9Action.isActive() ? "3.0" : "2.0", j.getString("jmsProviderSpecVersion"));
+        assertEquals(err, getExpectedJmsProviderSpecVersion(), j.getString("jmsProviderSpecVersion"));
     }
 
     /**
@@ -1367,5 +1369,15 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertEquals(err, "88.105.137", j.getString("jmsProviderVersion"));
         assertEquals(err, "2.0", j.getString("jmsProviderSpecVersion"));
         assertEquals(err, "AppDefinedClientId", j.getString("clientID"));
+    }
+
+    private String getExpectedJmsProviderSpecVersion() {
+        if (JakartaEE10Action.isActive()) {
+            return "3.1";
+        } else if (JakartaEE9Action.isActive()) {
+            return "3.0";
+        } else {
+            return "2.0";
+        }
     }
 }

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerJMSTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerJMSTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,6 +34,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -96,7 +97,7 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
         JsonObject props;
         assertNotNull(err, props = aspec.getJsonObject("properties.jmsra"));
         assertEquals(props.toString(), 2, props.size()); // increase this if we ever add additional configured values or default values
-        assertEquals(err, JakartaEE9Action.isActive() ? "jakarta.jms.Topic" : "javax.jms.Topic", props.getString("destinationType"));
+        assertEquals(err, JakartaEE9Action.isActive() || JakartaEE10Action.isActive() ? "jakarta.jms.Topic" : "javax.jms.Topic", props.getString("destinationType"));
 
         // jmsDestination
         JsonObject dest;
@@ -141,7 +142,7 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
         JsonObject props;
         assertNotNull(err, props = aspec.getJsonObject("properties.jmsra"));
         assertEquals(err, 2, props.size()); // increase this if we ever add additional configured values or default values
-        assertEquals(err, JakartaEE9Action.isActive() ? "jakarta.jms.Topic" : "javax.jms.Topic", props.getString("destinationType"));
+        assertEquals(err, JakartaEE9Action.isActive() || JakartaEE10Action.isActive() ? "jakarta.jms.Topic" : "javax.jms.Topic", props.getString("destinationType"));
 
         // jmsTopic
         JsonObject dest;

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,6 +35,7 @@ import org.junit.runner.RunWith;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -619,7 +620,8 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         JsonObject j = new HttpsRequest(server, "/ibm/api/config/dataSource/WrongDefaultAuth?" +
                                                 "id=WrongDefaultAuth&jndiName=jdbc/wrongdefaultauth&beginTranForVendorAPIs=true&" +
                                                 "commitOrRollbackOnCleanup=rollback&invalidProperty=The+property's+value.&" +
-                                                "queryTimeout=130&statementCacheSize=15&validationTimeout=20").run(JsonObject.class);
+                                                "queryTimeout=130&statementCacheSize=15&validationTimeout=20")
+                        .run(JsonObject.class);
         String err = "unexpected response: " + j;
         assertEquals(err, "dataSource", j.getString("configElementName"));
         assertEquals(err, "WrongDefaultAuth", j.getString("uid"));
@@ -691,7 +693,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         List<String> features = new ArrayList<String>();
         for (int i = 0; i < length; i++)
             features.add(ja.getString(i).toLowerCase());
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE9Action.isActive() || JakartaEE10Action.isActive()) {
             assertTrue(err, features.contains("componenttest-2.0"));
         } else {
             assertTrue(err, features.contains("componenttest-1.0"));

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/FATSuite.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/FATSuite.java
@@ -17,6 +17,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
@@ -36,6 +37,7 @@ public class FATSuite {
 
     @ClassRule
     public static RepeatTests r = MicroProfileActions.repeat(null, TestMode.FULL,
+                                                             MicroProfileActions.MP60, // EE10
                                                              MicroProfileActions.MP50, // EE9
                                                              MicroProfileActions.MP40); // EE8
 
@@ -47,7 +49,7 @@ public class FATSuite {
     }
 
     public static void setupServerSideAnnotations(LibertyServer server) {
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE9Action.isActive() || JakartaEE10Action.isActive()) {
             server.addEnvVar("CONNECTION_FACTORY", "jakarta.resource.cci.ConnectionFactory");
             server.addEnvVar("QUEUE_FACTORY", "jakarta.jms.QueueConnectionFactory");
             server.addEnvVar("TOPIC_FACTORY", "jakarta.jms.TopicConnectionFactory");

--- a/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
@@ -21,25 +21,34 @@ fat.project: true
 
 tested.features: mpOpenApi-2.0,\
                  mpOpenApi-3.0,\
+                 mpOpenApi-3.1,\
                  servlet-4.0,\
                  servlet-5.0,\
+                 servlet-6.0,\
                  concurrent-2.0,\
+                 concurrent-3.0,\
                  mpConfig-2.0,\
                  mpConfig-3.0,\
                  jsonp-1.1,\
                  jsonp-2.0,\
+                 jsonp-2.1,\
                  jaxrsclient-2.1,\
                  jaxrs-2.1,\
                  restfulws-3.0,\
+                 restfulws-3.1,\
                  componenttest-2.0,\
                  appSecurity-4.0,\
                  messaging-3.0,\
+                 messaging-3.1,\
                  messagingserver-3.0,\
                  messagingclient-3.0,\
                  connectors-2.0,\
+                 connectors-2.1,\
                  appsecurity-3.0,\
+                 appsecurity-5.0,\
                  cdi-2.0,\
-                 el-3.0
+                 el-3.0,\
+                 expressionLanguage-5.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.2;version=latest,\

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/FATSuite.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/FATSuite.java
@@ -20,6 +20,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.EE9PackageReplacementHelper;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
@@ -41,6 +42,7 @@ public class FATSuite {
 
     @ClassRule
     public static RepeatTests r1 = MicroProfileActions.repeat(null, TestMode.FULL,
+                                                              MicroProfileActions.MP60,
                                                               MicroProfileActions.MP50, // EE9
                                                               MicroProfileActions.MP40, // EE8
                                                               MicroProfileActions.MP30,
@@ -54,7 +56,7 @@ public class FATSuite {
     }
 
     public static void setupServerSideAnnotations(LibertyServer server) {
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE9Action.isActive() || JakartaEE10Action.isActive()) {
             server.addEnvVar("CONNECTION_FACTORY", "jakarta.resource.cci.ConnectionFactory");
             server.addEnvVar("QUEUE_FACTORY", "jakarta.jms.QueueConnectionFactory");
             server.addEnvVar("TOPIC_FACTORY", "jakarta.jms.TopicConnectionFactory");
@@ -72,14 +74,16 @@ public class FATSuite {
     }
 
     public static void assertClassEquals(String message, String expected, String actual) {
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE9Action.isActive() || JakartaEE10Action.isActive()) {
             expected = packageReplacementHelper.replacePackages(expected);
         }
         assertEquals(message, expected, actual);
     }
 
     public static String expectedJmsProviderSpecVersion() {
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE10Action.isActive()) {
+            return "3.1";
+        } else if (JakartaEE9Action.isActive()) {
             return "3.0";
         } else {
             return "2.0";

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,6 +40,7 @@ import com.ibm.ws.rest.handler.validator.loginmodule.TestLoginModule;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -69,7 +70,7 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
 
         FATSuite.setupServerSideAnnotations(server);
 
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE9Action.isActive() || JakartaEE10Action.isActive()) {
             //Transforming the java permission
             final String serverXml = "validatorCustomLoginModuleServer.xml";
             Path serverXmlFile = Paths.get("lib/LibertyFATTestFiles", serverXml);

--- a/dev/io.openliberty.rest.handler.config.openapi.2.0/bnd.bnd
+++ b/dev/io.openliberty.rest.handler.config.openapi.2.0/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,6 +20,11 @@ WS-TraceGroup: rest.config
 
 Include-Resource: \
     META-INF=resources/META-INF
+
+Import-Package: \
+    io.smallrye.openapi.runtime;version='[2.0.0,4.0.0)',\
+    io.smallrye.openapi.runtime.io;version='[2.0.0,4.0.0)',\
+    *
 
 Private-Package:\
   io.openliberty.rest.handler.config.openapi20.*

--- a/dev/io.openliberty.rest.handler.validator.openapi.2.0/bnd.bnd
+++ b/dev/io.openliberty.rest.handler.validator.openapi.2.0/bnd.bnd
@@ -22,6 +22,11 @@ WS-TraceGroup: rest.validation
 Private-Package:\
   io.openliberty.rest.handler.validator.openapi20.*
 
+Import-Package: \
+  io.smallrye.openapi.runtime;version='[2.0.0,4.0.0)',\
+  io.smallrye.openapi.runtime.io;version='[2.0.0,4.0.0)',\
+  *
+
 DynamicImport-Package:\
   javax.jms
 


### PR DESCRIPTION
* Update the config validation autofeatures and bundles to work with mpOpenAPI-3.1.
* Update the config validation FAT tests to run against EE10

Fixes #22320 