### PR TITLE
Improve FAT leaked server cleanup

### DIFF
--- a/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
@@ -380,6 +380,8 @@
 						<istrue value="${is.windows.platform}" />
 					</condition>
 
+					<echo>Waiting 30 seconds in case the server has not finished starting...</echo>
+					<sleep seconds="30"/>
 					<echo>Executing ${libertyInstallPath}/bin/${script.exec} ${script.cmd} stop ${serverDir}</echo>
 					<exec failonerror="false" executable="${script.exec}" dir="${libertyInstallPath}/bin" timeout="300000">
 						<arg line="${script.cmd}" />

--- a/dev/com.ibm.ws.jmx_fat/override/autoFVT/src/ant/launch.xml
+++ b/dev/com.ibm.ws.jmx_fat/override/autoFVT/src/ant/launch.xml
@@ -566,6 +566,8 @@
 						<istrue value="${is.windows.platform}" />
 					</condition>
 
+					<echo>Waiting 30 seconds in case the server has not finished starting...</echo>
+					<sleep seconds="30"/>
 					<echo>Executing ${libertyInstallPath}/bin/${script.exec} ${script.cmd} stop ${serverDir}</echo>
 					<exec failonerror="false" executable="${script.exec}" dir="${libertyInstallPath}/bin" timeout="300000">
 						<arg line="${script.cmd}" />

--- a/dev/com.ibm.ws.kernel.boot_fat/override/autoFVT/src/ant/launch.xml
+++ b/dev/com.ibm.ws.kernel.boot_fat/override/autoFVT/src/ant/launch.xml
@@ -566,6 +566,8 @@
 						<istrue value="${is.windows.platform}" />
 					</condition>
 
+					<echo>Waiting 30 seconds in case the server has not finished starting...</echo>
+					<sleep seconds="30"/>
 					<echo>Executing ${libertyInstallPath}/bin/${script.exec} ${script.cmd} stop ${serverDir}</echo>
 					<exec failonerror="false" executable="${script.exec}" dir="${libertyInstallPath}/bin" timeout="300000">
 						<arg line="${script.cmd}" />

--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -544,6 +544,8 @@
 						<istrue value="${is.windows.platform}" />
 					</condition>
 
+					<echo>Waiting 30 seconds in case the server has not finished starting...</echo>
+					<sleep seconds="30"/>
 					<echo>Executing ${libertyInstallPath}/bin/${script.exec} ${script.cmd} stop ${serverDir}</echo>
 					<exec failonerror="false" executable="${script.exec}" dir="${libertyInstallPath}/bin" timeout="300000">
 						<arg line="${script.cmd}" />

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -2471,25 +2471,6 @@ public class LibertyServer implements LogMonitorClient {
 
         boolean serverStarted = false;
 
-        if (checkForRestConnector.get()) {
-            //since this is going to connect to the secure port, that needs to be ready
-            //before an attempt to make the JMX connection
-            Log.info(c, method, "Checking that the JMX RestConnector is available and secured");
-            assertNotNull("CWWKO0219I.*ssl not received", waitForStringInLogUsingMark("CWWKO0219I.*ssl"));
-
-            assertNotNull("IBMJMXConnectorREST app did not report as ready", waitForStringInLogUsingMark("CWWKT0016I.*IBMJMXConnectorREST"));
-
-            assertNotNull("Security service did not report it was ready", waitForStringInLogUsingMark("CWWKS0008I"));
-
-            //backup the key file
-
-            try {
-                copyFileToTempDir("resources/security/key.jks", "key.jks");
-            } catch (Exception e) {
-                copyFileToTempDir("resources/security/key.p12", "key.p12");
-            }
-        }
-
         Log.info(c, method, "Waiting up to " + (serverStartTimeout / 1000)
                             + " seconds for server confirmation:  "
                             + START_MESSAGE_CODE.toString() + " to be found in " + consoleAbsPath);
@@ -2524,6 +2505,25 @@ public class LibertyServer implements LogMonitorClient {
             // (but the opposite isn't true since the server could already have been running)
             if (serverStarted) {
                 isStarted = true;
+            }
+
+            if (checkForRestConnector.get()) {
+                //since this is going to connect to the secure port, that needs to be ready
+                //before an attempt to make the JMX connection
+                Log.info(c, method, "Checking that the JMX RestConnector is available and secured");
+                assertNotNull("CWWKO0219I.*ssl not received", waitForStringInLogUsingMark("CWWKO0219I.*ssl"));
+
+                assertNotNull("IBMJMXConnectorREST app did not report as ready", waitForStringInLogUsingMark("CWWKT0016I.*IBMJMXConnectorREST"));
+
+                assertNotNull("Security service did not report it was ready", waitForStringInLogUsingMark("CWWKS0008I"));
+
+                //backup the key file
+
+                try {
+                    copyFileToTempDir("resources/security/key.jks", "key.jks");
+                } catch (Exception e) {
+                    copyFileToTempDir("resources/security/key.p12", "key.p12");
+                }
             }
         } catch (Exception e) {
             Log.error(c, method, e, "Exception thrown confirming server started in " + consoleAbsPath);


### PR DESCRIPTION
- add 30 second delay before stop in cleanup to allow time to finish starting
- move wait for SSL until after server start determined, otherwise server not stopped if there is an error
