### PR TITLE
[TS010666588] skip illegal characters in jvm.options. (release bug)

### DIFF
--- a/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client
+++ b/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client
@@ -450,7 +450,7 @@ mergeJVMOptions()
       saveIFS=$IFS
       IFS=$newline
       
-      for option in `readNativeFile "$jvmOptions" '[#-]' | tr -d '\r'`; do
+      for option in `readNativeFile "$jvmOptions" '[#-]' | LC_ALL=C tr -d '\r'`; do
         if [ -n "$option" ]; then
           case $option in
           \#*);;

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -786,7 +786,7 @@ mergeJVMOptions()
       saveIFS=$IFS
       IFS=$newline
 
-      for option in `readNativeFile "$jvmOptions" '[#-]' | tr -d '\r'`; do
+      for option in `readNativeFile "$jvmOptions" '[#-]' | LC_ALL=C tr -d '\r'`; do
         if [ -n "$option" ]; then
           case $option in
           \#*);;


### PR DESCRIPTION
This resolves IBM case TS010666588.

Reading a jvm.options file with an invalid character, e.g. `0xfc` will make Open Liberty and IBM Liberty stop reading the file on encountering the character in certain situations. This will make the server start without the JVM options after that character.

Circumstances:
* jvm.options is in ASCII/UTF-8
* jvm.options contains a non-standard char like `0xfc` which is invalid for ASCII and UTF-8.
* OS is Mac/AIX
* Language is set to anything ending with `.UTF-8`.

This bug does not appear, when:

* on Linux, regardless of language settings. It will always pass through invalid chars.
* On AIX/Mac when LANG=C is set _OR_ LANG= does not end in UTF-8 OR the file `jvm.options` is encoded properly.