### PR TITLE
check for ipv6 before creating topicHost

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/chfw/GenericEndpointImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/chfw/GenericEndpointImpl.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.sip.stack.transport.chfw;
 
+import java.net.*;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -471,7 +472,23 @@ public class GenericEndpointImpl {
 			topicHost = "ALL";
 		}
 		else{
-			topicHost = topicHost.replace(".", "_");
+			try {
+			InetAddress ipAddress = InetAddress.getByName(topicHost);
+			if (ipAddress instanceof Inet6Address) {
+			    // Remove colon from ipv6 address before constructing topicString
+			    topicHost = topicHost.replace(":", "_");
+
+			} else if (ipAddress instanceof Inet4Address) {
+			    // Remove dots from ipv4 address before constructing topicString
+			    topicHost = topicHost.replace(".", "_");
+			}
+			} catch (UnknownHostException e) {
+				
+			}
+		
+
+
+			//topicHost = topicHost.replace(".", "_");
 		}
 		topicString = GenericServiceConstants.TOPIC_PFX
 				+ topicHost + "/" + id + "/" + cid;

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/chfw/GenericEndpointImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/chfw/GenericEndpointImpl.java
@@ -10,7 +10,9 @@
  *******************************************************************************/
 package com.ibm.ws.sip.stack.transport.chfw;
 
-import java.net.*;
+import java.net.InetAddress;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/chfw/GenericEndpointImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/chfw/GenericEndpointImpl.java
@@ -13,6 +13,7 @@ package com.ibm.ws.sip.stack.transport.chfw;
 import java.net.InetAddress;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
+import java.net.UnknownHostException;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -479,21 +480,16 @@ public class GenericEndpointImpl {
 				if (ipAddress instanceof Inet6Address) {
 					// Remove colon from ipv6 address before constructing topicString
 					topicHost = topicHost.replace(":", "_");
-
 				} 
 				else if (ipAddress instanceof Inet4Address) {
 					// Remove dots from ipv4 address before constructing topicString
 					topicHost = topicHost.replace(".", "_");
 				}
-
 			} catch (UnknownHostException e) {
 				if (c_logger.isTraceDebugEnabled()){
-					c_logger.traceDebug("Error: GenericEndpointImpl applyNewConfiguration: " + e);
-					}
-				
+					c_logger.traceDebug("Error: GenericEndpointImpl applyNewConfiguration: " + e);}	
 			}
 
-			//topicHost = topicHost.replace(".", "_");
 		}
 		topicString = GenericServiceConstants.TOPIC_PFX
 				+ topicHost + "/" + id + "/" + cid;

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/chfw/GenericEndpointImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/chfw/GenericEndpointImpl.java
@@ -473,20 +473,23 @@ public class GenericEndpointImpl {
 		}
 		else{
 			try {
-			InetAddress ipAddress = InetAddress.getByName(topicHost);
-			if (ipAddress instanceof Inet6Address) {
-			    // Remove colon from ipv6 address before constructing topicString
-			    topicHost = topicHost.replace(":", "_");
+				InetAddress ipAddress = InetAddress.getByName(topicHost);
+				if (ipAddress instanceof Inet6Address) {
+					// Remove colon from ipv6 address before constructing topicString
+					topicHost = topicHost.replace(":", "_");
 
-			} else if (ipAddress instanceof Inet4Address) {
-			    // Remove dots from ipv4 address before constructing topicString
-			    topicHost = topicHost.replace(".", "_");
-			}
+				} 
+				else if (ipAddress instanceof Inet4Address) {
+					// Remove dots from ipv4 address before constructing topicString
+					topicHost = topicHost.replace(".", "_");
+				}
+
 			} catch (UnknownHostException e) {
+				if (c_logger.isTraceDebugEnabled()){
+					c_logger.traceDebug("Error: GenericEndpointImpl applyNewConfiguration: " + e);
+					}
 				
 			}
-		
-
 
 			//topicHost = topicHost.replace(".", "_");
 		}


### PR DESCRIPTION
Adding ipv6 support for creating sipEndpoints. Currently when trying to set up a sipEndpoint over an ipv6 interface we get a failure. 