### PR TITLE
On branch edburns-msft-dd-1618567-fileset-scaninterval-clarify-does-not-scan-for-changes-in-file

### DIFF
--- a/dev/com.ibm.ws.kernel.metatype.helper/resources/OSGI-INF/l10n/fileset.properties
+++ b/dev/com.ibm.ws.kernel.metatype.helper/resources/OSGI-INF/l10n/fileset.properties
@@ -31,4 +31,4 @@ fileset.attr.excludes.name=Excludes pattern
 fileset.attr.excludes.desc=The comma or space separated list of file name patterns to exclude from the search results, by default no files are excluded.
 #monitor
 fileset.attr.scan.name=Scan interval
-fileset.attr.scan.desc=Scanning interval to check the fileset for changes as a long with a time unit suffix h-hour, m-minute, s-second, ms-millisecond (e.g. 2ms or 5s). Disabled (scanInterval=0) by default. Note: the contents of the individual files are not scanned. Rather, the fileset itself is scanned to determine if files are added or removed from the set.
+fileset.attr.scan.desc=The scanning interval to determine whether files are added or removed from the fileset. The individual files are not scanned. The suffix for the interval of time is h-hour, m-minute, s-second, and ms-millisecond, for example, 2ms or 5s. The scanning interval is disabled by default and is disabled manually by setting the scan interval, scanInterval, to 0.

--- a/dev/com.ibm.ws.kernel.metatype.helper/resources/OSGI-INF/l10n/fileset.properties
+++ b/dev/com.ibm.ws.kernel.metatype.helper/resources/OSGI-INF/l10n/fileset.properties
@@ -31,4 +31,4 @@ fileset.attr.excludes.name=Excludes pattern
 fileset.attr.excludes.desc=The comma or space separated list of file name patterns to exclude from the search results, by default no files are excluded.
 #monitor
 fileset.attr.scan.name=Scan interval
-fileset.attr.scan.desc=Scanning interval to check the fileset for changes as a long with a time unit suffix h-hour, m-minute, s-second, ms-millisecond (e.g. 2ms or 5s). Disabled (scanInterval=0) by default.
+fileset.attr.scan.desc=Scanning interval to check the fileset for changes as a long with a time unit suffix h-hour, m-minute, s-second, ms-millisecond (e.g. 2ms or 5s). Disabled (scanInterval=0) by default. Note: the contents of the individual files are not scanned. Rather, the fileset itself is scanned to determine if files are added or removed from the set.


### PR DESCRIPTION
modified:   dev/com.ibm.ws.kernel.metatype.helper/resources/OSGI-INF/l10n/fileset.properties
@nottycode said:

> so I've verified with someone on our dev team that the change would be valid, so if you submit a PR it wouldn't be rejected as invalid. They might suggest alternative wording, but if you want to do the PR I'm happy to work with them to get it merged.

Signed-off-by: Ed Burns <edburns@microsoft.com>

