### PR TITLE
Changes needed to allow restfulWS30 tests to repeat for EE10

### DIFF
--- a/dev/io.openliberty.jakarta.restfulWS.3.0.api_fat/bnd.bnd
+++ b/dev/io.openliberty.jakarta.restfulWS.3.0.api_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -17,6 +17,12 @@ src: \
 	
 fat.project: true
 
+tested.features:\
+  restfulwsclient-3.1,\
+  restfulws-3.1,\
+  jsonp-2.1,\
+  xmlbinding-4.0,\
+  cdi-4.0
 
 -buildpath: \
 	io.openliberty.jakarta.servlet.5.0;version=latest,\

--- a/dev/io.openliberty.jakarta.restfulWS.3.0.api_fat/fat/src/io/openliberty/jakarta/restfulWS30api/fat/CanLoadRESTfulWS30APIsTest.java
+++ b/dev/io.openliberty.jakarta.restfulWS.3.0.api_fat/fat/src/io/openliberty/jakarta/restfulWS30api/fat/CanLoadRESTfulWS30APIsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,10 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.jakarta.restfulWS30api.fat;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -24,7 +28,6 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -32,10 +35,18 @@ import io.openliberty.jakarta.restfulWS30api.fat.app.canload.ApiTestServlet;
 
 @RunWith(FATRunner.class)
 public class CanLoadRESTfulWS30APIsTest extends FATServletClient {
+    static String[] ee9Array = {"restfulWSClient-3.0","xmlBinding-3.0"};
+    static Set<String> ee9Set = new HashSet<String>(Arrays.asList(ee9Array));
+    static String[] ee10Array = {"restfulWS-3.1","xmlBinding-4.0"};
+    static Set<String> ee10Set = new HashSet<String>(Arrays.asList(ee10Array));
+    
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(new FeatureReplacementAction("restfulWS-3.0", "restfulWSClient-3.0").withID("ClientFeature"));
+                    .andWith(new FeatureReplacementAction("restfulWS-3.0", "restfulWSClient-3.0").withID("ClientFeature"))
+                    .andWith(new FeatureReplacementAction(ee9Set, ee10Set).withID("EE10"))
+                    .andWith(new FeatureReplacementAction("restfulWS-3.1", "restfulWSClient-3.1").withID("EE10-ClientFeature"));
 
+                    
     public static final String APP_NAME = "jaxrs30api";
     public static final String SERVER_NAME = "jaxrs30api";
 

--- a/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/bnd.bnd
+++ b/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -21,6 +21,14 @@ src: \
     test-applications/applicationsingleton/src
 
 fat.project: true
+
+# These features get added programmatically
+tested.features: \
+  restfulwsclient-3.1,\
+  restfulws-3.1,\
+  jsonp-2.1,\
+  cdi-4.0,\
+  servlet-6.0
 
 -buildpath: \
     io.openliberty.jakarta.annotation.2.0;version=latest,\

--- a/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/fat/src/io/openliberty/restfulWS30/cdi30/fat/FATSuite.java
+++ b/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/fat/src/io/openliberty/restfulWS30/cdi30/fat/FATSuite.java
@@ -16,6 +16,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.RepeatTests;
 import io.openliberty.restfulWS30.cdi30.fat.test.ApplicationSingletonsTest;
 import io.openliberty.restfulWS30.cdi30.fat.test.Basic12Test;
@@ -36,5 +37,7 @@ import io.openliberty.restfulWS30.cdi30.fat.test.LifeCycleMismatch12Test;
 })
 public class FATSuite {
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification();
+    public static RepeatTests r = RepeatTests.withoutModification()
+        .andWith(new JakartaEE10Action().withID("EE10"));
+
 }

--- a/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/publish/servers/io.openliberty.restfulWS.3.0.cdi.3.0.fat.basic/server.xml
+++ b/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/publish/servers/io.openliberty.restfulWS.3.0.cdi.3.0.fat.basic/server.xml
@@ -6,5 +6,11 @@
 
     <include location="../fatTestPorts.xml"/>
 
-	<javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+    <javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+
+<!-- Added to allow EE10 to work as-is.  In EE10 the CDI "bean-discovery-mode" was switched from
+     "all" to "annotated" which requires all CDI managed classes to contain a Bean Defining Annotation.
+     Some tests have been changed to account for this while others have had this property
+     added so both scenarios are tested. -->
+    <cdi emptyBeansXmlCDI3Compatibility="true"/>
 </server>

--- a/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/publish/servers/io.openliberty.restfulWS.3.0.cdi.3.0.fat.lifecyclemismatch/server.xml
+++ b/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/publish/servers/io.openliberty.restfulWS.3.0.cdi.3.0.fat.lifecyclemismatch/server.xml
@@ -8,4 +8,11 @@
   	<include location="../fatTestPorts.xml"/>
   	<!-- <javaPermission className="java.util.PropertyPermission" name="resteasy.original.webapplicationexception.behavior" actions="read"/> -->
   	<!-- <javaPermission className="java.lang.RuntimePermission" name="getenv.resteasy.original.webapplicationexception.behavior"/> -->
+
+<!-- Added to allow EE10 to work as-is.  In EE10 the CDI "bean-discovery-mode" was switched from
+     "all" to "annotated" which requires all CDI managed classes to contain a Bean Defining Annotation.
+     Some tests have been changed to account for this while others have had this property
+     added so both scenarios are tested. -->
+    <cdi emptyBeansXmlCDI3Compatibility="true"/>
+
 </server>

