### PR TITLE
Update connectors inbound security feature description for EE 10

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/connectorsInboundSecurity-2.0/resources/l10n/io.openliberty.connectorsInboundSecurity-2.0.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/connectorsInboundSecurity-2.0/resources/l10n/io.openliberty.connectorsInboundSecurity-2.0.properties
@@ -14,4 +14,4 @@
 #NLS_MESSAGEFORMAT_NONE
 #
 
-description=This feature enables security inflow for resource adapters.
+description=This feature enables security inflow for resource adapters. This is the final release of this feature and is only compatible with Jakarta EE 9. For Jakarta EE 10, the same functionality is automatically enabled when the connectors and appSecurity features are enabled.


### PR DESCRIPTION
Notify users that the connector's inbound security feature is being superseded by an auto feature. 

