### PR TITLE
21770 rework sip logging extension

### DIFF
--- a/dev/com.ibm.websphere.javaee.servlet.sip.1.1/src/javax/servlet/sip/SipApplicationSession.java
+++ b/dev/com.ibm.websphere.javaee.servlet.sip.1.1/src/javax/servlet/sip/SipApplicationSession.java
@@ -252,6 +252,27 @@ public interface SipApplicationSession {
     Iterator getSessions(String protocol) throws IllegalStateException, NullPointerException, IllegalArgumentException;
     
     
+    
+    /**
+     * Returns an <code>Iterator</code> over the "protocol" session objects
+     * associated of the specified protocol associated with this application
+     * session. If the specified protocol is not supported, an empty
+     * <code>Iterator</code> is returned.
+     * If "SIP" is specified the result will be an <code>Iterator</code>
+     * over the set of {@link SipSession} objects belonging to this application
+     * session. For "HTTP" the result will be a list of
+     * <code>javax.servlet.http.HttpSession</code> objects.
+     * @param protocol a string identifying the protocol name, e.g. "SIP"
+     * @param boolean representing if SIP sessions should be created if none exist
+     * @return <code>Iterator</code> over protocol sessions of the
+     *      specified protocol  
+     * @throws IllegalStateException - if this application session is not valid
+     * @throws NullPointerException - if the protocol is null 
+     * @throws IllegalArgumentException - if the protocol is not understood by container.
+     * 
+     */
+    Iterator getSessions(String string, boolean b) throws IllegalStateException, NullPointerException, IllegalArgumentException; ;
+    
     /**
      * Returns the SipSession with the specified id belonging to this application 
      * session, or null if not found.
@@ -399,5 +420,8 @@ public interface SipApplicationSession {
      * @throws IllegalStateException
      */
     void setInvalidateWhenReady(boolean invalidateWhenReady) throws IllegalStateException;
+
+	
+    
 
 }

