### PR TITLE
PR for Issue 21157: Perform discovery for every OIDC request, not just for missing authz endpoint

### DIFF
--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationRequest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationRequest.java
@@ -37,6 +37,7 @@ public abstract class AuthorizationRequest {
     /**
      * Do not use; only for OSGi initialization
      */
+    @Deprecated
     public AuthorizationRequest() {
     }
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequest.java
@@ -63,11 +63,14 @@ public class JakartaOidcAuthorizationRequest extends AuthorizationRequest {
 
     private StorageType storageType;
 
+    protected JSONObject discoveryData = new JSONObject();
+
     protected AuthorizationRequestUtils requestUtils = new AuthorizationRequestUtils();
 
     /**
      * Do not use; needed for this to be a valid @Component object.
      */
+    @Deprecated
     public JakartaOidcAuthorizationRequest() {
         // Only for OSGi initialization
     }
@@ -102,6 +105,7 @@ public class JakartaOidcAuthorizationRequest extends AuthorizationRequest {
     @FFDCIgnore(Exception.class)
     public ProviderAuthenticationResult sendRequest() {
         try {
+            discoveryData = getProviderMetadata();
             return super.sendRequest();
         } catch (Exception e) {
             Tr.error(tc, "ERROR_SENDING_AUTHORIZATION_REQUEST", clientId, e.getMessage());
@@ -116,7 +120,6 @@ public class JakartaOidcAuthorizationRequest extends AuthorizationRequest {
             return authzEndpoint;
         }
         // Provider metadata is empty or authz endpoint is not in it, so perform discovery
-        JSONObject discoveryData = getProviderMetadata();
         authzEndpoint = (String) discoveryData.get(OidcDiscoveryConstants.METADATA_KEY_AUTHORIZATION_ENDPOINT);
         if (authzEndpoint == null) {
             String nlsMessage = Tr.formatMessage(tc, "DISCOVERY_METADATA_MISSING_VALUE", OidcDiscoveryConstants.METADATA_KEY_AUTHORIZATION_ENDPOINT);


### PR DESCRIPTION
Updates the Jakarta Security code to perform OIDC Discovery right at the start of each flow. Before, we were only performing discovery when the authorization endpoint URL wasn't configured in the provider metadata in the servlet annotation. This will ensure we always have the OP's metadata and that values in the provider metadata can be used to override values from the discovery data.

For #21157