### PR TITLE
Move websocket-2.1 to beta

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VisibilityTest.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VisibilityTest.java
@@ -390,7 +390,6 @@ public class VisibilityTest {
         // If they get marked beta, they should be removed from this list.
         expectedFailures.add("io.openliberty.jakarta.faces-4.0");
         expectedFailures.add("io.openliberty.jakarta.messaging-3.1");
-        expectedFailures.add("io.openliberty.jakarta.websocket-2.1");
         expectedFailures.add("io.openliberty.jakarta.authentication-3.0");
         expectedFailures.add("io.openliberty.jakarta.authorization-2.1");
         expectedFailures.add("io.openliberty.jakarta.security.enterprise-3.0");

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.websocket-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.websocket-2.1.feature
@@ -5,6 +5,6 @@ singleton=true
 -bundles=\
   io.openliberty.jakarta.websocket.2.1; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.websocket:jakarta.websocket-api:2.1.0", \
   io.openliberty.jakarta.websocket.client.2.1; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.websocket:jakarta.websocket-client-api:2.1.0"
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/websocket-2.1/io.openliberty.websocket-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/websocket-2.1/io.openliberty.websocket-2.1.feature
@@ -17,6 +17,6 @@ Subsystem-Name: Jakarta WebSocket 2.1
  io.openliberty.wsoc.2.1.internal
 -jars=io.openliberty.wsoc; location:=dev/api/ibm/
 -files=dev/api/ibm/javadoc/io.openliberty.wsoc_1.0-javadoc.zip
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel


### PR DESCRIPTION
fixes #22253
Dependent on the servlet-6.0 beta: https://github.com/OpenLiberty/open-liberty/pull/22400