### PR TITLE
Eclipse and bnd updates from recent changes

### DIFF
--- a/dev/com.ibm.jbatch.container/transformed10.bnd
+++ b/dev/com.ibm.jbatch.container/transformed10.bnd
@@ -14,4 +14,9 @@ Bundle-Name: Java Batch RI core runtime implementation Jakarta
 Bundle-SymbolicName: com.ibm.jbatch.container.jakarta.ee10
 Bundle-Description: Java Batch RI core runtime implementation; Jakarta Enabled
 
+javac.source: 11
+javac.target: 11
+
+Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
+
 -includeresource.ee10: @${repo;com.ibm.jbatch.internal.ee10}!/com/ibm/jbatch/container/persistence/jpa/extractor/*

--- a/dev/com.ibm.jbatch.internal.ee10/bnd.bnd
+++ b/dev/com.ibm.jbatch.internal.ee10/bnd.bnd
@@ -19,6 +19,8 @@ bVersion=1.0
 javac.source: 11
 javac.target: 11
 
+Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
+
 publish.wlp.jar.disabled: true
 
 
@@ -37,16 +39,9 @@ WS-TraceGroup: wsbatch
 Export-Package:\
  com.ibm.jbatch.container.persistence.jpa.extractor;provide:=true;version=2.0.0
 
-# Using version=! in order to not have a version attached to the import for packages that were removed
-# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
-# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
-##
-# Using '*' below causes problems with our two separate src dirs
-##
 Import-Package: org.eclipse.persistence.descriptors,\
     org.eclipse.persistence.sessions,\
 	*
-#Private-Package: com.ibm.jbatch.internal.*
 
 -buildpath: \
 	io.openliberty.persistence.3.1.thirdparty;version=latest,\

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/bnd.bnd
@@ -15,6 +15,11 @@ Bundle-Name: io.openliberty.microprofile.telemetry.1.0.internal
 Bundle-SymbolicName: io.openliberty.microprofile.telemetry.1.0.internal
 Bundle-Description: MicroProfile.telemetry, version 1.0
 
+javac.source: 11
+javac.target: 11
+
+Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
+
 src: src, resources
 
 #-cdiannotations:
@@ -49,8 +54,6 @@ Export-Package: \
 
 Private-Package: \
   io.openliberty.microprofile.telemetry.internal.cdi
-
-Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
 
 -buildpath: \
     io.openliberty.jakarta.restfulWS.3.1;version=latest,\

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/.classpath
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/bnd.bnd
@@ -62,7 +62,6 @@ src: src, resources
 	io.openliberty.security.oidcclientcore.internal.jakarta,\
 	com.ibm.ws.cdi.interfaces.jakarta;version=latest,\
 	io.openliberty.webcontainer.security.internal;version=latest,\
-	com.ibm.ws.security.javaeesec.cdi;version=latest,\
 	com.ibm.ws.security;version=latest,\
 	com.ibm.websphere.security;version=latest
 


### PR DESCRIPTION
- Re-remove the non Jakarta version of bundle in io.openliberty.security.jakartasec.3.0.internal.cdi that caused eclipse not to build.
- Add Java 11 settings there were missing from recently added / updated bundles.
- Clean up bnd file for EE10 batch function.
