### PR TITLE
Initial impl for OpenIdContext API for issue #22608

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/bnd.bnd
@@ -54,6 +54,7 @@ src: src, resources
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	io.openliberty.jakarta.authentication.3.0;version=latest,\
 	io.openliberty.jakarta.cdi.4.0,\
+	io.openliberty.jakarta.jsonp.2.1,\
 	io.openliberty.jakarta.security.3.0,\
 	io.openliberty.jakarta.servlet.6.0,\
 	io.openliberty.security.jakartasec.2.0.internal,\

--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/beans/OpenIdContextBean.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/beans/OpenIdContextBean.java
@@ -22,7 +22,6 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.security.authentication.utility.SubjectHelper;
 import com.ibm.ws.security.context.SubjectManager;
 
-import io.openliberty.security.jakartasec.credential.OidcTokensCredential;
 import io.openliberty.security.jakartasec.identitystore.OpenIdContextImpl;
 import jakarta.enterprise.context.SessionScoped;
 import jakarta.security.enterprise.identitystore.openid.OpenIdContext;
@@ -61,24 +60,21 @@ public class OpenIdContextBean implements Serializable {
 
         if (subject != null && !subjectHelper.isUnauthenticated(subject)) {
 
-            Set<OidcTokensCredential> oidcTokensCredentialSet = subject.getPrivateCredentials(OidcTokensCredential.class);
+            Set<OpenIdContextImpl> openIdContextImplSet = subject.getPrivateCredentials(OpenIdContextImpl.class);
 
-            if (oidcTokensCredentialSet == null || oidcTokensCredentialSet.isEmpty()) {
+            if (openIdContextImplSet == null || openIdContextImplSet.isEmpty()) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "getOpenIdContext() Got an authenticated subject, but did not find an OidcTokensCredential");
+                    Tr.debug(tc, "getOpenIdContext() Got an authenticated subject, but did not find an OpenIdContextImpl");
                 }
             } else {
-                if (oidcTokensCredentialSet.size() > 1) {
+                if (openIdContextImplSet.size() > 1) {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                        Tr.debug(tc, "getOpenIdContext() Multiple OidcTokensCredentials on the subject!");
+                        Tr.debug(tc, "getOpenIdContext() Multiple OpenIdContextImpl instances on the subject!");
                     }
                 }
-                OidcTokensCredential oidcTokensCredential = oidcTokensCredentialSet.iterator().next();
-                // TODO from oidcTokensCredential get or create an OpenIdContext
-            }
 
-            // TODO returning an empty OpenIdContext temporarily
-            openIdContext = new OpenIdContextImpl();
+                openIdContext = openIdContextImplSet.iterator().next();
+            }
         } else if (subject == null) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "getOpenIdContext The subject is null from SubjectManager.getCallerSubject");

--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/test/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanismTest.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/test/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanismTest.java
@@ -1,6 +1,7 @@
 package io.openliberty.security.jakartasec.cdi.beans;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -27,7 +28,7 @@ import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 
 import io.openliberty.security.jakartasec.JakartaSec30Constants;
 import io.openliberty.security.jakartasec.TestOpenIdAuthenticationMechanismDefinition;
-import io.openliberty.security.oidcclientcore.authentication.AuthorizationCodeFlow;
+import io.openliberty.security.jakartasec.identitystore.OpenIdContextImpl;
 import io.openliberty.security.oidcclientcore.client.Client;
 import io.openliberty.security.oidcclientcore.exceptions.AuthenticationResponseException;
 import io.openliberty.security.oidcclientcore.exceptions.TokenRequestException;
@@ -90,6 +91,7 @@ public class OidcHttpAuthenticationMechanismTest {
         client = mockery.mock(Client.class);
         tokenResponse = mockery.mock(TokenResponse.class);
         messageInfoMap = new HashMap<String, Object>();
+        clientSubject = new Subject();
     }
 
     @After
@@ -144,6 +146,7 @@ public class OidcHttpAuthenticationMechanismTest {
         AuthenticationStatus authenticationStatus = mechanism.validateRequest(request, response, httpMessageContext);
 
         assertEquals("The AuthenticationStatus must be SUCCESS.", AuthenticationStatus.SUCCESS, authenticationStatus);
+        assertNotNull("The client subject must have an OpenIdContextImpl instance.", clientSubject.getPrivateCredentials(OpenIdContextImpl.class).iterator().next());
     }
 
     @SuppressWarnings("unchecked")

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/bnd.bnd
@@ -58,6 +58,7 @@ instrument.classesExcludes: io/openliberty/security/jakartasec/internal/resource
     io.openliberty.jakarta.cdi.4.0;version=latest,\
     io.openliberty.jakarta.expressionLanguage.5.0;version=latest,\
     io.openliberty.org.apache.jasper.expressionLanguage.5.0;version=latest,\
