### PR TITLE
entity type always inferred

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/OrderRepo.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/OrderRepo.java
@@ -18,7 +18,7 @@ import io.openliberty.data.Repository;
 /**
  * Experiments with auto-generated keys.
  */
-@Data(Order.class)
+@Data
 public interface OrderRepo extends Repository<Order, Long> {
 
     @Query("UPDATE Order o SET o.total = o.total * :rate + :shipping WHERE o.id = :id")

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
@@ -18,7 +18,7 @@ import io.openliberty.data.Repository;
 /**
  *
  */
-@Data(Package.class)
+@Data
 public interface Packages extends Repository<Package, Integer> {
     List<Package> findByHeightBetween(float minHeight, float maxHeight);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Personnel.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Personnel.java
@@ -33,7 +33,7 @@ import io.openliberty.data.Where;
  * and experimenting with how generated repository method implementations
  * fit with asynchronous methods.
  */
-@Data(Person.class) // TODO infer the entity class?
+@Data
 public interface Personnel {
     @Asynchronous
     @Result(Integer.class)

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Reservations.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Reservations.java
@@ -41,7 +41,7 @@ import io.openliberty.data.Sorts;
 /**
  * Uses the Repository interface that is copied from Jakarta NoSQL
  */
-@Data(Reservation.class)
+@Data
 public interface Reservations extends Repository<Reservation, Long> {
     boolean deleteByHostIn(List<String> hosts);
 

--- a/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/Data.java
+++ b/dev/io.openliberty.data.internal_fat/test-bundles/data/src/io/openliberty/data/Data.java
@@ -23,7 +23,7 @@ import java.lang.annotation.Target;
  * For example,
  *
  * <pre>
- * &#64;Data(Product.class)
+ * &#64;Data
  * public interface Products {
  *     Product[] findByProductNameLikeOrderByPrice(String nameContains);
  *
@@ -40,11 +40,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface Data {
-    /**
-     * Entity class. By default, detect automatically.
-     */
-    Class<?> value() default void.class;
-
     /**
      * Returns the name of the provider of backend data access for
      * the entity.


### PR DESCRIPTION
Investigate whether it is possible to always infer the entity type and not require it on the data repository annotation.
Based on how discussions are going in Jakarta Data, it seems that a base repository interface will almost always be extended, which includes the entity type as a parameter.