### PR TITLE
Update TCK Results output

### DIFF
--- a/dev/fattest.simplicity/bnd.bnd
+++ b/dev/fattest.simplicity/bnd.bnd
@@ -46,6 +46,7 @@ Export-Package: \
         componenttest.topology.impl;version=2.0,\
         componenttest.topology.ldap;version=2.0,\
         componenttest.topology.utils;version=2.0,\
+        componenttest.topology.utils.tck;version=2.0,\
         componenttest.vulnerability;version=2.0,\
         io.openliberty.checkpoint.spi
 	

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -258,6 +258,8 @@ public class LibertyServer implements LogMonitorClient {
 
     protected static final String SERVER_CONFIG_FILE_NAME = "server.xml";
     protected static final String JVM_OPTIONS_FILE_NAME = "jvm.options";
+    protected static final String OPENLIBERTY_PROPERTIES_FILE_NAME = "openliberty.properties";
+    protected static final String COM_IBM_WEBSPHERE_PRODUCTVERSION_KEY = "com.ibm.websphere.productVersion";
 
     protected static final String EBCDIC_CHARSET_NAME = "IBM1047";
 
@@ -311,6 +313,10 @@ public class LibertyServer implements LogMonitorClient {
     private boolean logOnUpdate = true;
 
     protected boolean debuggingAllowed = true;
+
+    private Properties openLibertyProperties;
+
+    private String openLibertyVersion;
 
     /**
      * This returns whether or not debugging is "programatically" allowed
@@ -6928,5 +6934,42 @@ public class LibertyServer implements LogMonitorClient {
             }
         }
         return checkpointSupported;
+    }
+
+    protected String getOpenLibertyPropertiesFilePath() {
+        return this.getInstallRoot() + "/lib/versions/" + OPENLIBERTY_PROPERTIES_FILE_NAME;
+    }
+
+    protected RemoteFile getOpenLibertyPropertiesFile() throws Exception {
+        return LibertyFileManager.createRemoteFile(this.machine, this.getOpenLibertyPropertiesFilePath());
+    }
+
+    public Properties getOpenLibertyProperties() {
+        if (this.openLibertyProperties == null) {
+            this.openLibertyProperties = new Properties();
+            InputStream is = null;
+            try {
+                is = getOpenLibertyPropertiesFile().openForReading();
+                this.openLibertyProperties.load(is);
+            } catch (Exception e) {
+                LOG.warning("Unable to read openliberty.properties file: " + e.getMessage());
+            } finally {
+                if (is != null) {
+                    try {
+                        is.close();
+                    } catch (IOException e) {
+                        LOG.warning("Unable to close input stream for openliberty.properties file: " + e.getMessage());
+                    }
+                }
+            }
+        }
+        return this.openLibertyProperties;
+    }
+
+    public String getOpenLibertyVersion() {
+        if (this.openLibertyVersion == null) {
+            this.openLibertyVersion = (String) getOpenLibertyProperties().get(COM_IBM_WEBSPHERE_PRODUCTVERSION_KEY);
+        }
+        return this.openLibertyVersion;
     }
 }

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -6944,6 +6944,9 @@ public class LibertyServer implements LogMonitorClient {
         return LibertyFileManager.createRemoteFile(this.machine, this.getOpenLibertyPropertiesFilePath());
     }
 
+    /**
+     * @return the contents of the wlp/lib/versions/openliberty.properties file
+     */
     public Properties getOpenLibertyProperties() {
         if (this.openLibertyProperties == null) {
             this.openLibertyProperties = new Properties();
@@ -6966,6 +6969,9 @@ public class LibertyServer implements LogMonitorClient {
         return this.openLibertyProperties;
     }
 
+    /**
+     * @return the product version value from the openliberty.properties file
+     */
     public String getOpenLibertyVersion() {
         if (this.openLibertyVersion == null) {
             this.openLibertyVersion = (String) getOpenLibertyProperties().get(COM_IBM_WEBSPHERE_PRODUCTVERSION_KEY);

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/MvnUtils.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/MvnUtils.java
@@ -1162,6 +1162,11 @@ public class MvnUtils {
         return version;
     }
 
+    /**
+     * Generate a TCK Results file in AsciiDoc format
+     *
+     * @param resultInfo TCK Results metadata
+     */
     public static void preparePublicationFile(Map<String, String> resultInfo) {
         String javaMajorVersion = resultInfo.get("java_major_version");
         String javaVersion = resultInfo.get("java_info");
@@ -1170,6 +1175,7 @@ public class MvnUtils {
         String osVersion = resultInfo.get("os_name");
         String specName = resultInfo.get("feature_name");
         String specVersion = resultInfo.get("feature_version");
+        String rcVersion = getSpec()[2];
 
         TCKResultsInfo info = new TCKResultsInfo();
         info.setJavaMajorVersion(javaMajorVersion);
@@ -1179,14 +1185,20 @@ public class MvnUtils {
         info.setOsVersion(osVersion);
         info.setSpecName(specName);
         info.setSpecVersion(specVersion);
+        info.setRcVersion(rcVersion);
         preparePublicationFile(info);
     }
 
+    /**
+     * Generate a TCK Results file in AsciiDoc format
+     *
+     * @param resultInfo TCK Results metadata
+     */
     public static void preparePublicationFile(TCKResultsInfo resultInfo) {
-        TCKResultsWriter.preparePublicationFile(resultInfo, getSpec());
+        TCKResultsWriter.preparePublicationFile(resultInfo);
     }
 
-    public static String[] getSpec() {
+    private static String[] getSpec() {
         Pattern specNamePattern = Pattern.compile("microprofile(.*?)-tck:jar", Pattern.DOTALL);
         String specName = "";
         String specVersion = "";

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/MvnUtils.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/MvnUtils.java
@@ -1227,27 +1227,12 @@ public class MvnUtils {
     public static Map<String, String> getResultInfo(LibertyServer server) {
         Map<String, String> resultInfo = new HashMap<>();
         JavaInfo javaInfo = JavaInfo.forCurrentVM();
-        String productVersion = "";
         resultInfo.put("java_info", System.getProperty("java.runtime.name") + " (" + System.getProperty("java.runtime.version") + ')');
         resultInfo.put("java_major_version", String.valueOf(javaInfo.majorVersion()));
         resultInfo.put("os_name", System.getProperty("os.name"));
-        try {
-            List<String> matches = server.findStringsInLogs("product =");
-            if (!matches.isEmpty()) {
-                Pattern olVersionPattern = Pattern.compile("Liberty (.*?) \\(", Pattern.DOTALL);
-                Pattern wasVersionPattern = Pattern.compile("WebSphere Application Server (.*?) \\(", Pattern.DOTALL);
-                Matcher olNameMatcher = olVersionPattern.matcher(matches.get(0));
-                Matcher wasNameMatcher = wasVersionPattern.matcher(matches.get(0));
-                if (olNameMatcher.find()) {
-                    productVersion = olNameMatcher.group(1);
-                } else if (wasNameMatcher.find()) {
-                    productVersion = wasNameMatcher.group(1);
-                }
-                resultInfo.put("product_version", productVersion);
-            }
-        } finally {
-            return resultInfo;
-        }
+        resultInfo.put("product_version", server.getOpenLibertyVersion());
+
+        return resultInfo;
     }
 
     public static String capitalise(String spec) {

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsInfo.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsInfo.java
@@ -11,7 +11,7 @@
 package componenttest.topology.utils.tck;
 
 /**
- *
+ * Metadata about a set of TCK Results
  */
 public class TCKResultsInfo {
 
@@ -22,6 +22,7 @@ public class TCKResultsInfo {
     private String osVersion;// = resultInfo.get("os_name");
     private String specName;// = resultInfo.get("feature_name");
     private String specVersion;// = resultInfo.get("feature_version");
+    private String rcVersion;
 
     /**
      * @return the javaMajorVersion
@@ -119,6 +120,20 @@ public class TCKResultsInfo {
      */
     public void setSpecVersion(String specVersion) {
         this.specVersion = specVersion;
+    }
+
+    /**
+     * @return the rcVersion
+     */
+    public String getRcVersion() {
+        return rcVersion;
+    }
+
+    /**
+     * @param rcVersion the rcVersion to set
+     */
+    public void setRcVersion(String rcVersion) {
+        this.rcVersion = rcVersion;
     }
 
 }

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsInfo.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsInfo.java
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package componenttest.topology.utils.tck;
+
+/**
+ *
+ */
+public class TCKResultsInfo {
+
+    private String javaMajorVersion;// = resultInfo.get("java_major_version");
+    private String javaVersion;// = resultInfo.get("java_info");
+    private String openLibertyVersion;// = resultInfo.get("product_version");
+    private String type;// = resultInfo.get("results_type");
+    private String osVersion;// = resultInfo.get("os_name");
+    private String specName;// = resultInfo.get("feature_name");
+    private String specVersion;// = resultInfo.get("feature_version");
+
+    /**
+     * @return the javaMajorVersion
+     */
+    public String getJavaMajorVersion() {
+        return javaMajorVersion;
+    }
+
+    /**
+     * @param javaMajorVersion the javaMajorVersion to set
+     */
+    public void setJavaMajorVersion(String javaMajorVersion) {
+        this.javaMajorVersion = javaMajorVersion;
+    }
+
+    /**
+     * @return the javaVersion
+     */
+    public String getJavaVersion() {
+        return javaVersion;
+    }
+
+    /**
+     * @param javaVersion the javaVersion to set
+     */
+    public void setJavaVersion(String javaVersion) {
+        this.javaVersion = javaVersion;
+    }
+
+    /**
+     * @return the openLibertyVersion
+     */
+    public String getOpenLibertyVersion() {
+        return openLibertyVersion;
+    }
+
+    /**
+     * @param openLibertyVersion the openLibertyVersion to set
+     */
+    public void setOpenLibertyVersion(String openLibertyVersion) {
+        this.openLibertyVersion = openLibertyVersion;
+    }
+
+    /**
+     * @return the type
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @param type the type to set
+     */
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    /**
+     * @return the osVersion
+     */
+    public String getOsVersion() {
+        return osVersion;
+    }
+
+    /**
+     * @param osVersion the osVersion to set
+     */
+    public void setOsVersion(String osVersion) {
+        this.osVersion = osVersion;
+    }
+
+    /**
+     * @return the specName
+     */
+    public String getSpecName() {
+        return specName;
+    }
+
+    /**
+     * @param specName the specName to set
+     */
+    public void setSpecName(String specName) {
+        this.specName = specName;
+    }
+
+    /**
+     * @return the specVersion
+     */
+    public String getSpecVersion() {
+        return specVersion;
+    }
+
+    /**
+     * @param specVersion the specVersion to set
+     */
+    public void setSpecVersion(String specVersion) {
+        this.specVersion = specVersion;
+    }
+
+}

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
@@ -33,7 +33,8 @@ public class TCKResultsWriter {
         String specName = resultInfo.getSpecName();
         String specVersion = resultInfo.getSpecVersion();
 
-        Path outputPath = Paths.get("results", openLibertyVersion + "-Java" + javaMajorVersion + "-" + specName + "-" + specVersion + "-TCKResults.adoc");
+        String filename = openLibertyVersion + "-" + specName.replace(" ", "-") + "-" + specVersion + "-Java" + javaMajorVersion + "-TCKResults.adoc";
+        Path outputPath = Paths.get("results", filename);
         File outputFile = outputPath.toFile();
         SAXParserFactory factory = null;
         SAXParser saxParser = null;
@@ -77,15 +78,14 @@ public class TCKResultsWriter {
                                           ".\n\n== Open Liberty ", openLibertyVersion, " - MicroProfile ", specName, " ", specVersion,
                                           " Certification Summary (Java ", javaMajorVersion, ")\n\n",
                                           "* Product Name, Version and download URL (if applicable):\n",
-                                          "+\nhttps://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/",
+                                          "\nhttps://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/",
                                           openLibertyVersion, "/openliberty-runtime-", openLibertyVersion, ".zip[Open Liberty ", openLibertyVersion, "]\n",
-                                          "* Specification Name, Version and download URL:\n+\n",
+                                          "* Specification Name, Version and download URL:\n\n",
                                           "link:https://download.eclipse.org/microprofile/microprofile-", MPSpecLower, "-", specVersion, rcVersion,
                                           "/microprofile-", MPSpecLower, "-spec-", specVersion, rcVersion, ".html[MicroProfile ", specName, " ", specVersion,
-                                          rcVersion, "]\n\n* Public URL of TCK Results Summary:\n+\n", "link:", openLibertyVersion, "-Java", javaMajorVersion,
-                                          "-TCKResults.html[TCK results summary]\n\n",
-                                          "* Java runtime used to run the implementation:\n+\nJava ", javaMajorVersion, ": ", javaVersion,
-                                          "\n\n* Summary of the information for the certification environment, operating system, cloud, ...:\n+\n", "Java ", javaMajorVersion, ": ",
+                                          rcVersion, "]\n\n* Public URL of TCK Results Summary:\n\n", "link:", filename, "[TCK results summary]\n\n",
+                                          "* Java runtime used to run the implementation:\n\nJava ", javaMajorVersion, ": ", javaVersion,
+                                          "\n\n* Summary of the information for the certification environment, operating system, cloud, ...:\n\n", "Java ", javaMajorVersion, ": ",
                                           osVersion, "\n\nTest results:\n\n[source, text]\n----\n" };
                 for (String part : documentMain) {
                     adocContent += part;
@@ -93,27 +93,27 @@ public class TCKResultsWriter {
             } else {
                 String[] documentMain = { ".\n\n== Open Liberty ", openLibertyVersion, " ", type, " ", specName, " Certification Summary (Java ", javaMajorVersion, ")",
                                           "\n\n* Product Name, Version and download URL (if applicable):",
-                                          "\n+\nhttps://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/", openLibertyVersion, ".zip[Open Liberty ",
+                                          "\n\nhttps://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/", openLibertyVersion, ".zip[Open Liberty ",
                                           openLibertyVersion,
                                           "]\n\n",
-                                          "* Specification Name, Version and download URL:\n+\n",
+                                          "* Specification Name, Version and download URL:\n\n",
                                           "link:https://jakarta.ee/specifications/", specName, "/", specVersion, "[Jakarta EE ", specName, " ", specVersion, "]\n\n",
-                                          "* TCK Version, digital SHA-256 fingerprint and download URL:\n+\n",
+                                          "* TCK Version, digital SHA-256 fingerprint and download URL:\n\n",
                                           "https://download.eclipse.org/jakartaee/", ".zip[Jakarta EE]\n",
                                           "SHA-256: ``\n\n",
-                                          "* Public URL of TCK Results Summary:\n+\n",
-                                          "link:", openLibertyVersion, "-Java", javaMajorVersion, "-TCKResults.html[TCK results summary]\n\n",
+                                          "* Public URL of TCK Results Summary:\n\n",
+                                          "link:", filename, "[TCK results summary]\n\n",
                                           "* Any Additional Specification Certification Requirements:\n\n",
-                                          "+\nJakarta Contexts and Dependency Injection\n",
+                                          "\nJakarta Contexts and Dependency Injection\n",
                                           "link:https://download.eclipse.org/jakartaee/cdi/", "SHA-256:\n``\n",
-                                          "+\nJakarta Bean Validation\n",
+                                          "\nJakarta Bean Validation\n",
                                           "link:https://download.eclipse.org/jakartaee/bean-validation/", "SHA-256:\n``\n",
-                                          "+\nDependency Injection\n",
+                                          "\nDependency Injection\n",
                                           "link:https://download.eclipse.org/jakartaee/dependency-injection/", "SHA-256:\n``\n",
-                                          "+\nDebugging\n",
+                                          "\nDebugging\n",
                                           "link:https://download.eclipse.org/jakartaee/debugging/", "SHA-256:\n``\n",
-                                          "* Java runtime used to run the implementation:\n+\n", javaVersion,
-                                          "\n\n* Summary of the information for the certification environment, operating system, cloud, ...:\n+\n",
+                                          "* Java runtime used to run the implementation:\n\n", javaVersion,
+                                          "\n\n* Summary of the information for the certification environment, operating system, cloud, ...:\n\n",
                                           osVersion,
                                           "\n\nTest results:\n\n[source, text]\n----\n" };
                 for (String part : documentMain) {

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package componenttest.topology.utils.tck;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.xml.sax.SAXException;
+
+public class TCKResultsWriter {
+
+    public static void preparePublicationFile(TCKResultsInfo resultInfo, String[] specParts) {
+        String javaMajorVersion = resultInfo.getJavaMajorVersion();
+        String javaVersion = resultInfo.getJavaVersion();
+        String openLibertyVersion = resultInfo.getOpenLibertyVersion();
+        String type = resultInfo.getType();
+        String osVersion = resultInfo.getOsVersion();
+        String specName = resultInfo.getSpecName();
+        String specVersion = resultInfo.getSpecVersion();
+
+        Path outputPath = Paths.get("results", openLibertyVersion + "-Java" + javaMajorVersion + "-" + specName + "-" + specVersion + "-TCKResults.adoc");
+        File outputFile = outputPath.toFile();
+        SAXParserFactory factory = null;
+        SAXParser saxParser = null;
+        try {
+            factory = SAXParserFactory.newInstance();
+            saxParser = factory.newSAXParser();
+        } catch (ParserConfigurationException e) {
+            throw new RuntimeException(e);
+        } catch (SAXException e) {
+            throw new RuntimeException(e);
+        }
+        TestSuiteXmlParser xmlParser = new TestSuiteXmlParser();
+
+        try (FileWriter output = new FileWriter(outputFile)) {
+            Path junitPath = Paths.get("results", "junit");
+            File junitDirectory = junitPath.toFile();
+            for (final File xmlFile : junitDirectory.listFiles()) {
+                if (xmlFile.isDirectory()) {
+                    continue; //this shouldn't happen.
+                }
+                if (xmlFile.length() == 0) {
+                    continue; //this probably will happen. We create an empty file then populate it after we're expecting this method to run.
+                }
+                saxParser.parse(xmlFile, xmlParser);
+            }
+
+            String adocContent = "";
+            String MPversion = "";
+
+            String MPSpecLower = (specName.toLowerCase()).replace(" ", "-");
+            String rcVersion = specParts[2];
+            String[] documentStart = { ":page-layout: certification \n= TCK Results\n\n",
+                                       "As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of ",
+                                       type //MicroProfile or Jakarta EE
+            };
+            for (String part : documentStart) {
+                adocContent += part;
+            }
+            if (type.equals("MicroProfile")) {
+                String[] documentMain = { " ", specName, " ", specVersion,
+                                          ".\n\n== Open Liberty ", openLibertyVersion, " - MicroProfile ", specName, " ", specVersion,
+                                          " Certification Summary (Java ", javaMajorVersion, ")\n\n",
+                                          "* Product Name, Version and download URL (if applicable):\n",
+                                          "+\nhttps://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/",
+                                          openLibertyVersion, "/openliberty-runtime-", openLibertyVersion, ".zip[Open Liberty ", openLibertyVersion, "]\n",
+                                          "* Specification Name, Version and download URL:\n+\n",
+                                          "link:https://download.eclipse.org/microprofile/microprofile-", MPSpecLower, "-", specVersion, rcVersion,
+                                          "/microprofile-", MPSpecLower, "-spec-", specVersion, rcVersion, ".html[MicroProfile ", specName, " ", specVersion,
+                                          rcVersion, "]\n\n* Public URL of TCK Results Summary:\n+\n", "link:", openLibertyVersion, "-Java", javaMajorVersion,
+                                          "-TCKResults.html[TCK results summary]\n\n",
+                                          "* Java runtime used to run the implementation:\n+\nJava ", javaMajorVersion, ": ", javaVersion,
+                                          "\n\n* Summary of the information for the certification environment, operating system, cloud, ...:\n+\n", "Java ", javaMajorVersion, ": ",
+                                          osVersion, "\n\nTest results:\n\n[source, text]\n----\n" };
+                for (String part : documentMain) {
+                    adocContent += part;
+                }
+            } else {
+                String[] documentMain = { ".\n\n== Open Liberty ", openLibertyVersion, " ", type, " ", specName, " Certification Summary (Java ", javaMajorVersion, ")",
+                                          "\n\n* Product Name, Version and download URL (if applicable):",
+                                          "\n+\nhttps://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/", openLibertyVersion, ".zip[Open Liberty ",
+                                          openLibertyVersion,
+                                          "]\n\n",
+                                          "* Specification Name, Version and download URL:\n+\n",
+                                          "link:https://jakarta.ee/specifications/", specName, "/", specVersion, "[Jakarta EE ", specName, " ", specVersion, "]\n\n",
+                                          "* TCK Version, digital SHA-256 fingerprint and download URL:\n+\n",
+                                          "https://download.eclipse.org/jakartaee/", ".zip[Jakarta EE]\n",
+                                          "SHA-256: ``\n\n",
+                                          "* Public URL of TCK Results Summary:\n+\n",
+                                          "link:", openLibertyVersion, "-Java", javaMajorVersion, "-TCKResults.html[TCK results summary]\n\n",
+                                          "* Any Additional Specification Certification Requirements:\n\n",
+                                          "+\nJakarta Contexts and Dependency Injection\n",
+                                          "link:https://download.eclipse.org/jakartaee/cdi/", "SHA-256:\n``\n",
+                                          "+\nJakarta Bean Validation\n",
+                                          "link:https://download.eclipse.org/jakartaee/bean-validation/", "SHA-256:\n``\n",
+                                          "+\nDependency Injection\n",
+                                          "link:https://download.eclipse.org/jakartaee/dependency-injection/", "SHA-256:\n``\n",
+                                          "+\nDebugging\n",
+                                          "link:https://download.eclipse.org/jakartaee/debugging/", "SHA-256:\n``\n",
+                                          "* Java runtime used to run the implementation:\n+\n", javaVersion,
+                                          "\n\n* Summary of the information for the certification environment, operating system, cloud, ...:\n+\n",
+                                          osVersion,
+                                          "\n\nTest results:\n\n[source, text]\n----\n" };
+                for (String part : documentMain) {
+                    adocContent += part;
+                }
+            }
+            output.write(adocContent);
+            for (TestSuiteResult result : xmlParser.getResults()) {
+                output.write(result.toString());
+            }
+            output.write("----");
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (SAXException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TestCaseResult.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TestCaseResult.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package componenttest.topology.utils;
+package componenttest.topology.utils.tck;
 
 public class TestCaseResult {
     private boolean failure = false;

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TestSuiteResult.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TestSuiteResult.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package componenttest.topology.utils;
+package componenttest.topology.utils.tck;
 
 import java.util.List;
 import java.util.LinkedList;

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TestSuiteXmlParser.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TestSuiteXmlParser.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package componenttest.topology.utils;
+package componenttest.topology.utils.tck;
 
 import java.util.List;
 import java.util.LinkedList;
@@ -16,6 +16,7 @@ import java.util.Scanner;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 


### PR DESCRIPTION
#build

When the TCK adoc files were uploaded to RTC, they all had similar names and the content was getting mixed up. If you look at the TCK Results available in the Downloads tab of a build, the description given does not appear to match up with the contents of the file. e.g. A file that stated com.ibm.ws.concurrent.mp in the description could end up being the TCK results for MicroProfile Rest Client 1.2.