### PR TITLE
Issue 21156: Add EL to additional wrapper class for jakarta security 30

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/ELHelper.java
+++ b/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/ELHelper.java
@@ -38,7 +38,7 @@ import com.ibm.ws.security.javaeesec.CDIHelper;
  * Class to help with evaluating EL expressions for identity stores.
  */
 public class ELHelper {
-    private static final String OBFUSCATED_STRING = "******";
+    public static final String OBFUSCATED_STRING = "******";
     private static final TraceComponent tc = Tr.register(ELHelper.class);
 
     private static final ThreadLocal<Map<String, String>> valuesMap = new ThreadLocal<Map<String, String>>() {

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/bnd.bnd
@@ -20,6 +20,11 @@ Bundle-Name: Jakarta Security 3.0
 Bundle-SymbolicName: io.openliberty.security.jakartasec.3.0.internal
 Bundle-Description: Jakarta Security 3.0; version=${bVersion}
 
+WS-TraceGroup: \
+	OPENIDCONNECT
+
+Private-Package: io.openliberty.security.jakartasec.internal.resources.*
+
 Export-Package: \
     io.openliberty.security.jakartasec,\
     io.openliberty.security.jakartasec.identitystore
@@ -27,6 +32,8 @@ Export-Package: \
 Import-Package: \
     !io.openliberty.security.jakartasec.*,\
     *
+
+instrument.classesExcludes: io/openliberty/security/jakartasec/internal/resources/resources/*.class
 
 -buildpath: \
     com.ibm.ws.kernel.boot;version=latest,\

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/resources/io/openliberty/security/jakartasec/internal/resources/JakartaSecurity30Messages.nlsprops
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/resources/io/openliberty/security/jakartasec/internal/resources/JakartaSecurity30Messages.nlsprops
@@ -1,0 +1,36 @@
+###############################################################################
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#CMVCPATHNAME io.openliberty.security.jakartasec.3.0.internal/resources/io/openliberty/security/jakartasec/internal/resources/JakartaSecurity30Messages.nlsprops
+#COMPONENTPREFIX CWWKS
+#COMPONENTNAMEFOR WebSphere Application Server Jakarta Security 3.0
+#ISMESSAGEFILE TRUE
+#NLS_MESSAGEFORMAT_VAR
+#NLS_ENCODING=UNICODE
+# -------------------------------------------------------------------------------------------------
+
+# Message prefix block: 2500-2519
+
+#Note to translator, do not translate EL or OpenID
+JAKARTASEC_WARNING_OIDC_MECH_CONFIG=CWWKS2500W: The Expression Language (EL) expression for the {0} attribute of the OpenID authentication mechanism definition annotation cannot be resolved to a valid value. The value provided was ''{1}''. Ensure that the EL expression and the result are valid and ensure that any referenced beans that are used in the expression are resolvable. The default attribute value of ''{2}'' is used.
+JAKARTASEC_WARNING_OIDC_MECH_CONFIG.explanation=The attribute cannot be resolved as an expression. The EL result and the expected attribute value type might be mismatched. For example, if the expected attribute type is String, then the EL result must be a String.
+JAKARTASEC_WARNING_OIDC_MECH_CONFIG.useraction=Make sure that the annotation contains a valid configuration value. Ensure that the EL expressions are valid, that any referenced beans in the expression are resolvable, and that the type of the result corresponds with the attribute.
+
+JAKARTASEC_WARNING_CLAIM_DEF_CONFIG=CWWKS2501W: The Expression Language (EL) expression for the {0} attribute of the claims definition annotation cannot be resolved to a valid value. The value provided was ''{1}''. Ensure that the EL expression and the result are valid and ensure that any referenced beans that are used in the expression are resolvable. The default attribute value of ''{2}'' is used.
+JAKARTASEC_WARNING_CLAIM_DEF_CONFIG.explanation=The attribute cannot be resolved as an expression. The EL result and the expected attribute value type might be mismatched. For example, if the expected attribute type is String, then the EL result must be a String.
+JAKARTASEC_WARNING_CLAIM_DEF_CONFIG.useraction=Make sure that the annotation contains a valid configuration value. Ensure that the EL expressions are valid, that any referenced beans in the expression are resolvable, and that the type of the result corresponds with the attribute.
+
+JAKARTASEC_WARNING_LOGOUT_DEF_CONFIG=CWWKS2502W: The Expression Language (EL) expression for the {0} attribute of the logout definition annotation cannot be resolved to a valid value. The value provided was ''{1}''. Ensure that the EL expression and the result are valid and ensure that any referenced beans that are used in the expression are resolvable. The default attribute value of ''{2}'' is used.
+JAKARTASEC_WARNING_LOGOUT_DEF_CONFIG.explanation=The attribute cannot be resolved as an expression. The EL result and the expected attribute value type might be mismatched. For example, if the expected attribute type is String, then the EL result must be a String.
+JAKARTASEC_WARNING_LOGOUT_DEF_CONFIG.useraction=Make sure that the annotation contains a valid configuration value. Ensure that the EL expressions are valid, that any referenced beans in the expression are resolvable, and that the type of the result corresponds with the attribute.
+
+JAKARTASEC_WARNING_PROV_METADATA_CONFIG=CWWKS2502W: The Expression Language (EL) expression for the {0} attribute of the OpenID provider metadata annotation cannot be resolved to a valid value. The value provided was ''{1}''. Ensure that the EL expression and the result are valid and ensure that any referenced beans that are used in the expression are resolvable. The default attribute value of ''{2}'' is used.
+JAKARTASEC_WARNING_PROV_METADATA_CONFIG.explanation=The attribute cannot be resolved as an expression. The EL result and the expected attribute value type might be mismatched. For example, if the expected attribute type is String, then the EL result must be a String.
+JAKARTASEC_WARNING_PROV_METADATA_CONFIG.useraction=Make sure that the annotation contains a valid configuration value. Ensure that the EL expressions are valid, that any referenced beans in the expression are resolvable, and that the type of the result corresponds with the attribute.

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/ClaimsDefinitionWrapper.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/ClaimsDefinitionWrapper.java
@@ -10,30 +10,80 @@
  *******************************************************************************/
 package io.openliberty.security.jakartasec;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.security.javaeesec.identitystore.ELHelper;
+
 import io.openliberty.security.oidcclientcore.client.ClaimsMappingConfig;
 import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdConstant;
 
 /*
  * Wraps a Jakarta Security 3.0 ClaimDefinition into a feature independent implementation.
  */
 public class ClaimsDefinitionWrapper implements ClaimsMappingConfig {
 
+    private static final TraceComponent tc = Tr.register(ClaimsDefinitionWrapper.class);
+
     private final ClaimsDefinition claimsDefinition;
+
+    private final ELHelper elHelper;
+
+    private final String callerNameClaim;
+
+    private final String callerGroupsClaim;
 
     public ClaimsDefinitionWrapper(ClaimsDefinition claimsDefinition) {
         this.claimsDefinition = claimsDefinition;
+
+        this.elHelper = new ELHelper();
+
+        callerNameClaim = evaluateCallerNameClaim(true);
+        callerGroupsClaim = evaluateCallerGroupsClaim(true);
     }
 
-    // TODO: Evaluate EL expression.
     @Override
     public String getCallerNameClaim() {
-        return claimsDefinition.callerNameClaim();
+        return (callerNameClaim != null) ? callerNameClaim : evaluateCallerNameClaim(false);
     }
 
-    // TODO: Evaluate EL expression.
     @Override
     public String getCallerGroupsClaim() {
-        return claimsDefinition.callerGroupsClaim();
+        return (callerGroupsClaim != null) ? callerGroupsClaim : evaluateCallerGroupsClaim(false);
+    }
+
+    private String evaluateCallerNameClaim(boolean immediateOnly) {
+        return evaluateStringAttribute("callerNameClaim", claimsDefinition.callerNameClaim(), OpenIdConstant.PREFERRED_USERNAME, immediateOnly);
+    }
+
+    private String evaluateCallerGroupsClaim(boolean immediateOnly) {
+        return evaluateStringAttribute("callerGroupsClaim", claimsDefinition.callerGroupsClaim(), OpenIdConstant.GROUPS, immediateOnly);
+    }
+
+    @SuppressWarnings("static-access")
+    @FFDCIgnore(IllegalArgumentException.class)
+    private String evaluateStringAttribute(String attributeName, String attribute, String attributeDefault, boolean immediateOnly) {
+        try {
+            return elHelper.processString(attributeName, attribute, immediateOnly);
+        } catch (IllegalArgumentException e) {
+            if (immediateOnly && elHelper.isDeferredExpression(attribute)) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, attributeName, "Returning null since " + attributeName + " is a deferred expression and this is called on initialization.");
+                }
+                return null;
+            }
+
+            issueWarningMessage(attributeName, attribute, attributeDefault);
+
+            return attributeDefault;
+        }
+    }
+
+    private void issueWarningMessage(String attributeName, Object valueProvided, Object attributeDefault) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isWarningEnabled()) {
+            Tr.warning(tc, "JAKARTASEC_WARNING_CLAIM_DEF_CONFIG", new Object[] { attributeName, valueProvided, attributeDefault });
+        }
     }
 
 }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/JakartaSec30Constants.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/JakartaSec30Constants.java
