### PR TITLE
updates to entity annotations for records

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/Column.java
+++ b/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/Column.java
@@ -20,7 +20,7 @@ import java.lang.annotation.Target;
  * JNoSQL repository-related annotations work for relational database access.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.FIELD)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
 public @interface Column {
     String value() default "";
 }

--- a/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/Id.java
+++ b/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/Id.java
@@ -20,7 +20,7 @@ import java.lang.annotation.Target;
  * JNoSQL repository-related annotations work for relational database access.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.FIELD)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
 public @interface Id {
 
     String value() default "_id";


### PR DESCRIPTION
Update the annotations that we copied over from Jakarta NoSQL to include updates that went in there to allow for entity Id/Column annotations to be applied to Java record constructor parameters.