### PR TITLE
Increase Retry Interval to 200ns

### DIFF
--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/RemoteFile.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/RemoteFile.java
@@ -91,7 +91,7 @@ public class RemoteFile {
     /**
      * The amount of time to wait before retrying
      */
-    public static final long STANDARD_RETRY_INTERVAL_NS = TimeUnit.MILLISECONDS.toNanos(100); // 0.1s
+    public static final long STANDARD_RETRY_INTERVAL_NS = TimeUnit.MILLISECONDS.toNanos(200); // 0.1s
 
     public interface Operation {
         public boolean act() throws Exception;


### PR DESCRIPTION
Attempting to resolve https://github.com/OpenLiberty/open-liberty/issues/20339 by increasing the retry interval.

An intermittent build break exists where an OpenTracing server fails to be deleted due to being in use while using the RepeatTest feature. Checking to see if increasing the retry interval will help prevent the folder from being locked.