@@ -23,4 +23,6 @@ public class JakartaSec30Constants extends JavaEESecConstants {
 
     public static final String BASE_URL_DEFAULT = "${" + BASE_URL_VARIABLE + "}/Callback";
 
+    public static final String EMPTY_DEFAULT = "";
+
 }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/LogoutDefinitionWrapper.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/LogoutDefinitionWrapper.java
@@ -10,6 +10,11 @@
  *******************************************************************************/
 package io.openliberty.security.jakartasec;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.security.javaeesec.identitystore.ELHelper;
+
 import io.openliberty.security.oidcclientcore.client.LogoutConfig;
 import jakarta.security.enterprise.authentication.mechanism.http.openid.LogoutDefinition;
 
@@ -18,34 +23,112 @@ import jakarta.security.enterprise.authentication.mechanism.http.openid.LogoutDe
  */
 public class LogoutDefinitionWrapper implements LogoutConfig {
 
+    private static final TraceComponent tc = Tr.register(LogoutDefinitionWrapper.class);
+
     private final LogoutDefinition logoutDefinition;
+
+    private final ELHelper elHelper;
+
+    private final Boolean notifyProvider;
+
+    private final String redirectURI;
+
+    private final Boolean accessTokenExpiry;
+
+    private final Boolean identityTokenExpiry;
 
     public LogoutDefinitionWrapper(LogoutDefinition logoutDefinition) {
         this.logoutDefinition = logoutDefinition;
+
+        this.elHelper = new ELHelper();
+
+        this.notifyProvider = evaluateNotifyProvider(true);
+        this.redirectURI = evaluateRedirectURI(true);
+        this.accessTokenExpiry = evaluateAccessTokenExpiry(true);
+        this.identityTokenExpiry = evaluateIdentityTokenExpiry(true);
+
     }
 
-    // TODO: Evaluate EL expression.
     @Override
     public boolean isNotifyProvider() {
-        return logoutDefinition.notifyProvider();
+        return (notifyProvider != null) ? notifyProvider : evaluateNotifyProvider(false);
     }
 
-    // TODO: Evaluate EL expression.
+    private Boolean evaluateNotifyProvider(boolean immediateOnly) {
+        return evaluateBooleanAttribute("notifyProvider", logoutDefinition.notifyProvider(), false,
+                                        logoutDefinition.notifyProviderExpression(), immediateOnly);
+    }
+
     @Override
     public String getRedirectURI() {
-        return logoutDefinition.redirectURI();
+        return (redirectURI != null) ? redirectURI : evaluateRedirectURI(false);
     }
 
-    // TODO: Evaluate EL expression.
+    private String evaluateRedirectURI(boolean immediateOnly) {
+        return evaluateStringAttribute("redirectURI", logoutDefinition.redirectURI(), JakartaSec30Constants.EMPTY_DEFAULT, immediateOnly);
+    }
+
     @Override
     public boolean isAccessTokenExpiry() {
-        return logoutDefinition.accessTokenExpiry();
+        return (accessTokenExpiry != null) ? accessTokenExpiry : evaluateAccessTokenExpiry(false);
     }
 
-    // TODO: Evaluate EL expression.
+    private Boolean evaluateAccessTokenExpiry(boolean immediateOnly) {
+        return evaluateBooleanAttribute("accessTokenExpiryExpression", logoutDefinition.accessTokenExpiry(), false,
+                                        logoutDefinition.accessTokenExpiryExpression(), immediateOnly);
+    }
+
     @Override
     public boolean isIdentityTokenExpiry() {
-        return logoutDefinition.identityTokenExpiry();
+        return (identityTokenExpiry != null) ? identityTokenExpiry : evaluateIdentityTokenExpiry(false);
     }
 
+    private Boolean evaluateIdentityTokenExpiry(boolean immediateOnly) {
+        return evaluateBooleanAttribute("identityTokenExpiryExpression", logoutDefinition.identityTokenExpiry(), false,
+                                        logoutDefinition.identityTokenExpiryExpression(), immediateOnly);
+    }
+
+    @SuppressWarnings("static-access")
+    @FFDCIgnore(IllegalArgumentException.class)
+    private String evaluateStringAttribute(String attributeName, String attribute, String attributeDefault, boolean immediateOnly) {
+        try {
+            return elHelper.processString(attributeName, attribute, immediateOnly);
+        } catch (IllegalArgumentException e) {
+            if (immediateOnly && elHelper.isDeferredExpression(attribute)) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, attributeName, "Returning null since " + attributeName + " is a deferred expression and this is called on initialization.");
+                }
+                return null;
+            }
+
+            issueWarningMessage(attributeName, attribute, attributeDefault);
+
+            return attributeDefault;
+        }
+    }
+
+    @SuppressWarnings("static-access")
+    @FFDCIgnore(IllegalArgumentException.class)
+    private Boolean evaluateBooleanAttribute(String attributeName, boolean attribute, boolean attributeDefault, String attributeExpression, boolean immediateOnly) {
+        try {
+            return elHelper.processBoolean(attributeName, attributeExpression, attribute, immediateOnly);
+        } catch (IllegalArgumentException e) {
+            if (immediateOnly && elHelper.isDeferredExpression(attributeExpression)) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, attributeName, "Returning null since " + attributeName + " is a deferred expression and this is called on initialization.");
+                }
+                return null;
+            }
+
+            issueWarningMessage(attributeName, attributeExpression == null ? attribute : attributeExpression, attributeDefault);
+
+            return attributeDefault;
+        }
+    }
+
+    private void issueWarningMessage(String attributeName, Object valueProvided, Object attributeDefault) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isWarningEnabled()) {
+            Tr.warning(tc, "JAKARTASEC_WARNING_LOGOUT_DEF_CONFIG", new Object[] { attributeName, valueProvided, attributeDefault });
+        }
+    }
 }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/OpenIdAuthenticationMechanismDefinitionWrapper.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/OpenIdAuthenticationMechanismDefinitionWrapper.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package io.openliberty.security.jakartasec;
 
