### PR TITLE
PR for Issue 21171: Add logic for getting claims from tokens

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/bnd.bnd
@@ -60,7 +60,8 @@ src: src, resources
 	io.openliberty.security.jakartasec.3.0.internal,\
 	io.openliberty.security.oidcclientcore.internal.jakarta,\
 	com.ibm.ws.cdi.interfaces.jakarta;version=latest,\
-	com.ibm.ws.webcontainer.security;version=latest
+	com.ibm.ws.webcontainer.security;version=latest,\
+	com.ibm.ws.security.javaeesec.cdi;version=latest
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file,\

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/bnd.bnd
@@ -21,14 +21,14 @@ Bundle-SymbolicName: io.openliberty.security.jakartasec.3.0.internal
 Bundle-Description: Jakarta Security 3.0; version=${bVersion}
 
 WS-TraceGroup: \
-	OPENIDCONNECT
+    OPENIDCONNECT
 
 Private-Package: io.openliberty.security.jakartasec.internal.resources.*
 
 Export-Package: \
     io.openliberty.security.jakartasec,\
-    io.openliberty.security.jakartasec.identitystore,\
     io.openliberty.security.jakartasec.credential,\
+    io.openliberty.security.jakartasec.identitystore,\
     io.openliberty.security.jakartasec.tokens
 
 Import-Package: \
@@ -57,4 +57,12 @@ instrument.classesExcludes: io/openliberty/security/jakartasec/internal/resource
     com.ibm.websphere.javaee.cdi.2.0;version=latest,\
     com.ibm.websphere.javaee.el.3.0;version=latest,\
     com.ibm.ws.org.apache.jasper.el.3.0;version=latest,\
-    io.openliberty.jakarta.security.3.0 
+    io.openliberty.jakarta.security.3.0,\
+    com.ibm.ws.security.test.common;version=latest,\
+    org.jmock:jmock-legacy;version=2.5.0,\
+    org.jmock:jmock-junit4;strategy=exact;version=2.5.1,\
+    org.jmock:jmock;strategy=exact;version=2.5.1,\
+    com.ibm.ws.org.objenesis:objenesis;version=1.0,\
+    cglib:cglib-nodep;version=3.3.0,\
+    org.hamcrest:hamcrest-all;version=1.3,\
+    com.ibm.json4j;version=latest

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/bnd.bnd
@@ -46,7 +46,8 @@ instrument.classesExcludes: io/openliberty/security/jakartasec/internal/resource
     io.openliberty.jakarta.security.3.0,\
     io.openliberty.security.oidcclientcore.internal.jakarta,\
     io.openliberty.jakarta.jsonp.2.1,\
-	io.openliberty.jakarta.servlet.6.0
+    io.openliberty.jakarta.servlet.6.0,\
+    com.ibm.ws.org.jose4j;version=latest
 
 -testpath: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file,\

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
@@ -10,17 +10,23 @@
  *******************************************************************************/
 package io.openliberty.security.jakartasec.identitystore;
 
-import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.MalformedClaimException;
+
 import io.openliberty.security.jakartasec.credential.OidcTokensCredential;
+import io.openliberty.security.jakartasec.tokens.AccessTokenImpl;
 import io.openliberty.security.oidcclientcore.client.ClaimsMappingConfig;
 import io.openliberty.security.oidcclientcore.client.Client;
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 import io.openliberty.security.oidcclientcore.token.TokenResponse;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdConstant;
 import jakarta.security.enterprise.credential.Credential;
 import jakarta.security.enterprise.identitystore.CredentialValidationResult;
 import jakarta.security.enterprise.identitystore.IdentityStore;
