### PR TITLE
Jakarta security 30, process callerNameClaim and callerGroupsClaim from config and tokens, create valid CVR

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/bnd.bnd
@@ -76,6 +76,7 @@ src: src, resources
 	io.openliberty.jakarta.authentication.3.0;version=latest,\
 	io.openliberty.jakarta.security.3.0,\
 	io.openliberty.jakarta.cdi.4.0;version=latest,\
+	com.ibm.ws.security.common.jsonwebkey;version=latest,\
 	com.ibm.ws.security.javaeesec.1.0,\
 	com.ibm.json4j;version=latest,\
 	com.ibm.websphere.security;version=latest,\

--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/bnd.bnd
@@ -80,4 +80,5 @@ src: src, resources
 	com.ibm.ws.security.javaeesec.1.0,\
 	com.ibm.json4j;version=latest,\
 	com.ibm.websphere.security;version=latest,\
-	com.ibm.ws.container.service;version=latest
+	com.ibm.ws.container.service;version=latest,\
+	com.ibm.ws.org.jose4j;version=latest

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/bnd.bnd
@@ -46,7 +46,8 @@ instrument.classesExcludes: io/openliberty/security/jakartasec/internal/resource
     io.openliberty.jakarta.security.3.0,\
     io.openliberty.security.oidcclientcore.internal.jakarta,\
     io.openliberty.jakarta.jsonp.2.1,\
-	io.openliberty.jakarta.servlet.6.0
+	io.openliberty.jakarta.servlet.6.0,\
+	com.ibm.ws.org.jose4j;version=latest
 
 -testpath: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file,\

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/credential/OidcTokensCredential.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/credential/OidcTokensCredential.java
@@ -14,6 +14,8 @@ import io.openliberty.security.oidcclientcore.client.Client;
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 import io.openliberty.security.oidcclientcore.token.TokenResponse;
 import jakarta.security.enterprise.credential.Credential;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  *
@@ -23,18 +25,41 @@ public class OidcTokensCredential implements Credential {
     TokenResponse tokenResponse;
     Client client;
     OidcClientConfig oidcClientConfig;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
     
     public OidcTokensCredential(TokenResponse tokenResponse, Client client) {
         this.tokenResponse = tokenResponse;
         this.client = client;
     }
     
+    /**
+     * @param tokenResponse
+     * @param client
+     * @param request
+     * @param response
+     */
+    public OidcTokensCredential(TokenResponse tokenResponse, Client client, HttpServletRequest request, HttpServletResponse response) {
+        this.tokenResponse = tokenResponse;
+        this.client = client;
+        this.request = request;
+        this.response = response;
+    }
+
     public TokenResponse getTokenResponse() {
         return this.tokenResponse;
     }
     
     public Client getClient() {
         return this.client;
+    }
+    
+    public HttpServletRequest getRequest() {
+        return this.request;
+    }
+    
+    public HttpServletResponse getResponse() {
+        return this.response;
     }
 
 }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
