### PR TITLE
Produce and inject openIdContext 

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/bnd.bnd
@@ -29,6 +29,7 @@ Export-Package: \
 Import-Package: \
 	!*.internal.*,\
 	!com.ibm.ws.kernel.boot.cmdline,\
+	javax.security.auth,\
 	!javax.*,\
 	*   
 
@@ -60,7 +61,10 @@ src: src, resources
 	io.openliberty.security.jakartasec.3.0.internal,\
 	io.openliberty.security.oidcclientcore.internal.jakarta,\
 	com.ibm.ws.cdi.interfaces.jakarta;version=latest,\
-	io.openliberty.webcontainer.security.internal;version=latest
+	io.openliberty.webcontainer.security.internal;version=latest,\
+	com.ibm.ws.security.javaeesec.cdi;version=latest,\
+	com.ibm.ws.security;version=latest,\
+	com.ibm.websphere.security;version=latest
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file,\

--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/beans/OpenIdContextBean.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/beans/OpenIdContextBean.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.cdi.beans;
+
+import java.io.Serializable;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.Set;
+
+import javax.security.auth.Subject;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.security.authentication.utility.SubjectHelper;
+import com.ibm.ws.security.context.SubjectManager;
+
+import io.openliberty.security.jakartasec.credential.OidcTokensCredential;
+import io.openliberty.security.jakartasec.identitystore.OpenIdContextImpl;
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.security.enterprise.identitystore.openid.OpenIdContext;
+
+/**
+ * Session scoped bean to fetch the openIdContext from the thread. This can be used by the
+ *
+ * @OpenIdContextProducer to supply @Inject requests for the OpenIdContext.
+ */
+@SessionScoped
+public class OpenIdContextBean implements Serializable {
+
+    private static final long serialVersionUID = 1L; // TODO -- default or custom?? or switch to PassivationCapable instead of Serializable
+
+    private static final TraceComponent tc = Tr.register(OpenIdContextBean.class);
+
+    public OpenIdContext getOpenIdContext() {
+
+        Subject subject = null;
+        OpenIdContext openIdContext = null;
+
+        try {
+            subject = (Subject) java.security.AccessController.doPrivileged(new PrivilegedExceptionAction<Object>() {
+                @Override
+                public Object run() throws Exception {
+                    return new SubjectManager().getCallerSubject();
+                }
+            });
+        } catch (PrivilegedActionException pae) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "getOpenIdContext() Exception caught: " + pae);
+            }
+        }
+
+        SubjectHelper subjectHelper = new SubjectHelper();
+
+        if (subject != null && !subjectHelper.isUnauthenticated(subject)) {
+
+            Set<OidcTokensCredential> oidcTokensCredentialSet = subject.getPrivateCredentials(OidcTokensCredential.class);
+
+            if (oidcTokensCredentialSet == null || oidcTokensCredentialSet.isEmpty()) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "getOpenIdContext() Got an authenticated subject, but did not find an OidcTokensCredential");
+                }
+            } else {
+                if (oidcTokensCredentialSet.size() > 1) {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "getOpenIdContext() Multiple OidcTokensCredentials on the subject!");
+                    }
+                }
+                OidcTokensCredential oidcTokensCredential = oidcTokensCredentialSet.iterator().next();
+                // TODO from oidcTokensCredential get or create an OpenIdContext
+            }
+
+            // TODO returning an empty OpenIdContext temporarily
+            openIdContext = new OpenIdContextImpl();
+        } else if (subject == null) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "getOpenIdContext The subject is null from SubjectManager.getCallerSubject");
+            }
+        } else {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "getOpenIdContext The subject is not null but is unauthentictaed.");
+            }
+        }
+
+        if (openIdContext == null) {
+            // TODO: do we need to log message or throw an exception here or just trace?
+
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "getOpenIdContext() Did not find an openIdContext, returning null");
+            }
+        }
+
+        /*
+         * TODO: Could be returning null here -- do we want to return an empty or dummy openIdContext or stay with null if not found?
+         */
+        return openIdContext;
+    }
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/extensions/JakartaSecurity30CDIExtension.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/extensions/JakartaSecurity30CDIExtension.java
@@ -22,6 +22,7 @@ import org.osgi.service.component.annotations.Reference;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.cdi.CDIServiceUtils;
 import com.ibm.ws.security.javaeesec.cdi.extensions.HttpAuthenticationMechanismsTracker;
 import com.ibm.ws.security.javaeesec.cdi.extensions.PrimarySecurityCDIExtension;
 
@@ -32,6 +33,7 @@ import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
 import jakarta.enterprise.inject.spi.AnnotatedType;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.enterprise.inject.spi.ProcessAnnotatedType;
 import jakarta.enterprise.inject.spi.ProcessBeanAttributes;
