### PR TITLE
PR for Issue 21166: Send token request to OP and enhance discovery

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanism.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanism.java
@@ -29,6 +29,7 @@ import io.openliberty.security.oidcclientcore.client.Client;
 import io.openliberty.security.oidcclientcore.client.ClientManager;
 import io.openliberty.security.oidcclientcore.exceptions.AuthenticationResponseException;
 import io.openliberty.security.oidcclientcore.exceptions.TokenRequestException;
+import io.openliberty.security.oidcclientcore.token.JakartaOidcTokenRequest;
 import io.openliberty.security.oidcclientcore.token.TokenResponse;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
@@ -225,7 +226,7 @@ public class OidcHttpAuthenticationMechanism implements HttpAuthenticationMechan
 
         Hashtable<String, Object> customProperties = providerAuthenticationResult.getCustomProperties();
         if (customProperties != null) {
-            TokenResponse tokenResponse = (TokenResponse) customProperties.get(AuthorizationCodeFlow.AUTH_RESULT_CUSTOM_PROP_TOKEN_RESPONSE);
+            TokenResponse tokenResponse = (TokenResponse) customProperties.get(JakartaOidcTokenRequest.AUTH_RESULT_CUSTOM_PROP_TOKEN_RESPONSE);
             if (tokenResponse != null) {
                 // TODO: credential = new OidcTokensCredential(client, tokenResponse, userinfoResponse);
                 credential = new Credential() {

--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanism.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanism.java
@@ -23,10 +23,12 @@ import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 
 import io.openliberty.security.jakartasec.JakartaSec30Constants;
 import io.openliberty.security.jakartasec.OpenIdAuthenticationMechanismDefinitionWrapper;
+import io.openliberty.security.oidcclientcore.authentication.AuthorizationCodeFlow;
 import io.openliberty.security.oidcclientcore.authentication.AuthorizationRequestUtils;
 import io.openliberty.security.oidcclientcore.client.Client;
 import io.openliberty.security.oidcclientcore.client.ClientManager;
 import io.openliberty.security.oidcclientcore.exceptions.AuthenticationResponseException;
+import io.openliberty.security.oidcclientcore.exceptions.TokenRequestException;
 import io.openliberty.security.oidcclientcore.token.TokenResponse;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
@@ -182,6 +184,8 @@ public class OidcHttpAuthenticationMechanism implements HttpAuthenticationMechan
             status = processContinueFlowResult(providerAuthenticationResult, httpMessageContext);
         } catch (AuthenticationResponseException e) {
             status = httpMessageContext.notifyContainerAboutLogin(getCredentialValidationResultFromException(e));
+        } catch (TokenRequestException e) {
+            status = httpMessageContext.notifyContainerAboutLogin(CredentialValidationResult.INVALID_RESULT);
         }
 
         return status;
@@ -221,7 +225,7 @@ public class OidcHttpAuthenticationMechanism implements HttpAuthenticationMechan
 
         Hashtable<String, Object> customProperties = providerAuthenticationResult.getCustomProperties();
         if (customProperties != null) {
-            TokenResponse tokenResponse = (TokenResponse) customProperties.get("TOKEN_RESPONSE");
+            TokenResponse tokenResponse = (TokenResponse) customProperties.get(AuthorizationCodeFlow.AUTH_RESULT_CUSTOM_PROP_TOKEN_RESPONSE);
             if (tokenResponse != null) {
                 // TODO: credential = new OidcTokensCredential(client, tokenResponse, userinfoResponse);
                 credential = new Credential() {

--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/test/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanismTest.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/test/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanismTest.java
@@ -27,8 +27,10 @@ import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 
 import io.openliberty.security.jakartasec.JakartaSec30Constants;
 import io.openliberty.security.jakartasec.TestOpenIdAuthenticationMechanismDefinition;
+import io.openliberty.security.oidcclientcore.authentication.AuthorizationCodeFlow;
 import io.openliberty.security.oidcclientcore.client.Client;
 import io.openliberty.security.oidcclientcore.exceptions.AuthenticationResponseException;
+import io.openliberty.security.oidcclientcore.exceptions.TokenRequestException;
 import io.openliberty.security.oidcclientcore.token.TokenResponse;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
@@ -215,7 +217,7 @@ public class OidcHttpAuthenticationMechanismTest {
         });
     }
 
-    private void clientContinuesFlow(ProviderAuthenticationResult providerAuthenticationResult) throws AuthenticationResponseException {
+    private void clientContinuesFlow(ProviderAuthenticationResult providerAuthenticationResult) throws AuthenticationResponseException, TokenRequestException {
         mockery.checking(new Expectations() {
             {
                 one(client).continueFlow(request, response);
@@ -262,7 +264,7 @@ public class OidcHttpAuthenticationMechanismTest {
 
     private ProviderAuthenticationResult createSuccessfulProviderAuthenticationResult() {
         Hashtable<String, Object> customProperties = new Hashtable<String, Object>();
-        customProperties.put("TOKEN_RESPONSE", tokenResponse);
+        customProperties.put(AuthorizationCodeFlow.AUTH_RESULT_CUSTOM_PROP_TOKEN_RESPONSE, tokenResponse);
         return new ProviderAuthenticationResult(AuthResult.SUCCESS, HttpServletResponse.SC_OK, null, null, customProperties, null);
     }
 

--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/test/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanismTest.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/test/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanismTest.java
@@ -31,6 +31,7 @@ import io.openliberty.security.oidcclientcore.authentication.AuthorizationCodeFl
 import io.openliberty.security.oidcclientcore.client.Client;
 import io.openliberty.security.oidcclientcore.exceptions.AuthenticationResponseException;
 import io.openliberty.security.oidcclientcore.exceptions.TokenRequestException;
+import io.openliberty.security.oidcclientcore.token.JakartaOidcTokenRequest;
 import io.openliberty.security.oidcclientcore.token.TokenResponse;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
@@ -264,7 +265,7 @@ public class OidcHttpAuthenticationMechanismTest {
 
     private ProviderAuthenticationResult createSuccessfulProviderAuthenticationResult() {
         Hashtable<String, Object> customProperties = new Hashtable<String, Object>();
-        customProperties.put(AuthorizationCodeFlow.AUTH_RESULT_CUSTOM_PROP_TOKEN_RESPONSE, tokenResponse);
+        customProperties.put(JakartaOidcTokenRequest.AUTH_RESULT_CUSTOM_PROP_TOKEN_RESPONSE, tokenResponse);
         return new ProviderAuthenticationResult(AuthResult.SUCCESS, HttpServletResponse.SC_OK, null, null, customProperties, null);
     }
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
+++ b/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
@@ -35,7 +35,8 @@ Export-Package: \
 	io.openliberty.security.oidcclientcore.userinfo
 
 -dsannotations: \
-	io.openliberty.security.oidcclientcore.authentication.JakartaOidcAuthorizationRequest
+	io.openliberty.security.oidcclientcore.authentication.JakartaOidcAuthorizationRequest,\
+	io.openliberty.security.oidcclientcore.authentication.AuthorizationCodeFlow
 
 -buildpath: \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\

--- a/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
+++ b/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
@@ -35,8 +35,7 @@ Export-Package: \
 	io.openliberty.security.oidcclientcore.userinfo
 
 -dsannotations: \
-	io.openliberty.security.oidcclientcore.authentication.JakartaOidcAuthorizationRequest,\
-	io.openliberty.security.oidcclientcore.authentication.AuthorizationCodeFlow
+	io.openliberty.security.oidcclientcore.http.EndpointRequest
 
 -buildpath: \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\

--- a/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
+++ b/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
@@ -82,3 +82,12 @@ TOKEN_VALIDATION_EXCEPTION=CWWKS2415E: The {0} OpenID Connect client encountered
 TOKEN_VALIDATION_EXCEPTION.explanation=A problem might exist with the issuer, azp, iat, or exp claim validation, or with the token signature validation.
 TOKEN_VALIDATION_EXCEPTION.useraction=For more information, see the error in the message.
 
+TOKEN_REQUEST_ERROR=CWWKS2416E: The {0} OpenID Connect client encountered the following error while sending a request to the token endpoint of the OpenID Connect provider: {1}
+TOKEN_REQUEST_ERROR.explanation=The OpenID Connect client might be missing information, the request to the token endpoint failed, or another error occurred while processing the token endpoint response.
+TOKEN_REQUEST_ERROR.useraction=See the error in the message for more information. Verify that the OpenID Connect provider returned a code in the authentication response.
+
+# Do not translate "token_endpoint"
+TOKEN_ENDPOINT_MISSING=CWWKS2417E: The {0} OpenID Connect client cannot find a value for the token endpoint for the OpenID Connect provider.
+TOKEN_ENDPOINT_MISSING.explanation=The token endpoint URL is missing from the OpenID Connect provider metadata and the OpenID Connect client configuration.
+TOKEN_ENDPOINT_MISSING.useraction=Verify that the OpenID Connect provider metadata contains a token_endpoint value. A token endpoint can also be specified in the OpenID Connect client configuration.
+

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationCodeFlow.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationCodeFlow.java
@@ -10,24 +10,65 @@
  *******************************************************************************/
 package io.openliberty.security.oidcclientcore.authentication;
 
+import java.util.Hashtable;
+
+import javax.net.ssl.SSLSocketFactory;
+import javax.security.auth.Subject;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+
+import com.ibm.websphere.ras.ProtectedString;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.webcontainer.security.AuthResult;
 import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
+import com.ibm.wsspi.ssl.SSLSupport;
 
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
+import io.openliberty.security.oidcclientcore.client.OidcProviderMetadata;
 import io.openliberty.security.oidcclientcore.exceptions.AuthenticationResponseException;
+import io.openliberty.security.oidcclientcore.exceptions.TokenRequestException;
+import io.openliberty.security.oidcclientcore.token.TokenConstants;
+import io.openliberty.security.oidcclientcore.token.TokenRequestor;
+import io.openliberty.security.oidcclientcore.token.TokenRequestor.Builder;
+import io.openliberty.security.oidcclientcore.token.TokenResponse;
 
+@Component(service = AuthorizationCodeFlow.class, immediate = true, configurationPolicy = ConfigurationPolicy.IGNORE)
 public class AuthorizationCodeFlow extends AbstractFlow {
 
     public static final TraceComponent tc = Tr.register(AuthorizationCodeFlow.class);
 
-    private final OidcClientConfig oidcClientConfig;
+    public static final String AUTH_RESULT_CUSTOM_PROP_TOKEN_RESPONSE = "TOKEN_RESPONSE";
+
+    private static final String KEY_SSL_SUPPORT = "sslSupport";
+    private static volatile SSLSupport sslSupport;
+
+    private OidcClientConfig oidcClientConfig;
+
+    /**
+     * Do not use; needed for this to be a valid @Component object.
+     */
+    @Deprecated
+    public AuthorizationCodeFlow() {
+        // Only for OSGi initialization
+    }
 
     public AuthorizationCodeFlow(OidcClientConfig oidcClientConfig) {
         this.oidcClientConfig = oidcClientConfig;
+    }
+
+    @Reference(name = KEY_SSL_SUPPORT, policy = ReferencePolicy.DYNAMIC)
+    protected void setSslSupport(SSLSupport sslSupportSvc) {
+        sslSupport = sslSupportSvc;
+    }
+
+    protected void unsetSslSupport(SSLSupport sslSupportSvc) {
+        sslSupport = null;
     }
 
     @Override
@@ -44,11 +85,85 @@ public class AuthorizationCodeFlow extends AbstractFlow {
      * 8. (Not done for Jakarta Security 3.0) Client validates the ID token and retrieves the End-User's Subject Identifier.
      */
     @Override
-    public ProviderAuthenticationResult continueFlow(HttpServletRequest request, HttpServletResponse response) throws AuthenticationResponseException {
+    public ProviderAuthenticationResult continueFlow(HttpServletRequest request, HttpServletResponse response) throws AuthenticationResponseException, TokenRequestException {
         JakartaOidcAuthenticationResponseValidator responseValidator = new JakartaOidcAuthenticationResponseValidator(request, response, oidcClientConfig);
         responseValidator.validateResponse();
-        // TODO: Clear stored state value
+
+        TokenResponse tokenEndpointResponse = sendTokenRequest(request);
+
+        return createAuthenticationResultFromTokenResponse(tokenEndpointResponse);
+    }
+
+    TokenResponse sendTokenRequest(HttpServletRequest request) throws TokenRequestException {
+        String tokenEndpoint = getTokenEndpoint();
+        if (tokenEndpoint == null || tokenEndpoint.isEmpty()) {
+            String clientId = oidcClientConfig.getClientId();
+            String message = Tr.formatMessage(tc, "TOKEN_ENDPOINT_MISSING", clientId);
+            throw new TokenRequestException(clientId, message);
+        }
+        String authzCode = request.getParameter(TokenConstants.CODE);
+        return sendTokenRequestForCode(tokenEndpoint, authzCode);
+    }
+
+    String getTokenEndpoint() {
+        String tokenEndpoint = null;
+        OidcProviderMetadata providerMetadata = oidcClientConfig.getProviderMetadata();
+        if (providerMetadata != null) {
+            // Provider metadata overrides properties discovered via providerUri
+            tokenEndpoint = providerMetadata.getTokenEndpoint();
+            if (tokenEndpoint != null && !tokenEndpoint.isEmpty()) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Token endpoint found in the provider metadata: [" + tokenEndpoint + "]");
+                }
+                return tokenEndpoint;
+            }
+        }
+        return getTokenEndpointFromDiscoveryMetadata();
+    }
+
+    String getTokenEndpointFromDiscoveryMetadata() {
+        String tokenEndpoint = null;
+        // TODO
+//        JSONObject discoveryData = getProviderMetadata();
+//        tokenEndpoint = (String) discoveryData.get(OidcDiscoveryConstants.METADATA_KEY_TOKEN_ENDPOINT);
+//        if (tokenEndpoint == null) {
+//            String nlsMessage = Tr.formatMessage(tc, "DISCOVERY_METADATA_MISSING_VALUE", OidcDiscoveryConstants.METADATA_KEY_TOKEN_ENDPOINT);
+//            throw new OidcDiscoveryException(oidcClientConfig.getClientId(), oidcClientConfig.getProviderURI(), nlsMessage);
+//        }
+        return tokenEndpoint;
+    }
+
+    TokenResponse sendTokenRequestForCode(String tokenEndpoint, String authzCode) throws TokenRequestException {
+        String clientId = oidcClientConfig.getClientId();
+        String clientSecret = null;
+        ProtectedString clientSecretProtectedString = oidcClientConfig.getClientSecret();
+        if (clientSecretProtectedString != null) {
+            clientSecret = new String(clientSecretProtectedString.getChars());
+        }
+
+        Builder tokenRequestBuilder = new TokenRequestor.Builder(tokenEndpoint, clientId, clientSecret, oidcClientConfig.getRedirectURI(), authzCode);
+        tokenRequestBuilder.sslSocketFactory(getSSLSocketFactory());
+        tokenRequestBuilder.grantType(TokenConstants.AUTHORIZATION_CODE);
+        TokenRequestor tokenRequestor = tokenRequestBuilder.build();
+        try {
+            return tokenRequestor.requestTokens();
+        } catch (Exception e) {
+            throw new TokenRequestException(clientId, e.toString(), e);
+        }
+    }
+
+    SSLSocketFactory getSSLSocketFactory() {
+        if (sslSupport != null) {
+            return sslSupport.getSSLSocketFactory();
+        }
         return null;
+    }
+
+    ProviderAuthenticationResult createAuthenticationResultFromTokenResponse(TokenResponse tokenEndpointResponse) {
+        Hashtable<String, Object> customProperties = new Hashtable<>();
+        customProperties.put(AUTH_RESULT_CUSTOM_PROP_TOKEN_RESPONSE, tokenEndpointResponse);
+
+        return new ProviderAuthenticationResult(AuthResult.SUCCESS, HttpServletResponse.SC_OK, null, new Subject(), customProperties, null);
     }
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationCodeFlow.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationCodeFlow.java
@@ -10,65 +10,26 @@
  *******************************************************************************/
 package io.openliberty.security.oidcclientcore.authentication;
 
-import java.util.Hashtable;
-
-import javax.net.ssl.SSLSocketFactory;
-import javax.security.auth.Subject;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferencePolicy;
-
-import com.ibm.websphere.ras.ProtectedString;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.webcontainer.security.AuthResult;
 import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
-import com.ibm.wsspi.ssl.SSLSupport;
 
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
-import io.openliberty.security.oidcclientcore.client.OidcProviderMetadata;
 import io.openliberty.security.oidcclientcore.exceptions.AuthenticationResponseException;
 import io.openliberty.security.oidcclientcore.exceptions.TokenRequestException;
-import io.openliberty.security.oidcclientcore.token.TokenConstants;
-import io.openliberty.security.oidcclientcore.token.TokenRequestor;
-import io.openliberty.security.oidcclientcore.token.TokenRequestor.Builder;
-import io.openliberty.security.oidcclientcore.token.TokenResponse;
+import io.openliberty.security.oidcclientcore.token.JakartaOidcTokenRequest;
 
-@Component(service = AuthorizationCodeFlow.class, immediate = true, configurationPolicy = ConfigurationPolicy.IGNORE)
 public class AuthorizationCodeFlow extends AbstractFlow {
 
     public static final TraceComponent tc = Tr.register(AuthorizationCodeFlow.class);
 
-    public static final String AUTH_RESULT_CUSTOM_PROP_TOKEN_RESPONSE = "TOKEN_RESPONSE";
-
-    private static final String KEY_SSL_SUPPORT = "sslSupport";
-    private static volatile SSLSupport sslSupport;
-
-    private OidcClientConfig oidcClientConfig;
-
-    /**
-     * Do not use; needed for this to be a valid @Component object.
-     */
-    @Deprecated
-    public AuthorizationCodeFlow() {
-        // Only for OSGi initialization
-    }
+    private final OidcClientConfig oidcClientConfig;
 
     public AuthorizationCodeFlow(OidcClientConfig oidcClientConfig) {
         this.oidcClientConfig = oidcClientConfig;
-    }
-
-    @Reference(name = KEY_SSL_SUPPORT, policy = ReferencePolicy.DYNAMIC)
-    protected void setSslSupport(SSLSupport sslSupportSvc) {
-        sslSupport = sslSupportSvc;
-    }
-
-    protected void unsetSslSupport(SSLSupport sslSupportSvc) {
-        sslSupport = null;
     }
 
     @Override
@@ -89,81 +50,8 @@ public class AuthorizationCodeFlow extends AbstractFlow {
         JakartaOidcAuthenticationResponseValidator responseValidator = new JakartaOidcAuthenticationResponseValidator(request, response, oidcClientConfig);
         responseValidator.validateResponse();
 
-        TokenResponse tokenEndpointResponse = sendTokenRequest(request);
-
-        return createAuthenticationResultFromTokenResponse(tokenEndpointResponse);
-    }
-
-    TokenResponse sendTokenRequest(HttpServletRequest request) throws TokenRequestException {
-        String tokenEndpoint = getTokenEndpoint();
-        if (tokenEndpoint == null || tokenEndpoint.isEmpty()) {
-            String clientId = oidcClientConfig.getClientId();
-            String message = Tr.formatMessage(tc, "TOKEN_ENDPOINT_MISSING", clientId);
-            throw new TokenRequestException(clientId, message);
-        }
-        String authzCode = request.getParameter(TokenConstants.CODE);
-        return sendTokenRequestForCode(tokenEndpoint, authzCode);
-    }
-
-    String getTokenEndpoint() {
-        String tokenEndpoint = null;
-        OidcProviderMetadata providerMetadata = oidcClientConfig.getProviderMetadata();
-        if (providerMetadata != null) {
-            // Provider metadata overrides properties discovered via providerUri
-            tokenEndpoint = providerMetadata.getTokenEndpoint();
-            if (tokenEndpoint != null && !tokenEndpoint.isEmpty()) {
-                if (tc.isDebugEnabled()) {
-                    Tr.debug(tc, "Token endpoint found in the provider metadata: [" + tokenEndpoint + "]");
-                }
-                return tokenEndpoint;
-            }
-        }
-        return getTokenEndpointFromDiscoveryMetadata();
-    }
-
-    String getTokenEndpointFromDiscoveryMetadata() {
-        String tokenEndpoint = null;
-        // TODO
-//        JSONObject discoveryData = getProviderMetadata();
-//        tokenEndpoint = (String) discoveryData.get(OidcDiscoveryConstants.METADATA_KEY_TOKEN_ENDPOINT);
-//        if (tokenEndpoint == null) {
-//            String nlsMessage = Tr.formatMessage(tc, "DISCOVERY_METADATA_MISSING_VALUE", OidcDiscoveryConstants.METADATA_KEY_TOKEN_ENDPOINT);
-//            throw new OidcDiscoveryException(oidcClientConfig.getClientId(), oidcClientConfig.getProviderURI(), nlsMessage);
-//        }
-        return tokenEndpoint;
-    }
-
-    TokenResponse sendTokenRequestForCode(String tokenEndpoint, String authzCode) throws TokenRequestException {
-        String clientId = oidcClientConfig.getClientId();
-        String clientSecret = null;
-        ProtectedString clientSecretProtectedString = oidcClientConfig.getClientSecret();
-        if (clientSecretProtectedString != null) {
-            clientSecret = new String(clientSecretProtectedString.getChars());
-        }
-
-        Builder tokenRequestBuilder = new TokenRequestor.Builder(tokenEndpoint, clientId, clientSecret, oidcClientConfig.getRedirectURI(), authzCode);
-        tokenRequestBuilder.sslSocketFactory(getSSLSocketFactory());
-        tokenRequestBuilder.grantType(TokenConstants.AUTHORIZATION_CODE);
-        TokenRequestor tokenRequestor = tokenRequestBuilder.build();
-        try {
-            return tokenRequestor.requestTokens();
-        } catch (Exception e) {
-            throw new TokenRequestException(clientId, e.toString(), e);
-        }
-    }
-
-    SSLSocketFactory getSSLSocketFactory() {
-        if (sslSupport != null) {
-            return sslSupport.getSSLSocketFactory();
-        }
-        return null;
-    }
-
-    ProviderAuthenticationResult createAuthenticationResultFromTokenResponse(TokenResponse tokenEndpointResponse) {
-        Hashtable<String, Object> customProperties = new Hashtable<>();
-        customProperties.put(AUTH_RESULT_CUSTOM_PROP_TOKEN_RESPONSE, tokenEndpointResponse);
-
-        return new ProviderAuthenticationResult(AuthResult.SUCCESS, HttpServletResponse.SC_OK, null, new Subject(), customProperties, null);
+        JakartaOidcTokenRequest tokenRequest = new JakartaOidcTokenRequest(oidcClientConfig, request);
+        return tokenRequest.sendRequest();
     }
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationRequest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationRequest.java
@@ -17,12 +17,13 @@ import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 
 import io.openliberty.security.oidcclientcore.exceptions.OidcClientConfigurationException;
 import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
+import io.openliberty.security.oidcclientcore.http.EndpointRequest;
 import io.openliberty.security.oidcclientcore.storage.OidcClientStorageConstants;
 import io.openliberty.security.oidcclientcore.storage.OidcStorageUtils;
 import io.openliberty.security.oidcclientcore.storage.Storage;
 import io.openliberty.security.oidcclientcore.storage.StorageProperties;
 
-public abstract class AuthorizationRequest {
+public abstract class AuthorizationRequest extends EndpointRequest {
 
     protected HttpServletRequest request;
     protected HttpServletResponse response;
@@ -32,13 +33,6 @@ public abstract class AuthorizationRequest {
 
     protected AuthorizationRequestUtils requestUtils = new AuthorizationRequestUtils();
     protected OidcStorageUtils storageUtils = new OidcStorageUtils();
-
-    /**
-     * Do not use; only for OSGi initialization
-     */
-    @Deprecated
-    public AuthorizationRequest() {
-    }
 
     public AuthorizationRequest(HttpServletRequest request, HttpServletResponse response, String clientId) {
         this.request = request;

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/Flow.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/Flow.java
@@ -16,6 +16,7 @@ import javax.servlet.http.HttpServletResponse;
 import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 
 import io.openliberty.security.oidcclientcore.exceptions.AuthenticationResponseException;
+import io.openliberty.security.oidcclientcore.exceptions.TokenRequestException;
 
 public interface Flow {
 
@@ -30,6 +31,6 @@ public interface Flow {
      * Validates the Authentication Response that was the result of a previous call to <code>startFlow()</code>. If the response is
      * valid, this moves on to complete the authentication flow and obtains whatever tokens are appropriate.
      */
-    public ProviderAuthenticationResult continueFlow(HttpServletRequest request, HttpServletResponse response) throws AuthenticationResponseException;
+    public ProviderAuthenticationResult continueFlow(HttpServletRequest request, HttpServletResponse response) throws AuthenticationResponseException, TokenRequestException;
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthenticationResponseValidator.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthenticationResponseValidator.java
@@ -39,7 +39,7 @@ public class JakartaOidcAuthenticationResponseValidator extends AuthenticationRe
 
     private void instantiateStorage(OidcClientConfig config) {
         if (oidcClientConfig.isUseSession()) {
-            this.storage = new SessionBasedStorage();
+            this.storage = new SessionBasedStorage(request);
         } else {
             this.storage = new CookieBasedStorage(request, response);
         }
@@ -58,13 +58,16 @@ public class JakartaOidcAuthenticationResponseValidator extends AuthenticationRe
      * <li>If the request contains a parameter error, reply with CredentialValidationResult.INVALID_RESULT.</li>
      * </ul>
      * If none of the above listed additional conditions apply, the request is taken to be a valid callback and the authentication
-     * between the end-user (caller) and the OpenID Connect Provider is considered to have been successful.
+     * between the end-user (caller) and the OpenID Connect Provider is considered to have been successful. The authentication
+     * mechanism must now move to [the next step of the OpenID Connect flow] and mark this internally by clearing the stored State
+     * value (remove it from the HTTP session or Cookie).
      */
     @Override
     public void validateResponse() throws AuthenticationResponseException {
         String state = getAndVerifyStateValue();
         checkRequestAgainstRedirectUri(state);
         checkForErrorParameter();
+        clearStoredState(state);
     }
 
     /**
@@ -132,6 +135,11 @@ public class JakartaOidcAuthenticationResponseValidator extends AuthenticationRe
             String nlsMessage = Tr.formatMessage(tc, "CALLBACK_URL_INCLUDES_ERROR_PARAMETER", errorParameter);
             throw new AuthenticationResponseException(ValidationResult.INVALID_RESULT, oidcClientConfig.getClientId(), nlsMessage);
         }
+    }
+
+    void clearStoredState(String state) {
+        String storageKey = OidcStorageUtils.getStateStorageKey(state);
+        storage.remove(storageKey);
     }
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/client/Client.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/client/Client.java
@@ -18,10 +18,10 @@ import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 import io.openliberty.security.oidcclientcore.authentication.AbstractFlow;
 import io.openliberty.security.oidcclientcore.authentication.Flow;
 import io.openliberty.security.oidcclientcore.exceptions.AuthenticationResponseException;
+import io.openliberty.security.oidcclientcore.exceptions.TokenRequestException;
 import io.openliberty.security.oidcclientcore.token.TokenResponse;
 import io.openliberty.security.oidcclientcore.token.TokenResponseValidator;
 import io.openliberty.security.oidcclientcore.token.TokenValidationException;
-
 
 public class Client {
 
@@ -36,7 +36,7 @@ public class Client {
         return flow.startFlow(request, response);
     }
 
-    public ProviderAuthenticationResult continueFlow(HttpServletRequest request, HttpServletResponse response) throws AuthenticationResponseException {
+    public ProviderAuthenticationResult continueFlow(HttpServletRequest request, HttpServletResponse response) throws AuthenticationResponseException, TokenRequestException {
         Flow flow = AbstractFlow.getInstance(oidcClientConfig);
         return flow.continueFlow(request, response);
     }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/discovery/OidcDiscoveryConstants.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/discovery/OidcDiscoveryConstants.java
@@ -13,6 +13,7 @@ package io.openliberty.security.oidcclientcore.discovery;
 public class OidcDiscoveryConstants {
 
     public static final String METADATA_KEY_AUTHORIZATION_ENDPOINT = "authorization_endpoint";
+    public static final String METADATA_KEY_TOKEN_ENDPOINT = "token_endpoint";
 
     public static final String WELL_KNOWN_SUFFIX = ".well-known/openid-configuration";
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/TokenRequestException.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/TokenRequestException.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oidcclientcore.exceptions;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+public class TokenRequestException extends Exception {
+
+    public static final TraceComponent tc = Tr.register(TokenRequestException.class);
+
+    private static final long serialVersionUID = 1L;
+
+    private final String clientId;
+    private final String nlsMessage;
+
+    public TokenRequestException(String clientId, String nlsMessage) {
+        this.clientId = clientId;
+        this.nlsMessage = nlsMessage;
+    }
+
+    public TokenRequestException(String clientId, String nlsMessage, Throwable cause) {
+        super(cause);
+        this.clientId = clientId;
+        this.nlsMessage = nlsMessage;
+    }
+
+    @Override
+    public String getMessage() {
+        return Tr.formatMessage(tc, "TOKEN_REQUEST_ERROR", clientId, nlsMessage);
+    }
+
+}

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/http/EndpointRequest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/http/EndpointRequest.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oidcclientcore.http;
+
+import javax.net.ssl.SSLSocketFactory;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+
+import com.ibm.json.java.JSONObject;
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.wsspi.ssl.SSLSupport;
+
+import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
+import io.openliberty.security.oidcclientcore.discovery.DiscoveryHandler;
+import io.openliberty.security.oidcclientcore.discovery.OidcDiscoveryConstants;
+import io.openliberty.security.oidcclientcore.exceptions.OidcClientConfigurationException;
+import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
+
+@Component(service = EndpointRequest.class, immediate = true, configurationPolicy = ConfigurationPolicy.IGNORE)
+public class EndpointRequest {
+
+    public static final TraceComponent tc = Tr.register(EndpointRequest.class);
+
+    private static final String KEY_SSL_SUPPORT = "sslSupport";
+    private static volatile SSLSupport sslSupport;
+
+    @Reference(name = KEY_SSL_SUPPORT, policy = ReferencePolicy.DYNAMIC)
+    protected void setSslSupport(SSLSupport sslSupportSvc) {
+        sslSupport = sslSupportSvc;
+    }
+
+    protected void unsetSslSupport(SSLSupport sslSupportSvc) {
+        sslSupport = null;
+    }
+
+    protected SSLSocketFactory getSSLSocketFactory() {
+        if (sslSupport != null) {
+            return sslSupport.getSSLSocketFactory();
+        }
+        return null;
+    }
+
+    public DiscoveryHandler getDiscoveryHandler() {
+        SSLSocketFactory sslSocketFactory = getSSLSocketFactory();
+        return new DiscoveryHandler(sslSocketFactory);
+    }
+
+    public JSONObject getProviderDiscoveryMetadata(OidcClientConfig oidcClientConfig) {
+        JSONObject discoveryData = null;
+        try {
+            String discoveryUri = oidcClientConfig.getProviderURI();
+            if (discoveryUri == null || discoveryUri.isEmpty()) {
+                String clientId = oidcClientConfig.getClientId();
+                String nlsMessage = Tr.formatMessage(tc, "OIDC_CLIENT_MISSING_PROVIDER_URI", clientId);
+                throw new OidcClientConfigurationException(clientId, nlsMessage);
+            }
+            discoveryUri = addWellKnownSuffixIfNeeded(discoveryUri);
+            discoveryData = fetchProviderMetadataFromDiscoveryUrl(discoveryUri, oidcClientConfig.getClientId());
+        } catch (OidcClientConfigurationException | OidcDiscoveryException e) {
+            Tr.error(tc, e.getMessage());
+        }
+        return discoveryData;
+    }
+
+    /**
+     * Per https://jakarta.ee/specifications/security/3.0/jakarta-security-spec-3.0.html#metadata-configuration, the providerURI
+     * "defines the base URL of the OpenID Connect Provider where the /.well-known/openid-configuration is appended to (or used
+     * as-is when it is the well known configuration URL itself)."
+     */
+    String addWellKnownSuffixIfNeeded(String providerUri) {
+        if (!providerUri.endsWith(OidcDiscoveryConstants.WELL_KNOWN_SUFFIX)) {
+            if (!providerUri.endsWith("/")) {
+                providerUri += "/";
+            }
+            providerUri += OidcDiscoveryConstants.WELL_KNOWN_SUFFIX;
+        }
+        return providerUri;
+    }
+
+    JSONObject fetchProviderMetadataFromDiscoveryUrl(String discoveryUri, String clientId) throws OidcDiscoveryException {
+        DiscoveryHandler discoveryHandler = getDiscoveryHandler();
+        return discoveryHandler.fetchDiscoveryDataJson(discoveryUri, clientId);
+    }
+
+}

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/CookieBasedStorage.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/CookieBasedStorage.java
@@ -69,6 +69,7 @@ public class CookieBasedStorage implements Storage {
         return null;
     }
 
+    @Override
     public void remove(String name) {
         if (name == null) {
             if (tc.isDebugEnabled()) {

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/SessionBasedStorage.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/SessionBasedStorage.java
@@ -49,6 +49,7 @@ public class SessionBasedStorage implements Storage {
         return (String) value;
     }
 
+    @Override
     public void remove(String name) {
         HttpSession session = request.getSession();
         session.removeAttribute(name);

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/Storage.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/Storage.java
@@ -42,4 +42,9 @@ public interface Storage {
      */
     String get(String name);
 
+    /**
+     * Removes the value associated with the provided name from storage.
+     */
+    void remove(String name);
+
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/JakartaOidcTokenRequest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/JakartaOidcTokenRequest.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oidcclientcore.token;
+
+import java.util.Hashtable;
+
+import javax.security.auth.Subject;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.ibm.json.java.JSONObject;
+import com.ibm.websphere.ras.ProtectedString;
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.webcontainer.security.AuthResult;
+import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
+
+import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
+import io.openliberty.security.oidcclientcore.client.OidcProviderMetadata;
+import io.openliberty.security.oidcclientcore.discovery.OidcDiscoveryConstants;
+import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
+import io.openliberty.security.oidcclientcore.exceptions.TokenRequestException;
+import io.openliberty.security.oidcclientcore.http.EndpointRequest;
+import io.openliberty.security.oidcclientcore.token.TokenRequestor.Builder;
+
+public class JakartaOidcTokenRequest extends EndpointRequest {
+
+    public static final TraceComponent tc = Tr.register(JakartaOidcTokenRequest.class);
+
+    public static final String AUTH_RESULT_CUSTOM_PROP_TOKEN_RESPONSE = "TOKEN_RESPONSE";
+
+    private final OidcClientConfig oidcClientConfig;
+    private final OidcProviderMetadata providerMetadata;
+    private final HttpServletRequest request;
+
+    public JakartaOidcTokenRequest(OidcClientConfig oidcClientConfig, HttpServletRequest request) {
+        this.oidcClientConfig = oidcClientConfig;
+        this.providerMetadata = (oidcClientConfig == null) ? null : oidcClientConfig.getProviderMetadata();
+        this.request = request;
+    }
+
+    public ProviderAuthenticationResult sendRequest() throws TokenRequestException {
+        TokenResponse tokenEndpointResponse = sendTokenRequest();
+        return createAuthenticationResultFromTokenResponse(tokenEndpointResponse);
+    }
+
+    @FFDCIgnore(OidcDiscoveryException.class)
+    TokenResponse sendTokenRequest() throws TokenRequestException {
+        String tokenEndpoint = null;
+        try {
+            tokenEndpoint = getTokenEndpoint();
+        } catch (OidcDiscoveryException e) {
+            throw new TokenRequestException(oidcClientConfig.getClientId(), e.getMessage());
+        }
+        if (tokenEndpoint == null || tokenEndpoint.isEmpty()) {
+            String clientId = oidcClientConfig.getClientId();
+            String message = Tr.formatMessage(tc, "TOKEN_ENDPOINT_MISSING", clientId);
+            throw new TokenRequestException(clientId, message);
+        }
+        String authzCode = request.getParameter(TokenConstants.CODE);
+        return sendTokenRequestForCode(tokenEndpoint, authzCode);
+    }
+
+    String getTokenEndpoint() throws OidcDiscoveryException {
+        String tokenEndpoint = getTokenEndpointFromProviderMetadata();
+        if (tokenEndpoint != null) {
+            return tokenEndpoint;
+        }
+        return getTokenEndpointFromDiscoveryMetadata();
+    }
+
+    String getTokenEndpointFromProviderMetadata() {
+        if (providerMetadata != null) {
+            // Provider metadata overrides properties discovered via providerUri
+            String tokenEndpoint = providerMetadata.getTokenEndpoint();
+            if (tokenEndpoint != null && !tokenEndpoint.isEmpty()) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Token endpoint found in the provider metadata: [" + tokenEndpoint + "]");
+                }
+                return tokenEndpoint;
+            }
+        }
+        return null;
+    }
+
+    String getTokenEndpointFromDiscoveryMetadata() throws OidcDiscoveryException {
+        String tokenEndpoint = null;
+        JSONObject discoveryData = getProviderDiscoveryMetadata(oidcClientConfig);
+        if (discoveryData != null) {
+            tokenEndpoint = (String) discoveryData.get(OidcDiscoveryConstants.METADATA_KEY_TOKEN_ENDPOINT);
+        }
+        if (tokenEndpoint == null) {
+            String nlsMessage = Tr.formatMessage(tc, "DISCOVERY_METADATA_MISSING_VALUE", OidcDiscoveryConstants.METADATA_KEY_TOKEN_ENDPOINT);
+            throw new OidcDiscoveryException(oidcClientConfig.getClientId(), oidcClientConfig.getProviderURI(), nlsMessage);
+        }
+        return tokenEndpoint;
+    }
+
+    TokenResponse sendTokenRequestForCode(String tokenEndpoint, String authzCode) throws TokenRequestException {
+        String clientId = oidcClientConfig.getClientId();
+        String clientSecret = null;
+        ProtectedString clientSecretProtectedString = oidcClientConfig.getClientSecret();
+        if (clientSecretProtectedString != null) {
+            clientSecret = new String(clientSecretProtectedString.getChars());
+        }
+
+        Builder tokenRequestBuilder = createTokenRequestorBuilder(tokenEndpoint, clientId, clientSecret, authzCode);
+        tokenRequestBuilder.sslSocketFactory(getSSLSocketFactory());
+        tokenRequestBuilder.grantType(TokenConstants.AUTHORIZATION_CODE);
+        TokenRequestor tokenRequestor = tokenRequestBuilder.build();
+        try {
+            return tokenRequestor.requestTokens();
+        } catch (Exception e) {
+            throw new TokenRequestException(clientId, e.toString(), e);
+        }
+    }
+
+    Builder createTokenRequestorBuilder(String tokenEndpoint, String clientId, @Sensitive String clientSecret, String authzCode) {
+        return new TokenRequestor.Builder(tokenEndpoint, clientId, clientSecret, oidcClientConfig.getRedirectURI(), authzCode);
+    }
+
+    ProviderAuthenticationResult createAuthenticationResultFromTokenResponse(TokenResponse tokenEndpointResponse) {
+        Hashtable<String, Object> customProperties = new Hashtable<>();
+        customProperties.put(AUTH_RESULT_CUSTOM_PROP_TOKEN_RESPONSE, tokenEndpointResponse);
+
+        return new ProviderAuthenticationResult(AuthResult.SUCCESS, HttpServletResponse.SC_OK, null, new Subject(), customProperties, null);
+    }
+
+}

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequestTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequestTest.java
@@ -13,8 +13,6 @@ package io.openliberty.security.oidcclientcore.authentication;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import java.util.regex.Pattern;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -26,16 +24,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.ibm.json.java.JSONObject;
-import com.ibm.websphere.ras.Tr;
 import com.ibm.ws.security.test.common.CommonTestClass;
-import com.ibm.ws.webcontainer.security.AuthResult;
-import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 import io.openliberty.security.oidcclientcore.client.OidcProviderMetadata;
 import io.openliberty.security.oidcclientcore.discovery.DiscoveryHandler;
 import io.openliberty.security.oidcclientcore.discovery.OidcDiscoveryConstants;
-import io.openliberty.security.oidcclientcore.exceptions.OidcClientConfigurationException;
 import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
 import test.common.SharedOutputManager;
 
@@ -50,9 +44,7 @@ public class JakartaOidcAuthorizationRequestTest extends CommonTestClass {
     private final DiscoveryHandler discoveryHandler = mockery.mock(DiscoveryHandler.class);
     private final AuthorizationRequestParameters authzParameters = mockery.mock(AuthorizationRequestParameters.class);
 
-    private final String CWWKS2401E_OIDC_CLIENT_CONFIGURATION_ERROR = "CWWKS2401E";
     private final String CWWKS2403E_DISCOVERY_EXCEPTION = "CWWKS2403E";
-    private final String CWWKS2404E_OIDC_CLIENT_MISSING_PROVIDER_URI = "CWWKS2404E";
     private final String CWWKS2405E_DISCOVERY_METADATA_MISSING_VALUE = "CWWKS2405E";
 
     private final String clientId = "myOidcClientId";
@@ -89,7 +81,7 @@ public class JakartaOidcAuthorizationRequestTest extends CommonTestClass {
     private JakartaOidcAuthorizationRequest createJakartaOidcAuthorizationRequest(OidcProviderMetadata providerMetadata) {
         mockery.checking(new Expectations() {
             {
-                one(config).getClientId();
+                allowing(config).getClientId();
                 will(returnValue(clientId));
                 one(config).getProviderMetadata();
                 will(returnValue(providerMetadata));
@@ -99,18 +91,7 @@ public class JakartaOidcAuthorizationRequestTest extends CommonTestClass {
         });
         return new JakartaOidcAuthorizationRequest(request, response, config) {
             @Override
-            public ProviderAuthenticationResult sendRequest() {
-                try {
-                    discoveryData = getProviderMetadata();
-                    return null;
-                } catch (Exception e) {
-                    Tr.error(tc, "ERROR_SENDING_AUTHORIZATION_REQUEST", clientId, e.getMessage());
-                    return new ProviderAuthenticationResult(AuthResult.SEND_401, HttpServletResponse.SC_UNAUTHORIZED);
-                }
-            }
-
-            @Override
-            DiscoveryHandler getDiscoveryHandler() {
+            public DiscoveryHandler getDiscoveryHandler() {
                 return discoveryHandler;
             }
         };
@@ -173,128 +154,11 @@ public class JakartaOidcAuthorizationRequestTest extends CommonTestClass {
                     will(returnValue(discoveryData));
                 }
             });
-            // Have to call sendRequest() to populate the discovery data
-            authzRequest.sendRequest();
-
             String result = authzRequest.getAuthorizationEndpoint();
             assertEquals(authorizationEndpointUrl, result);
         } catch (Exception e) {
             outputMgr.failWithThrowable(testName.getMethodName(), e);
         }
-    }
-
-    @Test
-    public void test_getProviderMetadata_missingProviderUri() {
-        try {
-            mockery.checking(new Expectations() {
-                {
-                    one(config).getProviderURI();
-                    will(returnValue(null));
-                }
-            });
-            JSONObject result = authzRequest.getProviderMetadata();
-            fail("Should have thrown an exception but didn't. Got: " + result);
-        } catch (OidcClientConfigurationException e) {
-            verifyException(e, CWWKS2401E_OIDC_CLIENT_CONFIGURATION_ERROR + ".+" + CWWKS2404E_OIDC_CLIENT_MISSING_PROVIDER_URI);
-        } catch (Exception e) {
-            outputMgr.failWithThrowable(testName.getMethodName(), e);
-        }
-    }
-
-    @Test
-    public void test_getProviderMetadata_providerURIMissingWellKnownSuffix() throws OidcDiscoveryException {
-        final String expectedDiscoveryUrl = providerUrl + "/" + OidcDiscoveryConstants.WELL_KNOWN_SUFFIX;
-        final JSONObject discoveryData = new JSONObject();
-        try {
-            mockery.checking(new Expectations() {
-                {
-                    one(config).getProviderURI();
-                    will(returnValue(providerUrl));
-                    one(discoveryHandler).fetchDiscoveryDataJson(expectedDiscoveryUrl, clientId);
-                    will(returnValue(discoveryData));
-                }
-            });
-            JSONObject result = authzRequest.getProviderMetadata();
-            assertEquals(discoveryData, result);
-        } catch (Exception e) {
-            outputMgr.failWithThrowable(testName.getMethodName(), e);
-        }
-    }
-
-    @Test
-    public void test_getProviderMetadata_discoveryThrowsException() throws OidcDiscoveryException {
-        providerUrl = providerUrl + "/" + OidcDiscoveryConstants.WELL_KNOWN_SUFFIX;
-        try {
-            mockery.checking(new Expectations() {
-                {
-                    one(config).getProviderURI();
-                    will(returnValue(providerUrl));
-                    one(discoveryHandler).fetchDiscoveryDataJson(providerUrl, clientId);
-                    will(throwException(new OidcDiscoveryException(clientId, providerUrl, defaultExceptionMsg)));
-                }
-            });
-            JSONObject result = authzRequest.getProviderMetadata();
-            fail("Should have thrown an exception but didn't. Got: " + result);
-        } catch (OidcDiscoveryException e) {
-            verifyException(e, CWWKS2403E_DISCOVERY_EXCEPTION + ".+" + Pattern.quote(defaultExceptionMsg));
-        } catch (Exception e) {
-            outputMgr.failWithThrowable(testName.getMethodName(), e);
-        }
-    }
-
-    @Test
-    public void test_getProviderMetadata_goldenPath() throws OidcDiscoveryException {
-        providerUrl = providerUrl + "/" + OidcDiscoveryConstants.WELL_KNOWN_SUFFIX;
-        final JSONObject discoveryData = new JSONObject();
-        discoveryData.put(OidcDiscoveryConstants.METADATA_KEY_AUTHORIZATION_ENDPOINT, authorizationEndpointUrl);
-        try {
-            mockery.checking(new Expectations() {
-                {
-                    allowing(config).getProviderURI();
-                    will(returnValue(providerUrl));
-                    one(discoveryHandler).fetchDiscoveryDataJson(providerUrl, clientId);
-                    will(returnValue(discoveryData));
-                }
-            });
-            JSONObject result = authzRequest.getProviderMetadata();
-            assertEquals(discoveryData, result);
-
-            // Should get metadata from the cache, so shouldn't need another discoveryHandler call
-            JSONObject result2 = authzRequest.getProviderMetadata();
-            assertEquals(discoveryData, result2);
-        } catch (Exception e) {
-            outputMgr.failWithThrowable(testName.getMethodName(), e);
-        }
-    }
-
-    @Test
-    public void test_addWellKnownSuffixIfNeeded_noSuffix_noTrailingSlash() throws OidcDiscoveryException {
-        String input = providerUrl;
-        String result = authzRequest.addWellKnownSuffixIfNeeded(input);
-        String expectedValue = providerUrl + "/" + OidcDiscoveryConstants.WELL_KNOWN_SUFFIX;
-        assertEquals(expectedValue, result);
-    }
-
-    @Test
-    public void test_addWellKnownSuffixIfNeeded_noSuffix_withTrailingSlash() throws OidcDiscoveryException {
-        String input = providerUrl + "/";
-        String result = authzRequest.addWellKnownSuffixIfNeeded(input);
-        String expectedValue = providerUrl + "/" + OidcDiscoveryConstants.WELL_KNOWN_SUFFIX;
-        assertEquals(expectedValue, result);
-    }
-
-    @Test
-    public void test_addWellKnownSuffixIfNeeded_includesSuffix_notAsSeparatePath() throws OidcDiscoveryException {
-        String input = providerUrl + OidcDiscoveryConstants.WELL_KNOWN_SUFFIX;
-        String result = authzRequest.addWellKnownSuffixIfNeeded(input);
-        assertEquals(input, result);
-    }
-
-    @Test
-    public void test_addWellKnownSuffixIfNeeded_includesSuffix() throws OidcDiscoveryException {
-        String input = providerUrl + "/" + OidcDiscoveryConstants.WELL_KNOWN_SUFFIX;
-        String result = authzRequest.addWellKnownSuffixIfNeeded(input);
-        assertEquals(input, result);
     }
 
     @Test

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/http/EndpointRequestTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/http/EndpointRequestTest.java
@@ -1,0 +1,213 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oidcclientcore.http;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import javax.net.ssl.SSLSocketFactory;
+
+import org.jmock.Expectations;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.json.java.JSONObject;
+import com.ibm.ws.security.common.http.HttpUtils;
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
+import io.openliberty.security.oidcclientcore.discovery.DiscoveryHandler;
+import io.openliberty.security.oidcclientcore.discovery.OidcDiscoveryConstants;
+import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
+import test.common.SharedOutputManager;
+
+public class EndpointRequestTest extends CommonTestClass {
+
+    protected static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+
+    private final OidcClientConfig config = mockery.mock(OidcClientConfig.class);
+    private final SSLSocketFactory sslSocketFactory = mockery.mock(SSLSocketFactory.class);
+    private final HttpUtils mockedHttpUtils = mockery.mock(HttpUtils.class);
+
+    private final String CWWKS2401E_OIDC_CLIENT_CONFIGURATION_ERROR = "CWWKS2401E";
+    private final String CWWKS2403E_DISCOVERY_EXCEPTION = "CWWKS2403E";
+    private final String CWWKS2404E_OIDC_CLIENT_MISSING_PROVIDER_URI = "CWWKS2404E";
+
+    private final String clientId = "myOidcClientId";
+    private final String authorizationEndpointUrl = "https://localhost:8020/oidc/op/authorize";
+    private final String providerUrlBase = "https://localhost:8020/oidc/";
+
+    private String providerUrl = "https://localhost:8020/oidc/";
+
+    private DiscoveryHandler discoveryHandler = null;
+
+    private EndpointRequest endpointRequest;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void setUp() {
+        mockery.checking(new Expectations() {
+            {
+                allowing(config).getClientId();
+                will(returnValue(clientId));
+            }
+        });
+        discoveryHandler = new DiscoveryHandler(sslSocketFactory) {
+            @Override
+            protected HttpUtils getHttpUtils() {
+                return mockedHttpUtils;
+            }
+        };
+        endpointRequest = createEndpointRequest();
+        // Ensure provider URLs are unique for each test to avoid cache contamination between tests
+        providerUrl = providerUrlBase + testName.getMethodName();
+    }
+
+    @After
+    public void tearDown() {
+        outputMgr.resetStreams();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    private EndpointRequest createEndpointRequest() {
+        return new EndpointRequest() {
+            @Override
+            public DiscoveryHandler getDiscoveryHandler() {
+                return discoveryHandler;
+            }
+        };
+    }
+
+    @Test
+    public void test_getProviderDiscoveryMetadata_missingProviderUri() {
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    one(config).getProviderURI();
+                    will(returnValue(null));
+                }
+            });
+            JSONObject result = endpointRequest.getProviderDiscoveryMetadata(config);
+            assertNull("Result should not have been null but got " + result, result);
+            verifyLogMessage(outputMgr, CWWKS2401E_OIDC_CLIENT_CONFIGURATION_ERROR + ".+" + CWWKS2404E_OIDC_CLIENT_MISSING_PROVIDER_URI);
+        } catch (Exception e) {
+            outputMgr.failWithThrowable(testName.getMethodName(), e);
+        }
+    }
+
+    @Test
+    public void test_getProviderDiscoveryMetadata_providerURIMissingWellKnownSuffix() throws OidcDiscoveryException {
+        final String expectedDiscoveryUrl = providerUrl + "/" + OidcDiscoveryConstants.WELL_KNOWN_SUFFIX;
+        final JSONObject discoveryData = new JSONObject();
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    one(config).getProviderURI();
+                    will(returnValue(providerUrl));
+                    one(mockedHttpUtils).getHttpJsonRequest(sslSocketFactory, expectedDiscoveryUrl, true, false);
+                    will(returnValue(discoveryData.toString()));
+                }
+            });
+            JSONObject result = endpointRequest.getProviderDiscoveryMetadata(config);
+            assertEquals(discoveryData, result);
+        } catch (Exception e) {
+            outputMgr.failWithThrowable(testName.getMethodName(), e);
+        }
+    }
+
+    @Test
+    public void test_getProviderDiscoveryMetadata_discoveryThrowsException() throws OidcDiscoveryException {
+        providerUrl = providerUrl + "/" + OidcDiscoveryConstants.WELL_KNOWN_SUFFIX;
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    one(config).getProviderURI();
+                    will(returnValue(providerUrl));
+                    one(mockedHttpUtils).getHttpJsonRequest(sslSocketFactory, providerUrl, true, false);
+                    will(returnValue("Not JSON"));
+                }
+            });
+            JSONObject result = endpointRequest.getProviderDiscoveryMetadata(config);
+            assertNull("Result should not have been null but got " + result, result);
+            verifyLogMessage(outputMgr, CWWKS2403E_DISCOVERY_EXCEPTION + ".+" + "Unexpected character");
+        } catch (Exception e) {
+            outputMgr.failWithThrowable(testName.getMethodName(), e);
+        }
+    }
+
+    @Test
+    public void test_getProviderDiscoveryMetadata_goldenPath() throws OidcDiscoveryException {
+        providerUrl = providerUrl + "/" + OidcDiscoveryConstants.WELL_KNOWN_SUFFIX;
+        final JSONObject discoveryData = new JSONObject();
+        discoveryData.put(OidcDiscoveryConstants.METADATA_KEY_AUTHORIZATION_ENDPOINT, authorizationEndpointUrl);
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    allowing(config).getProviderURI();
+                    will(returnValue(providerUrl));
+                    one(mockedHttpUtils).getHttpJsonRequest(sslSocketFactory, providerUrl, true, false);
+                    will(returnValue(discoveryData.toString()));
+                }
+            });
+            JSONObject result = endpointRequest.getProviderDiscoveryMetadata(config);
+            assertEquals(discoveryData, result);
+
+            // Should get metadata from the cache, so shouldn't need another discoveryHandler call
+            JSONObject result2 = endpointRequest.getProviderDiscoveryMetadata(config);
+            assertEquals(discoveryData, result2);
+        } catch (Exception e) {
+            outputMgr.failWithThrowable(testName.getMethodName(), e);
+        }
+    }
+
+    @Test
+    public void test_addWellKnownSuffixIfNeeded_noSuffix_noTrailingSlash() throws OidcDiscoveryException {
+        String input = providerUrl;
+        String result = endpointRequest.addWellKnownSuffixIfNeeded(input);
+        String expectedValue = providerUrl + "/" + OidcDiscoveryConstants.WELL_KNOWN_SUFFIX;
+        assertEquals(expectedValue, result);
+    }
+
+    @Test
+    public void test_addWellKnownSuffixIfNeeded_noSuffix_withTrailingSlash() throws OidcDiscoveryException {
+        String input = providerUrl + "/";
+        String result = endpointRequest.addWellKnownSuffixIfNeeded(input);
+        String expectedValue = providerUrl + "/" + OidcDiscoveryConstants.WELL_KNOWN_SUFFIX;
+        assertEquals(expectedValue, result);
+    }
+
+    @Test
+    public void test_addWellKnownSuffixIfNeeded_includesSuffix_notAsSeparatePath() throws OidcDiscoveryException {
+        String input = providerUrl + OidcDiscoveryConstants.WELL_KNOWN_SUFFIX;
+        String result = endpointRequest.addWellKnownSuffixIfNeeded(input);
+        assertEquals(input, result);
+    }
+
+    @Test
+    public void test_addWellKnownSuffixIfNeeded_includesSuffix() throws OidcDiscoveryException {
+        String input = providerUrl + "/" + OidcDiscoveryConstants.WELL_KNOWN_SUFFIX;
+        String result = endpointRequest.addWellKnownSuffixIfNeeded(input);
+        assertEquals(input, result);
+    }
+
+}


### PR DESCRIPTION
- Sends the token request to the OP's token endpoint.
- Adds the token response to the custom properties in the `ProviderAuthenticationResult`.
- Clears the stored state once the authentication response is validated, per the spec.
- Enhances the discovery logic to move the cached discovery data to the `DiscoveryHandler` class.
- Moves some SSLSupport logic to a common `EndpointRequest` class to avoid duplicating OSGi logic.

For #21166