### PR TITLE
22535 faces mbean

### DIFF
--- a/dev/com.ibm.ws.javaee.dd/diff_jakartaee_10-9.txt
+++ b/dev/com.ibm.ws.javaee.dd/diff_jakartaee_10-9.txt
@@ -353,3 +353,51 @@ Details for the new JNDI reference elements:
   </xsd:complexType>
 
 ---
+
+Updates to: web-facesconfig_4_0.xsd:
+
+Removed constraint:
+
+  <xsd:element name="faces-config"
+               type="jakartaee:faces-configType">
+
+    <xsd:unique name="faces-config-managed-bean-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p> Managed bean names must be unique within a document.</p>
+
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:managed-bean"/>
+      <xsd:field xpath="jakartaee:managed-bean-name"/>
+    </xsd:unique>
+
+Removed element:
+
+  <xsd:complexType name="faces-configType">
+      <xsd:element name="managed-bean"
+                   type="jakartaee:faces-config-managed-beanType"/>
+
+Removed elements:
+
+  <xsd:complexType name="faces-config-applicationType">
+
+      <xsd:element name="property-resolver"
+                   type="jakartaee:fully-qualified-classType">
+      <xsd:element name="variable-resolver"
+                   type="jakartaee:fully-qualified-classType">
+
+Removed types:
+
+  <xsd:complexType name="faces-config-managed-beanType">
+  <xsd:complexType name="faces-config-managed-bean-extensionType">
+  <xsd:complexType name="faces-config-managed-bean-scopeOrNoneType">
+  <xsd:complexType name="faces-config-managed-propertyType">
+  <xsd:complexType name="faces-config-map-entryType">
+  <xsd:complexType name="faces-config-map-entriesType">
+  <xsd:complexType name="faces-config-value-classType">
+  <xsd:complexType name="faces-config-list-entriesType">
+
+---

--- a/dev/com.ibm.ws.javaee.dd/resources/com/ibm/ws/javaee/dd/schemas/web-facesconfig_4_0.xsd
+++ b/dev/com.ibm.ws.javaee.dd/resources/com/ibm/ws/javaee/dd/schemas/web-facesconfig_4_0.xsd
@@ -11,56 +11,56 @@
     <xsd:documentation>
 
       Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
-      
+
       This program and the accompanying materials are made available under the
       terms of the Eclipse Public License v. 2.0, which is available at
       http://www.eclipse.org/legal/epl-2.0.
-      
+
       This Source Code may also be made available under the following Secondary
       Licenses when the conditions for such availability set forth in the
       Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
       version 2 with the GNU Classpath Exception, which is available at
       https://www.gnu.org/software/classpath/license.html.
-      
+
       SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
-      
+
     </xsd:documentation>
   </xsd:annotation>
 
   <xsd:annotation>
     <xsd:documentation>
       <![CDATA[
-      <p>The XML Schema for the Jakarta Server Faces Application
+      <p>The XML Schema for the Jakarta Faces Application
       Configuration File (Version 4.0).</p>
-      
-      <p>All JavaServer Faces configuration files must indicate
-      the JavaServer Faces schema by indicating the JavaServer
-      Faces namespace:</p>
-      
+
+      <p>All Jakarta Faces configuration files must indicate
+      the Jakarta Faces schema by indicating the
+      Jakarta Faces namespace:</p>
+
       <p>https://jakarta.ee/xml/ns/jakartaee</p>
-      
+
       <p>and by indicating the version of the schema by
       using the version element as shown below:</p>
-      
+
       <pre>&lt;faces-config xmlns="https://jakarta.ee/xml/ns/jakartaee"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="..."
       version="4.0"&gt;
       ...
       &lt;/faces-config&gt;</pre>
-      
+
       <p>The instance documents may indicate the published
       version of the schema using xsi:schemaLocation attribute
       for jakartaee namespace with the following location:</p>
-      
+
       <p>https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_0.xsd</p>
-      
+
       ]]>
     </xsd:documentation>
   </xsd:annotation>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:element name="faces-config"
                type="jakartaee:faces-configType">
@@ -70,7 +70,7 @@
         <p>The "faces-config" element is the root of the configuration
         information hierarchy, and contains nested elements for all
         of the other configuration settings.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -79,7 +79,7 @@
         <xsd:documentation>
           <![CDATA[
           <p>Behavior IDs must be unique within a document.</p>
-          
+
           ]]>
         </xsd:documentation>
       </xsd:annotation>
@@ -91,7 +91,7 @@
         <xsd:documentation>
           <![CDATA[
           <p>Converter IDs must be unique within a document.</p>
-          
+
           ]]>
         </xsd:documentation>
       </xsd:annotation>
@@ -104,7 +104,7 @@
           <![CDATA[
           <p>'converter-for-class' element values must be unique
           within a document.</p>
-          
+
           ]]>
         </xsd:documentation>
       </xsd:annotation>
@@ -116,29 +116,17 @@
         <xsd:documentation>
           <![CDATA[
           <p> Validator IDs must be unique within a document.</p>
-          
+
           ]]>
         </xsd:documentation>
       </xsd:annotation>
       <xsd:selector xpath="jakartaee:validator"/>
       <xsd:field xpath="jakartaee:validator-id"/>
     </xsd:unique>
-    <xsd:unique name="faces-config-managed-bean-name-uniqueness">
-      <xsd:annotation>
-        <xsd:documentation>
-          <![CDATA[
-          <p> Managed bean names must be unique within a document.</p>
-          
-          ]]>
-        </xsd:documentation>
-      </xsd:annotation>
-      <xsd:selector xpath="jakartaee:managed-bean"/>
-      <xsd:field xpath="jakartaee:managed-bean-name"/>
-    </xsd:unique>
   </xsd:element>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-configType">
     <xsd:annotation>
@@ -147,7 +135,7 @@
         <p> The "faces-config" element is the root of the configuration
         information hierarchy, and contains nested elements for all
         of the other configuration settings.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -166,8 +154,6 @@
                    type="jakartaee:faces-config-componentType"/>
       <xsd:element name="converter"
                    type="jakartaee:faces-config-converterType"/>
-      <xsd:element name="managed-bean"
-                   type="jakartaee:faces-config-managed-beanType"/>
       <xsd:element name="flow-definition"
                    type="jakartaee:faces-config-flow-definitionType"/>
       <xsd:element name="name"
