### PR TITLE
Quicker HTTP2 upgrade header check

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/inbound/HttpInboundLink.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/inbound/HttpInboundLink.java
@@ -12,6 +12,7 @@ package com.ibm.ws.http.channel.internal.inbound;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -966,6 +967,11 @@ public class HttpInboundLink extends InboundProtocolLink implements InterChannel
         // looking for two headers.
         // connection header with a value of "upgrade"
         // upgrade header with a value of "h2c"
+
+        if (headers == Collections.EMPTY_MAP) {
+            return false; // no headers passed in
+        }
+
         boolean connection_upgrade = false;
         boolean upgrade_h2c = false;
         String headerValue = null;

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/upgrade/H2HandlerImpl.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/upgrade/H2HandlerImpl.java
@@ -51,16 +51,17 @@ public class H2HandlerImpl implements H2Handler {
         // Retrieve the needed header values for this request
         Map<String, String> h2Headers = null;
         HttpServletRequest hsrt = (HttpServletRequest) request;
-        Enumeration<String> headerNames = hsrt.getHeaderNames();
-        while (headerNames.hasMoreElements()) {
-            String headerName = headerNames.nextElement();
-            if (CONSTANT_connection.equalsIgnoreCase(headerName) || CONSTANT_upgrade.equalsIgnoreCase(headerName)) {
-                if (h2Headers == null) {
-                    h2Headers = new HashMap<String, String>();
-                }
-                h2Headers.put(headerName, hsrt.getHeader(headerName));
+
+        String upgradeHeaders = hsrt.getHeader(CONSTANT_upgrade);
+        if(upgradeHeaders != null) {
+            String connectionHeaders = hsrt.getHeader(CONSTANT_connection);
+            if(connectionHeaders != null) {
+                h2Headers = new HashMap<String, String>();
+                h2Headers.put(CONSTANT_connection,connectionHeaders);
+                h2Headers.put(CONSTANT_upgrade, upgradeHeaders);
             }
         }
+
         return ((Http2InboundConnection)hic).isHTTP2UpgradeRequest(h2Headers == null ? Collections.emptyMap() : h2Headers, false);
     }
 


### PR DESCRIPTION
The check for HTTP2 upgrade headers is slow - this change will make it quicker.