### PR TITLE
jakarta security 30, create credentialvalidationresult with issuer in addition to caller and group claims

### DIFF
--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenValidator.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenValidator.java
@@ -23,8 +23,7 @@ import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 public class TokenValidator {
 
     private String issuer;
-    private String issuerfromdiscovery;
-    private static String tokenepfromdiscovery;
+    private String issuerconfigured;
     private String subject = null;
     private List<String> audiences;
     private String azp = null;
@@ -195,66 +194,17 @@ public class TokenValidator {
      *
      */
     protected void validateIssuer() throws TokenValidationException {
-        String iss = getIssuer(oidcConfig);//oidcConfig.getProviderMetadata().getIssuer();
-        if (!iss.equals(this.issuer)) {
+        if (!issuerconfigured.equals(this.issuer)) {
             throw new TokenValidationException(oidcConfig.getClientId(), "issuer is [ " + this.issuer + " ], expecting  [ " + oidcConfig.getProviderMetadata().getIssuer() + " ]");
         }
-    }
-
-    public static String getIssuer(OidcClientConfig clientConfig) {
-        String issuer = null;
-        issuer = clientConfig.getProviderMetadata().getIssuer();
-        if (issuer == null || issuer.isEmpty()) {
-            issuer = getIssuerFromTokenEndpoint(clientConfig);
-            if (issuer != null) {
-                return issuer;
-            }
-        }
-        return issuer;
-    }
-
-    static String getIssuerFromTokenEndpoint(OidcClientConfig clientConfig) {
-        String issuer = null;
-        String tokenEndpoint = clientConfig.getProviderMetadata().getTokenEndpoint();
-        if (tokenEndpoint == null) {
-            tokenEndpoint = getTokenepFromDiscovery();
-        }
-        if (tokenEndpoint != null) {
-            int endOfSchemeIndex = tokenEndpoint.indexOf("//");
-            int lastSlashIndex = tokenEndpoint.lastIndexOf("/");
-            boolean urlContainsScheme = endOfSchemeIndex > -1;
-            boolean urlContainsSlash = lastSlashIndex > -1;
-            if ((!urlContainsScheme && !urlContainsSlash) || (urlContainsScheme && (lastSlashIndex == (endOfSchemeIndex + 1)))) {
-                issuer = tokenEndpoint;
-            } else {
-                issuer = tokenEndpoint.substring(0, lastSlashIndex);
-            }
-        }
-        return issuer;
-    }
-
-    /**
-     * @return
-     */
-    static String getTokenepFromDiscovery() {
-        return tokenepfromdiscovery;
     }
 
     /**
      * @param issuerFromDiscovery
      * @return
      */
-    public TokenValidator issuerfromdiscovery(String issuerFromDiscovery) {
-        this.issuerfromdiscovery = issuerFromDiscovery;
-        return this;
-    }
-
-    /**
-     * @param tokenepFromDiscovery
-     * @return
-     */
-    public TokenValidator tokenepfromdiscovery(String tokenepFromDiscovery) {
-        this.tokenepfromdiscovery = tokenepFromDiscovery;
+    public TokenValidator issuerconfigured(String issuerFromProviderMetadata) {
+        this.issuerconfigured = issuerFromProviderMetadata;
         return this;
     }
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/utils/CommonJose4jUtils.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/utils/CommonJose4jUtils.java
@@ -86,7 +86,7 @@ public class CommonJose4jUtils {
         private String clientid;
         private String clientsecret;
         private JWKSet jwkset;
-        private String issuer;
+        private String issuerconfigured;
 
         private TokenSignatureValidationBuilder() {
 
@@ -133,11 +133,11 @@ public class CommonJose4jUtils {
         }
 
         /**
-         * @param issuer
+         * @param issuerFromProviderMetadata
          * @return
          */
-        public TokenSignatureValidationBuilder issuer(String issuer) {
-            this.issuer = issuer;
+        public TokenSignatureValidationBuilder issuer(String issuerFromProviderMetadata) {
+            this.issuerconfigured = issuerFromProviderMetadata;
             return this;
         }
         
@@ -206,7 +206,7 @@ public class CommonJose4jUtils {
             }
             JwtConsumerBuilder builder = new JwtConsumerBuilder();
             builder.setRequireExpirationTime().setAllowedClockSkewInSeconds(120).setExpectedAudience(this.clientid).setExpectedIssuer(false,
-                                                                                                                                      this.issuer).setRequireSubject().setSkipDefaultAudienceValidation().setVerificationKey(key).setRelaxVerificationKeyValidation();
+                                                                                                                                      this.issuerconfigured).setRequireSubject().setSkipDefaultAudienceValidation().setVerificationKey(key).setRelaxVerificationKeyValidation();
 
             JwtConsumer jwtConsumer = builder.build();
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/token/TokenValidatorTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/token/TokenValidatorTest.java
@@ -101,9 +101,36 @@ public class TokenValidatorTest {
                     will(returnValue("oidcclientid"));
                 }
             });
-            tokenValidator = tokenValidator.issuer(iss_claim_from_token);
+            tokenValidator = tokenValidator.issuer(iss_claim_from_token).issuerconfigured(iss_from_config);          
             tokenValidator.validateIssuer();
 
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(methodName, t);
+        }
+    }
+    
+    @Test
+    public void testValidateIssuerNull() {
+        final String methodName = "testValidateIssuerNull";
+        String iss_claim_from_token = null;
+        String iss_from_config = "someotherissuer";
+        try {
+            
+            mock.checking(new Expectations() {
+                {
+                    allowing(oidcClientConfig).getProviderMetadata();//.getIssuer();
+                    will(returnValue(oidcmd));
+                    allowing(oidcmd).getIssuer();
+                    will(returnValue(iss_from_config));
+                    allowing(oidcClientConfig).getClientId();
+                    will(returnValue("oidcclientid"));
+                }
+            });
+            tokenValidator = tokenValidator.issuer(iss_claim_from_token).issuerconfigured(iss_from_config);
+            tokenValidator.validateIssuer();
+        } catch (TokenValidationException e) {
+            String error = e.getMessage();
+            assertTrue("message", error.contains("issuer"));
         } catch (Throwable t) {
             outputMgr.failWithThrowable(methodName, t);
         }
@@ -127,7 +154,7 @@ public class TokenValidatorTest {
                     will(returnValue("oidcclientid"));
                 }
             });
-            tokenValidator = tokenValidator.issuer(iss_claim_from_token);
+            tokenValidator = tokenValidator.issuer(iss_claim_from_token).issuerconfigured(iss_from_config);
             tokenValidator.validateIssuer();
 
         } catch (TokenValidationException e) {


### PR DESCRIPTION
-update creating CVR with issuer claim from tokens (or configured issuer), so this will be used as the realm 

