### PR TITLE
Resolved checkpoint time inconsistency in FeatureManager, fixes #22493

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
@@ -979,6 +979,10 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
     private void writeFeatureChangeMessages(long startTime, ProvisioningMode provisioningMode) {
         String time = TimestampUtils.getElapsedTimeNanos(startTime);
 
+        if (provisioningMode == ProvisioningMode.INITIAL_PROVISIONING && CheckpointPhase.getPhase() != CheckpointPhase.INACTIVE) {
+            time = TimestampUtils.getElapsedTime();
+        }
+
         if (provisioningMode == ProvisioningMode.UPDATE) {
             Tr.audit(tc, "COMPLETE_AUDIT", time);
         } else {


### PR DESCRIPTION
When a checkpoint occurs during FeatureManager startup, the time between checkpoint and restore is no longer included in the startup time.


