### PR TITLE
Mark Pages 3.1 (and Tags 3.0) as Beta

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VisibilityTest.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VisibilityTest.java
@@ -398,7 +398,6 @@ public class VisibilityTest {
         expectedFailures.add("io.openliberty.org.eclipse.microprofile.jwt-2.1");
         expectedFailures.add("io.openliberty.persistentExecutor.internal.ee-10.0"); // the persistentExecutor feature is no ship
         expectedFailures.add("io.openliberty.socialLogin1.0.internal.ee-10.0");
-        expectedFailures.add("io.openliberty.pages-3.1");
         expectedFailures.add("io.openliberty.batch-2.1");
 
         StringBuilder errorMessage = new StringBuilder();

--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VisibilityTest.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VisibilityTest.java
@@ -400,6 +400,12 @@ public class VisibilityTest {
         expectedFailures.add("io.openliberty.socialLogin1.0.internal.ee-10.0");
         expectedFailures.add("io.openliberty.batch-2.1");
 
+        expectedFailures.add("io.openliberty.openidConnectClient1.0.internal.ee-10.0");
+        expectedFailures.add("io.openliberty.adminCenter1.0.internal.ee-10.0");
+        expectedFailures.add("io.openliberty.openidConnectServer1.0.internal.ee-10.0");
+        expectedFailures.add("io.openliberty.webCache1.0.internal.ee-10.0");
+
+
         StringBuilder errorMessage = new StringBuilder();
         for (Entry<String, FeatureInfo> entry : features.entrySet()) {
             String featureName = entry.getKey();

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/pages-3.1/io.openliberty.pages-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/pages-3.1/io.openliberty.pages-3.1.feature
@@ -46,6 +46,6 @@ Subsystem-Name: Jakarta Server Pages 3.1
 -jars=com.ibm.websphere.appserver.spi.jsp; location:=dev/spi/ibm/, \
  io.openliberty.jakarta.pages.tld.3.0; location:=dev/api/spec/
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.jsp_1.0-javadoc.zip
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel


### PR DESCRIPTION
fixes #22254

Added the following to the expected failures: 
```
java.lang.AssertionError: Found features that are marked noship, but contain only beta/ga features without a noship feature dependency: 
If you recently marked a feature beta, you may need to add or remove from the expected failures list or have something to fix.
Found issues with io.openliberty.openidConnectClient1.0.internal.ee-10.0
     The feature is marked noship, but all dependencies are beta or ga
Found issues with io.openliberty.adminCenter1.0.internal.ee-10.0
     The feature is marked noship, but all dependencies are beta or ga
Found issues with io.openliberty.openidConnectServer1.0.internal.ee-10.0
     The feature is marked noship, but all dependencies are beta or ga
Found issues with io.openliberty.webCache1.0.internal.ee-10.0
     The feature is marked noship, but all dependencies are beta or ga
```


Note - Private feature already marked as beta:
https://github.com/OpenLiberty/open-liberty/blob/85546902dc3437b76cb644f869ca813893cf16a8/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.pages-3.1.feature#L8-L9