### PR TITLE
Skip testNegativeoTimeOut

### DIFF
--- a/dev/io.openliberty.wsoc.2.1.internal_fat/fat/src/io/openliberty/wsoc/tests/Basic21Test.java
+++ b/dev/io.openliberty.wsoc.2.1.internal_fat/fat/src/io/openliberty/wsoc/tests/Basic21Test.java
@@ -180,13 +180,17 @@ public class Basic21Test {
      * }
      */
 
-    @Mode(TestMode.LITE)
-    @Test
-    public void testNegativeoTimeOut() throws Exception {
-        timeout.testNegativeoTimeOut();
-        String result  = LS.waitForStringInTraceUsingMark("Session timeout -12 is less than 1. No timeout enabled");
-        assertNotNull("Timeout message not found!", result);
-    }
+     /*
+      * ALSO SKIPPED DUE TO Defect 291298
+      * @Mode(TestMode.LITE)
+      * @Test
+      * public void testNegativeoTimeOut() throws Exception {
+      *  timeout.testNegativeoTimeOut();
+      *  String result  = LS.waitForStringInTraceUsingMark("Session timeout -12 is less than 1. No timeout enabled");
+      *  assertNotNull("Timeout message not found!", result);
+      * }
+      */
+
 
     /*
      * testSSC means liberty wsoc impl is the client and server


### PR DESCRIPTION
Test verifies that a negatuve timeout does not set any timeout, but this connection to the server times out in jetty. 

This behavior is also tested via testSSCNegativeoTimeOut, so it should be okay to skip it. 

