### PR TITLE
Issue 22465: Add EL support for OpenIdProviderMetadataWrapper

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/JakartaSec30Constants.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/JakartaSec30Constants.java
@@ -12,6 +12,8 @@ package io.openliberty.security.jakartasec;
 
 import com.ibm.ws.security.javaeesec.JavaEESecConstants;
 
+import jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdConstant;
+
 /**
  * Constants for Java EE Security
  */
@@ -24,5 +26,14 @@ public class JakartaSec30Constants extends JavaEESecConstants {
     public static final String BASE_URL_DEFAULT = "${" + BASE_URL_VARIABLE + "}/Callback";
 
     public static final String EMPTY_DEFAULT = "";
+
+    public static final String SUBJECT_TYPE_SUPPORTED_DEFAULT = "public";
+
+    public static final String RESPONSE_TYPE_CODE = "code";
+
+    public static final String RESPONSE_TYPE_TOKEN = "token";
+
+    public static final String RESPONSE_TYPE_SUPPORTED_DEFAULT = RESPONSE_TYPE_CODE + "," + OpenIdConstant.IDENTITY_TOKEN + "," + RESPONSE_TYPE_TOKEN + " "
+                                                                 + OpenIdConstant.IDENTITY_TOKEN; //  "code,id_token,token id_token"
 
 }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/LogoutDefinitionWrapperTest.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/LogoutDefinitionWrapperTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package io.openliberty.security.jakartasec;
 
+import static io.openliberty.security.jakartasec.JakartaSec30Constants.EMPTY_DEFAULT;
 import static org.junit.Assert.assertEquals;
 
 import java.util.HashMap;
