### PR TITLE
Open com.sun.jndi.dns to jdk.naming.dns module

### DIFF
--- a/dev/com.ibm.ws.kernel.boot/publish/platform/java/java9.options
+++ b/dev/com.ibm.ws.kernel.boot/publish/platform/java/java9.options
@@ -7,6 +7,8 @@ java.base/sun.security.action=ALL-UNNAMED
 java.naming/com.sun.jndi.ldap=ALL-UNNAMED
 --add-exports
 java.naming/com.sun.jndi.url.ldap=ALL-UNNAMED
+--add-exports
+jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED
 # for Oracle Kerberos
 --add-exports
 java.security.jgss/sun.security.krb5.internal=ALL-UNNAMED


### PR DESCRIPTION
This is also required for com.ibm.ws.jndi.internal.WASInitialContextFactoryBuilder

Fixes: https://github.com/OpenLiberty/open-liberty/issues/22361
Signed-off-by: Mike Lothian <mike@fireburn.co.uk>
