### PR TITLE
Update to MicroProfile Fault Tolerance 4.0.1

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2329,7 +2329,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
       <artifactId>microprofile-fault-tolerance-api</artifactId>
-      <version>4.0</version>
+      <version>4.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.graphql</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -461,7 +461,7 @@ org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:1.1
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:2.0.1
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:2.1
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:3.0
-org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:4.0
+org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:4.0.1
 org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.2
 org.eclipse.microprofile.graphql:microprofile-graphql-api:2.0
 org.eclipse.microprofile.health:microprofile-health-api:1.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.faulttolerance-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.faulttolerance-4.0.feature
@@ -3,7 +3,7 @@ symbolicName=io.openliberty.org.eclipse.microprofile.faulttolerance-4.0
 singleton=true
 -features=io.openliberty.mpCompatible-5.0; ibm.tolerates:="6.0", \
   io.openliberty.jakarta.cdi-3.0; ibm.tolerates:="4.0"
--bundles=io.openliberty.org.eclipse.microprofile.faulttolerance.4.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:4.0"
+-bundles=io.openliberty.org.eclipse.microprofile.faulttolerance.4.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:4.0.1"
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/io.openliberty.microprofile.faulttolerance.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.faulttolerance.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <microprofile.config.version>3.0.1</microprofile.config.version>
-        <microprofile.faulttolerance.version>4.0</microprofile.faulttolerance.version>
+        <microprofile.faulttolerance.version>4.0.1</microprofile.faulttolerance.version>
         <microprofile.metrics.version>4.0</microprofile.metrics.version>
 
         <arquillian.version>1.7.0.Alpha12</arquillian.version>

--- a/dev/io.openliberty.org.eclipse.microprofile/faulttolerance.4.0.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile/faulttolerance.4.0.bnd
@@ -18,6 +18,6 @@ Export-Package: \
   org.eclipse.microprofile.faulttolerance.exceptions;version=1.0
 
 Include-Resource: \
-  @${repo;org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api;4.0;EXACT}
+  @${repo;org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api;4.0.1;EXACT}
 
 WS-TraceGroup: FAULTTOLERANCE


### PR DESCRIPTION
Pulls in the 4.0.1 service release for the MP FT API and TCK
#build