+import jakarta.security.enterprise.identitystore.openid.AccessToken;
 
 /**
  *
@@ -42,8 +48,9 @@ public class OidcIdentityStore implements IdentityStore {
             Client client = castCredential.getClient();
             if (tokenResponse != null && client != null) {
                 try {
-                    client.validate(tokenResponse);
-                    return createSuccessfulCredentialValidationResult(client.getOidcClientConfig(), tokenResponse);
+                    JwtClaims idTokenClaims = client.validate(tokenResponse);
+                    AccessToken accessToken = createAccessTokenFromTokenResponse(tokenResponse);
+                    return createCredentialValidationResult(client.getOidcClientConfig(), accessToken, idTokenClaims);
                 } catch (Exception e) {
                     return CredentialValidationResult.INVALID_RESULT;
                 }
@@ -52,29 +59,51 @@ public class OidcIdentityStore implements IdentityStore {
         return CredentialValidationResult.INVALID_RESULT;
     }
 
-    CredentialValidationResult createSuccessfulCredentialValidationResult(OidcClientConfig clientConfig, TokenResponse tokenResponse) {
+    AccessToken createAccessTokenFromTokenResponse(TokenResponse tokenResponse) {
+        Map<String, String> tokenResponseRawMap = tokenResponse.asMap();
+        long expiresIn = 0L;
+        if (tokenResponseRawMap.containsKey(OpenIdConstant.EXPIRES_IN)) {
+            expiresIn = Long.parseLong(tokenResponseRawMap.get(OpenIdConstant.EXPIRES_IN));
+        }
+        // TODO - determine what value to use here
+        long tokenMinValidityInMillis = 10 * 1000L;
+        return new AccessTokenImpl(tokenResponse.getAccessTokenString(), tokenResponse.getResponseGenerationTime(), expiresIn, tokenMinValidityInMillis);
+    }
+
+    /**
+     * Per https://jakarta.ee/specifications/security/3.0/jakarta-security-spec-3.0.html#caller-name-and-groups, the claim name
+     * that is used to define the Caller Name and optionally the Caller Groups from the OP can be defined by the following
+     * attributes:
+     * <ul>
+     * <li>Caller Name: OpenIdAuthenticationMechanismDefinition.claimsDefinition.callerNameClaim</li>
+     * <li>Caller Groups: OpenIdAuthenticationMechanismDefinition.claimsDefinition.callerGroupsClaim</li>
+     * </ul>
+     */
+    CredentialValidationResult createCredentialValidationResult(OidcClientConfig clientConfig, AccessToken accessToken, JwtClaims idTokenClaims) throws MalformedClaimException {
         String storeId = clientConfig.getClientId();
-        String caller = getCallerName(clientConfig, tokenResponse);
-        Set<String> groups = getCallerGroups(clientConfig, tokenResponse);
+        String caller = getCallerName(clientConfig, accessToken, idTokenClaims);
+        if (caller == null) {
+            return CredentialValidationResult.INVALID_RESULT;
+        }
+        Set<String> groups = getCallerGroups(clientConfig, accessToken, idTokenClaims);
         return new CredentialValidationResult(storeId, caller, null, caller, groups);
     }
 
