### PR TITLE
Fix one of the build failure captured in comment 4 of RTC 292562. Gen…

### DIFF
--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/BaseTestCase.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/BaseTestCase.java
@@ -77,17 +77,17 @@ public abstract class BaseTestCase {
      * Start server 1.
      *
      * @param server           The server to start.
-     * @param groupName        The group name (Hazelcast).
+     * @param clusterName      The cluster name (Hazelcast).
      * @param authCacheMaxSize The maximum size of the 'AuthCache' cache. 25000 if null.
      * @param authCacheTtl     The time to live for the 'AuthCache' cache. 600s if null.
      * @throws Exception If starting the server failed for some unforeseen reason.
      */
-    protected static void startServer1(LibertyServer server, String groupName, Integer authCacheMaxSize, Integer authCacheTtl) throws Exception {
+    protected static void startServer1(LibertyServer server, String clusterName, Integer authCacheMaxSize, Integer authCacheTtl) throws Exception {
 
         /*
          * Go to the specific provider's setup.
          */
-        TestPluginHelper.getTestPlugin().setupServer1(server, groupName, authCacheMaxSize, authCacheTtl);
+        TestPluginHelper.getTestPlugin().setupServer1(server, clusterName, authCacheMaxSize, authCacheTtl);
 
         /*
          * Start the server.
@@ -109,16 +109,16 @@ public abstract class BaseTestCase {
     /**
      * Start server 2.
      *
-     * @param server    The server to start.
-     * @param groupName The group name (Hazelcast).
+     * @param server      The server to start.
+     * @param clusterName The cluster name (Hazelcast).
      * @throws Exception If starting the server failed for some unforeseen reason.
      */
-    protected static void startServer2(LibertyServer server, String groupName) throws Exception {
+    protected static void startServer2(LibertyServer server, String clusterName) throws Exception {
 
         /*
          * Go to the specific provider's setup.
          */
-        TestPluginHelper.getTestPlugin().setupServer2(server, groupName);
+        TestPluginHelper.getTestPlugin().setupServer2(server, clusterName);
 
         /*
          * Setup HTTP(S) ports.

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/plugins/HazelcastTestPlugin.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/plugins/HazelcastTestPlugin.java
@@ -21,7 +21,7 @@ import componenttest.topology.impl.LibertyServer;
 public class HazelcastTestPlugin implements TestPlugin {
 
     @Override
-    public void setupServer1(LibertyServer server, String hazelcastGroupName, Integer authCacheMaxSize, Integer authCacheTtlSecs) throws Exception {
+    public void setupServer1(LibertyServer server, String hazelcastClusterName, Integer authCacheMaxSize, Integer authCacheTtlSecs) throws Exception {
         /*
          * Default the cache size and TTL to the default values for authCache->maxSize and authCache->timeout
          * from server.xml.
@@ -44,7 +44,8 @@ public class HazelcastTestPlugin implements TestPlugin {
         /*
          * Set JVM options.
          */
-        server.setJvmOptions(Arrays.asList("-Dhazelcast.authcache.max.size=" + authCacheMaxSize,
+        server.setJvmOptions(Arrays.asList("-Dhazelcast.cluster.name=" + hazelcastClusterName,
+                                           "-Dhazelcast.authcache.max.size=" + authCacheMaxSize,
                                            "-Dhazelcast.authcache.entry.ttl=" + authCacheTtlSecs,
                                            "-Dhazelcast.config.file=" + hazecastConfigFile,
                                            "-Dhazelcast.jcache.provider.type=server", // Start as a member
@@ -53,13 +54,14 @@ public class HazelcastTestPlugin implements TestPlugin {
     }
 
     @Override
-    public void setupServer2(LibertyServer server, String hazelcastGroupName) throws Exception {
+    public void setupServer2(LibertyServer server, String hazelcastClusterName) throws Exception {
         String hazecastConfigFile = "hazelcast-client-localhost-only.xml";
 
         /*
          * Set JVM options.
          */
-        server.setJvmOptions(Arrays.asList("-Dhazelcast.config.file=" + hazecastConfigFile,
+        server.setJvmOptions(Arrays.asList("-Dhazelcast.cluster.name=" + hazelcastClusterName,
+                                           "-Dhazelcast.config.file=" + hazecastConfigFile,
                                            "-Dhazelcast.jcache.provider.type=client", // Start as a client
                                            "-Dhazelcast.phone.home.enabled=false", // Don't phone home
                                            "-Dcom.ibm.ws.beta.edition=true")); // TODO Remove when GA'd

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/plugins/TestPlugin.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/plugins/TestPlugin.java
@@ -43,21 +43,21 @@ public interface TestPlugin {
      * Provider specific setup to run before starting server 1.
      *
      * @param server           The server to setup.
-     * @param groupName        The name of the group the server should be a member of (hazelcast).
+     * @param clusterName      The name of the cluster the server should be a member of (hazelcast).
      * @param authCacheMaxSize The size of the authentication cache.
      * @param authCacheTtlSecs The TTL of the authentication cache.
      * @throws Exception If there was an error setting up server 1.
      */
-    public void setupServer1(LibertyServer server, String groupName, Integer authCacheMaxSize, Integer authCacheTtlSecs) throws Exception;
+    public void setupServer1(LibertyServer server, String clusterName, Integer authCacheMaxSize, Integer authCacheTtlSecs) throws Exception;
 
     /**
      * Provider specific setup to run before starting server 2.
      *
-     * @param server    The server to setup.
-     * @param groupName The name of the group the server should be a member of (hazelcast).
+     * @param server      The server to setup.
+     * @param clusterName The name of the cluster the server should be a member of (hazelcast).
      * @throws Exception If there was an error setting up server 2.
      */
-    public void setupServer2(LibertyServer server, String groupName) throws Exception;
+    public void setupServer2(LibertyServer server, String clusterName) throws Exception;
 
     /**
      * Whether to skip any TTL tests.

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/publish/shared/resources/hazelcast/hazelcast-client-localhost-only.xml
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/publish/shared/resources/hazelcast/hazelcast-client-localhost-only.xml
@@ -13,6 +13,12 @@
 	xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-5.1.xsd"
 	xmlns="http://www.hazelcast.com/schema/client-config"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	
+    <!-- 
+         Use the randomly generated cluster names so that each test is not likely to join a cluster
+         that might already exist. Especially, if we had used the default.
+     -->
+    <cluster-name>${hazelcast.cluster.name}</cluster-name>
 
 	<network>
 		<connection-timeout>120000</connection-timeout>

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/publish/shared/resources/hazelcast/hazelcast-localhost-only-multicastDisabled.xml
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/publish/shared/resources/hazelcast/hazelcast-localhost-only-multicastDisabled.xml
@@ -13,6 +13,12 @@
 	xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-5.1.xsd"
 	xmlns="http://www.hazelcast.com/schema/config"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	
+    <!-- 
+         Use the randomly generated cluster names so that each test is not likely to join a cluster
+         that might already exist. Especially, if we had used the default.
+     -->
+    <cluster-name>${hazelcast.cluster.name}</cluster-name>
 
 	<network>
 		<join>

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/publish/shared/resources/hazelcast/hazelcast-localhost-only.xml
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/publish/shared/resources/hazelcast/hazelcast-localhost-only.xml
@@ -14,6 +14,12 @@
 	xmlns="http://www.hazelcast.com/schema/config"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
+    <!-- 
+         Use the randomly generated cluster names so that each test is not likely to join a cluster
+         that might already exist. Especially, if we had used the default.
+     -->
+    <cluster-name>${hazelcast.cluster.name}</cluster-name>
+
 	<executor-service name="default">
 		<pool-size>12</pool-size>
 	</executor-service>


### PR DESCRIPTION
…erate new cluster names for each test to ensure we don't join an already running cluster.

