### PR TITLE
like keyword and contains for non-collections

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -618,7 +618,7 @@ public class DataTestServlet extends FATServlet {
                              products.findByNameLike("2% TestFindLike"));
 
         // Escape characters are not possible for the repository Like keyword, however,
-        // consider using JPQL escape characters and ESCAPE '\' clause for StartsWith, EndsWith (and possibly Contains)
+        // consider using JPQL escape characters and ESCAPE '\' clause for StartsWith, EndsWith, and Contains
     }
 
     /**
@@ -1211,7 +1211,7 @@ public class DataTestServlet extends FATServlet {
                                              .collect(Collectors.toList()));
 
         assertIterableEquals(List.of(10030005L, 10030007L, 10030009L),
-                             reservations.findByLocationLikeOrderByMeetingID("%-2 B1%")
+                             reservations.findByLocationContainsOrderByMeetingID("-2 B1")
                                              .stream()
                                              .map(r -> r.meetingID)
                                              .collect(Collectors.toList()));
@@ -1375,9 +1375,9 @@ public class DataTestServlet extends FATServlet {
         assertEquals("Some results are missing", Collections.EMPTY_SET, expected);
 
         // Paging where the final page includes less than the maximum page size,
-        Page<Reservation> page1 = reservations.findByHostLike("testRepositoryCustom-host%",
-                                                              Pagination.page(1).size(4),
-                                                              Sort.desc("meetingID"));
+        Page<Reservation> page1 = reservations.findByHostStartsWith("testRepositoryCustom-host",
+                                                                    Pagination.page(1).size(4),
+                                                                    Sort.desc("meetingID"));
         assertIterableEquals(List.of(10030009L, 10030008L, 10030007L, 10030006L),
                              page1
                                              .getContent()
@@ -1398,9 +1398,9 @@ public class DataTestServlet extends FATServlet {
         assertEquals(null, page3.next());
 
         // Paging that comes out even:
-        page2 = reservations.findByHostLike("testRepositoryCustom-host%",
-                                            Pagination.page(2).size(3),
-                                            Sort.desc("meetingID"));
+        page2 = reservations.findByHostStartsWith("testRepositoryCustom-host",
+                                                  Pagination.page(2).size(3),
+                                                  Sort.desc("meetingID"));
         assertIterableEquals(List.of(10030006L, 10030005L, 10030004L),
                              page2
                                              .getContent()
@@ -1529,7 +1529,7 @@ public class DataTestServlet extends FATServlet {
                                                                         "050-2 A101",
                                                                         "050-2 H115"));
         assertIterableEquals(List.of(1012001L, 1012003L),
-                             reservations.findByLocationLikeOrderByMeetingID("% H115")
+                             reservations.findByLocationContainsOrderByMeetingID("H115")
                                              .stream()
                                              .map(r -> r.meetingID)
                                              .collect(Collectors.toList()));

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -474,7 +474,7 @@ public class DataTestServlet extends FATServlet {
         prod6.price = 7.49f;
         products.addOrModify(prod6);
 
-        List<String> uniqueProductNames = products.findByNameLike("TestDistinctAttribute");
+        List<String> uniqueProductNames = products.findByNameLike("TestDistinctAttribute %");
 
         // only 4 of the 6 names are unique
         assertIterableEquals(List.of("TestDistinctAttribute T-Shirt Size Extra Small",
@@ -560,6 +560,65 @@ public class DataTestServlet extends FATServlet {
         assertEquals(prod.name, p.name);
         assertEquals(prod.price, p.price, 0.001f);
         assertEquals(prod.description, p.description);
+    }
+
+    /**
+     * Use the % and _ characters, which are wildcards in JPQL, within query parameters.
+     */
+    @Test
+    public void testFindLike() throws Exception {
+        // Remove data from previous tests:
+        Product[] allProducts = products.findByVersionGreaterThanEqualOrderByPrice(-1);
+        if (allProducts.length > 0)
+            products.discontinueProducts(Arrays.stream(allProducts).map(p -> p.id).collect(Collectors.toSet()));
+
+        Product p1 = new Product();
+        p1.id = "TFL-1";
+        p1.name = "TestFindLike_1";
+        p1.price = 1.00f;
+        products.addOrModify(p1);
+
+        Product p2 = new Product();
+        p2.id = "TFL-2";
+        p2.name = "2% TestFindLike";
+        p2.price = 2.00f;
+        products.addOrModify(p2);
+
+        Product p10 = new Product();
+        p10.id = "TFL-10";
+        p10.name = "TestFindLike 1";
+        p10.price = 10.00f;
+        products.addOrModify(p10);
+
+        Product p100 = new Product();
+        p100.id = "TFL-100";
+        p100.name = "TestFindLike  1";
+        p100.price = 100.00f;
+        products.addOrModify(p100);
+
+        Product p200 = new Product();
+        p200.id = "TFL-200";
+        p200.name = "200 TestFindLike";
+        p200.price = 200.00f;
+        products.addOrModify(p200);
+
+        assertIterableEquals(List.of("2% TestFindLike",
+                                     "200 TestFindLike",
+                                     "TestFindLike  1",
+                                     "TestFindLike 1",
+                                     "TestFindLike_1"),
+                             products.findByNameLike("%TestFindLike%"));
+
+        // _ wildcard matches any single character
+        assertIterableEquals(List.of("TestFindLike 1", "TestFindLike_1"),
+                             products.findByNameLike("TestFindLike_1"));
+
+        // % wildcard matches 0 or more characters
+        assertIterableEquals(List.of("2% TestFindLike", "200 TestFindLike"),
+                             products.findByNameLike("2% TestFindLike"));
+
+        // Escape characters are not possible for the repository Like keyword, however,
+        // consider using JPQL escape characters and ESCAPE '\' clause for StartsWith, EndsWith (and possibly Contains)
     }
 
     /**
@@ -1152,14 +1211,14 @@ public class DataTestServlet extends FATServlet {
                                              .collect(Collectors.toList()));
 
         assertIterableEquals(List.of(10030005L, 10030007L, 10030009L),
-                             reservations.findByLocationLikeOrderByMeetingID("-2 B1")
+                             reservations.findByLocationLikeOrderByMeetingID("%-2 B1%")
                                              .stream()
                                              .map(r -> r.meetingID)
                                              .collect(Collectors.toList()));
 
         assertIterableEquals(List.of(10030001L, 10030002L, 10030004L, 10030006L, 10030008L),
                              reservations.findByMeetingIDOrLocationLikeAndStartAndStopOrHost(10030006,
-                                                                                             "050-2",
+                                                                                             "050-2 %",
                                                                                              OffsetDateTime.of(2022, 5, 25, 9, 0, 0, 0, CDT),
                                                                                              OffsetDateTime.of(2022, 5, 25, 10, 0, 0, 0, CDT),
                                                                                              "testRepositoryCustom-host4@example.org")
@@ -1268,7 +1327,7 @@ public class DataTestServlet extends FATServlet {
                                              .sorted()
                                              .collect(Collectors.toList()));
 
-        Publisher<Reservation> publisher = reservations.findByHostLikeOrderByMeetingID("testRepositoryCustom-host");
+        Publisher<Reservation> publisher = reservations.findByHostLikeOrderByMeetingID("testRepositoryCustom-host%");
         LinkedBlockingQueue<Object> results = new LinkedBlockingQueue<>();
         publisher.subscribe(new Subscriber<Reservation>() {
             final int REQUEST_SIZE = 3;
@@ -1316,7 +1375,7 @@ public class DataTestServlet extends FATServlet {
         assertEquals("Some results are missing", Collections.EMPTY_SET, expected);
 
         // Paging where the final page includes less than the maximum page size,
-        Page<Reservation> page1 = reservations.findByHostLike("testRepositoryCustom-host",
+        Page<Reservation> page1 = reservations.findByHostLike("testRepositoryCustom-host%",
                                                               Pagination.page(1).size(4),
                                                               Sort.desc("meetingID"));
         assertIterableEquals(List.of(10030009L, 10030008L, 10030007L, 10030006L),
@@ -1339,7 +1398,7 @@ public class DataTestServlet extends FATServlet {
         assertEquals(null, page3.next());
 
         // Paging that comes out even:
-        page2 = reservations.findByHostLike("testRepositoryCustom-host",
+        page2 = reservations.findByHostLike("testRepositoryCustom-host%",
                                             Pagination.page(2).size(3),
                                             Sort.desc("meetingID"));
         assertIterableEquals(List.of(10030006L, 10030005L, 10030004L),
@@ -1470,7 +1529,7 @@ public class DataTestServlet extends FATServlet {
                                                                         "050-2 A101",
                                                                         "050-2 H115"));
         assertIterableEquals(List.of(1012001L, 1012003L),
-                             reservations.findByLocationLikeOrderByMeetingID("H115")
+                             reservations.findByLocationLikeOrderByMeetingID("% H115")
                                              .stream()
                                              .map(r -> r.meetingID)
                                              .collect(Collectors.toList()));

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/ProductRepo.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/ProductRepo.java
@@ -34,7 +34,7 @@ public interface ProductRepo {
 
     @Select(value = "name", distinct = true)
     @OrderBy("name")
-    List<String> findByNameLike(String nameContains);
+    List<String> findByNameLike(String namePattern);
 
     Product[] findByVersionGreaterThanEqualOrderByPrice(long minVersion);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Reservations.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Reservations.java
@@ -51,7 +51,7 @@ public interface Reservations extends Repository<Reservation, Long> {
 
     Iterable<Reservation> findByHost(String host);
 
-    Collection<Reservation> findByLocationLikeOrderByMeetingID(String locationSubstring);
+    Collection<Reservation> findByLocationContainsOrderByMeetingID(String locationSubstring);
 
     List<Reservation> findByMeetingIDOrLocationLikeAndStartAndStopOrHost(long meetingID,
                                                                          String location,
@@ -96,9 +96,9 @@ public interface Reservations extends Repository<Reservation, Long> {
     // @Select({ "start", "stop" })
     // Stream<ReservedTimeSlot> findByStopOrStopOrStart(OffsetDateTime stop1, OffsetDateTime stop2, OffsetDateTime stop3);
 
-    Publisher<Reservation> findByHostLikeOrderByMeetingID(String hostSubstring);
+    Publisher<Reservation> findByHostLikeOrderByMeetingID(String hostMatcher);
 
-    Page<Reservation> findByHostLike(String hostSubstring, Pagination pagination, Sort sort);
+    Page<Reservation> findByHostStartsWith(String hostPrefix, Pagination pagination, Sort sort);
 
     LinkedHashSet<Reservation> findByInviteesContainsOrderByMeetingID(String invitee);
 

--- a/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/internal/DataPersistence.java
+++ b/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/internal/DataPersistence.java
@@ -15,9 +15,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 
@@ -234,9 +236,12 @@ public class DataPersistence {
             for (EntityType<?> entityType : model.getEntities()) {
                 entityType.getName();//TODO
                 LinkedHashMap<String, String> attributeNames = new LinkedHashMap<>();
+                Set<String> collectionAttributeNames = new HashSet<String>();
                 for (Attribute<?, ?> attr : entityType.getAttributes()) {
                     String attributeName = attr.getName();
-                    if (PersistentAttributeType.EMBEDDED.equals(attr.getPersistentAttributeType())) {
+                    PersistentAttributeType attributeType = attr.getPersistentAttributeType();
+
+                    if (PersistentAttributeType.EMBEDDED.equals(attributeType)) {
                         // TODO this only covers one level of embedded attributes, which is fine for now because this isn't a real implementation
                         EmbeddableType<?> embeddable = model.embeddable(attr.getJavaType());
                         for (Attribute<?, ?> embAttr : embeddable.getAttributes()) {
@@ -246,6 +251,8 @@ public class DataPersistence {
                         }
                     } else {
                         attributeNames.put(attributeName.toUpperCase(), attributeName);
+                        if (PersistentAttributeType.ELEMENT_COLLECTION.equals(attributeType))
+                            collectionAttributeNames.add(attributeName);
                     }
                 }
 
@@ -263,6 +270,7 @@ public class DataPersistence {
                 EntityInfo entityInfo = new EntityInfo(entityType.getName(), //
                                 entityClass, //
                                 attributeNames, //
+                                collectionAttributeNames, //
                                 keyAttributeNames.get(entityClass), //
                                 punit);
 

--- a/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/internal/EntityInfo.java
+++ b/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/internal/EntityInfo.java
@@ -11,6 +11,7 @@
 package io.openliberty.data.internal;
 
 import java.util.LinkedHashMap;
+import java.util.Set;
 
 import com.ibm.wsspi.persistence.PersistenceServiceUnit;
 
@@ -19,17 +20,21 @@ import com.ibm.wsspi.persistence.PersistenceServiceUnit;
 class EntityInfo {
     // upper case attribute name --> properly cased/qualified JPQL attribute name
     final LinkedHashMap<String, String> attributeNames;
+    final Set<String> collectionAttributeNames;
     final String keyName;
     final String name;
     final PersistenceServiceUnit persister;
     final Class<?> type;
 
     EntityInfo(String entityName, Class<?> entityClass,
-               LinkedHashMap<String, String> attributeNames, String keyAttributeName,
+               LinkedHashMap<String, String> attributeNames,
+               Set<String> collectionAttributeNames,
+               String keyAttributeName,
                PersistenceServiceUnit persister) {
         this.name = entityName;
         this.type = entityClass;
         this.attributeNames = attributeNames;
+        this.collectionAttributeNames = collectionAttributeNames;
         this.keyName = keyAttributeName;
         this.persister = persister;
     }

--- a/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/internal/QueryHandler.java
+++ b/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/internal/QueryHandler.java
@@ -267,7 +267,7 @@ public class QueryHandler<T> implements InvocationHandler {
                 q.append(attributeExpr).append(negated ? " NOT " : " ").append("LIKE CONCAT('%', ?").append(++paramCount).append(")");
                 break;
             case LIKE:
-                q.append(attributeExpr).append(negated ? " NOT " : " ").append("LIKE CONCAT('%', ?").append(++paramCount).append(", '%')");
+                q.append(attributeExpr).append(negated ? " NOT " : " ").append("LIKE ?").append(++paramCount);
                 break;
             case BETWEEN:
                 q.append(attributeExpr).append(negated ? " NOT " : " ").append("BETWEEN ?").append(++paramCount).append(" AND ?").append(++paramCount);

--- a/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/internal/QueryHandler.java
+++ b/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/internal/QueryHandler.java
@@ -181,7 +181,7 @@ public class QueryHandler<T> implements InvocationHandler {
     /**
      * Generates JPQL for a findBy or deleteBy condition such as MyColumn[Not?]Like
      */