+import static io.openliberty.security.jakartasec.JakartaSec30Constants.EMPTY_DEFAULT;
+
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -41,8 +43,6 @@ import jakarta.security.enterprise.authentication.mechanism.http.openid.PromptTy
 public class OpenIdAuthenticationMechanismDefinitionWrapper implements OidcClientConfig {
 
     private static final TraceComponent tc = Tr.register(OpenIdAuthenticationMechanismDefinitionWrapper.class);
-
-    private static final String EMPTY_DEFAULT = "";
 
     private final OpenIdAuthenticationMechanismDefinition oidcMechanismDefinition;
 
@@ -162,7 +162,7 @@ public class OpenIdAuthenticationMechanismDefinitionWrapper implements OidcClien
                 return null;
             }
 
-            issueWarningMessage("clientSecret", EMPTY_DEFAULT);
+            issueWarningMessage("clientSecret", ELHelper.OBFUSCATED_STRING, EMPTY_DEFAULT);
 
             result = EMPTY_DEFAULT; /* Default value from spec. */
         }
@@ -204,7 +204,7 @@ public class OpenIdAuthenticationMechanismDefinitionWrapper implements OidcClien
                 return null;
             }
 
-            issueWarningMessage("scopeExpression", EMPTY_DEFAULT);
+            issueWarningMessage("scopeExpression", scopeExpression, EMPTY_DEFAULT);
 
             return new String[] { OpenIdConstant.OPENID_SCOPE, OpenIdConstant.EMAIL_SCOPE, OpenIdConstant.PROFILE_SCOPE }; /* Default value from spec. */
         }
