### PR TITLE
Add Decryption support to ExternalTestService.getProperty()

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/utils/ExternalTestService.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/ExternalTestService.java
@@ -119,8 +119,8 @@ public class ExternalTestService {
                 if (!propertyObject.containsKey("Value")) {
                     throw new Exception("Property " + propertyName + " was found but contained no value. Full JSON is: " + propertyObject);
                 }
-                String base64Value = propertyObject.getString("Value");
-                return new String(Base64.getDecoder().decode(base64Value));
+                ServiceProperty prop = new ServiceProperty("", propertyName, propertyObject.getString("Value"));
+                return prop.getStringValue();
             } catch (Exception e) {
                 if (firstEx == null)
                     firstEx = e;


### PR DESCRIPTION
Needed to allow docker-hub-mirror continue working

