### PR TITLE
implement PassivationCapable in OidcIdentityStoreBean

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/extensions/OidcIdentityStoreBean.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/extensions/OidcIdentityStoreBean.java
@@ -26,11 +26,12 @@ import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.inject.spi.PassivationCapable;
 import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.enterprise.util.TypeLiteral;
 import jakarta.security.enterprise.identitystore.IdentityStore;
 
-public class OidcIdentityStoreBean implements Bean<IdentityStore> {
+public class OidcIdentityStoreBean implements Bean<IdentityStore>, PassivationCapable {
 
     private static final TraceComponent tc = Tr.register(OidcIdentityStoreBean.class);
 
@@ -98,6 +99,11 @@ public class OidcIdentityStoreBean implements Bean<IdentityStore> {
     @Override
     public Set<InjectionPoint> getInjectionPoints() {
         return Collections.emptySet();
+    }
+
+    @Override
+    public String getId() {
+        return id;
     }
 
 }


### PR DESCRIPTION
implement PassivationCapable in OidcIdentityStoreBean

doing so will resolve this warning in the logs:
`[WARNING ] WELD-001473: jakarta.enterprise.inject.spi.Bean implementation io.openliberty.security.jakartasec.cdi.extensions.OidcIdentityStoreBean@c3d140fb declared a normal scope but does not implementjakarta.enterprise.inject.spi.PassivationCapable. It won't be possible to inject this bean into a bean with a passivating scope (@SessionScoped, @ConversationScoped). This can be fixed by assigning the Bean implementation a unique id by implementing the PassivationCapable interface.`