@@ -233,7 +233,7 @@ public class OpenIdAuthenticationMechanismDefinitionWrapper implements OidcClien
                 return null;
             }
 
-            issueWarningMessage("promptExpression", EMPTY_DEFAULT);
+            issueWarningMessage("promptExpression", promptExpression, EMPTY_DEFAULT);
 
             return new PromptType[] {}; /* Default value from spec. */
         }
@@ -254,7 +254,7 @@ public class OpenIdAuthenticationMechanismDefinitionWrapper implements OidcClien
                 return null;
             }
 
-            issueWarningMessage("displayExpression", EMPTY_DEFAULT);
+            issueWarningMessage("displayExpression", displayExpression, EMPTY_DEFAULT);
 
             return DisplayType.PAGE; /* Default value from spec. */
         }
@@ -324,7 +324,7 @@ public class OpenIdAuthenticationMechanismDefinitionWrapper implements OidcClien
                 return null;
             }
 
-            issueWarningMessage(attributeName, attributeDefault);
+            issueWarningMessage(attributeName, attribute, attributeDefault);
 
             return attributeDefault;
         }
@@ -343,7 +343,7 @@ public class OpenIdAuthenticationMechanismDefinitionWrapper implements OidcClien
                 return null;
             }
 
-            issueWarningMessage(attributeName, attributeDefault);
+            issueWarningMessage(attributeName, attributeExpression == null ? attribute : attributeExpression, attributeDefault);
 
             return attributeDefault;
         }
