### PR TITLE
Updates for running tests on ARM

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/FATSuite.java
@@ -45,7 +45,7 @@ public class FATSuite extends TestContainerSuite {
                     // Use 5m timeout for local runs, 25m timeout for remote runs (extra time since the DB2 container can be slow to start)
                     .waitingFor(new LogMessageWaitStrategy()
                                     .withRegEx(".*DB2 SSH SETUP DONE.*")
-                                    .withStartupTimeout(Duration.ofMinutes(FATRunner.FAT_TEST_LOCALRUN ? 5 : 25)))
+                                    .withStartupTimeout(Duration.ofMinutes(FATRunner.FAT_TEST_LOCALRUN && !FATRunner.ARM_ARCHITECTURE ? 5 : 25)))
                     .withLogConsumer(new SimpleLogConsumer(FATSuite.class, "db2-ssl"))
                     .withReuse(true);
 }

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/containers/DB2KerberosContainer.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/containers/DB2KerberosContainer.java
@@ -45,7 +45,7 @@ public class DB2KerberosContainer extends Db2Container {
         withEnv("DB2_KRB5_PRINCIPAL", "db2srvc@EXAMPLE.COM");
         waitingFor(new LogMessageWaitStrategy()
                         .withRegEx("^.*SETUP SCRIPT COMPLETE.*$")
-                        .withStartupTimeout(Duration.ofMinutes(FATRunner.FAT_TEST_LOCALRUN ? 10 : 25)));
+                        .withStartupTimeout(Duration.ofMinutes(FATRunner.FAT_TEST_LOCALRUN && !FATRunner.ARM_ARCHITECTURE ? 10 : 25)));
         withLogConsumer(new SimpleLogConsumer(c, "DB2"));
     }
 

--- a/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryImageNameSubstitutor.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryImageNameSubstitutor.java
@@ -79,8 +79,9 @@ public class ArtifactoryImageNameSubstitutor extends ImageNameSubstitutor {
 
     static String getPrivateRegistry() {
         String artifactoryServer = System.getProperty(artifactoryRegistryKey);
-        if (artifactoryServer == null || artifactoryServer.isEmpty() || artifactoryServer.startsWith("${"))
-            throw new IllegalStateException("No private registry configured. System property '" + artifactoryRegistryKey + "' was: " + artifactoryServer);
+        if (artifactoryServer == null || artifactoryServer.isEmpty() || artifactoryServer.startsWith("${") || artifactoryServer.equals("null"))
+            throw new IllegalStateException("No private registry configured. System property '" + artifactoryRegistryKey + "' was: " + artifactoryServer + "  "
+                                            + "Ensure artifactory properties are set in gradle.startup.properties");
         if (artifactoryServer.startsWith("na.") || artifactoryServer.startsWith("eu."))
             artifactoryServer = artifactoryServer.substring(3);
         return "wasliberty-docker-remote." + artifactoryServer;

--- a/dev/fattest.simplicity/src/componenttest/containers/ExternalTestServiceDockerClientStrategy.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/ExternalTestServiceDockerClientStrategy.java
@@ -398,9 +398,16 @@ public class ExternalTestServiceDockerClientStrategy extends DockerClientProvide
 
             //State 4: Earlier version of TestContainers didn't support docker for windows
             // Assume a user on windows with no other preferences will want to use a remote host.
+            // ARM architecture can cause performance/starting issues with x86 containers, so also
+            // assume remote as the default.
             if (System.getProperty("os.name", "unknown").toLowerCase().contains("windows")) {
                 result = true;
                 reason = "Local operating system is Windows. Default container support not guaranteed.";
+                break;
+            }
+            if (FATRunner.ARM_ARCHITECTURE) {
+                result = true;
+                reason = "CPU architecture is ARM. x86 container support and performance not guaranteed.";
                 break;
             }
 

--- a/dev/fattest.simplicity/src/componenttest/custom/junit/runner/FATRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/custom/junit/runner/FATRunner.java
@@ -70,6 +70,8 @@ public class FATRunner extends BlockJUnit4ClassRunner {
     // Used to reduce timeouts to a sensible level when FATs are running locally
     public static final boolean FAT_TEST_LOCALRUN = Boolean.getBoolean("fat.test.localrun") && !Boolean.parseBoolean(System.getenv("CI"));
 
+    public static final boolean ARM_ARCHITECTURE = System.getProperty("os.arch").equals("aarch64") || System.getProperty("os.arch").equals("arm");
+
     private static final int MAX_FFDC_LINES = 1000;
     private static final boolean DISABLE_FFDC_CHECKING = Boolean.getBoolean("disable.ffdc.checking");
 

--- a/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerFactory.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerFactory.java
@@ -117,7 +117,7 @@ public class DatabaseContainerFactory {
                     acceptDB2License.invoke(cont);
                     //Add startup timeout since DB2 tends to take longer than the default 3 minutes on build machines.
                     Method withStartupTimeoutDB2 = cont.getClass().getMethod("withStartupTimeout", Duration.class);
-                    withStartupTimeoutDB2.invoke(cont, Duration.ofMinutes(FATRunner.FAT_TEST_LOCALRUN ? 5 : 15));
+                    withStartupTimeoutDB2.invoke(cont, Duration.ofMinutes(FATRunner.FAT_TEST_LOCALRUN && !FATRunner.ARM_ARCHITECTURE ? 5 : 15));
                     break;
                 case Derby:
                     break;

--- a/dev/io.openliberty.checkpoint_fat_persistence/fat/src/io/openliberty/checkpoint/fat/DB2Test.java
+++ b/dev/io.openliberty.checkpoint_fat_persistence/fat/src/io/openliberty/checkpoint/fat/DB2Test.java
@@ -59,7 +59,7 @@ public class DB2Test extends FATServletClient {
                     // Use 5m timeout for local runs, 25m timeout for remote runs (extra time since the DB2 container can be slow to start)
                     .waitingFor(new LogMessageWaitStrategy()
                                     .withRegEx(".*DB2 SSH SETUP DONE.*")
-                                    .withStartupTimeout(Duration.ofMinutes(FATRunner.FAT_TEST_LOCALRUN ? 5 : 25)))
+                                    .withStartupTimeout(Duration.ofMinutes(FATRunner.FAT_TEST_LOCALRUN && !FATRunner.ARM_ARCHITECTURE ? 5 : 25)))
                     .withLogConsumer(new SimpleLogConsumer(FATSuite.class, "db2-ssl"))
                     .withReuse(true);
 


### PR DESCRIPTION
Sets the default to using remote containers when running on ARM, due to decreased performance and failure to start with some x86 containers.
