### PR TITLE
Enable JSF23SelectOneRadioGroupTests.java for Jakarta EE10 Faces 4.0

### DIFF
--- a/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/JSF23SelectOneRadioGroupTests.java
+++ b/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/JSF23SelectOneRadioGroupTests.java
@@ -43,7 +43,6 @@ import componenttest.topology.impl.LibertyServer;
  */
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
-@SkipForRepeat(SkipForRepeat.EE10_FEATURES)
 public class JSF23SelectOneRadioGroupTests {
 
     protected static final Class<?> c = JSF23SelectOneRadioGroupTests.class;
@@ -80,6 +79,7 @@ public class JSF23SelectOneRadioGroupTests {
      * @throws Exception
      */
     @Test
+    @SkipForRepeat(SkipForRepeat.EE10_FEATURES)
     public void testSelectOneRadioGroup_AjaxRequest() throws Exception {
         try (WebClient webClient = new WebClient(BrowserVersion.CHROME)) {
             // Use a synchronizing ajax controller to allow proper ajax updating


### PR DESCRIPTION
for #22368

One failing test case is still not enabled. Looks to be passing manually but the second AJAX request does not look to be happening in the automation using HtmlUnit.