@@ -69,7 +70,7 @@ public class LogoutDefinitionWrapperTest {
         LogoutDefinition logoutDefinition = TestLogoutDefinition.getInstanceofAnnotation(null);
         LogoutDefinitionWrapper wrapper = new LogoutDefinitionWrapper(logoutDefinition);
 
-        assertEquals(TestLogoutDefinition.EMPTY_DEFAULT, wrapper.getRedirectURI());
+        assertEquals(EMPTY_DEFAULT, wrapper.getRedirectURI());
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/OpenIdAuthenticationMechanismDefinitionWrapperTest.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/OpenIdAuthenticationMechanismDefinitionWrapperTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package io.openliberty.security.jakartasec;
 
+import static io.openliberty.security.jakartasec.JakartaSec30Constants.EMPTY_DEFAULT;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
@@ -69,7 +70,6 @@ public class OpenIdAuthenticationMechanismDefinitionWrapperTest {
     private static final String TOKEN_AUTO_REFRESH_EXPRESSION = "tokenAutoRefreshExpression";
     private static final String TOKEN_MIN_VALIDITY = "tokenMinValidity";
     private static final String TOKEN_MIN_VALIDITY_EXPRESSION = "tokenMinValidityExpression";
-    private static final String EMPTY_DEFAULT = "";
     private static final String STRING_EL_EXPRESSION = "#{'blah'.concat('blah')}";
     private static final String EVALUATED_EL_EXPRESSION_STRING_RESULT = "blahblah";
     private static final String TRUE_EL_EXPRESSION = "#{true}";
@@ -469,8 +469,7 @@ public class OpenIdAuthenticationMechanismDefinitionWrapperTest {
 
             @Override
             public OpenIdProviderMetadata providerMetadata() {
-                // TODO Auto-generated method stub
-                return null;
+                return TestOpenIdProviderMetadataDefinition.getInstanceofAnnotation(null);
             }
 
             @Override

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/OpenIdProviderMetadataWrapperTest.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/OpenIdProviderMetadataWrapperTest.java
@@ -10,11 +10,13 @@
  *******************************************************************************/
 package io.openliberty.security.jakartasec;
 
+import static io.openliberty.security.jakartasec.JakartaSec30Constants.EMPTY_DEFAULT;
 import static junit.framework.Assert.assertEquals;
 
-import java.lang.annotation.Annotation;
+import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdProviderMetadata;
@@ -25,149 +27,176 @@ import jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdPr
  */
 public class OpenIdProviderMetadataWrapperTest {
 
-    private static String EMPTY_DEFAULT = "";
-    private static String AUTHORIZATION_ENDPOINT = "authorizationEndpoint";
-    private static String TOKEN_ENDPOINT = "tokenEndpoint";
-    private static String USERINFO_ENDPOINT = "userinfoEndpoint";
-    private static String END_SESSION_ENDPOINT = "endSessionEndpoint";
-    private static String JWKS_URI = "jwksURI";
-    private static String ISSUER = "issuer";
-    private static String SUBJECT_TYPE_SUPPORTED = "subjectTypeSupported";
-    private static String ID_TOKEN_SIGNING_ALGORITHMS_SUPPORTED = "idTokenSigningAlgorithmsSupported";
-    private static String RESPONSE_TYPE_SUPPORTED = "responseTypeSupported";
-    private static String SUBJECT_TYPE_SUPPORTED_DEFAULT = "public";
-    private static String ID_TOKEN_SIGNING_ALGORITHMS_SUPPORTED_DEFAULT = "RS256";
-    private static String RESPONSE_TYPE_SUPPORTED_DEFAULT = "code,id_token,token id_token";
+    private Map<String, Object> overrides;
+
+    private static final String STRING_EL_EXPRESSION = "#{'blah'.concat('blah')}";
+    private static final String EVALUATED_EL_EXPRESSION_STRING_RESULT = "blahblah";
+
+    @Before
+    public void setUp() {
+        overrides = new HashMap<String, Object>();
+    }
 
     @Test
     public void testGetAuthorizationEndpoint() {
-        OpenIdProviderMetadata providerMetadata = getInstanceofAnnotation(null);
+        OpenIdProviderMetadata providerMetadata = TestOpenIdProviderMetadataDefinition.getInstanceofAnnotation(null);
         OpenIdProviderMetadataWrapper wrapper = new OpenIdProviderMetadataWrapper(providerMetadata);
 
         assertEquals(EMPTY_DEFAULT, wrapper.getAuthorizationEndpoint());
     }
 
     @Test
+    public void testGetAuthorizationEndpoint_EL() {
+        overrides.put(TestOpenIdProviderMetadataDefinition.AUTHORIZATION_ENDPOINT, STRING_EL_EXPRESSION);
+
+        OpenIdProviderMetadata providerMetadata = TestOpenIdProviderMetadataDefinition.getInstanceofAnnotation(overrides);
+        OpenIdProviderMetadataWrapper wrapper = new OpenIdProviderMetadataWrapper(providerMetadata);
+
+        assertEquals(EVALUATED_EL_EXPRESSION_STRING_RESULT, wrapper.getAuthorizationEndpoint());
+    }
+
+    @Test
     public void testGetTokenEndpoint() {
-        OpenIdProviderMetadata providerMetadata = getInstanceofAnnotation(null);
+        OpenIdProviderMetadata providerMetadata = TestOpenIdProviderMetadataDefinition.getInstanceofAnnotation(null);
         OpenIdProviderMetadataWrapper wrapper = new OpenIdProviderMetadataWrapper(providerMetadata);
 
         assertEquals(EMPTY_DEFAULT, wrapper.getTokenEndpoint());
     }
 
     @Test
+    public void testGetTokenEndpoint_EL() {
+        overrides.put(TestOpenIdProviderMetadataDefinition.TOKEN_ENDPOINT, STRING_EL_EXPRESSION);
+
+        OpenIdProviderMetadata providerMetadata = TestOpenIdProviderMetadataDefinition.getInstanceofAnnotation(overrides);
+        OpenIdProviderMetadataWrapper wrapper = new OpenIdProviderMetadataWrapper(providerMetadata);
+
+        assertEquals(EVALUATED_EL_EXPRESSION_STRING_RESULT, wrapper.getTokenEndpoint());
+    }
+
+    @Test
     public void testGetUserinfoEndpoint() {
-        OpenIdProviderMetadata providerMetadata = getInstanceofAnnotation(null);
+        OpenIdProviderMetadata providerMetadata = TestOpenIdProviderMetadataDefinition.getInstanceofAnnotation(null);
         OpenIdProviderMetadataWrapper wrapper = new OpenIdProviderMetadataWrapper(providerMetadata);
 
         assertEquals(EMPTY_DEFAULT, wrapper.getUserinfoEndpoint());
     }
 
     @Test
+    public void testGetUserinfoEndpoint_EL() {
+        overrides.put(TestOpenIdProviderMetadataDefinition.USERINFO_ENDPOINT, STRING_EL_EXPRESSION);
+
+        OpenIdProviderMetadata providerMetadata = TestOpenIdProviderMetadataDefinition.getInstanceofAnnotation(overrides);
+        OpenIdProviderMetadataWrapper wrapper = new OpenIdProviderMetadataWrapper(providerMetadata);
+
+        assertEquals(EVALUATED_EL_EXPRESSION_STRING_RESULT, wrapper.getUserinfoEndpoint());
+    }
+
+    @Test
     public void testGetEndSessionEndpoint() {
-        OpenIdProviderMetadata providerMetadata = getInstanceofAnnotation(null);
+        OpenIdProviderMetadata providerMetadata = TestOpenIdProviderMetadataDefinition.getInstanceofAnnotation(null);
         OpenIdProviderMetadataWrapper wrapper = new OpenIdProviderMetadataWrapper(providerMetadata);
 
         assertEquals(EMPTY_DEFAULT, wrapper.getEndSessionEndpoint());
     }
 
     @Test
+    public void testGetEndSessionEndpoint_EL() {
+        overrides.put(TestOpenIdProviderMetadataDefinition.END_SESSION_ENDPOINT, STRING_EL_EXPRESSION);
+
+        OpenIdProviderMetadata providerMetadata = TestOpenIdProviderMetadataDefinition.getInstanceofAnnotation(overrides);
+        OpenIdProviderMetadataWrapper wrapper = new OpenIdProviderMetadataWrapper(providerMetadata);
+
+        assertEquals(EVALUATED_EL_EXPRESSION_STRING_RESULT, wrapper.getEndSessionEndpoint());
+    }
+
+    @Test
     public void testGetJwksURI() {
-        OpenIdProviderMetadata providerMetadata = getInstanceofAnnotation(null);
+        OpenIdProviderMetadata providerMetadata = TestOpenIdProviderMetadataDefinition.getInstanceofAnnotation(null);
         OpenIdProviderMetadataWrapper wrapper = new OpenIdProviderMetadataWrapper(providerMetadata);
 
         assertEquals(EMPTY_DEFAULT, wrapper.getJwksURI());
     }
 
     @Test
+    public void testGetJwksURI_EL() {
+        overrides.put(TestOpenIdProviderMetadataDefinition.JWKS_URI, STRING_EL_EXPRESSION);
+
+        OpenIdProviderMetadata providerMetadata = TestOpenIdProviderMetadataDefinition.getInstanceofAnnotation(overrides);
+        OpenIdProviderMetadataWrapper wrapper = new OpenIdProviderMetadataWrapper(providerMetadata);
+
+        assertEquals(EVALUATED_EL_EXPRESSION_STRING_RESULT, wrapper.getJwksURI());
+    }
+
+    @Test
     public void testGetIssuer() {
-        OpenIdProviderMetadata providerMetadata = getInstanceofAnnotation(null);
+        OpenIdProviderMetadata providerMetadata = TestOpenIdProviderMetadataDefinition.getInstanceofAnnotation(null);
         OpenIdProviderMetadataWrapper wrapper = new OpenIdProviderMetadataWrapper(providerMetadata);
 
         assertEquals(EMPTY_DEFAULT, wrapper.getIssuer());
     }
 
     @Test
-    public void testGetSubjectTypeSupported() {
-        OpenIdProviderMetadata providerMetadata = getInstanceofAnnotation(null);
+    public void testGetIssuer_EL() {
+        overrides.put(TestOpenIdProviderMetadataDefinition.ISSUER, STRING_EL_EXPRESSION);
+
+        OpenIdProviderMetadata providerMetadata = TestOpenIdProviderMetadataDefinition.getInstanceofAnnotation(overrides);
         OpenIdProviderMetadataWrapper wrapper = new OpenIdProviderMetadataWrapper(providerMetadata);
 
-        assertEquals(SUBJECT_TYPE_SUPPORTED_DEFAULT, wrapper.getSubjectTypeSupported());
+        assertEquals(EVALUATED_EL_EXPRESSION_STRING_RESULT, wrapper.getIssuer());
+    }
+
+    @Test
+    public void testGetSubjectTypeSupported() {
+        OpenIdProviderMetadata providerMetadata = TestOpenIdProviderMetadataDefinition.getInstanceofAnnotation(null);
+        OpenIdProviderMetadataWrapper wrapper = new OpenIdProviderMetadataWrapper(providerMetadata);
+
+        assertEquals(TestOpenIdProviderMetadataDefinition.SUBJECT_TYPE_SUPPORTED_DEFAULT, wrapper.getSubjectTypeSupported());
+    }
+
+    @Test
+    public void testGetSubjectTypeSupported_EL() {
+        overrides.put(TestOpenIdProviderMetadataDefinition.SUBJECT_TYPE_SUPPORTED, STRING_EL_EXPRESSION);
+
+        OpenIdProviderMetadata providerMetadata = TestOpenIdProviderMetadataDefinition.getInstanceofAnnotation(overrides);
+        OpenIdProviderMetadataWrapper wrapper = new OpenIdProviderMetadataWrapper(providerMetadata);
+
+        assertEquals(EVALUATED_EL_EXPRESSION_STRING_RESULT, wrapper.getSubjectTypeSupported());
     }
 
     @Test
     public void testGetIdTokenSigningAlgorithmsSupported() {
-        OpenIdProviderMetadata providerMetadata = getInstanceofAnnotation(null);
+        OpenIdProviderMetadata providerMetadata = TestOpenIdProviderMetadataDefinition.getInstanceofAnnotation(null);
         OpenIdProviderMetadataWrapper wrapper = new OpenIdProviderMetadataWrapper(providerMetadata);
 
-        assertEquals(ID_TOKEN_SIGNING_ALGORITHMS_SUPPORTED_DEFAULT, wrapper.getIdTokenSigningAlgorithmsSupported());
+        assertEquals(TestOpenIdProviderMetadataDefinition.ID_TOKEN_SIGNING_ALGORITHMS_SUPPORTED_DEFAULT, wrapper.getIdTokenSigningAlgorithmsSupported());
+    }
+
+    @Test
+    public void testGetIdTokenSigningAlgorithmsSupported_EL() {
+        overrides.put(TestOpenIdProviderMetadataDefinition.ID_TOKEN_SIGNING_ALGORITHMS_SUPPORTED, STRING_EL_EXPRESSION);
+
+        OpenIdProviderMetadata providerMetadata = TestOpenIdProviderMetadataDefinition.getInstanceofAnnotation(overrides);
+        OpenIdProviderMetadataWrapper wrapper = new OpenIdProviderMetadataWrapper(providerMetadata);
+
+        assertEquals(EVALUATED_EL_EXPRESSION_STRING_RESULT, wrapper.getIdTokenSigningAlgorithmsSupported());
     }
 
     @Test
     public void testGetResponseTypeSupported() {
-        OpenIdProviderMetadata providerMetadata = getInstanceofAnnotation(null);
+        OpenIdProviderMetadata providerMetadata = TestOpenIdProviderMetadataDefinition.getInstanceofAnnotation(null);
         OpenIdProviderMetadataWrapper wrapper = new OpenIdProviderMetadataWrapper(providerMetadata);
 
-        assertEquals(RESPONSE_TYPE_SUPPORTED_DEFAULT, wrapper.getResponseTypeSupported());
+        assertEquals(TestOpenIdProviderMetadataDefinition.RESPONSE_TYPE_SUPPORTED_DEFAULT, wrapper.getResponseTypeSupported());
     }
 
-    private OpenIdProviderMetadata getInstanceofAnnotation(final Map<String, Object> overrides) {
-        OpenIdProviderMetadata annotation = new OpenIdProviderMetadata() {
+    @Test
+    public void testGetResponseTypeSupported_EL() {
+        overrides.put(TestOpenIdProviderMetadataDefinition.RESPONSE_TYPE_SUPPORTED, STRING_EL_EXPRESSION);
 
-            @Override
-            public Class<? extends Annotation> annotationType() {
-                return null;
-            }
+        OpenIdProviderMetadata providerMetadata = TestOpenIdProviderMetadataDefinition.getInstanceofAnnotation(overrides);
+        OpenIdProviderMetadataWrapper wrapper = new OpenIdProviderMetadataWrapper(providerMetadata);
 
-            @Override
-            public String authorizationEndpoint() {
-                return (overrides != null && overrides.containsKey(AUTHORIZATION_ENDPOINT)) ? (String) overrides.get(AUTHORIZATION_ENDPOINT) : EMPTY_DEFAULT;
-            }
-
-            @Override
-            public String tokenEndpoint() {
-                return (overrides != null && overrides.containsKey(TOKEN_ENDPOINT)) ? (String) overrides.get(TOKEN_ENDPOINT) : EMPTY_DEFAULT;
-            }
-
-            @Override
-            public String userinfoEndpoint() {
-                return (overrides != null && overrides.containsKey(USERINFO_ENDPOINT)) ? (String) overrides.get(USERINFO_ENDPOINT) : EMPTY_DEFAULT;
-            }
-
-            @Override
-            public String endSessionEndpoint() {
-                return (overrides != null && overrides.containsKey(END_SESSION_ENDPOINT)) ? (String) overrides.get(END_SESSION_ENDPOINT) : EMPTY_DEFAULT;
-            }
-
-            @Override
-            public String jwksURI() {
-                return (overrides != null && overrides.containsKey(JWKS_URI)) ? (String) overrides.get(JWKS_URI) : EMPTY_DEFAULT;
-            }
-
-            @Override
-            public String issuer() {
-                return (overrides != null && overrides.containsKey(ISSUER)) ? (String) overrides.get(ISSUER) : EMPTY_DEFAULT;
-            }
-
-            @Override
-            public String subjectTypeSupported() {
-                return (overrides != null && overrides.containsKey(SUBJECT_TYPE_SUPPORTED)) ? (String) overrides.get(SUBJECT_TYPE_SUPPORTED) : SUBJECT_TYPE_SUPPORTED_DEFAULT;
-            }
-
-            @Override
-            public String idTokenSigningAlgorithmsSupported() {
-                return (overrides != null
-                        && overrides.containsKey(ID_TOKEN_SIGNING_ALGORITHMS_SUPPORTED)) ? (String) overrides.get(ID_TOKEN_SIGNING_ALGORITHMS_SUPPORTED) : ID_TOKEN_SIGNING_ALGORITHMS_SUPPORTED_DEFAULT;
-            }
-
-            @Override
-            public String responseTypeSupported() {
-                return (overrides != null && overrides.containsKey(RESPONSE_TYPE_SUPPORTED)) ? (String) overrides.get(RESPONSE_TYPE_SUPPORTED) : RESPONSE_TYPE_SUPPORTED_DEFAULT;
-            }
-
-        };
-
-        return annotation;
+        assertEquals(EVALUATED_EL_EXPRESSION_STRING_RESULT, wrapper.getResponseTypeSupported());
     }
 
 }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/TestLogoutDefinition.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/TestLogoutDefinition.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package io.openliberty.security.jakartasec;
 
+import static io.openliberty.security.jakartasec.JakartaSec30Constants.EMPTY_DEFAULT;
+
 import java.lang.annotation.Annotation;
 import java.util.Map;
 
@@ -17,7 +19,6 @@ import jakarta.security.enterprise.authentication.mechanism.http.openid.LogoutDe
 
 public class TestLogoutDefinition {
 
-    protected static String EMPTY_DEFAULT = "";
     protected static String NOTIFY_PROVIDER = "notifyProvider";
     protected static String NOTIFY_PROVIDER_EXPRESSION = "notifyProviderExpression";
     protected static String REDIRECT_URI = "redirectURI";

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/TestOpenIdProviderMetadataDefinition.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/TestOpenIdProviderMetadataDefinition.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.jakartasec;
+
+import static io.openliberty.security.jakartasec.JakartaSec30Constants.EMPTY_DEFAULT;
+
+import java.lang.annotation.Annotation;
+import java.util.Map;
+
+import jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdConstant;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdProviderMetadata;
+
+public class TestOpenIdProviderMetadataDefinition {
+
+    protected static String AUTHORIZATION_ENDPOINT = "authorizationEndpoint";
+    protected static String TOKEN_ENDPOINT = "tokenEndpoint";
+    protected static String USERINFO_ENDPOINT = "userinfoEndpoint";
+    protected static String END_SESSION_ENDPOINT = "endSessionEndpoint";
+    protected static String JWKS_URI = "jwksURI";
+    protected static String ISSUER = "issuer";
+    protected static String SUBJECT_TYPE_SUPPORTED = "subjectTypeSupported";
+    protected static String ID_TOKEN_SIGNING_ALGORITHMS_SUPPORTED = "idTokenSigningAlgorithmsSupported";
+    protected static String RESPONSE_TYPE_SUPPORTED = "responseTypeSupported";
+    protected static String SUBJECT_TYPE_SUPPORTED_DEFAULT = JakartaSec30Constants.SUBJECT_TYPE_SUPPORTED_DEFAULT;
+    protected static String ID_TOKEN_SIGNING_ALGORITHMS_SUPPORTED_DEFAULT = OpenIdConstant.DEFAULT_JWT_SIGNED_ALGORITHM;
+    protected static String RESPONSE_TYPE_SUPPORTED_DEFAULT = JakartaSec30Constants.RESPONSE_TYPE_SUPPORTED_DEFAULT;
+
+    protected static OpenIdProviderMetadata getInstanceofAnnotation(final Map<String, Object> overrides) {
+        OpenIdProviderMetadata annotation = new OpenIdProviderMetadata() {
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return null;
+            }
+
+            @Override
+            public String authorizationEndpoint() {
+                return (overrides != null && overrides.containsKey(AUTHORIZATION_ENDPOINT)) ? (String) overrides.get(AUTHORIZATION_ENDPOINT) : EMPTY_DEFAULT;
+            }
+
+            @Override
+            public String tokenEndpoint() {
+                return (overrides != null && overrides.containsKey(TOKEN_ENDPOINT)) ? (String) overrides.get(TOKEN_ENDPOINT) : EMPTY_DEFAULT;
+            }
+
+            @Override
+            public String userinfoEndpoint() {
+                return (overrides != null && overrides.containsKey(USERINFO_ENDPOINT)) ? (String) overrides.get(USERINFO_ENDPOINT) : EMPTY_DEFAULT;
+            }
+
+            @Override
+            public String endSessionEndpoint() {
+                return (overrides != null && overrides.containsKey(END_SESSION_ENDPOINT)) ? (String) overrides.get(END_SESSION_ENDPOINT) : EMPTY_DEFAULT;
+            }
+
+            @Override
+            public String jwksURI() {
+                return (overrides != null && overrides.containsKey(JWKS_URI)) ? (String) overrides.get(JWKS_URI) : EMPTY_DEFAULT;
+            }
+
+            @Override
+            public String issuer() {
+                return (overrides != null && overrides.containsKey(ISSUER)) ? (String) overrides.get(ISSUER) : EMPTY_DEFAULT;
+            }
+
+            @Override
+            public String subjectTypeSupported() {
+                return (overrides != null && overrides.containsKey(SUBJECT_TYPE_SUPPORTED)) ? (String) overrides.get(SUBJECT_TYPE_SUPPORTED) : SUBJECT_TYPE_SUPPORTED_DEFAULT;
+            }
+
+            @Override
+            public String idTokenSigningAlgorithmsSupported() {
+                return (overrides != null
+                        && overrides.containsKey(ID_TOKEN_SIGNING_ALGORITHMS_SUPPORTED)) ? (String) overrides.get(ID_TOKEN_SIGNING_ALGORITHMS_SUPPORTED) : ID_TOKEN_SIGNING_ALGORITHMS_SUPPORTED_DEFAULT;
+            }
+
+            @Override
+            public String responseTypeSupported() {
+                return (overrides != null && overrides.containsKey(RESPONSE_TYPE_SUPPORTED)) ? (String) overrides.get(RESPONSE_TYPE_SUPPORTED) : RESPONSE_TYPE_SUPPORTED_DEFAULT;
+            }
+
+        };
+
+        return annotation;
+    }
+}


### PR DESCRIPTION
Fixes #22465 

Added EL support and unit tests for `OpenIdProviderMetadataWrapper`

For new unit tests, added `TestOpenIdProviderMetadataDefinition`

Updated OpenIdAuthenticationMechanismDefinitionWrapperTest to test with `OpenIdProviderMetadataWrapper`

Consolidate more `EMPTY_DEFAULT` constants