### PR TITLE
Change to no longer transform the idp application 3 times.

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/ShibbolethHelpers.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/ShibbolethHelpers.java
@@ -484,10 +484,10 @@ public class ShibbolethHelpers {
         // copy the appropriate version of the idp.war file
         if (System.getProperty("java.specification.version").matches("1\\.[789]")) {
             Log.info(thisClass, thisMethod, "################## Copying the 3.1.1 version of Shibbolet ##################h");
-            LibertyFileManager.copyFileIntoLiberty(theServer.getMachine(), theServer.getServerRoot() + "/test-apps", "idp.war", theServer.getServerRoot() + "/test-apps/idp-war-3.3.1.war");
+            LibertyFileManager.copyFileIntoLiberty(theServer.getMachine(), theServer.getServerRoot() + "/test-apps", "idp.war", theServer.getServerRoot() + "/idp-apps/idp-war-3.3.1.war");
         } else {
             Log.info(thisClass, thisMethod, "################## Copying the 4.1.0 version of Shibboleth ##################");
-            LibertyFileManager.copyFileIntoLiberty(theServer.getMachine(), theServer.getServerRoot() + "/test-apps", "idp.war", theServer.getServerRoot() + "/test-apps/idp-war-4.1.0.war");
+            LibertyFileManager.copyFileIntoLiberty(theServer.getMachine(), theServer.getServerRoot() + "/test-apps", "idp.war", theServer.getServerRoot() + "/idp-apps/idp-war-4.1.0.war");
         }
 
     }

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/ShibbolethCommon.gradle
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/ShibbolethCommon.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -43,11 +43,11 @@ task copyShibbolethServer (dependsOn: [':com.ibm.ws.security.fat.common:assemble
     // copyShibbolethTestAppFilesToServer  (copy both 3.3.1 and 4.1.0 and let the tests decide at runtime which to use)
    	copy {
 	  from new File(project(':com.ibm.ws.security.saml.sso_fat.common').buildDir, 'test-application/idp-war-3.3.1.war')
- 	  into new File(autoFvtDir, "publish/servers/${serverName}/test-apps")
+ 	  into new File(autoFvtDir, "publish/servers/${serverName}/idp-apps")
 	}
 	copy {
 	  from new File(project(':com.ibm.ws.security.saml.sso_fat.common').buildDir, 'test-application/idp-war-4.1.0.war')
-	  into new File(autoFvtDir, "publish/servers/${serverName}/test-apps")
+	  into new File(autoFvtDir, "publish/servers/${serverName}/idp-apps")
 	}
  
     // copySecurityKeysToServer


### PR DESCRIPTION
- Update to put the idp wars in an idp-tests instead of test-apps directory so that the apps isn't transformed 3 times
- Update the copy of the right app to use idp-apps to copy from when copying to the test-apps dir.