--- a/dev/com.ibm.websphere.javaee.servlet.sip.1.1/src/javax/servlet/sip/SipApplicationSession.java
+++ b/dev/com.ibm.websphere.javaee.servlet.sip.1.1/src/javax/servlet/sip/SipApplicationSession.java
@@ -271,7 +271,11 @@ public interface SipApplicationSession {
      * @throws IllegalArgumentException - if the protocol is not understood by container.
      * 
      */
+<<<<<<< HEAD
     Iterator getSessions(String string, boolean b) throws IllegalStateException, NullPointerException, IllegalArgumentException; ;
+=======
+    Iterator getSessions(String protocol, boolean create) throws IllegalStateException, NullPointerException, IllegalArgumentException; ;
+>>>>>>> 99428801b7 (new code path to retrieved sip application session in SipLogExtension class)
     
     /**
      * Returns the SipSession with the specified id belonging to this application 

--- a/dev/com.ibm.websphere.javaee.servlet.sip.1.1/src/javax/servlet/sip/SipApplicationSession.java
+++ b/dev/com.ibm.websphere.javaee.servlet.sip.1.1/src/javax/servlet/sip/SipApplicationSession.java
@@ -271,11 +271,8 @@ public interface SipApplicationSession {
      * @throws IllegalArgumentException - if the protocol is not understood by container.
      * 
      */
-<<<<<<< HEAD
-    Iterator getSessions(String string, boolean b) throws IllegalStateException, NullPointerException, IllegalArgumentException; ;
-=======
+
     Iterator getSessions(String protocol, boolean create) throws IllegalStateException, NullPointerException, IllegalArgumentException; ;
->>>>>>> 99428801b7 (new code path to retrieved sip application session in SipLogExtension class)
     
     /**
      * Returns the SipSession with the specified id belonging to this application 

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/servlets/SipApplicationSessionImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/servlets/SipApplicationSessionImpl.java
@@ -675,6 +675,7 @@ implements SipApplicationSession {
 
 			//Moti: we create new ArrayList to prevent later any modification
 			// to the iterator on that list.
+<<<<<<< HEAD
 			
 				List<IBMSipSession> result = new ArrayList<IBMSipSession>(size); //approximation only.
 					synchronized (m_transactionUsers) {
@@ -689,6 +690,20 @@ implements SipApplicationSession {
 						}
 					}
 			return result;
+=======
+				List<IBMSipSession> result = new ArrayList<IBMSipSession>(size); //approximation only.
+				synchronized (m_transactionUsers) {
+						TransactionUserWrapper tu = null;
+						for (int i = 0 ; i < size ; i++) {
+							tu = m_transactionUsers.get(i);
+							result.addAll(tu.getAllSipSessions(create));
+						}
+				}
+				if (c_logger.isTraceDebugEnabled()) {
+						c_logger.traceDebug(this, "getAllSIPSessions", "found SIP sessions. count:"+result.size());
+				}	
+				return result;
+>>>>>>> 99428801b7 (new code path to retrieved sip application session in SipLogExtension class)
 			}
 			
 		}
@@ -1807,6 +1822,7 @@ implements SipApplicationSession {
 		m_sessionKeyBaseKey = skbt;
 	}
 	
+<<<<<<< HEAD
 	public Iterator getSessions(String protocol, boolean b) {
 		if (protocol.equalsIgnoreCase("SIP"))  {  //get SIP application sessions  
 			if (c_logger.isTraceDebugEnabled()) {
@@ -1814,6 +1830,15 @@ implements SipApplicationSession {
 			}
 			
 			if (b) {  //boolean is true	
+=======
+	public Iterator getSessions(String protocol, boolean create) {
+		if (protocol.equalsIgnoreCase("SIP"))  {  //get SIP application sessions  
+			if (c_logger.isTraceDebugEnabled()) {
+				c_logger.traceDebug("getSessions(" + protocol + ", " + create + " detected.");
+			}
+			
+			if (create) {  //boolean is true	
+>>>>>>> 99428801b7 (new code path to retrieved sip application session in SipLogExtension class)
 					return (Iterator)getAllSIPSessions(true).iterator();
 				}
 		

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/servlets/SipApplicationSessionImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/servlets/SipApplicationSessionImpl.java
@@ -669,23 +669,28 @@ implements SipApplicationSession {
 				}
 				return Collections.EMPTY_LIST;
 			}
-			int size = m_transactionUsers.size();
+			
+			else {
+				int size = m_transactionUsers.size();
 
 			//Moti: we create new ArrayList to prevent later any modification
 			// to the iterator on that list.
-			List<IBMSipSession> result = new ArrayList<IBMSipSession>(size); //approximation only.
-			synchronized (m_transactionUsers) {
-				TransactionUserWrapper tu = null;
-				for (int i = 0 ; i < size ; i++) {
-					tu = m_transactionUsers.get(i);
-					result.addAll(tu.getAllSipSessions(create));
-				}
-			}
-			if (c_logger.isTraceDebugEnabled()) {
-				c_logger.traceDebug(this, "getAllSIPSessions", "found SIP sessions. count:"+result.size());
-			}
-
+			
+				List<IBMSipSession> result = new ArrayList<IBMSipSession>(size); //approximation only.
+					synchronized (m_transactionUsers) {
+						TransactionUserWrapper tu = null;
+						for (int i = 0 ; i < size ; i++) {
+						tu = m_transactionUsers.get(i);
+						result.addAll(tu.getAllSipSessions(create));
+						}
+			
+						if (c_logger.isTraceDebugEnabled()) {
+							c_logger.traceDebug(this, "getAllSIPSessions", "found SIP sessions. count:"+result.size());
+						}
+					}
 			return result;
+			}
+			
 		}
 	}
 
@@ -721,6 +726,7 @@ implements SipApplicationSession {
 		}
 
 	}
+	
 
 	/**
 	 * @see javax.servlet.sip.SipApplicationSession#getSipSession(java.lang.String)
@@ -1800,4 +1806,36 @@ implements SipApplicationSession {
 		}
 		m_sessionKeyBaseKey = skbt;
 	}
+	
+	public Iterator getSessions(String protocol, boolean b) {
+		if (protocol.equalsIgnoreCase("SIP"))  {  //get SIP application sessions  
+			if (c_logger.isTraceDebugEnabled()) {
+				c_logger.traceDebug("getSessions(" + protocol + ", " + b + " detected.");
+			}
+			
+			if (b) {  //boolean is true	
+					return (Iterator)getAllSIPSessions(true).iterator();
+				}
+		
+			else {  //boolean is false
+					return (Iterator)getAllSIPSessions(false).iterator();
+				}
+		}
+		
+		else if (protocol.equalsIgnoreCase("HTTP")){
+			return Collections.EMPTY_MAP.keySet().iterator();
+		}
+			
+		else { 
+
+			SipAppDesc sipAppDesc = getAppDescriptor();
+			if(sipAppDesc != null && !sipAppDesc.isJSR289Application()){
+				return Collections.EMPTY_MAP.keySet().iterator();				
+			}
+
+			throw new IllegalArgumentException("Unsupported protocol type " + protocol);
+		}
+	}
+
+		
 }

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/servlets/SipApplicationSessionImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/servlets/SipApplicationSessionImpl.java
@@ -1814,11 +1814,10 @@ implements SipApplicationSession {
 		if (protocol.equalsIgnoreCase("SIP"))  {  //get SIP application sessions  
 			if (create) {  //boolean is true	
 					return (Iterator)getAllSIPSessions(true).iterator();
-				}
-		
+			} 
 			else {  //boolean is false
 					return (Iterator)getAllSIPSessions(false).iterator();
-				}
+			}
 		}
 		
 		else if (protocol.equalsIgnoreCase("HTTP")){ //protocol is HTTP
@@ -1830,7 +1829,6 @@ implements SipApplicationSession {
 			if(sipAppDesc != null && !sipAppDesc.isJSR289Application()){
 				return Collections.EMPTY_MAP.keySet().iterator();				
 			}
-
 			throw new IllegalArgumentException("Unsupported protocol type " + protocol);
 		}
 	}

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/servlets/SipApplicationSessionImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/servlets/SipApplicationSessionImpl.java
@@ -675,22 +675,6 @@ implements SipApplicationSession {
 
 			//Moti: we create new ArrayList to prevent later any modification
 			// to the iterator on that list.
-<<<<<<< HEAD
-			
-				List<IBMSipSession> result = new ArrayList<IBMSipSession>(size); //approximation only.
-					synchronized (m_transactionUsers) {
-						TransactionUserWrapper tu = null;
-						for (int i = 0 ; i < size ; i++) {
-						tu = m_transactionUsers.get(i);
-						result.addAll(tu.getAllSipSessions(create));
-						}
-			
-						if (c_logger.isTraceDebugEnabled()) {
-							c_logger.traceDebug(this, "getAllSIPSessions", "found SIP sessions. count:"+result.size());
-						}
-					}
-			return result;
-=======
 				List<IBMSipSession> result = new ArrayList<IBMSipSession>(size); //approximation only.
 				synchronized (m_transactionUsers) {
 						TransactionUserWrapper tu = null;
@@ -703,7 +687,7 @@ implements SipApplicationSession {
 						c_logger.traceDebug(this, "getAllSIPSessions", "found SIP sessions. count:"+result.size());
 				}	
 				return result;
->>>>>>> 99428801b7 (new code path to retrieved sip application session in SipLogExtension class)
+
 			}
 			
 		}
@@ -1822,23 +1806,13 @@ implements SipApplicationSession {
 		m_sessionKeyBaseKey = skbt;
 	}
 	
-<<<<<<< HEAD
-	public Iterator getSessions(String protocol, boolean b) {
+	public Iterator getSessions(String protocol, boolean create){
+		if (c_logger.isTraceDebugEnabled()) {
+			c_logger.traceDebug("getSessions(" + protocol + ", " + create + " detected.");
+		}
+
 		if (protocol.equalsIgnoreCase("SIP"))  {  //get SIP application sessions  
-			if (c_logger.isTraceDebugEnabled()) {
-				c_logger.traceDebug("getSessions(" + protocol + ", " + b + " detected.");
-			}
-			
-			if (b) {  //boolean is true	
-=======
-	public Iterator getSessions(String protocol, boolean create) {
-		if (protocol.equalsIgnoreCase("SIP"))  {  //get SIP application sessions  
-			if (c_logger.isTraceDebugEnabled()) {
-				c_logger.traceDebug("getSessions(" + protocol + ", " + create + " detected.");
-			}
-			
 			if (create) {  //boolean is true	
->>>>>>> 99428801b7 (new code path to retrieved sip application session in SipLogExtension class)
 					return (Iterator)getAllSIPSessions(true).iterator();
 				}
 		
@@ -1847,12 +1821,11 @@ implements SipApplicationSession {
 				}
 		}
 		
-		else if (protocol.equalsIgnoreCase("HTTP")){
+		else if (protocol.equalsIgnoreCase("HTTP")){ //protocol is HTTP
 			return Collections.EMPTY_MAP.keySet().iterator();
 		}
 			
-		else { 
-
+		else { //protocol is not SIP and not HTTP, we don't handle it
 			SipAppDesc sipAppDesc = getAppDescriptor();
 			if(sipAppDesc != null && !sipAppDesc.isJSR289Application()){
 				return Collections.EMPTY_MAP.keySet().iterator();				

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/tu/TransactionUserBase.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/tu/TransactionUserBase.java
@@ -611,8 +611,10 @@ public class TransactionUserBase extends ReplicatableImpl {
 	 * @return
 	 */
 	List<IBMSipSession> getAllSipSessions(List<IBMSipSession> sessions, boolean create){
-		if(_sipSession == null){
-			getSipSession(create);
+		if(create) { //boolean is true, create new SIP sessions if there are none
+			if(_sipSession == null){
+				getSipSession(create);
+				}
 		}
 		if(_sipSession != null){
 			sessions.add(_sipSession);	
@@ -620,10 +622,6 @@ public class TransactionUserBase extends ReplicatableImpl {
 		return sessions;
 	}
 
-	/**
-	 * Invalidate the Transaction User and Remove it from the TransactionUserTable
-	 *
-	 */
 	protected void invalidateBase(boolean removeFromAppSession) {
 
 		if (c_logger.isTraceEntryExitEnabled()) {

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/tu/TransactionUserBase.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/tu/TransactionUserBase.java
@@ -611,10 +611,8 @@ public class TransactionUserBase extends ReplicatableImpl {
 	 * @return
 	 */
 	List<IBMSipSession> getAllSipSessions(List<IBMSipSession> sessions, boolean create){
-		if(create) { //boolean is true, create new SIP sessions if there are none
-			if(_sipSession == null){
+		if(create && _sipSession == null) { //boolean is true, create new SIP sessions when there are none
 				getSipSession(create);
-				}
 		}
 		if(_sipSession != null){
 			sessions.add(_sipSession);	

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/tu/TransactionUserBase.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/tu/TransactionUserBase.java
@@ -620,6 +620,10 @@ public class TransactionUserBase extends ReplicatableImpl {
 		return sessions;
 	}
 
+	/**
+	 * Invalidate the Transaction User and Remove it from the TransactionUserTable
+	 *
+	 */
 	protected void invalidateBase(boolean removeFromAppSession) {
 
 		if (c_logger.isTraceEntryExitEnabled()) {

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/util/SipLogExtension.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/util/SipLogExtension.java
@@ -169,6 +169,9 @@ public class SipLogExtension {
      * @return call ID
      */
     private static String getCallId() {
+    	//try catch block needed to catch NPE thrown by logger
+    	//in case ThreadLocalStorage.getApplicationSession() returns NULL
+    	//see open-liberty issue #21770
     	try {
     	SipApplicationSession sas = ThreadLocalStorage.getApplicationSession();
     	if (sas != null) {
@@ -203,6 +206,9 @@ public class SipLogExtension {
      * @return SIP session ID
      */
     private static String getSessionId() {
+    	//try catch block needed to catch NPE thrown by logger
+    	//in case ThreadLocalStorage.getApplicationSession() returns NULL
+    	//see open-liberty issue #21770
     	try {
     	SipApplicationSession sas = ThreadLocalStorage.getApplicationSession();
     	if (sas != null) {
@@ -237,7 +243,9 @@ public class SipLogExtension {
      * @return second call ID
      */
     private static String getSecondCallId() {
-    	
+    	//try catch block needed to catch NPE thrown by logger
+    	//in case ThreadLocalStorage.getApplicationSession() returns NULL
+    	//see open-liberty issue #21770
     	try {
     	SipApplicationSession sas = ThreadLocalStorage.getApplicationSession();
     	
@@ -269,8 +277,9 @@ public class SipLogExtension {
      * @return second SIP session ID
      */
     private static String getSecondSessionId() {
-    	
-    	
+    	//try catch block needed to catch NPE thrown by logger
+    	//in case ThreadLocalStorage.getApplicationSession() returns NULL
+    	//see open-liberty issue #21770
     	try {
     		SipApplicationSession sas = ThreadLocalStorage.getApplicationSession();
     	

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/util/SipLogExtension.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/util/SipLogExtension.java
@@ -11,7 +11,6 @@
 package com.ibm.ws.sip.container.util;
 
 import java.util.Iterator;
-
 import javax.servlet.sip.SipApplicationSession;
 import javax.servlet.sip.SipSession;
 
@@ -141,12 +140,15 @@ public class SipLogExtension {
      * @return SAS ID
      */
     private static String getSasId() {
-    	
+    	try {
     	SipApplicationSession sas = ThreadLocalStorage.getApplicationSession();
     	if (sas != null) {
     		return sas.getId(); 
     	}
     	
+    	} catch (NullPointerException e) {
+    		
+    	}
     	//If there's no SAS on ThreadLocal, get the ID from the TU on ThreadLocal
 		TransactionUserWrapper tu = ThreadLocalStorage.getTuWrapper();
 		if (tu != null) {
@@ -167,10 +169,10 @@ public class SipLogExtension {
      * @return call ID
      */
     private static String getCallId() {
-    	
+    	try {
     	SipApplicationSession sas = ThreadLocalStorage.getApplicationSession();
     	if (sas != null) {
-    		Iterator<SipSession> i = sas.getSessions("SIP");
+    		Iterator<SipSession> i = sas.getSessions("SIP", false);
     		//Get the first call ID
     		if (i.hasNext()) {
     			SipSession session = i.next();
@@ -188,6 +190,9 @@ public class SipLogExtension {
 			}
 		}
 		
+    	} catch (NullPointerException e ) {
+    		
+    	}
 		//Look for the call ID on the stack's ThreadLocal
 		return com.ibm.ws.sip.stack.util.ThreadLocalStorage.getCallID();
     }
@@ -198,10 +203,10 @@ public class SipLogExtension {
      * @return SIP session ID
      */
     private static String getSessionId() {
-    	
+    	try {
     	SipApplicationSession sas = ThreadLocalStorage.getApplicationSession();
     	if (sas != null) {
-    		Iterator<SipSession> i = sas.getSessions("SIP");
+    		Iterator<SipSession> i = sas.getSessions("SIP", false);
     		//Get the first session ID
     		if (i.hasNext()) {
     			SipSession session = i.next();
@@ -217,7 +222,11 @@ public class SipLogExtension {
 			} catch (IllegalStateException e) {
 				// this exception can be thrown when the transaction is in TERMINATED state
 			}
-		}
+		} 
+		
+    	} catch (NullPointerException e ) {
+    		
+    	}
 		
 		return null;
     }
@@ -229,10 +238,12 @@ public class SipLogExtension {
      */
     private static String getSecondCallId() {
     	
+    	try {
     	SipApplicationSession sas = ThreadLocalStorage.getApplicationSession();
     	
     	if (sas != null) {
-    		Iterator<SipSession> i = sas.getSessions("SIP");
+    		
+    		Iterator<SipSession> i = sas.getSessions("SIP", false);
     		int sessionsCounter = 0;
     		//When there are several SIP sessions and/or call IDs associated 
     		//with the same SAS, only the first two will be printed.
@@ -246,6 +257,9 @@ public class SipLogExtension {
     		}
     	}
     	
+    	} catch (NullPointerException e ) {
+    		
+    	}
 		return null;
     }
     
@@ -256,10 +270,12 @@ public class SipLogExtension {
      */
     private static String getSecondSessionId() {
     	
-    	SipApplicationSession sas = ThreadLocalStorage.getApplicationSession();
+    	
+    	try {
+    		SipApplicationSession sas = ThreadLocalStorage.getApplicationSession();
     	
     	if (sas != null) {
-    		Iterator<SipSession> i = sas.getSessions("SIP");
+    		Iterator<SipSession> i = sas.getSessions("SIP", false);
     		int sessionsCounter = 0;
     		//When there are several SIP sessions and/or call IDs associated 
     		//with the same SAS, only the first two will be printed.
@@ -271,8 +287,12 @@ public class SipLogExtension {
     				return session.getId();
     			}
     		}
-    	}
+    	}	
+		
+    } catch (NullPointerException e) {
     	
-		return null;
+    }
+    	return null;
     }
 }
+


### PR DESCRIPTION
When HPEL logging is enabled, the SipLogExtension class is calling getSessions("SIP") method, which results is the sipcontainer creating new application sessions when none exist. This behavior is wrong, logging activity should not result in the creation of new sipp application sessions. 


fixes  #21770