+    io.openliberty.org.eclipse.parsson.1.1,\
     io.openliberty.jakarta.security.3.0,\
     com.ibm.ws.security.test.common;version=latest,\
     org.jmock:jmock-legacy;version=2.5.0,\

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OpenIdContextImpl.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OpenIdContextImpl.java
@@ -10,8 +10,10 @@
  *******************************************************************************/
 package io.openliberty.security.jakartasec.identitystore;
 
+import java.io.StringReader;
 import java.util.Optional;
 
+import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.security.enterprise.identitystore.openid.AccessToken;
 import jakarta.security.enterprise.identitystore.openid.IdentityToken;
@@ -26,53 +28,70 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class OpenIdContextImpl implements OpenIdContext {
 
-    private static final long serialVersionUID = 1L; // TO-DO, added due to warning, do we need a generated UID?
+    private static final long serialVersionUID = 1L;
 
-    @Override
-    public AccessToken getAccessToken() {
-        // TODO Auto-generated method stub
-        return null;
+    private final String subjectIdentifier;
+    private final String tokenType;
+    private final AccessToken accessToken;
+    private final IdentityToken identityToken;
+    private final OpenIdClaims userinfoClaims;
+    private final JsonObject providerMetadata; // TODO: Store JSON String instead for serialization
+
+    private RefreshToken refreshToken;
+    private Long expiresIn;
+
+    public OpenIdContextImpl(String subjectIdentifier, String tokenType, AccessToken accessToken, IdentityToken identityToken, OpenIdClaims userinfoClaims,
+                             JsonObject providerMetadata) {
+        this.subjectIdentifier = subjectIdentifier;
+        this.tokenType = tokenType;
+        this.accessToken = accessToken;
+        this.identityToken = identityToken;
+        this.userinfoClaims = userinfoClaims;
+        this.providerMetadata = providerMetadata;
     }
 
-    @Override
-    public OpenIdClaims getClaims() {
-        // TODO Auto-generated method stub
-        return null;
+    public void setRefreshToken(RefreshToken refreshToken) {
+        this.refreshToken = refreshToken;
     }
 
-    @Override
-    public Optional<Long> getExpiresIn() {
-        // TODO Auto-generated method stub
-        return Optional.empty();
-    }
-
-    @Override
-    public IdentityToken getIdentityToken() {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public Optional<RefreshToken> getRefreshToken() {
-        // TODO Auto-generated method stub
-        return Optional.empty();
+    public void setExpiresIn(Long expiresIn) {
+        this.expiresIn = expiresIn;
     }
 
     @Override
     public String getSubject() {
-        // TODO Auto-generated method stub
-        return null;
+        return subjectIdentifier;
     }
 
     @Override
     public String getTokenType() {
-        // TODO Auto-generated method stub
-        return null;
+        return tokenType;
     }
 
     @Override
-    public JsonObject getProviderMetadata() {
-        return null;
+    public AccessToken getAccessToken() {
+        return accessToken;
+    }
+
+    @Override
+    public IdentityToken getIdentityToken() {
+        return identityToken;
+    }
+
+    @Override
+    public Optional<RefreshToken> getRefreshToken() {
+        if (refreshToken != null) {
+            return Optional.of(refreshToken);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Long> getExpiresIn() {
+        if (expiresIn != null) {
+            return Optional.of(expiresIn);
+        }
+        return Optional.empty();
     }
 
     @Override
@@ -82,7 +101,19 @@ public class OpenIdContextImpl implements OpenIdContext {
     }
 
     @Override
-    public Optional getStoredValue(HttpServletRequest request, HttpServletResponse response, String key) {
+    public OpenIdClaims getClaims() {
+        return userinfoClaims;
+    }
+
+    @Override
+    public JsonObject getProviderMetadata() {
+        // Clone providerMetadata before returning it to avoid modifications.
+        return Json.createReader(new StringReader(providerMetadata.toString())).readObject();
+    }
+
+    @Override
+    public <T> Optional<T> getStoredValue(HttpServletRequest request, HttpServletResponse response, String key) {
+        // TODO: Get value from Storage subsystem.
         return null;
     }
 

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/identitystore/OpenIdContextImplTest.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/identitystore/OpenIdContextImplTest.java
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.identitystore;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.Optional;
+
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdConstant;
+import jakarta.security.enterprise.identitystore.openid.AccessToken;
+import jakarta.security.enterprise.identitystore.openid.IdentityToken;
+import jakarta.security.enterprise.identitystore.openid.OpenIdClaims;
+import jakarta.security.enterprise.identitystore.openid.OpenIdContext;
+import jakarta.security.enterprise.identitystore.openid.RefreshToken;
+
+public class OpenIdContextImplTest {
+
+    private static final String SUBJECT_IN_ID_TOKEN = "Jackson";
+    private static final String TOKEN_TYPE_BEARER = "Bearer";
+    private static final String TOKEN_TYPE_MAC = "MAC";
+    private static final Long ONE_HOUR = Long.valueOf(3600);
+
+    private final Mockery mockery = new JUnit4Mockery();
+
+    private AccessToken accessToken;
+    private IdentityToken identityToken;
+    private RefreshToken refreshToken;
+    private OpenIdClaims userinfoClaims;
+    private JsonObject providerMetadata;
+    private JsonObject jsonObject;
+    private OpenIdContext openIdContext;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        accessToken = mockery.mock(AccessToken.class);
+        identityToken = mockery.mock(IdentityToken.class);
+        refreshToken = mockery.mock(RefreshToken.class);
+        userinfoClaims = mockery.mock(OpenIdClaims.class);
+        providerMetadata = Json.createObjectBuilder().add(OpenIdConstant.ISSUER, "https://localhost:9443/oidc/endpoint/OP/authorize").build();
+
+        openIdContext = new OpenIdContextImpl(SUBJECT_IN_ID_TOKEN, TOKEN_TYPE_BEARER, accessToken, identityToken, userinfoClaims, providerMetadata);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void testGetSubject() {
+        assertEquals("The subject identifier must be set.", SUBJECT_IN_ID_TOKEN, openIdContext.getSubject());
+    }
+
+    @Test
+    public void testGetTokenType() {
+        assertEquals("The token type must be set.", TOKEN_TYPE_BEARER, openIdContext.getTokenType());
+    }
+
+    @Test
+    public void testGetAccessToken() {
+        assertEquals("The access token must be set.", accessToken, openIdContext.getAccessToken());
+    }
+
+    @Test
+    public void testGetIdentityToken() {
+        assertEquals("The identity token must be set.", identityToken, openIdContext.getIdentityToken());
+    }
+
+    @Test
+    public void testGetRefreshToken_notSet() {
+        Optional<RefreshToken> optionalRefreshToken = openIdContext.getRefreshToken();
+
+        assertFalse("The refresh token must not be set.", optionalRefreshToken.isPresent());
+    }
+
+    @Test
+    public void testGetRefreshToken_set() {
+        ((OpenIdContextImpl) openIdContext).setRefreshToken(refreshToken);
+        Optional<RefreshToken> optionalRefreshToken = openIdContext.getRefreshToken();
+
+        assertEquals("The refresh token must be set.", refreshToken, optionalRefreshToken.get());
+    }
+
+    @Test
+    public void testGetExpiresIn_notSet() {
+        Optional<Long> optionalExpiresIn = openIdContext.getExpiresIn();
+
+        assertFalse("The 'expires in' must not be set.", optionalExpiresIn.isPresent());
+    }
+
+    @Test
+    public void testGetExpiresIn_set() {
+        ((OpenIdContextImpl) openIdContext).setExpiresIn(ONE_HOUR);
+        Optional<Long> optionalExpiresIn = openIdContext.getExpiresIn();
+
+        assertEquals("The 'expires in' must be set.", ONE_HOUR, optionalExpiresIn.get());
+    }
+
+//
+//    @Test
+//    public void testGetClaimsJson() {
+//        fail("Not yet implemented");
+//    }
+//
+    @Test
+    public void testGetClaims() {
+        assertEquals("The userinfo claims must be set.", userinfoClaims, openIdContext.getClaims());
+    }
+
+    @Test
+    public void testGetProviderMetadata() {
+        assertEquals("The provider metadata must be set.", providerMetadata, openIdContext.getProviderMetadata());
+    }
+//
+//    @Test
+//    public void testGetStoredValue() {
+//        fail("Not yet implemented");
+//    }
+
+}


### PR DESCRIPTION
For issue #22608

Initial implementation of the OpenIdContext API. Returns subject, various tokens, token type, expires in, and provider metadata.

NOT implemented here are returning the Userinfo claims as JsonObject and returning a stored value.