### PR TITLE
Turn mpTelemetry off by default

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/suite/FATSuite.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/suite/FATSuite.java
@@ -21,11 +21,13 @@ import componenttest.rules.repeater.FeatureSet;
 import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
 import io.openliberty.microprofile.telemetry.internal.tests.AutoInstrumentationTest;
+import io.openliberty.microprofile.telemetry.internal.tests.TracingNotEnabledTest;
 
 @RunWith(Suite.class)
 @SuiteClasses({
                 AlwaysPassesTest.class, // Must keep this test to run something in the Java 6 builds.
-                AutoInstrumentationTest.class
+                AutoInstrumentationTest.class,
+                TracingNotEnabledTest.class
 })
 
 /**

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AutoInstrumentationTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AutoInstrumentationTest.java
@@ -56,6 +56,7 @@ public class AutoInstrumentationTest extends MicroProfileTelemetryTestBase {
         server.addEnvVar(ENV_OTEL_SERVICE_NAME, OTEL_SERVICE_NAME_SYSTEM);
         server.addEnvVar(ENV_OTEL_TRACES_EXPORTER, OTEL_TRACES_EXPORTER_JAEGER);
         server.addEnvVar(ENV_OTEL_EXPORTER_JAEGER_ENDPOINT, "http://" + jaegerHost + ":" + jaegerGrpcPort);
+        server.addEnvVar(ENV_OTEL_SDK_ENABLED, OTEL_SDK_ENABLED); //Enable tracing
 
         // Construct the test application
         WebArchive system = ShrinkWrap.create(WebArchive.class, "system.war");

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/MicroProfileTelemetryTestBase.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/MicroProfileTelemetryTestBase.java
@@ -49,12 +49,14 @@ public abstract class MicroProfileTelemetryTestBase {
     public static final int JAEGER_GRPC_PORT = 14250;
     public static final Duration CONTAINER_STARTUP_TIMEOUT = Duration.ofSeconds(240);
 
+
+    public static final String ENV_OTEL_SDK_ENABLED = "OTEL_EXPERIMENTAL_SDK_ENABLED";
+    public static final String OTEL_SDK_ENABLED = "true";
     public static final String ENV_OTEL_SERVICE_NAME = "OTEL_SERVICE_NAME";
     public static final String OTEL_SERVICE_NAME_SYSTEM = "system";
     public static final String ENV_OTEL_TRACES_EXPORTER = "OTEL_TRACES_EXPORTER";
     public static final String OTEL_TRACES_EXPORTER_JAEGER = "jaeger";
     public static final String ENV_OTEL_EXPORTER_JAEGER_ENDPOINT = "OTEL_EXPORTER_JAEGER_ENDPOINT";
-
     public static final String JAEGER_QUERY_URL = "http://%s:%s/api/traces";
     public static final String JAEGER_QUERY_PARAMS = "?start=%d&limit=%d&service=%s";
     public static final int JAEGER_QUERY_LIMIT = 20;

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/TracingNotEnabledTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/TracingNotEnabledTest.java
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
+
+@RunWith(FATRunner.class)
+@Mode(TestMode.LITE)
+public class TracingNotEnabledTest extends MicroProfileTelemetryTestBase {
+
+    private static Class<?> c = AutoInstrumentationTest.class;
+    private static LibertyServer server = LibertyServerFactory.getLibertyServer("testServer1");
+    private static final int NUM_OF_CALLS = 3;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        String os = System.getProperty("os.name").toLowerCase();
+        Log.info(c, "setUp", "os.name = " + os);
+
+        clearContainerOutput();
+        String jaegerHost = jaegerContainer.getHost();
+        String jaegerGrpcPort = String.valueOf(jaegerContainer.getMappedPort(JAEGER_GRPC_PORT));
+        Log.info(c, "setUp", "Jaeger container: host=" + jaegerHost + "  port=" + jaegerGrpcPort);
+        server.addEnvVar(ENV_OTEL_SERVICE_NAME, OTEL_SERVICE_NAME_SYSTEM);
+        server.addEnvVar(ENV_OTEL_TRACES_EXPORTER, OTEL_TRACES_EXPORTER_JAEGER);
+        server.addEnvVar(ENV_OTEL_EXPORTER_JAEGER_ENDPOINT, "http://" + jaegerHost + ":" + jaegerGrpcPort);
+        //server.addEnvVar(ENV_OTEL_SDK_ENABLED, OTEL_SDK_ENABLED); tracing not enabled
+        // Construct the test application
+        WebArchive system = ShrinkWrap.create(WebArchive.class, "system.war");
+        system.addPackages(true, "io.openliberty.guides.system");
+        ShrinkHelper.exportAppToServer(server, system);
+        serverStart();
+    }
+
+    @Before
+    public void setUpTest() throws Exception {
+
+        if (!server.isStarted()) {
+            serverStart();
+        }
+        server.addInstalledAppForValidation("system");
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @AfterClass
+    public static void completeTest() throws Exception {
+        try {
+            if (server.isStarted()) {
+                Log.info(c, "competeTest", "---> Stopping server..");
+                server.stopServer("TRAS4301W");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void serverStart() throws Exception {
+        Log.info(c, "serverStart", "--->  Starting Server.. ");
+        server.startServer();
+    }
+
+    @Override
+    protected LibertyServer getServer() {
+        return server;
+    }
+    @Test
+    public void notEnabledTest() throws JSONException, InterruptedException {
+        int count = NUM_OF_CALLS;
+        String result = null;
+        while (count > 0) {
+            result = runApp(getAppUrl("system/properties"));
+            count--;
+            try {
+                Thread.sleep(10000);
+            } catch (InterruptedException e) {
+            }
+        }
+        Log.info(c, "systemSpanTest", "system = " + result);
+        assertNotNull("result is null", result);
+        // Query Jaeger for spans
+        int retries = 10;
+        JSONArray dataArray = null;
+        do {
+            Thread.sleep(1000); // Delay for 1 second
+            String json = queryJaeger();
+            Log.info(c, "systemSpanTest", "Jaeger json = " + json);
+            assertNotNull("Jaeger returned empty json", json);
+            //
+            // The normal return JSON structure will be like this:
+            // {
+            //   "data":[
+            //     {
+            //       "traceID":"...",
+            //       "spans":[...],
+            //       "processes": { },
+            //       "warnings":"..."
+            //     }
+            //     {
+            //       "traceID":"...",
+            //       "spans":[...],
+            //       "processes": { },
+            //       "warnings":"..."
+            //     }
+            //   ],
+            //  "total":0,
+            //  "limit":0,
+            //  "offest":0,
+            //  "errors":"null"
+            // }
+            JSONObject jobj = new JSONObject(json);
+            // Make sure erorrs is null
+            assertTrue("errors is not null", jobj.getString("errors").equals("null"));
+            // Make sure data contains the same number of spans as the number of JAX-RS calls
+            dataArray = jobj.getJSONArray("data");
+            retries--;
+        } while ((retries > 0) && ((dataArray == null) || (dataArray.length() < NUM_OF_CALLS)));
+        assertEquals("data contains spans but tracing is not enabled", 0, dataArray.length());
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/resources/META-INF/microprofile-config.properties
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/resources/META-INF/microprofile-config.properties
@@ -1,3 +1,4 @@
 otel.exporter.jaeger.endpoint=http://localhost:14250
 otel.traces.exporter=jaeger
 otel.exporter.jaeger.timeout=10000
+otel.experimental.sdk.enabled=true


### PR DESCRIPTION
For issue #19172 

By default, MicroProfile Telemetry tracing is off. In order to enable any of the tracing aspects, the configuration otel.experimental.sdk.enabled=true must be specified in any of the config sources available via MicroProfile Config. This property is read once when the application is starting. Any changes afterwards will not take effect unless the application is restarted.