### PR TITLE
remove mavenCoordinates from temporary nonship bundle to get past line length error

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.nosql-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.nosql-1.0.feature
@@ -10,7 +10,7 @@ singleton=true
   io.openliberty.noShip-1.0
 -bundles=\
   io.openliberty.jakarta.jsonp.2.1; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.json:jakarta.json-api:2.1.0",\
-  io.openliberty.jakarta.nosql.1.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.nosql.communication:communication-core:1.0.0-b4,jakarta.nosql.communication:communication-column:1.0.0-b4,jakarta.nosql.communication:communication-document:1.0.0-b4,jakarta.nosql.communication:communication-key-value:1.0.0-b4,jakarta.nosql.communication:communication-query:1.0.0-b4,jakarta.nosql.mapping:mapping-core:1.0.0-b4,jakarta.nosql.mapping:mapping-column:1.0.0-b4,jakarta.nosql.mapping:mapping-document:1.0.0-b4,jakarta.nosql.mapping:mapping-key-value:1.0.0-b4"
+  io.openliberty.jakarta.nosql.1.0; location:="dev/api/spec/,lib/"
 kind=noship
 edition=full
 WLP-Activation-Type: parallel


### PR DESCRIPTION
Update being made to non-ship feature that we are only using for testing.  The update works around this error:

```
started_689840546049565/wlp/lib/features/io.openliberty.jakarta.nosql-1.0.mf.  Exception: line too long 
```