### PR TITLE
EJB Persistent timer test - ignore shut down error

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerTestHelper.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerTestHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -93,6 +93,13 @@ public class PersistentTimerTestHelper {
         // persistent.internal.InvokerTask run starts for a persistent timer during server shutdown,
         // but EJB timer service throws exception due to server stopping.
         ignoreList.add("CWWKC1503W.*server is stopping");
+
+        // J2CA0046E: Method reserve caught an exception during creation of the ManagedConnection for resource
+        //            dataSource[DefaultDataSource], throwing ResourceAllocationException. Original exception:
+        //            Pool requests blocked, connection pool is being shut down.
+        //
+        // fast server start and shutdown.
+        ignoreList.add("J2CA0046E:.*shut down");
 
         String[] stringArr = new String[ignoreList.size()];
         return ignoreList.toArray(stringArr);


### PR DESCRIPTION
Some of the tests start up a server and shut it down soon after, which can cause slow components to not fully come up before the server starts shutting down causing error printouts unrelated to the test, adding an ignore for one.