### PR TITLE
Added wait for server config update for hideMessage logging tests

### DIFF
--- a/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/TestHideMessages.java
+++ b/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/TestHideMessages.java
@@ -62,7 +62,7 @@ public class TestHideMessages {
         assertTrue("Hidden Message CWWKZ0058I should not be seen in messages.log",
                    msgServer.findStringsInLogs("CWWKZ0058I:", msgServer.getMatchingLogFile("messages.log")).isEmpty());
         assertTrue("Hidden Message CWWKZ0058I should not be seen in console.log",
-                   msgServer.findStringsInLogs("CWWKZ0058I:", msgServer.getMatchingLogFile("console.log")).isEmpty());
+                   msgServer.findStringsInLogs("CWWKZ0058I:", msgServer.getConsoleLogFile()).isEmpty());
         assertFalse("Hidden Message CWWKZ0058I should be seen in trace", msgServer.findStringsInTrace("CWWKZ0058I:").isEmpty());
         assertFalse("Info message about redirection to trace file should be logged",
                     msgServer.findStringsInLogs("TRAS3001I:", msgServer.getMatchingLogFile("messages.log")).isEmpty());
@@ -75,7 +75,7 @@ public class TestHideMessages {
         Log.info(logClass, name.getMethodName(), "Entering test " + name.getMethodName());
         // Need to capture CWWKF0012I messages that are in the logs from initial startup
         int initial_messages_size_CWWKF0012I = msgServer.findStringsInLogs("CWWKF0012I:", msgServer.getMatchingLogFile("messages.log")).size();
-        int initial_console_size_CWWKF0012I = msgServer.findStringsInLogs("CWWKF0012I:", msgServer.getMatchingLogFile("console.log")).size();
+        int initial_console_size_CWWKF0012I = msgServer.findStringsInLogs("CWWKF0012I:", msgServer.getConsoleLogFile()).size();
         int initial_trace_size_CWWKF0012I = msgServer.findStringsInTrace("CWWKF0012I:").size();
 
         msgServer.setServerConfigurationFile(TWO_HIDDEN_MESSAGE_SERVER);
@@ -83,7 +83,7 @@ public class TestHideMessages {
         assertTrue("Hidden Message CWWKZ0058I should not be seen in messages.log",
                    msgServer.findStringsInLogs("CWWKZ0058I:", msgServer.getMatchingLogFile("messages.log")).isEmpty());
         assertTrue("Hidden Message CWWKZ0058I should not be seen in console.log",
-                   msgServer.findStringsInLogs("CWWKZ0058I:", msgServer.getMatchingLogFile("console.log")).isEmpty());
+                   msgServer.findStringsInLogs("CWWKZ0058I:", msgServer.getConsoleLogFile()).isEmpty());
         assertFalse("Hidden Message CWWKZ0058I should be seen in trace", msgServer.findStringsInTrace("CWWKZ0058I:").isEmpty());
 
         //This will wait for feature update completion message since we are adding a new feature. And CWWKF0012I should be seen before that
@@ -91,7 +91,7 @@ public class TestHideMessages {
         assertTrue("Hidden Message CWWKF0012I should not be seen in messages.log",
                    msgServer.findStringsInLogs("CWWKF0012I:", msgServer.getMatchingLogFile("messages.log")).size() == initial_messages_size_CWWKF0012I);
         assertTrue("Hidden Message CWWKF0012I should not be seen in console.log",
-                   msgServer.findStringsInLogs("CWWKF0012I:", msgServer.getMatchingLogFile("console.log")).size() == initial_console_size_CWWKF0012I);
+                   msgServer.findStringsInLogs("CWWKF0012I:", msgServer.getConsoleLogFile()).size() == initial_console_size_CWWKF0012I);
         assertTrue("Hidden Message CWWKF0012I should be seen in trace",
                    msgServer.findStringsInTrace("CWWKF0012I:").size() == (initial_trace_size_CWWKF0012I + 1));
 
@@ -112,24 +112,31 @@ public class TestHideMessages {
         assertTrue("Hidden Message CWWKF0012I should not be seen in messages.log",
                    msgServer.findStringsInLogs("CWWKZ0058I:", msgServer.getMatchingLogFile("messages.log")).isEmpty());
         assertTrue("Hidden Message CWWKF0012I should not be seen in console.log",
-                   msgServer.findStringsInLogs("CWWKZ0058I:", msgServer.getMatchingLogFile("console.log")).isEmpty());
+                   msgServer.findStringsInLogs("CWWKZ0058I:", msgServer.getConsoleLogFile()).isEmpty());
         assertFalse("Hidden Message CWWKF0012I should be seen in trace", msgServer.findStringsInTrace("CWWKZ0058I:").isEmpty());
         assertFalse("Info message about hidden messageID prefixes should be logged",
                     msgServer.findStringsInLogs("TRAS3001I:", msgServer.getMatchingLogFile("messages.log")).isEmpty());
 
         msgServer.setServerConfigurationFile(HIDE_MSG_ATTRIBUTE_REMOVAL);
 
-        // This will wait for feature update completion message since we are adding a new feature. And CWWKF0012I should be seen before that
+        // This will wait for feature update completion message since we are adding a new feature.
         msgServer.waitForConfigUpdateInLogUsingMark(null);
 
-        // Ensure the mark is set here, so the find methods do not find the previous messages before the mark.
+        // Ensure the mark is set here for messages.log, so the find methods do not find the previous messages before the mark.
         msgServer.setMarkToEndOfLog(msgServer.getMatchingLogFile("messages.log"));
 
-        // Second, test if the previously hidden messageID prefixes are showing up in message.log/console.log after server configuration update.
+        // Ensure the mark is set here for console.log, so the find methods do not find the previous messages before the mark.
+        msgServer.setMarkToEndOfLog(msgServer.getMatchingLogFile("console.log"));
+
+        // Wait for the CWWKF0012I message. Should return a maximum of 2 instances of the CWWKF0012I:
+        // At server startup and another after the hide message attribute removal.
+        msgServer.waitForMultipleStringsInLog(2, "CWWKF0012I:");
+
+        // Second, test if the previously hidden messageID (CWWKF0012I) prefixes are showing up in message.log/console.log after server configuration update.
         assertTrue("Hidden Message CWWKF0012I should be seen in messages.log",
                    msgServer.findStringsInLogs("CWWKF0012I:", msgServer.getMatchingLogFile("messages.log")).size() > 0);
         assertTrue("Hidden Message CWWKF0012I should be seen in console.log",
-                   msgServer.findStringsInLogs("CWWKF0012I:", msgServer.getMatchingLogFile("console.log")).size() > 0);
+                   msgServer.findStringsInLogs("CWWKF0012I:", msgServer.getConsoleLogFile()).size() > 0);
         assertTrue("Info message about hidden messageID prefixes should not be logged",
                    msgServer.findStringsInLogsUsingMark("TRAS3001I:", msgServer.getMatchingLogFile("messages.log")).isEmpty());
 


### PR DESCRIPTION
fixes #22518
- On z/OS platforms, the server config update is slow to update, hence the test fails. Added a wait for config update.