### PR TITLE
Part2 SessionCookieConfig new APIs

### DIFF
--- a/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionApplicationParameters.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionApplicationParameters.java
@@ -82,7 +82,7 @@ public class SessionApplicationParameters {
         return sapSessionTimeout;
     }
 
-    SessionCookieConfig getSessionCookieConfig() {
+    public SessionCookieConfig getSessionCookieConfig() {
         return sapSessionCookieConfig;
     }
 

--- a/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionContext.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionContext.java
@@ -210,6 +210,8 @@ public class SessionContext {
         sessionMgrCustomizer.setIDGenerator(new IDGeneratorImpl(SessionManagerConfig.getSessionIDLength()));
 
         //Servlet 6.0 - change to interface SessionCookieConfig
+        //_sap.getSessionCookieConfig returns the webAppConfig sessionCookieConfig.
+        //if not null, those cookie info will replace the SMC cookieconfig
         SessionCookieConfig sessionCookieConfig = _sap.getSessionCookieConfig();
         if (sessionCookieConfig != null) {
             _smc.updateCookieInfo(sessionCookieConfig);

--- a/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionCookieConfigImpl.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionCookieConfigImpl.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.session;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.logging.Level;
@@ -126,6 +127,10 @@ public class SessionCookieConfigImpl implements SessionCookieConfig, Cloneable {
             }
             this.attributes.put(name, value);
         }
+    }
+    
+    protected Map<String, String> getAttributes() {
+        return (this.attributes == null) ? Collections.<String, String> emptyMap() : Collections.<String, String> unmodifiableMap(this.attributes);
     }
    
     @Override

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfiguratorHelper.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfiguratorHelper.java
@@ -2652,9 +2652,13 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
         }                
     }
 
-    private void configureSessionConfig(SessionConfig sessionConfig) {
+    protected void configureSessionConfig(SessionConfig sessionConfig) {
         if (sessionConfig == null) {
             return;
+        }
+        
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "configureSessionConfig ");
         }
 
         Map<String, ConfigItem<String>> sessionConfigItemMap = configurator.getConfigItemMap("session-config");

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/session/impl/SessionContextRegistryImpl.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/session/impl/SessionContextRegistryImpl.java
@@ -314,6 +314,7 @@ public class SessionContextRegistryImpl extends SessionContextRegistry implement
         }
 
         //make sure they are the same object
+        //This set the webAppConfig SCC to be the SessionMangerConfig/Session SCC !!
         ctx.getConfiguration().setSessionCookieConfig(iSctx.getWASSessionConfig().getSessionCookieConfig());
         //clone in SessionContext does not update this smc object but the _smc object in SessionContext
         //ctx.getConfiguration().setSessionManagerConfigBase(smc);

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebAppConfiguration.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebAppConfiguration.java
@@ -1135,8 +1135,9 @@ public abstract class WebAppConfiguration extends BaseConfiguration implements W
     public void setSessionCookieConfig(SessionCookieConfig scc) {
         if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE))
         {
-            logger.logp(Level.FINE, CLASS_NAME, "setSessionCookieConfig", " scc [" + scc + "] for application [" + this.getApplicationName() + "] , this -> " + this);
+            logger.logp(Level.FINE, CLASS_NAME, "setSessionCookieConfig", " scc [" + scc + "] for application [" + this.getApplicationName() + "] , replaced scc [" + sessionCookieConfig + "] , this -> " + this);
         }
+
         this.sessionCookieConfig = scc;
     }
 

--- a/dev/io.openliberty.session.6.0.internal/src/io/openliberty/session/impl/SessionCookieConfigImpl60.java
+++ b/dev/io.openliberty.session.6.0.internal/src/io/openliberty/session/impl/SessionCookieConfigImpl60.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package io.openliberty.session.impl;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.logging.Level;
@@ -56,7 +55,7 @@ public class SessionCookieConfigImpl60 extends SessionCookieConfigImpl implement
 
     @Override
     public Map<String, String> getAttributes() {
-        return (this.attributes == null) ? Collections.<String, String> emptyMap() : Collections.<String, String> unmodifiableMap(this.attributes);
+        return super.getAttributes();
     }
 
     @Override

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/osgi/container/config/WebAppConfiguratorHelper60.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/osgi/container/config/WebAppConfiguratorHelper60.java
@@ -16,6 +16,8 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.container.service.app.deploy.WebModuleInfo;
 import com.ibm.ws.container.service.config.ServletConfigurator;
