### PR TITLE
cache HTTP session in SRTServletRequest

### DIFF
--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletRequest.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletRequest.java
@@ -214,6 +214,9 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
     
     protected static final boolean SERVLET_PATH_FOR_DEFAULT_MAPPING = Boolean.valueOf(WCCustomProperties.SERVLET_PATH_FOR_DEFAULT_MAPPING).booleanValue();
 
+    private HttpSession ourHTTPSession = null;
+    private boolean triedToGetHTTPSession = false;
+
     public SRTServletRequest(SRTConnectionContext context)
     {
         this._connContext = context;
@@ -325,6 +328,9 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
             checkRequestObjectInUse();
         }
 
+        ourHTTPSession = null;
+        triedToGetHTTPSession = false;
+        
         try {
 
             if (req == null) {
@@ -2262,8 +2268,13 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
         if (WCCustomProperties.CHECK_REQUEST_OBJECT_IN_USE){
             checkRequestObjectInUse();
         }
-        // return _connContext.getSessionAPISupport().getSession(create);
-        return _requestContext.getSession(create, ((WebAppDispatcherContext) this.getDispatchContext()).getWebApp());
+
+        if(create || ((ourHTTPSession == null) && (triedToGetHTTPSession == false))) {
+            // return _connContext.getSessionAPISupport().getSession(create);
+            ourHTTPSession = _requestContext.getSession(create, ((WebAppDispatcherContext) this.getDispatchContext()).getWebApp());
+            triedToGetHTTPSession = true;
+        }
+        return ourHTTPSession;
     }
 
     public boolean isRequestedSessionIdFromCookie()


### PR DESCRIPTION
Profiles show repeated calls to SRTServletRequest.getSession so let's cache the session after the first getSession call, to reduce work required to respond to subsequent calls to getSession.