### PR TITLE
fix logging permissions error in Java Security Builds

### DIFF
--- a/dev/com.ibm.ws.logging_fat/test-applications/quick-log-test/src/com/ibm/ws/logging/fat/quick/log/test/QuickLogTest.java
+++ b/dev/com.ibm.ws.logging_fat/test-applications/quick-log-test/src/com/ibm/ws/logging/fat/quick/log/test/QuickLogTest.java
@@ -145,7 +145,7 @@ public class QuickLogTest extends HttpServlet {
 			return new RunResult(action, reqThreads, duration, delay, 0);
 		
 		Logger logger = Logger.getLogger("com.ibm.somelogger.QuickLogTest");
-		logger.setLevel(Level.ALL);
+		//logger.setLevel(Level.ALL);
 
 		// create the action runnables
         Action actions[] = new Action[reqThreads];


### PR DESCRIPTION
#build

Specifically in Java Security builds, when setting a logging level, ie. `logger.setLevel(Level.ALL);` in an application, you will get a permissions error:

```
Exception thrown by application class 'java.security.AccessController.throwACE:176'
An exception occurred: java.lang.Throwable: java.security.AccessControlException: Access denied ("java.util.logging.LoggingPermission" "control"))
```

As referenced in the oracle docs (https://docs.oracle.com/javase/8/docs/technotes/guides/security/permissions.html):
```
A SecurityManager will check the java.util.logging.LoggingPermission object when code running with a SecurityManager calls one of the logging control methods (such as Logger.setLevel).
Currently there is only one named LoggingPermission, "control". control grants the ability to control the logging configuration; for example by adding or removing Handlers, by adding or removing Filters, or by changing logging levels.
```

Since setting the logging level is not needed for the application in the test, removing setting the log level to resolve the issue.