### PR TITLE
Implement try finally to predestroy / release managed object

### DIFF
--- a/dev/com.ibm.ws.jsp.2.3_fat/.classpath
+++ b/dev/com.ibm.ws.jsp.2.3_fat/.classpath
@@ -3,6 +3,7 @@
     <classpathentry kind="src" path="fat/src"/>
     <classpathentry kind="src" path="test-applications/TestInjection.war/src"/>
     <classpathentry kind="src" path="test-applications/TestEL.war/src"/>
+    <classpathentry kind="src" path="test-applications/TestPreDestroy.war/src"/>
     <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
     <classpathentry kind="con" path="aQute.bnd.classpath.container"/>
     <classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jsp.2.3_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jsp.2.3_fat/bnd.bnd
@@ -16,7 +16,8 @@ bVersion=1.0
 src: \
     fat/src,\
     test-applications/TestInjection.war/src,\
-    test-applications/TestEL.war/src
+    test-applications/TestEL.war/src,\
+    test-applications/TestPreDestroy.war/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestPreDestroy.war/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestPreDestroy.war/resources/META-INF/permissions.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+    version="7">
+
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>getClassLoader</name>
+   </permission>
+   
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>accessClassInPackage.com.sun.beans.editors</name>
+   </permission>
+   
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>accessDeclaredMembers</name>
+   </permission>
+   
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>accessDeclaredMembers</name>
+   </permission>
+   
+   <permission>
+      <class-name>java.lang.reflect.ReflectPermission</class-name>
+      <name>suppressAccessChecks</name>
+   </permission>
+      
+</permissions>

--- a/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestPreDestroy.war/resources/WEB-INF/sample.tld
+++ b/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestPreDestroy.war/resources/WEB-INF/sample.tld
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<taglib>
+   <tlib-version>1.2</tlib-version>
+   <jsp-version>2.3</jsp-version>
+   <short-name>Sample TLD</short-name>
+   <tag>
+      <name>Sample</name>
+      <tag-class>com.ibm.ws.jsp23.fat.predestroy.SampleTag</tag-class>
+      <body-content>scriptless</body-content>
+   </tag>
+</taglib>

--- a/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestPreDestroy.war/resources/index.jsp
+++ b/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestPreDestroy.war/resources/index.jsp
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<%@ taglib prefix = "test" uri = "WEB-INF/sample.tld"%>
+<html>
+   <head>
+      <title>sample tag</title>
+   </head>
+   
+   <body>
+      <test:Sample> </test:Sample>
+   </body>
+</html>

--- a/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestPreDestroy.war/src/com/ibm/ws/jsp23/fat/predestroy/SampleTag.java
+++ b/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestPreDestroy.war/src/com/ibm/ws/jsp23/fat/predestroy/SampleTag.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jsp23.fat.predestroy;
+
+import java.io.IOException;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.servlet.jsp.JspTagException;
+import javax.servlet.jsp.PageContext;
+import javax.servlet.jsp.tagext.Tag;
+
+/*
+ * When an exception is thrown from doEndTag, we want to ensure
+ * predestroy is still called (via try-finally in OL PR 22478 / PH49514). 
+ * In WAS 9, this also ensures instances of this class are removed
+ * from the WASAnnotationHelper map. 
+ */
+public class SampleTag implements Tag {
+  private PageContext pageContext;
+  
+  private Tag parent;
+  
+  @PreDestroy
+  public void doPreDestroy() {
+    System.out.println("DESTROY CALLED for " + this.toString());
+  }
+  
+  @PostConstruct
+  public void doPostConstruct() {
+    System.out.println("CONSTRUCT CALLED for " + this.toString());
+  }
+  
+  public void setPageContext(PageContext pageContext) {
+    this.pageContext = pageContext;
+  }
+  
+  public void setParent(Tag parent) {
+    this.parent = parent;
+  }
+  
+  public Tag getParent() {
+    return this.parent;
+  }
+  
+  public int doStartTag() throws JspTagException {
+    return 0;
+  }
+  
+  public int doEndTag() throws JspTagException {  
+        throw new JspTagException("Purposefully thrown Exception");
+  }
+  
+  public void release() {}
+}

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/inmemory/generator/InMemoryGenerateJspVisitor.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/inmemory/generator/InMemoryGenerateJspVisitor.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2005 IBM Corporation and others.
+ * Copyright (c) 1997, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jsp.inmemory.generator;
 
@@ -47,7 +44,7 @@ public class InMemoryGenerateJspVisitor extends GenerateJspVisitor {
 		} catch (IOException e) {
             throw new JspCoreException(e);
 		}
