### PR TITLE
Add initial test for checkpoint and WebSocket

### DIFF
--- a/dev/io.openliberty.checkpoint_fat/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat/bnd.bnd
@@ -24,7 +24,8 @@ src: \
 	test-applications/timeoutTest/src,\
 	test-applications/restClient/src,\
 	test-applications/jndiTest/src,\
-	test-applications/appsecurity/src
+	test-applications/appsecurity/src,\
+	test-applications/webSocketTest/src
 
 fat.project: true
 
@@ -96,6 +97,7 @@ tested.features:\
 	com.ibm.websphere.javaee.security.1.0;version=latest,\
 	com.ibm.websphere.security;version=latest,\
 	commons-httpclient:commons-httpclient;version=3.1,\
-  	com.ibm.ws.org.apache.httpcomponents;version=latest
+  	com.ibm.ws.org.apache.httpcomponents;version=latest,\
+	com.ibm.websphere.javaee.websocket.1.1
 
 -sub: *.bnd

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FATSuite.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FATSuite.java
@@ -52,7 +52,8 @@ import componenttest.topology.impl.LibertyServer;
                 RESTclientTest.class,
                 JNDITest.class,
                 CRIULogLevelTest.class,
-                AppsecurityTest.class
+                AppsecurityTest.class,
+                WebSocketTest.class
 })
 public class FATSuite {
     public static void copyAppsAppToDropins(LibertyServer server, String appName) throws Exception {

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/WebSocketTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/WebSocketTest.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.checkpoint.fat;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfCheckpointNotSupported;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpUtils;
+import io.openliberty.checkpoint.spi.CheckpointPhase;
+import junit.framework.Assert;
+import webSocketTest.AlternateEndpoint;
+import webSocketTest.DefaultEndpoint;
+import webSocketTest.SocketClient;
+import webSocketTest.SocketStartup;
+
+@RunWith(FATRunner.class)
+@SkipIfCheckpointNotSupported
+public class WebSocketTest {
+
+    public static final String APP_NAME = "webSocketTest";
+
+    @Server("webSocketServer")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void exportWebApp() throws Exception {
+        server.deleteAllDropinApplications();
+        WebArchive webappWar = ShrinkWrap.create(WebArchive.class, "webSocketWAR.war")
+                        .addClass(AlternateEndpoint.class)
+                        .addClass(DefaultEndpoint.class)
+                        .addClass(SocketClient.class)
+                        .addClass(SocketStartup.class);
+        ShrinkHelper.exportAppToServer(server, webappWar, DeployOptions.OVERWRITE);
+    }
+
+    @Test
+    public void testWebSocket() throws Exception {
+
+        server.startServer();
+
+        int responseCode = HttpUtils.getHttpConnection(server, "webSocket/startup").getResponseCode();
+
+        if (responseCode < 200 || responseCode >= 300) {
+            Assert.fail("non 200 HTTP response code: " + responseCode);
+        }
+
+        server.findStringsInLogs("MESSAGE CLIENT: data 1");
+        server.findStringsInLogs("message received Server: data 1");
+        server.findStringsInLogs("MESSAGE CLIENT: data 2");
+        server.findStringsInLogs("message received Server: data 2");
+        server.findStringsInLogs("MESSAGE CLIENT: data 3");
+        server.findStringsInLogs("message received Server: data 3");
+
+        server.stopServer();
+
+        server.setCheckpoint(CheckpointPhase.APPLICATIONS);
+        server.startServer();
+        server.stopServer();
+
+        ServerConfiguration config = server.getServerConfiguration();
+        config.getVariables().getById("socketEndpoint").setValue("alternate");
+        server.updateServerConfiguration(config);
+
+        server.checkpointRestore();
+
+        int responseCode2 = HttpUtils.getHttpConnection(server, "webSocket/startup").getResponseCode();
+
+        if (responseCode2 < 200 || responseCode2 >= 300) {
+            Assert.fail("non 200 HTTP response code: " + responseCode2);
+        }
+
+        server.findStringsInLogs("MESSAGE CLIENT: data 1");
+        server.findStringsInLogs("message received alternate Server: data 1");
+        server.findStringsInLogs("MESSAGE CLIENT: data 2");
+        server.findStringsInLogs("message received alternate Server: data 2");
+        server.findStringsInLogs("MESSAGE CLIENT: data 3");
+        server.findStringsInLogs("message received alternate Server: data 3");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stopServer();
+    }
+
+}

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/webSocketServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/webSocketServer/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
+io.openliberty.checkpoint.allowed.features=timedexit-1.0
+io.openliberty.checkpoint.dump.threads=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/webSocketServer/jvm.options
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/webSocketServer/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/webSocketServer/server.xml
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/webSocketServer/server.xml
@@ -1,0 +1,27 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="webSocketServer">
+
+    <featureManager>
+        <feature>websocket-1.1</feature>
+        <feature>servlet-4.0</feature>
+        <feature>mpConfig-2.0</feature>
+        <feature>cdi-2.0</feature>
+        <feature>checkpoint-1.0</feature>
+    </featureManager>
+
+	<include location="../fatTestPorts.xml"/>
+    <applicationManager autoExpand="true"/>
+    <variable id="socketEndpoint" name="socketEndpoint" value="chat" />
+    <variable id="clientSocket" name="clientSocket" value="ws://localhost:${bvt.prop.HTTP_default}/webSocket/${socketEndpoint}"/>
+    <webApplication id="webSocketWAR" location="webSocketWAR.war" name="webSocketWAR" contextRoot="webSocket"/>
+    <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
+</server>

--- a/dev/io.openliberty.checkpoint_fat/test-applications/openAPIapp/src/io/openliberty/checkpoint_fat/ApplicationRoot.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/openAPIapp/src/io/openliberty/checkpoint_fat/ApplicationRoot.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.checkpoint_fat;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/server")
+public class ApplicationRoot extends Application {
+
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/webSocketTest/src/webSocketTest/AlternateEndpoint.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/webSocketTest/src/webSocketTest/AlternateEndpoint.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package webSocketTest;
+
+import java.io.IOException;
+
+import javax.websocket.*;
+import javax.websocket.server.ServerEndpoint;
+
+@ServerEndpoint(value = "/alternate")
+public class AlternateEndpoint {
+
+    public static Session currentSession;
+
+    @OnOpen
+    public void onOpen(Session session) throws IOException {
+        currentSession = session;
+        System.out.println("Alternate SOCKET OPENED");
+    }
+
+    @OnMessage
+    public void onMessage(String message) throws IOException, InterruptedException {
+        System.out.println("message received alternate Server: " + message);
+        Thread.sleep(2500);
+        send(message);
+    }
+
+    @OnClose
+    public void closing() {
+        try {
+            currentSession.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        System.out.println("closing alternate socket endpoint");
+    }
+
+    public static void send(String message) throws IOException {
+        currentSession.getBasicRemote().sendText(message);
+    }
+
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/webSocketTest/src/webSocketTest/DefaultEndpoint.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/webSocketTest/src/webSocketTest/DefaultEndpoint.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package webSocketTest;
+
+import java.io.IOException;
+
+import javax.websocket.OnClose;
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+import javax.websocket.server.ServerEndpoint;
+
+@ServerEndpoint(value = "/chat")
+public class DefaultEndpoint {
+
+    public static Session currentSession;
+
+    @OnOpen
+    public void onOpen(Session session) throws IOException {
+        currentSession = session;
+        System.out.println("SOCKET OPENED");
+    }
+
+    @OnMessage
+    public void onMessage(String message) throws IOException, InterruptedException {
+        System.out.println("message received Server: " + message);
+        Thread.sleep(2500);
+        send(message);
+    }
+
+    @OnClose
+    public void closing() {
+        try {
+            currentSession.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        System.out.println("closing socket endpoint");
+    }
+
+    public static void send(String message) throws IOException {
+        currentSession.getBasicRemote().sendText(message);
+    }
+
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/webSocketTest/src/webSocketTest/SocketClient.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/webSocketTest/src/webSocketTest/SocketClient.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package webSocketTest;
+
+import java.io.IOException;
+
+import javax.websocket.ClientEndpoint;
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+
+@ClientEndpoint
+public class SocketClient {
+    public static Session currentSession;
+
+    @OnOpen
+    public void onOpen(Session session) throws IOException {
+        currentSession = session;
+        System.out.println("SOCKET OPENED");
+    }
+
+    public static void send(String message) throws IOException {
+        currentSession.getBasicRemote().sendText(message);
+    }
+
+    @OnMessage
+    public void processMessage(String message) {
+        System.out.println("MESSAGE CLIENT: " + message);
+    }
+
+    public static void close() {
+        try {
+            currentSession.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/webSocketTest/src/webSocketTest/SocketStartup.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/webSocketTest/src/webSocketTest/SocketStartup.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package webSocketTest;
+
+import java.io.IOException;
+import java.net.URI;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.websocket.ContainerProvider;
+import javax.websocket.WebSocketContainer;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@WebServlet(urlPatterns = "/startup")
+@ApplicationScoped
+public class SocketStartup extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    @ConfigProperty(name = "clientSocket")
+    private String uriEndpoint;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        final WebSocketContainer webSocketContainer = ContainerProvider.getWebSocketContainer();
+        try {
+            webSocketContainer.connectToServer(SocketClient.class, URI.create(uriEndpoint));
+        } catch (IOException | javax.websocket.DeploymentException e) {
+            e.printStackTrace();
+        }
+
+        for (int i = 1; i <= 3; i++) {
+            SocketClient.send("data " + i);
+            try {
+                Thread.sleep(5000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+        SocketClient.close();
+    }
+
+}


### PR DESCRIPTION
Created a test application that queries a WebSocket endpoint based on the "clientEndpoint" variable in the server.xml file. After checkpoint, this variable is modified to an alternate endpoint, which is then queried on restore.