### PR TITLE
update OidcHttpAuthenticationMechanism to store full request

### DIFF
--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequest.java
@@ -10,7 +10,10 @@
  *******************************************************************************/
 package io.openliberty.security.oidcclientcore.authentication;
 
+import java.util.Base64;
+import java.util.Enumeration;
 import java.util.Set;
+import java.util.StringJoiner;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -37,6 +40,10 @@ import io.openliberty.security.oidcclientcore.storage.StorageProperties;
 public class JakartaOidcAuthorizationRequest extends AuthorizationRequest {
 
     public static final TraceComponent tc = Tr.register(JakartaOidcAuthorizationRequest.class);
+
+    public static final String STORED_REQUEST_METHOD = "STORED_REQUEST_METHOD";
+    public static final String STORED_REQUEST_HEADERS = "STORED_REQUEST_HEADERS";
+    public static final String STORED_REQUEST_PARAMS = "STORED_REQUEST_PARAMS";
 
     private enum StorageType {
         COOKIE, SESSION
@@ -279,8 +286,60 @@ public class JakartaOidcAuthorizationRequest extends AuthorizationRequest {
     }
 
     void storeFullRequest() {
-        // TODO
+        Base64.Encoder encoder = Base64.getEncoder();
+        storeRequestCookies(encoder);
+        storeRequestMethod(encoder);
+        storeRequestHeaders(encoder);
+        storeRequestParameters(encoder);
+    }
 
+    void storeRequestCookies(Base64.Encoder encoder) {
+        // cookies should be automatically restored during redirection to original resource
+    }
+
+    void storeRequestMethod(Base64.Encoder encoder) {
+        String method = request.getMethod();
+        String encodedMethod = encoder.encodeToString(method.getBytes());
+        storage.store(STORED_REQUEST_METHOD, encodedMethod);
+    }
+
+    void storeRequestHeaders(Base64.Encoder encoder) {
+        StringJoiner headerJoiner = new StringJoiner("&");
+        Enumeration<String> headerNames = request.getHeaderNames();
+        while (headerNames.hasMoreElements()) {
+            String headerName = headerNames.nextElement();
+            String encodedHeaderName = encoder.encodeToString(headerName.getBytes());
+            StringJoiner valueJoiner = new StringJoiner(".");
+            Enumeration<String> headerValues = request.getHeaders(headerName);
+            while (headerValues.hasMoreElements()) {
+                String headerValue = headerValues.nextElement();
+                String encodedHeaderValue = encoder.encodeToString(headerValue.getBytes());
+                valueJoiner.add(encodedHeaderValue);
+            }
+            String encodedHeaderValues = valueJoiner.toString();
+            headerJoiner.add(encodedHeaderName + ":" + encodedHeaderValues);
+        }
+        String encodedHeaders = headerJoiner.toString();
+        storage.store(STORED_REQUEST_HEADERS, encodedHeaders);
+    }
+
+    void storeRequestParameters(Base64.Encoder encoder) {
+        StringJoiner paramJoiner = new StringJoiner("&");
+        Enumeration<String> paramNames = request.getParameterNames();
+        while (paramNames.hasMoreElements()) {
+            String paramName = paramNames.nextElement();
+            String encodedParamName = encoder.encodeToString(paramName.getBytes());
+            StringJoiner valueJoiner = new StringJoiner(".");
+            String[] paramValues = request.getParameterValues(paramName);
+            for (String paramValue : paramValues) {
+                String encodedParamValue = encoder.encodeToString(paramValue.getBytes());
+                valueJoiner.add(encodedParamValue);
+            }
+            String encodedParamValues = valueJoiner.toString();
+            paramJoiner.add(encodedParamName + ":" + encodedParamValues);
+        }
+        String encodedParams = paramJoiner.toString();
+        storage.store(STORED_REQUEST_PARAMS, encodedParams);
     }
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequestTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequestTest.java
@@ -10,8 +10,15 @@
  *******************************************************************************/
 package io.openliberty.security.oidcclientcore.authentication;
 
+import static io.openliberty.security.oidcclientcore.authentication.JakartaOidcAuthorizationRequest.STORED_REQUEST_HEADERS;
+import static io.openliberty.security.oidcclientcore.authentication.JakartaOidcAuthorizationRequest.STORED_REQUEST_METHOD;
+import static io.openliberty.security.oidcclientcore.authentication.JakartaOidcAuthorizationRequest.STORED_REQUEST_PARAMS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -31,6 +38,7 @@ import io.openliberty.security.oidcclientcore.client.OidcProviderMetadata;
 import io.openliberty.security.oidcclientcore.discovery.DiscoveryHandler;
 import io.openliberty.security.oidcclientcore.discovery.OidcDiscoveryConstants;
 import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
+import io.openliberty.security.oidcclientcore.storage.SessionBasedStorage;
 import test.common.SharedOutputManager;
 
 public class JakartaOidcAuthorizationRequestTest extends CommonTestClass {
@@ -43,6 +51,7 @@ public class JakartaOidcAuthorizationRequestTest extends CommonTestClass {
     private final OidcProviderMetadata providerMetadata = mockery.mock(OidcProviderMetadata.class);
     private final DiscoveryHandler discoveryHandler = mockery.mock(DiscoveryHandler.class);
     private final AuthorizationRequestParameters authzParameters = mockery.mock(AuthorizationRequestParameters.class);
+    private final SessionBasedStorage sessionBasedStorage = mockery.mock(SessionBasedStorage.class);
 
     private final String CWWKS2403E_DISCOVERY_EXCEPTION = "CWWKS2403E";
     private final String CWWKS2405E_DISCOVERY_METADATA_MISSING_VALUE = "CWWKS2405E";
@@ -90,6 +99,11 @@ public class JakartaOidcAuthorizationRequestTest extends CommonTestClass {
             }
         });
         return new JakartaOidcAuthorizationRequest(request, response, config) {
+
+            {
+                this.storage = sessionBasedStorage;
+            }
+
             @Override
             public DiscoveryHandler getDiscoveryHandler() {
                 return discoveryHandler;
@@ -247,6 +261,42 @@ public class JakartaOidcAuthorizationRequestTest extends CommonTestClass {
             }
         });
         authzRequest.addExtraParameters(authzParameters);
+    }
+
+    @Test
+    public void test_storeFullRequest() throws Exception {
+        String requestMethod = "POST";
+
+        Enumeration<String> headerNames = Collections.enumeration(Arrays.asList("Content-Type"));
+        Enumeration<String> contentTypes = Collections.enumeration(Arrays.asList("application/x-www-form-urlencoded"));
+
+        Enumeration<String> paramNames = Collections.enumeration(Arrays.asList("id", "language"));
+        String[] ids = new String[] { "1234" };
+        String[] languages = new String[] { "Java" };
+
+        mockery.checking(new Expectations() {
+            {
+                one(request).getMethod();
+                will(returnValue(requestMethod));
+                one(sessionBasedStorage).store(with(equal(STORED_REQUEST_METHOD)), with(any(String.class)));
+
+                one(request).getHeaderNames();
+                will(returnValue(headerNames));
+                one(request).getHeaders("Content-Type");
+                will(returnValue(contentTypes));
+                one(sessionBasedStorage).store(with(equal(STORED_REQUEST_HEADERS)), with(any(String.class)));
+
+                one(request).getParameterNames();
+                will(returnValue(paramNames));
+                one(request).getParameterValues("id");
+                will(returnValue(ids));
+                one(request).getParameterValues("language");
+                will(returnValue(languages));
+                one(sessionBasedStorage).store(with(equal(STORED_REQUEST_PARAMS)), with(any(String.class)));
+            }
+        });
+
+        authzRequest.storeFullRequest();
     }
 
 }


### PR DESCRIPTION
for #21164

store the following request data when `redirectToOriginalResource` is true and the auth flow is container-initiated:

- cookies (should automatically be restored when redirecting to original resource, so this doesn't actually have to be stored)
- method
- headers
- params (query params and params from body/payload)

the data is stored in the session if `useSession` is set to true, otherwise it is stored in cookies. this data will be used later to restore the original request after redirecting the user to the original resource.