### PR TITLE
Remove unnecessary repeater rules

### DIFF
--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/LogsVerificationTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/LogsVerificationTest.java
@@ -19,7 +19,6 @@ import java.util.Map;
 
 import org.junit.After;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -32,9 +31,6 @@ import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipIfCheckpointNotSupported;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.MicroProfileActions;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 import io.openliberty.checkpoint.spi.CheckpointPhase;
@@ -46,11 +42,8 @@ public class LogsVerificationTest {
     public TestName testName = new TestName();
     public static final String APP_NAME = "app2";
 
-    @Server("checkpointFATServer")
+    @Server("checkpointfat.log.verification.test")
     public static LibertyServer server;
-
-    @ClassRule
-    public static RepeatTests repeatTest = MicroProfileActions.repeat("checkpointFATServer", TestMode.LITE, MicroProfileActions.MP41, MicroProfileActions.MP50);
 
     @BeforeClass
     public static void setUpClass() throws Exception {

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/OSGiConsoleTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/OSGiConsoleTest.java
@@ -15,7 +15,6 @@ import java.util.Map;
 
 import org.junit.After;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -28,9 +27,6 @@ import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipIfCheckpointNotSupported;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.MicroProfileActions;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 import io.openliberty.checkpoint.spi.CheckpointPhase;
@@ -41,11 +37,8 @@ public class OSGiConsoleTest {
 
     public static final String APP_NAME = "app2";
 
-    @Server("checkpointFATServer")
+    @Server("checkpointfat.osgi.console.test")
     public static LibertyServer server;
-
-    @ClassRule
-    public static RepeatTests repeatTest = MicroProfileActions.repeat("checkpointFATServer", TestMode.LITE, MicroProfileActions.MP41, MicroProfileActions.MP50);
 
     @Rule
     public TestName name = new TestName();

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointfat.log.verification.test/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointfat.log.verification.test/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
+io.openliberty.checkpoint.allowed.features=timedexit-1.0,componenttest-1.0,componenttest-2.0
+io.openliberty.checkpoint.dump.threads=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointfat.log.verification.test/jvm.options
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointfat.log.verification.test/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointfat.log.verification.test/server.xml
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointfat.log.verification.test/server.xml
@@ -1,0 +1,22 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+    <applicationManager startTimeout="90s"/>
+    <featureManager>
+        <feature>servlet-4.0</feature>
+        <feature>componenttest-1.0</feature>
+        <feature>checkpoint-1.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    
+    <variable name="VARIABLE_SOURCE_DIRS" defaultValue="defaultSrcDir" />
+</server>

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointfat.osgi.console.test/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointfat.osgi.console.test/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
+io.openliberty.checkpoint.allowed.features=timedexit-1.0,componenttest-1.0,componenttest-2.0
+io.openliberty.checkpoint.dump.threads=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointfat.osgi.console.test/jvm.options
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointfat.osgi.console.test/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointfat.osgi.console.test/server.xml
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointfat.osgi.console.test/server.xml
@@ -1,0 +1,22 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+    <applicationManager startTimeout="90s"/>
+    <featureManager>
+        <feature>servlet-4.0</feature>
+        <feature>componenttest-1.0</feature>
+        <feature>checkpoint-1.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    
+    <variable name="VARIABLE_SOURCE_DIRS" defaultValue="defaultSrcDir" />
+</server>


### PR DESCRIPTION
Remove EE repeater where the use of the EE app is incidental to what the FAT is testing and where the same app is already repeated in other FAT tests


