### PR TITLE
use explicit version for hamcrest

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -3844,7 +3844,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.27</version>
+      <version>1.32</version>
     </dependency>
     <dependency>
       <groupId>wsdl4j</groupId>

--- a/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -47,6 +47,12 @@
                 <artifactId>jboss-servlet-api_3.0_spec</artifactId>
                 <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
             </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-all</artifactId>
+                <version>1.3</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This test works with hamcrest 2.1 and throws a class not found exception on hamcrest 1.1

Without an explicit dependency it uses whatever it finds in .m2 and falls back to 1.1