@@ -57,6 +59,11 @@ public class JakartaSecurity30CDIExtension implements Extension {
 
     public JakartaSecurity30CDIExtension() {
         applicationName = HttpAuthenticationMechanismsTracker.getApplicationName();
+    }
+
+    public void beforeBeanDiscovery(@Observes BeforeBeanDiscovery bbd, BeanManager bm) {
+        AnnotatedType<OpenIdContextProducer> producer = bm.createAnnotatedType(OpenIdContextProducer.class);
+        bbd.addAnnotatedType(producer, CDIServiceUtils.getAnnotatedTypeIdentifier(producer, this.getClass()));
     }
 
     @SuppressWarnings("static-access")

--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/extensions/OpenIdContextProducer.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/extensions/OpenIdContextProducer.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.cdi.extensions;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+import io.openliberty.security.jakartasec.cdi.beans.OpenIdContextBean;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.identitystore.openid.OpenIdContext;
+
+/**
+ * Produces the OpenIdContext from the CallerSubject for Injection annotations.
+ */
+public class OpenIdContextProducer {
+
+    private static final TraceComponent tc = Tr.register(OpenIdContextProducer.class);
+
+    @Inject
+    OpenIdContextBean openIdContextBean;
+
+    /**
+     * Fetch the OpenIdContext from the @OpenIdContextBean. The OpenIdContext must be SessionScoped we so
+     * need to load it from a bean.
+     *
+     * @param injectionPoint
+     * @return
+     */
+    @Produces
+    @Dependent
+    public OpenIdContext getOpenIdContext(InjectionPoint injectionPoint) {
+
+        if (openIdContextBean == null) {
+            // TODO -- log nls message here or is this impossible?
+
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "openIdContextBean was null, cannot get openIdContext, returning null ");
+            }
+            return null;
+        }
+
+        return openIdContextBean.getOpenIdContext();
+    }
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/bnd.bnd.disabled
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/bnd.bnd.disabled
@@ -35,5 +35,6 @@ javac.target: 11
 	com.ibm.websphere.javaee.cdi.2.0;version=latest,\
 	com.ibm.ws.org.slf4j.api;version=latest,\
 	io.openliberty.jakarta.cdi.4.0;version=latest,\
-	jakarta.inject.jakarta.inject-api;version=latest
+	jakarta.inject.jakarta.inject-api;version=latest, \
+	io.openliberty.security.jakartasec.3.0.internal
 

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/SimplestAnnotated.war/src/oidc/servlets/CallbackServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/SimplestAnnotated.war/src/oidc/servlets/CallbackServlet.java
@@ -12,6 +12,8 @@ package oidc.servlets;
 
 import java.io.IOException;
 
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.identitystore.openid.OpenIdContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.annotation.WebServlet;
@@ -24,14 +26,15 @@ public class CallbackServlet extends HttpServlet {
 
     private static final long serialVersionUID = -417476984908088827L;
 
-//    @Inject
-//    private OpenIdContext context;
+    @Inject
+    private OpenIdContext context;
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
 //        response.getWriter().println(context.getAccessToken());
         ServletOutputStream sos = response.getOutputStream();
         System.out.println("got here");
+        System.out.println("OpenIdContext is " + context);
         sos.println("got here");
     }
 

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/SimplestAnnotated.war/src/oidc/servlets/OidcAnnotatedServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/SimplestAnnotated.war/src/oidc/servlets/OidcAnnotatedServlet.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 
 import jakarta.annotation.security.DeclareRoles;
 import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
 import jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdProviderMetadata;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletOutputStream;
@@ -34,6 +35,7 @@ import jakarta.servlet.http.HttpServletResponse;
                                          clientId = "client_1",
                                          clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
                                          redirectURI = "https://localhost:8940/SimplestAnnotated/Callback",
+                                         claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub"),
                                          providerMetadata = @OpenIdProviderMetadata(
                                                                                     authorizationEndpoint = "https://localhost:8920/oidc/endpoint/OP1/authorize",
                                                                                     tokenEndpoint = "https://localhost:8920/oidc/endpoint/OP1/token"))


### PR DESCRIPTION
Support for issue https://github.com/OpenLiberty/open-liberty/issues/21166

Created an OpenIdContextProducer

Uses an OpenIdContextBean that is `@SessionScoped` to fetch the callerSubject.

TODO: Must complete the OpenIdContext from the `OidcTokensCredential` in the Subject. (currently hitting `OpenIdContextBean 3 getOpenIdContext() Got an authenticated subject, but did not find an OidcTokensCredential` ) see #22626

TODO: Review for adding unit tests.

TODO: Evaluate for NLS messages, see #22626