-    String getCallerName(OidcClientConfig clientConfig, TokenResponse tokenResponse) {
+    String getCallerName(OidcClientConfig clientConfig, AccessToken accessToken, JwtClaims idTokenClaims) throws MalformedClaimException {
         String callerNameClaim = getCallerNameClaim(clientConfig);
         if (callerNameClaim == null || callerNameClaim.isEmpty()) {
             return null;
         }
-        // TODO
-        return null;
+        return getClaimValueFromTokens(callerNameClaim, accessToken, idTokenClaims, String.class);
     }
 
-    Set<String> getCallerGroups(OidcClientConfig clientConfig, TokenResponse tokenResponse) {
+    @SuppressWarnings("unchecked")
+    Set<String> getCallerGroups(OidcClientConfig clientConfig, AccessToken accessToken, JwtClaims idTokenClaims) throws MalformedClaimException {
         String callerGroupClaim = getCallerGroupsClaim(clientConfig);
         if (callerGroupClaim == null || callerGroupClaim.isEmpty()) {
             return null;
         }
-        // TODO
-        return Collections.emptySet();
+        return getClaimValueFromTokens(callerGroupClaim, accessToken, idTokenClaims, Set.class);
     }
 
     String getCallerNameClaim(OidcClientConfig clientConfig) {
@@ -91,6 +120,54 @@ public class OidcIdentityStore implements IdentityStore {
             return claimsMappingConfig.getCallerGroupsClaim();
         }
         return null;
+    }
+
+    /**
+     * Per https://jakarta.ee/specifications/security/3.0/jakarta-security-spec-3.0.html#caller-name-and-groups, the following
+     * logic is used to determine the value of the Caller Name and Caller Groups:
+     * <ul>
+     * <li>If the specified claim exists and has a non-empty value in the Access Token, this Access Token claim value is taken.
+     * <li>If not resolved yet, and the specified claim exists and has a non-empty value in the Identity Token, this Identity Token claim value is taken.
+     * <li>If not resolved yet, and the specified claim exists and has a non-empty value in the User Info Token, this User Info Token claim value is taken.
+     * </ul>
+     */
+    <T> T getClaimValueFromTokens(String claim, AccessToken accessToken, JwtClaims idTokenClaims, Class<T> claimType) throws MalformedClaimException {
+        T claimValue = getClaimFromAccessToken(accessToken, claim);
+        if (valueExistsAndIsNotEmpty(claimValue, claimType)) {
+            return claimValue;
+        }
+        claimValue = getClaimFromIdToken(idTokenClaims, claim, claimType);
+        if (valueExistsAndIsNotEmpty(claimValue, claimType)) {
+            return claimValue;
+        }
+        // TODO - get claimValue from User Info
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    <T> T getClaimFromAccessToken(AccessToken accessToken, String claim) {
+        if (accessToken.isJWT()) {
+            return (T) accessToken.getClaim(claim);
+        }
+        return null;
+    }
+
+    <T> T getClaimFromIdToken(JwtClaims idTokenClaims, String claim, Class<T> claimType) throws MalformedClaimException {
+        return idTokenClaims.getClaimValue(claim, claimType);
+    }
+
+    @SuppressWarnings("rawtypes")
+    <T> boolean valueExistsAndIsNotEmpty(T claimValue, Class<T> claimType) {
+        if (claimValue == null) {
+            return false;
+        }
+        if (claimType.equals(String.class) && ((String) claimValue).isEmpty()) {
+            return false;
+        }
+        if (claimType.equals(Set.class) && ((Set) claimValue).isEmpty()) {
+            return false;
+        }
+        return true;
     }
 
 }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/identitystore/OidcIdentityStoreTest.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/identitystore/OidcIdentityStoreTest.java
@@ -16,6 +16,8 @@ import static org.junit.Assert.assertNull;
 import java.util.Set;
 
 import org.jmock.Expectations;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.MalformedClaimException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -27,6 +29,7 @@ import com.ibm.ws.security.test.common.CommonTestClass;
 import io.openliberty.security.oidcclientcore.client.ClaimsMappingConfig;
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 import io.openliberty.security.oidcclientcore.token.TokenResponse;
+import jakarta.security.enterprise.identitystore.openid.AccessToken;
 import test.common.SharedOutputManager;
 
 public class OidcIdentityStoreTest extends CommonTestClass {
@@ -36,6 +39,8 @@ public class OidcIdentityStoreTest extends CommonTestClass {
     private final OidcClientConfig config = mockery.mock(OidcClientConfig.class);
     private final ClaimsMappingConfig claimsMappingConfig = mockery.mock(ClaimsMappingConfig.class);
     private final TokenResponse tokenResponse = mockery.mock(TokenResponse.class);
+    private final AccessToken accessToken = mockery.mock(AccessToken.class);
+    private final JwtClaims idTokenClaims = mockery.mock(JwtClaims.class);
 
     private OidcIdentityStore identityStore;
 
@@ -63,28 +68,28 @@ public class OidcIdentityStoreTest extends CommonTestClass {
     // TODO - createSuccessfulCredentialValidationResult
 
     @Test
-    public void test_getCallerName_noClaimsMapping() {
+    public void test_getCallerName_noClaimsMapping() throws MalformedClaimException {
         mockery.checking(new Expectations() {
             {
                 one(config).getClaimsMappingConfig();
                 will(returnValue(null));
             }
         });
-        String result = identityStore.getCallerName(config, tokenResponse);
+        String result = identityStore.getCallerName(config, accessToken, idTokenClaims);
         assertNull("Result should have been null but was [" + result + "].", result);
     }
 
     // TODO - getCallerName
 
     @Test
-    public void test_getCallerGroups_noClaimsMapping() {
+    public void test_getCallerGroups_noClaimsMapping() throws MalformedClaimException {
         mockery.checking(new Expectations() {
             {
                 one(config).getClaimsMappingConfig();
                 will(returnValue(null));
             }
         });
-        Set<String> result = identityStore.getCallerGroups(config, tokenResponse);
+        Set<String> result = identityStore.getCallerGroups(config, accessToken, idTokenClaims);
         assertNull("Result should have been null but was [" + result + "].", result);
     }
 
@@ -171,5 +176,10 @@ public class OidcIdentityStoreTest extends CommonTestClass {
         String result = identityStore.getCallerGroupsClaim(config);
         assertEquals(claim, result);
     }
+
+    // TODO - getClaimValueFromTokens
+    // TODO - getClaimFromAccessToken
+    // TODO - getClaimFromIdToken
+    // TODO - valueExistsAndIsNotEmpty
 
 }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/identitystore/OidcIdentityStoreTest.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/identitystore/OidcIdentityStoreTest.java
@@ -1,0 +1,175 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.identitystore;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Set;
+
+import org.jmock.Expectations;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import io.openliberty.security.oidcclientcore.client.ClaimsMappingConfig;
+import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
+import io.openliberty.security.oidcclientcore.token.TokenResponse;
+import test.common.SharedOutputManager;
+
+public class OidcIdentityStoreTest extends CommonTestClass {
+
+    protected static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+
+    private final OidcClientConfig config = mockery.mock(OidcClientConfig.class);
+    private final ClaimsMappingConfig claimsMappingConfig = mockery.mock(ClaimsMappingConfig.class);
+    private final TokenResponse tokenResponse = mockery.mock(TokenResponse.class);
+
+    private OidcIdentityStore identityStore;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void setUp() {
+        identityStore = new OidcIdentityStore();
+    }
+
+    @After
+    public void tearDown() {
+        outputMgr.resetStreams();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    // TODO - createSuccessfulCredentialValidationResult
+
+    @Test
+    public void test_getCallerName_noClaimsMapping() {
+        mockery.checking(new Expectations() {
+            {
+                one(config).getClaimsMappingConfig();
+                will(returnValue(null));
+            }
+        });
+        String result = identityStore.getCallerName(config, tokenResponse);
+        assertNull("Result should have been null but was [" + result + "].", result);
+    }
+
+    // TODO - getCallerName
+
+    @Test
+    public void test_getCallerGroups_noClaimsMapping() {
+        mockery.checking(new Expectations() {
+            {
+                one(config).getClaimsMappingConfig();
+                will(returnValue(null));
+            }
+        });
+        Set<String> result = identityStore.getCallerGroups(config, tokenResponse);
+        assertNull("Result should have been null but was [" + result + "].", result);
+    }
+
+    // TODO - getCallerGroups
+
+    @Test
+    public void test_getCallerNameClaim_noClaimsMapping() {
+        mockery.checking(new Expectations() {
+            {
+                one(config).getClaimsMappingConfig();
+                will(returnValue(null));
+            }
+        });
+        String result = identityStore.getCallerNameClaim(config);
+        assertNull("Result should have been null but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_getCallerNameClaim_noClaimConfigured() {
+        mockery.checking(new Expectations() {
+            {
+                one(config).getClaimsMappingConfig();
+                will(returnValue(claimsMappingConfig));
+                one(claimsMappingConfig).getCallerNameClaim();
+                will(returnValue(null));
+            }
+        });
+        String result = identityStore.getCallerNameClaim(config);
+        assertNull("Result should have been null but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_getCallerNameClaim() {
+        final String claim = "myCallerNameClaim";
+        mockery.checking(new Expectations() {
+            {
+                one(config).getClaimsMappingConfig();
+                will(returnValue(claimsMappingConfig));
+                one(claimsMappingConfig).getCallerNameClaim();
+                will(returnValue(claim));
+            }
+        });
+        String result = identityStore.getCallerNameClaim(config);
+        assertEquals(claim, result);
+    }
+
+    @Test
+    public void test_getCallerGroupsClaim_noClaimsMapping() {
+        mockery.checking(new Expectations() {
+            {
+                one(config).getClaimsMappingConfig();
+                will(returnValue(null));
+            }
+        });
+        String result = identityStore.getCallerGroupsClaim(config);
+        assertNull("Result should have been null but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_getCallerGroupsClaim_noClaimConfigured() {
+        mockery.checking(new Expectations() {
+            {
+                one(config).getClaimsMappingConfig();
+                will(returnValue(claimsMappingConfig));
+                one(claimsMappingConfig).getCallerGroupsClaim();
+                will(returnValue(null));
+            }
+        });
+        String result = identityStore.getCallerGroupsClaim(config);
+        assertNull("Result should have been null but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_getCallerGroupsClaim() {
+        final String claim = "myCallerGroupsClaim";
+        mockery.checking(new Expectations() {
+            {
+                one(config).getClaimsMappingConfig();
+                will(returnValue(claimsMappingConfig));
+                one(claimsMappingConfig).getCallerGroupsClaim();
+                will(returnValue(claim));
+            }
+        });
+        String result = identityStore.getCallerGroupsClaim(config);
+        assertEquals(claim, result);
+    }
+
+}

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/client/Client.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/client/Client.java
@@ -13,6 +13,8 @@ package io.openliberty.security.oidcclientcore.client;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.jose4j.jwt.JwtClaims;
+
 import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 
 import io.openliberty.security.oidcclientcore.authentication.AbstractFlow;
@@ -45,9 +47,9 @@ public class Client {
         return flow.continueFlow(request, response);
     }
 
-    public void validate(TokenResponse tokenResponse) throws TokenValidationException {
+    public JwtClaims validate(TokenResponse tokenResponse) throws TokenValidationException {
         TokenResponseValidator tokenResponseValidator = new TokenResponseValidator(this.oidcClientConfig);
-        tokenResponseValidator.validate(tokenResponse);
+        return tokenResponseValidator.validate(tokenResponse);
     }
 
     public void logout() {

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/client/Client.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/client/Client.java
@@ -31,6 +31,10 @@ public class Client {
         this.oidcClientConfig = oidcClientConfig;
     }
 
+    public OidcClientConfig getOidcClientConfig() {
+        return oidcClientConfig;
+    }
+
     public ProviderAuthenticationResult startFlow(HttpServletRequest request, HttpServletResponse response) {
         Flow flow = AbstractFlow.getInstance(oidcClientConfig);
         return flow.startFlow(request, response);
@@ -40,7 +44,7 @@ public class Client {
         Flow flow = AbstractFlow.getInstance(oidcClientConfig);
         return flow.continueFlow(request, response);
     }
-    
+
     public void validate(TokenResponse tokenResponse) throws TokenValidationException {
         TokenResponseValidator tokenResponseValidator = new TokenResponseValidator(this.oidcClientConfig);
         tokenResponseValidator.validate(tokenResponse);

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenResponse.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenResponse.java
@@ -20,31 +20,31 @@ import com.ibm.json.java.JSONObject;
 public class TokenResponse {
 
     private final JSONObject rawResponse;
-    private final String idToken;
-    private final String accessToken;
-    private final String refreshToken;
+    private final String idTokenString;
+    private final String accessTokenString;
+    private final String refreshTokenString;
     private final Instant responseGenerationTime;
 
     private Map<String, String> responseAsMap = null;
 
     public TokenResponse(JSONObject rawResponse, String idToken, String accessToken, String refreshToken) {
         this.rawResponse = rawResponse;
-        this.idToken = idToken;
-        this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
+        this.idTokenString = idToken;
+        this.accessTokenString = accessToken;
+        this.refreshTokenString = refreshToken;
         this.responseGenerationTime = Instant.now();
     }
 
-    public String getIdToken() {
-        return idToken;
+    public String getIdTokenString() {
+        return idTokenString;
     }
 
-    public String getAccessToken() {
-        return accessToken;
+    public String getAccessTokenString() {
+        return accessTokenString;
     }
 
-    public String getRefreshToken() {
-        return refreshToken;
+    public String getRefreshTokenString() {
+        return refreshTokenString;
     }
 
     @SuppressWarnings("unchecked")

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/token/TokenRequestorTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/token/TokenRequestorTest.java
@@ -111,9 +111,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         TokenResponse tokenResponse = tokenRequestor.requestTokens();
 
-        assertEquals(accessToken, tokenResponse.getAccessToken());
-        assertEquals(refreshToken, tokenResponse.getRefreshToken());
-        assertEquals(idToken, tokenResponse.getIdToken());
+        assertEquals(accessToken, tokenResponse.getAccessTokenString());
+        assertEquals(refreshToken, tokenResponse.getRefreshTokenString());
+        assertEquals(idToken, tokenResponse.getIdTokenString());
         assertNotNull("The token response generation time must be set.", tokenResponse.getResponseGenerationTime());
     }
 
@@ -134,9 +134,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         TokenResponse tokenResponse = tokenRequestor.requestTokens();
 
-        assertEquals(accessToken, tokenResponse.getAccessToken());
-        assertEquals(refreshToken, tokenResponse.getRefreshToken());
-        assertEquals(idToken, tokenResponse.getIdToken());
+        assertEquals(accessToken, tokenResponse.getAccessTokenString());
+        assertEquals(refreshToken, tokenResponse.getRefreshTokenString());
+        assertEquals(idToken, tokenResponse.getIdTokenString());
     }
 
     @Test
@@ -155,9 +155,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         TokenResponse tokenResponse = tokenRequestor.requestTokens();
 
-        assertEquals(accessToken, tokenResponse.getAccessToken());
-        assertEquals(refreshToken, tokenResponse.getRefreshToken());
-        assertEquals(idToken, tokenResponse.getIdToken());
+        assertEquals(accessToken, tokenResponse.getAccessTokenString());
+        assertEquals(refreshToken, tokenResponse.getRefreshTokenString());
+        assertEquals(idToken, tokenResponse.getIdTokenString());
     }
 
     @Test
@@ -179,9 +179,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         TokenResponse tokenResponse = tokenRequestor.requestTokens();
 
-        assertEquals(accessToken, tokenResponse.getAccessToken());
-        assertEquals(refreshToken, tokenResponse.getRefreshToken());
-        assertEquals(idToken, tokenResponse.getIdToken());
+        assertEquals(accessToken, tokenResponse.getAccessTokenString());
+        assertEquals(refreshToken, tokenResponse.getRefreshTokenString());
+        assertEquals(idToken, tokenResponse.getIdTokenString());
     }
 
     @Test
@@ -207,9 +207,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         TokenResponse tokenResponse = tokenRequestor.requestTokens();
 
-        assertEquals(accessToken, tokenResponse.getAccessToken());
-        assertEquals(refreshToken, tokenResponse.getRefreshToken());
-        assertEquals(idToken, tokenResponse.getIdToken());
+        assertEquals(accessToken, tokenResponse.getAccessTokenString());
+        assertEquals(refreshToken, tokenResponse.getRefreshTokenString());
+        assertEquals(idToken, tokenResponse.getIdTokenString());
     }
 
     @Test
@@ -229,9 +229,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         TokenResponse tokenResponse = tokenRequestor.requestTokens();
 
-        assertEquals(accessToken, tokenResponse.getAccessToken());
-        assertEquals(refreshToken, tokenResponse.getRefreshToken());
-        assertEquals(idToken, tokenResponse.getIdToken());
+        assertEquals(accessToken, tokenResponse.getAccessTokenString());
+        assertEquals(refreshToken, tokenResponse.getRefreshTokenString());
+        assertEquals(idToken, tokenResponse.getIdTokenString());
     }
 
     @Test
@@ -254,9 +254,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         TokenResponse tokenResponse = tokenRequestor.requestTokens();
 
-        assertEquals(accessToken, tokenResponse.getAccessToken());
-        assertEquals(refreshToken, tokenResponse.getRefreshToken());
-        assertEquals(idToken, tokenResponse.getIdToken());
+        assertEquals(accessToken, tokenResponse.getAccessTokenString());
+        assertEquals(refreshToken, tokenResponse.getRefreshTokenString());
+        assertEquals(idToken, tokenResponse.getIdTokenString());
     }
 
 }


### PR DESCRIPTION
Adds initial logic for getting Caller Name and Caller Group claims from the access token or ID token, depending on where the claim is available.
    
For #21171