@@ -176,19 +162,19 @@
         <xsd:annotation>
           <xsd:documentation>
             <![CDATA[
-            <p> <span class="changed_modified_2_2">The</span> "name" element 
+            <p> <span class="changed_modified_2_2">The</span> "name" element
             within the top level "faces-config"
             element declares the name of this application
             configuration resource.  Such names are used
             in the document ordering scheme specified in section
-            JSF.11.4.6.</p>
-            
-            <p class="changed_added_2_2">This value is taken to be the 
-            defining document id of any &lt;flow-definition&gt; elements 
+            11.3.8 "Ordering of Artifacts" of the Jakarta Faces Specification Document.</p>
+
+            <p class="changed_added_2_2">This value is taken to be the
+            defining document id of any &lt;flow-definition&gt; elements
             defined in this Application Configuration Resource file.  If this
-            element is not specified, the runtime must take the empty string 
+            element is not specified, the runtime must take the empty string
             as its value.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -221,35 +207,35 @@
         <xsd:documentation>
 
           The metadata-complete attribute defines whether this
-          JavaServer Faces application is complete, or whether
+          Faces application is complete, or whether
           the class files available to this module and packaged with
           this application should be examined for annotations
           that specify configuration information.
-          
-          This attribute is only inspected on the application 
+
+          This attribute is only inspected on the application
           configuration resource file located at "WEB-INF/faces-config.xml".
           The presence of this attribute on any application configuration
           resource other than the one located at "WEB-INF/faces-config.xml",
           including any files named using the jakarta.faces.CONFIG_FILES
           attribute, must be ignored.
-          
-          If metadata-complete is set to "true", the JavaServer Faces
+
+          If metadata-complete is set to "true", the Faces
           runtime must ignore any annotations that specify configuration
           information, which might be present in the class files
           of the application.
-          
+
           If metadata-complete is not specified or is set to
-          "false", the JavaServer Faces runtime must examine the class
+          "false", the Faces runtime must examine the class
           files of the application for annotations, as specified by
           the specification.
-          
-          If "WEB-INF/faces-config.xml" is not present, the JavaServer
+
+          If "WEB-INF/faces-config.xml" is not present, the
           Faces runtime will assume metadata-complete to be "false".
-          
+
           The value of this attribute will have no impact on
           runtime annotations such as @ResourceDependency or
           @ListenerFor.
-          
+
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
@@ -261,7 +247,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-extensionType">
     <xsd:annotation>
@@ -269,7 +255,7 @@
         <![CDATA[
         <p> Extension element for faces-config.  It may contain
         implementation specific content.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -284,14 +270,16 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-orderingType">
     <xsd:annotation>
       <xsd:documentation>
         <![CDATA[
-        <p> Please see section JSF.11.4.6 for the specification of this element.</p>
-        
+        <p> Please see section
+        11.3.8 "Ordering of Artifacts" of the Jakarta Faces Specification Document
+        for the specification of this element.</p>
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -308,7 +296,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-ordering-orderingType">
     <xsd:annotation>
@@ -319,7 +307,7 @@
         declared on its faces-config element.  This element can also contain
         a single "others" element which specifies that this document comes
         before or after other documents within the application.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -337,7 +325,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-ordering-othersType">
     <xsd:annotation>
@@ -346,9 +334,10 @@
         <p> This element indicates that the ordering sub-element in which
         it was placed should take special action regarding the ordering
         of this application resource relative to other
-        application configuration resources.  See section JSF.11.4.6
+        application configuration resources.
+        See section 11.3.8 "Ordering of Artifacts" of the Jakarta Faces Specification Document
         for the complete specification.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -357,15 +346,17 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-absoluteOrderingType">
     <xsd:annotation>
       <xsd:documentation>
         <![CDATA[
         <p> Only relevant if this is placed within the /WEB-INF/faces-config.xml.
-        Please see section JSF.11.4.6 for the specification for details.</p>
-        
+        Please see
+        section 11.3.8 "Ordering of Artifacts" of the Jakarta Faces Specification Document
+        for the specification for details.</p>
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -384,7 +375,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-applicationType">
     <xsd:annotation>
@@ -393,10 +384,10 @@
         <p> The "application" element provides a mechanism to define the
         various per-application-singleton implementation artifacts for
         a particular web application that is utilizing
-        JavaServer Faces.  For nested elements that are not specified,
-        the Jakarta Server Faces implementation must provide a suitable 
+        Jakarta Faces.  For nested elements that are not specified,
+        the Jakarta Faces implementation must provide a suitable
         default.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -412,7 +403,7 @@
             ActionListener implementation class that will be
             called during the Invoke Application phase of the
             request processing lifecycle.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -425,7 +416,7 @@
             <p> The "default-render-kit-id" element allows the
             application to define a renderkit to be used other
             than the standard one.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -440,7 +431,7 @@
             the JavaDocs for the "java.util.ResourceBundle"
             class for more information on the syntax of
             resource bundle names.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -455,9 +446,9 @@
             NavigationHandler implementation class that will
             be called during the Invoke Application phase
             of the request processing lifecycle, if the
-            default ActionListener (provided by the Jakarta Server 
-            Faces implementation) is used.</p>
-            
+            default ActionListener (provided by the Jakarta Faces
+            implementation) is used.</p>
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -474,7 +465,7 @@
             request processing lifecycle.  The faces
             implementation must provide a default
             implementation of this class.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -491,7 +482,7 @@
             request processing lifecycle.  The faces
             implementation must provide a default
             implementation of this class.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -506,37 +497,7 @@
             jakarta.el.ELResolver implementation class
             that will be used during the processing of
             EL expressions.</p>
-            
-            ]]>
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="property-resolver"
-                   type="jakartaee:fully-qualified-classType">
-        <xsd:annotation>
-          <xsd:documentation>
-            <![CDATA[
-            <p> The "property-resolver" element contains the fully
-            qualified class name of the concrete
-            PropertyResolver implementation class that will
-            be used during the processing of value binding
-            expressions.</p>
-            
-            ]]>
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="variable-resolver"
-                   type="jakartaee:fully-qualified-classType">
-        <xsd:annotation>
-          <xsd:documentation>
-            <![CDATA[
-            <p> The "variable-resolver" element contains the fully
-            qualified class name of the concrete
-            VariableResolver implementation class that will
-            be used during the processing of value binding
-            expressions.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -554,7 +515,7 @@
             constructor based decorator pattern used for
             other application singletons will be
             honored.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -569,7 +530,7 @@
             library contracts that, if present in the application, must be made
             available for use as templates of the specified views.
             </p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -584,7 +545,7 @@
             concrete jakarta.faces.component.search.SearchExpressionHandler
             implementation class that will be used for processing of a
             search expression.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -599,7 +560,7 @@
             concrete jakarta.faces.component.search.SearchKeywordResolver
             implementation class that will be used during the processing
             of a search expression keyword.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -624,7 +585,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-application-resource-bundleType">
     <xsd:annotation>
@@ -637,7 +598,7 @@
         Application.getResourceBundle() passing the current
         FacesContext for this request and the value of the var
         element below.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -650,7 +611,7 @@
             <![CDATA[
             <p> The fully qualified class name of the
             java.util.ResourceBundle instance.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -663,7 +624,7 @@
             <p> The name by which this ResourceBundle instance
             is retrieved by a call to
             Application.getResourceBundle().</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -674,7 +635,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-application-resource-library-contractsType">
     <xsd:annotation>
@@ -685,7 +646,7 @@
         library contracts that, if present in the application, must be made
         available for use as templates of the specified views.
         </p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -700,7 +661,7 @@
             <p classes="changed_added_2_2">Declare a mapping between a collection
             of views in the application and the list of contracts (if present in the application)
             that may be used as a source for templates and resources for those views.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -711,7 +672,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-application-resource-library-contracts-contract-mappingType">
     <xsd:annotation>
@@ -722,7 +683,7 @@
         library contracts that, if present in the application, must be made
         available for use as templates of the specified views.
         </p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -735,10 +696,10 @@
           <xsd:documentation>
             <![CDATA[
             <p class="changed_added_2_2">The "url-pattern" element
-            specifies the collection of views in this application that 
+            specifies the collection of views in this application that
             are allowed to use the corresponding contracts.
             </p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -754,7 +715,7 @@
             if available to the application, may be used by the views
             matched by the corresponding "url-pattern"
             </p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -765,7 +726,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-application-extensionType">
     <xsd:annotation>
@@ -773,7 +734,7 @@
         <![CDATA[
         <p> Extension element for application.  It may contain
         implementation specific content.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -788,7 +749,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-factoryType">
     <xsd:annotation>
@@ -796,10 +757,10 @@
         <![CDATA[
         <p> The "factory" element provides a mechanism to define the
         various Factories that comprise parts of the implementation
-        of JavaServer Faces.  For nested elements that are not
-        specified, the Jakarta Server Faces implementation must provide a 
+        of Jakarta Faces.  For nested elements that are not
+        specified, the Jakarta Faces implementation must provide a
         suitable default.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -816,7 +777,7 @@
             be called when
             FactoryFinder.getFactory(APPLICATION_FACTORY) is
             called.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -832,7 +793,7 @@
             be called when
             FactoryFinder.getFactory(EXCEPTION_HANDLER_FACTORY)
             is called.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -848,7 +809,7 @@
             be called when
             FactoryFinder.getFactory(EXTERNAL_CONTEXT_FACTORY)
             is called.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -864,7 +825,7 @@
             be called when
             FactoryFinder.getFactory(FACES_CONTEXT_FACTORY)
             is called.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -880,7 +841,7 @@
             be called when
             FactoryFinder.getFactory(FACELET_CACHE_FACTORY)
             is called.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -895,7 +856,7 @@
             PartialViewContextFactory implementation class that will
             be called when FactoryFinder.getFactory
             (FactoryFinder.PARTIAL_VIEW_CONTEXT_FACTORY) is called.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -909,7 +870,7 @@
             qualified class name of the concrete LifecycleFactory
             implementation class that will be called when
             FactoryFinder.getFactory(LIFECYCLE_FACTORY) is called.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -924,7 +885,7 @@
             ViewDeclarationLanguageFactory
             implementation class that will be called when
             FactoryFinder.getFactory(VIEW_DECLARATION_FACTORY) is called.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -939,7 +900,7 @@
             ViewDeclarationLanguageFactory
             implementation class that will be called when
             FactoryFinder.getFactory(TAG_HANDLER_DELEGATE_FACTORY) is called.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -954,7 +915,7 @@
             implementation class that will be called when
             FactoryFinder.getFactory(RENDER_KIT_FACTORY) is
             called.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -969,7 +930,7 @@
             implementation class that will be called when
             FactoryFinder.getFactory(VISIT_CONTEXT_FACTORY) is
             called.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -985,7 +946,7 @@
             be called when
             FactoryFinder.getFactory(FLASH_FACTORY) is
             called.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -1001,7 +962,7 @@
             be called when
             FactoryFinder.getFactory(FLOW_HANDLER_FACTORY) is
             called.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -1011,10 +972,10 @@
         <xsd:annotation>
           <xsd:documentation>
             <![CDATA[
-            <p class="changed_added_2_3"> The "client-window-factory" element contains the fully 
-            qualified class name of the concrete ClientWindowFactory implementation class that 
-            will be called when FactoryFinder.getFactory(CLIENT_WINDOW_FACTORY) is called.</p>  
-            
+            <p class="changed_added_2_3"> The "client-window-factory" element contains the fully
+            qualified class name of the concrete ClientWindowFactory implementation class that
+            will be called when FactoryFinder.getFactory(CLIENT_WINDOW_FACTORY) is called.</p>
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -1031,7 +992,7 @@
             be called when
             FactoryFinder.getFactory(SEARCH_EXPRESSION_CONTEXT_FACTORY)
             is called.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -1046,7 +1007,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-factory-extensionType">
     <xsd:annotation>
@@ -1054,7 +1015,7 @@
         <![CDATA[
         <p> Extension element for factory.  It may contain
         implementation specific content.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1069,7 +1030,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-attributeType">
     <xsd:annotation>
@@ -1078,10 +1039,10 @@
         <p> The "attribute" element represents a named, typed, value
         associated with the parent UIComponent via the generic
         attributes mechanism.</p>
-        
+
         <p>Attribute names must be unique within the scope of the parent
         (or related) component.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1096,7 +1057,7 @@
             which the corresponding value will be stored, in the
             generic attributes of the UIComponent we are related
             to.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -1108,7 +1069,7 @@
             <![CDATA[
             <p> The "attribute-class" element represents the Java type
             of the value associated with this attribute name.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -1129,7 +1090,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-attribute-extensionType">
     <xsd:annotation>
@@ -1137,7 +1098,7 @@
         <![CDATA[
         <p> Extension element for attribute.  It may contain
         implementation specific content.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1152,7 +1113,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-componentType">
     <xsd:annotation>
@@ -1163,13 +1124,13 @@
         specified type identifier, along with its associated
         properties and attributes.  Component types must be unique
         within the entire web application.</p>
-        
+
         <p>Nested "attribute" elements identify generic attributes that
         are recognized by the implementation logic of this component.
         Nested "property" elements identify JavaBeans properties of
         the component class that may be exposed for manipulation
         via tools.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1183,7 +1144,7 @@
             <p> The "component-type" element represents the name under
             which the corresponding UIComponent class should be
             registered.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -1196,7 +1157,7 @@
             <p> The "component-class" element represents the fully
             qualified class name of a concrete UIComponent
             implementation class.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -1223,7 +1184,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-component-extensionType">
     <xsd:annotation>
@@ -1231,7 +1192,7 @@
         <![CDATA[
         <p> Extension element for component.  It may contain
         implementation specific content.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1246,7 +1207,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-default-localeType">
     <xsd:annotation>
@@ -1254,17 +1215,17 @@
         <![CDATA[
         <p> The "default-locale" element declares the default locale
         for this application instance.</p>
-        
+
         <p class="modified_added_2_3">
         To facilitate BCP 47 this element first needs to be parsed by the
         Locale.forLanguageTag method. If it does not return a Locale with
         a language the old specification below needs to take effect.
         </p>
-        
+
         <p>It must be specified as :language:[_:country:[_:variant:]]
         without the colons, for example "ja_JP_SJIS".  The
         separators between the segments may be '-' or '_'.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1277,7 +1238,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-default-valueType">
     <xsd:annotation>
@@ -1288,7 +1249,7 @@
         from the "suggested-value" in that the property or attribute
         must take the value, whereas in "suggested-value" taking the
         value is optional.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1307,7 +1268,7 @@
         <p> EL expressions present within a faces config file
         must start with the character sequence of '#{' and
         end with '}'.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1317,7 +1278,7 @@
   </xsd:simpleType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-facetType">
     <xsd:annotation>
@@ -1325,7 +1286,7 @@
         <![CDATA[
         <p> Define the name and other design-time information for a facet
         that is associated with a renderer or a component.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1339,7 +1300,7 @@
             <p> The "facet-name" element represents the facet name
             under which a UIComponent will be added to its parent.
             It must be of type "Identifier".</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -1354,7 +1315,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-facet-extensionType">
     <xsd:annotation>
@@ -1362,7 +1323,7 @@
         <![CDATA[
         <p> Extension element for facet.  It may contain implementation
         specific content.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1377,7 +1338,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-from-view-idType">
     <xsd:annotation>
@@ -1386,28 +1347,28 @@
         <p><span class="changed_modified_2_2">The</span>
         value of from-view-id must contain one of the following
         values:</p>
-        
+
         <ul>
-        
+
         <li><p>The exact match for a view identifier that is recognized
         by the the ViewHandler implementation being used (such as
         "/index.jsp" if you are using the default ViewHandler).</p></li>
-        
+
         <li><p class="changed_added_2_2">The exact match of a flow node id
         in the current flow, or a flow id of another flow.</p></li>
-        
+
         <li><p> A proper prefix of a view identifier, plus a trailing
         "*" character.  This pattern indicates that all view
         identifiers that match the portion of the pattern up to the
         asterisk will match the surrounding rule.  When more than one
         match exists, the match with the longest pattern is selected.
         </p></li>
-        
+
         <li><p>An "*" character, which means that this pattern applies
         to all view identifiers.  </p></li>
-        
+
         </ul>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1420,7 +1381,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-from-actionType">
     <xsd:annotation>
@@ -1432,7 +1393,7 @@
         in order to select the navigation rule.  If not specified,
         this rule will be relevant no matter which action reference
         was executed (or if no action reference was executed).</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1445,7 +1406,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-ifType">
     <xsd:annotation>
@@ -1462,17 +1423,17 @@
         present, the navigation handler will match a null outcome
         and use the condition return value to determine if the
         case should be considered a match.</p>
-        
+
         <div class="changed_added_2_2">
-        
+
         <p>When used in a <code>&lt;switch&gt;</code> within a flow, if the
         expresion returns <code>true</code>, the
         <code>&lt;from-outcome&gt;</code> sibling element's outcome is used as
         the id of the node in the flow graph to which control must be
         passed.</p>
-        
+
         </div>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1485,18 +1446,18 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-flow-definition-parameter-valueType">
     <xsd:annotation>
       <xsd:documentation>
         <![CDATA[
         <p class="changed_added_2_2"></p>
-        
+
         <div class="changed_added_2_2">
-        
+
         </div>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1509,7 +1470,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-converterType">
     <xsd:annotation>
@@ -1519,7 +1480,7 @@
         implementation class that should be registered under the
         specified converter identifier.  Converter identifiers must
         be unique within the entire web application.</p>
-        
+
         <p>Nested "attribute" elements identify generic attributes that
         may be configured on the corresponding UIComponent in order
         to affect the operation of the Converter.  Nested "property"
@@ -1529,7 +1490,7 @@
         elements are intended to allow component developers to
         more completely describe their components to tools and users.
         These elements have no required runtime semantics.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1544,7 +1505,7 @@
               <p> The "converter-id" element represents the
               identifier under which the corresponding
               Converter class should be registered.</p>
-              
+
               ]]>
             </xsd:documentation>
           </xsd:annotation>
@@ -1557,7 +1518,7 @@
               <p> The "converter-for-class" element represents the
               fully qualified class name for which a Converter
               class will be registered.</p>
-              
+
               ]]>
             </xsd:documentation>
           </xsd:annotation>
@@ -1571,7 +1532,7 @@
             <p> The "converter-class" element represents the fully
             qualified class name of a concrete Converter
             implementation class.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -1589,7 +1550,7 @@
             operation of the Converter.  This attribute is
             primarily for design-time tools and is not
             specified to have any meaning at runtime.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -1607,7 +1568,7 @@
             the Converter.  This attribute is primarily for
             design-time tools and is not specified to have
             any meaning at runtime.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -1622,7 +1583,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-converter-extensionType">
     <xsd:annotation>
@@ -1630,7 +1591,7 @@
         <![CDATA[
         <p> Extension element for converter.  It may contain
         implementation specific content.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1645,7 +1606,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-lifecycleType">
     <xsd:annotation>
@@ -1654,7 +1615,7 @@
         <p> The "lifecycle" element provides a mechanism to specify
         modifications to the behaviour of the default Lifecycle
         implementation for this web application.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1670,7 +1631,7 @@
             qualified class name of the concrete PhaseListener
             implementation class that will be registered on
             the Lifecycle.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -1685,7 +1646,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-lifecycle-extensionType">
     <xsd:annotation>
@@ -1693,7 +1654,7 @@
         <![CDATA[
         <p> Extension element for lifecycle.  It may contain
         implementation specific content.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1713,7 +1674,7 @@
         <![CDATA[
         <p> The localeType defines valid locale defined by ISO-639-1
         and ISO-3166.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1723,7 +1684,7 @@
   </xsd:simpleType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-locale-configType">
     <xsd:annotation>
@@ -1731,7 +1692,7 @@
         <![CDATA[
         <p> The "locale-config" element allows the app developer to
         declare the supported locales for this application.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1749,7 +1710,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-default-validatorsType">
     <xsd:annotation>
@@ -1759,7 +1720,7 @@
         register a set of validators, referenced by identifier, that
         are automatically assigned to any EditableValueHolder component
         in the application, unless overridden or disabled locally.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1773,7 +1734,7 @@
             <![CDATA[
             <p> The "validator-id" element represents the identifier
             of a registered validator.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -1784,116 +1745,8 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
 
-  <xsd:complexType name="faces-config-managed-beanType">
-    <xsd:annotation>
-      <xsd:documentation>
-        <![CDATA[
-        <p> The "managed-bean" element represents a JavaBean, of a
-        particular class, that will be dynamically instantiated
-        at runtime (by the default VariableResolver implementation)
-        if it is referenced as the first element of a value binding
-        expression, and no corresponding bean can be identified in
-        any scope.  In addition to the creation of the managed bean,
-        and the optional storing of it into the specified scope,
-        the nested managed-property elements can be used to
-        initialize the contents of settable JavaBeans properties of
-        the created instance.</p>
-        
-        ]]>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:sequence>
-      <xsd:group ref="jakartaee:descriptionGroup"/>
-      <xsd:element name="managed-bean-name"
-                   type="jakartaee:java-identifierType">
-        <xsd:annotation>
-          <xsd:documentation>
-            <![CDATA[
-            <p> The "managed-bean-name" element represents the
-            attribute name under which a managed bean will
-            be searched for, as well as stored (unless the
-            "managed-bean-scope" value is "none").</p>
-            
-            ]]>
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="managed-bean-class"
-                   type="jakartaee:fully-qualified-classType">
-        <xsd:annotation>
-          <xsd:documentation>
-            <![CDATA[
-            <p> The "managed-bean-class" element represents the fully
-            qualified class name of the Java class that will be
-            used`to instantiate a new instance if creation of the
-            specified`managed bean is requested.</p>
-            
-            <p>The specified class must conform to standard JavaBeans
-            conventions.  In particular, it must have a public
-            zero-arguments constructor, and zero or more public
-            property setters.</p>
-            
-            ]]>
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="managed-bean-scope"
-                   type="jakartaee:faces-config-managed-bean-scopeOrNoneType">
-        <xsd:annotation>
-          <xsd:documentation>
-            <![CDATA[
-            <p> The "managed-bean-scope" element represents the scope
-            into which a newly created instance of the specified
-            managed bean will be stored (unless the value is
-            "none").</p>
-            
-            ]]>
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:choice>
-        <xsd:element name="managed-property"
-                     type="jakartaee:faces-config-managed-propertyType"
-                     minOccurs="0"
-                     maxOccurs="unbounded"/>
-        <xsd:element name="map-entries"
-                     type="jakartaee:faces-config-map-entriesType"/>
-        <xsd:element name="list-entries"
-                     type="jakartaee:faces-config-list-entriesType"/>
-      </xsd:choice>
-      <xsd:element name="managed-bean-extension"
-                   type="jakartaee:faces-config-managed-bean-extensionType"
-                   minOccurs="0"
-                   maxOccurs="unbounded"/>
-    </xsd:sequence>
-    <xsd:attribute name="eager"
-                   type="xsd:boolean"
-                   use="optional">
-      <xsd:annotation>
-        <xsd:documentation>
-          <![CDATA[
-          <p> This attribute is only considered when associated with
-          an application-scoped managed bean. If the value of the eager
-          attribute is true the runtime must instantiate this class
-          and store the instance within the application scope when the
-          application starts.</p>
-          
-          <p>If eager is unspecified or is false, the default "lazy"
-          instantiation and scoped storage of the managed bean
-          will occur.</p>
-          
-          ]]>
-        </xsd:documentation>
-      </xsd:annotation>
-    </xsd:attribute>
-    <xsd:attribute name="id"
-                   type="xsd:ID"/>
-  </xsd:complexType>
-
-
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-flow-definitionType">
     <xsd:annotation>
@@ -1901,14 +1754,14 @@
         <![CDATA[
         <p class="changed_added_2_2">Top level element for a flow
         definition.</p>
-        
+
         <div class="changed_added_2_2">
-        
+
         <p>If there is no <code>&lt;start-node&gt;</code> element declared, it
         is assumed to be <code>&lt;flowName&gt;.xhtml</code>.</p>
-        
+
         </div>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -1924,7 +1777,7 @@
             flow graph.  The start node may be any of the node types mentioned in
             the class javadocs for <code><a target="_"
             href="jakarta/faces/flow/FlowHandler.html">FlowHandler</a></code>.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -1972,10 +1825,10 @@
           <![CDATA[
           <p class="changed_added_2_2">The id of this flow.  The id
           must be unique within the Application configuration Resource
-          file in which this flow is defined.  The value of this attribute, 
+          file in which this flow is defined.  The value of this attribute,
           combined with the value of the &lt;faces-config&gt;&lt;name&gt; element
-          must globally identify the flow within the application.<p> 
-          
+          must globally identify the flow within the application.<p>
+
           ]]>
         </xsd:documentation>
       </xsd:annotation>
@@ -1983,7 +1836,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-flow-definition-faces-method-callType">
     <xsd:annotation>
@@ -1991,8 +1844,8 @@
         <![CDATA[
         <p class="changed_added_2_2">Invoke a method, passing parameters if necessary.
         The return from the method is used as the outcome for where to go next in the
-        flow.  If the method is a void method, the default outcome is used.<p> 
-        
+        flow.  If the method is a void method, the default outcome is used.<p>
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -2010,7 +1863,7 @@
             <![CDATA[
             <p class="changed_added_2_2">A parameter to pass when calling the method
             identified in the "method" element that is a sibling of this element.<p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2019,7 +1872,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-flow-definition-faces-method-call-methodType">
     <xsd:simpleContent>
@@ -2031,7 +1884,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-flow-definition-flow-call-parameterType">
     <xsd:annotation>
@@ -2039,7 +1892,7 @@
         <![CDATA[
         <p class="changed_added_2_2">A parameter to pass when calling the method
         identified in the "method" element that is a sibling of this element.<p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -2050,10 +1903,10 @@
         <xsd:annotation>
           <xsd:documentation>
             <![CDATA[
-            <p class="changed_added_2_2"> The optional "class" element within a "parameter" element 
+            <p class="changed_added_2_2"> The optional "class" element within a "parameter" element
             will be interpreted as the fully qualified class name for the type
             of the "value" element.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2066,7 +1919,7 @@
             <p class="changed_added_2_2"> The "value" element within an "parameter"
             must be a literal string or an EL Expression whose "get" will be called when the "method"
             associated with this element is invoked.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2075,17 +1928,17 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-flow-definition-viewType">
     <xsd:annotation>
       <xsd:documentation>
         <![CDATA[
         <p class="changed_added_2_2">Define a view node in a flow graph.</p>
-        
+
         <p>This element must contain exactly one
         <code>&lt;vdl-document&gt;</code> element.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -2098,7 +1951,7 @@
             <p class="changed_added_2_2 changed_modified_2_3">
             Define the path to the vdl-document for the enclosing view.
             <p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2112,7 +1965,7 @@
           <![CDATA[
           <p class="changed_added_2_2">The id of this view.  It must be
           unique within the flow.</p>
-          
+
           ]]>
         </xsd:documentation>
       </xsd:annotation>
@@ -2120,25 +1973,25 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-flow-definition-switchType">
     <xsd:annotation>
       <xsd:documentation>
         <![CDATA[
         <p class="changed_added_2_2">Define a switch node in a flow graph.</p>
-        
+
         <div class="changed_added_2_2">
-        
+
         <p>This element must contain one or more
         <code>&lt;case&gt;</code> elements.  When control passes to the
         <code>&lt;switch&gt;</code> node, each of the cases must be considered
         in order and control must past to the <code>&lt;from-outcome&gt;</code>
-        of the first one whose <code>&lt;if&gt;</code> expression evaluates to 
+        of the first one whose <code>&lt;if&gt;</code> expression evaluates to
         <code>true</code>.</p>
-        
+
         </div>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -2153,7 +2006,7 @@
             <p class="changed_added_2_2">Defines a case that must be
             considered in the list of cases in the
             <code>&lt;switch&gt;</code>.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2167,7 +2020,7 @@
             <p class="changed_added_2_2">Defines the default case that will
             be taken if none of the other cases in the
             <code>&lt;switch&gt;</code> are taken.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2181,7 +2034,7 @@
           <![CDATA[
           <p class="changed_added_2_2">The id of this switch.  It must be
           unique within the flow.</p>
-          
+
           ]]>
         </xsd:documentation>
       </xsd:annotation>
@@ -2189,7 +2042,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-flow-definition-switch-caseType">
     <xsd:annotation>
@@ -2197,7 +2050,7 @@
         <![CDATA[
         <p class="changed_added_2_2">Defines a case that will
         be considered in the <code>&lt;switch&gt;</code>.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -2210,9 +2063,9 @@
           <xsd:documentation>
             <![CDATA[
             <p class="changed_added_2_2">If this EL expression evaluates to
-            <code>true</code>, the corresponding <code>from-outcome</code> will 
+            <code>true</code>, the corresponding <code>from-outcome</code> will
             be the outcome taken by the enclosing <code>&lt;switch&gt;</code></p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2235,10 +2088,10 @@
             for any outcome value, with the assumption that the
             condition specified in the "if" element ultimately
             determines if this rule is a match.</p>
-            
+
             <p class="changed_added_2_2">If used in a faces flow, this element
             represents the node id to which control will be passed.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2250,19 +2103,19 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-flow-definition-flow-returnType">
     <xsd:annotation>
       <xsd:documentation>
         <![CDATA[
         <p class="changed_added_2_2">Define a return node in a flow graph.</p>
-        
+
         <div class="changed_added_2_2">
-        
+
         <p>This element must contain exactly one <code>&lt;from-outcome&gt;</code> element.</p>
         </div>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -2274,7 +2127,7 @@
             <![CDATA[
             <p class="changed_added_2_2">This element
             represents the node id to which control will be passed.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2287,7 +2140,7 @@
         <xsd:documentation>
           <![CDATA[
           <p class="changed_added_2_2">The id of this flow-return.</p>
-          
+
           ]]>
         </xsd:documentation>
       </xsd:annotation>
@@ -2295,20 +2148,20 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-flow-definition-flow-callType">
     <xsd:annotation>
       <xsd:documentation>
         <![CDATA[
         <p class="changed_added_2_2">Define a call node in a flow graph.</p>
-        
+
         <div class="changed_added_2_2">
-        
-        <p>This element must contain exactly one <code>&lt;flow-reference&gt;</code> element, 
+
+        <p>This element must contain exactly one <code>&lt;flow-reference&gt;</code> element,
         which must contain exactly one <code>&lt;flow-id&gt;</code> element.</p>
         </div>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -2319,7 +2172,7 @@
           <xsd:documentation>
             <![CDATA[
             <p class="changed_added_2_2">The flow id of the called flow.<p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2333,7 +2186,7 @@
             <![CDATA[
             <p class="changed_added_2_2">A parameter to pass when calling the flow
             identified in the "flow-reference" element that is a sibling of this element.<p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2346,7 +2199,7 @@
         <xsd:documentation>
           <![CDATA[
           <p class="changed_added_2_2">The id of this flow-return.</p>
-          
+
           ]]>
         </xsd:documentation>
       </xsd:annotation>
@@ -2354,18 +2207,18 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-flow-definition-flow-call-flow-referenceType">
     <xsd:annotation>
       <xsd:documentation>
         <![CDATA[
         <p class="changed_added_2_2">Identifiy the called flow.</p>
-        
+
         <div class="changed_added_2_2">
-        
+
         </div>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -2377,7 +2230,7 @@
           <xsd:documentation>
             <![CDATA[
             <p>The document id of the called flow.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2388,7 +2241,7 @@
           <xsd:documentation>
             <![CDATA[
             <p>The id of the called flow.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2397,14 +2250,14 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-flow-definition-initializerType">
     <xsd:annotation>
       <xsd:documentation>
         <![CDATA[
         <p class="changed_added_2_2">A <code>MethodExpression</code> that will be invoked when the flow is entered.<p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -2417,14 +2270,14 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-flow-definition-finalizerType">
     <xsd:annotation>
       <xsd:documentation>
         <![CDATA[
         <p class="changed_added_2_2">A <code>MethodExpression</code> that will be invoked when the flow is exited.<p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -2437,7 +2290,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-flow-definition-inbound-parameterType">
     <xsd:annotation>
@@ -2445,7 +2298,7 @@
         <![CDATA[
         <p class="changed_added_2_2">A named parameter whose value will be populated
         with a correspondingly named parameter within an "outbound-parameter" element.<p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -2457,9 +2310,9 @@
             <![CDATA[
             <p class="changed_added_2_2"> The "name" element within an "inbound-parameter"
             element declares the name of this parameter
-            to be passed into a flow.  There must be 
+            to be passed into a flow.  There must be
             a sibling "value" element in the same parent as this element.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2471,9 +2324,9 @@
             <![CDATA[
             <p class="changed_added_2_2"> The "value" element within an "inbound-parameter"
             must be an EL Expression whose value will be set with the correspondingly
-            named "outbound-parameter" when this flow is entered, if such a 
+            named "outbound-parameter" when this flow is entered, if such a
             parameter exists.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2482,16 +2335,16 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-flow-definition-flow-call-outbound-parameterType">
     <xsd:annotation>
       <xsd:documentation>
         <![CDATA[
-        <p class="changed_added_2_2">A named parameter whose value will be 
+        <p class="changed_added_2_2">A named parameter whose value will be
         passed to a correspondingly named parameter within an "inbound-parameter" element
         on the target flow.<p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -2501,10 +2354,10 @@
         <xsd:annotation>
           <xsd:documentation>
             <![CDATA[
-            <p class="changed_added_2_2"> The "name" element within an "outbound-parameter" element 
-            declares the name of this parameter to be passed out of a flow.  There must be 
+            <p class="changed_added_2_2"> The "name" element within an "outbound-parameter" element
+            declares the name of this parameter to be passed out of a flow.  There must be
             a sibling "value" element in the same parent as this element.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2517,7 +2370,7 @@
             <p class="changed_added_2_2"> The "value" element within an "outbound-parameter"
             must be a literal string or an EL Expression whose "get" will be called when the "flow-call"
             containing this element is traversed to go to a new flow.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2526,201 +2379,8 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
 
-  <xsd:complexType name="faces-config-managed-bean-extensionType">
-    <xsd:annotation>
-      <xsd:documentation>
-        <![CDATA[
-        <p> Extension element for managed-bean.  It may contain
-        implementation specific content.</p>
-        
-        ]]>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:sequence>
-      <xsd:any minOccurs="0"
-               maxOccurs="unbounded"
-               namespace="##any"
-               processContents="lax"/>
-    </xsd:sequence>
-    <xsd:attribute name="id"
-                   type="xsd:ID"/>
-  </xsd:complexType>
-
-
-<!-- **************************************************** -->
-
-  <xsd:complexType name="faces-config-managed-bean-scopeOrNoneType">
-    <xsd:annotation>
-      <xsd:documentation>
-        <![CDATA[
-        [
-        
-        <p> Defines the legal values for the <managed-bean-scope>
-        element's body content, which includes all of the scopes
-        normally used in a web application, plus the "none" value
-        indicating that a created bean should not be stored into
-        any scope.  Alternatively, an EL expression may be used
-        as the value of this element.  The result of evaluating this
-        expression must by of type java.util.Map.</p>
-        
-        ]]>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:simpleContent>
-      <xsd:restriction base="jakartaee:string">
-        <xsd:pattern value="view|request|session|application|none|#\{.*\}"/>
-      </xsd:restriction>
-    </xsd:simpleContent>
-  </xsd:complexType>
-
-
-<!-- **************************************************** -->
-
-  <xsd:complexType name="faces-config-managed-propertyType">
-    <xsd:annotation>
-      <xsd:documentation>
-        <![CDATA[
-        <p> The "managed-property" element represents an individual
-        property of a managed bean that will be configured to the
-        specified value (or value set) if the corresponding
-        managed bean is automatically created.</p>
-        
-        ]]>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:sequence>
-      <xsd:group ref="jakartaee:descriptionGroup"/>
-      <xsd:element name="property-name"
-                   type="jakartaee:string">
-        <xsd:annotation>
-          <xsd:documentation>
-            <![CDATA[
-            <p> The "property-name" element represents the JavaBeans
-            property name under which the corresponding value may
-            be stored.</p>
-            
-            ]]>
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="property-class"
-                   type="jakartaee:java-typeType"
-                   minOccurs="0">
-        <xsd:annotation>
-          <xsd:documentation>
-            <![CDATA[
-            <p> The "property-class" element represents the Java type
-            of the value associated with this property name.
-            If not specified, it can be inferred from existing
-            classes; however, this element should be specified
-            if the configuration file is going to be the source
-            for generating the corresponding classes.</p>
-            
-            ]]>
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:choice>
-        <xsd:element name="map-entries"
-                     type="jakartaee:faces-config-map-entriesType"/>
-        <xsd:element name="null-value"
-                     type="jakartaee:faces-config-null-valueType"/>
-        <xsd:element name="value"
-                     type="jakartaee:faces-config-valueType"/>
-        <xsd:element name="list-entries"
-                     type="jakartaee:faces-config-list-entriesType"/>
-      </xsd:choice>
-    </xsd:sequence>
-    <xsd:attribute name="id"
-                   type="xsd:ID"/>
-  </xsd:complexType>
-
-
-<!-- **************************************************** -->
-
-  <xsd:complexType name="faces-config-map-entryType">
-    <xsd:annotation>
-      <xsd:documentation>
-        <![CDATA[
-        <p> The "map-entry" element reprsents a single key-entry pair
-        that will be added to the computed value of a managed
-        property of type java.util.Map.</p>
-        
-        ]]>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:sequence>
-      <xsd:element name="key"
-                   type="jakartaee:string">
-        <xsd:annotation>
-          <xsd:documentation>
-            <![CDATA[
-            <p> The "key" element is the String representation of a
-            map key that will be stored in a managed property of
-            type java.util.Map.</p>
-            
-            ]]>
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:choice>
-        <xsd:element name="null-value"
-                     type="jakartaee:faces-config-null-valueType"/>
-        <xsd:element name="value"
-                     type="jakartaee:faces-config-valueType"/>
-      </xsd:choice>
-    </xsd:sequence>
-    <xsd:attribute name="id"
-                   type="xsd:ID"/>
-  </xsd:complexType>
-
-
-<!-- **************************************************** -->
-
-  <xsd:complexType name="faces-config-map-entriesType">
-    <xsd:annotation>
-      <xsd:documentation>
-        <![CDATA[
-        <p> The "map-entries' element represents a set of key-entry pairs
-        that will be added to the computed value of a managed property
-        of type java.util.Map.  In addition, the Java class types
-        of the key and entry values may be optionally declared.</p>
-        
-        ]]>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:sequence>
-      <xsd:element name="key-class"
-                   type="jakartaee:fully-qualified-classType"
-                   minOccurs="0">
-        <xsd:annotation>
-          <xsd:documentation>
-            <![CDATA[
-            <p> The "key-class" element defines the Java type to which
-            each "key" element in a set of "map-entry" elements
-            will be converted to.  If omitted, "java.lang.String"
-            is assumed.</p>
-            
-            ]]>
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="value-class"
-                   type="jakartaee:faces-config-value-classType"
-                   minOccurs="0"/>
-      <xsd:element name="map-entry"
-                   type="jakartaee:faces-config-map-entryType"
-                   minOccurs="0"
-                   maxOccurs="unbounded"/>
-    </xsd:sequence>
-    <xsd:attribute name="id"
-                   type="xsd:ID"/>
-  </xsd:complexType>
-
-
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-navigation-caseType">
     <xsd:annotation>
@@ -2731,7 +2391,7 @@
         combination of conditions that must match for this case to
         be executed, and the view id of the component tree that
         should be selected next.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -2758,7 +2418,7 @@
             for any outcome value, with the assumption that the
             condition specified in the "if" element ultimately
             determines if this rule is a match.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2769,8 +2429,9 @@
         <xsd:annotation>
           <xsd:documentation>
             <![CDATA[
-            <p> Please see section JSF.7.4.2 for the specification of this element.</p>
-            
+            <p> Please see section 7.4.2 "Default NavigationHandler Algorithm" of the Jakarta Faces Specification Document
+            for the specification of this element.</p>
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2780,17 +2441,17 @@
         <xsd:annotation>
           <xsd:documentation>
             <![CDATA[
-            <p><span class="changed_modified_2_2">The "to-view-id" element 
-            contains the view identifier (<span class="changed_added_2_2">or 
+            <p><span class="changed_modified_2_2">The "to-view-id" element
+            contains the view identifier (<span class="changed_added_2_2">or
             flow node id, or flow id</span>)
-            of the next view (<span class="changed_added_2_2">or flow node or 
+            of the next view (<span class="changed_added_2_2">or flow node or
             flow</span>) that should be displayed if this
             navigation rule is matched. If the contents is a
             value expression, it should be resolved by the
             navigation handler to obtain the view (
-            <span class="changed_added_2_2">or flow node or flow</span>) 
+            <span class="changed_added_2_2">or flow node or flow</span>)
             identifier.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2802,11 +2463,11 @@
           <xsd:documentation>
             <![CDATA[
             <p class="changed_added_2_2">The document id of the called flow.
-            If this element appears in a &lt;navigation-case&gt; nested within 
+            If this element appears in a &lt;navigation-case&gt; nested within
             a &lt;flow-definition&gt;, it must be ignored because navigation
-            cases within flows may only navigate among the view nodes of that 
+            cases within flows may only navigate among the view nodes of that
             flow.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2820,7 +2481,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-navigation-ruleType">
     <xsd:annotation>
@@ -2831,7 +2492,7 @@
         NavigationHandler implementation to make decisions on
         what view should be displayed next, based on the
         view id being processed.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -2853,7 +2514,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-navigation-rule-extensionType">
     <xsd:annotation>
@@ -2861,7 +2522,7 @@
         <![CDATA[
         <p> Extension element for navigation-rule.  It may contain
         implementation specific content.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -2876,7 +2537,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-null-valueType">
     <xsd:annotation>
@@ -2888,11 +2549,11 @@
         created.  This is different from omitting the managed
         property element entirely, which will cause no
         property setter to be called for this property.</p>
-        
+
         <p>The "null-value" element can only be used when the
         associated "property-class" identifies a Java class,
         not a Java primitive.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -2901,7 +2562,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-propertyType">
     <xsd:annotation>
@@ -2909,13 +2570,13 @@
         <![CDATA[
         <p> The "property" element represents a JavaBean property of the
         Java class represented by our parent element.</p>
-        
+
         <p>Property names must be unique within the scope of the Java
         class that is represented by the parent element, and must
         correspond to property names that will be recognized when
         performing introspection against that class via
         java.beans.Introspector.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -2929,7 +2590,7 @@
             <p> The "property-name" element represents the JavaBeans
             property name under which the corresponding value
             may be stored.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2945,7 +2606,7 @@
             classes; however, this element should be specified if
             the configuration file is going to be the source for
             generating the corresponding classes.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -2966,19 +2627,19 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-protected-viewsType">
     <xsd:annotation>
       <xsd:documentation>
         <![CDATA[
         <p class="changed_added_2_2">Any view that matches any of the
-        url-patterns in this element may only be reached from another Jakarta Server 
-        Faces view in the same web application. Because the runtime is aware of
+        url-patterns in this element may only be reached from another Jakarta Faces
+        view in the same web application. Because the runtime is aware of
         which views are protected, any navigation from an unprotected
         view to a protected view is automatically subject to
         protection.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -2990,7 +2651,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-property-extensionType">
     <xsd:annotation>
@@ -2998,7 +2659,7 @@
         <![CDATA[
         <p> Extension element for property.  It may contain
         implementation specific content.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -3013,7 +2674,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-redirectType">
     <xsd:annotation>
@@ -3023,7 +2684,7 @@
         specified "to-view-id" should be accomplished by
         performing an HTTP redirect rather than the usual
         ViewHandler mechanisms.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -3041,7 +2702,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-redirect-viewParamType">
     <xsd:annotation>
@@ -3054,7 +2715,7 @@
         maintained to preserve backwards compatibility.
         Implementations must treat this element the same as
         "redirect-param".</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -3069,7 +2730,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-redirect-redirectParamType">
     <xsd:annotation>
@@ -3079,7 +2740,7 @@
         a "redirect" element, contains child "name"
         and "value" elements that must be included in the
         redirect url when the redirect is performed.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -3094,7 +2755,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-referenced-beanType">
     <xsd:annotation>
@@ -3106,8 +2767,8 @@
         used by design time tools to construct user interface dialogs
         based on the properties of the specified class.  The presence
         or absence of a referenced bean element has no impact on the
-        JavaServer Faces runtime environment inside a web application.</p>
-        
+        Jakarta Faces runtime environment inside a web application.</p>
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -3123,7 +2784,7 @@
             referenced bean may be assumed to be stored, in one
             of 'request', 'session', 'view', 'application'
             or a custom scope.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -3137,7 +2798,7 @@
             fully qualified class name of the Java class
             (either abstract or concrete) or Java interface
             implemented by the corresponding referenced bean.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -3148,7 +2809,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-render-kitType">
     <xsd:annotation>
@@ -3159,7 +2820,7 @@
         render-kit-id.  If no render-kit-id is specified, the
         identifier of the default RenderKit
         (RenderKitFactory.DEFAULT_RENDER_KIT) is assumed.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -3174,7 +2835,7 @@
             <p> The "render-kit-id" element represents an identifier
             for the RenderKit represented by the parent
             "render-kit" element.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -3188,7 +2849,7 @@
             <p> The "render-kit-class" element represents the fully
             qualified class name of a concrete RenderKit
             implementation class.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -3211,7 +2872,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-client-behavior-rendererType">
     <xsd:annotation>
@@ -3223,10 +2884,10 @@
         in the RenderKit associated with the parent "render-kit"
         element.  Client Behavior renderer type must be unique within the RenderKit
         associated with the parent "render-kit" element.</p>
-        
+
         <p>Nested "attribute" elements identify generic component
         attributes that are recognized by this renderer.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -3239,7 +2900,7 @@
             <p> The "client-behavior-renderer-type" element represents a renderer type
             identifier for the Client Behavior Renderer represented by the parent
             "client-behavior-renderer" element.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -3252,7 +2913,7 @@
             <p> The "client-behavior-renderer-class" element represents the fully
             qualified class name of a concrete Client Behavior Renderer
             implementation class.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -3263,7 +2924,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-rendererType">
     <xsd:annotation>
@@ -3276,10 +2937,10 @@
         element.  Combinations of component family and
         renderer type must be unique within the RenderKit
         associated with the parent "render-kit" element.</p>
-        
+
         <p>Nested "attribute" elements identify generic component
         attributes that are recognized by this renderer.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -3293,7 +2954,7 @@
             <p> The "component-family" element represents the
             component family for which the Renderer represented
             by the parent "renderer" element will be used.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -3306,7 +2967,7 @@
             <p> The "renderer-type" element represents a renderer type
             identifier for the Renderer represented by the parent
             "renderer" element.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -3319,7 +2980,7 @@
             <p> The "renderer-class" element represents the fully
             qualified class name of a concrete Renderer
             implementation class.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -3342,7 +3003,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-renderer-extensionType">
     <xsd:annotation>
@@ -3350,7 +3011,7 @@
         <![CDATA[
         <p> Extension element for renderer.  It may contain implementation
         specific content.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -3365,7 +3026,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-render-kit-extensionType">
     <xsd:annotation>
@@ -3373,7 +3034,7 @@
         <![CDATA[
         <p> Extension element for render-kit.  It may contain
         implementation specific content.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -3388,7 +3049,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-suggested-valueType">
     <xsd:annotation>
@@ -3398,7 +3059,7 @@
         attribute in which this element resides.  This value is
         advisory only and is intended for tools to use when
         populating pallettes.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -3408,7 +3069,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-supported-localeType">
     <xsd:annotation>
@@ -3416,17 +3077,17 @@
         <![CDATA[
         <p> The "supported-locale" element allows authors to declare
         which locales are supported in this application instance.</p>
-        
+
         <p class="modified_added_2_3">
         To facilitate BCP 47 this element first needs to be parsed by the
         Locale.forLanguageTag method. If it does not return a Locale with
         a language the old specification below needs to take effect.
         </p>
-        
+
         <p>It must be specified as :language:[_:country:[_:variant:]]
         without the colons, for example "ja_JP_SJIS".  The
         separators between the segments may be '-' or '_'.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -3439,7 +3100,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-behaviorType">
     <xsd:annotation>
@@ -3449,7 +3110,7 @@
         implementation class that should be registered under the
         specified behavior identifier.  Behavior identifiers must
         be unique within the entire web application.</p>
-        
+
         <p>Nested "attribute" elements identify generic attributes that
         may be configured on the corresponding UIComponent in order
         to affect the operation of the Behavior.  Nested "property"
@@ -3459,7 +3120,7 @@
         elements are intended to allow component developers to
         more completely describe their components to tools and users.
         These elements have no required runtime semantics.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -3473,7 +3134,7 @@
             <p> The "behavior-id" element represents the identifier
             under which the corresponding Behavior class should
             be registered.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -3486,7 +3147,7 @@
             <p> The "behavior-class" element represents the fully
             qualified class name of a concrete Behavior
             implementation class.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -3504,7 +3165,7 @@
             operation of the Behavior.  This attribute is
             primarily for design-time tools and is not
             specified to have any meaning at runtime.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -3522,7 +3183,7 @@
             the Behavior.  This attribute is primarily for
             design-time tools and is not specified to have
             any meaning at runtime.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -3537,7 +3198,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-behavior-extensionType">
     <xsd:annotation>
@@ -3545,7 +3206,7 @@
         <![CDATA[
         <p> Extension element for behavior.  It may contain
         implementation specific content.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -3560,7 +3221,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-validatorType">
     <xsd:annotation>
@@ -3570,7 +3231,7 @@
         implementation class that should be registered under the
         specified validator identifier.  Validator identifiers must
         be unique within the entire web application.</p>
-        
+
         <p>Nested "attribute" elements identify generic attributes that
         may be configured on the corresponding UIComponent in order
         to affect the operation of the Validator.  Nested "property"
@@ -3580,7 +3241,7 @@
         elements are intended to allow component developers to
         more completely describe their components to tools and users.
         These elements have no required runtime semantics.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -3594,7 +3255,7 @@
             <p> The "validator-id" element represents the identifier
             under which the corresponding Validator class should
             be registered.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -3607,7 +3268,7 @@
             <p> The "validator-class" element represents the fully
             qualified class name of a concrete Validator
             implementation class.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -3625,7 +3286,7 @@
             operation of the Validator.  This attribute is
             primarily for design-time tools and is not
             specified to have any meaning at runtime.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -3643,7 +3304,7 @@
             the Validator.  This attribute is primarily for
             design-time tools and is not specified to have
             any meaning at runtime.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -3658,7 +3319,7 @@
   </xsd:complexType>
 
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-validator-extensionType">
     <xsd:annotation>
@@ -3666,7 +3327,7 @@
         <![CDATA[
         <p> Extension element for validator.  It may contain
         implementation specific content.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -3690,7 +3351,7 @@
         that will be used to calculate the required value.
         It will be converted as specified for the actual
         property type.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -3698,63 +3359,7 @@
   </xsd:simpleType>
 
 
-<!-- **************************************************** -->
-
-  <xsd:complexType name="faces-config-value-classType">
-    <xsd:annotation>
-      <xsd:documentation>
-        <![CDATA[
-        <p> The "value-class" element defines the Java type to which each
-        "value" element's value will be converted to, prior to adding
-        it to the "list-entries" list for a managed property that is
-        a java.util.List, or a "map-entries" map for a managed
-        property that is a java.util.Map.</p>
-        
-        ]]>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:simpleContent>
-      <xsd:restriction base="jakartaee:fully-qualified-classType">
-        <xsd:attribute name="id"
-                       type="xsd:ID"/>
-      </xsd:restriction>
-    </xsd:simpleContent>
-  </xsd:complexType>
-
-
-<!-- **************************************************** -->
-
-  <xsd:complexType name="faces-config-list-entriesType">
-    <xsd:annotation>
-      <xsd:documentation>
-        <![CDATA[
-        <p> The "list-entries" element represents a set of initialization
-        elements for a managed property that is a java.util.List or an
-        array.  In the former case, the "value-class" element can
-        optionally be used to declare the Java type to which each
-        value should be converted before adding it to the Collection.</p>
-        
-        ]]>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:sequence>
-      <xsd:element name="value-class"
-                   type="jakartaee:faces-config-value-classType"
-                   minOccurs="0"/>
-      <xsd:choice minOccurs="0"
-                  maxOccurs="unbounded">
-        <xsd:element name="null-value"
-                     type="jakartaee:faces-config-null-valueType"/>
-        <xsd:element name="value"
-                     type="jakartaee:faces-config-valueType"/>
-      </xsd:choice>
-    </xsd:sequence>
-    <xsd:attribute name="id"
-                   type="xsd:ID"/>
-  </xsd:complexType>
-
-
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
 
   <xsd:complexType name="faces-config-system-event-listenerType">
     <xsd:annotation>
@@ -3768,7 +3373,7 @@
         listener instance, and allow selecting the kinds of classes that
         can be the source of events that are delivered to the listener
         instance.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>
@@ -3783,7 +3388,7 @@
             SystemEventListener implementation class that will be
             called when events of the type specified by the
             "system-event-class" are sent by the runtime.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -3798,7 +3403,7 @@
             which events will be delivered to the class whose fully
             qualified class name is given by the
             "system-event-listener-class" element.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -3814,7 +3419,7 @@
             source for the event to be delivered to the class whose
             fully qualified class name is given by the
             "system-event-listener-class" element.</p>
-            
+
             ]]>
           </xsd:documentation>
         </xsd:annotation>
@@ -3830,7 +3435,7 @@
         <![CDATA[
         <p> This type contains the recognized versions of
         faces-config supported.</p>
-        
+
         ]]>
       </xsd:documentation>
     </xsd:annotation>

--- a/dev/com.ibm.ws.javaee.dd/src/com/ibm/ws/javaee/dd/web/common/package-info.java
+++ b/dev/com.ibm.ws.javaee.dd/src/com/ibm/ws/javaee/dd/web/common/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010,2022 IBM Corporation and others.
+ * Copyright (c) 2010, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,4 +13,3 @@
  */
 @org.osgi.annotation.versioning.Version("1.4")
 package com.ibm.ws.javaee.dd.web.common;
-

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/jsf/FacesConfigType.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/jsf/FacesConfigType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 IBM Corporation and others.
+ * Copyright (c) 2011, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -105,6 +105,8 @@ import com.ibm.ws.javaee.ddmodel.jsf.FacesConfigType.ManagedBeanType.ListType;
  *   <xsd:attribute name="id" type="xsd:ID"/>
  *   <xsd:attribute name="version" type="javaee:faces-config-versionType" use="required"/>
  *</xsd:complexType>
+ *
+ *Note: 'managed-bean' is removed by EE 10 / Faces 4.0
  */
 public class FacesConfigType extends DDParser.ElementContentParsable implements FacesConfig, DDParser.RootParsable {
     public FacesConfigType(String path) {
@@ -212,7 +214,7 @@ public class FacesConfigType extends DDParser.ElementContentParsable implements 
     Map<XSDTokenType, ConverterType> converterForClassToConverterMap;
     // unique faces-config-validator-ID-uniqueness
     Map<XSDTokenType, ValidatorType> validatorIDToValidatorMap;
-    // unique faces-config-managed-bean-name-uniqueness
+    // unique faces-config-managed-bean-name-uniqueness // Not used at EE 10 / Faces 4.0 or higher
     Map<XSDTokenType, ManagedBeanType> managedBeanNameToManagedBeanMap;
 
     final String path;
@@ -242,14 +244,14 @@ public class FacesConfigType extends DDParser.ElementContentParsable implements 
     @Override
     public void finish(DDParser parser) throws ParseException {
         super.finish(parser);
-        if ( version == null ) {
+        if (version == null) {
             // Ensure that the local version variable is assigned.
             //
             // Previously, only the two DTD based formats might
             // be missing a version attribute.  Changes to enable
             // more descriptor deviations mean that other cases
             // might also be missing a version attribute.
-            version = parser.parseToken( parser.getDottedVersionText() );            
+            version = parser.parseToken(parser.getDottedVersionText());
         }
     }
 
@@ -291,7 +293,8 @@ public class FacesConfigType extends DDParser.ElementContentParsable implements 
             this.converter = converter;
             return true;
         }
-        if ("managed-bean".equals(localName)) {
+        // 'managed-bean' was removed by EE 10 / Faces 4.0
+        if ((parser.version < FacesConfig.VERSION_4_0) && "managed-bean".equals(localName)) {
             ManagedBeanType managed_bean = new ManagedBeanType();
             parser.parse(managed_bean);
             addManagedBean(managed_bean);

--- a/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/DDTestBase.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/DDTestBase.java
@@ -560,6 +560,12 @@ public class DDTestBase implements PlatformVersion {
     public static final String[] XML_ERROR_MESSAGES =
             { "CWWKC2272E" };
 
+    public static final String XML_ERROR_ALT_UNEXPECTED_CHILD =
+            "unexpected.child.element";
+    
+    public static final String[] XML_ERROR_UNEXPECTED_CHILD =
+            { "CWWKC2259E" };
+    
     //
 
     public static void verifySuccess(String altMessage, String... requiredMessages) {

--- a/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/jsf/JSFAppTest.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/jsf/JSFAppTest.java
@@ -10,10 +10,13 @@
  *******************************************************************************/
 package com.ibm.ws.javaee.ddmodel.jsf;
 
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import com.ibm.ws.javaee.dd.jsf.FacesConfig;
+import com.ibm.ws.javaee.dd.jsf.FacesConfigManagedBean;
 
 public class JSFAppTest extends JSFAppTestBase {
     @Test
@@ -349,4 +352,38 @@ public class JSFAppTest extends JSFAppTestBase {
     }
 
     // TODO: JSF 3.0 / Jakarta EE 9 cases
+    //
+
+    // Managed beans tests:
+    //
+    // Support for 'managed-bean' elements was removed by EE 10 / Faces 4.0:
+
+    public static final String MANAGED_BEAN_TEXT =
+        "<managed-bean>" +
+            "<managed-bean-name>TestBean</managed-bean-name>" +
+            "<managed-bean-class>com.Test.TestBean</managed-bean-class>" +
+            "<managed-bean-scope>request</managed-bean-scope>" +
+        "</managed-bean>";
+
+    // The 'managed-bean' element should be parsed at faces 3.0:
+    
+    @Test
+    public void testFaces30_Managedbean() throws Exception {    
+        FacesConfig facesConfig = parse( jsf(FacesConfig.VERSION_3_0, MANAGED_BEAN_TEXT), FacesConfig.VERSION_3_0 );
+        List<FacesConfigManagedBean> mbeans = facesConfig.getManagedBeans();
+
+        Assert.assertNotNull("Failed to parse any managed beans", mbeans);
+        Assert.assertEquals("Expected a single parsed managed bean", 1, mbeans.size());
+    }
+    
+    // The 'managed-bean' element should *not* be parsed at faces 4_0:
+    
+    // CWWKC2259E: Unexpected child element managed-bean of parent element faces-config
+    // encountered in the myWar.war : WEB-INF/faces-config.xml deployment descriptor on line 7.
+    
+    @Test
+    public void testFaces40_Managedbean() throws Exception {    
+        parse( jsf(FacesConfig.VERSION_4_0, MANAGED_BEAN_TEXT), FacesConfig.VERSION_4_0,
+               XML_ERROR_ALT_UNEXPECTED_CHILD, XML_ERROR_UNEXPECTED_CHILD);
+    }    
 }


### PR DESCRIPTION
For issue #22535: Update the faces schema to the 4.0 final version, and update the parser to match.
That means, faces parsing no longer recognizes managed-bean elements when the schema version is 4.0 or higher.