### PR TITLE
Update jetty version in pom.xml for telemetry TCK

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -31,7 +31,7 @@
         <defaultSuiteFiles>tck-suite.xml</defaultSuiteFiles>
         <suiteXmlFile>${defaultSuiteFiles}</suiteXmlFile>
         <targetDirectory>${project.basedir}/target</targetDirectory>
-        <jetty.version>9.4.31.v20200723</jetty.version>
+        <jetty.version>9.4.41.v20210516</jetty.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Updated jetty version to 9.4.41.v20210516 as old version has vulnerabilities 