### PR TITLE
PR for Issue 21171: Initial code for getting caller name and groups from tokens

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/bnd.bnd
@@ -60,7 +60,8 @@ src: src, resources
 	io.openliberty.security.jakartasec.3.0.internal,\
 	io.openliberty.security.oidcclientcore.internal.jakarta,\
 	com.ibm.ws.cdi.interfaces.jakarta;version=latest,\
-	com.ibm.ws.webcontainer.security;version=latest
+	com.ibm.ws.webcontainer.security;version=latest,\
+	com.ibm.ws.security.javaeesec.cdi;version=latest
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file,\

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/bnd.bnd
@@ -21,14 +21,14 @@ Bundle-SymbolicName: io.openliberty.security.jakartasec.3.0.internal
 Bundle-Description: Jakarta Security 3.0; version=${bVersion}
 
 WS-TraceGroup: \
-	OPENIDCONNECT
+    OPENIDCONNECT
 
 Private-Package: io.openliberty.security.jakartasec.internal.resources.*
 
 Export-Package: \
     io.openliberty.security.jakartasec,\
-    io.openliberty.security.jakartasec.identitystore,\
     io.openliberty.security.jakartasec.credential,\
+    io.openliberty.security.jakartasec.identitystore,\
     io.openliberty.security.jakartasec.tokens
 
 Import-Package: \
@@ -57,4 +57,12 @@ instrument.classesExcludes: io/openliberty/security/jakartasec/internal/resource
     com.ibm.websphere.javaee.cdi.2.0;version=latest,\
     com.ibm.websphere.javaee.el.3.0;version=latest,\
     com.ibm.ws.org.apache.jasper.el.3.0;version=latest,\