@@ -42,7 +42,7 @@ public class OidcIdentityStore implements IdentityStore {
             Client client = castCredential.getClient();
             if (tokenResponse != null && client != null) {
                 try {
-                    client.validate(tokenResponse);
+                    client.validate(tokenResponse,castCredential.getRequest(), castCredential.getResponse());
                     return createSuccessfulCredentialValidationResult(client.getOidcClientConfig(), tokenResponse);
                 } catch (Exception e) {
                     return CredentialValidationResult.INVALID_RESULT;

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
@@ -10,17 +10,21 @@
  *******************************************************************************/
 package io.openliberty.security.jakartasec.identitystore;
 
-import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
-
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.MalformedClaimException;
 import io.openliberty.security.jakartasec.credential.OidcTokensCredential;
+import io.openliberty.security.jakartasec.tokens.AccessTokenImpl;
 import io.openliberty.security.oidcclientcore.client.ClaimsMappingConfig;
 import io.openliberty.security.oidcclientcore.client.Client;
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 import io.openliberty.security.oidcclientcore.token.TokenResponse;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdConstant;
 import jakarta.security.enterprise.credential.Credential;
 import jakarta.security.enterprise.identitystore.CredentialValidationResult;
 import jakarta.security.enterprise.identitystore.IdentityStore;
+import jakarta.security.enterprise.identitystore.openid.AccessToken;
 
 /**
  *
@@ -42,8 +46,9 @@ public class OidcIdentityStore implements IdentityStore {
             Client client = castCredential.getClient();
             if (tokenResponse != null && client != null) {
                 try {
-                    client.validate(tokenResponse,castCredential.getRequest(), castCredential.getResponse());
-                    return createSuccessfulCredentialValidationResult(client.getOidcClientConfig(), tokenResponse);
+                    JwtClaims idTokenClaims = client.validate(tokenResponse, castCredential.getRequest(), castCredential.getResponse());
+                    AccessToken accessToken = createAccessTokenFromTokenResponse(client.getOidcClientConfig(), tokenResponse);
+                    return createCredentialValidationResult(client.getOidcClientConfig(), accessToken, idTokenClaims);
                 } catch (Exception e) {
                     return CredentialValidationResult.INVALID_RESULT;
                 }
@@ -51,30 +56,53 @@ public class OidcIdentityStore implements IdentityStore {
         }
         return CredentialValidationResult.INVALID_RESULT;
     }
+    
+    AccessToken createAccessTokenFromTokenResponse(OidcClientConfig oidcClientConfig, TokenResponse tokenResponse) {
+        Map<String, String> tokenResponseRawMap = tokenResponse.asMap();
+        long expiresIn = 0L;
+        if (tokenResponseRawMap.containsKey(OpenIdConstant.EXPIRES_IN)) {
+            expiresIn = Long.parseLong(tokenResponseRawMap.get(OpenIdConstant.EXPIRES_IN));
+        }
+        
+        long tokenMinValidityInMillis =  oidcClientConfig.getTokenMinValidity();
+        return new AccessTokenImpl(tokenResponse.getAccessTokenString(), tokenResponse.getResponseGenerationTime(), expiresIn, tokenMinValidityInMillis);
+    }
+    
 
-    CredentialValidationResult createSuccessfulCredentialValidationResult(OidcClientConfig clientConfig, TokenResponse tokenResponse) {
+    /**
+     * Per https://jakarta.ee/specifications/security/3.0/jakarta-security-spec-3.0.html#caller-name-and-groups, the claim name
+     * that is used to define the Caller Name and optionally the Caller Groups from the OP can be defined by the following
+     * attributes:
+     * <ul>
+     * <li>Caller Name: OpenIdAuthenticationMechanismDefinition.claimsDefinition.callerNameClaim</li>
+     * <li>Caller Groups: OpenIdAuthenticationMechanismDefinition.claimsDefinition.callerGroupsClaim</li>
+     * </ul>
+     */
+    CredentialValidationResult createCredentialValidationResult(OidcClientConfig clientConfig, AccessToken accessToken, JwtClaims idTokenClaims) throws MalformedClaimException {
         String storeId = clientConfig.getClientId();
-        String caller = getCallerName(clientConfig, tokenResponse);
-        Set<String> groups = getCallerGroups(clientConfig, tokenResponse);
+        String caller = getCallerName(clientConfig, accessToken, idTokenClaims);
+        if (caller == null) {
+            return CredentialValidationResult.INVALID_RESULT;
+        }
+        Set<String> groups = getCallerGroups(clientConfig, accessToken, idTokenClaims);
         return new CredentialValidationResult(storeId, caller, null, caller, groups);
     }
-
-    String getCallerName(OidcClientConfig clientConfig, TokenResponse tokenResponse) {
+    
+    String getCallerName(OidcClientConfig clientConfig, AccessToken accessToken, JwtClaims idTokenClaims) throws MalformedClaimException {
         String callerNameClaim = getCallerNameClaim(clientConfig);
         if (callerNameClaim == null || callerNameClaim.isEmpty()) {
             return null;
         }
-        // TODO
-        return null;
+        return getClaimValueFromTokens(callerNameClaim, accessToken, idTokenClaims, String.class);
     }
 
-    Set<String> getCallerGroups(OidcClientConfig clientConfig, TokenResponse tokenResponse) {
+    @SuppressWarnings("unchecked")
+    Set<String> getCallerGroups(OidcClientConfig clientConfig, AccessToken accessToken, JwtClaims idTokenClaims) throws MalformedClaimException {
         String callerGroupClaim = getCallerGroupsClaim(clientConfig);
         if (callerGroupClaim == null || callerGroupClaim.isEmpty()) {
             return null;
         }
-        // TODO
-        return Collections.emptySet();
+        return getClaimValueFromTokens(callerGroupClaim, accessToken, idTokenClaims, Set.class);
     }
 
     String getCallerNameClaim(OidcClientConfig clientConfig) {
@@ -91,6 +119,54 @@ public class OidcIdentityStore implements IdentityStore {
             return claimsMappingConfig.getCallerGroupsClaim();
         }
         return null;
+    }
+    
+    /**
+     * Per https://jakarta.ee/specifications/security/3.0/jakarta-security-spec-3.0.html#caller-name-and-groups, the following
+     * logic is used to determine the value of the Caller Name and Caller Groups:
+     * <ul>
+     * <li>If the specified claim exists and has a non-empty value in the Access Token, this Access Token claim value is taken.
+     * <li>If not resolved yet, and the specified claim exists and has a non-empty value in the Identity Token, this Identity Token claim value is taken.
+     * <li>If not resolved yet, and the specified claim exists and has a non-empty value in the User Info Token, this User Info Token claim value is taken.
+     * </ul>
+     */
+    <T> T getClaimValueFromTokens(String claim, AccessToken accessToken, JwtClaims idTokenClaims, Class<T> claimType) throws MalformedClaimException {
+        T claimValue = getClaimFromAccessToken(accessToken, claim);
+        if (valueExistsAndIsNotEmpty(claimValue, claimType)) {
+            return claimValue;
+        }
+        claimValue = getClaimFromIdToken(idTokenClaims, claim, claimType);
+        if (valueExistsAndIsNotEmpty(claimValue, claimType)) {
+            return claimValue;
+        }
+        // TODO - get claimValue from User Info
+        return null;
+    }
+    
+    @SuppressWarnings("unchecked")
+    <T> T getClaimFromAccessToken(AccessToken accessToken, String claim) {
+        if (accessToken.isJWT()) {
+            return (T) accessToken.getClaim(claim);
+        }
+        return null;
+    }
+
+    <T> T getClaimFromIdToken(JwtClaims idTokenClaims, String claim, Class<T> claimType) throws MalformedClaimException {
+        return idTokenClaims.getClaimValue(claim, claimType);
+    }
+
+    @SuppressWarnings("rawtypes")
+    <T> boolean valueExistsAndIsNotEmpty(T claimValue, Class<T> claimType) {
+        if (claimValue == null) {
+            return false;
+        }
+        if (claimType.equals(String.class) && ((String) claimValue).isEmpty()) {
+            return false;
+        }
+        if (claimType.equals(Set.class) && ((Set) claimValue).isEmpty()) {
+            return false;
+        }
+        return true;
     }
 
 }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/identitystore/OidcIdentityStoreTest.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/identitystore/OidcIdentityStoreTest.java
@@ -16,6 +16,8 @@ import static org.junit.Assert.assertNull;
 import java.util.Set;
 
 import org.jmock.Expectations;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.MalformedClaimException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -27,6 +29,7 @@ import com.ibm.ws.security.test.common.CommonTestClass;
 import io.openliberty.security.oidcclientcore.client.ClaimsMappingConfig;
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 import io.openliberty.security.oidcclientcore.token.TokenResponse;
+import jakarta.security.enterprise.identitystore.openid.AccessToken;
 import test.common.SharedOutputManager;
 
 public class OidcIdentityStoreTest extends CommonTestClass {
@@ -36,6 +39,8 @@ public class OidcIdentityStoreTest extends CommonTestClass {
     private final OidcClientConfig config = mockery.mock(OidcClientConfig.class);
     private final ClaimsMappingConfig claimsMappingConfig = mockery.mock(ClaimsMappingConfig.class);
     private final TokenResponse tokenResponse = mockery.mock(TokenResponse.class);
+    private final AccessToken accessToken = mockery.mock(AccessToken.class);
+    private final JwtClaims idTokenClaims = mockery.mock(JwtClaims.class);
 
     private OidcIdentityStore identityStore;
 
@@ -63,28 +68,28 @@ public class OidcIdentityStoreTest extends CommonTestClass {
     // TODO - createSuccessfulCredentialValidationResult
 
     @Test
-    public void test_getCallerName_noClaimsMapping() {
+    public void test_getCallerName_noClaimsMapping() throws MalformedClaimException {
         mockery.checking(new Expectations() {
             {
                 one(config).getClaimsMappingConfig();
                 will(returnValue(null));
             }
         });
-        String result = identityStore.getCallerName(config, tokenResponse);
+        String result = identityStore.getCallerName(config, accessToken, idTokenClaims);
         assertNull("Result should have been null but was [" + result + "].", result);
     }
 
     // TODO - getCallerName
 
     @Test
-    public void test_getCallerGroups_noClaimsMapping() {
+    public void test_getCallerGroups_noClaimsMapping() throws MalformedClaimException {
         mockery.checking(new Expectations() {
             {
                 one(config).getClaimsMappingConfig();
                 will(returnValue(null));
             }
         });
-        Set<String> result = identityStore.getCallerGroups(config, tokenResponse);
+        Set<String> result = identityStore.getCallerGroups(config, accessToken, idTokenClaims);
         assertNull("Result should have been null but was [" + result + "].", result);
     }
 
@@ -171,5 +176,11 @@ public class OidcIdentityStoreTest extends CommonTestClass {
         String result = identityStore.getCallerGroupsClaim(config);
         assertEquals(claim, result);
     }
+    
+
+    // TODO - getClaimValueFromTokens
+    // TODO - getClaimFromAccessToken
+    // TODO - getClaimFromIdToken
+    // TODO - valueExistsAndIsNotEmpty
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationRequest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationRequest.java
@@ -20,7 +20,6 @@ import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
 import io.openliberty.security.oidcclientcore.http.EndpointRequest;
 import io.openliberty.security.oidcclientcore.storage.OidcClientStorageConstants;
 import io.openliberty.security.oidcclientcore.storage.OidcStorageUtils;
-import io.openliberty.security.oidcclientcore.storage.Storage;
 import io.openliberty.security.oidcclientcore.storage.StorageProperties;
 
 public abstract class AuthorizationRequest extends EndpointRequest {
@@ -29,7 +28,6 @@ public abstract class AuthorizationRequest extends EndpointRequest {
     protected HttpServletResponse response;
     protected String clientId;
 
-    protected Storage storage;
 
     protected AuthorizationRequestUtils requestUtils = new AuthorizationRequestUtils();
     protected OidcStorageUtils storageUtils = new OidcStorageUtils();

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationRequest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationRequest.java
@@ -20,6 +20,7 @@ import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
 import io.openliberty.security.oidcclientcore.http.EndpointRequest;
 import io.openliberty.security.oidcclientcore.storage.OidcClientStorageConstants;
 import io.openliberty.security.oidcclientcore.storage.OidcStorageUtils;
+import io.openliberty.security.oidcclientcore.storage.Storage;
 import io.openliberty.security.oidcclientcore.storage.StorageProperties;
 
 public abstract class AuthorizationRequest extends EndpointRequest {
@@ -27,6 +28,7 @@ public abstract class AuthorizationRequest extends EndpointRequest {
     protected HttpServletRequest request;
     protected HttpServletResponse response;
     protected String clientId;
+    protected Storage storage;
 
 
     protected AuthorizationRequestUtils requestUtils = new AuthorizationRequestUtils();

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequest.java
@@ -28,24 +28,17 @@ import io.openliberty.security.oidcclientcore.client.OidcProviderMetadata;
 import io.openliberty.security.oidcclientcore.discovery.OidcDiscoveryConstants;
 import io.openliberty.security.oidcclientcore.exceptions.OidcClientConfigurationException;
 import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
-import io.openliberty.security.oidcclientcore.storage.CookieBasedStorage;
 import io.openliberty.security.oidcclientcore.storage.CookieStorageProperties;
 import io.openliberty.security.oidcclientcore.storage.OidcStorageUtils;
-import io.openliberty.security.oidcclientcore.storage.SessionBasedStorage;
 import io.openliberty.security.oidcclientcore.storage.StorageProperties;
 
 public class JakartaOidcAuthorizationRequest extends AuthorizationRequest {
 
     public static final TraceComponent tc = Tr.register(JakartaOidcAuthorizationRequest.class);
 
-    private enum StorageType {
-        COOKIE, SESSION
-    }
-
     private OidcClientConfig config = null;
     private OidcProviderMetadata providerMetadata = null;
 
-    private StorageType storageType;
 
     protected AuthorizationRequestUtils requestUtils = new AuthorizationRequestUtils();
 
@@ -53,17 +46,7 @@ public class JakartaOidcAuthorizationRequest extends AuthorizationRequest {
         super(request, response, config.getClientId());
         this.config = config;
         this.providerMetadata = (config == null) ? null : config.getProviderMetadata();
-        instantiateStorage(config);
-    }
-
-    private void instantiateStorage(OidcClientConfig config) {
-        if (config.isUseSession()) {
-            this.storage = new SessionBasedStorage(request);
-            this.storageType = StorageType.SESSION;
-        } else {
-            this.storage = new CookieBasedStorage(request, response);
-            this.storageType = StorageType.COOKIE;
-        }
+        instantiateStorage(config, request, response);
     }
 
     @Override

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequest.java
@@ -28,16 +28,22 @@ import io.openliberty.security.oidcclientcore.client.OidcProviderMetadata;
 import io.openliberty.security.oidcclientcore.discovery.OidcDiscoveryConstants;
 import io.openliberty.security.oidcclientcore.exceptions.OidcClientConfigurationException;
 import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
+import io.openliberty.security.oidcclientcore.storage.CookieBasedStorage;
 import io.openliberty.security.oidcclientcore.storage.CookieStorageProperties;
 import io.openliberty.security.oidcclientcore.storage.OidcStorageUtils;
+import io.openliberty.security.oidcclientcore.storage.SessionBasedStorage;
 import io.openliberty.security.oidcclientcore.storage.StorageProperties;
 
 public class JakartaOidcAuthorizationRequest extends AuthorizationRequest {
 
     public static final TraceComponent tc = Tr.register(JakartaOidcAuthorizationRequest.class);
 
+    private enum StorageType {
+        COOKIE, SESSION
+    }
     private OidcClientConfig config = null;
     private OidcProviderMetadata providerMetadata = null;
+    private StorageType storageType;
 
 
     protected AuthorizationRequestUtils requestUtils = new AuthorizationRequestUtils();
@@ -46,7 +52,17 @@ public class JakartaOidcAuthorizationRequest extends AuthorizationRequest {
         super(request, response, config.getClientId());
         this.config = config;
         this.providerMetadata = (config == null) ? null : config.getProviderMetadata();
-        instantiateStorage(config, request, response);
+        instantiateStorage(config);
+    }
+    
+    private void instantiateStorage(OidcClientConfig config) {
+        if (config.isUseSession()) {
+            this.storage = new SessionBasedStorage(request);
+            this.storageType = StorageType.SESSION;
+        } else {
+            this.storage = new CookieBasedStorage(request, response);
+            this.storageType = StorageType.COOKIE;
+        }
     }
 
     @Override

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/client/Client.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/client/Client.java
@@ -13,6 +13,7 @@ package io.openliberty.security.oidcclientcore.client;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.ibm.ws.security.common.jwk.impl.JWKSet;
 import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 
 import io.openliberty.security.oidcclientcore.authentication.AbstractFlow;
@@ -26,6 +27,9 @@ import io.openliberty.security.oidcclientcore.token.TokenValidationException;
 public class Client {
 
     private final OidcClientConfig oidcClientConfig;
+    private static JWKSet jwkSet = null;
+    HttpServletRequest request;
+    HttpServletResponse response;
 
     public Client(OidcClientConfig oidcClientConfig) {
         this.oidcClientConfig = oidcClientConfig;
@@ -41,13 +45,24 @@ public class Client {
     }
 
     public ProviderAuthenticationResult continueFlow(HttpServletRequest request, HttpServletResponse response) throws AuthenticationResponseException, TokenRequestException {
+        this.request = request;
+        this.response = response;
         Flow flow = AbstractFlow.getInstance(oidcClientConfig);
         return flow.continueFlow(request, response);
     }
 
     public void validate(TokenResponse tokenResponse) throws TokenValidationException {
         TokenResponseValidator tokenResponseValidator = new TokenResponseValidator(this.oidcClientConfig);
+        tokenResponseValidator.setRequest(this.request);
+        tokenResponseValidator.setResponse(this.response);
+        tokenResponseValidator.setJwkSet(getJwkSet());
         tokenResponseValidator.validate(tokenResponse);
+    }
+    public JWKSet getJwkSet() {
+        if (jwkSet == null) { 
+            jwkSet = new JWKSet();
+        }
+        return jwkSet;
     }
 
     public void logout() {

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/client/Client.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/client/Client.java
@@ -28,8 +28,6 @@ public class Client {
 
     private final OidcClientConfig oidcClientConfig;
     private static JWKSet jwkSet = null;
-    HttpServletRequest request;
-    HttpServletResponse response;
 
     public Client(OidcClientConfig oidcClientConfig) {
         this.oidcClientConfig = oidcClientConfig;
@@ -45,16 +43,14 @@ public class Client {
     }
 
     public ProviderAuthenticationResult continueFlow(HttpServletRequest request, HttpServletResponse response) throws AuthenticationResponseException, TokenRequestException {
-        this.request = request;
-        this.response = response;
         Flow flow = AbstractFlow.getInstance(oidcClientConfig);
         return flow.continueFlow(request, response);
     }
 
-    public void validate(TokenResponse tokenResponse) throws TokenValidationException {
+    public void validate(TokenResponse tokenResponse, HttpServletRequest request, HttpServletResponse response) throws TokenValidationException {
         TokenResponseValidator tokenResponseValidator = new TokenResponseValidator(this.oidcClientConfig);
-        tokenResponseValidator.setRequest(this.request);
-        tokenResponseValidator.setResponse(this.response);
+        tokenResponseValidator.setRequest(request);
+        tokenResponseValidator.setResponse(response);
         tokenResponseValidator.setJwkSet(getJwkSet());
         tokenResponseValidator.validate(tokenResponse);
     }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/client/Client.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/client/Client.java
@@ -12,7 +12,7 @@ package io.openliberty.security.oidcclientcore.client;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
+import org.jose4j.jwt.JwtClaims;
 import com.ibm.ws.security.common.jwk.impl.JWKSet;
 import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 
@@ -47,12 +47,12 @@ public class Client {
         return flow.continueFlow(request, response);
     }
 
-    public void validate(TokenResponse tokenResponse, HttpServletRequest request, HttpServletResponse response) throws TokenValidationException {
+    public JwtClaims validate(TokenResponse tokenResponse, HttpServletRequest request, HttpServletResponse response) throws TokenValidationException {
         TokenResponseValidator tokenResponseValidator = new TokenResponseValidator(this.oidcClientConfig);
         tokenResponseValidator.setRequest(request);
         tokenResponseValidator.setResponse(response);
         tokenResponseValidator.setJwkSet(getJwkSet());
-        tokenResponseValidator.validate(tokenResponse);
+        return tokenResponseValidator.validate(tokenResponse);
     }
     public JWKSet getJwkSet() {
         if (jwkSet == null) { 

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/http/EndpointRequest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/http/EndpointRequest.java
@@ -11,8 +11,6 @@
 package io.openliberty.security.oidcclientcore.http;
 
 import javax.net.ssl.SSLSocketFactory;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -29,20 +27,12 @@ import io.openliberty.security.oidcclientcore.discovery.DiscoveryHandler;
 import io.openliberty.security.oidcclientcore.discovery.OidcDiscoveryConstants;
 import io.openliberty.security.oidcclientcore.exceptions.OidcClientConfigurationException;
 import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
-import io.openliberty.security.oidcclientcore.storage.CookieBasedStorage;
-import io.openliberty.security.oidcclientcore.storage.SessionBasedStorage;
-import io.openliberty.security.oidcclientcore.storage.Storage;
+
 
 @Component(service = EndpointRequest.class, immediate = true, configurationPolicy = ConfigurationPolicy.IGNORE)
 public class EndpointRequest {
 
     public static final TraceComponent tc = Tr.register(EndpointRequest.class);
-    protected String state;
-    protected Storage storage;
-    protected enum StorageType {
-        COOKIE, SESSION
-    }
-    protected StorageType storageType;
     private static final String KEY_SSL_SUPPORT = "sslSupport";
     private static volatile SSLSupport sslSupport;
 
@@ -60,20 +50,6 @@ public class EndpointRequest {
             return sslSupport.getSSLSocketFactory();
         }
         return null;
-    }
-    
-    public void instantiateStorage(OidcClientConfig config, HttpServletRequest request, HttpServletResponse response) {
-        if (config.isUseSession()) {
-            this.storage = new SessionBasedStorage(request);
-            this.storageType = StorageType.SESSION;
-        } else {
-            this.storage = new CookieBasedStorage(request, response);
-            this.storageType = StorageType.COOKIE;
-        }
-    }
-
-    public Storage getStorage() {
-        return this.storage;
     }
 
     public DiscoveryHandler getDiscoveryHandler() {

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/http/EndpointRequest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/http/EndpointRequest.java
@@ -11,6 +11,8 @@
 package io.openliberty.security.oidcclientcore.http;
 
 import javax.net.ssl.SSLSocketFactory;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -27,12 +29,20 @@ import io.openliberty.security.oidcclientcore.discovery.DiscoveryHandler;
 import io.openliberty.security.oidcclientcore.discovery.OidcDiscoveryConstants;
 import io.openliberty.security.oidcclientcore.exceptions.OidcClientConfigurationException;
 import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
+import io.openliberty.security.oidcclientcore.storage.CookieBasedStorage;
+import io.openliberty.security.oidcclientcore.storage.SessionBasedStorage;
+import io.openliberty.security.oidcclientcore.storage.Storage;
 
 @Component(service = EndpointRequest.class, immediate = true, configurationPolicy = ConfigurationPolicy.IGNORE)
 public class EndpointRequest {
 
     public static final TraceComponent tc = Tr.register(EndpointRequest.class);
-
+    protected String state;
+    protected Storage storage;
+    protected enum StorageType {
+        COOKIE, SESSION
+    }
+    protected StorageType storageType;
     private static final String KEY_SSL_SUPPORT = "sslSupport";
     private static volatile SSLSupport sslSupport;
 
@@ -50,6 +60,20 @@ public class EndpointRequest {
             return sslSupport.getSSLSocketFactory();
         }
         return null;
+    }
+    
+    public void instantiateStorage(OidcClientConfig config, HttpServletRequest request, HttpServletResponse response) {
+        if (config.isUseSession()) {
+            this.storage = new SessionBasedStorage(request);
+            this.storageType = StorageType.SESSION;
+        } else {
+            this.storage = new CookieBasedStorage(request, response);
+            this.storageType = StorageType.COOKIE;
+        }
+    }
+
+    public Storage getStorage() {
+        return this.storage;
     }
 
     public DiscoveryHandler getDiscoveryHandler() {

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/IdTokenValidator.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/IdTokenValidator.java
@@ -10,14 +10,20 @@
  *******************************************************************************/
 package io.openliberty.security.oidcclientcore.token;
 
+import com.ibm.websphere.ras.annotation.Sensitive;
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
+import io.openliberty.security.oidcclientcore.storage.OidcStorageUtils;
+import io.openliberty.security.oidcclientcore.storage.Storage;
 
 /**
  *
  */
 public class IdTokenValidator extends TokenValidator {
     
-    String nonce;
+    private String nonce;
+    private String state;
+    private Storage storage;
+    private String secret;
 
     /**
      * @param clientConfig
@@ -30,15 +36,44 @@ public class IdTokenValidator extends TokenValidator {
         this.nonce = nonce;
         return this;
     }
+    
+    /**
+     * @param string
+     */
+    public IdTokenValidator state(String state) {
+        this.state = state;
+        return this;
+    }
+
+    /**
+     * @param storage
+     */
+    public IdTokenValidator storage(Storage storage) {
+        this.storage = storage;
+        return this;
+    }
+
+    /**
+     * @param clientSecret
+     */
+    public IdTokenValidator secret(@Sensitive String clientSecret) {
+        this.secret = clientSecret;
+        return this;   
+    }
 
     @Override
     public void validate() throws TokenValidationException {
         super.validate();
-        validateNonce();
-        
+        validateNonce();  
     }
-    void validateNonce() throws TokenValidationException {
-        // TODO : need access to Storage and state param value to compute nonce
+    protected void validateNonce() throws TokenValidationException {
+        String cookieName = OidcStorageUtils.getNonceStorageKey(this.oidcConfig.getClientId(), state);
+        String cookieValue = OidcStorageUtils.createNonceStorageValue(nonce, state, secret);
+        String storedCookieValue = storage.get(cookieName);
+        storage.remove(cookieName);
+        if (!(cookieValue.equals(storedCookieValue))) {
+            throw new TokenValidationException(this.oidcConfig.getClientId(), "The nonce [ " + this.nonce + " ]" + "in the token does not match the nonce that was specified in the request to the OpenID Connect provider");
+        }
     }
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenResponse.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenResponse.java
@@ -20,31 +20,31 @@ import com.ibm.json.java.JSONObject;
 public class TokenResponse {
 
     private final JSONObject rawResponse;
-    private final String idToken;
-    private final String accessToken;
-    private final String refreshToken;
+    private final String idTokenString;
+    private final String accessTokenString;
+    private final String refreshTokenString;
     private final Instant responseGenerationTime;
 
     private Map<String, String> responseAsMap = null;
 
     public TokenResponse(JSONObject rawResponse, String idToken, String accessToken, String refreshToken) {
         this.rawResponse = rawResponse;
-        this.idToken = idToken;
-        this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
+        this.idTokenString = idToken;
+        this.accessTokenString = accessToken;
+        this.refreshTokenString = refreshToken;
         this.responseGenerationTime = Instant.now();
     }
 
-    public String getIdToken() {
-        return idToken;
+    public String getIdTokenString() {
+        return idTokenString;
     }
 
-    public String getAccessToken() {
-        return accessToken;
+    public String getAccessTokenString() {
+        return accessTokenString;
     }
 
-    public String getRefreshToken() {
-        return refreshToken;
+    public String getRefreshTokenString() {
+        return refreshTokenString;
     }
 
     @SuppressWarnings("unchecked")

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenResponseValidator.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenResponseValidator.java
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package io.openliberty.security.oidcclientcore.token;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.jose4j.jws.JsonWebSignature;
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.MalformedClaimException;
@@ -20,9 +23,14 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferencePolicy;
 
+import com.ibm.json.java.JSONObject;
 import com.ibm.websphere.ras.ProtectedString;
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.security.common.jwk.impl.JWKSet;
 import com.ibm.wsspi.ssl.SSLSupport;
 
+import io.openliberty.security.oidcclientcore.authentication.AuthorizationRequestParameters;
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 import io.openliberty.security.oidcclientcore.http.EndpointRequest;
 import io.openliberty.security.oidcclientcore.utils.CommonJose4jUtils;
@@ -34,16 +42,22 @@ import io.openliberty.security.oidcclientcore.utils.CommonJose4jUtils.TokenSigna
 @Component(service = TokenResponseValidator.class, immediate = true, configurationPolicy = ConfigurationPolicy.IGNORE)
 public class TokenResponseValidator {
 
+    public static final TraceComponent tc = Tr.register(TokenResponseValidator.class);
     private static final String KEY_EP_REQUEST = "endpointRequest";
-    private static volatile EndpointRequest eprequest;
+    public static volatile EndpointRequest eprequest;
     private static final String KEY_SSL_SUPPORT = "sslSupport";
-    private static volatile SSLSupport sslSupport;
+    public static volatile SSLSupport sslSupport;
+    static boolean initialized = false;
 
     OidcClientConfig clientConfig;
     CommonJose4jUtils jose4jutil = new CommonJose4jUtils();
+    JWKSet jwkset;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    JSONObject discoveredProviderMetadata = null;
 
     public TokenResponseValidator() {
-
+        //initialized = true;
     }
 
     /**
@@ -51,7 +65,6 @@ public class TokenResponseValidator {
      */
     public TokenResponseValidator(OidcClientConfig oidcClientConfig) {
         this.clientConfig = oidcClientConfig;
-
     }
     
     @Reference(name = KEY_SSL_SUPPORT, policy = ReferencePolicy.DYNAMIC)
@@ -66,6 +79,7 @@ public class TokenResponseValidator {
     @Reference(name = KEY_EP_REQUEST, policy = ReferencePolicy.DYNAMIC)
     protected void setEndpointRequest(EndpointRequest eprequestService) {
         eprequest = eprequestService;
+        Tr.debug(tc, "AMMII, service = " + eprequest);
     }
 
     protected void unsetEndpointRequest(EndpointRequest eprequestService) {
@@ -94,6 +108,11 @@ public class TokenResponseValidator {
         JwtClaims jwtClaims = null;
         if (jwtcontext != null && jwtcontext.getJwtClaims() != null) {
             jwtClaims = jwtcontext.getJwtClaims();
+            String clientSecret = null;
+            ProtectedString clientSecretProtectedString = clientConfig.getClientSecret();
+            if (clientSecretProtectedString != null) {
+                clientSecret = new String(clientSecretProtectedString.getChars());
+            }
             // must have claims - iat and exp
             try {
                 if (jwtClaims.getIssuedAt() == null) {
@@ -101,11 +120,24 @@ public class TokenResponseValidator {
                 }
                 if (jwtClaims.getExpirationTime() == null) {
                     throw new TokenValidationException(this.clientConfig.getClientId(), "token is missing required exp claim");
-                }
+                }           
                 TokenValidator tokenValidator = new IdTokenValidator(clientConfig);
+                if ((clientConfig.getProviderMetadata().getIssuer() == null ||  clientConfig.getProviderMetadata().getIssuer().isEmpty())
+                                && (clientConfig.getProviderMetadata().getTokenEndpoint() == null || clientConfig.getProviderMetadata().getTokenEndpoint().isEmpty())) {
+                    this.discoveredProviderMetadata = getProviderDiscoveryMetadadata();//eprequest.getProviderDiscoveryMetadata(clientConfig);
+                    if (discoveredProviderMetadata != null) {
+                        tokenValidator.issuerfromdiscovery(((String)discoveredProviderMetadata.get("issuer")));
+                        tokenValidator.tokenepfromdiscovery(((String)discoveredProviderMetadata.get("token_endpoint")));
+                    }
+                        //TODO : throw TokenValidationException if we don't have valid discovered data
+                }
                 tokenValidator.issuer(jwtClaims.getIssuer()).subject(jwtClaims.getSubject()).audiences(jwtClaims.getAudience()).azp(((String) jwtClaims.getClaimValue("azp"))).iat(jwtClaims.getIssuedAt()).exp(jwtClaims.getExpirationTime()).nbf(jwtClaims.getNotBefore());
-                if (jwtClaims.hasClaim("nonce")) {
+                if (jwtClaims.hasClaim("nonce")) {  
                     ((IdTokenValidator) tokenValidator).nonce(((String) jwtClaims.getClaimValue("nonce")));
+                    ((IdTokenValidator) tokenValidator).state(getStateParameter());
+                    ((IdTokenValidator) tokenValidator).secret(clientSecret);
+                    eprequest.instantiateStorage(clientConfig, request, response);
+                    ((IdTokenValidator) tokenValidator).storage(eprequest.getStorage());
                     ((IdTokenValidator) tokenValidator).validate();
                 } else {
                     tokenValidator.validate();
@@ -114,30 +146,71 @@ public class TokenResponseValidator {
                 throw new TokenValidationException(this.clientConfig.getClientId(), e.getMessage());
             }
 
-        }
-        
-        try {
-            JsonWebStructure jsonStruct = jose4jutil.getJsonWebStructureFromJwtContext(jwtcontext);
-            if (jsonStruct == null || !(jsonStruct instanceof JsonWebSignature)) {
-                throw new TokenValidationException(this.clientConfig.getClientId(),"jsonwebsignature error");
+            try {
+                JsonWebStructure jsonStruct = jose4jutil.getJsonWebStructureFromJwtContext(jwtcontext);
+                if (jsonStruct == null || !(jsonStruct instanceof JsonWebSignature)) {
+                    throw new TokenValidationException(this.clientConfig.getClientId(), "jsonwebsignature error");
+                }
+                TokenSignatureValidationBuilder tokenSignatureValidationBuilder = jose4jutil.signaturevalidationbuilder();
+                String jwkuri = getJwkUri();
+                tokenSignatureValidationBuilder.signature(jsonStruct).sslsupport(sslSupport).issuer(TokenValidator.getIssuer(clientConfig)).jwkuri(jwkuri)
+                                .clientid(clientConfig.getClientId());
+
+                tokenSignatureValidationBuilder.clientsecret(clientSecret);
+                tokenSignatureValidationBuilder.jwkset(jwkset);
+                tokenSignatureValidationBuilder.parseJwtWithValidation(idtoken);
+            } catch (Exception e) {
+                throw new TokenValidationException(this.clientConfig.getClientId(), e.getMessage());
             }
-            TokenSignatureValidationBuilder tokenSignatureValidationBuilder = jose4jutil.signaturevalidationbuilder();
-                 
-            tokenSignatureValidationBuilder.signature(jsonStruct)
-                                           .sslsupport(sslSupport)
-                                           .issuer(TokenValidator.getIssuer(clientConfig))
-                                           .jwkuri(clientConfig.getProviderMetadata().getJwksURI()) //TODO : use discover data if needed
-                                           .clientid(clientConfig.getClientId());
-            String clientSecret = null;
-            ProtectedString clientSecretProtectedString = clientConfig.getClientSecret();
-            if (clientSecretProtectedString != null) {
-                clientSecret = new String(clientSecretProtectedString.getChars());
-            }
-            tokenSignatureValidationBuilder.clientsecret(clientSecret);
-            tokenSignatureValidationBuilder.parseJwtWithValidation(idtoken);
-        }catch (Exception e) {
-            throw new TokenValidationException(this.clientConfig.getClientId(), e.getMessage());
         }
+    }
+
+    /**
+     * @return
+     */
+    private JSONObject getProviderDiscoveryMetadadata() {
+        if (this.discoveredProviderMetadata == null) {
+            this.discoveredProviderMetadata = eprequest.getProviderDiscoveryMetadata(clientConfig);
+        }
+        return this.discoveredProviderMetadata;
+    }
+
+    /**
+     * @return
+     */
+    private String getJwkUri() {
+        String jwkuri = null;
+        jwkuri = clientConfig.getProviderMetadata().getJwksURI();
+        if ((jwkuri == null || jwkuri.isEmpty()) && getProviderDiscoveryMetadadata() != null) {
+            jwkuri = (String)(this.discoveredProviderMetadata.get("jwks_uri"));
+        }
+        return jwkuri;
+    }
+
+    public String getStateParameter() {
+        return request.getParameter(AuthorizationRequestParameters.STATE);
+      //TODO: maybe throw an exception right here if this state is not valid
+    }
+
+    /**
+     * @param jwkSet
+     */
+    public void setJwkSet(JWKSet jwkSet) {
+        this.jwkset = jwkSet;    
+    }
+
+    /**
+     * @param request
+     */
+    public void setRequest(HttpServletRequest request) {
+        this.request = request;       
+    }
+
+    /**
+     * @param response
+     */
+    public void setResponse(HttpServletResponse response) {
+        this.response = response;        
     }
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenResponseValidator.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenResponseValidator.java
@@ -104,11 +104,11 @@ public class TokenResponseValidator {
     /**
      * @param tokenResponse
      */
-    public void validate(TokenResponse tokenResponse) throws TokenValidationException {
+    public JwtClaims validate(TokenResponse tokenResponse) throws TokenValidationException {
         String idtoken = null;
 
         if (tokenResponse != null) {
-            idtoken = tokenResponse.getIdToken();
+            idtoken = tokenResponse.getIdTokenString();
         }
 
         JwtContext jwtcontext = null;
@@ -173,11 +173,12 @@ public class TokenResponseValidator {
 
                 tokenSignatureValidationBuilder.clientsecret(clientSecret);
                 tokenSignatureValidationBuilder.jwkset(jwkset);
-                tokenSignatureValidationBuilder.parseJwtWithValidation(idtoken);
+                return tokenSignatureValidationBuilder.parseJwtWithValidation(idtoken);
             } catch (Exception e) {
                 throw new TokenValidationException(this.clientConfig.getClientId(), e.getMessage());
             }
         }
+        throw new TokenValidationException(this.clientConfig.getClientId(), "not a valid token to continue the flow");
     }
 
     /**

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenValidator.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenValidator.java
@@ -10,12 +10,10 @@
  *******************************************************************************/
 package io.openliberty.security.oidcclientcore.token;
 
+import java.util.ArrayList;
 import java.util.List;
 
-
 import org.jose4j.jwt.NumericDate;
-
-import com.ibm.websphere.ras.Tr;
 
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 
@@ -25,16 +23,17 @@ import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 public class TokenValidator {
 
     private String issuer;
+    private String issuerfromdiscovery;
+    private static String tokenepfromdiscovery;
     private String subject = null;
     private List<String> audiences;
     private String azp = null;
     private NumericDate iat;
     private NumericDate exp;
     private NumericDate notBefore = null;
-    private OidcClientConfig oidcConfig;
-    
-    private long clockSkewInSeconds = 120; // default value in seconds
-    
+    protected OidcClientConfig oidcConfig;
+
+    private final long clockSkewInSeconds = 120; // default value in seconds
 
     /**
      * @param clientConfig
@@ -48,7 +47,7 @@ public class TokenValidator {
      * @return
      */
     public TokenValidator issuer(String issuer) {
-        this.issuer= issuer;
+        this.issuer = issuer;
         return this;
     }
 
@@ -64,7 +63,7 @@ public class TokenValidator {
      * @param audience
      */
     public TokenValidator audiences(List<String> audience) {
-        this.audiences = audiences;
+        this.audiences = new ArrayList<String>(audience);
         return this;
     }
 
@@ -73,7 +72,7 @@ public class TokenValidator {
      */
     public TokenValidator azp(String azp) {
         this.azp = azp;
-        return this;     
+        return this;
     }
 
     /**
@@ -86,7 +85,7 @@ public class TokenValidator {
 
     /**
      * @param expirationTime
-     * @return 
+     * @return
      */
     public TokenValidator exp(NumericDate exp) {
         this.exp = exp;
@@ -95,7 +94,7 @@ public class TokenValidator {
 
     /**
      * @param notBefore
-     * @return 
+     * @return
      */
     public TokenValidator nbf(NumericDate notBefore) {
         this.notBefore = notBefore;
@@ -103,7 +102,7 @@ public class TokenValidator {
     }
 
     /**
-     * 
+     *
      */
     public void validate() throws TokenValidationException {
         validateIssuer();
@@ -113,11 +112,11 @@ public class TokenValidator {
         validateExpiration();
         validateIssuedAt();
         validateNotBefore();
-        
+
     }
 
     /**
-     * 
+     *
      */
     protected void validateNotBefore() throws TokenValidationException {
         if (this.notBefore != null) {
@@ -125,11 +124,11 @@ public class TokenValidator {
             if (now + (this.clockSkewInSeconds * 1000) < this.iat.getValueInMillis()) {
                 throw new TokenValidationException(oidcConfig.getClientId(), "nbf claim must be in past");
             }
-        } 
+        }
     }
 
     /**
-     * 
+     *
      */
     protected void validateIssuedAt() throws TokenValidationException {
         long now = System.currentTimeMillis();
@@ -139,30 +138,30 @@ public class TokenValidator {
     }
 
     /**
-     * @throws TokenValidationException 
-     * 
+     * @throws TokenValidationException
+     *
      */
     protected void validateExpiration() throws TokenValidationException {
         long now = System.currentTimeMillis();
         if (now - (this.clockSkewInSeconds * 1000) > this.exp.getValueInMillis()) {
             throw new TokenValidationException(oidcConfig.getClientId(), "exp claim must be in future");
-        }        
+        }
     }
 
     /**
-     * 
+     *
      */
     protected void validateAZP() throws TokenValidationException {
         if (this.azp != null) {
             if (!(oidcConfig.getClientId().equals(this.azp))) {
                 throw new TokenValidationException(oidcConfig.getClientId(), "azp is [ " + this.azp + " ], expecting  [ " + oidcConfig.getClientId() + " ]");
             }
-        } 
+        }
     }
 
     /**
-     * @throws TokenValidationException 
-     * 
+     * @throws TokenValidationException
+     *
      */
     protected void validateAudiences() throws TokenValidationException {
         if (this.audiences != null && !(this.audiences.isEmpty())) {
@@ -172,36 +171,36 @@ public class TokenValidator {
                     throw new TokenValidationException(oidcConfig.getClientId(), "audience is [ " + this.audiences.get(0) + " ], expecting [ " + oidcConfig.getClientId() + " ]");
                 }
             } else if (this.azp == null) {
-                // if more than one audience, then azp claim is a must     
-                throw new TokenValidationException(oidcConfig.getClientId(), "multiple audiences present [ " + this.audiences(audiences).toString() + " ], but required azp claim is missing");
+                // if more than one audience, then azp claim is a must
+                throw new TokenValidationException(oidcConfig.getClientId(), "multiple audiences present [ " + this.audiences(audiences).toString()
+                                                                             + " ], but required azp claim is missing");
             }
-        }  
+        }
     }
 
     /**
-     * @throws TokenValidationException 
-     * 
+     * @throws TokenValidationException
+     *
      */
     protected void validateSubject() throws TokenValidationException {
         if (this.subject != null) {
             if (this.subject.isEmpty()) {
                 throw new TokenValidationException(oidcConfig.getClientId(), "subject claim is present but empty");
             }
-        }      
+        }
     }
-
 
     /**
-     * @throws TokenValidationException 
-     * 
+     * @throws TokenValidationException
+     *
      */
     protected void validateIssuer() throws TokenValidationException {
-        String iss = getIssuer(oidcConfig);//oidcConfig.getProviderMetadata().getIssuer();        
-        if (!iss.equals(this.issuer)) {           
+        String iss = getIssuer(oidcConfig);//oidcConfig.getProviderMetadata().getIssuer();
+        if (!iss.equals(this.issuer)) {
             throw new TokenValidationException(oidcConfig.getClientId(), "issuer is [ " + this.issuer + " ], expecting  [ " + oidcConfig.getProviderMetadata().getIssuer() + " ]");
-        }       
+        }
     }
-    
+
     public static String getIssuer(OidcClientConfig clientConfig) {
         String issuer = null;
         issuer = clientConfig.getProviderMetadata().getIssuer();
@@ -211,13 +210,15 @@ public class TokenValidator {
                 return issuer;
             }
         }
-        //TODO : try discovery data?       
         return issuer;
     }
 
     static String getIssuerFromTokenEndpoint(OidcClientConfig clientConfig) {
         String issuer = null;
         String tokenEndpoint = clientConfig.getProviderMetadata().getTokenEndpoint();
+        if (tokenEndpoint == null) {
+            tokenEndpoint = getTokenepFromDiscovery();
+        }
         if (tokenEndpoint != null) {
             int endOfSchemeIndex = tokenEndpoint.indexOf("//");
             int lastSlashIndex = tokenEndpoint.lastIndexOf("/");
@@ -228,8 +229,32 @@ public class TokenValidator {
             } else {
                 issuer = tokenEndpoint.substring(0, lastSlashIndex);
             }
-        }       
+        }
         return issuer;
     }
 
+    /**
+     * @return
+     */
+    static String getTokenepFromDiscovery() {
+        return tokenepfromdiscovery;
+    }
+
+    /**
+     * @param issuerFromDiscovery
+     * @return
+     */
+    public TokenValidator issuerfromdiscovery(String issuerFromDiscovery) {
+        this.issuerfromdiscovery = issuerFromDiscovery;
+        return this;
+    }
+
+    /**
+     * @param tokenepFromDiscovery
+     * @return
+     */
+    public TokenValidator tokenepfromdiscovery(String tokenepFromDiscovery) {
+        this.tokenepfromdiscovery = tokenepFromDiscovery;
+        return this;
+    }
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/utils/CommonJose4jUtils.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/utils/CommonJose4jUtils.java
@@ -85,7 +85,7 @@ public class CommonJose4jUtils {
         private String jwkuri;
         private String clientid;
         private String clientsecret;
-        JWKSet jwkset = new JWKSet(); // TODO: this should be per Client?
+        private JWKSet jwkset;
         private String issuer;
 
         private TokenSignatureValidationBuilder() {
@@ -140,6 +140,15 @@ public class CommonJose4jUtils {
             this.issuer = issuer;
             return this;
         }
+        
+
+        /**
+         * @param jwkset
+         */
+        public TokenSignatureValidationBuilder jwkset(JWKSet jwkset) {
+           this.jwkset = jwkset;
+           return this; 
+        }
 
         /**
          * @return
@@ -150,11 +159,11 @@ public class CommonJose4jUtils {
          * @throws KeyStoreException
          */
         public Key getVerificationKey() throws KeyStoreException, PrivilegedActionException, IOException, InterruptedException, Exception {
-            String kid = this.signature.getKeyIdHeaderValue();
-            String x5t = this.signature.getX509CertSha1ThumbprintHeaderValue();
             if (getSignatureAlgorithm() != null && getSignatureAlgorithm().startsWith("HS")) {
                 return new HmacKey(clientsecret.getBytes("UTF-8"));
             }
+            String kid = this.signature.getKeyIdHeaderValue();
+            String x5t = this.signature.getX509CertSha1ThumbprintHeaderValue();
             return createJwkRetriever().getPublicKeyFromJwk(kid, x5t, "sig", false);
         }
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/token/TokenRequestorTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/token/TokenRequestorTest.java
@@ -111,9 +111,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         TokenResponse tokenResponse = tokenRequestor.requestTokens();
 
-        assertEquals(accessToken, tokenResponse.getAccessToken());
-        assertEquals(refreshToken, tokenResponse.getRefreshToken());
-        assertEquals(idToken, tokenResponse.getIdToken());
+        assertEquals(accessToken, tokenResponse.getAccessTokenString());
+        assertEquals(refreshToken, tokenResponse.getRefreshTokenString());
+        assertEquals(idToken, tokenResponse.getIdTokenString());
         assertNotNull("The token response generation time must be set.", tokenResponse.getResponseGenerationTime());
     }
 
@@ -134,9 +134,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         TokenResponse tokenResponse = tokenRequestor.requestTokens();
 
-        assertEquals(accessToken, tokenResponse.getAccessToken());
-        assertEquals(refreshToken, tokenResponse.getRefreshToken());
-        assertEquals(idToken, tokenResponse.getIdToken());
+        assertEquals(accessToken, tokenResponse.getAccessTokenString());
+        assertEquals(refreshToken, tokenResponse.getRefreshTokenString());
+        assertEquals(idToken, tokenResponse.getIdTokenString());
     }
 
     @Test
@@ -155,9 +155,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         TokenResponse tokenResponse = tokenRequestor.requestTokens();
 
-        assertEquals(accessToken, tokenResponse.getAccessToken());
-        assertEquals(refreshToken, tokenResponse.getRefreshToken());
-        assertEquals(idToken, tokenResponse.getIdToken());
+        assertEquals(accessToken, tokenResponse.getAccessTokenString());
+        assertEquals(refreshToken, tokenResponse.getRefreshTokenString());
+        assertEquals(idToken, tokenResponse.getIdTokenString());
     }
 
     @Test
@@ -179,9 +179,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         TokenResponse tokenResponse = tokenRequestor.requestTokens();
 
-        assertEquals(accessToken, tokenResponse.getAccessToken());
-        assertEquals(refreshToken, tokenResponse.getRefreshToken());
-        assertEquals(idToken, tokenResponse.getIdToken());
+        assertEquals(accessToken, tokenResponse.getAccessTokenString());
+        assertEquals(refreshToken, tokenResponse.getRefreshTokenString());
+        assertEquals(idToken, tokenResponse.getIdTokenString());
     }
 
     @Test
@@ -207,9 +207,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         TokenResponse tokenResponse = tokenRequestor.requestTokens();
 
-        assertEquals(accessToken, tokenResponse.getAccessToken());
-        assertEquals(refreshToken, tokenResponse.getRefreshToken());
-        assertEquals(idToken, tokenResponse.getIdToken());
+        assertEquals(accessToken, tokenResponse.getAccessTokenString());
+        assertEquals(refreshToken, tokenResponse.getRefreshTokenString());
+        assertEquals(idToken, tokenResponse.getIdTokenString());
     }
 
     @Test
@@ -229,9 +229,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         TokenResponse tokenResponse = tokenRequestor.requestTokens();
 
-        assertEquals(accessToken, tokenResponse.getAccessToken());
-        assertEquals(refreshToken, tokenResponse.getRefreshToken());
-        assertEquals(idToken, tokenResponse.getIdToken());
+        assertEquals(accessToken, tokenResponse.getAccessTokenString());
+        assertEquals(refreshToken, tokenResponse.getRefreshTokenString());
+        assertEquals(idToken, tokenResponse.getIdTokenString());
     }
 
     @Test
@@ -254,9 +254,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         TokenResponse tokenResponse = tokenRequestor.requestTokens();
 
-        assertEquals(accessToken, tokenResponse.getAccessToken());
-        assertEquals(refreshToken, tokenResponse.getRefreshToken());
-        assertEquals(idToken, tokenResponse.getIdToken());
+        assertEquals(accessToken, tokenResponse.getAccessTokenString());
+        assertEquals(refreshToken, tokenResponse.getRefreshTokenString());
+        assertEquals(idToken, tokenResponse.getIdTokenString());
     }
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/token/TokenValidatorTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/token/TokenValidatorTest.java
@@ -97,7 +97,7 @@ public class TokenValidatorTest {
                     will(returnValue(oidcmd));
                     allowing(oidcmd).getIssuer();
                     will(returnValue(iss_from_config));
-                    one(oidcClientConfig).getClientId();
+                    allowing(oidcClientConfig).getClientId();
                     will(returnValue("oidcclientid"));
                 }
             });
@@ -123,7 +123,7 @@ public class TokenValidatorTest {
                     will(returnValue(oidcmd));
                     allowing(oidcmd).getIssuer();
                     will(returnValue(iss_from_config));
-                    one(oidcClientConfig).getClientId();
+                    allowing(oidcClientConfig).getClientId();
                     will(returnValue("oidcclientid"));
                 }
             });
@@ -171,8 +171,8 @@ public class TokenValidatorTest {
                 {
                     allowing(oidcClientConfig).getProviderMetadata();//.getIssuer();
                     will(returnValue(oidcmd));
-                    one(oidcClientConfig).getClientId();
-                    will(returnValue("oidcclientid"));
+                    allowing(oidcClientConfig).getClientId();
+                    will(returnValue("client01"));
                 }
             });
             tokenValidator = tokenValidator.audiences(aud_claim_from_token);
@@ -199,7 +199,7 @@ public class TokenValidatorTest {
                 {
                     allowing(oidcClientConfig).getProviderMetadata();//.getIssuer();
                     will(returnValue(oidcmd));
-                    one(oidcClientConfig).getClientId();
+                    allowing(oidcClientConfig).getClientId();
                     will(returnValue("oidcclientid"));
                 }
             });


### PR DESCRIPTION

-update oidcidentitystore to extract caller name claim and caller group claim(there are default values defined for these in the spec but these can be configured  via OpenIdAuthenticationMechanismDefinition.claimsDefinition.callerNameClaim and OpenIdAuthenticationMechanismDefinition.claimsDefinition.callerGroupsClaim) from the tokens

-update oidcidentitystore to create CredentialValidationResult with that above extracted caller and groups 
