### PR TITLE
Fix CDI12ExtensionTest on EE10

### DIFF
--- a/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/apps/helloworld/HelloWorldExtensionTestServlet.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/apps/helloworld/HelloWorldExtensionTestServlet.java
@@ -18,6 +18,7 @@ package com.ibm.ws.cdi.extension.apps.helloworld;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Destroyed;
 import javax.enterprise.context.Initialized;
 import javax.enterprise.context.RequestScoped;
@@ -29,6 +30,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+@ApplicationScoped
 @WebServlet("/hello")
 public class HelloWorldExtensionTestServlet extends HttpServlet {
 
@@ -40,7 +42,8 @@ public class HelloWorldExtensionTestServlet extends HttpServlet {
 
     private static final long serialVersionUID = 8549700799591343964L;
 
-    public static void onStart(@Observes @Initialized(RequestScoped.class) Object e, EventMetadata em) {
+    public static void onStart(@Observes
+    @Initialized(RequestScoped.class) Object e, EventMetadata em) {
 
         if (beanStartMetaData == null) {
 
@@ -52,7 +55,8 @@ public class HelloWorldExtensionTestServlet extends HttpServlet {
 
     }
 
-    public static void onStop(@Observes @Destroyed(RequestScoped.class) Object e, EventMetadata em) {
+    public static void onStop(@Observes
+    @Destroyed(RequestScoped.class) Object e, EventMetadata em) {
 
         if (beanStopMetaData == null) {
 

--- a/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/tests/CDI12ExtensionTest.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/tests/CDI12ExtensionTest.java
@@ -35,7 +35,6 @@ import com.ibm.ws.cdi.extension.apps.multipleWar.war1.WAR1MyBean;
 import com.ibm.ws.cdi.extension.apps.multipleWar.war1.WAR1TestServlet;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
@@ -84,10 +83,10 @@ public class CDI12ExtensionTest {
         WebArchive helloWorldExtensionTest = ShrinkWrap.create(WebArchive.class, "helloWorldExtensionTest.war");
         helloWorldExtensionTest.addClass(HelloWorldExtensionTestServlet.class);
         helloWorldExtensionTest.addClass(HelloWorldExtensionBean.class);
-        CDIArchiveHelper.addBeansXML(helloWorldExtensionTest, DiscoveryMode.DEFAULT, CDIVersion.CDI10);
+        CDIArchiveHelper.addBeansXML(helloWorldExtensionTest, DiscoveryMode.DEFAULT, CDIVersion.CDI11);
 
         EnterpriseArchive helloWorldExtension = ShrinkWrap.create(EnterpriseArchive.class,
-                                                                 "helloWorldExension.ear");
+                                                                  "helloWorldExension.ear");
         helloWorldExtension.setApplicationXML(HelloWorldExtensionTestServlet.class.getPackage(), "application.xml");
 
         helloWorldExtension.addAsModule(helloWorldExtensionTest);
@@ -104,7 +103,6 @@ public class CDI12ExtensionTest {
     }
 
     @Test
-    @SkipForRepeat(CDIExtensionRepeatActions.EE10_PLUS_ID) //currently does not work on EE10, don't know why - https://github.com/OpenLiberty/open-liberty/issues/19900
     public void testHelloWorldExtensionServlet() throws Exception {
         HttpUtils.findStringInUrl(server, "/helloWorldExtension/hello", "Hello World CDI 1.2!");
 


### PR DESCRIPTION
Previously a CDI 1.0 beans.xml was added. This results in a bean-discovery-mode of "all" on 3.0 and earlier but "annotated" on 4.0.

Instead, use a CDI 1.1 beans.xml which explicitly states a bean-discovery-mode of "annotated" and annotate all bean classes appropriately.

Fixes #19900