-    io.openliberty.jakarta.security.3.0 
+    io.openliberty.jakarta.security.3.0,\
+    com.ibm.ws.security.test.common;version=latest,\
+    org.jmock:jmock-legacy;version=2.5.0,\
+    org.jmock:jmock-junit4;strategy=exact;version=2.5.1,\
+    org.jmock:jmock;strategy=exact;version=2.5.1,\
+    com.ibm.ws.org.objenesis:objenesis;version=1.0,\
+    cglib:cglib-nodep;version=3.3.0,\
+    org.hamcrest:hamcrest-all;version=1.3,\
+    com.ibm.json4j;version=latest

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/identitystore/OidcIdentityStoreTest.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/identitystore/OidcIdentityStoreTest.java
@@ -1,0 +1,175 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.identitystore;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Set;
+
+import org.jmock.Expectations;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import io.openliberty.security.oidcclientcore.client.ClaimsMappingConfig;
+import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
+import io.openliberty.security.oidcclientcore.token.TokenResponse;
+import test.common.SharedOutputManager;
+
+public class OidcIdentityStoreTest extends CommonTestClass {
+
+    protected static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+
+    private final OidcClientConfig config = mockery.mock(OidcClientConfig.class);
+    private final ClaimsMappingConfig claimsMappingConfig = mockery.mock(ClaimsMappingConfig.class);
+    private final TokenResponse tokenResponse = mockery.mock(TokenResponse.class);
+
+    private OidcIdentityStore identityStore;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void setUp() {
+        identityStore = new OidcIdentityStore();
+    }
+
+    @After
+    public void tearDown() {
+        outputMgr.resetStreams();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    // TODO - createSuccessfulCredentialValidationResult
+
+    @Test
+    public void test_getCallerName_noClaimsMapping() {
+        mockery.checking(new Expectations() {
+            {
+                one(config).getClaimsMappingConfig();
+                will(returnValue(null));
+            }
+        });
+        String result = identityStore.getCallerName(config, tokenResponse);
+        assertNull("Result should have been null but was [" + result + "].", result);
+    }
+
+    // TODO - getCallerName
+
+    @Test
+    public void test_getCallerGroups_noClaimsMapping() {
+        mockery.checking(new Expectations() {
+            {
+                one(config).getClaimsMappingConfig();
+                will(returnValue(null));
+            }
+        });
+        Set<String> result = identityStore.getCallerGroups(config, tokenResponse);
+        assertNull("Result should have been null but was [" + result + "].", result);
+    }
+
+    // TODO - getCallerGroups
+
+    @Test
+    public void test_getCallerNameClaim_noClaimsMapping() {
+        mockery.checking(new Expectations() {
+            {
+                one(config).getClaimsMappingConfig();
+                will(returnValue(null));
+            }
+        });
+        String result = identityStore.getCallerNameClaim(config);
+        assertNull("Result should have been null but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_getCallerNameClaim_noClaimConfigured() {
+        mockery.checking(new Expectations() {
+            {
+                one(config).getClaimsMappingConfig();
+                will(returnValue(claimsMappingConfig));
+                one(claimsMappingConfig).getCallerNameClaim();
+                will(returnValue(null));
+            }
+        });
+        String result = identityStore.getCallerNameClaim(config);
+        assertNull("Result should have been null but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_getCallerNameClaim() {
+        final String claim = "myCallerNameClaim";
+        mockery.checking(new Expectations() {
+            {
+                one(config).getClaimsMappingConfig();
+                will(returnValue(claimsMappingConfig));
+                one(claimsMappingConfig).getCallerNameClaim();
+                will(returnValue(claim));
+            }
+        });
+        String result = identityStore.getCallerNameClaim(config);
+        assertEquals(claim, result);
+    }
+
+    @Test
+    public void test_getCallerGroupsClaim_noClaimsMapping() {
+        mockery.checking(new Expectations() {
+            {
+                one(config).getClaimsMappingConfig();
+                will(returnValue(null));
+            }
+        });
+        String result = identityStore.getCallerGroupsClaim(config);
+        assertNull("Result should have been null but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_getCallerGroupsClaim_noClaimConfigured() {
+        mockery.checking(new Expectations() {
+            {
+                one(config).getClaimsMappingConfig();
+                will(returnValue(claimsMappingConfig));
+                one(claimsMappingConfig).getCallerGroupsClaim();
+                will(returnValue(null));
+            }
+        });
+        String result = identityStore.getCallerGroupsClaim(config);
+        assertNull("Result should have been null but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_getCallerGroupsClaim() {
+        final String claim = "myCallerGroupsClaim";
+        mockery.checking(new Expectations() {
+            {
+                one(config).getClaimsMappingConfig();
+                will(returnValue(claimsMappingConfig));
+                one(claimsMappingConfig).getCallerGroupsClaim();
+                will(returnValue(claim));
+            }
+        });
+        String result = identityStore.getCallerGroupsClaim(config);
+        assertEquals(claim, result);
+    }
+
+}

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/client/Client.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/client/Client.java
@@ -31,6 +31,10 @@ public class Client {
         this.oidcClientConfig = oidcClientConfig;
     }
 
+    public OidcClientConfig getOidcClientConfig() {
+        return oidcClientConfig;
+    }
+
     public ProviderAuthenticationResult startFlow(HttpServletRequest request, HttpServletResponse response) {
         Flow flow = AbstractFlow.getInstance(oidcClientConfig);
         return flow.startFlow(request, response);
@@ -40,7 +44,7 @@ public class Client {
         Flow flow = AbstractFlow.getInstance(oidcClientConfig);
         return flow.continueFlow(request, response);
     }
-    
+
     public void validate(TokenResponse tokenResponse) throws TokenValidationException {
         TokenResponseValidator tokenResponseValidator = new TokenResponseValidator(this.oidcClientConfig);
         tokenResponseValidator.validate(tokenResponse);


### PR DESCRIPTION
- Sets up an `OidcTokensCredential` object in the `OidcHttpAuthenticationMechanism` that can be validated by the `OidcIdentityStore`
- Adds skeleton code for getting `callerNameClaim` and `callerGroupsClaim`; implementation still TBD

For #21171