+import com.ibm.ws.javaee.dd.web.common.CookieConfig;
+import com.ibm.ws.javaee.dd.web.common.SessionConfig;
 import com.ibm.ws.resource.ResourceRefConfigFactory;
 import com.ibm.ws.webcontainer.osgi.osgi.WebContainerConstants;
 import com.ibm.ws.webcontainer40.osgi.container.config.WebAppConfiguratorHelper40;
@@ -37,14 +39,35 @@ public class WebAppConfiguratorHelper60 extends WebAppConfiguratorHelper40 {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "Constructor , web module--> " + moduleName);
         }
+    }
 
-        if (webAppConfiguration.getSessionCookieConfig() == null) {
-            SessionCookieConfig sessionCookieConfig = new SessionCookieConfigImpl60();
-            webAppConfiguration.setSessionCookieConfig(sessionCookieConfig);
+    @Override
+    protected void configureSessionConfig(SessionConfig sessionConfig) {
+        if (sessionConfig == null) {
+            return;
+        }
 
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, " Created sessionCookieConfig [{0}]", sessionCookieConfig);
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "WebAppConfiguratorHelper60, configureSessionConfig");
+        }
+
+        CookieConfig cookieConfig = sessionConfig.getCookieConfig();
+
+        if (cookieConfig != null) {
+            SessionCookieConfig sessionCookieConfigImpl = webAppConfiguration.getSessionCookieConfig();
+
+            //create SessionCookieConfigImpl60 only if the <cookie-config> presents in web.xml
+            // AND if the webApp does not have SCC yet. create here so the super can use it.
+            if (webAppConfiguration.getSessionCookieConfig() == null) {
+                SessionCookieConfig sessionCookieConfig = new SessionCookieConfigImpl60();
+                webAppConfiguration.setSessionCookieConfig(sessionCookieConfig);
+
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, " Created sessionCookieConfig [{0}]", sessionCookieConfig);
+                }
             }
         }
+
+        super.configureSessionConfig(sessionConfig);
     }
 }

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/session/impl/HttpSessionContextImpl60.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/session/impl/HttpSessionContextImpl60.java
@@ -44,14 +44,27 @@ public class HttpSessionContextImpl60 extends HttpSessionContext31Impl {
     public HttpSessionContextImpl60(SessionManagerConfig smc, SessionApplicationParameters sap, SessionStoreService sessionStoreService) {
         super(smc, sap, sessionStoreService);
 
+        /*
+         * Upon super() returns, SessionContext has configured all the necessary for this application.
+         * If the SessionCookieConfig (SCC) has configured (i.e cookie-config presents)
+         * the webapp's SCC 6.0 should have copied/replaced the SMC's SCC (i.e SMC's SCC is now updated to the SessionCookieConfigImpl60)
+         */
         if (TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_CORE.isLoggable(Level.FINE)) {
             LoggingUtil.SESSION_LOGGER_CORE.log(Level.FINE, methodClassName + " Constructor");
         }
 
-        SessionCookieConfig scc = smc.getSessionCookieConfig();
-
-        //override the default sccimpl with version 6 sccimpl
-        smc.setClonedCookieConfig(new SessionCookieConfigImpl60(scc.getName(), scc.getDomain(), scc.getPath(), scc.getComment(), scc.getMaxAge(), scc.isHttpOnly(), scc.isSecure()));
+        /*
+         * If the WebAppConfiguration still does not have the SCC at this point, create SCC 6.0, copy over the SCC info and set to the SMC
+         * This only happens if there is no cookie-config in web.xml. We need SCC 6.0 instance by now in case the SCI will
+         * programmatically set it during application startup
+         */
+        if (sap.getSessionCookieConfig() == null) {
+            if (TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_CORE.isLoggable(Level.FINE)) {
+                LoggingUtil.SESSION_LOGGER_CORE.log(Level.FINE, methodClassName + " Constructor , WebAppConfiguration does not have SCC; create SCC 60 version and set to SMC");
+            }
+            SessionCookieConfig scc = smc.getSessionCookieConfig();
+            smc.setClonedCookieConfig(new SessionCookieConfigImpl60(scc.getName(), scc.getDomain(), scc.getPath(), scc.getComment(), scc.getMaxAge(), scc.isHttpOnly(), scc.isSecure()));
+        }
     }
 
     /**


### PR DESCRIPTION
Continue from https://github.com/OpenLiberty/open-liberty/pull/22372

Update the creation of the SessionCookieConfigImpl60 (SCC).  In part1, it was created during the WebAppConfiguratorHelper60 which is not correct.  It should only be created when : 

1. there is a cookie-config element in web.xml 
OR 
2. right before the application start AND there still no SCC in the WebAppConfiguration.  (Need to create at that time in case programmatically SCI add the cookie config during app startup).  Also populated its value with the SessionManagerConfig's SCC

