### PR TITLE
fixes for jbatch fats

### DIFF
--- a/dev/com.ibm.ws.jbatch.open_fat/fat/src/batch/fat/junit/BatchJobOperatorApiWithAppSecurityTest.java
+++ b/dev/com.ibm.ws.jbatch.open_fat/fat/src/batch/fat/junit/BatchJobOperatorApiWithAppSecurityTest.java
@@ -230,7 +230,8 @@ public class BatchJobOperatorApiWithAppSecurityTest {
     }
 
     @Test
-    @AllowedFFDC({"jakarta.servlet.ServletException"})
+    @AllowedFFDC({"jakarta.servlet.ServletException",
+        "com.ibm.jbatch.container.exception.PersistenceException"})
     @ExpectedFFDC({ "com.ibm.jbatch.container.exception.BatchContainerRuntimeException",
                     "java.lang.Exception" })
     public void testAbandonAsMonitor() throws Exception {

--- a/dev/com.ibm.ws.jbatch.open_fat/fat/src/batch/fat/junit/DDLTest.java
+++ b/dev/com.ibm.ws.jbatch.open_fat/fat/src/batch/fat/junit/DDLTest.java
@@ -82,6 +82,7 @@ public class DDLTest extends BatchFATHelper {
             Assert.assertTrue("DDL Generation did not produce a file", ddlFile.exists() && ddlFile.isFile());
             Assert.assertTrue("DDL Generation produced an empty file", ddlFile.length() > 0);
         } catch (Exception exception) {
+            Log.error(DDLTest.class, "testddlGenProducesOutput", exception);
             Assert.fail("An exception occurred while generating DDL file.");
         }
     }
@@ -108,6 +109,7 @@ public class DDLTest extends BatchFATHelper {
             Assert.assertTrue("DDL File is missing table JOBINSTANCE", sqlFromDDL.contains("CREATE TABLE JBATCH.JOBINSTANCE"));
 
         } catch (Exception exception) {
+            Log.error(DDLTest.class, "testddlGenContainsCorrectTables", exception);
             Assert.fail("Test failed due to an unexpected exception.");
         }
     }
@@ -222,6 +224,7 @@ public class DDLTest extends BatchFATHelper {
 
             Assert.assertTrue("Got a good return code when a bad return code was expected.", 200 != rc);
         } catch (Exception exception) {
+            Log.error(DDLTest.class, "testBadDDL", exception);
             Assert.fail("Encountered an unexpected exception.");
         }
     }


### PR DESCRIPTION
Completed open-liberty personal build running these fats, as well as validated locally.

Adds an allowed ffdc to fix case where occasionally one test finds an allowed ffdc from another test.   No real way around it due to occasional slow ffdc processing while next test continues.

Also updates tests that generate ddl to use different way of calling ddlgen.  A previous WebSphere Liberty test added a temporary test to validate this way would work on iseries.  Since it does, now converting all the ddl gen tests to use that way of calling it.