-    private int generateRepositoryQueryCondition(Class<?> entityClass, String expression, StringBuilder q, int paramCount) {
+    private int generateRepositoryQueryCondition(EntityInfo entityInfo, String expression, StringBuilder q, int paramCount) {
         int length = expression.length();
 
         Condition condition = Condition.EQUALS;
@@ -251,8 +251,8 @@ public class QueryHandler<T> implements InvocationHandler {
         else
             a.append("o.");
 
-        String name = persistence.getAttributeName(attribute, entityClass, data.provider());
-        a.append(name == null ? attribute : name);
+        String name = persistence.getAttributeName(attribute, entityInfo.type, data.provider());
+        a.append(name = name == null ? attribute : name);
 
         if (upper || lower)
             a.append(")");
@@ -273,7 +273,10 @@ public class QueryHandler<T> implements InvocationHandler {
                 q.append(attributeExpr).append(negated ? " NOT " : " ").append("BETWEEN ?").append(++paramCount).append(" AND ?").append(++paramCount);
                 break;
             case CONTAINS:
-                q.append(" ?").append(++paramCount).append(negated ? " NOT " : " ").append("MEMBER OF ").append(attributeExpr);
+                if (entityInfo.collectionAttributeNames.contains(name))
+                    q.append(" ?").append(++paramCount).append(negated ? " NOT " : " ").append("MEMBER OF ").append(attributeExpr);
+                else
+                    q.append(attributeExpr).append(negated ? " NOT " : " ").append("LIKE CONCAT('%', ?").append(++paramCount).append(", '%')");
                 break;
             default:
                 q.append(attributeExpr).append(negated ? " NOT " : "").append(condition.operator).append('?').append(++paramCount);
@@ -295,7 +298,7 @@ public class QueryHandler<T> implements InvocationHandler {
             if (iNext < 0)
                 iNext = Math.max(and, or);
             String condition = iNext < 0 ? conditions.substring(i) : conditions.substring(i, iNext);
-            paramCount = generateRepositoryQueryCondition(entityInfo.type, condition, q, paramCount);
+            paramCount = generateRepositoryQueryCondition(entityInfo, condition, q, paramCount);
             if (iNext > 0) {
                 q.append(iNext == and ? " AND " : " OR ");
                 iNext += (iNext == and ? 3 : 2);


### PR DESCRIPTION
Behavior of the JNoSQL Like keyword isn't well documented, and this pull is speculating how it might apply to JPQL when wildcards are used.  Also, I've updated the examples with a Contains keyword, which was previously only for collection types to also apply to string types, giving it the previous usage that we had in place for Like.  This will make both more intuitive given their names.