@@ -362,15 +362,15 @@ public class OpenIdAuthenticationMechanismDefinitionWrapper implements OidcClien
                 return null;
             }
 
-            issueWarningMessage(attributeName, attributeDefault);
+            issueWarningMessage(attributeName, attributeExpression == null ? attribute : attributeExpression, attributeDefault);
 
             return attributeDefault;
         }
     }
 
-    private void issueWarningMessage(String attributeName, Object attributeDefault) {
+    private void issueWarningMessage(String attributeName, Object valueProvided, Object attributeDefault) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isWarningEnabled()) {
-            Tr.warning(tc, "JAKARTASEC_WARNING_OIDC_MECH_CONFIG", new Object[] { attributeName, attributeDefault });
+            Tr.warning(tc, "JAKARTASEC_WARNING_OIDC_MECH_CONFIG", new Object[] { attributeName, valueProvided, attributeDefault });
         }
     }
 

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/TraceConstants.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/TraceConstants.java
@@ -8,11 +8,14 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-/**
- * @version 1.0.0
- */
-@org.osgi.annotation.versioning.Version("1.0.0")
-@TraceOptions(traceGroup = TraceConstants.TRACE_GROUP, messageBundle = TraceConstants.MESSAGE_BUNDLE)
 package io.openliberty.security.jakartasec;
 