--- a/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/test-applications/basic/src/io/openliberty/restfulWS30/cdi30/fat/basic/Student.java
+++ b/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/test-applications/basic/src/io/openliberty/restfulWS30/cdi30/fat/basic/Student.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/test-applications/complex/src/io/openliberty/restfulWS30/cdi30/fat/complex/ContextRequestFilter.java
+++ b/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/test-applications/complex/src/io/openliberty/restfulWS30/cdi30/fat/complex/ContextRequestFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@ package io.openliberty.restfulWS30.cdi30.fat.complex;
 
 import java.io.IOException;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
@@ -19,6 +20,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.UriInfo;
 import jakarta.ws.rs.ext.Providers;
 
+@Dependent
 public class ContextRequestFilter implements ContainerRequestFilter {
     @Context
     private UriInfo uriInfo;

--- a/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/test-applications/complex/src/io/openliberty/restfulWS30/cdi30/fat/complex/SimpleBean.java
+++ b/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/test-applications/complex/src/io/openliberty/restfulWS30/cdi30/fat/complex/SimpleBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,9 @@ package io.openliberty.restfulWS30.cdi30.fat.complex;
 
 import javax.annotation.PreDestroy;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class SimpleBean {
 
     String _response;

--- a/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/test-applications/complex/src/io/openliberty/restfulWS30/cdi30/fat/complex/Student.java
+++ b/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/test-applications/complex/src/io/openliberty/restfulWS30/cdi30/fat/complex/Student.java
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package io.openliberty.restfulWS30.cdi30.fat.complex;
 
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
 public class Student implements Person {
 
     @Override

--- a/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/test-applications/complex/src/io/openliberty/restfulWS30/cdi30/fat/complex/Teacher.java
+++ b/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/test-applications/complex/src/io/openliberty/restfulWS30/cdi30/fat/complex/Teacher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,9 +10,11 @@
  *******************************************************************************/
 package io.openliberty.restfulWS30.cdi30.fat.complex;
 
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
 
 @Alternative
+@ApplicationScoped
 public class Teacher implements Person {
 
     @Override

--- a/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/test-applications/lifecyclemethod/src/io/openliberty/restfulWS30/cdi30/fat/lifecyclemethod/LifeCycleStudent.java
+++ b/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/test-applications/lifecyclemethod/src/io/openliberty/restfulWS30/cdi30/fat/lifecyclemethod/LifeCycleStudent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,10 @@
  *******************************************************************************/
 package io.openliberty.restfulWS30.cdi30.fat.lifecyclemethod;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+
+@ApplicationScoped
 public class LifeCycleStudent implements LifeCyclePerson {
 
     @Override

--- a/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/test-applications/lifecyclemethod/src/io/openliberty/restfulWS30/cdi30/fat/lifecyclemethod/LifeCycleTeacher.java
+++ b/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/test-applications/lifecyclemethod/src/io/openliberty/restfulWS30/cdi30/fat/lifecyclemethod/LifeCycleTeacher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,9 +10,11 @@
  *******************************************************************************/
 package io.openliberty.restfulWS30.cdi30.fat.lifecyclemethod;
 
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
 
 @Alternative
+@ApplicationScoped
 public class LifeCycleTeacher implements LifeCyclePerson {
 
     @Override

--- a/dev/io.openliberty.restfulWS.3.0.client_fat/bnd.bnd
+++ b/dev/io.openliberty.restfulWS.3.0.client_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -19,6 +19,13 @@ src: \
 	
 fat.project: true
 
+# These features get added programmatically
+tested.features: \
+  restfulwsclient-3.1,\
+  restfulws-3.1,\
+  jsonp-2.1,\
+  cdi-4.0,\
+  servlet-6.0
 
 -buildpath: \
   com.ibm.websphere.org.eclipse.microprofile.rest.client.1.3;version=latest,\

--- a/dev/io.openliberty.restfulWS.3.0.client_fat/fat/src/io/openliberty/restfulWS30/client/fat/FATSuite.java
+++ b/dev/io.openliberty.restfulWS.3.0.client_fat/fat/src/io/openliberty/restfulWS30/client/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.RepeatTests;
 import io.openliberty.restfulWS30.client.fat.test.PathParamTest;
 
@@ -28,5 +30,6 @@ import io.openliberty.restfulWS30.client.fat.test.PathParamTest;
 })
 public class FATSuite { 
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification();
+    public static RepeatTests r = RepeatTests.withoutModification()
+                    .andWith(new JakartaEE10Action().withID("EE10"));
 }

--- a/dev/io.openliberty.restfulWS.3.0_fat/bnd.bnd
+++ b/dev/io.openliberty.restfulWS.3.0_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -17,6 +17,16 @@ src: \
 	
 fat.project: true
 
+# These features get added programmatically
+tested.features: \
+  restfulwsclient-3.1,\
+  restfulws-3.1,\
+  jsonp-2.1,\
+  cdi-4.0,\
+  connectors-2.1,\
+  jsonb-3.0,\
+  expressionlanguage-5.0,\
+  xmlbinding-4.0
 
 -buildpath: \
     io.openliberty.jakarta.enterpriseBeans.4.0;version=latest,\

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/FATSuite.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
@@ -35,5 +36,7 @@ import componenttest.rules.repeater.RepeatTests;
 })
 public class FATSuite {
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification();
+    public static RepeatTests r = RepeatTests.withoutModification()
+        .andWith(new JakartaEE10Action().withID("EE10"));
+
 }


### PR DESCRIPTION
The purpose of this PR is to repeat the restfulws30 tests on EE10 (restfulws-3.1).  

Several of the changes in this PR were required due to a CDI behavior change for EE10 where the `bean-discovery-mode` was changed from `all` to `annotated` requiring CDI managed beans to contain a BDA (Bean Defining Annotation).
A work-around for this is to add the following property to the server.xml:
`<cdi emptyBeansXmlCDI3Compatibility="true"/>`
I used this work-around in some tests so that both alternatives are represented.