### PR TITLE
PR for Issue 21165: Add unit tests for OIDC response validation

### DIFF
--- a/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
+++ b/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
@@ -74,5 +74,6 @@ Export-Package: \
 	io.openliberty.org.apache.commons.logging;version=latest,\
 	com.ibm.ws.logging;version=latest,\
 	com.ibm.ws.container.service.compat;version=latest,\
-	com.ibm.ws.org.slf4j.api;version=latest
+	com.ibm.ws.org.slf4j.api;version=latest,\
+	com.ibm.websphere.security;version=latest
 	

--- a/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
+++ b/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
@@ -61,11 +61,11 @@ STATE_VALUE_IN_CALLBACK_NOT_STORED=CWWKS2410E: The OpenID Connect client cannot 
 STATE_VALUE_IN_CALLBACK_NOT_STORED.explanation=The state parameter might be from an old authorization request, or the value for the state parameter is incorrect.
 STATE_VALUE_IN_CALLBACK_NOT_STORED.useraction=Verify that the state parameter in the callback request matches a state value for a recent OpenID Connect request.
 
-STATE_VALUE_IN_CALLBACK_DOES_NOT_MATCH_STORED_VALUE=CWWKS2411E: The [{0}] state parameter that is included in the callback request does not match the [{1}] state value that is stored by the OpenID Connect client.
+STATE_VALUE_IN_CALLBACK_DOES_NOT_MATCH_STORED_VALUE=CWWKS2411E: The [{0}] state parameter that is included in the callback request does not match the state value that is stored by the OpenID Connect client.
 STATE_VALUE_IN_CALLBACK_DOES_NOT_MATCH_STORED_VALUE.explanation=The state parameter might be from an old authorization request, or the value for the state parameter is incorrect.
 STATE_VALUE_IN_CALLBACK_DOES_NOT_MATCH_STORED_VALUE.useraction=Verify that the state parameter in the callback request matches a state value for a recent OpenID Connect request.
 
-STATE_VALUE_IN_CALLBACK_OUTSIDE_ALLOWED_TIME_FRAME=CWWKS2412E: The [{0}] state parameter that is included in the callback request is outside of its valid time frame. The state value was created at {1} and is valid from {2} to {3}.
+STATE_VALUE_IN_CALLBACK_OUTSIDE_ALLOWED_TIME_FRAME=CWWKS2412E: The [{0}] state parameter that is included in the callback request is outside of its valid time frame. The state value was created at {1} and is valid from {2} to {3}. The current time is {4}.
 STATE_VALUE_IN_CALLBACK_OUTSIDE_ALLOWED_TIME_FRAME.explanation=The OpenID Connect provider took too long to respond, or the user took too long to authenticate with the OpenID Connect provider.
 STATE_VALUE_IN_CALLBACK_OUTSIDE_ALLOWED_TIME_FRAME.useraction=Ensure that the user does not take too much time to authenticate with the OpenID Connect provider.
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthenticationResponseValidator.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthenticationResponseValidator.java
@@ -67,7 +67,7 @@ public abstract class AuthenticationResponseValidator {
                 throw new AuthenticationResponseException(ValidationResult.INVALID_RESULT, clientId, e.getMessage());
             }
         } else {
-            String nlsMessage = Tr.formatMessage(tc, "STATE_VALUE_IN_CALLBACK_DOES_NOT_MATCH_STORED_VALUE", stateParameter, storedStateValue);
+            String nlsMessage = Tr.formatMessage(tc, "STATE_VALUE_IN_CALLBACK_DOES_NOT_MATCH_STORED_VALUE", stateParameter);
             throw new AuthenticationResponseException(ValidationResult.INVALID_RESULT, clientId, nlsMessage);
         }
     }
@@ -85,7 +85,7 @@ public abstract class AuthenticationResponseValidator {
                 Tr.debug(tc, "error current: " + currentTime + "  ran at:" + timestampFromStateValue);
                 Tr.debug(tc, "current time must be between " + minDate + " and " + maxDate);
             }
-            throw new StateTimestampException(responseState, minDate, maxDate);
+            throw new StateTimestampException(responseState, currentTime, minDate, maxDate);
         }
     }
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/StateTimestampException.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/StateTimestampException.java
@@ -25,12 +25,14 @@ public class StateTimestampException extends Exception {
 
     private final String state;
     private final long timestampFromStateValue;
+    private final long now;
     private final long minDate;
     private final long maxDate;
 
-    public StateTimestampException(String state, long minDate, long maxDate) {
+    public StateTimestampException(String state, long now, long minDate, long maxDate) {
         this.state = state;
         this.timestampFromStateValue = Utils.convertNormalizedTimeStampToLong(state);
+        this.now = now;
         this.minDate = minDate;
         this.maxDate = maxDate;
     }
@@ -41,7 +43,8 @@ public class StateTimestampException extends Exception {
 
     @Override
     public String getMessage() {
-        return Tr.formatMessage(tc, "STATE_VALUE_IN_CALLBACK_OUTSIDE_ALLOWED_TIME_FRAME", state, getDateString(timestampFromStateValue), getDateString(minDate), getDateString(maxDate));
+        return Tr.formatMessage(tc, "STATE_VALUE_IN_CALLBACK_OUTSIDE_ALLOWED_TIME_FRAME", state, getDateString(timestampFromStateValue), getDateString(minDate),
+                                getDateString(maxDate), getDateString(now));
     }
 
 }


### PR DESCRIPTION
- Minor updates to a couple NLS messages.
- Adds more unit tests for `JakartaOidcAuthenticationResponseValidator` class.

For #21165 