-import com.ibm.websphere.ras.annotation.TraceOptions;
+/**
+ *
+ */
+public class TraceConstants {
+
+    public static final String TRACE_GROUP = "OpenIdConnect";
+    public static final String MESSAGE_BUNDLE = "io.openliberty.security.jakartasec.internal.resources.JakartaSecurity30Messages";
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/ClaimsDefinitionWrapperTest.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/ClaimsDefinitionWrapperTest.java
@@ -10,8 +10,12 @@
  *******************************************************************************/
 package io.openliberty.security.jakartasec;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
 import org.junit.Test;
 
 import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
@@ -21,6 +25,16 @@ import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDe
  * retrieving and evaluating both EL expressions and literal settings as called for in Jakarta Security 3.0.
  */
 public class ClaimsDefinitionWrapperTest {
+
+    private Map<String, Object> overrides;
+
+    private static final String STRING_EL_EXPRESSION = "#{'blah'.concat('blah')}";
+    private static final String EVALUATED_EL_EXPRESSION_STRING_RESULT = "blahblah";
+
+    @Before
+    public void setUp() {
+        overrides = new HashMap<String, Object>();
+    }
 
     @Test
     public void testGetCallerNameClaim() {
@@ -36,6 +50,26 @@ public class ClaimsDefinitionWrapperTest {
         ClaimsDefinitionWrapper wrapper = new ClaimsDefinitionWrapper(claimsDefinition);
 
         assertEquals(TestClaimsDefinition.CALLER_GROUPS_CLAIM_DEFAULT, wrapper.getCallerGroupsClaim());
+    }
+
+    @Test
+    public void testGetCallerNameClaim_EL() {
+        overrides.put(TestClaimsDefinition.CALLER_NAME_CLAIM, STRING_EL_EXPRESSION);
+
+        ClaimsDefinition claimsDefinition = TestClaimsDefinition.getInstanceofAnnotation(overrides);
+        ClaimsDefinitionWrapper wrapper = new ClaimsDefinitionWrapper(claimsDefinition);
+
+        assertEquals(EVALUATED_EL_EXPRESSION_STRING_RESULT, wrapper.getCallerNameClaim());
+    }
+
+    @Test
+    public void testGetCallerGroupsClaim_EL() {
+        overrides.put(TestClaimsDefinition.CALLER_GROUPS_CLAIM, STRING_EL_EXPRESSION);
+
+        ClaimsDefinition claimsDefinition = TestClaimsDefinition.getInstanceofAnnotation(overrides);
+        ClaimsDefinitionWrapper wrapper = new ClaimsDefinitionWrapper(claimsDefinition);
+
+        assertEquals(EVALUATED_EL_EXPRESSION_STRING_RESULT, wrapper.getCallerGroupsClaim());
     }
 
 }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/LogoutDefinitionWrapperTest.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/LogoutDefinitionWrapperTest.java
@@ -10,11 +10,18 @@
  *******************************************************************************/
 package io.openliberty.security.jakartasec;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import jakarta.security.enterprise.authentication.mechanism.http.openid.LogoutDefinition;
+import test.common.SharedOutputManager;
 
 /**
  * Verify that the {@link LogoutDefinitionWrapper} provides proper support for
@@ -22,12 +29,39 @@ import jakarta.security.enterprise.authentication.mechanism.http.openid.LogoutDe
  */
 public class LogoutDefinitionWrapperTest {
 
+    private Map<String, Object> overrides;
+
+    private static final String STRING_EL_EXPRESSION = "#{'blah'.concat('blah')}";
+    private static final String EVALUATED_EL_EXPRESSION_STRING_RESULT = "blahblah";
+
+    SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("*=all");
+    @Rule
+    public TestRule outputRule = outputMgr;
+
+    @Before
+    public void setUp() {
+        overrides = new HashMap<String, Object>();
+    }
+
     @Test
     public void testIsNotifyProvider() {
         LogoutDefinition logoutDefinition = TestLogoutDefinition.getInstanceofAnnotation(null);
         LogoutDefinitionWrapper wrapper = new LogoutDefinitionWrapper(logoutDefinition);
 
         assertEquals(false, wrapper.isNotifyProvider());
+    }
+
+    /**
+     * Test that the EL option works to resolve a boolean value for notifyProvider
+     */
+    @Test
+    public void testIsNotifyProvider_EL() {
+        overrides.put(TestLogoutDefinition.NOTIFY_PROVIDER_EXPRESSION, "#{ 9 > 6}");
+
+        LogoutDefinition logoutDefinition = TestLogoutDefinition.getInstanceofAnnotation(overrides);
+        LogoutDefinitionWrapper wrapper = new LogoutDefinitionWrapper(logoutDefinition);
+
+        assertEquals(true, wrapper.isNotifyProvider());
     }
 
     @Test
@@ -38,9 +72,48 @@ public class LogoutDefinitionWrapperTest {
         assertEquals(TestLogoutDefinition.EMPTY_DEFAULT, wrapper.getRedirectURI());
     }
 
+    /**
+     * Test that we can resolve an EL for the the redirectURI
+     */
+    @Test
+    public void testGetRedirectURI_EL() {
+        overrides.put(TestLogoutDefinition.REDIRECT_URI, STRING_EL_EXPRESSION);
+
+        LogoutDefinition logoutDefinition = TestLogoutDefinition.getInstanceofAnnotation(overrides);
+        LogoutDefinitionWrapper wrapper = new LogoutDefinitionWrapper(logoutDefinition);
+
+        assertEquals(EVALUATED_EL_EXPRESSION_STRING_RESULT, wrapper.getRedirectURI());
+    }
+
     @Test
     public void testIsAccessTokenExpiry() {
         LogoutDefinition logoutDefinition = TestLogoutDefinition.getInstanceofAnnotation(null);
+        LogoutDefinitionWrapper wrapper = new LogoutDefinitionWrapper(logoutDefinition);
+
+        assertEquals(false, wrapper.isAccessTokenExpiry());
+    }
+
+    /**
+     * Test that the EL option works to resolve a boolean value for notifyProvider
+     */
+    @Test
+    public void testIsAccessTokenExpiry_EL() {
+        overrides.put(TestLogoutDefinition.ACCESS_TOKEN_EXPIRY_EXPRESSION, "#{ 9 > 6}");
+
+        LogoutDefinition logoutDefinition = TestLogoutDefinition.getInstanceofAnnotation(overrides);
+        LogoutDefinitionWrapper wrapper = new LogoutDefinitionWrapper(logoutDefinition);
+
+        assertEquals(true, wrapper.isAccessTokenExpiry());
+    }
+
+    /**
+     * Test with an expression that resolves to a non-Boolean value. We should default to false.
+     */
+    @Test
+    public void testIsAccessTokenExpiryBadValue() {
+        overrides.put(TestLogoutDefinition.ACCESS_TOKEN_EXPIRY_EXPRESSION, STRING_EL_EXPRESSION);
+
+        LogoutDefinition logoutDefinition = TestLogoutDefinition.getInstanceofAnnotation(overrides);
         LogoutDefinitionWrapper wrapper = new LogoutDefinitionWrapper(logoutDefinition);
 
         assertEquals(false, wrapper.isAccessTokenExpiry());
@@ -52,6 +125,19 @@ public class LogoutDefinitionWrapperTest {
         LogoutDefinitionWrapper wrapper = new LogoutDefinitionWrapper(logoutDefinition);
 
         assertEquals(false, wrapper.isIdentityTokenExpiry());
+    }
+
+    /**
+     * Test that the EL option works to resolve a boolean value for notifyProvider
+     */
+    @Test
+    public void testIsIdentityTokenExpiry_EL() {
+        overrides.put(TestLogoutDefinition.IDENTITY_TOKEN_EXPIRY_EXPRESSION, "#{ 9 > 6}");
+
+        LogoutDefinition logoutDefinition = TestLogoutDefinition.getInstanceofAnnotation(overrides);
+        LogoutDefinitionWrapper wrapper = new LogoutDefinitionWrapper(logoutDefinition);
+
+        assertEquals(true, wrapper.isIdentityTokenExpiry());
     }
 
 }


### PR DESCRIPTION
Fixes #21156 

Added EL processing for:
- ClaimsDefinitionWrapper
- LogoutDefinitionWrapper

Added EL tests for both of the updated Wrappers above

Added support for an nlsprops files to log a warning when we can't process an EL for all the wrappers in this package. Claimed messages 2500-2519 in the message list wiki.

OpenIdProviderMetadataWrapper was having problems so I decided to split it into its own issue: #22465

I copied around the `evaluate...` and `issueWarningMessage` methods -- these could be refactored and moved to a helper class.