### PR TITLE
Add EE10 repeats for JAXRS 2.x and 2.1 tests

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2021 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -49,7 +49,14 @@ tested.features: \
   jsonb-3.0,\
   appsecurity-4.0,\
   expressionlanguage-4.0,\
-  pages-3.0
+  pages-3.0,\
+  xmlws-3.0,\
+  xmlbinding-3.0,\
+  servlet-6.0,\
+  concurrent-3.0,\
+  expressionlanguage-5.0,\
+  appsecurity-5.0,\
+  pages-3.1
 
 -buildpath: \
   com.ibm.websphere.javaee.annotation.1.2;version=latest,\

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/FATSuite.java
@@ -45,6 +45,7 @@ import com.ibm.ws.jaxrs20.client.fat.test.XmlBindingTest;
 import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
@@ -82,5 +83,6 @@ public class FATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModificationInFullMode()
     .andWith(FeatureReplacementAction.EE8_FEATURES().withID("JAXRS-2.1"))
-    .andWith(new JakartaEE9Action().alwaysAddFeature("jsonb-2.0"));
+    .andWith(new JakartaEE9Action().alwaysAddFeature("jsonb-2.0"))
+    .andWith(new JakartaEE10Action().alwaysAddFeature("jsonb-3.0"));
 }

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/BasicClientTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/BasicClientTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -127,13 +127,13 @@ public class BasicClientTest extends AbstractTest {
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Continue to skip this test for EE9 as there is nothing in the spec that requires the preserves = or lack thereof for the query param in the request.  Updated https://github.com/OpenLiberty/open-liberty/issues/12742 
+    @SkipForRepeat({"EE9_FEATURES","EE10_FEATURES"}) // Continue to skip this test for EE9 as there is nothing in the spec that requires the preserves = or lack thereof for the query param in the request.  Updated https://github.com/OpenLiberty/open-liberty/issues/12742 
     public void testQueryParam() throws Exception {
         this.runTestOnServer(target, "testQueryParam", null, "OK");
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Continue to skip this test for EE9 as there is nothing in the spec that requires the webcontainer to process the query parameters thus the query parameter will not be null.
+    @SkipForRepeat({"EE9_FEATURES","EE10_FEATURES"}) // Continue to skip this test for EE9 as there is nothing in the spec that requires the webcontainer to process the query parameters thus the query parameter will not be null.
     public void testQueryParamWebcontainerNoEquals() throws Exception {
         String uri = "http://" + serverRef.getHostname()
                      + ":"

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/IBMJson4JProvidersTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/IBMJson4JProvidersTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,7 +26,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // Continue to skip these tests for EE9 as JSON4JObjectProvider is not supported
+@SkipForRepeat({"EE9_FEATURES","EE10_FEATURES"}) // Continue to skip these tests for EE9 as JSON4JObjectProvider is not supported
 public class IBMJson4JProvidersTest extends AbstractTest {
 
     @Server("jaxrs20.client.IBMJson4JProvidersTest")

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRS20ClientAsyncInvokerTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRS20ClientAsyncInvokerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -122,7 +122,7 @@ public class JAXRS20ClientAsyncInvokerTest extends AbstractTest {
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue https://github.com/OpenLiberty/open-liberty/issues/16651
+//    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue https://github.com/OpenLiberty/open-liberty/issues/16651
     @AllowedFFDC("javax.ws.rs.ProcessingException")
     public void testAsyncInvoker_getConnectionTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
@@ -137,7 +137,7 @@ public class JAXRS20ClientAsyncInvokerTest extends AbstractTest {
 
     @Test
     @AllowedFFDC("javax.ws.rs.ProcessingException")
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue https://github.com/OpenLiberty/open-liberty/issues/16651
+//    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue https://github.com/OpenLiberty/open-liberty/issues/16651
     public void testAsyncInvoker_postConnectionTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(asyncInvokerTarget, "testAsyncInvoker_postConnectionTimeout", p, "Timeout as expected");
@@ -151,7 +151,7 @@ public class JAXRS20ClientAsyncInvokerTest extends AbstractTest {
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue https://github.com/OpenLiberty/open-liberty/issues/16651
+//    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue https://github.com/OpenLiberty/open-liberty/issues/16651
     @AllowedFFDC("javax.ws.rs.ProcessingException")
     public void testAsyncInvoker_getConnectionTimeoutwithInvocationCallback() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
@@ -166,7 +166,7 @@ public class JAXRS20ClientAsyncInvokerTest extends AbstractTest {
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue https://github.com/OpenLiberty/open-liberty/issues/16651
+//    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue https://github.com/OpenLiberty/open-liberty/issues/16651
     @AllowedFFDC("javax.ws.rs.ProcessingException")
     public void testAsyncInvoker_postConnectionTimeoutwithInvocationCallback() throws Exception {
         Map<String, String> p = new HashMap<String, String>();

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRS20ClientInvocationTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRS20ClientInvocationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
@@ -71,7 +72,7 @@ public class JAXRS20ClientInvocationTest extends AbstractTest {
     @Test    
     public void testClientClass() throws Exception {
         Map<String, String> p = new HashMap<String, String>();        
-        if (JakartaEE9Action.isActive()) {
+        if ((JakartaEE9Action.isActive()) || (JakartaEE10Action.isActive())) {
             this.runTestOnServer(invocationTarget, "testClientClass", p, "io.openliberty.org.jboss.resteasy.common.client.LibertyResteasyClientImpl");
         } else {
             this.runTestOnServer(invocationTarget, "testClientClass", p, "com.ibm.ws.jaxrs20.client.JAXRSClientImpl");
@@ -79,7 +80,7 @@ public class JAXRS20ClientInvocationTest extends AbstractTest {
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue https://github.com/OpenLiberty/open-liberty/issues/16650
+//    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue https://github.com/OpenLiberty/open-liberty/issues/16650
     public void testInvocation_invoke1() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(invocationTarget, "testInvocation_invoke1", p, "Good book");

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLFiltersTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLFiltersTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,7 +30,7 @@ import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
-@SkipForRepeat("EE9_FEATURES") // Continue to skip this test for EE9 as Default SSL is not supported yet
+@SkipForRepeat({"EE9_FEATURES","EE10_FEATURES"}) // Continue to skip this test for EE9 as Default SSL is not supported yet
 @RunWith(FATRunner.class)
 public class JAXRSClientSSLFiltersTest extends AbstractTest {
 

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/jaxrs20.client.JAXRS20ClientAsyncInvokerTest/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/jaxrs20.client.JAXRS20ClientAsyncInvokerTest/bootstrap.properties
@@ -1,12 +1,12 @@
 bootstrap.include=../testports.properties
 
-com.ibm.ws.logging.trace.specification=*=info:\
-com.ibm.ws.jaxrs*=all:\
-com.ibm.websphere.jaxrs*=all:\
-org.apache.cxf.*=all:\
-RESTfulWS=all:\
-org.jboss.resteasy.*=all:\
-io.openliberty.org.jboss.*=all:\
-io.openliberty.restfulWS.*=all
+#com.ibm.ws.logging.trace.specification=*=info:\
+#com.ibm.ws.jaxrs*=all:\
+#com.ibm.websphere.jaxrs*=all:\
+#org.apache.cxf.*=all:\
+#RESTfulWS=all:\
+#org.jboss.resteasy.*=all:\
+#io.openliberty.org.jboss.*=all:\
+#io.openliberty.restfulWS.*=all
 
 com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/jaxrs20.client.JAXRS20ClientAsyncInvokerTest2/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/jaxrs20.client.JAXRS20ClientAsyncInvokerTest2/bootstrap.properties
@@ -1,12 +1,12 @@
 bootstrap.include=../testports.properties
 
-com.ibm.ws.logging.trace.specification=*=info:\
-com.ibm.ws.jaxrs*=all:\
-com.ibm.websphere.jaxrs*=all:\
-org.apache.cxf.*=all:\
-RESTfulWS=all:\
-org.jboss.resteasy.*=all:\
-io.openliberty.org.jboss.*=all:\
-io.openliberty.restfulWS.*=all
+#com.ibm.ws.logging.trace.specification=*=info:\
+#com.ibm.ws.jaxrs*=all:\
+#com.ibm.websphere.jaxrs*=all:\
+#org.apache.cxf.*=all:\
+#RESTfulWS=all:\
+#org.jboss.resteasy.*=all:\
+#io.openliberty.org.jboss.*=all:\
+#io.openliberty.restfulWS.*=all
 
 com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/jaxrs20.client.JAXRSLtpaClientTest/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/jaxrs20.client.JAXRSLtpaClientTest/bootstrap.properties
@@ -1,7 +1,7 @@
 bootstrap.include=../testports.properties
 
-com.ibm.ws.logging.trace.specification=*=info:\
-com.ibm.ws.jaxrs*=all:\
-com.ibm.websphere.jaxrs*=all:\
-org.apache.cxf.*=all
-com.ibm.ws.logging.max.file.size=0
+#com.ibm.ws.logging.trace.specification=*=info:\
+#com.ibm.ws.jaxrs*=all:\
+#com.ibm.websphere.jaxrs*=all:\
+#org.apache.cxf.*=all
+#com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/jaxrs20.client.JAXRSLtpaServerTest/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/jaxrs20.client.JAXRSLtpaServerTest/bootstrap.properties
@@ -1,7 +1,7 @@
 bootstrap.include=../testports.properties
 
-com.ibm.ws.logging.trace.specification=*=info:\
-com.ibm.ws.jaxrs*=all:\
-com.ibm.websphere.jaxrs*=all:\
-org.apache.cxf.*=all
-com.ibm.ws.logging.max.file.size=0
+#com.ibm.ws.logging.trace.specification=*=info:\
+#com.ibm.ws.jaxrs*=all:\
+#com.ibm.websphere.jaxrs*=all:\
+#org.apache.cxf.*=all
+#com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/bnd.bnd
@@ -82,7 +82,20 @@ tested.features: \
   xmlWS-3.0,\
   mpmetrics-4.0,\
   microprofile-5.0,\
-  jakartaee-9.1
+  jakartaee-9.1,\
+  expressionlanguage-5.0,\
+  restfulwsclient-3.1,\
+  appsecurity-5.0,\
+  restfulws-3.1,\
+  xmlbinding-4.0,\
+  cdi-4.0,\
+  servlet-6.0,\
+  pages-3.1,\
+  xmlWS-4.0,\
+  mpmetrics-5.0,\
+  microprofile-6.0,\
+  jakartaee-10.0
+  
 
 -buildpath: \
   com.ibm.websphere.javaee.annotation.1.2,\

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/AnnotationScanTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/AnnotationScanTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,6 +38,7 @@ import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
@@ -421,7 +422,7 @@ public class AnnotationScanTest {
      * the Application init-param element.
      */
     @Test
-    @SkipForRepeat(JakartaEE9Action.ID) // this actually should be fine under the EE8/EE9 spec - but it would ignore any Application subclasses
+    @SkipForRepeat({JakartaEE9Action.ID, JakartaEE10Action.ID}) // this actually should be fine under the EE8/EE9 spec - but it would ignore any Application subclasses
     public void testServletSpecifiedWithoutApplicationInitParam() throws Exception {
         assertEquals("Did not find expected warning indicating servlet is missing Application init-param", 1,
                      server.findStringsInLogs("CWWKW0101W.*annotationscan.*App7IBMRestServlet.*com.ibm.websphere.jaxrs.server.IBMRestServlet").size());
@@ -434,12 +435,12 @@ public class AnnotationScanTest {
     @Test
     public void testServletSpecifiedWithInvalidApplicationClass() throws Exception {
         int messageCount = 0;
-        if (JakartaEE9Action.isActive()) {
+        if ((JakartaEE9Action.isActive()) || (JakartaEE10Action.isActive())) {
             messageCount = server.findStringsInLogs("SRVE0271E.*NotAnAppIBMRestServlet.*annotationscan.*com.ibm.ws.jaxrs.fat.annotation.multipleapp.MyResource3.*jakarta.ws.rs.core.Application").size();
         } else {
             messageCount = server.findStringsInLogs("CWWKW0102W.*annotationscan.*NotAnAppIBMRestServlet.*com.ibm.ws.jaxrs.fat.annotation.multipleapp.MyResource3").size();
         }
-        assertEquals("Did not find expected warning indicating servlet contains invalid Application class; jakarta=" + JakartaEE9Action.isActive(), 1,
+        assertEquals("Did not find expected warning indicating servlet contains invalid Application class; jakarta=" + ((JakartaEE9Action.isActive()) || (JakartaEE10Action.isActive())) , 1,
                      messageCount);
     }
 }

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/CheckFeature12Test.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/CheckFeature12Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,7 +32,7 @@ import componenttest.topology.impl.LibertyServer;
  * the server had to be restarted if the cdi-1.0 feature was added after the server had started.
  */
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // this test is not applicable for EE9 because restfulWS-3.0 always enables cdi-3.0
+@SkipForRepeat({"EE9_FEATURES", "EE10_FEATURES"}) // this test is not applicable for EE9 because restfulWS-3.0 always enables cdi-3.0
 public class CheckFeature12Test {
 
     @Server("com.ibm.ws.jaxrs.fat.checkFeature")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/ClientTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/ClientTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -170,7 +170,7 @@ public class ClientTest extends AbstractTest {
      */
     @Mode(TestMode.FULL)
     @Test
-    @SkipForRepeat("EE9_FEATURES") // RESTEasy does not honor CXF properties
+    @SkipForRepeat({"EE9_FEATURES", "EE10_FEATURES"}) // RESTEasy does not honor CXF properties
     public void testReadTimeoutTimeout_cxfProp() throws Exception {
         this.runTestOnServer(target, "testReadTimeoutTimeout_cxfProp", null, "OK");
     }

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/ExceptionMappingWithOTTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/ExceptionMappingWithOTTest.java
@@ -42,7 +42,7 @@ import componenttest.topology.impl.LibertyServer;
  * the MP OT mapper.
  */
 @RunWith(FATRunner.class)
-@SkipForRepeat(JakartaEE10Action.ID) // MP Open Tracing doesn't support EE10 until MP 6
+@SkipForRepeat(JakartaEE10Action.ID) //MP Open Tracing replace with MP Telemetry so this test is not valid beyond EE9
 public class ExceptionMappingWithOTTest {
 
     @Server("com.ibm.ws.jaxrs.fat.exceptionMappingWithOT")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/ExtraProvidersTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/ExtraProvidersTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,6 +23,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
@@ -116,7 +117,7 @@ public class ExtraProvidersTest extends AbstractTest {
      */
     @Test
     public void testNoPublicConstructorProvider() {
-        final String prefix = JakartaEE9Action.isActive() ? "CWWKW1305W" : "CWWKW0100W";
+        final String prefix = ((JakartaEE9Action.isActive()) || (JakartaEE10Action.isActive())) ? "CWWKW1305W" : "CWWKW0100W";
         assertNotNull("No warning logged for provider without a public constructor - expected " + prefix,
                       server.waitForStringInLog(prefix + ".*com.ibm.ws.jaxrs.fat.extraproviders.NoPublicConstructorProvider"));
         assertNotNull("No warning logged for provider (declared via Application classes) without a public constructor - expected " + prefix,

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/FATSuite.java
@@ -17,6 +17,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -82,5 +83,8 @@ public class FATSuite {
     public static RepeatTests r = RepeatTests.withoutModification()
                     .andWith(FeatureReplacementAction.EE8_FEATURES().withID("JAXRS-2.1"))
                     .andWith(new JakartaEE9Action().alwaysAddFeature("jsonb-2.0").removeFeature("mpMetrics-2.3").addFeature("mpMetrics-4.0")
-                             .removeFeature("microProfile-1.3").addFeature("microProfile-5.0"));
+                             .removeFeature("microProfile-1.3").addFeature("microProfile-5.0"))
+                    .andWith(new JakartaEE10Action().alwaysAddFeature("jsonb-3.0").removeFeature("jsonb-2.0").removeFeature("mpMetrics-2.3").removeFeature("mpMetrics-4.0").removeFeature("microProfile-1.3").addFeature("mpMetrics-5.0")
+                             .removeFeature("microProfile-5.0").addFeature("microProfile-6.0"));
+
 }

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/HelloWorldTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/HelloWorldTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,6 +29,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
@@ -101,7 +102,7 @@ public class HelloWorldTest {
         // the spec doesn't mention charsets in terms of matching to resources...
         // RESTEasy says an invalid charset is a client error, and returns 400
         // CXF says it doesn't match any resource methods and returns 415
-        if (JakartaEE9Action.isActive()) {
+        if ((JakartaEE9Action.isActive()) || (JakartaEE10Action.isActive())) {
             assertEquals(400, status);
         } else {
             assertEquals(415, status);

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/JAXRS20ClientServerBookTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/JAXRS20ClientServerBookTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,7 +28,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // this test application uses CXF-specific extras that are not available in RESTEasy / EE9
+@SkipForRepeat({"EE9_FEATURES", "EE10_FEATURES"}) // this test application uses CXF-specific extras that are not available in RESTEasy / EE9
 public class JAXRS20ClientServerBookTest extends AbstractTest {
 
     @Server("com.ibm.ws.jaxrs.fat.bookstore")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/ParamsTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/ParamsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -53,6 +53,7 @@ import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
@@ -1337,7 +1338,7 @@ public class ParamsTest {
      * Tests the constructor query parameter is processed.
      */
     @Test
-    @SkipForRepeat("EE9_FEATURES") // query params in constructors are not allowed in EE9, since they are a CDI bean
+    @SkipForRepeat({"EE9_FEATURES", "EE10_FEATURES"}) // query params in constructors are not allowed in EE9, since they are a CDI bean
     public void testConstructorQueryParam() throws Exception {
         assertEquals("deleteConstructorQueryID:HelloWorld",
                      sendGoodRequestAndGetResponse("query?queryid=HelloWorld", HttpDelete.class));
@@ -1424,7 +1425,7 @@ public class ParamsTest {
      */
     @Test
     public void testMultipleQueryParam() throws Exception {
-        String ctorVal = JakartaEE9Action.isActive() ? "notvalid-exceptInEE9" : "somequeryid";
+        String ctorVal = ((JakartaEE9Action.isActive()) || (JakartaEE10Action.isActive())) ? "notvalid-exceptInEE9" : "somequeryid";
         assertEquals("getMultiQueryParameter:" + ctorVal + ";hi;789;1moreparam2go",
                      sendGoodRequestAndGetResponse("query/multiple?queryid=somequeryid&multiParam1=hi&123Param=789&1MOREParam=1moreparam2go",
                                                    HttpGet.class));

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/RestMetricsTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/RestMetricsTest.java
@@ -41,6 +41,7 @@ import com.ibm.ws.jaxrs.fat.restmetrics.MetricsUnmappedUncheckedException;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.topology.impl.LibertyServer;
@@ -205,6 +206,7 @@ public class RestMetricsTest {
         ensureEmptyMonitorStats(ABORT_METHOD_INDEX);
     }
 
+    @SkipForRepeat("EE10_FEATURES") //Skipping until MP Metrics is upgraded for MP 6.0
     @Test
     @AllowedFFDC({"org.apache.cxf.interceptor.Fault", "org.jboss.resteasy.spi.UnhandledException"})
     public void testCheckedExceptions() throws IOException {
@@ -223,6 +225,7 @@ public class RestMetricsTest {
         runCheckMonitorStats(200, CHECKED_METHOD_INDEX);
     }
 
+    @SkipForRepeat("EE10_FEATURES") //Skipping until MP Metrics is upgraded for MP 6.0
     @Test
     @AllowedFFDC({"com.ibm.ws.jaxrs.fat.restmetrics.MetricsUnmappedUncheckedException", "org.jboss.resteasy.spi.UnhandledException"})
     public void testUncheckedExceptions() throws IOException {

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/SameClassInGetClassesAndGetSingletonsTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/SameClassInGetClassesAndGetSingletonsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,8 +34,8 @@ import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
-@RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // getSingletons should not be used in EE9
+@RunWith(FATRunner.class) 
+@SkipForRepeat({"EE9_FEATURES", "EE10_FEATURES"}) // EE9/10 do not process classes in getSingletons if also in getClasses, so this test is moot for EE9 and beyond.
 public class SameClassInGetClassesAndGetSingletonsTest {
 
     @Server("com.ibm.ws.jaxrs.fat.getCgetS")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/ServiceScopeTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/ServiceScopeTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,8 +13,6 @@ package com.ibm.ws.jaxrs20.fat;
 import static com.ibm.ws.jaxrs20.fat.TestUtils.getBaseTestUri;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-
-import java.util.logging.Logger;
 
 import org.apache.wink.client.ClientConfig;
 import org.apache.wink.client.ClientResponse;
@@ -35,17 +33,13 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // this test uses a CXF-specific property that is not applicable in RESTEasy (EE9)
+@SkipForRepeat({"EE9_FEATURES", "EE10_FEATURES"}) // this test uses a CXF-specific property that is not applicable in RESTEasy (EE9)
 public class ServiceScopeTest {
 
     @Server("com.ibm.ws.jaxrs.fat.service.scope")
     public static LibertyServer server;
 
     private static final String war = "servicescope";
-    private static final String clz = ServiceScopeTest.class.getName();
-    private static final Logger LOG = Logger.getLogger(clz);
-    private static String INITIAL_TEST_URI = getBaseTestUri(war, "app1/resource/initial");
-    private static String VERIFY_TEST_URI = getBaseTestUri(war, "app1/resource/verify");
     private RestClient client;
 
 

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/StandardProvidersTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/StandardProvidersTest.java
@@ -57,7 +57,6 @@ import componenttest.topology.impl.LibertyServer;
  * Centralized test for built-in standard providers required by the JAX-RS specification.
  */
 @RunWith(FATRunner.class)
-//@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class StandardProvidersTest {
 
     @Server("com.ibm.ws.jaxrs.fat.providers")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/UriInfoTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/UriInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,7 +25,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // currently broken due to client @Context UriInfo injection failing
+@SkipForRepeat({"EE9_FEATURES", "EE10_FEATURES"}) // currently broken due to client @Context UriInfo injection failing
 public class UriInfoTest extends FATServletClient {
 
     private static final String app = "uriInfo";

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/ValidationTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/ValidationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,6 +34,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
@@ -145,7 +146,7 @@ public class ValidationTest {
         HttpResponse resp = client.execute(getMethod);
         assertEquals(200, resp.getStatusLine().getStatusCode());
         String c = asString(resp);
-        if (JakartaEE9Action.isActive()) {
+        if ((JakartaEE9Action.isActive()) || (JakartaEE10Action.isActive())) {
             assertEquals("default1", c);
         } else {
             assertTrue("Returned message body was: " + c, "context1".equals(c) || "query1".equals(c));
@@ -169,7 +170,7 @@ public class ValidationTest {
         HttpResponse resp = client.execute(getMethod);
         assertEquals(200, resp.getStatusLine().getStatusCode());
         String c = asString(resp);
-        if (JakartaEE9Action.isActive()) {
+        if ((JakartaEE9Action.isActive()) || (JakartaEE10Action.isActive())) {
             assertEquals("default1", c);
         } else {
             assertTrue("Returned message body was: " + c, "queryInt1".equals(c) || "queryString1".equals(c));
@@ -393,7 +394,7 @@ public class ValidationTest {
     public void testNonPublicMethodPathWarning() throws Exception {
         // The CXF impl results in a servlet init error (500) when no resource methods/classes are found
         // whereas RESTEasy correctly (IMO) returns the 404.
-        final int expectedResponseCode = JakartaEE9Action.isActive() ? 404 : 500;
+        final int expectedResponseCode = ((JakartaEE9Action.isActive()) || (JakartaEE10Action.isActive())) ? 404 : 500;
 
         try {
             String uri1 = getBaseTestUri(valwar, "pathmethod", "pathwarnings/private");

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/WADLTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/WADLTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -39,7 +39,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // WADL is not supported in EE9
+@SkipForRepeat({"EE9_FEATURES", "EE10_FEATURES"}) // WADL is not supported in EE9
 public class WADLTest {
 
     @Server("com.ibm.ws.jaxrs.fat.wadl")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.providers/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.providers/bootstrap.properties
@@ -1,7 +1,1 @@
-com.ibm.ws.logging.trace.specification=*=info:\
-com.ibm.ws.jaxrs*=all:\
-com.ibm.websphere.jaxrs*=all:\
-org.apache.cxf.*=all
-com.ibm.ws.logging.max.file.size=0
-
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/helloworld/src/com/ibm/ws/jaxrs/fat/helloworld/HelloWorldResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/helloworld/src/com/ibm/ws/jaxrs/fat/helloworld/HelloWorldResource.java
@@ -65,7 +65,6 @@ public class HelloWorldResource {
     @Path("/{uniqueid : ([0-9a-t]{8}|[0-9a-t]{11})}/{testString}")
     public String getMessage(@PathParam("uniqueid") String uniqueid,
                              @PathParam("testString") String testString) {
-        System.out.println("Jim... " +  HelloWorldResource.message + ":" + uniqueid + ":" + testString);
         return HelloWorldResource.message + ":" + uniqueid + ":" + testString;
     }
 

--- a/dev/com.ibm.ws.jaxrs.2.1.cdi.2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.1.cdi.2.0_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2021 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -21,7 +21,17 @@ src: \
 
 fat.project: true
 
-tested.features: restfulwsclient-3.0, servlet-5.0, restfulws-3.0, restfulws-3.1, cdi-3.0, jsonp-2.0, concurrent-2.0, enterprisebeanslite-4.0
+tested.features: \
+    restfulwsclient-3.0,\
+    servlet-5.0,\
+    restfulws-3.0,\
+    restfulws-3.1,\
+    cdi-3.0,\
+    jsonp-2.0,\
+    concurrent-2.0,\
+    enterprisebeanslite-4.0,\
+    servlet-6.0,\
+    concurrent-3.0
 
 -buildpath: \
   com.ibm.websphere.javaee.annotation.1.2;version=latest,\

--- a/dev/com.ibm.ws.jaxrs.2.1.cdi.2.0_fat/fat/src/com/ibm/ws/jaxrs21/cdi20/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.cdi.2.0_fat/fat/src/com/ibm/ws/jaxrs21/cdi20/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -32,5 +33,7 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(new JakartaEE9Action());
+                    .andWith(new JakartaEE9Action())
+                    .andWith(new JakartaEE10Action());
+
 }

--- a/dev/com.ibm.ws.jaxrs.2.1.cdi.2.0_fat/fat/src/com/ibm/ws/jaxrs21/cdi20/fat/ProviderTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.cdi.2.0_fat/fat/src/com/ibm/ws/jaxrs21/cdi20/fat/ProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -54,7 +55,7 @@ public class ProviderTest extends FATServletClient {
                                             "isWriteable Hello",
                                             "writeTo Hello",                                                
                                             "post1"));
-        if (JakartaEE9Action.isActive()) {
+        if ((JakartaEE9Action.isActive()) || (JakartaEE10Action.isActive())) {
             states.add("WSJdbcDataSource");
         } else {
             states.add("ApplicationInjectionProxy");

--- a/dev/com.ibm.ws.jaxrs.2.1.cdi.2.0_fat/test-applications/resourceinfoatstartup/src/jaxrs21/fat/resourceinfoatstartup/App.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.cdi.2.0_fat/test-applications/resourceinfoatstartup/src/jaxrs21/fat/resourceinfoatstartup/App.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 IBM Corporation and others.
+ * Copyright (c) 2010, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,15 +14,17 @@ import java.util.HashSet;
 import java.util.Set;
 
 import javax.annotation.Resource;
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
+import javax.enterprise.context.Dependent;
 import javax.sql.DataSource;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
 
 @ApplicationPath("/")
 @Stateless
 @LocalBean
+@Dependent
 public class App extends Application {
 
     @Resource(description = "Application Data Source", name = "jdbc/TestDataSource")

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2021 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -38,7 +38,8 @@ tested.features: \
   jsonb-2.0, \
   jsonb-3.0, \
   appsecurity-4.0, \
-  expressionlanguage-4.0
+  expressionlanguage-4.0,\
+  servlet-6.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.2,\

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,6 +29,7 @@ import com.ibm.ws.jaxrs21.client.fat.test.JAXRS21ReactiveSampleTest;
 import com.ibm.ws.jaxrs21.client.fat.test.JAXRS21TimeoutClientTest;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -49,5 +50,7 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(new JakartaEE9Action().alwaysAddFeature("jsonb-2.0"));
+                    .andWith(new JakartaEE9Action().alwaysAddFeature("jsonb-2.0"))
+                    .andWith(new JakartaEE10Action().alwaysAddFeature("jsonb-3.0"));
+;
 }

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientCXFRxInvokerTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientCXFRxInvokerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,7 +25,6 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
@@ -212,28 +211,24 @@ public class JAXRS21ClientCXFRxInvokerTest extends JAXRS21AbstractTest {
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue  https://github.com/OpenLiberty/open-liberty/issues/16648
     public void testObservableRxInvoker_getCbConnectionTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(cxfRxInvokerTarget, "testObservableRxInvoker_getCbConnectionTimeout", p, "Timeout as expected");
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue  https://github.com/OpenLiberty/open-liberty/issues/16648
     public void testObservableRxInvoker_getIbmConnectionTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(cxfRxInvokerTarget, "testObservableRxInvoker_getIbmConnectionTimeout", p, "Timeout as expected");
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue  https://github.com/OpenLiberty/open-liberty/issues/16648
     public void testFlowableRxInvoker_getCbConnectionTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(cxfRxInvokerTarget, "testFlowableRxInvoker_getCbConnectionTimeout", p, "Timeout as expected");
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue  https://github.com/OpenLiberty/open-liberty/issues/16648
     public void testFlowableRxInvoker_getIbmConnectionTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(cxfRxInvokerTarget, "testFlowableRxInvoker_getIbmConnectionTimeout", p, "Timeout as expected");
@@ -264,28 +259,24 @@ public class JAXRS21ClientCXFRxInvokerTest extends JAXRS21AbstractTest {
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue  https://github.com/OpenLiberty/open-liberty/issues/16648
     public void testObservableRxInvoker_postCbConnectionTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(cxfRxInvokerTarget, "testObservableRxInvoker_postCbConnectionTimeout", p, "Timeout as expected");
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue  https://github.com/OpenLiberty/open-liberty/issues/16648
     public void testObservableRxInvoker_postIbmConnectionTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(cxfRxInvokerTarget, "testObservableRxInvoker_postIbmConnectionTimeout", p, "Timeout as expected");
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue  https://github.com/OpenLiberty/open-liberty/issues/16648
     public void testFlowableRxInvoker_postCbConnectionTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(cxfRxInvokerTarget, "testFlowableRxInvoker_postCbConnectionTimeout", p, "Timeout as expected");
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue  https://github.com/OpenLiberty/open-liberty/issues/16648
     public void testFlowableRxInvoker_postIbmConnectionTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(cxfRxInvokerTarget, "testFlowableRxInvoker_postIbmConnectionTimeout", p, "Timeout as expected");

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientCompletionStageRxInvokerTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientCompletionStageRxInvokerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,7 +25,6 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
@@ -212,21 +211,18 @@ public class JAXRS21ClientCompletionStageRxInvokerTest extends JAXRS21AbstractTe
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue https://github.com/OpenLiberty/open-liberty/issues/16651
     public void testCompletionStageRxInvoker_getCbConnectionTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(completionStageRxInvokerTarget, "testCompletionStageRxInvoker_getCbConnectionTimeout", p, "Timeout as expected");
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue https://github.com/OpenLiberty/open-liberty/issues/16651
     public void testCompletionStageRxInvoker_getIbmConnectionTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(completionStageRxInvokerTarget, "testCompletionStageRxInvoker_getIbmConnectionTimeout", p, "Timeout as expected");
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue https://github.com/OpenLiberty/open-liberty/issues/16651
     public void testCompletionStageRxInvoker_getIbmOverridesCbConnectionTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(completionStageRxInvokerTarget, "testCompletionStageRxInvoker_getIbmOverridesCbConnectionTimeout", p, "Timeout as expected");
@@ -251,21 +247,18 @@ public class JAXRS21ClientCompletionStageRxInvokerTest extends JAXRS21AbstractTe
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue https://github.com/OpenLiberty/open-liberty/issues/16651
     public void testCompletionStageRxInvoker_postCbConnectionTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(completionStageRxInvokerTarget, "testCompletionStageRxInvoker_postCbConnectionTimeout", p, "Timeout as expected");
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue https://github.com/OpenLiberty/open-liberty/issues/16651
     public void testCompletionStageRxInvoker_postIbmConnectionTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(completionStageRxInvokerTarget, "testCompletionStageRxInvoker_postIbmConnectionTimeout", p, "Timeout as expected");
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue https://github.com/OpenLiberty/open-liberty/issues/16651
     public void testCompletionStageRxInvoker_postIbmOverridesCbConnectionTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(completionStageRxInvokerTarget, "testCompletionStageRxInvoker_postIbmOverridesCbConnectionTimeout", p, "Timeout as expected");

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientJerseyRxInvokerTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientJerseyRxInvokerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,7 +27,6 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
@@ -234,42 +233,36 @@ public class JAXRS21ClientJerseyRxInvokerTest extends JAXRS21AbstractTest {
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue  https://github.com/OpenLiberty/open-liberty/issues/16648
     public void testRxObservableInvoker_getConnectionTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(jerseyRxInvokerTarget, "testRxObservableInvoker_getConnectionTimeout", p, "Timeout as expected");
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue  https://github.com/OpenLiberty/open-liberty/issues/16648
     public void testRxFlowableInvoker_getConnectionTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(jerseyRxInvokerTarget, "testRxFlowableInvoker_getConnectionTimeout", p, "Timeout as expected");
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue  https://github.com/OpenLiberty/open-liberty/issues/16648
     public void testRxObservableInvoker_postReceiveTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(jerseyRxInvokerTarget, "testRxObservableInvoker_postReceiveTimeout", p, "Timeout as expected");
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue  https://github.com/OpenLiberty/open-liberty/issues/16648
     public void testRxFlowableInvoker_postReceiveTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(jerseyRxInvokerTarget, "testRxFlowableInvoker_postReceiveTimeout", p, "Timeout as expected");
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue  https://github.com/OpenLiberty/open-liberty/issues/16648
     public void testRxObservableInvoker_postConnectionTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(jerseyRxInvokerTarget, "testRxObservableInvoker_postConnectionTimeout", p, "Timeout as expected");
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Skip this test for EE9 as this test is failing intermittently with EE9.  See issue  https://github.com/OpenLiberty/open-liberty/issues/16648
     public void testRxFlowableInvoker_postConnectionTimeout() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         this.runTestOnServer(jerseyRxInvokerTarget, "testRxFlowableInvoker_postConnectionTimeout", p, "Timeout as expected");

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientSSLProxyAuthTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientSSLProxyAuthTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -249,9 +249,10 @@ public class JAXRS21ClientSSLProxyAuthTest extends JAXRS21AbstractTest {
         // amF4cnNVc2VyOm15UGEkJHdvcmQ=").withSecure(false)); //jaxrsUser:myPa$$word
     }
 
-//    @Test TODO: intermittent test bug "Socket output is already shutdown"
-    @MinimumJavaLevel(javaLevel = 11) // TODO: https://github.com/OpenLiberty/open-liberty/issues/18849
-    @SkipForRepeat("EE9_FEATURES") // RESTEasy only supports properties set on ClientBuilder
+ // TODO: https://github.com/OpenLiberty/open-liberty/issues/18849
+    @Test
+    @MinimumJavaLevel(javaLevel = 11)
+    @SkipForRepeat({"EE9_FEATURES","EE10_FEATURES"}) // RESTEasy only supports properties set on ClientBuilder
     public void testTunnelThroughProxyToHTTPSEndpoint_Client() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         p.put("param", "helloRochester");
@@ -314,7 +315,7 @@ public class JAXRS21ClientSSLProxyAuthTest extends JAXRS21AbstractTest {
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // RESTEasy only supports properties set on ClientBuilder
+    @SkipForRepeat({"EE9_FEATURES","EE10_FEATURES"}) // RESTEasy only supports properties set on ClientBuilder
     public void testTunnelThroughProxyToHTTPEndpointTimeout_Client() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         p.put("param", "helloRochester");
@@ -354,8 +355,8 @@ public class JAXRS21ClientSSLProxyAuthTest extends JAXRS21AbstractTest {
         // amF4cnNVc2VyOm15UGEkJHdvcmQ=").withSecure(false)); //jaxrsUser:myPa$$word
     }
 
-//    @Test TODO: intermittent test bug "Socket output is already shutdown"
-    @SkipForRepeat("EE9_FEATURES") // RESTEasy only supports properties set on ClientBuilder
+    @Test
+    @SkipForRepeat({"EE9_FEATURES","EE10_FEATURES"}) // RESTEasy only supports properties set on ClientBuilder
     public void testTunnelThroughProxyToHTTPSEndpoint_WebTarget() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         p.put("param", "helloRochester");
@@ -417,7 +418,7 @@ public class JAXRS21ClientSSLProxyAuthTest extends JAXRS21AbstractTest {
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // RESTEasy only supports properties set on ClientBuilder
+    @SkipForRepeat({"EE9_FEATURES","EE10_FEATURES"}) // RESTEasy only supports properties set on ClientBuilder
     public void testTunnelThroughProxyToHTTPEndpointTimeout_WebTarget() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         p.put("param", "helloRochester");

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientSSLTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientSSLTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -88,7 +88,6 @@ public class JAXRS21ClientSSLTest extends JAXRS21AbstractTest {
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Currently, RESTEasy only allows SSLContext to be set from ClientBuilder
     public void testClientBasicSSL_Client() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         p.put("param", "alex");
@@ -96,7 +95,6 @@ public class JAXRS21ClientSSLTest extends JAXRS21AbstractTest {
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Currently, RESTEasy only allows SSLContext to be set from ClientBuilder
     public void testClientBasicSSL_WebTarget() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         p.put("param", "alex");
@@ -111,7 +109,7 @@ public class JAXRS21ClientSSLTest extends JAXRS21AbstractTest {
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // Needs more investigation, but also runs into the same issue with SSLContext only being set from ClientBuilder
+    @SkipForRepeat({"EE9_FEATURES","EE10_FEATURES"}) // Needs more investigation, but also runs into the same issue with SSLContext only being set from ClientBuilder
     public void testClientBasicSSL_CustomizedSSLContext() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         p.put("param", "alex");

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/publish/servers/jaxrs21.client.JAXRS21ClientCXFRxInvokerTest/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/publish/servers/jaxrs21.client.JAXRS21ClientCXFRxInvokerTest/bootstrap.properties
@@ -1,9 +1,1 @@
 bootstrap.include=../testports.properties
-
-com.ibm.ws.logging.trace.specification=*=info:\
-com.ibm.ws.jaxrs*=all:\
-com.ibm.websphere.jaxrs*=all:\
-org.apache.cxf.*=all:\
-RESTfulWS=all:\
-org.jboss.resteasy.*=all
-com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/publish/servers/jaxrs21.client.JAXRS21ClientCompletionStageRxInvokerTest/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/publish/servers/jaxrs21.client.JAXRS21ClientCompletionStageRxInvokerTest/bootstrap.properties
@@ -1,10 +1,3 @@
 bootstrap.include=../testports.properties
 
-com.ibm.ws.logging.trace.specification=*=info:\
-com.ibm.ws.jaxrs*=all:\
-com.ibm.websphere.jaxrs*=all:\
-org.apache.cxf.*=all:\
-RESTfulWS=all:\
-org.jboss.resteasy.*=all
-
 com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/publish/servers/jaxrs21.client.JAXRS21ClientJerseyRxInvokerTest/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/publish/servers/jaxrs21.client.JAXRS21ClientJerseyRxInvokerTest/bootstrap.properties
@@ -1,9 +1,1 @@
 bootstrap.include=../testports.properties
-
-com.ibm.ws.logging.trace.specification=*=info:\
-com.ibm.ws.jaxrs*=all:\
-com.ibm.websphere.jaxrs*=all:\
-org.apache.cxf.*=all:\
-RESTfulWS=all:\
-org.jboss.resteasy.*=all
-com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/publish/servers/jaxrs21.client.JAXRS21ProxyAuthTest/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/publish/servers/jaxrs21.client.JAXRS21ProxyAuthTest/bootstrap.properties
@@ -1,6 +1,1 @@
 bootstrap.include=../testports.properties
-
-com.ibm.ws.logging.trace.specification=*=info:\
-org.apache.cxf.transport.http.*=all:\
-RESTfulWS=all:\
-org.jboss.resteasy.*=all

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/publish/servers/jaxrs21.client.JAXRS21ReactiveSampleTest/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/publish/servers/jaxrs21.client.JAXRS21ReactiveSampleTest/bootstrap.properties
@@ -1,9 +1,1 @@
 bootstrap.include=../testports.properties
-
-com.ibm.ws.logging.trace.specification=*=info:\
-com.ibm.ws.jaxrs*=all:\
-com.ibm.websphere.jaxrs*=all:\
-org.apache.cxf.*=all:\
-RESTfulWS=all:\
-org.jboss.resteasy.*=all
-com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/publish/servers/jaxrs21.client.JAXRS21TimeoutClientTest/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/publish/servers/jaxrs21.client.JAXRS21TimeoutClientTest/bootstrap.properties
@@ -1,4 +1,1 @@
 bootstrap.include=../testports.properties
-
-#com.ibm.ws.logging.trace.specification=*=info:\com.ibm.ws.jaxrs*=all:\com.ibm.websphere.jaxrs*=all:\org.apache.cxf.*=all:\ClassLoadingService=all:\RESTfulWS=all:\org.jboss.resteasy.*=all
-com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2021 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -34,7 +34,8 @@ tested.features: \
   jsonp-2.0,\
   xmlBinding-3.0,\
   xmlBinding-4.0,\
-  servlet-5.0
+  servlet-5.0,\
+  servlet-6.0
 
 
 -buildpath: \

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/BasicSseTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/BasicSseTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@
 package com.ibm.ws.jaxrs21.sse.fat;
 
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE10_FEATURES;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -83,7 +84,7 @@ public class BasicSseTest extends FATServletClient {
     }
 
     @Test
-    @SkipForRepeat(EE9_FEATURES) // per spec discussions, only unrecoverable connection-related errors should trigger onError
+    @SkipForRepeat({EE9_FEATURES, EE10_FEATURES}) // per spec discussions, only unrecoverable connection-related errors should trigger onError
     public void testErrorSse() throws Exception {
         runTest(server, SERVLET_PATH, "testErrorSse");
     }

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/DelaySseTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/DelaySseTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,6 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -33,7 +34,9 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(new JakartaEE9Action().alwaysAddFeature("jsonb-2.0").alwaysAddFeature("xmlBinding-3.0"));
+                    .andWith(new JakartaEE9Action().alwaysAddFeature("jsonb-2.0").alwaysAddFeature("xmlBinding-3.0"))
+                    .andWith(new JakartaEE10Action().alwaysAddFeature("jsonb-3.0").alwaysAddFeature("xmlBinding-4.0"));
+
 }
 
 

--- a/dev/com.ibm.ws.jaxrs.2.1_fat/fat/src/com/ibm/ws/jaxrs21/fat/CxfReservedTypeAndCTypeTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat/fat/src/com/ibm/ws/jaxrs21/fat/CxfReservedTypeAndCTypeTest.java
@@ -23,12 +23,12 @@ import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTestAction;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
-
 import typeAndCType.ClientTestServlet;
 
 /**
@@ -44,7 +44,7 @@ import typeAndCType.ClientTestServlet;
  * system property.
  * 
  */
-@SkipForRepeat(JakartaEE9Action.ID) // only applies to CXF, not RESTEasy
+@SkipForRepeat({JakartaEE9Action.ID, JakartaEE10Action.ID}) // only applies to CXF, not RESTEasy
 @RunWith(FATRunner.class)
 public class CxfReservedTypeAndCTypeTest extends FATServletClient {
 

--- a/dev/com.ibm.ws.jaxrs.2.1_fat/fat/src/com/ibm/ws/jaxrs21/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat/fat/src/com/ibm/ws/jaxrs21/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019,2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -33,5 +34,6 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-        .andWith(new JakartaEE9Action());
+        .andWith(new JakartaEE9Action())
+        .andWith(new JakartaEE10Action());
 }

--- a/dev/com.ibm.ws.jaxrs.2.1_fat/fat/src/com/ibm/ws/jaxrs21/fat/JAXRS21SecurityContextTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat/fat/src/com/ibm/ws/jaxrs21/fat/JAXRS21SecurityContextTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,10 +23,11 @@ import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
-@SkipForRepeat(JakartaEE9Action.ID)
+@SkipForRepeat({JakartaEE9Action.ID, JakartaEE10Action.ID})
 @RunWith(FATRunner.class)
 public class JAXRS21SecurityContextTest {
 

--- a/dev/com.ibm.ws.jaxrs.2.1_fat/fat/src/com/ibm/ws/jaxrs21/fat/JAXRS21SecuritySSLTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat/fat/src/com/ibm/ws/jaxrs21/fat/JAXRS21SecuritySSLTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,10 +33,11 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
-@SkipForRepeat(JakartaEE9Action.ID) // currently broken due to @Context constructor injection failing when using CDI
+@SkipForRepeat({JakartaEE9Action.ID, JakartaEE10Action.ID}) // currently broken due to @Context constructor injection failing when using CDI
 @RunWith(FATRunner.class)
 public class JAXRS21SecuritySSLTest {
 

--- a/dev/com.ibm.ws.jaxrs.2.1_fat/fat/src/com/ibm/ws/jaxrs21/fat/UriInfoTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat/fat/src/com/ibm/ws/jaxrs21/fat/UriInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,11 +21,12 @@ import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
-@SkipForRepeat(JakartaEE9Action.ID)
+@SkipForRepeat({JakartaEE9Action.ID, JakartaEE10Action.ID})
 @RunWith(FATRunner.class)
 public class UriInfoTest extends FATServletClient {
 

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2018 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -27,7 +27,24 @@ src: \
   test-applications/subResourceApp/src
 
 fat.project: true
-tested.features: cdi-2.0, cdi-1.2, jaxrs-2.1, jaxrs-2.0, mpconfig-1.4, restfulWSClient-3.0, restfulWS-3.0, jsonb-2.0, jsonbcontainer-2.0, servlet-5.0
+tested.features: \
+    cdi-2.0,\
+    cdi-1.2,\
+    jaxrs-2.1,\
+    jaxrs-2.0,\
+    mpconfig-1.4,\
+    restfulWSClient-3.0,\
+    restfulWS-3.0,\
+    jsonb-2.0,\
+    jsonbcontainer-2.0,\
+    servlet-5.0,\
+    restfulWSClient-3.1,\
+    restfulWS-3.1,\
+    jsonp-2.1,\
+    cdi-4.0,\
+    jsonb-3.0,\
+    servlet-6.0,\
+    jsonbcontainer-3.0
 
 
 -buildpath: \

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/ClassSubResTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/ClassSubResTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,12 +20,13 @@ import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import jaxrs21.fat.classSubRes.ClassSubResTestServlet;
 
-@SkipForRepeat(JakartaEE9Action.ID) // multiple errors needs investigation
+@SkipForRepeat({JakartaEE9Action.ID, JakartaEE10Action.ID}) // multiple errors needs investigation
 @RunWith(FATRunner.class)
 public class ClassSubResTest extends FATServletClient {
 

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -38,5 +39,6 @@ public class FATSuite {
     @ClassRule
     public static RepeatTests r = 
         RepeatTests.withoutModification()
-                   .andWith(new JakartaEE9Action());
+                   .andWith(new JakartaEE9Action())
+                   .andWith(new JakartaEE10Action());
 }

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/FormBehaviorTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/FormBehaviorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,12 +20,13 @@ import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import jaxrs21.fat.form.FormBehaviorTestServlet;
 
-@SkipForRepeat(JakartaEE9Action.ID) // RESTEasy does not support the proper form behavior from issue https://github.com/eclipse-ee4j/jaxrs-api/issues/659
+@SkipForRepeat({JakartaEE9Action.ID, JakartaEE10Action.ID}) // RESTEasy does not support the proper form behavior from issue https://github.com/eclipse-ee4j/jaxrs-api/issues/659
 // see also: https://github.com/OpenLiberty/open-liberty/pull/5281
 @RunWith(FATRunner.class)
 public class FormBehaviorTest extends FATServletClient {

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/PackageJsonBTestNoFeature.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/PackageJsonBTestNoFeature.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,12 +23,13 @@ import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import jaxrs21.fat.jsonb.JsonBTestServlet;
 
-@SkipForRepeat(JakartaEE9Action.ID) // failures when comparing JSON
+@SkipForRepeat({JakartaEE9Action.ID, JakartaEE10Action.ID}) // failures when comparing JSON
 @RunWith(FATRunner.class)
 public class PackageJsonBTestNoFeature extends FATServletClient {
 

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/PackageJsonBTestWithFeature.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/PackageJsonBTestWithFeature.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,12 +24,13 @@ import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import jaxrs21.fat.jsonb.JsonBTestServlet;
 
-@SkipForRepeat(JakartaEE9Action.ID) //JSON-B Provider implementation seems to be broken in Jakarta package space...
+@SkipForRepeat({JakartaEE9Action.ID, JakartaEE10Action.ID}) //JSON-B Provider implementation seems to be broken in Jakarta package space...
 @RunWith(FATRunner.class)
 public class PackageJsonBTestWithFeature extends FATServletClient {
 

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/SubResourceTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/SubResourceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,12 +20,13 @@ import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import jaxrs21.fat.subresource.SubResourceTestServlet;
 
-@SkipForRepeat(JakartaEE9Action.ID) // blocked on https://issues.redhat.com/browse/RESTEASY-2652
+@SkipForRepeat({JakartaEE9Action.ID, JakartaEE10Action.ID}) // blocked on https://issues.redhat.com/browse/RESTEASY-2652
 @RunWith(FATRunner.class)
 public class SubResourceTest extends FATServletClient {
                     

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.classSubRes/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.classSubRes/server.xml
@@ -2,6 +2,7 @@
   <featureManager>
     <feature>componenttest-1.0</feature>
     <feature>jaxrs-2.1</feature>
+    <feature>servlet-4.0</feature>
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>    

--- a/dev/com.ibm.ws.jaxrs.2.x.webcontainer_fat/fat/src/com/ibm/ws/jaxrs2x/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.x.webcontainer_fat/fat/src/com/ibm/ws/jaxrs2x/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -31,6 +32,7 @@ public class FATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
                     .andWith(FeatureReplacementAction.EE8_FEATURES().withID("JAXRS-2.1"))
-                    .andWith(new JakartaEE9Action());
+                    .andWith(new JakartaEE9Action())
+                    .andWith(new JakartaEE10Action());
 
 }

--- a/dev/com.ibm.ws.jaxrs.2.x.webcontainer_fat/fat/src/com/ibm/ws/jaxrs2x/fat/JaxRsJsonPTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.x.webcontainer_fat/fat/src/com/ibm/ws/jaxrs2x/fat/JaxRsJsonPTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,8 +15,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -29,7 +27,6 @@ import com.ibm.websphere.simplicity.log.Log;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
@@ -44,11 +41,6 @@ public class JaxRsJsonPTest {
     public static void setup() throws Exception {
 
         ShrinkHelper.defaultDropinApp(server, jsonpwar, "com.ibm.ws.jaxrs2x.fat.jsonp.service");
-
-        if (JakartaEE9Action.isActive()) {
-            Path someArchive = Paths.get("publish/servers/" + server.getServerName() + "/dropins/jsonp.war");
-            JakartaEE9Action.transformApp(someArchive);
-        }
 
         // Make sure we don't fail because we try to start an
         // already started server

--- a/dev/com.ibm.ws.jaxrs.2.x.webcontainer_fat/fat/src/com/ibm/ws/jaxrs2x/fat/MultipartTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.x.webcontainer_fat/fat/src/com/ibm/ws/jaxrs2x/fat/MultipartTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,8 +15,6 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
@@ -38,7 +36,6 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
@@ -58,11 +55,6 @@ public class MultipartTest {
 
         WebArchive app = ShrinkHelper.buildDefaultApp(thirdpartylibwar, "com.ibm.ws.jaxrs2x.fat.thirdparty.multipart");
         ShrinkHelper.exportAppToServer(server, app);
-        if (JakartaEE9Action.isActive()) {
-            Path someArchive = Paths.get("publish/servers/" + server.getServerName() + "/apps/thirdpartylib.war");
-            JakartaEE9Action.transformApp(someArchive);
-        }
-        server.addInstalledAppForValidation(thirdpartylibwar);
 
         // Make sure we don't fail because we try to start an
         // already started server

--- a/dev/com.ibm.ws.jaxrs.2.x.webcontainer_fat/publish/servers/com.ibm.ws.jaxrs2x.fat.thirdpartylib/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.x.webcontainer_fat/publish/servers/com.ibm.ws.jaxrs2x.fat.thirdpartylib/server.xml
@@ -4,6 +4,7 @@
     <!-- Enable features -->
     <featureManager>
 		 <feature>jaxrs-2.0</feature> 		
+		 <feature>servlet-3.1</feature> 		
     </featureManager>
    <application context-root="/thirdpartylib" type="war" location="thirdpartylib.war">
         <classloader apiTypeVisibility="spec,ibm-api,third-party"/>

--- a/dev/com.ibm.ws.jaxrs.defaultexceptionmapper_fat/fat/src/com/ibm/ws/jaxrs/defaultexceptionmapper_fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.defaultexceptionmapper_fat/fat/src/com/ibm/ws/jaxrs/defaultexceptionmapper_fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,36 +10,21 @@
  *******************************************************************************/
 package com.ibm.ws.jaxrs.defaultexceptionmapper_fat;
 
-import java.nio.file.Paths;
-
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
 @SuiteClasses(DefaultExceptionMapperTest.class)
 @RunWith(Suite.class)
 public class FATSuite {
 
-    private static final String TEST_BUNDLE = "publish/files/bundles/test.exceptionmapper.jar";
-
-    private static boolean firstRun = true;
-
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModificationInFullMode()
-                                             .andWith(FeatureReplacementAction.EE9_FEATURES().removeFeature("test.exceptionmapper-2.0").addFeature("test.exceptionmapper-3.0"));
+                                             .andWith(FeatureReplacementAction.EE9_FEATURES().removeFeature("test.exceptionmapper-2.0").addFeature("test.exceptionmapper-3.0"))
+                                             .andWith(FeatureReplacementAction.EE10_FEATURES().removeFeature("test.exceptionmapper-2.0").addFeature("test.exceptionmapper-3.0"));
 
-    @BeforeClass
-    public static void transformTestBundle() {
-        if (firstRun) {
-            JakartaEE9Action.transformApp(Paths.get(TEST_BUNDLE),
-                                          Paths.get(TEST_BUNDLE.replace(".jar", ".jakarta.jar")));
-            firstRun = false;
-        }
-    }
 }

--- a/dev/com.ibm.ws.jaxrs.defaultexceptionmapper_fat/test.exceptionmapper.jakarta.bnd
+++ b/dev/com.ibm.ws.jaxrs.defaultexceptionmapper_fat/test.exceptionmapper.jakarta.bnd
@@ -1,0 +1,9 @@
+-include= ~../cnf/resources/bnd/transform.props
+
+Bundle-SymbolicName: test.exceptionmapper.jakarta
+
+Private-Package: com.ibm.ws.jaxrs.defaultexceptionmapper_fat.mapper
+
+bVersion=1.0
+
+-dsannotations: *

--- a/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/org/jboss/resteasy/plugins/providers/multipart/Mime4JWorkaround.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/org/jboss/resteasy/plugins/providers/multipart/Mime4JWorkaround.java
@@ -1,0 +1,295 @@
+package org.jboss.resteasy.plugins.providers.multipart;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.apache.james.mime4j.MimeException;
+import org.apache.james.mime4j.MimeIOException;
+import org.apache.james.mime4j.codec.DecodeMonitor;
+import org.apache.james.mime4j.dom.Message;
+import org.apache.james.mime4j.field.DefaultFieldParser;
+import org.apache.james.mime4j.field.LenientFieldParser;
+import org.apache.james.mime4j.message.BodyFactory;
+import org.apache.james.mime4j.message.DefaultBodyDescriptorBuilder;
+import org.apache.james.mime4j.message.MessageImpl;
+import org.apache.james.mime4j.parser.MimeStreamParser;
+import org.apache.james.mime4j.storage.AbstractStorageProvider;
+import org.apache.james.mime4j.storage.DefaultStorageProvider;
+import org.apache.james.mime4j.storage.Storage;
+import org.apache.james.mime4j.storage.StorageBodyFactory;
+import org.apache.james.mime4j.storage.StorageOutputStream;
+import org.apache.james.mime4j.storage.StorageProvider;
+import org.apache.james.mime4j.storage.ThresholdStorageProvider;
+import org.apache.james.mime4j.stream.BodyDescriptorBuilder;
+import org.apache.james.mime4j.stream.MimeConfig;
+import org.jboss.resteasy.plugins.providers.multipart.i18n.LogMessages;
+import org.jboss.resteasy.spi.config.Configuration;
+import org.jboss.resteasy.spi.config.ConfigurationFactory;
+
+/**
+ * Copy code from org.apache.james.mime4j.message.DefaultMessageBuilder.parseMessage().
+ * Alter said code to use Mime4JWorkaroundBinaryEntityBuilder instead of EntityBuilder.
+ */
+public class Mime4JWorkaround {
+   static final String MEM_THRESHOLD_PROPERTY = "org.jboss.resteasy.plugins.providers.multipart.memoryThreshold";
+   static final int DEFAULT_MEM_THRESHOLD = 1024;
+
+    /**
+     * This is a rough copy of DefaultMessageBuilder.parseMessage() modified to use a Mime4JWorkaround as the contentHandler instead
+     * of an EntityBuilder.
+     * <p>
+     *
+     * @param is
+     * @return
+     * @throws IOException
+     * @throws MimeIOException
+     * @see org.apache.james.mime4j.message.DefaultMessageBuilder#parseMessage(java.io.InputStream)
+     */
+    public static Message parseMessage(InputStream is) throws IOException, MimeIOException {
+        try {
+            MessageImpl message = new MessageImpl();
+            MimeConfig cfg = MimeConfig.DEFAULT;
+            boolean strict = cfg.isStrictParsing();
+            DecodeMonitor mon = strict ? DecodeMonitor.STRICT : DecodeMonitor.SILENT;
+            BodyDescriptorBuilder bdb = new DefaultBodyDescriptorBuilder(null, strict ? DefaultFieldParser.getParser() : LenientFieldParser.getParser(), mon);
+
+            StorageProvider storageProvider;
+            if (ConfigurationFactory.getInstance().getConfiguration().getOptionalValue(DefaultStorageProvider.DEFAULT_STORAGE_PROVIDER_PROPERTY, String.class).orElse(null) != null) {
+                storageProvider = DefaultStorageProvider.getInstance();
+            } else {
+                StorageProvider backend = new CustomTempFileStorageProvider();
+                storageProvider = new ThresholdStorageProvider(backend, getMemThreshold());
+            }
+            BodyFactory bf = new StorageBodyFactory(storageProvider, mon);
+
+            MimeStreamParser parser = new MimeStreamParser(cfg, mon, bdb);
+            // EntityBuilder expect the parser will send ParserFields for the well known fields
+            // It will throw exceptions, otherwise.
+            parser.setContentHandler(new Mime4jWorkaroundBinaryEntityBuilder(message, bf));
+            parser.setContentDecoding(false);
+            parser.setRecurse();
+
+            parser.parse(is);
+            return message;
+        } catch (MimeException e) {
+            throw new MimeIOException(e);
+        }
+    }
+
+    static int getMemThreshold()
+    {
+       try
+       {
+          Configuration cfg = ConfigurationFactory.getInstance().getConfiguration();
+          int threshold = Integer.parseInt(cfg.getOptionalValue(MEM_THRESHOLD_PROPERTY, String.class).orElse(
+                Integer.toString(DEFAULT_MEM_THRESHOLD)));
+          if (threshold > -1)
+          {
+             return threshold;
+          }
+          LogMessages.LOGGER.debugf("Negative threshold, %s, specified. Using default value", threshold);
+       }
+       catch (Exception e)
+       {
+          LogMessages.LOGGER.debug("Exception caught parsing memory threshold. Using default value.", e);
+       }
+       return DEFAULT_MEM_THRESHOLD;
+    }
+
+    /**
+     * A custom TempFileStorageProvider that do no set deleteOnExit on temp files,
+     * to avoid memory leaks (see https://issues.apache.org/jira/browse/MIME4J-251)
+     *
+     */
+    private static class CustomTempFileStorageProvider extends AbstractStorageProvider
+    {
+
+        private static final String DEFAULT_PREFIX = "m4j";
+
+        private final String prefix;
+
+        private final String suffix;
+
+        private final File directory;
+
+        CustomTempFileStorageProvider()
+        {
+            this(DEFAULT_PREFIX, null, null);
+        }
+
+        CustomTempFileStorageProvider(final String prefix, final String suffix, final File directory)
+        {
+            if (prefix == null || prefix.length() < 3)
+                throw new IllegalArgumentException("invalid prefix");
+
+            if (directory != null && !directory.isDirectory() && !directory.mkdirs())
+                throw new IllegalArgumentException("invalid directory");
+
+            this.prefix = prefix;
+            this.suffix = suffix;
+            this.directory = directory;
+        }
+
+        public StorageOutputStream createStorageOutputStream() throws IOException
+        {
+            return new TempFileStorageOutputStream(createTempFile(prefix, suffix, directory));
+        }
+
+        private static File createTempFile(String prefix, String suffix, File directory) throws IOException
+        {
+            boolean java2SecurityEnabled = System.getSecurityManager() != null;
+            if (java2SecurityEnabled)
+            {
+                try {
+                    return AccessController.doPrivileged((PrivilegedExceptionAction<File>) () ->
+                        File.createTempFile(prefix, suffix, directory));
+                } catch (PrivilegedActionException pae) {
+                    Throwable cause = pae.getCause();
+                    if (cause instanceof IOException)
+                    {
+                        throw (IOException) cause;
+                    } else throw new RuntimeException(cause);
+                }
+            }
+            return File.createTempFile(prefix, suffix, directory);
+        }
+
+        private static FileOutputStream createFileOutputStream(File file) throws IOException
+        {
+            boolean java2SecurityEnabled = System.getSecurityManager() != null;
+            if (java2SecurityEnabled)
+            {
+                try {
+                    return AccessController.doPrivileged((PrivilegedExceptionAction<FileOutputStream>) () ->
+                        new FileOutputStream(file));
+                } catch (PrivilegedActionException pae) {
+                    Throwable cause = pae.getCause();
+                    if (cause instanceof IOException)
+                    {
+                        throw (IOException) cause;
+                    } else throw new RuntimeException(cause);
+                }
+            }
+            return new FileOutputStream(file);
+        }
+
+        private static final class TempFileStorageOutputStream extends StorageOutputStream
+        {
+            private File file;
+
+            private OutputStream out;
+
+            TempFileStorageOutputStream(final File file) throws IOException
+            {
+                this.file = file;
+                this.out = createFileOutputStream(file);
+            }
+
+            @Override
+            public void close() throws IOException
+            {
+                super.close();
+                out.close();
+            }
+
+            @Override
+            protected void write0(byte[] buffer, int offset, int length) throws IOException
+            {
+                out.write(buffer, offset, length);
+            }
+
+            @Override
+            protected Storage toStorage0() throws IOException
+            {
+                // out has already been closed because toStorage calls close
+                return new TempFileStorage(file);
+            }
+        }
+
+        private static final class TempFileStorage implements Storage
+        {
+
+            private File file;
+
+            private static final Set<File> filesToDelete = new HashSet<File>();
+
+            TempFileStorage(final File file)
+            {
+                this.file = file;
+            }
+
+            public void delete()
+            {
+                // deleting a file might not immediately succeed if there are still
+                // streams left open (especially under Windows). so we keep track of
+                // the files that have to be deleted and try to delete all these
+                // files each time this method gets invoked.
+
+                // a better but more complicated solution would be to start a
+                // separate thread that tries to delete the files periodically.
+
+                synchronized (filesToDelete)
+                {
+                    if (file != null)
+                    {
+                        filesToDelete.add(file);
+                        file = null;
+                    }
+
+                    for (Iterator<File> iterator = filesToDelete.iterator(); iterator.hasNext();)
+                    {
+                        File f = iterator.next();
+ 
+                        if (deleteFile(f)) //Liberty: Awaiting https://issues.redhat.com/projects/RESTEASY/issues/RESTEASY-3212
+                        {
+                            iterator.remove();
+                        }
+                    }
+                }
+            }
+            // Liberty start: Awaiting https://issues.redhat.com/projects/RESTEASY/issues/RESTEASY-3212
+            private static boolean deleteFile(File file) 
+            {
+                boolean deleted;
+                boolean java2SecurityEnabled = System.getSecurityManager() != null;
+                if (java2SecurityEnabled)
+                {
+                    deleted = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+                        @Override
+                        public Boolean run() {
+                            return file.delete();
+                         }
+                     });
+                } else {
+                   deleted = file.delete();
+                }
+                return deleted;
+            }  //Liberty end
+
+
+            public InputStream getInputStream() throws IOException
+            {
+                if (file == null)
+                    throw new IllegalStateException("storage has been deleted");
+
+                return new BufferedInputStream(new FileInputStream(file));
+            }
+
+        }
+    }
+
+}
+
+


### PR DESCRIPTION
Ensuring that all FAT tests that were repeated for EE9 and now repeated for EE10 as well.