-        fragmentHelperClassWriter = new FragmentHelperClassWriter(className);
+        fragmentHelperClassWriter = new FragmentHelperClassWriter(className, jspOptions);
         boolean reuseTags = false;
         if (jspOptions.isUsePageTagPool() ||
             jspOptions.isUseThreadTagPool()) {

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/inmemory/generator/InMemoryGenerateTagFileVisitor.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/inmemory/generator/InMemoryGenerateTagFileVisitor.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2005 IBM Corporation and others.
+ * Copyright (c) 1997, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jsp.inmemory.generator;
 
@@ -47,7 +44,7 @@ public class InMemoryGenerateTagFileVisitor extends GenerateTagFileVisitor {
 		} catch (IOException e) {
             throw new JspCoreException(e);
 		}
-        fragmentHelperClassWriter = new FragmentHelperClassWriter(className);
+        fragmentHelperClassWriter = new FragmentHelperClassWriter(className, jspOptions);
         boolean reuseTags = false;
         if (jspOptions.isUsePageTagPool() ||
             jspOptions.isUseThreadTagPool()) {

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/ClassicTagGenerator.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/ClassicTagGenerator.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2004 IBM Corporation and others.
+ * Copyright (c) 1997, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jsp.translator.visitor.generator;
 
@@ -41,49 +38,34 @@ public class ClassicTagGenerator extends BaseTagGenerator {
     private CleanupTaglibLookupWriter cleanupTaglibLookupWriter = null; //247815
     //PK60565 pushBodyCountVarDeclOrig has a value if we are within a TryCatchFinally tag.  Need to restore original value in case of nested tags.
     private String pushBodyCountVarDeclOrig = null; //PK60565
-    private JspVisitorInputMap inputMap=null; //jsp2.1work
+    private JspVisitorInputMap inputMap = null; //jsp2.1work
 
     public ClassicTagGenerator(
-        boolean reuseTag,
-        boolean genTagInMethod,
-        boolean existingTag,
-        String baseVar,
-        String tagEvalVar,
-        String tagPushBodyCountVar,
-        int nestingLevel,
-        boolean isTagFile,
-        boolean hasBody,
-        boolean hasJspBody,
-        String tagHandlerVar,
-        Element element,
-        TagLibraryCache tagLibraryCache,
-        JspConfiguration jspConfiguration,
-        JspCoreContext ctxt,
-        TagClassInfo tagClassInfo,
-        TagInfo ti,
-        Map persistentData,
-        ValidateResult.CollectedTagData collectedTagData,
-        FragmentHelperClassWriter fragmentHelperClassWriter,
-        JspOptions jspOptions,
-        JspVisitorInputMap inputMap) {
+                               boolean reuseTag,
+                               boolean genTagInMethod,
+                               boolean existingTag,
+                               String baseVar,
+                               String tagEvalVar,
+                               String tagPushBodyCountVar,
+                               int nestingLevel,
+                               boolean isTagFile,
+                               boolean hasBody,
+                               boolean hasJspBody,
+                               String tagHandlerVar,
+                               Element element,
+                               TagLibraryCache tagLibraryCache,
+                               JspConfiguration jspConfiguration,
+                               JspCoreContext ctxt,
+                               TagClassInfo tagClassInfo,
+                               TagInfo ti,
+                               Map persistentData,
+                               ValidateResult.CollectedTagData collectedTagData,
+                               FragmentHelperClassWriter fragmentHelperClassWriter,
+                               JspOptions jspOptions,
+                               JspVisitorInputMap inputMap) {
 
-        super(
-            nestingLevel,
-            isTagFile,
-            hasBody,
-            hasJspBody,
-            tagHandlerVar,
-            element,
-            tagLibraryCache,
-            jspConfiguration,
-            ctxt,
-            tagClassInfo,
-            ti,
-            persistentData,
-            collectedTagData,
-            fragmentHelperClassWriter,
-            jspOptions);
-            
+        super(nestingLevel, isTagFile, hasBody, hasJspBody, tagHandlerVar, element, tagLibraryCache, jspConfiguration, ctxt, tagClassInfo, ti, persistentData, collectedTagData, fragmentHelperClassWriter, jspOptions);
+
         this.reuseTag = reuseTag;
         this.genTagInMethod = genTagInMethod;
         this.existingTag = existingTag;
@@ -91,12 +73,12 @@ public class ClassicTagGenerator extends BaseTagGenerator {
         this.baseVar = baseVar;
         this.tagEvalVar = tagEvalVar;
         this.tagPushBodyCountVar = tagPushBodyCountVar;
-        this.inputMap=inputMap;
-        
+        this.inputMap = inputMap;
+
         //247815 Start
         if (reuseTag) {
-        	cleanupTaglibLookupWriter = (CleanupTaglibLookupWriter)persistentData.get("CleanupTaglibLookupWriter");
-            initTaglibLookupWriter = (InitTaglibLookupWriter)persistentData.get("InitTaglibLookupWriter");
+            cleanupTaglibLookupWriter = (CleanupTaglibLookupWriter) persistentData.get("CleanupTaglibLookupWriter");
+            initTaglibLookupWriter = (InitTaglibLookupWriter) persistentData.get("InitTaglibLookupWriter");
         }
         //247815 End
     }
@@ -107,31 +89,37 @@ public class ClassicTagGenerator extends BaseTagGenerator {
         saveScriptingVars(tagStartWriter, VariableInfo.AT_BEGIN);
 
         if (reuseTag == false || tagClassInfo.implementsJspIdConsumer()) {//jsp2.1work
-            
+
             // LIDB4147-24
-            if (!jspOptions.isDisableResourceInjection()){		//PM06063
-                
+            if (!jspOptions.isDisableResourceInjection()) { //PM06063
+
                 // have CDI create and inject the managed object
-            	tagStartWriter.print ("com.ibm.ws.managedobject.ManagedObject " + tagHandlerVar + "_mo = ");
-                tagStartWriter.print ("_jspx_iaHelper.inject(");
-                tagStartWriter.print (tagClassInfo.getTagClassName() + ".class");
-            	tagStartWriter.println (");");
-            
-            	// get the underlying object from the managed object
+                tagStartWriter.print("com.ibm.ws.managedobject.ManagedObject " + tagHandlerVar + "_mo = ");
+                tagStartWriter.print("_jspx_iaHelper.inject(");
+                tagStartWriter.print(tagClassInfo.getTagClassName() + ".class");
+                tagStartWriter.println(");");
+
+                // get the underlying object from the managed object
                 tagStartWriter.print(tagClassInfo.getTagClassName());
                 tagStartWriter.print(" ");
-                tagStartWriter.print(tagHandlerVar);   
-                tagStartWriter.print(" = ");           
-                tagStartWriter.println("("+tagClassInfo.getTagClassName()+")"+tagHandlerVar+"_mo.getObject();"); 
+                tagStartWriter.print(tagHandlerVar);
+                tagStartWriter.print(" = ");
+                tagStartWriter.println("(" + tagClassInfo.getTagClassName() + ")" + tagHandlerVar + "_mo.getObject();");
 
-            	tagStartWriter.print ("_jspx_iaHelper.doPostConstruct(");
-            	tagStartWriter.print (tagHandlerVar);
-            	tagStartWriter.println (");");
-            	
-                tagStartWriter.print ("_jspx_iaHelper.addTagHandlerToCdiMap(");
-                tagStartWriter.print (tagHandlerVar + ", " + tagHandlerVar + "_mo");
-                tagStartWriter.println (");");
-                
+                if (genTagInMethod) {
+                    tagStartWriter.println("try {");
+                } else {
+                    tagStartWriter.println("_jspTagList.add(" + tagHandlerVar + ");");
+                }
+
+                tagStartWriter.print("_jspx_iaHelper.doPostConstruct(");
+                tagStartWriter.print(tagHandlerVar);
+                tagStartWriter.println(");");
+
+                tagStartWriter.print("_jspx_iaHelper.addTagHandlerToCdiMap(");
+                tagStartWriter.print(tagHandlerVar + ", " + tagHandlerVar + "_mo");
+                tagStartWriter.println(");");
+
             } else {
                 // not using CDI
                 tagStartWriter.print(tagClassInfo.getTagClassName());
@@ -141,12 +129,17 @@ public class ClassicTagGenerator extends BaseTagGenerator {
                 tagStartWriter.print("new ");
                 tagStartWriter.print(tagClassInfo.getTagClassName());
                 tagStartWriter.println("();");
+
+                if (genTagInMethod) {
+                    tagStartWriter.println("try {");
+                } else {
+                    tagStartWriter.println("_jspTagList.add(" + tagHandlerVar + ");");
+                }
             }
-            
+
             tagStartWriter.println();
-        }
-        else {
-        	//PM26777 start
+        } else {
+            //PM26777 start
             if (genTagInMethod || (isFragment && !existingTag)) {
                 tagStartWriter.print(tagClassInfo.getTagClassName());
                 tagStartWriter.print(" ");
@@ -160,14 +153,14 @@ public class ClassicTagGenerator extends BaseTagGenerator {
         generateSetParent(tagStartWriter);
         //PK60565 saves original pushBodyCountVarDeclaration value
         if (tagClassInfo.implementsTryCatchFinally()) {
-            pushBodyCountVarDeclOrig = (String)persistentData.get("pushBodyCountVarDeclaration");
+            pushBodyCountVarDeclOrig = (String) persistentData.get("pushBodyCountVarDeclaration");
         } //PK60565 end
         return tagStartWriter;
     }
 
     public MethodWriter generateTagMiddle() throws JspCoreException {
         MethodWriter tagMiddleWriter = new MethodWriter();
-        String pushBodyCountVar = (String)persistentData.get("pushBodyCountVar");
+        String pushBodyCountVar = (String) persistentData.get("pushBodyCountVar");
         //PK65013 - start
         String pageContextVar = Constants.JSP_PAGE_CONTEXT_ORIG;
         if (isTagFile && jspOptions.isModifyPageContextVariable()) {
@@ -176,29 +169,28 @@ public class ClassicTagGenerator extends BaseTagGenerator {
         //PK65013 - end
         // JspIdConsumer (after context has been set)
         if (tagClassInfo.implementsJspIdConsumer()) {
-        	tagMiddleWriter.print(tagHandlerVar);
-        	tagMiddleWriter.print(".setJspId(\"");
-        	tagMiddleWriter.print(createJspId(inputMap));
-        	tagMiddleWriter.println("\");");
+            tagMiddleWriter.print(tagHandlerVar);
+            tagMiddleWriter.print(".setJspId(\"");
+            tagMiddleWriter.print(createJspId(inputMap));
+            tagMiddleWriter.println("\");");
         }
         if (tagClassInfo.implementsTryCatchFinally()) {
             //begin 230150: reuse TryCatchFinally counter object when pooling is enabled.
             //PM26777 start
-            if ((jspOptions.isUsePageTagPool() == false && jspOptions.isUseThreadTagPool() == false) || genTagInMethod == true || (isFragment && !existingTag)){ 
-        		tagMiddleWriter.print("int[] ");
-            }	
+            if ((jspOptions.isUsePageTagPool() == false && jspOptions.isUseThreadTagPool() == false) || genTagInMethod == true || (isFragment && !existingTag)) {
+                tagMiddleWriter.print("int[] ");
+            }
             //PM26777 end
             //end 230150: reuse TryCatchFinally counter object when pooling is enabled.
-        	tagMiddleWriter.print(tagPushBodyCountVar);
+            tagMiddleWriter.print(tagPushBodyCountVar);
             tagMiddleWriter.println(" = new int[] { 0 };");
             tagMiddleWriter.println("try {");
-            persistentData.put("pushBodyCountVarDeclaration", tagPushBodyCountVar);  // defect 363508
+            persistentData.put("pushBodyCountVarDeclaration", tagPushBodyCountVar); // defect 363508
         }
 
         if (genTagInMethod == false && reuseTag && isFragment == false) {
             tagMiddleWriter.print(tagEvalVar);
-        }
-        else {
+        } else {
             tagMiddleWriter.print("int ");
             tagMiddleWriter.print(tagEvalVar);
         }
@@ -206,7 +198,7 @@ public class ClassicTagGenerator extends BaseTagGenerator {
         tagMiddleWriter.print(" = ");
         tagMiddleWriter.print(tagHandlerVar);
         tagMiddleWriter.println(".doStartTag();");
-        
+
         if (!tagClassInfo.implementsBodyTag()) {
             syncScriptingVars(tagMiddleWriter, VariableInfo.AT_BEGIN);
         }
@@ -215,11 +207,11 @@ public class ClassicTagGenerator extends BaseTagGenerator {
             tagMiddleWriter.print("if (");
             tagMiddleWriter.print(tagEvalVar);
             tagMiddleWriter.println(" != javax.servlet.jsp.tagext.Tag.SKIP_BODY) {");
-            
+
             // PM48052 start
             // If doStartTag does a pushBody(Writer writer) then we need to make sure we get the
             // correct writer.
-            tagMiddleWriter.println("out = "+pageContextVar+".getOut();");
+            tagMiddleWriter.println("out = " + pageContextVar + ".getOut();");
             // PM48052 end
 
             declareScriptingVars(tagMiddleWriter, VariableInfo.NESTED);
@@ -230,14 +222,13 @@ public class ClassicTagGenerator extends BaseTagGenerator {
                 tagMiddleWriter.print(tagEvalVar);
                 tagMiddleWriter.println(" != javax.servlet.jsp.tagext.Tag.EVAL_BODY_INCLUDE) {");
                 //PK65013 change pageContext variable to customizable one.
-                tagMiddleWriter.println("out = "+pageContextVar+".pushBody();");
+                tagMiddleWriter.println("out = " + pageContextVar + ".pushBody();");
 
                 if (tagClassInfo.implementsTryCatchFinally()) {
                     tagMiddleWriter.print(tagPushBodyCountVar);
                     tagMiddleWriter.print("[0]++;");
                     tagMiddleWriter.println();
-                }
-                else if (pushBodyCountVar != null) {
+                } else if (pushBodyCountVar != null) {
                     tagMiddleWriter.print(pushBodyCountVar);
                     tagMiddleWriter.print("[0]++;");
                     tagMiddleWriter.println();
@@ -255,8 +246,7 @@ public class ClassicTagGenerator extends BaseTagGenerator {
                 syncScriptingVars(tagMiddleWriter, VariableInfo.AT_BEGIN);
                 syncScriptingVars(tagMiddleWriter, VariableInfo.NESTED);
 
-            }
-            else {
+            } else {
                 syncScriptingVars(tagMiddleWriter, VariableInfo.NESTED);
             }
 
@@ -276,28 +266,28 @@ public class ClassicTagGenerator extends BaseTagGenerator {
         //PK65013 - end
         generateJspAttributeSetters();
         MethodWriter tagEndWriter = new MethodWriter();
-        String pushBodyCountVar = (String)persistentData.get("pushBodyCountVar");
-        int methodNesting =  ((Integer)persistentData.get("methodNesting")).intValue();
+        String pushBodyCountVar = (String) persistentData.get("pushBodyCountVar");
+        int methodNesting = ((Integer) persistentData.get("methodNesting")).intValue();
         if (hasBody || hasJspBody) {
             if (tagClassInfo.implementsIterationTag()) {
-				//PK31135
-				if (!jspOptions.isUseIterationEval()) { //PK31135
-	                tagEndWriter.print("int evalDoAfterBody = ");
-	                tagEndWriter.print(tagHandlerVar);
-	                tagEndWriter.println(".doAfterBody();");
-	
-	                syncScriptingVars(tagEndWriter, VariableInfo.AT_BEGIN);
-	                syncScriptingVars(tagEndWriter, VariableInfo.NESTED);
-	
-	                tagEndWriter.println("if (evalDoAfterBody != javax.servlet.jsp.tagext.BodyTag.EVAL_BODY_AGAIN) break;");
-	
-	                tagEndWriter.println("} while (true);");
-				//PK31135
-				} else {
-					tagEndWriter.println("} while (");
-					tagEndWriter.println(tagHandlerVar);
-					tagEndWriter.println(".doAfterBody() == javax.servlet.jsp.tagext.BodyTag.EVAL_BODY_AGAIN);");
-				} //PK31135
+                //PK31135
+                if (!jspOptions.isUseIterationEval()) { //PK31135
+                    tagEndWriter.print("int evalDoAfterBody = ");
+                    tagEndWriter.print(tagHandlerVar);
+                    tagEndWriter.println(".doAfterBody();");
+
+                    syncScriptingVars(tagEndWriter, VariableInfo.AT_BEGIN);
+                    syncScriptingVars(tagEndWriter, VariableInfo.NESTED);
+
+                    tagEndWriter.println("if (evalDoAfterBody != javax.servlet.jsp.tagext.BodyTag.EVAL_BODY_AGAIN) break;");
+
+                    tagEndWriter.println("} while (true);");
+                    //PK31135
+                } else {
+                    tagEndWriter.println("} while (");
+                    tagEndWriter.println(tagHandlerVar);
+                    tagEndWriter.println(".doAfterBody() == javax.servlet.jsp.tagext.BodyTag.EVAL_BODY_AGAIN);");
+                } //PK31135
             }
 
             restoreScriptingVars(tagEndWriter, VariableInfo.NESTED);
@@ -306,12 +296,11 @@ public class ClassicTagGenerator extends BaseTagGenerator {
                 tagEndWriter.print("if (");
                 tagEndWriter.print(tagEvalVar);
                 //PK65013 change pageContext variable to customizable one.
-                tagEndWriter.println(" != javax.servlet.jsp.tagext.Tag.EVAL_BODY_INCLUDE) out = "+pageContextVar+".popBody();");
+                tagEndWriter.println(" != javax.servlet.jsp.tagext.Tag.EVAL_BODY_INCLUDE) out = " + pageContextVar + ".popBody();");
                 if (tagClassInfo.implementsTryCatchFinally()) {
                     tagEndWriter.print(tagPushBodyCountVar);
                     tagEndWriter.println("[0]--;");
-                }
-                else if (pushBodyCountVar != null) {
+                } else if (pushBodyCountVar != null) {
                     tagEndWriter.print(pushBodyCountVar);
                     tagEndWriter.println("[0]--;");
                 }
@@ -323,32 +312,13 @@ public class ClassicTagGenerator extends BaseTagGenerator {
         tagEndWriter.print("if (");
         tagEndWriter.print(tagHandlerVar);
         tagEndWriter.println(".doEndTag() == javax.servlet.jsp.tagext.Tag.SKIP_PAGE) {");
-        
-        if (reuseTag == false || tagClassInfo.implementsJspIdConsumer()) {//jsp2.1work
-            // LIDB4147-24
-             
-        	if (!jspOptions.isDisableResourceInjection()){		//PM06063
-            	    tagEndWriter.print ("_jspx_iaHelper.doPreDestroy(");
-            	    tagEndWriter.print (tagHandlerVar);
-            	    tagEndWriter.println (");");
-            	
-                    tagEndWriter.print ("_jspx_iaHelper.cleanUpTagHandlerFromCdiMap(");
-                    tagEndWriter.print (tagHandlerVar);
-                    tagEndWriter.println (");");
-        	} 
-             
-            tagEndWriter.println();
-             
-            tagEndWriter.println(tagHandlerVar + ".release();");
-        }
-        
+
         if (isTagFile || isFragment) {
-        	// begin 242714: enhance error reporting for SkipPageException.
-        	//tagEndWriter.println("throw new javax.servlet.jsp.SkipPageException();");
-            tagEndWriter.println("throw new com.ibm.ws.jsp.runtime.WsSkipPageException(\"Tag file or fragment [" +tagHandlerVar +"] doEndTag returned SKIP_PAGE\");");
-        	// end 242714: enhance error reporting for SkipPageException.
-        }
-        else {
+            // begin 242714: enhance error reporting for SkipPageException.
+            //tagEndWriter.println("throw new javax.servlet.jsp.SkipPageException();");
+            tagEndWriter.println("throw new com.ibm.ws.jsp.runtime.WsSkipPageException(\"Tag file or fragment [" + tagHandlerVar + "] doEndTag returned SKIP_PAGE\");");
+            // end 242714: enhance error reporting for SkipPageException.
+        } else {
             tagEndWriter.println((methodNesting > 0) ? "return true;" : "return;");
         }
         tagEndWriter.println("}");
@@ -357,11 +327,11 @@ public class ClassicTagGenerator extends BaseTagGenerator {
         // If doEndTag does a popBody() then we need to make sure we get the
         // correct writer, if we are generated in a method then no need to reset
         // the writer as it a method variable.
-        if(!genTagInMethod){
-            tagEndWriter.println("out = "+pageContextVar+".getOut();");
+        if (!genTagInMethod) {
+            tagEndWriter.println("out = " + pageContextVar + ".getOut();");
         }
         // PM48052 end
-        
+
         syncScriptingVars(tagEndWriter, VariableInfo.AT_BEGIN);
 
         if (tagClassInfo.implementsTryCatchFinally()) {
@@ -371,7 +341,7 @@ public class ClassicTagGenerator extends BaseTagGenerator {
             tagEndWriter.print(tagPushBodyCountVar);
             tagEndWriter.println("[0]-- > 0)");
             //PK65013 change pageContext variable to customizable one.
-            tagEndWriter.print("out = "+pageContextVar+".popBody();");
+            tagEndWriter.print("out = " + pageContextVar + ".popBody();");
             tagEndWriter.println();
 
             tagEndWriter.print(tagHandlerVar);
@@ -387,22 +357,12 @@ public class ClassicTagGenerator extends BaseTagGenerator {
 
         if (reuseTag == false || tagClassInfo.implementsJspIdConsumer()) {//jsp2.1work
             //           LIDB4147-24
-             
-        	if (!jspOptions.isDisableResourceInjection()){		//PM06063
-            	    tagEndWriter.print ("_jspx_iaHelper.doPreDestroy(");
-            	    tagEndWriter.print (tagHandlerVar);
-            	    tagEndWriter.println (");");
-            	
-            	    tagEndWriter.print ("_jspx_iaHelper.cleanUpTagHandlerFromCdiMap(");
-            	    tagEndWriter.print (tagHandlerVar);
-            	    tagEndWriter.println (");");
-        	}
-             
-            tagEndWriter.println();
-             
-            tagEndWriter.println(tagHandlerVar + ".release();");
+
+            if (!genTagInMethod) {
+                tagEndWriter.println("_jsp_cleanUpTag(" + tagHandlerVar + ", _jspTagList);");
+            }
         }
-        
+
         //PK60565 putting back the orig value for pushBodyCountVarDeclaration
         if (tagClassInfo.implementsTryCatchFinally()) {
             persistentData.put("pushBodyCountVarDeclaration", pushBodyCountVarDeclOrig); //PK60565
@@ -417,60 +377,59 @@ public class ClassicTagGenerator extends BaseTagGenerator {
     public void generateInitialization(JavaCodeWriter writer) {
         if (reuseTag && existingTag == false) {
             if (tagClassInfo.implementsJspIdConsumer() == false) {//jsp2.1work
-	       if (jspOptions.isUsePageTagPool()) {
-	             //247815 Start
-                     // LIDB4147-24
-                     
-                     if (!jspOptions.isDisableResourceInjection()){		//PM06063
-                         // have CDI create and inject the managed object
-                         initTaglibLookupWriter.print ("com.ibm.ws.managedobject.ManagedObject " + tagHandlerVar + "_mo = ");
-                         initTaglibLookupWriter.print ("_jspx_iaHelper.inject(");
-                         initTaglibLookupWriter.print (tagClassInfo.getTagClassName() + ".class");
-                         initTaglibLookupWriter.println (");");
-                     
-                         // get the underlying object from the managed object
-                         initTaglibLookupWriter.print(tagClassInfo.getTagClassName());
-                         initTaglibLookupWriter.print(" ");
-                         initTaglibLookupWriter.print(tagHandlerVar);   
-                         initTaglibLookupWriter.print(" = ");           
-                         initTaglibLookupWriter.println("("+tagClassInfo.getTagClassName()+")"+tagHandlerVar+"_mo.getObject();"); 
+                if (jspOptions.isUsePageTagPool()) {
+                    //247815 Start
+                    // LIDB4147-24
 
-                     	initTaglibLookupWriter.print ("_jspx_iaHelper.doPostConstruct(");
-                     	initTaglibLookupWriter.print (tagHandlerVar);
-                     	initTaglibLookupWriter.println (");");
-                     	
-                     	initTaglibLookupWriter.print ("_jspx_iaHelper.addTagHandlerToCdiMap(");
-                     	initTaglibLookupWriter.print (tagHandlerVar + ", " + tagHandlerVar + "_mo");
-                     	initTaglibLookupWriter.println (");");
-                     } else {
-                         // CDI is not enabled
-                         initTaglibLookupWriter.print(tagClassInfo.getTagClassName());
-                         initTaglibLookupWriter.print(" ");
-                         initTaglibLookupWriter.print(tagHandlerVar);
-                         initTaglibLookupWriter.print(" = ");
-                         initTaglibLookupWriter.print("new ");
-                         initTaglibLookupWriter.print(tagClassInfo.getTagClassName());
-                         initTaglibLookupWriter.print("();");
+                    if (!jspOptions.isDisableResourceInjection()) { //PM06063
+                        // have CDI create and inject the managed object
+                        initTaglibLookupWriter.print("com.ibm.ws.managedobject.ManagedObject " + tagHandlerVar + "_mo = ");
+                        initTaglibLookupWriter.print("_jspx_iaHelper.inject(");
+                        initTaglibLookupWriter.print(tagClassInfo.getTagClassName() + ".class");
+                        initTaglibLookupWriter.println(");");
 
-                         initTaglibLookupWriter.println();
-                      
-                     }
-                     
-	                initTaglibLookupWriter.println();
-	                initTaglibLookupWriter.println("_jspx_TagLookup.put(\"" + tagHandlerVar + "\", " + tagHandlerVar + ");");
-	                //247815 End
-	            }
-	            else if (jspOptions.isUseThreadTagPool()) {
-	                String tagKey = ti.getTagClassName() + collectedTagData.getVarNameSuffix();
-	                //247815 Start
-	                initTaglibLookupWriter.print(tagClassInfo.getTagClassName());
-	                initTaglibLookupWriter.print(" ");
-	                initTaglibLookupWriter.print(tagHandlerVar);
-	                initTaglibLookupWriter.print(" = (" + tagClassInfo.getTagClassName() + ")getTagHandler(request, \"" + tagKey + "\", \"" + ti.getTagClassName() + "\");");
-	                initTaglibLookupWriter.println();
-	                initTaglibLookupWriter.println("_jspx_TagLookup.put(\"" + tagHandlerVar + "\", " + tagHandlerVar + ");");
-	                //247815 End
-	            }
+                        // get the underlying object from the managed object
+                        initTaglibLookupWriter.print(tagClassInfo.getTagClassName());
+                        initTaglibLookupWriter.print(" ");
+                        initTaglibLookupWriter.print(tagHandlerVar);
+                        initTaglibLookupWriter.print(" = ");
+                        initTaglibLookupWriter.println("(" + tagClassInfo.getTagClassName() + ")" + tagHandlerVar + "_mo.getObject();");
+
+                        initTaglibLookupWriter.print("_jspx_iaHelper.doPostConstruct(");
+                        initTaglibLookupWriter.print(tagHandlerVar);
+                        initTaglibLookupWriter.println(");");
+
+                        initTaglibLookupWriter.print("_jspx_iaHelper.addTagHandlerToCdiMap(");
+                        initTaglibLookupWriter.print(tagHandlerVar + ", " + tagHandlerVar + "_mo");
+                        initTaglibLookupWriter.println(");");
+                    } else {
+                        // CDI is not enabled
+                        initTaglibLookupWriter.print(tagClassInfo.getTagClassName());
+                        initTaglibLookupWriter.print(" ");
+                        initTaglibLookupWriter.print(tagHandlerVar);
+                        initTaglibLookupWriter.print(" = ");
+                        initTaglibLookupWriter.print("new ");
+                        initTaglibLookupWriter.print(tagClassInfo.getTagClassName());
+                        initTaglibLookupWriter.print("();");
+
+                        initTaglibLookupWriter.println();
+
+                    }
+
+                    initTaglibLookupWriter.println();
+                    initTaglibLookupWriter.println("_jspx_TagLookup.put(\"" + tagHandlerVar + "\", " + tagHandlerVar + ");");
+                    //247815 End
+                } else if (jspOptions.isUseThreadTagPool()) {
+                    String tagKey = ti.getTagClassName() + collectedTagData.getVarNameSuffix();
+                    //247815 Start
+                    initTaglibLookupWriter.print(tagClassInfo.getTagClassName());
+                    initTaglibLookupWriter.print(" ");
+                    initTaglibLookupWriter.print(tagHandlerVar);
+                    initTaglibLookupWriter.print(" = (" + tagClassInfo.getTagClassName() + ")getTagHandler(request, \"" + tagKey + "\", \"" + ti.getTagClassName() + "\");");
+                    initTaglibLookupWriter.println();
+                    initTaglibLookupWriter.println("_jspx_TagLookup.put(\"" + tagHandlerVar + "\", " + tagHandlerVar + ");");
+                    //247815 End
+                }
             }
             //247815 Start
             writer.print(tagClassInfo.getTagClassName());
@@ -479,11 +438,11 @@ public class ClassicTagGenerator extends BaseTagGenerator {
             writer.println(" = null;");
             //247815 End
             //begin 230150: reuse TryCatchFinally counter object when pooling is enabled.
-            if (tagClassInfo.implementsTryCatchFinally()) {  // defect 315723
-	            writer.print("int[] ");
-	            writer.print(tagPushBodyCountVar);
-	            writer.println(" = new int[] { 0 };");
-	            persistentData.put("pushBodyCountVarDeclaration", tagPushBodyCountVar); // defect 363508
+            if (tagClassInfo.implementsTryCatchFinally()) { // defect 315723
+                writer.print("int[] ");
+                writer.print(tagPushBodyCountVar);
+                writer.println(" = new int[] { 0 };");
+                persistentData.put("pushBodyCountVarDeclaration", tagPushBodyCountVar); // defect 363508
             }
             //end 230150: reuse TryCatchFinally counter object when pooling is enabled.
             writer.println("int " + tagEvalVar + " = 0;");
@@ -493,42 +452,41 @@ public class ClassicTagGenerator extends BaseTagGenerator {
     public void generateFinally(JavaCodeWriter writer) {
         if (reuseTag && existingTag == false) {
             if (tagClassInfo.implementsJspIdConsumer() == false) {//jsp2.1work
-	            if (jspOptions.isUsePageTagPool()) {
-	                //247815 Start
-	                cleanupTaglibLookupWriter.print(tagClassInfo.getTagClassName());
-	                cleanupTaglibLookupWriter.print(" ");
-	                cleanupTaglibLookupWriter.print(tagHandlerVar);
-	                cleanupTaglibLookupWriter.println(" = (" + tagClassInfo.getTagClassName() + ")_jspx_TagLookup.get(\"" + tagHandlerVar + "\");");
-                     
-                     // LIDB4147-24
-                     
-	                if (!jspOptions.isDisableResourceInjection()){		//PM06063
-                     	    cleanupTaglibLookupWriter.println ("_jspx_iaHelper.doPreDestroy(");
-                     	    cleanupTaglibLookupWriter.println (tagHandlerVar);
-                     	    cleanupTaglibLookupWriter.println (");");
-                     	
-                     	    cleanupTaglibLookupWriter.print ("_jspx_iaHelper.cleanUpTagHandlerFromCdiMap(");
-                     	    cleanupTaglibLookupWriter.print (tagHandlerVar);
-                     	    cleanupTaglibLookupWriter.println (");");
-	                }
-                     
-                     cleanupTaglibLookupWriter.println();
-                     
-                     cleanupTaglibLookupWriter.print(tagHandlerVar);
-	                cleanupTaglibLookupWriter.println(".release();");
-                     
-	                //247815 End
-	            }
-	            else if (jspOptions.isUseThreadTagPool()) {
-	                String tagKey = ti.getTagClassName() + collectedTagData.getVarNameSuffix();
-	                //247815 Start
-	                cleanupTaglibLookupWriter.print(tagClassInfo.getTagClassName());
-	                cleanupTaglibLookupWriter.print(" ");
-	                cleanupTaglibLookupWriter.print(tagHandlerVar);
-	                cleanupTaglibLookupWriter.println(" = (" + tagClassInfo.getTagClassName() + ")_jspx_TagLookup.get(\"" + tagHandlerVar + "\");");
-	                cleanupTaglibLookupWriter.println("putTagHandler(request, \"" + tagKey + "\", " + tagHandlerVar + ");");
-	                //247815 End
-	            }
+                if (jspOptions.isUsePageTagPool()) {
+                    //247815 Start
+                    cleanupTaglibLookupWriter.print(tagClassInfo.getTagClassName());
+                    cleanupTaglibLookupWriter.print(" ");
+                    cleanupTaglibLookupWriter.print(tagHandlerVar);
+                    cleanupTaglibLookupWriter.println(" = (" + tagClassInfo.getTagClassName() + ")_jspx_TagLookup.get(\"" + tagHandlerVar + "\");");
+
+                    // LIDB4147-24
+
+                    if (!jspOptions.isDisableResourceInjection()) { //PM06063
+                        cleanupTaglibLookupWriter.println("_jspx_iaHelper.doPreDestroy(");
+                        cleanupTaglibLookupWriter.println(tagHandlerVar);
+                        cleanupTaglibLookupWriter.println(");");
+
+                        cleanupTaglibLookupWriter.print("_jspx_iaHelper.cleanUpTagHandlerFromCdiMap(");
+                        cleanupTaglibLookupWriter.print(tagHandlerVar);
+                        cleanupTaglibLookupWriter.println(");");
+                    }
+
+                    cleanupTaglibLookupWriter.println();
+
+                    cleanupTaglibLookupWriter.print(tagHandlerVar);
+                    cleanupTaglibLookupWriter.println(".release();");
+
+                    //247815 End
+                } else if (jspOptions.isUseThreadTagPool()) {
+                    String tagKey = ti.getTagClassName() + collectedTagData.getVarNameSuffix();
+                    //247815 Start
+                    cleanupTaglibLookupWriter.print(tagClassInfo.getTagClassName());
+                    cleanupTaglibLookupWriter.print(" ");
+                    cleanupTaglibLookupWriter.print(tagHandlerVar);
+                    cleanupTaglibLookupWriter.println(" = (" + tagClassInfo.getTagClassName() + ")_jspx_TagLookup.get(\"" + tagHandlerVar + "\");");
+                    cleanupTaglibLookupWriter.println("putTagHandler(request, \"" + tagKey + "\", " + tagHandlerVar + ");");
+                    //247815 End
+                }
             }
         }
     }

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/ClassicTagGenerator.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/ClassicTagGenerator.java
@@ -108,17 +108,9 @@ public class ClassicTagGenerator extends BaseTagGenerator {
 
                 if (genTagInMethod) {
                     tagStartWriter.println("try {");
-                } else {
-                    tagStartWriter.println("_jspTagList.add(" + tagHandlerVar + ");");
-                }
+                } 
 
-                tagStartWriter.print("_jspx_iaHelper.doPostConstruct(");
-                tagStartWriter.print(tagHandlerVar);
-                tagStartWriter.println(");");
-
-                tagStartWriter.print("_jspx_iaHelper.addTagHandlerToCdiMap(");
-                tagStartWriter.print(tagHandlerVar + ", " + tagHandlerVar + "_mo");
-                tagStartWriter.println(");");
+                tagStartWriter.print("_jsp_tagPostConstruct(" +tagHandlerVar+ ", " + (!genTagInMethod ? "_jspTagList, " : "null, ") + tagHandlerVar + "_mo" + ");");
 
             } else {
                 // not using CDI

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/GenerateJspVisitor.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/GenerateJspVisitor.java
@@ -36,27 +36,26 @@ public class GenerateJspVisitor extends GenerateVisitor {
     protected String serviceMethodName = Constants.SERVICE_METHOD_NAME;
     protected String jspClassName = null;
     protected String jspPackageName = null;
-	protected String jspSourceFileName = null;
+    protected String jspSourceFileName = null;
 
-	static private Logger logger;
-	private static final String CLASS_NAME="com.ibm.ws.jsp.translator.visitor.generator.GenerateJspVisitor";
-	static{
-		logger = Logger.getLogger("com.ibm.ws.jsp");
-	}
+    static private Logger logger;
+    private static final String CLASS_NAME = "com.ibm.ws.jsp.translator.visitor.generator.GenerateJspVisitor";
+    static {
+        logger = Logger.getLogger("com.ibm.ws.jsp");
+    }
 
     public GenerateJspVisitor(JspVisitorUsage visitorUsage,
                               JspConfiguration jspConfiguration,
                               JspCoreContext context,
                               HashMap resultMap,
-                              JspVisitorInputMap inputMap)
-        throws JspCoreException {
+                              JspVisitorInputMap inputMap) throws JspCoreException {
         super(visitorUsage, jspConfiguration, context, resultMap, inputMap, "JspValidate");
         result = new GenerateJspResult(visitorUsage.getJspVisitorDefinition().getId());
-        JspResources jspFiles = (JspResources)inputMap.get("JspFiles");
+        JspResources jspFiles = (JspResources) inputMap.get("JspFiles");
         jspClassName = jspFiles.getClassName();
         jspPackageName = jspFiles.getPackageName();
         jspSourceFileName = jspFiles.getGeneratedSourceFile().toString();
-		jspSourceFileName = jspSourceFileName.replace('\\','/'); // defect 204907
+        jspSourceFileName = jspSourceFileName.replace('\\', '/'); // defect 204907
         createWriter(jspFiles.getGeneratedSourceFile().getPath(), jspClassName, result.getCustomTagMethodJspIdMap()); //232818
     }
 
@@ -66,24 +65,24 @@ public class GenerateJspVisitor extends GenerateVisitor {
     }
 
     public void visit(Document jspDocument, int visitCount) throws JspCoreException {
-        ValidateJspResult validatorResult = (ValidateJspResult)resultMap.get("JspValidate");
+        ValidateJspResult validatorResult = (ValidateJspResult) resultMap.get("JspValidate");
         boolean genSessionVariable = validatorResult.isGenSessionVariable();
 
         switch (visitCount) {
             case CodeGenerationPhase.IMPORT_SECTION: {
-				if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)) {
-					logger.logp(Level.FINEST, CLASS_NAME, "visit","entering code generation phase IMPORT_SECTION");
-				}
+                if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+                    logger.logp(Level.FINEST, CLASS_NAME, "visit", "entering code generation phase IMPORT_SECTION");
+                }
                 generateImportSection(validatorResult);
                 break;
             }
 
             case CodeGenerationPhase.CLASS_SECTION: {
-				if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)) {
-					logger.logp(Level.FINEST, CLASS_NAME, "visit","entering code generation phase CLASS_SECTION");
-				}
+                if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+                    logger.logp(Level.FINEST, CLASS_NAME, "visit", "entering code generation phase CLASS_SECTION");
+                }
                 generateClassSection(validatorResult);
-                if(PagesVersionHandler.isPages31Loaded()){
+                if (PagesVersionHandler.isPages31Loaded()) {
                     generateIsErrorOnELFoundMethod(jspConfiguration.errorOnELNotFound());
                     generateImportGetters();
                 }
@@ -91,43 +90,43 @@ public class GenerateJspVisitor extends GenerateVisitor {
             }
 
             case CodeGenerationPhase.STATIC_SECTION: {
-				if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)) {
-					logger.logp(Level.FINEST, CLASS_NAME, "visit","entering code generation phase STATIC_SECTION");
-				}
+                if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+                    logger.logp(Level.FINEST, CLASS_NAME, "visit", "entering code generation phase STATIC_SECTION");
+                }
                 generateStaticSection();
                 break;
             }
 
             case CodeGenerationPhase.INIT_SECTION: {
-				if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)) {
-					logger.logp(Level.FINEST, CLASS_NAME, "visit","entering code generation phase INIT_SECTION");
-				}
+                if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+                    logger.logp(Level.FINEST, CLASS_NAME, "visit", "entering code generation phase INIT_SECTION");
+                }
 
                 generateInitSection(validatorResult);
                 break;
             }
 
             case CodeGenerationPhase.METHOD_INIT_SECTION: {
-				if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)) {
-					logger.logp(Level.FINEST, CLASS_NAME, "visit","entering code generation phase METHOD_INIT_SECTION");
-				}
+                if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+                    logger.logp(Level.FINEST, CLASS_NAME, "visit", "entering code generation phase METHOD_INIT_SECTION");
+                }
                 generateServiceInitSection(validatorResult, genSessionVariable);
                 break;
             }
 
             case CodeGenerationPhase.METHOD_SECTION: {
-				if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)) {
-					logger.logp(Level.FINEST, CLASS_NAME, "visit","entering code generation phase METHOD_SECTION");
-				}
+                if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+                    logger.logp(Level.FINEST, CLASS_NAME, "visit", "entering code generation phase METHOD_SECTION");
+                }
 
                 generateServiceSection(validatorResult, genSessionVariable, jspDocument);
                 break;
             }
 
             case CodeGenerationPhase.FINALLY_SECTION: {
-				if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)) {
-					logger.logp(Level.FINEST, CLASS_NAME, "visit","entering code generation phase FINALLY_SECTION");
-				}
+                if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+                    logger.logp(Level.FINEST, CLASS_NAME, "visit", "entering code generation phase FINALLY_SECTION");
+                }
                 generateFinallySection();
                 break;
             }
@@ -141,15 +140,14 @@ public class GenerateJspVisitor extends GenerateVisitor {
             writer.println("}");
             boolean poolingTagMethodsCreated = false;
             for (Iterator itr = methodWriterList.iterator(); itr.hasNext();) {
-                MethodWriter methodWriter = (MethodWriter)itr.next();
+                MethodWriter methodWriter = (MethodWriter) itr.next();
                 //247815 Start
                 if (methodWriter instanceof InitTaglibLookupWriter) {
-                    InitTaglibLookupWriter w = (InitTaglibLookupWriter)methodWriter;
+                    InitTaglibLookupWriter w = (InitTaglibLookupWriter) methodWriter;
                     w.complete();
                     poolingTagMethodsCreated = true;
-                }
-                else if (methodWriter instanceof CleanupTaglibLookupWriter) {
-                    CleanupTaglibLookupWriter w = (CleanupTaglibLookupWriter)methodWriter;
+                } else if (methodWriter instanceof CleanupTaglibLookupWriter) {
+                    CleanupTaglibLookupWriter w = (CleanupTaglibLookupWriter) methodWriter;
                     w.complete();
                 }
                 //247815 End
@@ -157,11 +155,11 @@ public class GenerateJspVisitor extends GenerateVisitor {
             }
 
             //247815 Start
-            if ((jspOptions.isUsePageTagPool() || jspOptions.isUseThreadTagPool())&& poolingTagMethodsCreated == false) {
+            if ((jspOptions.isUsePageTagPool() || jspOptions.isUseThreadTagPool()) && poolingTagMethodsCreated == false) {
                 InitTaglibLookupWriter initTaglibLookupWriter = new InitTaglibLookupWriter(jspOptions.isUseThreadTagPool());
                 initTaglibLookupWriter.complete();
                 writer.printMultiLn(initTaglibLookupWriter.toString());
-                CleanupTaglibLookupWriter cleanupTaglibLookupWriter =  new CleanupTaglibLookupWriter(jspOptions.isUseThreadTagPool());
+                CleanupTaglibLookupWriter cleanupTaglibLookupWriter = new CleanupTaglibLookupWriter(jspOptions.isUseThreadTagPool());
                 cleanupTaglibLookupWriter.complete();
                 writer.printMultiLn(cleanupTaglibLookupWriter.toString());
             }
@@ -174,29 +172,29 @@ public class GenerateJspVisitor extends GenerateVisitor {
 
             writer.println("}");
 
-			if(jspOptions.isKeepGenerated() == true){
-				writer.println("/*");
-				writer.println(jspSourceFileName+" was generated @ " + new java.util.Date());
-				writer.println(GeneratorUtils.fullClassfileInformation);
-				writer.println(" ");
-				writer.println("********************************************************");
-				writer.println("The JSP engine configuration parameters were set as follows:");
-				writer.println(jspOptions.toString());
-				writer.println("********************************************************");
-				writer.println("The following JSP Configuration Parameters were obtained from web.xml:");
-				writer.println(" ");
-				writer.println("prelude list = [" + jspConfiguration.getPreludeList() +"]");
-				writer.println("coda list = [" + jspConfiguration.getCodaList() +"]");
-				writer.println("elIgnored = [" + jspConfiguration.elIgnored() +"]");
-				writer.println("pageEncoding = [" + jspConfiguration.getPageEncoding() +"]");
-				writer.println("isXML = [" + jspConfiguration.isXml() +"]");
-				writer.println("scriptingInvalid = [" + jspConfiguration.scriptingInvalid() +"]");
-				writer.println("trimDirectiveWhitespaces = [" + jspConfiguration.isTrimDirectiveWhitespaces() +"]"); // jsp2.1work
-				writer.println("deferredSyntaxAllowedAsLiteral = [" + jspConfiguration.isDeferredSyntaxAllowedAsLiteral() +"]"); // jsp2.1ELwork
+            if (jspOptions.isKeepGenerated() == true) {
+                writer.println("/*");
+                writer.println(jspSourceFileName + " was generated @ " + new java.util.Date());
+                writer.println(GeneratorUtils.fullClassfileInformation);
+                writer.println(" ");
+                writer.println("********************************************************");
+                writer.println("The JSP engine configuration parameters were set as follows:");
+                writer.println(jspOptions.toString());
+                writer.println("********************************************************");
+                writer.println("The following JSP Configuration Parameters were obtained from web.xml:");
+                writer.println(" ");
+                writer.println("prelude list = [" + jspConfiguration.getPreludeList() + "]");
+                writer.println("coda list = [" + jspConfiguration.getCodaList() + "]");
+                writer.println("elIgnored = [" + jspConfiguration.elIgnored() + "]");
+                writer.println("pageEncoding = [" + jspConfiguration.getPageEncoding() + "]");
+                writer.println("isXML = [" + jspConfiguration.isXml() + "]");
+                writer.println("scriptingInvalid = [" + jspConfiguration.scriptingInvalid() + "]");
+                writer.println("trimDirectiveWhitespaces = [" + jspConfiguration.isTrimDirectiveWhitespaces() + "]"); // jsp2.1work
+                writer.println("deferredSyntaxAllowedAsLiteral = [" + jspConfiguration.isDeferredSyntaxAllowedAsLiteral() + "]"); // jsp2.1ELwork
 
-				writer.println("*/");
+                writer.println("*/");
 
-			}
+            }
 
         }
 
@@ -205,7 +203,7 @@ public class GenerateJspVisitor extends GenerateVisitor {
     // Added for Pages 3.1's errorOnELNotFound option
     private void generateIsErrorOnELFoundMethod(boolean flag) {
         writer.println("public boolean isErrorOnELNotFound() {");
-        writer.println("return "+ flag  + ";");
+        writer.println("return " + flag + ";");
         writer.println("}");
     }
 
@@ -230,7 +228,7 @@ public class GenerateJspVisitor extends GenerateVisitor {
         writer.println("package " + servletPackageName + ";");
         writer.println();
 
-        for(int i = 0; i < Constants.STANDARD_IMPORTS.length; i++)
+        for (int i = 0; i < Constants.STANDARD_IMPORTS.length; i++)
             writer.println("import " + (String) Constants.STANDARD_IMPORTS[i] + ";");
 
         writer.println();
@@ -240,27 +238,26 @@ public class GenerateJspVisitor extends GenerateVisitor {
         writer.println();
         writer.print("public final class " + jspClassName + " extends ");
         String extendsClass = validatorResult.getExtendsClass();
-        writer.print(extendsClass == null
-                ? jspServletBase
-                : extendsClass);
+        writer.print(extendsClass == null ? jspServletBase : extendsClass);
         interfaces.add("com.ibm.ws.jsp.runtime.JspClassInformation");
-        if(PagesVersionHandler.isPages31OrHigherLoaded()){
+        if (PagesVersionHandler.isPages31OrHigherLoaded()) {
             interfaces.add("com.ibm.ws.jsp.runtime.DirectiveInfo");
         }
 
-        /*  SingleThreadModel was removed in Servlet 6.0 (Pages 3.1)
-         *  For Page 3.1, the jsp service method is synchronized instead (performance hit)
-         *  isThreadSafe is not recommended anymore. 
-         */ 
+        /*
+         * SingleThreadModel was removed in Servlet 6.0 (Pages 3.1)
+         * For Page 3.1, the jsp service method is synchronized instead (performance hit)
+         * isThreadSafe is not recommended anymore.
+         */
 
         boolean singleThreaded = validatorResult.isSingleThreaded();
 
-        if(PagesVersionHandler.isPages30OrLowerLoaded()) {
-            if (singleThreaded) { 
+        if (PagesVersionHandler.isPages30OrLowerLoaded()) {
+            if (singleThreaded) {
                 interfaces.add("SingleThreadModel");
             }
         } else {
-            if (singleThreaded) { 
+            if (singleThreaded) {
                 logger.logp(Level.WARNING, CLASS_NAME, "generateClassSection", "jsp.isthreadsafe.warning");
             }
         }
@@ -277,43 +274,47 @@ public class GenerateJspVisitor extends GenerateVisitor {
         writer.println(" {");
         writer.println();
         GeneratorUtils.generateFactoryInitialization(writer, jspConfiguration.getConfigManager().isJCDIEnabled());
-		writer.println();
+        writer.println();
         GeneratorUtils.generateDependencyList(writer, validatorResult, context, jspOptions.isTrackDependencies());
-		writer.println();
+        writer.println();
 
         // LIDB4147-24
 
-		if (!jspOptions.isDisableResourceInjection()){		//PM06063
-			GeneratorUtils.generateInjectionSection (writer);
-		}													//PM06063
+        if (!jspOptions.isDisableResourceInjection()) { //PM06063
+            GeneratorUtils.generateInjectionSection(writer);
+        } //PM06063
 
         writer.println();
 
-		// begin 228118: JSP container should recompile if debug enabled and jsp was not compiled in debug.
-		//GeneratorUtils.generateVersionInformation(writer);
-		GeneratorUtils.generateVersionInformation(writer, jspOptions.isDebugEnabled());
-		// end 228118: JSP container should recompile if debug enabled and jsp was not compiled in debug.
+        // begin 228118: JSP container should recompile if debug enabled and jsp was not compiled in debug.
+        //GeneratorUtils.generateVersionInformation(writer);
+        GeneratorUtils.generateVersionInformation(writer, jspOptions.isDebugEnabled());
+        // end 228118: JSP container should recompile if debug enabled and jsp was not compiled in debug.
+
+        if (!(jspOptions.isUsePageTagPool() || jspOptions.isUseThreadTagPool())) {
+            GeneratorUtils.generate_tagCleanUp_methods(writer, !jspOptions.isDisableResourceInjection()); // PH49514
+        }
 
         // PK81147 start
-		// declare class variable to indicate whether _jspInit() has been called.
-		writer.println();
-		writer.println("private boolean _jspx_isJspInited = false;");
-		writer.println();
+        // declare class variable to indicate whether _jspInit() has been called.
+        writer.println();
+        writer.println("private boolean _jspx_isJspInited = false;");
+        writer.println();
 
-        if(PagesVersionHandler.isPages31OrHigherLoaded()){
+        if (PagesVersionHandler.isPages31OrHigherLoaded()) {
             writer.println();
             writer.println("private static java.util.List<String> importPackageList = new java.util.ArrayList<String>();");
             writer.println("private static java.util.List<String> importClassList = new java.util.ArrayList<String>();");
             writer.println("private static java.util.List<String> importStaticList = new java.util.ArrayList<String>();");
             writer.println();
-            
+
             // Cannot place this in the ImportGenerator since that is only run when the import directive is included in the page
             // the imports below are required for all pages 
             writer.println("static {");
             // Pages 1.10 Directive Packages java.lang.*, jakarta.servlet.*, jakarta.servlet.jsp.*, and jakarta.servlet.http.* are imported implicitly by the JSP container.
-			writer.println("importPackageList.add(\"jakarta.servlet\");");
-			writer.println("importPackageList.add(\"jakarta.servlet.jsp\");");
-			writer.println("importPackageList.add(\"jakarta.servlet.http\");");
+            writer.println("importPackageList.add(\"jakarta.servlet\");");
+            writer.println("importPackageList.add(\"jakarta.servlet.jsp\");");
+            writer.println("importPackageList.add(\"jakarta.servlet.http\");");
             writer.println("}");
         }
 
@@ -334,11 +335,10 @@ public class GenerateJspVisitor extends GenerateVisitor {
         writer.println("static {");
     }
 
-    protected void generateInitSection(ValidateJspResult validatorResult)
-        throws JspCoreException {
+    protected void generateInitSection(ValidateJspResult validatorResult) throws JspCoreException {
         writer.println("}");
         writer.println();
-        GeneratorUtils.generateInitSectionCode(writer, GeneratorUtils.JSP_FILE_TYPE, jspOptions);  //PM06063
+        GeneratorUtils.generateInitSectionCode(writer, GeneratorUtils.JSP_FILE_TYPE, jspOptions); //PM06063
         writer.println();
         GeneratorUtils.generateELFunctionCode(writer, validatorResult);
         writer.println();
@@ -348,28 +348,30 @@ public class GenerateJspVisitor extends GenerateVisitor {
         writer.println();
 
         /*
-         *  Mark recommened using synchonized, but with a performance caveat
-         *  https://github.com/jakartaee/pages/issues/206#issuecomment-934272204
+         * Mark recommened using synchonized, but with a performance caveat
+         * https://github.com/jakartaee/pages/issues/206#issuecomment-934272204
          */
         String sync = "";
-        if(PagesVersionHandler.isPages31OrHigherLoaded()){
-            if(validatorResult.isSingleThreaded()){
+        if (PagesVersionHandler.isPages31OrHigherLoaded()) {
+            if (validatorResult.isSingleThreaded()) {
                 sync = " synchronized";
             }
         }
 
         writer.println(
-            "public" + sync + " void "
-                + serviceMethodName
-                + "("
-                + "HttpServletRequest request, "
-                + "HttpServletResponse  response)");
+                       "public" + sync + " void "
+                       + serviceMethodName
+                       + "("
+                       + "HttpServletRequest request, "
+                       + "HttpServletResponse  response)");
 
         writer.println("    throws java.io.IOException, ServletException {");
         writer.println();
-        result.setServiceMethodLineNumber(((JavaFileWriter)writer).getCurrentLineNumber());
+        result.setServiceMethodLineNumber(((JavaFileWriter) writer).getCurrentLineNumber());
         //writer.println("JspFactory _jspxFactory = null;");
         writer.println("PageContext pageContext = null;");
+
+        GeneratorUtils.generate__jspTagList_variable(writer);
 
         if (genSessionVariable)
             writer.println("HttpSession session = null;");
@@ -402,8 +404,7 @@ public class GenerateJspVisitor extends GenerateVisitor {
         // 247815 Start
         if (jspOptions.isUsePageTagPool()) {
             writer.println("java.util.HashMap _jspx_TagLookup = initTaglibLookup();"); //247815
-        }
-        else if (jspOptions.isUseThreadTagPool()) {
+        } else if (jspOptions.isUseThreadTagPool()) {
             writer.println("java.util.HashMap _jspx_TagLookup = initTaglibLookup(request);"); //247815
         }
         // 247815 End
@@ -422,46 +423,44 @@ public class GenerateJspVisitor extends GenerateVisitor {
         if (contentType == null) {
             if (jspConfiguration.isXml()) {
                 contentType = "text/xml";
-            }
-            else {
+            } else {
                 contentType = "text/html";
             }
         }
 
         if (contentType.indexOf("charset=") < 0) {
             if (jspConfiguration.isXml()) {
-            	// 221843: add only if autoResponseEncoding is false. Else leave it to webcontainer.
-            	if ( autoResponseEncoding == false){
-            		contentType += ";charset=UTF-8";
-            	}
-            }
-            else {
+                // 221843: add only if autoResponseEncoding is false. Else leave it to webcontainer.
+                if (autoResponseEncoding == false) {
+                    contentType += ";charset=UTF-8";
+                }
+            } else {
                 String pageEncoding = validatorResult.getPageEncoding();
                 if (pageEncoding != null && pageEncoding.equals("") == false) {
                     contentType += ";charset=" + pageEncoding;
-                }
-                else {
+                } else {
                     //pageEncoding = jspConfiguration.getPageEncoding();
                     String responseEncoding = jspConfiguration.getResponseEncoding();
-                    if(responseEncoding!=null && !responseEncoding.equals("")){
-                    	contentType += ";charset=" + responseEncoding;
+                    if (responseEncoding != null && !responseEncoding.equals("")) {
+                        contentType += ";charset=" + responseEncoding;
                     }
 
-                    /* -
-                    if (pageEncoding != null && pageEncoding.equals("") == false) {
-                        contentType += ";charset=" + pageEncoding;
-                    }
-                    */
+                    /*
+                     * -
+                     * if (pageEncoding != null && pageEncoding.equals("") == false) {
+                     * contentType += ";charset=" + pageEncoding;
+                     * }
+                     */
                     // 248722: remove defect 221843; spec mandates that if no charset is specified, then defer to webcontainer.
                     // section JSP.4.2 Response Character Encoding
-                    else{
-	                	// 221843: add only if autoResponseEncoding is false. Else leave it to webcontainer.
-	                    /*
-	                    else if(autoResponseEncoding == false){
-	                        	contentType += ";charset=ISO-8859-1";
-	                	}
-	                	*/
-                    	logger.logp(Level.FINEST, CLASS_NAME, "generateServiceSection","JSP did not specify charset; defer to webcontainer");
+                    else {
+                        // 221843: add only if autoResponseEncoding is false. Else leave it to webcontainer.
+                        /*
+                         * else if(autoResponseEncoding == false){
+                         * contentType += ";charset=ISO-8859-1";
+                         * }
+                         */
+                        logger.logp(Level.FINEST, CLASS_NAME, "generateServiceSection", "JSP did not specify charset; defer to webcontainer");
                     }
                     // 248722: spec mandates that if no charset is specified, then defer to webcontainer.
                 }
@@ -474,15 +473,15 @@ public class GenerateJspVisitor extends GenerateVisitor {
         int bufferSize = validatorResult.getBufferSize();
         boolean autoFlush = validatorResult.isAutoFlush();
         writer.println(
-            "pageContext = _jspxFactory.getPageContext(this, request, response, "
-                + writer.quoteString(error)
-                + ", "
-                + genSessionVariable
-                + ", "
-                + bufferSize
-                + ", "
-                + autoFlush
-                + ");");
+                       "pageContext = _jspxFactory.getPageContext(this, request, response, "
+                       + writer.quoteString(error)
+                       + ", "
+                       + genSessionVariable
+                       + ", "
+                       + bufferSize
+                       + ", "
+                       + autoFlush
+                       + ");");
         writer.println();
         writer.println("application = pageContext.getServletContext();");
         writer.println("config = pageContext.getServletConfig();");
@@ -491,7 +490,7 @@ public class GenerateJspVisitor extends GenerateVisitor {
         writer.println("out = pageContext.getOut();");
         writer.println("_jspx_out = out;");
         writer.println();
-        writer.println("pageContext.setAttribute(\""+Constants.JSP_EXPRESSION_FACTORY_OBJECT+"\", _el_expressionfactory);");
+        writer.println("pageContext.setAttribute(\"" + Constants.JSP_EXPRESSION_FACTORY_OBJECT + "\", _el_expressionfactory);");
 
         if (jspConfiguration.isXml()) {
             boolean omitXmlDeclaration = false;
@@ -501,12 +500,11 @@ public class GenerateJspVisitor extends GenerateVisitor {
             }
             Element outputElement = null;
             if (jspDocument.getElementsByTagNameNS(Constants.JSP_NAMESPACE, Constants.JSP_OUTPUT_TYPE).getLength() > 0) {
-                outputElement = (Element)jspDocument.getDocumentElement().getElementsByTagNameNS(Constants.JSP_NAMESPACE, Constants.JSP_OUTPUT_TYPE).item(0);
+                outputElement = (Element) jspDocument.getDocumentElement().getElementsByTagNameNS(Constants.JSP_NAMESPACE, Constants.JSP_OUTPUT_TYPE).item(0);
                 String s = outputElement.getAttribute("omit-xml-declaration");
                 if (s.equalsIgnoreCase("no") || s.equalsIgnoreCase("false")) {
                     omitXmlDeclaration = false;
-                }
-                else if (s.equalsIgnoreCase("yes") || s.equalsIgnoreCase("true")) {
+                } else if (s.equalsIgnoreCase("yes") || s.equalsIgnoreCase("true")) {
                     omitXmlDeclaration = true;
                 }
             }
@@ -523,10 +521,10 @@ public class GenerateJspVisitor extends GenerateVisitor {
             }
             //PK17173 begin
             String doctype = "";
-            if (outputElement!=null)
-            	doctype=outputElement.getAttribute("doctype-root-element");
-            if (outputElement != null && !doctype.equals("")) {   //PK17173 end
-                String docTypeRootElement =  outputElement.getAttribute("doctype-root-element");
+            if (outputElement != null)
+                doctype = outputElement.getAttribute("doctype-root-element");
+            if (outputElement != null && !doctype.equals("")) { //PK17173 end
+                String docTypeRootElement = outputElement.getAttribute("doctype-root-element");
                 String docTypeSystem = outputElement.getAttribute("doctype-system");
                 String docTypePublic = outputElement.getAttribute("doctype-public");
 
@@ -534,8 +532,7 @@ public class GenerateJspVisitor extends GenerateVisitor {
                 if (docTypePublic.equals("") == false) {
                     writer.print(" PUBLIC \\\"" + docTypePublic + "\\\" \\\"" + docTypeSystem + "\\\">\\n\");");
                     writer.println();
-                }
-                else {
+                } else {
                     writer.print(" SYSTEM \\\"" + docTypeSystem + "\\\">\\n\");");
                     writer.println();
                 }
@@ -552,20 +549,25 @@ public class GenerateJspVisitor extends GenerateVisitor {
         writer.println("out.clearBuffer();");
         writer.println("if (pageContext != null) pageContext.handlePageException(t);");
         writer.println("}");
-    	// begin 242714: enhance error reporting for SkipPageException.
+        // begin 242714: enhance error reporting for SkipPageException.
         writer.println("else if (t instanceof com.ibm.ws.jsp.runtime.WsSkipPageException){");
         writer.println("((com.ibm.ws.jsp.runtime.WsSkipPageException)t).printStackTraceIfTraceEnabled();");
         writer.println("}");
-    	// end 242714: enhance error reporting for SkipPageException.
+        // end 242714: enhance error reporting for SkipPageException.
 
         writer.println("} finally {");
+
+        if (!(jspOptions.isUsePageTagPool() || jspOptions.isUseThreadTagPool())) {
+            writer.println("_jsp_cleanUpTagArrayList(_jspTagList);");
+        }
+
         //writer.println("if (_jspxFactory != null) _jspxFactory.releasePageContext(pageContext);");
         writer.println("_jspxFactory.releasePageContext(pageContext);");
+
         //247815 Start
         if (jspOptions.isUsePageTagPool()) {
             writer.println("cleanupTaglibLookup(_jspx_TagLookup);");
-        }
-        else if (jspOptions.isUseThreadTagPool()) {
+        } else if (jspOptions.isUseThreadTagPool()) {
             writer.println("cleanupTaglibLookup(request, _jspx_TagLookup);");
         }
         //247815 End

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/GenerateJspVisitor.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/GenerateJspVisitor.java
@@ -295,6 +295,10 @@ public class GenerateJspVisitor extends GenerateVisitor {
             GeneratorUtils.generate_tagCleanUp_methods(writer, !jspOptions.isDisableResourceInjection()); // PH49514
         }
 
+        if(!jspOptions.isDisableResourceInjection()){
+            GeneratorUtils.generate_tagPostConstruct_method(writer);
+        }
+
         // PK81147 start
         // declare class variable to indicate whether _jspInit() has been called.
         writer.println();

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/GenerateTagFileVisitor.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/GenerateTagFileVisitor.java
@@ -360,6 +360,10 @@ public class GenerateTagFileVisitor extends GenerateVisitor {
             GeneratorUtils.generate_tagCleanUp_methods(writer, !jspOptions.isDisableResourceInjection()); // PH49514
         }
 
+        if(!jspOptions.isDisableResourceInjection()){
+            GeneratorUtils.generate_tagPostConstruct_method(writer);
+        }
+
         if (ti.hasDynamicAttributes()) {
             writer.println("private java.util.HashMap _jspx_dynamic_attrs = new java.util.HashMap();");
         }

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/GenerateTagFileVisitor.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/GenerateTagFileVisitor.java
@@ -40,112 +40,110 @@ import com.ibm.wsspi.jsp.resource.translation.TagFileResources;
 public class GenerateTagFileVisitor extends GenerateVisitor {
     protected GenerateTagFileResult result = null;
     protected TagFileResources tagFileFiles = null;
-  
-	static private Logger logger;
-	private static final String CLASS_NAME="com.ibm.ws.jsp.translator.visitor.generator.GenerateTagFileVisitor";
-	static{
-		logger = Logger.getLogger("com.ibm.ws.jsp");
-	}
-    
+
+    static private Logger logger;
+    private static final String CLASS_NAME = "com.ibm.ws.jsp.translator.visitor.generator.GenerateTagFileVisitor";
+    static {
+        logger = Logger.getLogger("com.ibm.ws.jsp");
+    }
+
     public GenerateTagFileVisitor(JspVisitorUsage visitorUsage,
-                                  JspConfiguration jspConfiguration, 
-                                  JspCoreContext context, 
+                                  JspConfiguration jspConfiguration,
+                                  JspCoreContext context,
                                   HashMap resultMap,
-                                  JspVisitorInputMap inputMap) 
-        throws JspCoreException {
+                                  JspVisitorInputMap inputMap) throws JspCoreException {
         super(visitorUsage, jspConfiguration, context, resultMap, inputMap, "TagFileValidate");
         result = new GenerateTagFileResult(visitorUsage.getJspVisitorDefinition().getId());
-        tagFileFiles = (TagFileResources)inputMap.get("TagFileFiles");
+        tagFileFiles = (TagFileResources) inputMap.get("TagFileFiles");
         createWriter(tagFileFiles.getGeneratedSourceFile().getPath(), tagFileFiles.getClassName(), result.getCustomTagMethodJspIdMap()); //232818
     }
-    
+
     public JspVisitorResult getResult() throws JspCoreException {
         closeWriter();
         return result;
     }
-    
+
     public void visit(Document jspDocument, int visitCount) throws JspCoreException {
-        ValidateTagFileResult validatorResult = (ValidateTagFileResult)resultMap.get("TagFileValidate");
-        
+        ValidateTagFileResult validatorResult = (ValidateTagFileResult) resultMap.get("TagFileValidate");
+
         switch (visitCount) {
             case CodeGenerationPhase.IMPORT_SECTION: {
-				if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)) {
-					logger.logp(Level.FINEST, CLASS_NAME, "visit","entering code generation phase IMPORT_SECTION");
-				}
+                if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+                    logger.logp(Level.FINEST, CLASS_NAME, "visit", "entering code generation phase IMPORT_SECTION");
+                }
                 generateImportSection(validatorResult);
                 break;
             }
-            
+
             case CodeGenerationPhase.CLASS_SECTION: {
-				if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)) {
-					logger.logp(Level.FINEST, CLASS_NAME, "visit","entering code generation phase CLASS_SECTION");
-				}
+                if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+                    logger.logp(Level.FINEST, CLASS_NAME, "visit", "entering code generation phase CLASS_SECTION");
+                }
                 generateClassSection(validatorResult);
                 break;
             }
-            
+
             case CodeGenerationPhase.STATIC_SECTION: {
-				if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)) {
-					logger.logp(Level.FINEST, CLASS_NAME, "visit","entering code generation phase STATIC_SECTION");
-				}
+                if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+                    logger.logp(Level.FINEST, CLASS_NAME, "visit", "entering code generation phase STATIC_SECTION");
+                }
                 generateStaticSection();
                 break;
             }
-            
+
             case CodeGenerationPhase.INIT_SECTION: {
-				if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)) {
-					logger.logp(Level.FINEST, CLASS_NAME, "visit","entering code generation phase INIT_SECTION");
-				}
+                if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+                    logger.logp(Level.FINEST, CLASS_NAME, "visit", "entering code generation phase INIT_SECTION");
+                }
                 generateInitSection(validatorResult);
                 break;
             }
-            
+
             case CodeGenerationPhase.METHOD_INIT_SECTION: {
-				if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)) {
-					logger.logp(Level.FINEST, CLASS_NAME, "visit","entering code generation phase METHOD_INIT_SECTION");
-				}
+                if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+                    logger.logp(Level.FINEST, CLASS_NAME, "visit", "entering code generation phase METHOD_INIT_SECTION");
+                }
                 generateDoTagInitSection(validatorResult);
                 break;
             }
-            
+
             case CodeGenerationPhase.METHOD_SECTION: {
-				if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)) {
-					logger.logp(Level.FINEST, CLASS_NAME, "visit","entering code generation phase METHOD_SECTION");
-				}
+                if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+                    logger.logp(Level.FINEST, CLASS_NAME, "visit", "entering code generation phase METHOD_SECTION");
+                }
                 generateDoTagSection(validatorResult, jspDocument);
                 break;
             }
-            
+
             case CodeGenerationPhase.FINALLY_SECTION: {
-				if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)) {
-					logger.logp(Level.FINEST, CLASS_NAME, "visit","entering code generation phase FINALLY_SECTION");
-				}
+                if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+                    logger.logp(Level.FINEST, CLASS_NAME, "visit", "entering code generation phase FINALLY_SECTION");
+                }
                 generateFinallySection();
                 break;
-            } 
+            }
         }
-        
+
         super.visit(jspDocument, visitCount);
-        
+
         if (visitCount == CodeGenerationPhase.FINALLY_SECTION) {
             writer.println("}");
             writer.println("}");
 
-			if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)) {
-				logger.logp(Level.FINEST, CLASS_NAME, "visit","entering code generation phase METHOD_WRITE");
-			}
-    
+            if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+                logger.logp(Level.FINEST, CLASS_NAME, "visit", "entering code generation phase METHOD_WRITE");
+            }
+
             boolean poolingTagMethodsCreated = false;
             for (Iterator itr = methodWriterList.iterator(); itr.hasNext();) {
-                MethodWriter methodWriter = (MethodWriter)itr.next();
+                MethodWriter methodWriter = (MethodWriter) itr.next();
                 //247815 Start
                 if (methodWriter instanceof InitTaglibLookupWriter) {
-                    InitTaglibLookupWriter w = (InitTaglibLookupWriter)methodWriter;
+                    InitTaglibLookupWriter w = (InitTaglibLookupWriter) methodWriter;
                     w.complete();
                     poolingTagMethodsCreated = true;
-                }
-                else if (methodWriter instanceof CleanupTaglibLookupWriter) {
-                    CleanupTaglibLookupWriter w = (CleanupTaglibLookupWriter)methodWriter;
+                } else if (methodWriter instanceof CleanupTaglibLookupWriter) {
+                    CleanupTaglibLookupWriter w = (CleanupTaglibLookupWriter) methodWriter;
                     w.complete();
                     poolingTagMethodsCreated = true;
                 }
@@ -158,105 +156,103 @@ public class GenerateTagFileVisitor extends GenerateVisitor {
                 InitTaglibLookupWriter initTaglibLookupWriter = new InitTaglibLookupWriter(jspOptions.isUseThreadTagPool());
                 initTaglibLookupWriter.complete();
                 writer.printMultiLn(initTaglibLookupWriter.toString());
-                CleanupTaglibLookupWriter cleanupTaglibLookupWriter =  new CleanupTaglibLookupWriter(jspOptions.isUseThreadTagPool());
+                CleanupTaglibLookupWriter cleanupTaglibLookupWriter = new CleanupTaglibLookupWriter(jspOptions.isUseThreadTagPool());
                 cleanupTaglibLookupWriter.complete();
                 writer.printMultiLn(cleanupTaglibLookupWriter.toString());
             }
             //247815 End
-            
-			if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)) {
-				logger.logp(Level.FINEST, CLASS_NAME, "visit","entering code generation phase FRAGMENT_HELPER");
-			}
+
+            if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+                logger.logp(Level.FINEST, CLASS_NAME, "visit", "entering code generation phase FRAGMENT_HELPER");
+            }
 
             if (fragmentHelperClassWriter.isUsed()) {
                 fragmentHelperClassWriter.generatePostamble();
                 writer.printMultiLn(fragmentHelperClassWriter.toString());
             }
-    
+
             writer.println("}");
         }
     }
 
-
     protected void generateImportSection(ValidateTagFileResult validatorResult) {
-        TagFileInfo tfi = (TagFileInfo)inputMap.get("TagFileInfo");
-        TagLibraryInfoImpl tli = (TagLibraryInfoImpl)tfi.getTagInfo().getTagLibrary();
+        TagFileInfo tfi = (TagFileInfo) inputMap.get("TagFileInfo");
+        TagLibraryInfoImpl tli = (TagLibraryInfoImpl) tfi.getTagInfo().getTagLibrary();
         String tagFilePath = null;
         if (tfi.getPath().startsWith("/WEB-INF/tags")) {
             tagFilePath = tfi.getPath().substring(tfi.getPath().indexOf("/WEB-INF/tags") + 13);
-        }
-        else if (tfi.getPath().startsWith("/META-INF/tags")) {
+        } else if (tfi.getPath().startsWith("/META-INF/tags")) {
             tagFilePath = tfi.getPath().substring(tfi.getPath().indexOf("/META-INF/tags") + 14);
         }
         tagFilePath = tagFilePath.substring(0, tagFilePath.lastIndexOf("/"));
         //PM70267 start
         if (tagFilePath.indexOf("-") > -1) {
             tagFilePath = com.ibm.ws.jsp.translator.utils.NameMangler.handlePackageName(tagFilePath);
-            if (!tagFilePath.startsWith(".")) { 
+            if (!tagFilePath.startsWith(".")) {
                 tagFilePath = "." + tagFilePath;
             }
         }
         //PM70267 end
 
         tagFilePath = tagFilePath.replace('/', '.');
-        
+
         String tagFilePackageName = Constants.TAGFILE_PACKAGE_NAME + "." + tli.getOriginatorId();
         if (tagFilePath.length() > 0)
             tagFilePackageName += tagFilePath;
         writer.println("package " + tagFilePackageName + ";");
         writer.println();
-        
-        for(int i = 0; i < Constants.STANDARD_IMPORTS.length; i++)
+
+        for (int i = 0; i < Constants.STANDARD_IMPORTS.length; i++)
             writer.println("import " + (String) Constants.STANDARD_IMPORTS[i] + ";");
-        
+
         writer.println();
     }
-    
+
     protected void generateClassSection(ValidateTagFileResult validatorResult) {
         writer.println();
         writer.print("public class " + tagFileFiles.getClassName() + " extends javax.servlet.jsp.tagext.SimpleTagSupport");
-        
+
         ArrayList<String> implementingInterfaces = new ArrayList<String>();
 
-        if(PagesVersionHandler.isPages31OrHigherLoaded()){
+        if (PagesVersionHandler.isPages31OrHigherLoaded()) {
             implementingInterfaces.add("com.ibm.ws.jsp.runtime.DirectiveInfo");
         }
 
-        TagFileInfo tfi = (TagFileInfo)inputMap.get("TagFileInfo");
+        TagFileInfo tfi = (TagFileInfo) inputMap.get("TagFileInfo");
         TagInfo ti = tfi.getTagInfo();
         if (ti.hasDynamicAttributes()) {
             implementingInterfaces.add("javax.servlet.jsp.tagext.DynamicAttributes");
         }
 
-        if(implementingInterfaces.size() > 0){
+        if (implementingInterfaces.size() > 0) {
             writer.print(" implements");
             int size = implementingInterfaces.size();
-            for(int i = 0; i < size; i++){
+            for (int i = 0; i < size; i++) {
                 writer.print(" " + implementingInterfaces.get(i));
-                if(i < size -1 ){
+                if (i < size - 1) {
                     writer.print(",");
                 }
             }
         }
-        
+
         writer.println(" {");
         GeneratorUtils.generateFactoryInitialization(writer, jspConfiguration.getConfigManager().isJCDIEnabled());
-		writer.println();
+        writer.println();
 
-        if(PagesVersionHandler.isPages31OrHigherLoaded()){
+        if (PagesVersionHandler.isPages31OrHigherLoaded()) {
             writer.println();
             writer.println("private static java.util.List<String> importPackageList = new java.util.ArrayList<String>();");
             writer.println("private static java.util.List<String> importClassList = new java.util.ArrayList<String>();");
             writer.println("private static java.util.List<String> importStaticList = new java.util.ArrayList<String>();");
             writer.println();
-            
+
             // Cannot place this in the ImportGenerator since that is only run when the import directive is included in the page
             // the imports below are required for all pages 
             writer.println("static {");
             // Pages 1.10 Directive Packages java.lang.*, jakarta.servlet.*, jakarta.servlet.jsp.*, and jakarta.servlet.http.* are imported implicitly by the JSP container.
-			writer.println("importPackageList.add(\"jakarta.servlet\");");
-			writer.println("importPackageList.add(\"jakarta.servlet.jsp\");");
-			writer.println("importPackageList.add(\"jakarta.servlet.http\");");
+            writer.println("importPackageList.add(\"jakarta.servlet\");");
+            writer.println("importPackageList.add(\"jakarta.servlet.jsp\");");
+            writer.println("importPackageList.add(\"jakarta.servlet.http\");");
             writer.println("}");
         }
     }
@@ -265,11 +261,11 @@ public class GenerateTagFileVisitor extends GenerateVisitor {
         writer.println();
         writer.println("static {");
     }
-    
+
     protected void generateInitSection(ValidateTagFileResult validatorResult) throws JspCoreException {
-        TagFileInfo tfi = (TagFileInfo)inputMap.get("TagFileInfo");
+        TagFileInfo tfi = (TagFileInfo) inputMap.get("TagFileInfo");
         TagInfo ti = tfi.getTagInfo();
-        
+
         boolean aliasSeen = false;
         TagVariableInfo[] tagVars = ti.getTagVariableInfos();
         for (int i = 0; i < tagVars.length; i++) {
@@ -280,16 +276,15 @@ public class GenerateTagFileVisitor extends GenerateVisitor {
         }
         writer.println("}");
         writer.println();
-        GeneratorUtils.generateInitSectionCode(writer, GeneratorUtils.TAG_FILE_TYPE, jspOptions);        //PM06063
-        writer.println();        
+        GeneratorUtils.generateInitSectionCode(writer, GeneratorUtils.TAG_FILE_TYPE, jspOptions); //PM06063
+        writer.println();
         GeneratorUtils.generateELFunctionCode(writer, validatorResult);
         writer.println("private JspContext jspContext;");
         writer.println("private java.io.Writer _jspx_sout;");
-        
+
         if (aliasSeen) {
             writer.println("public void setJspContext(JspContext ctx, java.util.Map aliasMap) {");
-        }
-        else {
+        } else {
             writer.println("public void setJspContext( JspContext ctx ) {");
         }
         writer.println("super.setJspContext(ctx);");
@@ -300,19 +295,19 @@ public class GenerateTagFileVisitor extends GenerateVisitor {
         for (int i = 0; i < tagVars.length; i++) {
 
             switch (tagVars[i].getScope()) {
-                case VariableInfo.NESTED :
+                case VariableInfo.NESTED:
                     writer.println("if (_jspx_nested == null)");
                     writer.println("_jspx_nested = new java.util.ArrayList();");
                     writer.print("_jspx_nested.add(");
                     break;
 
-                case VariableInfo.AT_BEGIN :
+                case VariableInfo.AT_BEGIN:
                     writer.println("if (_jspx_at_begin == null)");
                     writer.println("_jspx_at_begin = new java.util.ArrayList();");
                     writer.print("_jspx_at_begin.add(");
                     break;
 
-                case VariableInfo.AT_END :
+                case VariableInfo.AT_END:
                     writer.println("if (_jspx_at_end == null)");
                     writer.println("_jspx_at_end = new java.util.ArrayList();");
                     writer.print("_jspx_at_end.add(");
@@ -321,20 +316,18 @@ public class GenerateTagFileVisitor extends GenerateVisitor {
 
             writer.print(GeneratorUtils.quote(tagVars[i].getNameGiven()));
             writer.print(");");
-            writer.println();     
+            writer.println();
         }
-        if(PagesVersionHandler.isPages31OrHigherLoaded()){
+        if (PagesVersionHandler.isPages31OrHigherLoaded()) {
             if (aliasSeen) {
                 writer.println("this.jspContext = new org.apache.jasper.runtime.JspContextWrapper(ctx, this, _jspx_nested, _jspx_at_begin, _jspx_at_end, aliasMap);");
-            } 
-            else {
+            } else {
                 writer.println("this.jspContext = new org.apache.jasper.runtime.JspContextWrapper(ctx, this, _jspx_nested, _jspx_at_begin, _jspx_at_end, null);");
             }
         } else {
             if (aliasSeen) {
                 writer.println("this.jspContext = new org.apache.jasper.runtime.JspContextWrapper(ctx, _jspx_nested, _jspx_at_begin, _jspx_at_end, aliasMap);");
-            } 
-            else {
+            } else {
                 writer.println("this.jspContext = new org.apache.jasper.runtime.JspContextWrapper(ctx, _jspx_nested, _jspx_at_begin, _jspx_at_end, null);");
             }
         }
@@ -345,9 +338,9 @@ public class GenerateTagFileVisitor extends GenerateVisitor {
         writer.println("return this.jspContext;");
         writer.println("}");
 
-        if(PagesVersionHandler.isPages31OrHigherLoaded()){
+        if (PagesVersionHandler.isPages31OrHigherLoaded()) {
             writer.println(" public boolean isErrorOnELNotFound() {");
-            writer.println("return "+ validatorResult.isErrorOnELNotFound()  + ";");
+            writer.println("return " + validatorResult.isErrorOnELNotFound() + ";");
             writer.println("}");
 
             writer.println(" public java.util.List<String> getImportClassList() {");
@@ -363,6 +356,10 @@ public class GenerateTagFileVisitor extends GenerateVisitor {
             writer.println("}");
         }
 
+        if (!(jspOptions.isUsePageTagPool() || jspOptions.isUseThreadTagPool())) {
+            GeneratorUtils.generate_tagCleanUp_methods(writer, !jspOptions.isDisableResourceInjection()); // PH49514
+        }
+
         if (ti.hasDynamicAttributes()) {
             writer.println("private java.util.HashMap _jspx_dynamic_attrs = new java.util.HashMap();");
         }
@@ -372,8 +369,7 @@ public class GenerateTagFileVisitor extends GenerateVisitor {
             writer.print("private ");
             if (attrInfos[i].isFragment()) {
                 writer.print("javax.servlet.jsp.tagext.JspFragment ");
-            }
-            else {
+            } else {
                 /* Defect 213290 */
                 writer.print(GeneratorUtils.toJavaSourceType(attrInfos[i].getTypeName()));
                 writer.print(" ");
@@ -389,8 +385,7 @@ public class GenerateTagFileVisitor extends GenerateVisitor {
                 writer.print("public ");
                 if (attrInfos[i].isFragment()) {
                     writer.print("javax.servlet.jsp.tagext.JspFragment ");
-                }
-                else {
+                } else {
                     /* Defect 213290 */
                     writer.print(GeneratorUtils.toJavaSourceType(attrInfos[i].getTypeName()));
                     writer.print(" ");
@@ -411,8 +406,7 @@ public class GenerateTagFileVisitor extends GenerateVisitor {
                 if (attrInfos[i].isFragment()) {
                     writer.print("(");
                     writer.print("javax.servlet.jsp.tagext.JspFragment ");
-                }
-                else {
+                } else {
                     writer.print("(");
                     /* Defect 213290 */
                     writer.print(GeneratorUtils.toJavaSourceType(attrInfos[i].getTypeName()));
@@ -437,17 +431,17 @@ public class GenerateTagFileVisitor extends GenerateVisitor {
                 writer.println();
             }
         }
-        
+
         if (ti.hasDynamicAttributes()) {
             writer.println("public void setDynamicAttribute(String uri, String localName, Object value) throws javax.servlet.jsp.JspException {");
             writer.println("if (uri == null) _jspx_dynamic_attrs.put(localName, value);");
             writer.println("}");
         }
-        
+
     }
-    
+
     protected void generateDoTagInitSection(ValidateTagFileResult validatorResult) {
-        TagFileInfo tfi = (TagFileInfo)inputMap.get("TagFileInfo");
+        TagFileInfo tfi = (TagFileInfo) inputMap.get("TagFileInfo");
         TagInfo ti = tfi.getTagInfo();
         //PK65013 - start
         String pageContextVar = Constants.JSP_PAGE_CONTEXT_ORIG;
@@ -455,26 +449,30 @@ public class GenerateTagFileVisitor extends GenerateVisitor {
             pageContextVar = Constants.JSP_PAGE_CONTEXT_NEW;
         }
         //PK65013 - end
-        
+
         //PM12658 start - keep track of doTag line number for debug mode (smap generation)
-        result.setTagMethodLineNumber(((JavaFileWriter)writer).getCurrentLineNumber());
+        result.setTagMethodLineNumber(((JavaFileWriter) writer).getCurrentLineNumber());
         //PM12658 end
         writer.println("public void doTag() throws javax.servlet.jsp.JspException, java.io.IOException {");
-        writer.println("PageContext "+pageContextVar+" = (PageContext)jspContext;");
-        writer.println("javax.servlet.http.HttpServletRequest request = (javax.servlet.http.HttpServletRequest) "+pageContextVar+".getRequest();");        //PK66299
-        writer.println("javax.servlet.http.HttpServletResponse response = (javax.servlet.http.HttpServletResponse) "+pageContextVar+".getResponse();");    //PK66299
-        writer.println("javax.servlet.http.HttpSession session = "+pageContextVar+".getSession();");
-        writer.println("javax.servlet.ServletContext application = "+pageContextVar+".getServletContext();");
-        writer.println("javax.servlet.ServletConfig config = "+pageContextVar+".getServletConfig();");
+        writer.println("PageContext " + pageContextVar + " = (PageContext)jspContext;");
+        writer.println("javax.servlet.http.HttpServletRequest request = (javax.servlet.http.HttpServletRequest) " + pageContextVar + ".getRequest();"); //PK66299
+        writer.println("javax.servlet.http.HttpServletResponse response = (javax.servlet.http.HttpServletResponse) " + pageContextVar + ".getResponse();"); //PK66299
+        writer.println("javax.servlet.http.HttpSession session = " + pageContextVar + ".getSession();");
+        writer.println("javax.servlet.ServletContext application = " + pageContextVar + ".getServletContext();");
+        writer.println("javax.servlet.ServletConfig config = " + pageContextVar + ".getServletConfig();");
         writer.println("javax.servlet.jsp.JspWriter out = jspContext.getOut();");
+
+        if (!(jspOptions.isUsePageTagPool() || jspOptions.isUseThreadTagPool())) {
+            GeneratorUtils.generate__jspTagList_variable(writer);
+        }
+
         writer.println();
-        
+
         // 247815 Start
         if (jspOptions.isUsePageTagPool()) {
             writer.println("java.util.HashMap _jspx_TagLookup = initTaglibLookup();");
             writer.println();
-        }
-        else if (jspOptions.isUseThreadTagPool()) {
+        } else if (jspOptions.isUseThreadTagPool()) {
             writer.println("java.util.HashMap _jspx_TagLookup = new java.util.HashMap();");
             writer.println();
         }
@@ -483,7 +481,7 @@ public class GenerateTagFileVisitor extends GenerateVisitor {
         // jsp2.1ELwork
         writer.println("_jspInit(config);");
         writer.println();
-        
+
         // defect 386311 begin
         // set current JspContext on ELContext
         writer.println("jspContext.getELContext().putContext(JspContext.class,jspContext);");
@@ -491,14 +489,14 @@ public class GenerateTagFileVisitor extends GenerateVisitor {
         boolean varMapperInit = false;
         TagAttributeInfo[] attrInfos = ti.getAttributes();
         for (int i = 0; i < attrInfos.length; i++) {
-        	String attrName = attrInfos[i].getName();
-        	if(attrInfos[i].isDeferredMethod()||attrInfos[i].isDeferredValue()){
-        		if(!varMapperInit){
-        			writer.print("javax.el.VariableMapper _jspx_varmap= jspContext.getELContext().getVariableMapper();");
-        			writer.println();
-        			varMapperInit = true;
-        		}
-        		writer.print("javax.el.ValueExpression _jspx_ve");
+            String attrName = attrInfos[i].getName();
+            if (attrInfos[i].isDeferredMethod() || attrInfos[i].isDeferredValue()) {
+                if (!varMapperInit) {
+                    writer.print("javax.el.VariableMapper _jspx_varmap= jspContext.getELContext().getVariableMapper();");
+                    writer.println();
+                    varMapperInit = true;
+                }
+                writer.print("javax.el.ValueExpression _jspx_ve");
                 writer.print(Integer.toString(i));
                 writer.print(" = _jspx_varmap.setVariable(");
                 writer.print(GeneratorUtils.quote(attrName));
@@ -513,76 +511,74 @@ public class GenerateTagFileVisitor extends GenerateVisitor {
                 }
                 writer.print(");");
                 writer.println();
-                
-        	}else{
-        		writer.print("if (" + GeneratorUtils.toGetterMethod(attrName) + " != null) ");
-                writer.print(" "+pageContextVar+".setAttribute(");
-        		writer.print(GeneratorUtils.quote(attrName));
-            	writer.print(", ");
-            	writer.print(GeneratorUtils.toGetterMethod(attrName));
-            	writer.print(");");
-            	writer.println();
-        	}
+
+            } else {
+                writer.print("if (" + GeneratorUtils.toGetterMethod(attrName) + " != null) ");
+                writer.print(" " + pageContextVar + ".setAttribute(");
+                writer.print(GeneratorUtils.quote(attrName));
+                writer.print(", ");
+                writer.print(GeneratorUtils.toGetterMethod(attrName));
+                writer.print(");");
+                writer.println();
+            }
         }
 
         if (ti.hasDynamicAttributes()) {
-            writer.print(pageContextVar+".setAttribute(\"");
-            writer.print(((TagFileTagInfo)ti).getDynamicAttributesMapName());
+            writer.print(pageContextVar + ".setAttribute(\"");
+            writer.print(((TagFileTagInfo) ti).getDynamicAttributesMapName());
             writer.print("\", _jspx_dynamic_attrs);");
             writer.println();
         }
     }
-    
+
     protected void generateDoTagSection(ValidateTagFileResult validatorResult, Document jspDocument) {
         writer.println("try {");
         if (jspConfiguration.isXml()) {
             boolean omitXmlDeclaration = true;
             Element outputElement = null;
-            
+
             if (jspDocument.getElementsByTagNameNS(Constants.JSP_NAMESPACE, Constants.JSP_OUTPUT_TYPE).getLength() > 0) {
-                outputElement = (Element)jspDocument.getDocumentElement().getElementsByTagNameNS(Constants.JSP_NAMESPACE, Constants.JSP_OUTPUT_TYPE).item(0);
+                outputElement = (Element) jspDocument.getDocumentElement().getElementsByTagNameNS(Constants.JSP_NAMESPACE, Constants.JSP_OUTPUT_TYPE).item(0);
                 String s = outputElement.getAttribute("omit-xml-declaration");
                 if (s.equalsIgnoreCase("no") || s.equalsIgnoreCase("false")) {
                     omitXmlDeclaration = false;
-                }
-                else if (s.equalsIgnoreCase("yes") || s.equalsIgnoreCase("true")) {
+                } else if (s.equalsIgnoreCase("yes") || s.equalsIgnoreCase("true")) {
                     omitXmlDeclaration = true;
                 }
             }
-            
+
             if (omitXmlDeclaration == false) {
                 String pageEncoding = validatorResult.getPageEncoding();
                 if (pageEncoding == null || pageEncoding.equals("")) {
                     pageEncoding = jspConfiguration.getPageEncoding();
                     if (pageEncoding == null || pageEncoding.equals("")) {
-                        pageEncoding = "UTF-8";    
+                        pageEncoding = "UTF-8";
                     }
                 }
                 writer.println("out.write(\"<?xml version=\\\"1.0\\\" encoding=\\\"" + pageEncoding + "\\\"?>\\n\");");
             }
-            
+
             //PK17173 begin
             String doctype = "";
-            if (outputElement!=null)
-            	doctype=outputElement.getAttribute("doctype-root-element");
-            if (outputElement != null && !doctype.equals("")) {    //PK17173 end
-                String docTypeRootElement =  outputElement.getAttribute("doctype-root-element");
+            if (outputElement != null)
+                doctype = outputElement.getAttribute("doctype-root-element");
+            if (outputElement != null && !doctype.equals("")) { //PK17173 end
+                String docTypeRootElement = outputElement.getAttribute("doctype-root-element");
                 String docTypeSystem = outputElement.getAttribute("doctype-system");
                 String docTypePublic = outputElement.getAttribute("doctype-public");
-                
+
                 writer.print("out.write(\"<!DOCTYPE " + docTypeRootElement);
                 if (docTypePublic.equals("") == false) {
                     writer.print(" PUBLIC \\\"" + docTypePublic + "\\\" \\\"" + docTypeSystem + "\\\">\\n\");");
-                    writer.println();     
-                }
-                else {
+                    writer.println();
+                } else {
                     writer.print(" SYSTEM \\\"" + docTypeSystem + "\\\">\\n\");");
-                    writer.println();     
+                    writer.println();
                 }
             }
         }
     }
-    
+
     protected void generateFinallySection() {
         writer.println("} catch( Throwable t ) {");
         writer.println("if( t instanceof javax.servlet.jsp.SkipPageException )");
@@ -600,6 +596,10 @@ public class GenerateTagFileVisitor extends GenerateVisitor {
         //247815 Start
         if (jspOptions.isUsePageTagPool()) {
             writer.println("cleanupTaglibLookup(_jspx_TagLookup);");
+        }
+
+        if (!(jspOptions.isUsePageTagPool() || jspOptions.isUseThreadTagPool())) {
+            writer.println("_jsp_cleanUpTagArrayList(_jspTagList);");
         }
         //247815 End
     }

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/GenerateVisitor.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/GenerateVisitor.java
@@ -80,7 +80,7 @@ public abstract class GenerateVisitor extends JspVisitor {
         catch (IOException e) {
             throw new JspCoreException(e);
         }
-        fragmentHelperClassWriter = new FragmentHelperClassWriter(className);
+        fragmentHelperClassWriter = new FragmentHelperClassWriter(className, jspOptions);
         boolean reuseTags = false;
         if (jspOptions.isUsePageTagPool() ||
             jspOptions.isUseThreadTagPool()) {

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/GeneratorUtils.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/GeneratorUtils.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2004 IBM Corporation and others.
+ * Copyright (c) 1997, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jsp.translator.visitor.generator;
 
@@ -32,20 +29,19 @@ import com.ibm.ws.jsp.webcontainerext.JSPExtensionFactory;
 import com.ibm.wsspi.jsp.context.JspCoreContext;
 import com.ibm.wsspi.webcontainer.WCCustomProperties;
 
-
 public class GeneratorUtils {
-	static private Logger logger;
-	private static final String CLASS_NAME="com.ibm.ws.jsp.translator.visitor.generator.GeneratorUtils";
-	static{
-		logger = Logger.getLogger("com.ibm.ws.jsp");
-	}
-	
-	public static String classfileVersion= JSPExtensionFactory.getGeneratorUtilsExtFactory().getGeneratorUtilsExt().getClassFileVersion();
-	public static String fullClassfileInformation="unknown";
-	public static int TAG_FILE_TYPE=1;
-	public static int JSP_FILE_TYPE=2;
-	
-	//PM21395 
+    static private Logger logger;
+    private static final String CLASS_NAME = "com.ibm.ws.jsp.translator.visitor.generator.GeneratorUtils";
+    static {
+        logger = Logger.getLogger("com.ibm.ws.jsp");
+    }
+
+    public static String classfileVersion = JSPExtensionFactory.getGeneratorUtilsExtFactory().getGeneratorUtilsExt().getClassFileVersion();
+    public static String fullClassfileInformation = "unknown";
+    public static int TAG_FILE_TYPE = 1;
+    public static int JSP_FILE_TYPE = 2;
+
+    //PM21395 
     public static String quote(String s) {
         return quote(s, false);
     }
@@ -55,7 +51,7 @@ public class GeneratorUtils {
         if (s == null)
             return "null";
         //PM21395 starts
-        if (flag){
+        if (flag) {
             s = s.replaceAll("&quot;", "\"");
         }
         //PM21395 ends
@@ -87,47 +83,47 @@ public class GeneratorUtils {
 
     //PM81674 start
     public static String handleEscapes(String exp) {
-        
+
         boolean evalExpressionFollowingTwoBackslashes = WCCustomProperties.EVAL_EXPRESSION_FOLLOWING_TWO_BACKSLASHES; //PM81674
-        
-        if(com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)){
-            logger.logp(Level.FINEST, CLASS_NAME, "handleEscapes","expression = ["+exp+"]");
-            logger.logp(Level.FINEST, CLASS_NAME, "handleEscapes","evalExpressionFollowingTwoBackslashes = ["+evalExpressionFollowingTwoBackslashes+"]");
+
+        if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+            logger.logp(Level.FINEST, CLASS_NAME, "handleEscapes", "expression = [" + exp + "]");
+            logger.logp(Level.FINEST, CLASS_NAME, "handleEscapes", "evalExpressionFollowingTwoBackslashes = [" + evalExpressionFollowingTwoBackslashes + "]");
         }
-        
+
         //749106.1 start
         if (!evalExpressionFollowingTwoBackslashes) {
             return exp;
         }
         //749106.1 end
-        
+
         if (exp.indexOf("${") == -1) {
             return exp;
         }
-            
-        boolean inEL = false;               
+
+        boolean inEL = false;
         int len = exp.length();
         StringBuilder sb = new StringBuilder();
-            
+
         for (int x = 0; x < len; x++) {
             char c = exp.charAt(x);
-            
+
             if (c == '$') {
-                if (((x+1) < len) && (exp.charAt(x+1) == '{')) {
+                if (((x + 1) < len) && (exp.charAt(x + 1) == '{')) {
                     inEL = true;
                     sb.append("${");
                     x++;
                 } else {
                     sb.append(c);
                 }
-            } else if (c == '}') { 
+            } else if (c == '}') {
                 inEL = false;
                 sb.append(c);
             } else if (c == '\\' && !inEL) {
-                if ((x+4) < len) {                          
-                    if (exp.substring(x, x+4).equals("\\\\\\\\")) {                                 
+                if ((x + 4) < len) {
+                    if (exp.substring(x, x + 4).equals("\\\\\\\\")) {
                         sb.append("${'\\\\\\\\'}");
-                        x = x + 3;                                  
+                        x = x + 3;
                     } else {
                         sb.append(c);
                     }
@@ -136,14 +132,14 @@ public class GeneratorUtils {
                 }
             } else {
                 sb.append(c);
-            }                       
+            }
         }
-                            
-        if(com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)){
-            logger.logp(Level.FINEST, CLASS_NAME, "handleEscapes","after processing expression = ["+sb.toString()+"]");
+
+        if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+            logger.logp(Level.FINEST, CLASS_NAME, "handleEscapes", "after processing expression = [" + sb.toString() + "]");
         }
-            
-        return sb.toString();               
+
+        return sb.toString();
     }
     //PM81674 end
 
@@ -162,14 +158,14 @@ public class GeneratorUtils {
     //  PK65013 - already know if this isTagFile or not and pageContextVar is set accordingly
     public static void generateLocalVariables(JavaCodeWriter out, Element jspElement, String pageContextVar) throws JspCoreException {
         if (hasUseBean(jspElement)) {
-            out.println("HttpSession session = "+pageContextVar+".getSession();");
-            out.println("ServletContext application = "+pageContextVar+".getServletContext();");
+            out.println("HttpSession session = " + pageContextVar + ".getSession();");
+            out.println("ServletContext application = " + pageContextVar + ".getServletContext();");
         }
         if (hasUseBean(jspElement) || hasIncludeAction(jspElement) || hasSetProperty(jspElement) || hasForwardAction(jspElement)) {
-            out.println("HttpServletRequest request = (HttpServletRequest)"+pageContextVar+".getRequest();");
+            out.println("HttpServletRequest request = (HttpServletRequest)" + pageContextVar + ".getRequest();");
         }
         if (hasIncludeAction(jspElement)) {
-            out.println("HttpServletResponse response = (HttpServletResponse)"+pageContextVar+".getResponse();");
+            out.println("HttpServletResponse response = (HttpServletResponse)" + pageContextVar + ".getResponse();");
         }
     }
 
@@ -215,26 +211,19 @@ public class GeneratorUtils {
         if (expectedType.isPrimitive()) {
             if (expectedType.equals(Boolean.TYPE)) {
                 classType = Boolean.class.getName();
-            }
-            else if (expectedType.equals(Byte.TYPE)) {
+            } else if (expectedType.equals(Byte.TYPE)) {
                 classType = Byte.class.getName();
-            }
-            else if (expectedType.equals(Character.TYPE)) {
+            } else if (expectedType.equals(Character.TYPE)) {
                 classType = Character.class.getName();
-            }
-            else if (expectedType.equals(Short.TYPE)) {
+            } else if (expectedType.equals(Short.TYPE)) {
                 classType = Short.class.getName();
-            }
-            else if (expectedType.equals(Integer.TYPE)) {
+            } else if (expectedType.equals(Integer.TYPE)) {
                 classType = Integer.class.getName();
-            }
-            else if (expectedType.equals(Long.TYPE)) {
+            } else if (expectedType.equals(Long.TYPE)) {
                 classType = Long.class.getName();
-            }
-            else if (expectedType.equals(Float.TYPE)) {
+            } else if (expectedType.equals(Float.TYPE)) {
                 classType = Float.class.getName();
-            }
-            else if (expectedType.equals(Double.TYPE)) {
+            } else if (expectedType.equals(Double.TYPE)) {
                 classType = Double.class.getName();
             }
         }
@@ -247,49 +236,43 @@ public class GeneratorUtils {
         if (expectedType.isPrimitive()) {
             if (expectedType.equals(Boolean.TYPE)) {
                 primitiveConverterMethod = "booleanValue";
-            }
-            else if (expectedType.equals(Byte.TYPE)) {
+            } else if (expectedType.equals(Byte.TYPE)) {
                 primitiveConverterMethod = "byteValue";
-            }
-            else if (expectedType.equals(Character.TYPE)) {
+            } else if (expectedType.equals(Character.TYPE)) {
                 primitiveConverterMethod = "charValue";
-            }
-            else if (expectedType.equals(Short.TYPE)) {
+            } else if (expectedType.equals(Short.TYPE)) {
                 primitiveConverterMethod = "shortValue";
-            }
-            else if (expectedType.equals(Integer.TYPE)) {
+            } else if (expectedType.equals(Integer.TYPE)) {
                 primitiveConverterMethod = "intValue";
-            }
-            else if (expectedType.equals(Long.TYPE)) {
+            } else if (expectedType.equals(Long.TYPE)) {
                 primitiveConverterMethod = "longValue";
-            }
-            else if (expectedType.equals(Float.TYPE)) {
+            } else if (expectedType.equals(Float.TYPE)) {
                 primitiveConverterMethod = "floatValue";
-            }
-            else if (expectedType.equals(Double.TYPE)) {
+            } else if (expectedType.equals(Double.TYPE)) {
                 primitiveConverterMethod = "doubleValue";
             }
         }
-    	return primitiveConverterMethod;
+        return primitiveConverterMethod;
     }
 
     /**
      * Produces a String representing a call to the EL interpreter.
-     * @param expression a String containing zero or more "${}" expressions
-     * @param expectedType the expected type of the interpreted result
-     * @param defaultPrefix Default prefix, or literal "null"
-     * @param fnmapvar Variable pointing to a function map.
-     * @param XmlEscape True if the result should do XML escaping
+     * 
+     * @param expression     a String containing zero or more "${}" expressions
+     * @param expectedType   the expected type of the interpreted result
+     * @param defaultPrefix  Default prefix, or literal "null"
+     * @param fnmapvar       Variable pointing to a function map.
+     * @param XmlEscape      True if the result should do XML escaping
      * @param pageContextVar Variable for PageContext variable name in generated Java code.
      * @return a String representing a call to the EL interpreter.
      */
     public static String interpreterCall(
-        boolean isTagFile,
-        String expression,
-        Class expectedType,
-        String fnmapvar,
-        boolean XmlEscape,
-        String pageContextVar) {  //PK65013
+                                         boolean isTagFile,
+                                         String expression,
+                                         Class expectedType,
+                                         String fnmapvar,
+                                         boolean XmlEscape,
+                                         String pageContextVar) { //PK65013
 
         return JSPExtensionFactory.getGeneratorUtilsExtFactory().getGeneratorUtilsExt().interpreterCall(isTagFile,
                                                                                                         expression,
@@ -306,7 +289,7 @@ public class GeneratorUtils {
         sb.append(',');
         sb.append("_el_expressionfactory");
         sb.append(".createValueExpression(");
-        if (true/*isELInput*/) { // optimize
+        if (true/* isELInput */) { // optimize
             sb.append(elContext);
             sb.append(',');
         }
@@ -333,11 +316,12 @@ public class GeneratorUtils {
             sb.append(".getELContext()");
             sb.append(")");
         }
-        attrValue = sb.toString();    	
-    	return sb.toString();
+        attrValue = sb.toString();
+        return sb.toString();
     }
 
-    public static String createMethodExpression(StringBuffer sb, String mark, String elContext, String attrValue, boolean isELinput, Class c, TagAttributeInfo tai, String jspCtxt) {
+    public static String createMethodExpression(StringBuffer sb, String mark, String elContext, String attrValue, boolean isELinput, Class c, TagAttributeInfo tai,
+                                                String jspCtxt) {
         sb.append("new org.apache.jasper.el.JspMethodExpression(");
         sb.append(quote(mark));
         sb.append(',');
@@ -362,17 +346,16 @@ public class GeneratorUtils {
 
         sb.append("}))");
         attrValue = sb.toString();
-    	return sb.toString();
+        return sb.toString();
     }
-    
+
     public static String toJavaSourceTypeFromTld(String type) {
         if (type == null || "void".equals(type)) {
             return "Void.TYPE";
         }
         return type + ".class";
     }
-    
-    
+
     public static String[] getParameterTypeNames(TagAttributeInfo tai) {
         if (tai != null) {
             if (GeneratorUtils.isDeferredMethodInput(tai)) {
@@ -411,7 +394,6 @@ public class GeneratorUtils {
         return "java.lang.Object";
     }
 
-    
     public static String nextTemporaryVariableName(Map persistentData) {
         String nextTempVar = "_jspx_temp";
 
@@ -430,62 +412,58 @@ public class GeneratorUtils {
 
     //PK65013 add method parameter pageContextVar
     public static String attributeValue(
-        String valueIn,
-        boolean encode,
-        Class expectedType,
-        JspConfiguration jspConfig,
-        boolean isTagFile,
-        String pageContextVar) {
+                                        String valueIn,
+                                        boolean encode,
+                                        Class expectedType,
+                                        JspConfiguration jspConfig,
+                                        boolean isTagFile,
+                                        String pageContextVar) {
         String value = valueIn;
         value = value.replaceAll("&gt;", ">");
         value = value.replaceAll("&lt;", "<");
         value = value.replaceAll("&amp;", "&");
         value = value.replaceAll("<\\%", "<%");
         value = value.replaceAll("%\\>", "%>");
-		if(com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)){
-			logger.logp(Level.FINEST, CLASS_NAME, "attributeValue","valueIn = ["+valueIn+"]");
-			logger.logp(Level.FINEST, CLASS_NAME, "attributeValue","encode = ["+encode+"]");
-			logger.logp(Level.FINEST, CLASS_NAME, "attributeValue","expectedType = ["+expectedType+"]");
-			logger.logp(Level.FINEST, CLASS_NAME, "attributeValue","isTagFile = ["+isTagFile+"]");
-		}
+        if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+            logger.logp(Level.FINEST, CLASS_NAME, "attributeValue", "valueIn = [" + valueIn + "]");
+            logger.logp(Level.FINEST, CLASS_NAME, "attributeValue", "encode = [" + encode + "]");
+            logger.logp(Level.FINEST, CLASS_NAME, "attributeValue", "expectedType = [" + expectedType + "]");
+            logger.logp(Level.FINEST, CLASS_NAME, "attributeValue", "isTagFile = [" + isTagFile + "]");
+        }
         if (JspTranslatorUtil.isExpression(value)) {
             value = value.substring(2, value.length() - 1);
             if (encode) {
-                value = "org.apache.jasper.runtime.JspRuntimeLibrary.URLEncode(String.valueOf(" + 
-                value + 
-                "), request.getCharacterEncoding())";//PK03712
+                value = "org.apache.jasper.runtime.JspRuntimeLibrary.URLEncode(String.valueOf(" +
+                        value +
+                        "), request.getCharacterEncoding())";//PK03712
             }
-    		if(com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)){
-    			logger.logp(Level.FINEST, CLASS_NAME, "attributeValue","isExpression. value = ["+value+"]");
-    		}
-        }
-        else if (JspTranslatorUtil.isELInterpreterInput(value, jspConfig)) {
-        	if(encode){
+            if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+                logger.logp(Level.FINEST, CLASS_NAME, "attributeValue", "isExpression. value = [" + value + "]");
+            }
+        } else if (JspTranslatorUtil.isELInterpreterInput(value, jspConfig)) {
+            if (encode) {
                 //PK65013 - add pageContextVar parameter
-        	    value = "org.apache.jasper.runtime.JspRuntimeLibrary.URLEncode(" + 
-        	            interpreterCall(isTagFile, value, expectedType, "_jspx_fnmap", false, pageContextVar) + 
-						", request.getCharacterEncoding())";
-        	}
-        	else{
+                value = "org.apache.jasper.runtime.JspRuntimeLibrary.URLEncode(" +
+                        interpreterCall(isTagFile, value, expectedType, "_jspx_fnmap", false, pageContextVar) +
+                        ", request.getCharacterEncoding())";
+            } else {
                 //PK65013 - add pageContextVar parameter
                 value = interpreterCall(isTagFile, value, expectedType, "_jspx_fnmap", false, pageContextVar);
-        	}
-    		if(com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)){
-    			logger.logp(Level.FINEST, CLASS_NAME, "attributeValue","isELInterpreterInput. value = ["+value+"]");
-    		}
-        }
-        else {
+            }
+            if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+                logger.logp(Level.FINEST, CLASS_NAME, "attributeValue", "isELInterpreterInput. value = [" + value + "]");
+            }
+        } else {
             if (encode) {
                 value = "org.apache.jasper.runtime.JspRuntimeLibrary.URLEncode("
                         + quote(value)
                         + ", request.getCharacterEncoding())";
-            }
-            else {
+            } else {
                 value = quote(value);
             }
-    		if(com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)){
-    			logger.logp(Level.FINEST, CLASS_NAME, "attributeValue","default. value = ["+value+"]");
-    		}
+            if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
+                logger.logp(Level.FINEST, CLASS_NAME, "attributeValue", "default. value = [" + value + "]");
+            }
         }
 
         return (value);
@@ -520,8 +498,7 @@ public class GeneratorUtils {
                 caw.write('%');
                 caw.write('>');
                 i = i + 3;
-            }
-            else
+            } else
                 caw.write(chars[i]);
         }
         return caw.toCharArray();
@@ -530,9 +507,9 @@ public class GeneratorUtils {
     public static char[] escapeQuotes(char[] chars) {
         char[] c = escapeScriptingStart(chars);
         c = escapeScriptingEnd(c);
-        return (c);    
+        return (c);
     }
-    
+
     private static char[] escapeScriptingStart(char[] chars) {
         // Prescan to convert <\% to <%
         String s = new String(chars);
@@ -565,11 +542,9 @@ public class GeneratorUtils {
         return (chars);
     }
 
+    public static void generateELFunctionCode(JavaCodeWriter writer, ValidateResult validatorResult) throws JspCoreException {
 
-    public static void generateELFunctionCode(JavaCodeWriter writer, ValidateResult validatorResult)
-        throws JspCoreException {
-        
-        JSPExtensionFactory.getGeneratorUtilsExtFactory().getGeneratorUtilsExt().generateELFunctionCode(writer, validatorResult);        
+        JSPExtensionFactory.getGeneratorUtilsExtFactory().getGeneratorUtilsExt().generateELFunctionCode(writer, validatorResult);
     }
 
     public static void generateDependencyList(JavaCodeWriter writer, ValidateResult validatorResult, JspCoreContext context, boolean isTrackDependencies) {
@@ -580,26 +555,26 @@ public class GeneratorUtils {
             writer.print("_jspx_dependants = new String[");
             if (validatorResult.getDependencyList().size() > 0) {
                 writer.print("" + validatorResult.getDependencyList().size());
-            }
-            else {
+            } else {
                 writer.print("" + 0);
             }
             writer.print("];");
             writer.println();
 
             int count = 0;
-            String dependencyName=null;
+            String dependencyName = null;
             long dependencyTimeStamp;
             //String dependencyFullName=null;
             //File dependencyFile=null;
             for (Iterator itr = validatorResult.getDependencyList().iterator(); itr.hasNext();) {
-                writer.print("_jspx_dependants["+(count++)+"] = \"");
-                dependencyName=(String) itr.next();
+                writer.print("_jspx_dependants[" + (count++) + "] = \"");
+                dependencyName = (String) itr.next();
                 dependencyTimeStamp = context.getRealTimeStamp(dependencyName);
                 //dependencyFullName=context.getRealPath(dependencyName);
                 //dependencyFile = new File(dependencyFullName);
                 //writer.print(dependencyName+Constants.TIMESTAMP_DELIMETER+dependencyFile.lastModified() + Constants.TIMESTAMP_DELIMETER+ (new java.util.Date(dependencyFile.lastModified())).toString());
-                writer.print(dependencyName+Constants.TIMESTAMP_DELIMETER+dependencyTimeStamp + Constants.TIMESTAMP_DELIMETER+ (new java.util.Date(dependencyTimeStamp)).toString());
+                writer.print(dependencyName + Constants.TIMESTAMP_DELIMETER + dependencyTimeStamp + Constants.TIMESTAMP_DELIMETER
+                             + (new java.util.Date(dependencyTimeStamp)).toString());
                 writer.print("\";");
                 writer.println();
             }
@@ -612,46 +587,75 @@ public class GeneratorUtils {
         writer.println("}");
     }
 
-	public static void generateVersionInformation(JavaCodeWriter writer, boolean isDebugClassFile) {
-		writer.println("private static String _jspx_classVersion;");
-		//		 begin 228118: JSP container should recompile if debug enabled and jsp was not compiled in debug.
-		writer.println("private static boolean _jspx_isDebugClassFile;");
-		//		 end 228118: JSP container should recompile if debug enabled and jsp was not compiled in debug.		
+    /*
+     * Following three methods were added for PH49514
+     */
+    public static void generate__jspTagList_variable(JavaCodeWriter writer) {
+        writer.println("java.util.ArrayList _jspTagList = new java.util.ArrayList();");
+        writer.println();
+    }
 
-		writer.println("static {");
-		writer.print("_jspx_classVersion = new String(");
-		writer.print("\"" + classfileVersion);
-		writer.print("\");");
-		writer.println();
+    public static void generate_tagCleanUp_methods(JavaCodeWriter writer, boolean resourceInjectionEnabled) {
+        writer.println("public void _jsp_cleanUpTag(Object tag, java.util.ArrayList tagList) {");
+        if(resourceInjectionEnabled) { // if not disabled, then the _jspx_iaHelper is not available
+            writer.println("  _jspx_iaHelper.doPreDestroy(tag);");
+            writer.println("  _jspx_iaHelper.cleanUpTagHandlerFromCdiMap(tag);");
+        }
+        writer.println("  if (tag instanceof javax.servlet.jsp.tagext.Tag) {");
+        writer.println("    ((javax.servlet.jsp.tagext.Tag) tag).release();");
+        writer.println("  }");
+        writer.println("  if(tagList != null){");
+        writer.println("    tagList.remove(tag);");
+        writer.println("  }");
+        writer.println("}");
+        writer.println();
+        writer.println("public void _jsp_cleanUpTagArrayList(java.util.ArrayList tagList) {");
+        writer.println("  if(!tagList.isEmpty()) {");
+        writer.println("    for(int i = 0; i < tagList.size(); i++ ) {");
+        writer.println("      _jsp_cleanUpTag(tagList.get(i), null);");
+        writer.println("    }");
+        writer.println("  }");
+        writer.println("}");
+    }
 
-		//		 begin 228118: JSP container should recompile if debug enabled and jsp was not compiled in debug.
-		writer.print("_jspx_isDebugClassFile = ");
-		writer.print("" + isDebugClassFile);
-		writer.print(";");
-		writer.println();
-		//		 end 228118: JSP container should recompile if debug enabled and jsp was not compiled in debug.	
-		
-		writer.println("}");
-		writer.println();
+    public static void generateVersionInformation(JavaCodeWriter writer, boolean isDebugClassFile) {
+        writer.println("private static String _jspx_classVersion;");
+        //		 begin 228118: JSP container should recompile if debug enabled and jsp was not compiled in debug.
+        writer.println("private static boolean _jspx_isDebugClassFile;");
+        //		 end 228118: JSP container should recompile if debug enabled and jsp was not compiled in debug.		
 
-		writer.println("public String getVersionInformation() {");
-		writer.println("return _jspx_classVersion;");
-		writer.println("}");
+        writer.println("static {");
+        writer.print("_jspx_classVersion = new String(");
+        writer.print("\"" + classfileVersion);
+        writer.print("\");");
+        writer.println();
 
-		//		 begin 228118: JSP container should recompile if debug enabled and jsp was not compiled in debug.
-		writer.println("public boolean isDebugClassFile() {");
-		writer.println("return _jspx_isDebugClassFile;");
-		writer.println("}");
-		//		 end 228118: JSP container should recompile if debug enabled and jsp was not compiled in debug.	
+        //		 begin 228118: JSP container should recompile if debug enabled and jsp was not compiled in debug.
+        writer.print("_jspx_isDebugClassFile = ");
+        writer.print("" + isDebugClassFile);
+        writer.print(";");
+        writer.println();
+        //		 end 228118: JSP container should recompile if debug enabled and jsp was not compiled in debug.	
 
-		
-	}
+        writer.println("}");
+        writer.println();
+
+        writer.println("public String getVersionInformation() {");
+        writer.println("return _jspx_classVersion;");
+        writer.println("}");
+
+        //		 begin 228118: JSP container should recompile if debug enabled and jsp was not compiled in debug.
+        writer.println("public boolean isDebugClassFile() {");
+        writer.println("return _jspx_isDebugClassFile;");
+        writer.println("}");
+        //		 end 228118: JSP container should recompile if debug enabled and jsp was not compiled in debug.	
+
+    }
 
     public static String coerceToPrimitiveBoolean(String s, boolean isNamedAttribute) {
         if (isNamedAttribute) {
             return "org.apache.jasper.runtime.JspRuntimeLibrary.coerceToBoolean(" + s + ")";
-        }
-        else {
+        } else {
             if (s == null || s.length() == 0)
                 return "false";
             else
@@ -662,12 +666,10 @@ public class GeneratorUtils {
     public static String coerceToBoolean(String s, boolean isNamedAttribute) {
         if (isNamedAttribute) {
             return "(Boolean) org.apache.jasper.runtime.JspRuntimeLibrary.coerce(" + s + ", Boolean.class)";
-        }
-        else {
+        } else {
             if (s == null || s.length() == 0) {
                 return "new Boolean(false)";
-            }
-            else {
+            } else {
                 // Detect format error at translation time
                 return "new Boolean(" + Boolean.valueOf(s).toString() + ")";
             }
@@ -677,8 +679,7 @@ public class GeneratorUtils {
     public static String coerceToPrimitiveByte(String s, boolean isNamedAttribute) {
         if (isNamedAttribute) {
             return "org.apache.jasper.runtime.JspRuntimeLibrary.coerceToByte(" + s + ")";
-        }
-        else {
+        } else {
             if (s == null || s.length() == 0)
                 return "(byte) 0";
             else
@@ -689,12 +690,10 @@ public class GeneratorUtils {
     public static String coerceToByte(String s, boolean isNamedAttribute) {
         if (isNamedAttribute) {
             return "(Byte) org.apache.jasper.runtime.JspRuntimeLibrary.coerce(" + s + ", Byte.class)";
-        }
-        else {
+        } else {
             if (s == null || s.length() == 0) {
                 return "new Byte((byte) 0)";
-            }
-            else {
+            } else {
                 // Detect format error at translation time
                 return "new Byte((byte)" + Byte.valueOf(s).toString() + ")";
             }
@@ -704,12 +703,10 @@ public class GeneratorUtils {
     public static String coerceToChar(String s, boolean isNamedAttribute) {
         if (isNamedAttribute) {
             return "org.apache.jasper.runtime.JspRuntimeLibrary.coerceToChar(" + s + ")";
-        }
-        else {
+        } else {
             if (s == null || s.length() == 0) {
                 return "(char) 0";
-            }
-            else {
+            } else {
                 char ch = s.charAt(0);
                 // this trick avoids escaping issues
                 return "((char) " + (int) ch + ")";
@@ -720,12 +717,10 @@ public class GeneratorUtils {
     public static String coerceToCharacter(String s, boolean isNamedAttribute) {
         if (isNamedAttribute) {
             return "(Character) org.apache.jasper.runtime.JspRuntimeLibrary.coerce(" + s + ", Character.class)";
-        }
-        else {
+        } else {
             if (s == null || s.length() == 0) {
                 return "new Character((char) 0)";
-            }
-            else {
+            } else {
                 char ch = s.charAt(0);
                 // this trick avoids escaping issues
                 return "new Character((char) " + (int) ch + ")";
@@ -736,8 +731,7 @@ public class GeneratorUtils {
     public static String coerceToPrimitiveDouble(String s, boolean isNamedAttribute) {
         if (isNamedAttribute) {
             return "org.apache.jasper.runtime.JspRuntimeLibrary.coerceToDouble(" + s + ")";
-        }
-        else {
+        } else {
             if (s == null || s.length() == 0)
                 return "(double) 0";
             else
@@ -748,12 +742,10 @@ public class GeneratorUtils {
     public static String coerceToDouble(String s, boolean isNamedAttribute) {
         if (isNamedAttribute) {
             return "(Double) org.apache.jasper.runtime.JspRuntimeLibrary.coerce(" + s + ", Double.class)";
-        }
-        else {
+        } else {
             if (s == null || s.length() == 0) {
                 return "new Double(0)";
-            }
-            else {
+            } else {
                 // Detect format error at translation time
                 return "new Double(" + Double.valueOf(s).toString() + ")";
             }
@@ -763,8 +755,7 @@ public class GeneratorUtils {
     public static String coerceToPrimitiveFloat(String s, boolean isNamedAttribute) {
         if (isNamedAttribute) {
             return "org.apache.jasper.runtime.JspRuntimeLibrary.coerceToFloat(" + s + ")";
-        }
-        else {
+        } else {
             if (s == null || s.length() == 0)
                 return "(float) 0";
             else
@@ -775,12 +766,10 @@ public class GeneratorUtils {
     public static String coerceToFloat(String s, boolean isNamedAttribute) {
         if (isNamedAttribute) {
             return "(Float) org.apache.jasper.runtime.JspRuntimeLibrary.coerce(" + s + ", Float.class)";
-        }
-        else {
+        } else {
             if (s == null || s.length() == 0) {
                 return "new Float(0)";
-            }
-            else {
+            } else {
                 // Detect format error at translation time
                 return "new Float(" + Float.valueOf(s).toString() + "f)";
             }
@@ -790,8 +779,7 @@ public class GeneratorUtils {
     public static String coerceToInt(String s, boolean isNamedAttribute) {
         if (isNamedAttribute) {
             return "org.apache.jasper.runtime.JspRuntimeLibrary.coerceToInt(" + s + ")";
-        }
-        else {
+        } else {
             if (s == null || s.length() == 0)
                 return "0";
             else
@@ -802,12 +790,10 @@ public class GeneratorUtils {
     public static String coerceToInteger(String s, boolean isNamedAttribute) {
         if (isNamedAttribute) {
             return "(Integer) org.apache.jasper.runtime.JspRuntimeLibrary.coerce(" + s + ", Integer.class)";
-        }
-        else {
+        } else {
             if (s == null || s.length() == 0) {
                 return "new Integer(0)";
-            }
-            else {
+            } else {
                 // Detect format error at translation time
                 return "new Integer(" + Integer.valueOf(s).toString() + ")";
             }
@@ -817,8 +803,7 @@ public class GeneratorUtils {
     public static String coerceToPrimitiveShort(String s, boolean isNamedAttribute) {
         if (isNamedAttribute) {
             return "org.apache.jasper.runtime.JspRuntimeLibrary.coerceToShort(" + s + ")";
-        }
-        else {
+        } else {
             if (s == null || s.length() == 0)
                 return "(short) 0";
             else
@@ -829,12 +814,10 @@ public class GeneratorUtils {
     public static String coerceToShort(String s, boolean isNamedAttribute) {
         if (isNamedAttribute) {
             return "(Short) org.apache.jasper.runtime.JspRuntimeLibrary.coerce(" + s + ", Short.class)";
-        }
-        else {
+        } else {
             if (s == null || s.length() == 0) {
                 return "new Short((short) 0)";
-            }
-            else {
+            } else {
                 // Detect format error at translation time
                 return "new Short(\"" + Short.valueOf(s).toString() + "\")";
             }
@@ -844,8 +827,7 @@ public class GeneratorUtils {
     public static String coerceToPrimitiveLong(String s, boolean isNamedAttribute) {
         if (isNamedAttribute) {
             return "org.apache.jasper.runtime.JspRuntimeLibrary.coerceToLong(" + s + ")";
-        }
-        else {
+        } else {
             if (s == null || s.length() == 0)
                 return "(long) 0";
             else
@@ -856,18 +838,16 @@ public class GeneratorUtils {
     public static String coerceToLong(String s, boolean isNamedAttribute) {
         if (isNamedAttribute) {
             return "(Long) org.apache.jasper.runtime.JspRuntimeLibrary.coerce(" + s + ", Long.class)";
-        }
-        else {
+        } else {
             if (s == null || s.length() == 0) {
                 return "new Long(0)";
-            }
-            else {
+            } else {
                 // Detect format error at translation time
                 return "new Long(" + Long.valueOf(s).toString() + "l)";
             }
         }
     }
-    
+
     /* Defect 213290 */
     public static String toJavaSourceType(String type) {
 
@@ -880,34 +860,33 @@ public class GeneratorUtils {
         for (int i = 1; i < type.length(); i++) {
             if (type.charAt(i) == '[') {
                 dims++;
-            }
-            else {
+            } else {
                 switch (type.charAt(i)) {
-                    case 'Z' :
+                    case 'Z':
                         t = "boolean";
                         break;
-                    case 'B' :
+                    case 'B':
                         t = "byte";
                         break;
-                    case 'C' :
+                    case 'C':
                         t = "char";
                         break;
-                    case 'D' :
+                    case 'D':
                         t = "double";
                         break;
-                    case 'F' :
+                    case 'F':
                         t = "float";
                         break;
-                    case 'I' :
+                    case 'I':
                         t = "int";
                         break;
-                    case 'J' :
+                    case 'J':
                         t = "long";
                         break;
-                    case 'S' :
+                    case 'S':
                         t = "short";
                         break;
-                    case 'L' :
+                    case 'L':
                         t = type.substring(i + 1, type.indexOf(';'));
                         break;
                     default:
@@ -925,62 +904,62 @@ public class GeneratorUtils {
 
     //PM06063
     public static void generateInitSectionCode(JavaCodeWriter writer, int type) {
-    	generateInitSectionCode(writer, type, null);
+        generateInitSectionCode(writer, type, null);
     }
     //PM06063
-    
+
     //jsp2.1work
-    public static void generateInitSectionCode(JavaCodeWriter writer, int type, JspOptions jspOptions) {  	//PM06063
+    public static void generateInitSectionCode(JavaCodeWriter writer, int type, JspOptions jspOptions) { //PM06063
         writer.println("private javax.el.ExpressionFactory _el_expressionfactory;");
-        if (type==GeneratorUtils.TAG_FILE_TYPE) {
+        if (type == GeneratorUtils.TAG_FILE_TYPE) {
             //LIDB4147-24 & 443243 : need to define injection helpers for .tag files
-        	if (jspOptions == null || !jspOptions.isDisableResourceInjection()){	                        //PM06063
-        		generateInjectionSection(writer);
-        	}																								//PM06063
+            if (jspOptions == null || !jspOptions.isDisableResourceInjection()) { //PM06063
+                generateInjectionSection(writer);
+            } //PM06063
             writer.println("private void _jspInit(ServletConfig config) {");
         } else {
-        	writer.println("public void _jspInit() {");
+            writer.println("public void _jspInit() {");
         }
         writer.print("_el_expressionfactory");
         writer.print(" = _jspxFactory.getJspApplicationContext(");
-        if (type==GeneratorUtils.TAG_FILE_TYPE) {
-        	writer.print("config");
+        if (type == GeneratorUtils.TAG_FILE_TYPE) {
+            writer.print("config");
         } else {
-        	writer.print("getServletConfig()");
+            writer.print("getServletConfig()");
         }
         writer.print(".getServletContext()).getExpressionFactory();");
         writer.println();
         writer.println();
-        
+
         // LIDB4147-24
-        if (jspOptions == null || !jspOptions.isDisableResourceInjection()){		//PM06063
-        	
-        	writer.print ("com.ibm.wsspi.webcontainer.annotation.AnnotationHelperManager _jspx_aHelper = ");
-        	writer.print ("com.ibm.wsspi.webcontainer.annotation.AnnotationHelperManager.getInstance (");
-        	//443243: need to have the servletConfig to get the servletContext
-        	if (type==GeneratorUtils.TAG_FILE_TYPE) {
-        		writer.print("config");
-        	} else {
-        		writer.print("getServletConfig()");
-        	}
-        	writer.println(".getServletContext());");
-        	writer.println ("_jspx_iaHelper = _jspx_aHelper.getAnnotationHelper();");
-        }								                                            //PM06063
-        
+        if (jspOptions == null || !jspOptions.isDisableResourceInjection()) { //PM06063
+
+            writer.print("com.ibm.wsspi.webcontainer.annotation.AnnotationHelperManager _jspx_aHelper = ");
+            writer.print("com.ibm.wsspi.webcontainer.annotation.AnnotationHelperManager.getInstance (");
+            //443243: need to have the servletConfig to get the servletContext
+            if (type == GeneratorUtils.TAG_FILE_TYPE) {
+                writer.print("config");
+            } else {
+                writer.print("getServletConfig()");
+            }
+            writer.println(".getServletContext());");
+            writer.println("_jspx_iaHelper = _jspx_aHelper.getAnnotationHelper();");
+        } //PM06063
+
         //PK81147 start
         //if this is a JSP page, need to set this to true to indicate that we have already run_jspInit() for this generated servlet.  
-        if(type==GeneratorUtils.JSP_FILE_TYPE){
+        if (type == GeneratorUtils.JSP_FILE_TYPE) {
             writer.println("_jspx_isJspInited = true;");
         }
         //PK81147 end
-        
-        writer.println("}");
-		
-	}
 
-	public static void generateFactoryInitialization(JavaCodeWriter writer, boolean jcdiWrapIt) {
+        writer.println("}");
+
+    }
+
+    public static void generateFactoryInitialization(JavaCodeWriter writer, boolean jcdiWrapIt) {
         //If jcdi is enabled, we need to return a wrapped factory, that can be used to get a wrappedExpressionFactory 
-	    writer.print("private static final JspFactory _jspxFactory = ");
+        writer.print("private static final JspFactory _jspxFactory = ");
         if (jcdiWrapIt) {
             writer.print("new org.apache.jasper.runtime.JcdiWrappedJspFactoryImpl(");
         }
@@ -989,11 +968,11 @@ public class GeneratorUtils {
             writer.print(")");
         }
         writer.println(";");
-	}
-     
-     // LIDB4147-24
-     
-     public static void generateInjectionSection (JavaCodeWriter writer) {
-          writer.println ("private com.ibm.wsspi.webcontainer.annotation.AnnotationHelper _jspx_iaHelper;");
-     }
+    }
+
+    // LIDB4147-24
+
+    public static void generateInjectionSection(JavaCodeWriter writer) {
+        writer.println("private com.ibm.wsspi.webcontainer.annotation.AnnotationHelper _jspx_iaHelper;");
+    }
 }

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/GeneratorUtils.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/GeneratorUtils.java
@@ -595,6 +595,16 @@ public class GeneratorUtils {
         writer.println();
     }
 
+    public static void generate_tagPostConstruct_method(JavaCodeWriter writer) {
+        writer.println("public void _jsp_tagPostConstruct(Object tag, java.util.ArrayList tagList, com.ibm.ws.managedobject.ManagedObject mo) {");
+        writer.println( "if(tagList != null) {");
+        writer.println( "tagList.add(tag);");
+         writer.println("}");
+        writer.println("_jspx_iaHelper.doPostConstruct(tag);");
+        writer.println("_jspx_iaHelper.addTagHandlerToCdiMap(tag, mo);");
+        writer.println("}");
+    }
+
     public static void generate_tagCleanUp_methods(JavaCodeWriter writer, boolean resourceInjectionEnabled) {
         writer.println("public void _jsp_cleanUpTag(Object tag, java.util.ArrayList tagList) {");
         if(resourceInjectionEnabled) { // if not disabled, then the _jspx_iaHelper is not available

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/OptimizedTagGenerator.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/OptimizedTagGenerator.java
@@ -126,17 +126,9 @@ public class OptimizedTagGenerator extends BaseTagGenerator implements TagGenera
 
                 if (genTagInMethod) {
                     tagStartWriter.println("try {");
-                } else {
-                     tagStartWriter.println ("_jspTagList.add("+ tagHandlerVar + ");");
-                }
+                } 
 
-                tagStartWriter.print("_jspx_iaHelper.doPostConstruct(");
-                tagStartWriter.print(tagHandlerVar);
-                tagStartWriter.println(");");
-
-                tagStartWriter.print("_jspx_iaHelper.addTagHandlerToCdiMap(");
-                tagStartWriter.print(tagHandlerVar + ", " + tagHandlerVar + "_mo");
-                tagStartWriter.println(");");
+                tagStartWriter.print("_jsp_tagPostConstruct(" +tagHandlerVar+ ", " + (!genTagInMethod ? "_jspTagList, " : "null, ") + tagHandlerVar + "_mo" + ");");
 
             } else {
 

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/OptimizedTagGenerator.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/OptimizedTagGenerator.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2004 IBM Corporation and others.
+ * Copyright (c) 1997, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jsp.translator.visitor.generator;
 
@@ -45,11 +42,13 @@ public class OptimizedTagGenerator extends BaseTagGenerator implements TagGenera
     protected Map attrMap = new HashMap();
     protected List declaredIdList = null;
     protected String tagPushBodyCountVar = null;
-    
+    private boolean genTagInMethod = false;
+
     public OptimizedTagGenerator(OptimizedTag optimizedTag,
-                                 String tagPushBodyCountVar, 
+                                 String tagPushBodyCountVar,
                                  int nestingLevel,
                                  boolean isTagFile,
+                                 boolean genTagInMethod,
                                  boolean hasBody,
                                  boolean hasJspBody,
                                  String tagHandlerVar,
@@ -63,91 +62,84 @@ public class OptimizedTagGenerator extends BaseTagGenerator implements TagGenera
                                  ValidateResult.CollectedTagData collectedTagData,
                                  FragmentHelperClassWriter fragmentHelperClassWriter,
                                  JspOptions jspOptions) {
-        super(nestingLevel,
-              isTagFile,
-              hasBody,
-              hasJspBody,
-              tagHandlerVar,
-              element,
-              tagLibraryCache,
-              jspConfiguration,
-              ctxt,
-              tagClassInfo,
-              ti,
-              persistentData,
-              collectedTagData,
-              fragmentHelperClassWriter,
-              jspOptions);
-        
+        super(nestingLevel, isTagFile, hasBody, hasJspBody, tagHandlerVar, element, tagLibraryCache, jspConfiguration, ctxt, tagClassInfo, ti, persistentData, collectedTagData, fragmentHelperClassWriter, jspOptions);
+
         this.jspOptions = jspOptions; //PK65013
         this.optimizedTag = optimizedTag;
         this.tagPushBodyCountVar = tagPushBodyCountVar;
-        
+        this.genTagInMethod = genTagInMethod;
+
         NamedNodeMap nodeAttrs = element.getAttributes();
         for (int i = 0; i < nodeAttrs.getLength(); i++) {
-            Attr attr = (Attr)nodeAttrs.item(i);
+            Attr attr = (Attr) nodeAttrs.item(i);
             if (attr.getName().equals("jsp:id") == false && attr.getName().startsWith("xmlns") == false) {
                 attrMap.put(attr.getName(), Boolean.FALSE);
             }
         }
-        
+
         NodeList nl = element.getChildNodes();
         for (int i = 0; i < nl.getLength(); i++) {
             Node childNode = nl.item(i);
             if (childNode.getNodeType() == Node.ELEMENT_NODE) {
-                Element childElement = (Element)childNode;
-                if (childElement.getNamespaceURI() != null && 
-                    childElement.getNamespaceURI().equals(Constants.JSP_NAMESPACE) && 
+                Element childElement = (Element) childNode;
+                if (childElement.getNamespaceURI() != null &&
+                    childElement.getNamespaceURI().equals(Constants.JSP_NAMESPACE) &&
                     childElement.getLocalName().equals(Constants.JSP_ATTRIBUTE_TYPE)) {
-                        String name = childElement.getAttribute("name");
-                        if (name.indexOf(':') != -1) {
-                            name = name.substring(name.indexOf(':') + 1);
-                        }
-                        attrMap.put(name, Boolean.TRUE);
+                    String name = childElement.getAttribute("name");
+                    if (name.indexOf(':') != -1) {
+                        name = name.substring(name.indexOf(':') + 1);
+                    }
+                    attrMap.put(name, Boolean.TRUE);
                 }
             }
         }
-        
-        declaredIdList = (List)persistentData.get("declaredIdList");
+
+        declaredIdList = (List) persistentData.get("declaredIdList");
         if (declaredIdList == null) {
             declaredIdList = new ArrayList();
             persistentData.put("declaredIdList", declaredIdList);
         }
     }
-    
+
     public boolean optimizePossible() {
         return optimizedTag.doOptimization(this);
     }
-    
+
     public MethodWriter generateTagStart() throws JspCoreException {
         tagStartWriter = new MethodWriter();
         if (hasBody) {
-            
+
             // LIDB4147-24
-            if (!jspOptions.isDisableResourceInjection()){		//PM06063
+            if (!jspOptions.isDisableResourceInjection()) { //PM06063
                 // have CDI create and inject the managed object
-                tagStartWriter.print ("com.ibm.ws.managedobject.ManagedObject " + tagHandlerVar + "_mo = ");
-                tagStartWriter.print ("_jspx_iaHelper.inject(");
-                tagStartWriter.print (tagClassInfo.getTagClassName() + ".class");
-                tagStartWriter.println (");");
-            
+                tagStartWriter.print("com.ibm.ws.managedobject.ManagedObject " + tagHandlerVar + "_mo = ");
+                tagStartWriter.print("_jspx_iaHelper.inject(");
+                tagStartWriter.print(tagClassInfo.getTagClassName() + ".class");
+                tagStartWriter.println(");");
+
                 // get the underlying object from the managed object
                 tagStartWriter.print(tagClassInfo.getTagClassName());
                 tagStartWriter.print(" ");
-                tagStartWriter.print(tagHandlerVar);   
-                tagStartWriter.print(" = ");           
-                tagStartWriter.println("("+tagClassInfo.getTagClassName()+")"+tagHandlerVar+"_mo.getObject();"); 
+                tagStartWriter.print(tagHandlerVar);
+                tagStartWriter.print(" = ");
+                tagStartWriter.println("(" + tagClassInfo.getTagClassName() + ")" + tagHandlerVar + "_mo.getObject();");
 
-            	tagStartWriter.print ("_jspx_iaHelper.doPostConstruct(");
-            	tagStartWriter.print (tagHandlerVar);
-            	tagStartWriter.println (");");
-            	
-                tagStartWriter.print ("_jspx_iaHelper.addTagHandlerToCdiMap(");
-                tagStartWriter.print (tagHandlerVar + ", " + tagHandlerVar + "_mo");
-                tagStartWriter.println (");");
-                
+                if (genTagInMethod) {
+                    tagStartWriter.println("try {");
+                } else {
+                     tagStartWriter.println ("_jspTagList.add("+ tagHandlerVar + ");");
+                }
+
+                tagStartWriter.print("_jspx_iaHelper.doPostConstruct(");
+                tagStartWriter.print(tagHandlerVar);
+                tagStartWriter.println(");");
+
+                tagStartWriter.print("_jspx_iaHelper.addTagHandlerToCdiMap(");
+                tagStartWriter.print(tagHandlerVar + ", " + tagHandlerVar + "_mo");
+                tagStartWriter.println(");");
+
             } else {
-                
+
                 // not using CDI
                 tagStartWriter.print(tagClassInfo.getTagClassName());
                 tagStartWriter.print(" ");
@@ -157,13 +149,17 @@ public class OptimizedTagGenerator extends BaseTagGenerator implements TagGenera
                 tagStartWriter.print(tagClassInfo.getTagClassName());
                 tagStartWriter.print("();");
                 tagStartWriter.println();
+
+                if (!genTagInMethod) {
+                    tagStartWriter.println ("_jspTagList.add("+ tagHandlerVar + ");");
+                }
             }
-            
+
             tagStartWriter.println();
         }
         return tagStartWriter;
     }
-    
+
     public MethodWriter generateTagMiddle() throws JspCoreException {
         tagMiddleWriter = new MethodWriter();
         if (tagClassInfo.implementsTryCatchFinally()) {
@@ -174,7 +170,7 @@ public class OptimizedTagGenerator extends BaseTagGenerator implements TagGenera
         }
         return tagMiddleWriter;
     }
-    
+
     public MethodWriter generateTagEnd() throws JspCoreException {
         generateJspAttributeSetters();
         currentWriter = tagMiddleWriter;
@@ -184,47 +180,47 @@ public class OptimizedTagGenerator extends BaseTagGenerator implements TagGenera
         optimizedTag.generateEnd(this);
         return tagEndWriter;
     }
-    
+
     public void generateImports(JavaCodeWriter writer) {
         currentWriter = writer;
         optimizedTag.generateImports(this);
     }
-    
+
     public void generateDeclarations(JavaCodeWriter writer) {
         currentWriter = writer;
         optimizedTag.generateDeclarations(this);
     }
-    
+
     protected void generateSetterCall(String attrName,
                                       String evalAttrValue,
                                       String uri,
                                       MethodWriter setterWriter,
                                       boolean isDymanic) {
-        optimizedTag.setAttribute(attrName, evalAttrValue);                                              
+        optimizedTag.setAttribute(attrName, evalAttrValue);
     }
-    
+
     public void writeSource(String source) {
         currentWriter.println(source);
     }
-    
+
     public void writeImport(String importId, String importSource) {
         if (declaredIdList.contains(importId) == false) {
             currentWriter.println(importSource);
-            declaredIdList.add(importId);                                
+            declaredIdList.add(importId);
         }
     }
-    
+
     public void writeDeclaration(String declarationId, String declarationSource) {
         if (declaredIdList.contains(declarationId) == false) {
-            currentWriter.println(declarationSource);                    
-            declaredIdList.add(declarationId);                                
+            currentWriter.println(declarationSource);
+            declaredIdList.add(declarationId);
         }
     }
-    
+
     public String createTemporaryVariable() {
         return GeneratorUtils.nextTemporaryVariableName(persistentData);
     }
-    
+
     public boolean hasAttribute(String attrName) {
         return attrMap.containsKey(attrName);
     }
@@ -232,11 +228,11 @@ public class OptimizedTagGenerator extends BaseTagGenerator implements TagGenera
     public boolean isJspAttribute(String attrName) {
         boolean b = false;
         if (attrMap.containsKey(attrName)) {
-            b = ((Boolean)attrMap.get(attrName)).booleanValue();    
+            b = ((Boolean) attrMap.get(attrName)).booleanValue();
         }
         return b;
     }
-    
+
     public OptimizedTag getParent() {
         OptimizedTag parentTag = null;
         if (parentTagInstanceInfo != null) {
@@ -245,17 +241,20 @@ public class OptimizedTagGenerator extends BaseTagGenerator implements TagGenera
         return parentTag;
     }
 
-    public void generateInitialization(JavaCodeWriter writer) {}
-    public void generateFinally(JavaCodeWriter writer) {}
-    
+    public void generateInitialization(JavaCodeWriter writer) {
+    }
+
+    public void generateFinally(JavaCodeWriter writer) {
+    }
+
     public boolean hasBody() {
         return hasBody;
     }
-    
+
     public boolean hasJspBody() {
         return hasJspBody;
     }
-    
+
     //PK65013 start
     public JspOptions getJspOptions() {
         return jspOptions;

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/SimpleTagGenerator.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/SimpleTagGenerator.java
@@ -78,17 +78,9 @@ public class SimpleTagGenerator extends BaseTagGenerator {
 
             if (genTagInMethod) {
                 tagStartWriter.println("try {");
-            } else {
-                 tagStartWriter.println ("_jspTagList.add("+ tagHandlerVar + ");");
-            }
+            } 
 
-            tagStartWriter.print("_jspx_iaHelper.doPostConstruct(");
-            tagStartWriter.print(tagHandlerVar);
-            tagStartWriter.println(");");
-
-            tagStartWriter.print("_jspx_iaHelper.addTagHandlerToCdiMap(");
-            tagStartWriter.print(tagHandlerVar + ", " + tagHandlerVar + "_mo");
-            tagStartWriter.println(");");
+            tagStartWriter.print("_jsp_tagPostConstruct(" +tagHandlerVar+ ", " + (!genTagInMethod ? "_jspTagList, " : "null, ") + tagHandlerVar + "_mo" + ");");
 
         } else {
             // not using CDI


### PR DESCRIPTION
fixes #11453

Implements try - finally with the Tag methods to always clean up resources. For example:

```
  private boolean _jspx_meth_c_out_23(javax.servlet.jsp.tagext.JspTag _jspx_th_c_forTokens_11, PageContext pageContext, int[] _jspx_push_body_count_c_forTokens_11)
     throws Throwable {
    JspWriter out = pageContext.getOut();
    com.ibm.ws.managedobject.ManagedObject _jspx_th_c_out_23_mo = _jspx_iaHelper.inject(org.apache.taglibs.standard.tag.rt.core.OutTag.class);
    org.apache.taglibs.standard.tag.rt.core.OutTag _jspx_th_c_out_23 = (org.apache.taglibs.standard.tag.rt.core.OutTag)_jspx_th_c_out_23_mo.getObject();
    try {
       ...
      int _jspx_eval_c_out_23 = _jspx_th_c_out_23.doStartTag();
      if (_jspx_th_c_out_23.doEndTag() == javax.servlet.jsp.tagext.Tag.SKIP_PAGE) {
        return true;
      }
      return false;
    } finally {
      _jsp_cleanUpTag(_jspx_th_c_out_23, null);
    }
  }
```


For the jsp service method (and JSP Fragments invoke methods), I created a list which has tags added and removed. In the finally method, if any tags are left over, they are cleaned up.

```
java.util.ArrayList _jspTagList = new java.util.ArrayList();

try { 
...
 _jsp_tagPostConstruct(_jspx_th_c_catch_0, _jspTagList, _jspx_th_c_catch_0_mo);
...
_jsp_cleanUpTag(_jspx_th_c_catch_0, _jspTagList);
...
    } finally {
      _jsp_cleanUpTagArrayList(_jspTagList);
      _jspxFactory.releasePageContext(pageContext);
    }
```


This fix handles various scenarios (Tag Pooling & Resource Injection) to avoid regressions. 

- Tag Pooling Disabled +  Resource Injection Disabled
- Tag Pooling Enabled  +  Resource Injection Enabled
- Tag Pooling Disabled  +  Resource Injection Enabled
- Tag Pooling Enabled  +  Resource Injection Disabled



This fix creates 3 three jsp methods to reduce the size of the jsp service method (to avoid hitting the 65k byte limit) 

- `public void _jsp_cleanUpTag(Object tag, java.util.ArrayList tagList)`  <--- Calls predestroy / release ( and removed the tag from the list if the list in not null) 
- `public void _jsp_cleanUpTagArrayList(java.util.ArrayList tagList)`   <--- Cleans up List 
- `public void _jsp_tagPostConstruct(Object tag, java.util.ArrayList tagList,  com.ibm.ws.managedobject.ManagedObject mo)`  <-- calls doPostConstruct, addTagHandlerToCdiMap and adds the tag to the list if it's not null.  **THIS METHOD is UNIQUE to LIBERTY** 


