### PR TITLE
preparing to share jwk utilities between oidc and jakarta30 security and other minor updates

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-5.0/io.openliberty.appSecurity-5.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-5.0/io.openliberty.appSecurity-5.0.feature
@@ -29,6 +29,7 @@ Subsystem-Name: Application Security 5.0 (Jakarta Security 3.0)
   com.ibm.ws.org.apache.commons.lang3, \
   com.ibm.ws.org.apache.httpcomponents, \
   com.ibm.ws.org.jose4j, \
+  com.ibm.ws.security.common.jsonwebkey, \
   io.openliberty.org.apache.commons.codec, \
   io.openliberty.org.apache.commons.logging, \
   io.openliberty.security.common.internal, \

--- a/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JwKRetriever.java
+++ b/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JwKRetriever.java
@@ -89,6 +89,7 @@ public class JwKRetriever {
 
     String configId = null;
     String sslConfigurationName = null;
+    boolean defaultSSLConfig = false;
     String jwkEndpointUrl = null; // jwksUri
 
     String sigAlg = null;
@@ -153,7 +154,15 @@ public class JwKRetriever {
         this.keyLocation = keyLocation;
         this.httpUtils = new HttpUtils();
     }
-
+    
+    public void defaultssl() {
+        this.defaultSSLConfig = true;
+    }
+    
+    public boolean isdefaultssl() {
+        return this.defaultSSLConfig;
+    }
+    
     public void setSignatureAlgorithm(String signatureAlgorithm) {
         this.sigAlg = signatureAlgorithm;
     }
@@ -800,7 +809,11 @@ public class JwKRetriever {
             SSLSupport sslSupport) throws SSLException {
         SSLSocketFactory sslSocketFactory = null;
         try {
-            sslSocketFactory = SecuritySSLUtils.getSSLSocketFactory(sslSupport, sslConfigurationName);
+            if (isdefaultssl()) {
+                sslSocketFactory = SecuritySSLUtils.getSSLSocketFactory(sslSupport);
+            } else {
+                sslSocketFactory = SecuritySSLUtils.getSSLSocketFactory(sslSupport, sslConfigurationName);
+            }
         } catch (javax.net.ssl.SSLException e) {
             throw new SSLException(e);
         } catch (NoSSLSocketFactoryException e) {

--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/ssl/SecuritySSLUtils.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/ssl/SecuritySSLUtils.java
@@ -27,5 +27,15 @@ public class SecuritySSLUtils {
         }
         return sslSocketFactory;
     }
-
+    
+    public static SSLSocketFactory getSSLSocketFactory(SSLSupport sslSupport) throws SSLException, NoSSLSocketFactoryException {
+        SSLSocketFactory sslSocketFactory = null;
+        if (sslSupport != null) {
+            sslSocketFactory = sslSupport.getSSLSocketFactory();
+        }
+        if (sslSocketFactory == null) {
+            throw new NoSSLSocketFactoryException();
+        }
+        return sslSocketFactory;
+    }
 }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/bnd.bnd
@@ -22,10 +22,10 @@ Bundle-Description: Jakarta Security 3.0; version=${bVersion}
 
 Export-Package: \
     io.openliberty.security.jakartasec,\
-    io.openliberty.security.jakartasec.identitystore
+    io.openliberty.security.jakartasec.identitystore,\
+    io.openliberty.security.jakartasec.credential
 
 Import-Package: \
-    !io.openliberty.security.jakartasec.*,\
     *
 
 -buildpath: \

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/credential/package-info.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/credential/package-info.java
@@ -9,6 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 /**
- *
+ * @version 1.0.0
  */
+@org.osgi.annotation.versioning.Version("1.0.0")
 package io.openliberty.security.jakartasec.credential;

--- a/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
+++ b/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
@@ -55,7 +55,8 @@ Export-Package: \
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.ssl;version=latest,\
-	com.ibm.ws.org.jose4j;version=latest
+	com.ibm.ws.org.jose4j;version=latest,\
+	com.ibm.ws.security.common.jsonwebkey;version=latest
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file,\

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/IdTokenValidator.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/IdTokenValidator.java
@@ -38,7 +38,7 @@ public class IdTokenValidator extends TokenValidator {
         
     }
     void validateNonce() throws TokenValidationException {
-        // TODO : 
+        // TODO : need access to Storage and state param value to compute nonce
     }
 
 }


### PR DESCRIPTION
update appSecurity-5.0 feature - add jsonwebkey bundle
update io.openliberty.security.oidcclientcore.internal project bnd and add the bundle to build path
update io.openliberty.security.jakartasec.3.0.internal bnd file to export credential package and also allow importing from the same bundle (to prevent NCDF errors when we are validating OidcTokensCredential using the IdentityStore)

