### PR TITLE
Issue #19456: Configure infinispan to run with and without near-side …

### DIFF
--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/BaseTestCase.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/BaseTestCase.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
@@ -498,5 +499,12 @@ public abstract class BaseTestCase {
         sb.append(response.getContentAsString());
 
         Log.info(CLASS, methodName, "Got page response: " + sb.toString());
+    }
+
+    /**
+     * Assume that we should not skip tests based on the boolean system property <code>skip.tests</code>.
+     */
+    protected static void assumeShouldNotSkipTests() {
+        Assume.assumeTrue(!Boolean.getBoolean("skip.tests"));
     }
 }

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheAuthCacheFailureTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheAuthCacheFailureTest.java
@@ -29,6 +29,7 @@ import com.ibm.ws.webcontainer.security.test.servlets.ServletClient;
 import componenttest.annotation.CheckForLeakedPasswords;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -39,6 +40,7 @@ import componenttest.topology.impl.LibertyServer;
  * Test failover to the local in-memory authentication cache when there are failures with retrieving
  * objects from the JCache.
  */
+@SkipIfSysProp("skip.tests=true")
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class JCacheAuthCacheFailureTest extends BaseTestCase {
@@ -53,6 +55,8 @@ public class JCacheAuthCacheFailureTest extends BaseTestCase {
 
     @BeforeClass
     public static void beforeClass() {
+        assumeShouldNotSkipTests();
+
         /*
          * Transform apps for EE9+.
          */

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheAuthenticationCacheServerRestartTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheAuthenticationCacheServerRestartTest.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -25,6 +26,7 @@ import com.ibm.ws.webcontainer.security.test.servlets.ServletClient;
 import componenttest.annotation.CheckForLeakedPasswords;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -34,6 +36,7 @@ import componenttest.topology.impl.LibertyServer;
  * Contains distributed JCache authentication cache tests for server restart.
  */
 @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
+@SkipIfSysProp("skip.tests=true")
 @SuppressWarnings("restriction")
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
@@ -43,6 +46,11 @@ public class JCacheAuthenticationCacheServerRestartTest extends BaseTestCase {
 
     @Server("io.openliberty.jcache.internal.fat.auth.cache.restart.1")
     public static LibertyServer server1;
+
+    @BeforeClass
+    public static void beforeClass() {
+        assumeShouldNotSkipTests();
+    }
 
     @Before
     public void before() throws Exception {

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheAuthenticationCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheAuthenticationCacheTest.java
@@ -26,6 +26,7 @@ import com.ibm.ws.webcontainer.security.test.servlets.ServletClient;
 
 import componenttest.annotation.CheckForLeakedPasswords;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -36,6 +37,7 @@ import io.openliberty.jcache.internal.fat.plugins.TestPluginHelper;
 /**
  * Contains distributed JCache authentication cache tests for LTPA and basic authentication.
  */
+@SkipIfSysProp("skip.tests=true")
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
 public class JCacheAuthenticationCacheTest extends BaseTestCase {
@@ -52,6 +54,8 @@ public class JCacheAuthenticationCacheTest extends BaseTestCase {
 
     @BeforeClass
     public static void beforeClass() {
+        assumeShouldNotSkipTests();
+
         /*
          * Transform apps for EE9+.
          */

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheCustomPrincipalCastingTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheCustomPrincipalCastingTest.java
@@ -28,6 +28,7 @@ import com.ibm.ws.webcontainer.security.test.servlets.BasicAuthClient;
 
 import componenttest.annotation.CheckForLeakedPasswords;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -44,6 +45,7 @@ import componenttest.topology.impl.LibertyServer;
  * expectation is that when the JCache, the application, and the login module that inserts
  * the credentials all use the same library, that there should be no issues with casting.
  */
+@SkipIfSysProp("skip.tests=true")
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class JCacheCustomPrincipalCastingTest extends BaseTestCase {
@@ -66,6 +68,8 @@ public class JCacheCustomPrincipalCastingTest extends BaseTestCase {
 
     @BeforeClass
     public static void beforeClass() {
+        assumeShouldNotSkipTests();
+
         /*
          * Backup the original / starting configurations for each server.
          */

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheDeleteAuthCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheDeleteAuthCacheTest.java
@@ -28,6 +28,7 @@ import com.ibm.ws.webcontainer.security.test.servlets.ServletClient;
 
 import componenttest.annotation.CheckForLeakedPasswords;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -37,6 +38,7 @@ import componenttest.topology.impl.LibertyServer;
 /**
  * Contains distributed JCache authentication cache tests for the DeleteAuthCache Mbean.
  */
+@SkipIfSysProp("skip.tests=true")
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
 public class JCacheDeleteAuthCacheTest extends BaseTestCase {
@@ -53,6 +55,8 @@ public class JCacheDeleteAuthCacheTest extends BaseTestCase {
 
     @BeforeClass
     public static void beforeClass() {
+        assumeShouldNotSkipTests();
+
         /*
          * Transform apps for EE9+.
          */

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheDynamicUpdateTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheDynamicUpdateTest.java
@@ -31,6 +31,7 @@ import componenttest.annotation.CheckForLeakedPasswords;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -40,6 +41,7 @@ import componenttest.topology.impl.LibertyServer;
  * Contains distributed JCache test dynamic server.xml changes
  */
 @SuppressWarnings("restriction")
+@SkipIfSysProp("skip.tests=true")
 @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
@@ -54,6 +56,8 @@ public class JCacheDynamicUpdateTest extends BaseTestCase {
 
     @BeforeClass
     public static void setup() throws Exception {
+        assumeShouldNotSkipTests();
+
         String groupName = UUID.randomUUID().toString();
         /*
          * Start server 1.
@@ -107,7 +111,7 @@ public class JCacheDynamicUpdateTest extends BaseTestCase {
     public void addAndRemoveCaches() throws Exception {
         // Create a working cache configuration
         updateLibertyServer("CacheManager", "CachingProvider", "org.infinispan.jcache.remote.JCachingProvider", "InfinispanLib", "CustomLoginLib",
-                            "file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props");
+                            "file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}");
         ServerConfiguration current = server1.getServerConfiguration();
 
         // Add second and third cache
@@ -274,7 +278,7 @@ public class JCacheDynamicUpdateTest extends BaseTestCase {
          * ***********************************************************************
          */
         updateLibertyServer("CacheManager", "CachingProvider", "org.infinispan.jcache.remote.JCachingProvider", "InfinispanLib", "CustomLoginLib",
-                            "file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props");
+                            "file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}");
 
         /*
          * All issues have been fixed, so wait for the auth cache to start.

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheJwtAuthenticationCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheJwtAuthenticationCacheTest.java
@@ -26,6 +26,7 @@ import com.ibm.ws.webcontainer.security.test.servlets.SSLBasicAuthClient;
 
 import componenttest.annotation.CheckForLeakedPasswords;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -37,6 +38,7 @@ import io.openliberty.jcache.internal.fat.plugins.TestPluginHelper;
  * Contains distributed JCache authentication cache tests for JWT SSO.
  */
 // TODO JtiNonceCache (both of them) for Oidc and mpJwt...
+@SkipIfSysProp("skip.tests=true")
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class JCacheJwtAuthenticationCacheTest extends BaseTestCase {
@@ -53,6 +55,8 @@ public class JCacheJwtAuthenticationCacheTest extends BaseTestCase {
 
     @BeforeClass
     public static void beforeClass() {
+        assumeShouldNotSkipTests();
+
         /*
          * Transform apps for EE9+.
          */

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheJwtLoggedOutCookieCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheJwtLoggedOutCookieCacheTest.java
@@ -28,6 +28,7 @@ import com.ibm.ws.webcontainer.security.test.servlets.SSLFormLoginClient;
 
 import componenttest.annotation.CheckForLeakedPasswords;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -38,6 +39,7 @@ import componenttest.topology.impl.LibertyServer;
  * Contains distributed JCache logged out cookie cache tests for JWT SSO.
  */
 // TODO TAIJwtUtils, LoggedOutJwtSsoCookieCache
+@SkipIfSysProp("skip.tests=true")
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class JCacheJwtLoggedOutCookieCacheTest extends BaseTestCase {
@@ -53,6 +55,8 @@ public class JCacheJwtLoggedOutCookieCacheTest extends BaseTestCase {
 
     @BeforeClass
     public static void beforeClass() {
+        assumeShouldNotSkipTests();
+
         /*
          * Transform apps for EE9+.
          */

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheLtpaLoggedOutCookieCacheServerRestartTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheLtpaLoggedOutCookieCacheServerRestartTest.java
@@ -26,6 +26,7 @@ import com.ibm.ws.webcontainer.security.test.servlets.SSLFormLoginClient;
 import componenttest.annotation.CheckForLeakedPasswords;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -35,6 +36,7 @@ import componenttest.topology.impl.LibertyServer;
  * Contains distributed JCache logged out server restart cookie cache test for LTPA.
  * This won't work in hazelcast because hazelcast runs the cache on the Liberty server.
  */
+@SkipIfSysProp("skip.tests=true")
 @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @SuppressWarnings("restriction")
 @RunWith(FATRunner.class)
@@ -47,6 +49,8 @@ public class JCacheLtpaLoggedOutCookieCacheServerRestartTest extends BaseTestCas
 
     @Before
     public void before() throws Exception {
+        assumeShouldNotSkipTests();
+
         UUID groupName = UUID.randomUUID();
 
         /*

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheLtpaLoggedOutCookieCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheLtpaLoggedOutCookieCacheTest.java
@@ -27,6 +27,7 @@ import com.ibm.ws.webcontainer.security.test.servlets.SSLFormLoginClient;
 
 import componenttest.annotation.CheckForLeakedPasswords;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -36,6 +37,7 @@ import componenttest.topology.impl.LibertyServer;
 /**
  * Contains distributed JCache logged out cookie cache tests for LTPA.
  */
+@SkipIfSysProp("skip.tests=true")
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class JCacheLtpaLoggedOutCookieCacheTest extends BaseTestCase {
@@ -50,6 +52,8 @@ public class JCacheLtpaLoggedOutCookieCacheTest extends BaseTestCase {
 
     @BeforeClass
     public static void beforeClass() {
+        assumeShouldNotSkipTests();
+
         /*
          * Transform apps for EE9+.
          */

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheOauth20AuthenticationCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheOauth20AuthenticationCacheTest.java
@@ -40,6 +40,7 @@ import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.TestHelpers;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -50,6 +51,7 @@ import io.openliberty.jcache.internal.fat.docker.KeycloakContainer;
 /**
  * Test OAuth2 with distributed authentication cache.
  */
+@SkipIfSysProp("skip.tests=true")
 @SuppressWarnings("restriction")
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
@@ -74,6 +76,8 @@ public class JCacheOauth20AuthenticationCacheTest extends BaseTestCase {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
+        assumeShouldNotSkipTests();
+
         /*
          * Start the Keycloak IDP.
          */

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheOidcClientAuthenticationCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheOidcClientAuthenticationCacheTest.java
@@ -41,6 +41,7 @@ import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.TestHelpers;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -57,6 +58,7 @@ import io.openliberty.jcache.internal.fat.docker.KeycloakContainer;
  * - com.ibm.ws.security.jwt.internal.JwtTokenConsumerImpl (oidcLogin / org.jose4j.jwx.Headers are not serializable)
  * - com.ibm.ws.security.openidconnect.client.jose4j.OidcTokenImpl (openidConnectClient / org.jose4j.jwt.JwtClaims are not serializable)
  */
+@SkipIfSysProp("skip.tests=true")
 @SuppressWarnings("restriction")
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
@@ -81,6 +83,8 @@ public class JCacheOidcClientAuthenticationCacheTest extends BaseTestCase {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
+        assumeShouldNotSkipTests();
+
         /*
          * Start the Keycloak IDP.
          */

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheOidcLoginAuthenticationCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheOidcLoginAuthenticationCacheTest.java
@@ -40,6 +40,7 @@ import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.TestHelpers;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -56,6 +57,7 @@ import io.openliberty.jcache.internal.fat.docker.KeycloakContainer;
  * - com.ibm.ws.security.jwt.internal.JwtTokenConsumerImpl (oidcLogin / org.jose4j.jwx.Headers are not serializable)
  * - com.ibm.ws.security.openidconnect.client.jose4j.OidcTokenImpl (openidConnectClient / org.jose4j.jwt.JwtClaims are not serializable)
  */
+@SkipIfSysProp("skip.tests=true")
 @SuppressWarnings("restriction")
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
@@ -80,6 +82,8 @@ public class JCacheOidcLoginAuthenticationCacheTest extends BaseTestCase {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
+        assumeShouldNotSkipTests();
+
         /*
          * Start the Keycloak IDP.
          */

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheProviderInAppTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheProviderInAppTest.java
@@ -20,6 +20,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -31,6 +32,7 @@ import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.CheckForLeakedPasswords;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -42,14 +44,20 @@ import componenttest.topology.impl.LibertyServer;
  * This doesn't necessarily mean the JCache provider is using JCache, just that the provider
  * can load and is not regressed by our JCache feature.
  */
+@SkipIfSysProp("skip.tests=true")
+@SkipForRepeat(JakartaEE9Action.ID) // No value gained
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-@SkipForRepeat(JakartaEE9Action.ID) // No value gained
 public class JCacheProviderInAppTest extends BaseTestCase {
     private final Class<?> CLASS = JCacheProviderInAppTest.class;
 
     @Server("io.openliberty.jcache.internal.fat.provider.in.app.1")
     public static LibertyServer server1;
+
+    @BeforeClass
+    public static void beforeClass() {
+        assumeShouldNotSkipTests();
+    }
 
     @Before
     public void before() throws Exception {

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheSamlAuthenticationCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheSamlAuthenticationCacheTest.java
@@ -47,6 +47,7 @@ import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -57,6 +58,7 @@ import io.openliberty.jcache.internal.fat.docker.KeycloakContainer;
 /**
  * Test SAML with distributed authentication cache.
  */
+@SkipIfSysProp("skip.tests=true")
 @SuppressWarnings("restriction")
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
@@ -80,6 +82,8 @@ public class JCacheSamlAuthenticationCacheTest extends BaseTestCase {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
+        assumeShouldNotSkipTests();
+
         /*
          * Start the Keycloak IDP.
          */

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheSpnegoAuthenticationCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheSpnegoAuthenticationCacheTest.java
@@ -38,6 +38,7 @@ import com.ibm.ws.webcontainer.security.test.servlets.BasicAuthClient;
 
 import componenttest.annotation.CheckForLeakedPasswords;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -48,6 +49,7 @@ import io.openliberty.jcache.internal.fat.testresource.KdcResource;
 /**
  * Test the distributed authentication cache with GSS credentials generated from SPNEGO authentication.
  */
+@SkipIfSysProp("skip.tests=true")
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
 public class JCacheSpnegoAuthenticationCacheTest extends BaseTestCase {
@@ -105,6 +107,8 @@ public class JCacheSpnegoAuthenticationCacheTest extends BaseTestCase {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
+        assumeShouldNotSkipTests();
+
         /*
          * Transform apps for EE9+.
          */

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/fat/src/io/openliberty/jcache/internal/fat/FATSuite.java
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/fat/src/io/openliberty/jcache/internal/fat/FATSuite.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package io.openliberty.jcache.internal.fat;
 
+import java.util.Random;
+
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -17,6 +19,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.websphere.simplicity.Machine;
+import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.containers.TestContainerSuite;
 import componenttest.rules.repeater.EmptyAction;
@@ -61,9 +64,22 @@ public class FATSuite extends TestContainerSuite {
     @ClassRule
     public static InfinispanContainer infinispan = new InfinispanContainer();
 
+    private static String hotrodFile;
+    private static final String HOTROD_FILE = "infinispan_hotrod.props";
+    private static final String HOTROD_NEARCACHE_FILE = "infinispan_hotrod_near_cache.props";
+
+    static {
+        /*
+         * Choose one of the Hotrod properties files. This will ensure we test with and without nearside cache.
+         */
+        boolean forceNearCache = Boolean.getBoolean("fat.test.force.nearcache");
+        hotrodFile = (forceNearCache || new Random().nextBoolean()) ? HOTROD_NEARCACHE_FILE : HOTROD_FILE;
+        Log.info(FATSuite.class, "<clinit>", "Infinispan will use the following Hotrod props file: " + hotrodFile);
+    }
+
     @BeforeClass
     public static void beforeSuite() throws Exception {
-        TestPluginHelper.setTestPlugin(new InfinispanTestPlugin());
+        TestPluginHelper.setTestPlugin(new InfinispanTestPlugin(hotrodFile));
 
         /*
          * Delete the Infinispan jars that might have been left around by previous test buckets.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/fat/src/io/openliberty/jcache/internal/fat/plugins/InfinispanTestPlugin.java
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/fat/src/io/openliberty/jcache/internal/fat/plugins/InfinispanTestPlugin.java
@@ -22,6 +22,12 @@ import io.openliberty.jcache.internal.fat.FATSuite;
  */
 public class InfinispanTestPlugin implements TestPlugin {
 
+    private final String hotrodFile;
+
+    public InfinispanTestPlugin(String hotrodFile) {
+        this.hotrodFile = hotrodFile;
+    }
+
     @Override
     public void setupServer1(LibertyServer server, String clusterName, Integer authCacheMaxSize, Integer authCacheTtlSecs) throws Exception {
         /*
@@ -42,6 +48,7 @@ public class InfinispanTestPlugin implements TestPlugin {
                                            "-Dauthcache.max.size=" + authCacheMaxSize,
                                            "-Dauthcache.entry.ttl=" + (1000 * authCacheTtlSecs),
                                            "-Dinfinispan.client.hotrod.uri=" + FATSuite.infinispan.getHotRodUri(),
+                                           "-Dinfinispan.hotrod.file=" + hotrodFile,
                                            "-Dcom.ibm.ws.beta.edition=true")); // TODO Remove when GA'd
     }
 
@@ -52,6 +59,7 @@ public class InfinispanTestPlugin implements TestPlugin {
          */
         server.setJvmOptions(Arrays.asList("-Dinfinispan.cluster.name=" + clusterName,
                                            "-Dinfinispan.client.hotrod.uri=" + FATSuite.infinispan.getHotRodUri(),
+                                           "-Dinfinispan.hotrod.file=" + hotrodFile,
                                            "-Dcom.ibm.ws.beta.edition=true")); // TODO Remove when GA'd
     }
 

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.auth.cache.1/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.auth.cache.1/server.xml
@@ -38,7 +38,7 @@
 	 -->
 	<cache id="AuthCache" name="AuthCache">
 		<cacheManager
-			uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+			uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 
             <!-- 
                  The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.auth.cache.2/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.auth.cache.2/server.xml
@@ -42,7 +42,7 @@
 
 	<cacheManager id="CacheManager"
 		cachingProviderRef="CachingProvider"
-		uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+		uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 
 		<!-- 
 			The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.auth.cache.casting.1/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.auth.cache.casting.1/server.xml
@@ -36,7 +36,7 @@
 	 -->
 	<cache id="AuthCache" name="AuthCache">
 		<cacheManager
-			uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+			uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 
             <!-- 
                  The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.auth.cache.casting.2/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.auth.cache.casting.2/server.xml
@@ -40,7 +40,7 @@
 
 	<cacheManager id="CacheManager"
 		cachingProviderRef="CachingProvider"
-		uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+		uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 		
         <!-- 
              The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.auth.cache.failure.1/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.auth.cache.failure.1/server.xml
@@ -38,7 +38,7 @@
 	 -->
 	<cache id="AuthCache" name="AuthCache">
 		<cacheManager
-			uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+			uri="file:///${shared.resource.dir}/infinispan/">
 
             <!-- 
                  The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.auth.cache.failure.2/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.auth.cache.failure.2/server.xml
@@ -42,7 +42,7 @@
 
 	<cacheManager id="CacheManager"
 		cachingProviderRef="CachingProvider"
-		uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+		uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 		
         <!-- 
              The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.auth.cache.restart.1/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.auth.cache.restart.1/server.xml
@@ -39,7 +39,7 @@
 	 -->
 	<cache id="AuthCache" name="AuthCache">
 		<cacheManager
-			uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+			uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 
             <!-- 
                  The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.delete.auth.cache.1/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.delete.auth.cache.1/server.xml
@@ -41,7 +41,7 @@
 	 -->
 	<cache id="AuthCache" name="AuthCache">
 		<cacheManager
-			uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+			uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 
             <!-- 
                  The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.delete.auth.cache.2/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.delete.auth.cache.2/server.xml
@@ -45,7 +45,7 @@
 
 	<cacheManager id="CacheManager"
 		cachingProviderRef="CachingProvider"
-		uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+		uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 
         <!-- 
              The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.jwt.auth.cache.1/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.jwt.auth.cache.1/server.xml
@@ -41,7 +41,7 @@
 	 -->
 	<cache id="AuthCache" name="AuthCache">
 		<cacheManager
-			uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+			uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 
             <!-- 
                  The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.jwt.auth.cache.2/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.jwt.auth.cache.2/server.xml
@@ -45,7 +45,7 @@
 
 	<cacheManager id="CacheManager"
 		cachingProviderRef="CachingProvider"
-		uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+		uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 
         <!-- 
              The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.jwt.cookie.cache.1/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.jwt.cookie.cache.1/server.xml
@@ -39,7 +39,7 @@
         Configure the CachingProvider and CacheManager.
      -->
 	<cacheManager id="CacheManager"
-		uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+		uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 
         <!-- 
              The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.jwt.cookie.cache.2/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.jwt.cookie.cache.2/server.xml
@@ -44,7 +44,7 @@
 
 	<cacheManager id="CacheManager"
 		cachingProviderRef="CachingProvider"
-		uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+		uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 		
         <!-- 
              The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.ltpa.cookie.cache.1/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.ltpa.cookie.cache.1/server.xml
@@ -37,7 +37,7 @@
         Configure the CachingProvider and CacheManager.
      -->
 	<cacheManager id="CacheManager"
-		uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+		uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 
         <!-- 
              The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.ltpa.cookie.cache.2/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.ltpa.cookie.cache.2/server.xml
@@ -42,7 +42,7 @@
 
 	<cacheManager id="CacheManager"
 		cachingProviderRef="CachingProvider"
-		uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+		uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 		
         <!-- 
              The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.ltpa.cookie.cache.restart.1/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.ltpa.cookie.cache.restart.1/server.xml
@@ -38,7 +38,7 @@
         Configure the CachingProvider and CacheManager.
      -->
 	<cacheManager id="CacheManager"
-		uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+		uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 
         <!-- 
              The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.oauth20.auth.cache.1/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.oauth20.auth.cache.1/server.xml
@@ -49,7 +49,7 @@
         Configure the CachingProvider and CacheManager.
      -->
 	<cacheManager id="CacheManager"
-		uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+		uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 
         <!-- 
              The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.oauth20.auth.cache.2/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.oauth20.auth.cache.2/server.xml
@@ -54,7 +54,7 @@
 
 	<cacheManager id="CacheManager"
 		cachingProviderRef="CachingProvider"
-		uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+		uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 		
         <!-- 
              The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.oidcclient.auth.cache.1/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.oidcclient.auth.cache.1/server.xml
@@ -49,7 +49,7 @@
         Configure the CachingProvider and CacheManager.
      -->
 	<cacheManager id="CacheManager"
-		uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+		uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 
         <!-- 
              The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.oidcclient.auth.cache.2/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.oidcclient.auth.cache.2/server.xml
@@ -54,7 +54,7 @@
 
 	<cacheManager id="CacheManager"
 		cachingProviderRef="CachingProvider"
-		uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+		uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 		
         <!-- 
              The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.oidclogin.auth.cache.1/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.oidclogin.auth.cache.1/server.xml
@@ -49,7 +49,7 @@
         Configure the CachingProvider and CacheManager.
      -->
 	<cacheManager id="CacheManager"
-		uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+		uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 
         <!-- 
              The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.oidclogin.auth.cache.2/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.oidclogin.auth.cache.2/server.xml
@@ -54,7 +54,7 @@
 
 	<cacheManager id="CacheManager"
 		cachingProviderRef="CachingProvider"
-		uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+		uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 		
         <!-- 
              The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.provider.in.app.1/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.provider.in.app.1/server.xml
@@ -39,7 +39,7 @@
           -->
 	<cache id="AuthCache" name="AuthCache" cacheManagerRef="CacheManager" />
 	<cacheManager id="CacheManager"
-		uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+		uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 
 		<properties
 			infinispan.client.hotrod.uri="${infinispan.client.hotrod.uri}" />

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.saml.auth.cache.1/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.saml.auth.cache.1/server.xml
@@ -39,7 +39,7 @@
         Configure the CachingProvider and CacheManager.
      -->
 	<cacheManager id="CacheManager"
-		uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+		uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 
         <!-- 
              The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.saml.auth.cache.2/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.saml.auth.cache.2/server.xml
@@ -44,7 +44,7 @@
 
 	<cacheManager id="CacheManager"
 		cachingProviderRef="CachingProvider"
-		uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+		uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 
         <!-- 
              The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.spnego.auth.cache.1/server.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/servers/io.openliberty.jcache.internal.fat.spnego.auth.cache.1/server.xml
@@ -40,7 +40,7 @@
         Configure the CachingProvider and CacheManager.
      -->
 	<cacheManager id="CacheManager"
-		uri="file:///${shared.resource.dir}/infinispan/infinispan_hotrod.props">
+		uri="file:///${shared.resource.dir}/infinispan/${infinispan.hotrod.file}">
 
         <!-- 
              The system property can't be read from the Hotrod properties file, so define it here.

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/shared/resources/infinispan/AuthCache_NearCache.xml
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/shared/resources/infinispan/AuthCache_NearCache.xml
@@ -1,0 +1,38 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+
+<!--
+    For testing we use a local cache to avoid errors / warnings since we run
+    the Infinispan server in a remote Docker container. These issues result
+    in a 6-7x performance degradation in the test (even though they still passed).
+    
+    A customer would probably want to use a distributed, replicated or scattered cache.
+ -->
+<local-cache name="AuthCache" statistics="true">
+	<!-- 
+		Set the maximum cache size that corresponds to authCache->maxSize.
+	-->
+	<memory max-count="25000" when-full="REMOVE" />
+	
+	<!-- 
+		Set expiry policy that corresponds to authCache->timeout.
+		
+		NOTE: Using max-idle with near-cache is unsupported, 
+		      so set lifespan instead.
+	-->
+	<expiration max-idle="-1" lifespan="600000" />
+	
+	<!-- 
+		Set encoding for keys / values.
+	 -->
+	<encoding media-type="application/x-java-serialized-object" />
+</local-cache>
+ 

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/publish/shared/resources/infinispan/infinispan_hotrod_near_cache.props
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/publish/shared/resources/infinispan/infinispan_hotrod_near_cache.props
@@ -29,8 +29,8 @@ infinispan.client.hotrod.sasl_mechanism=DIGEST-MD5
 #
 # Cache specific configuration.
 #
-infinispan.client.hotrod.cache.[AuthCache].configuration_uri=file:///${shared.resource.dir}/infinispan/AuthCache.xml
-infinispan.client.hotrod.cache.[AuthCache].near_cache.mode=DISABLED
+infinispan.client.hotrod.cache.[AuthCache].configuration_uri=file:///${shared.resource.dir}/infinispan/AuthCache_NearCache.xml
+infinispan.client.hotrod.cache.[AuthCache].near_cache.mode=INVALIDATED
 
 infinispan.client.hotrod.cache.[LoggedOutCookieCache].configuration_uri=file:///${shared.resource.dir}/infinispan/LoggedOutCookieCache.xml
-infinispan.client.hotrod.cache.[LoggedOutCookieCache].near_cache.mode=DISABLED
+infinispan.client.hotrod.cache.[LoggedOutCookieCache].near_cache.mode=INVALIDATED


### PR DESCRIPTION
…cache randomly each run. Update FAT tests to not run if skip.test system property is set. This will help with the eXtreme Scale fat in WS-CD-Open which can't run with Java 11 or on zOS at this time.

fixes #19456