### PR TITLE
PR for Issue 21171: Add call to UserInfo endpoint

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
@@ -210,7 +210,10 @@ public class OidcIdentityStore implements IdentityStore {
             return null;
         }
         List<String> groups = getClaimValueFromTokens(callerGroupClaim, accessToken, idTokenClaims, userInfoClaims, List.class);
-        return Set.copyOf(groups);
+        if (groups != null) {
+            return Set.copyOf(groups);
+        }
+        return null;
     }
 
     String getCallerNameClaim(OidcClientConfig clientConfig) {

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
@@ -10,20 +10,28 @@
  *******************************************************************************/
 package io.openliberty.security.jakartasec.identitystore;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.MalformedClaimException;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
 import io.openliberty.security.jakartasec.credential.OidcTokensCredential;
 import io.openliberty.security.jakartasec.tokens.AccessTokenImpl;
 import io.openliberty.security.jakartasec.tokens.IdentityTokenImpl;
+import io.openliberty.security.jakartasec.tokens.OpenIdClaimsImpl;
 import io.openliberty.security.jakartasec.tokens.RefreshTokenImpl;
 import io.openliberty.security.oidcclientcore.client.ClaimsMappingConfig;
 import io.openliberty.security.oidcclientcore.client.Client;
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
+import io.openliberty.security.oidcclientcore.exceptions.UserInfoResponseException;
 import io.openliberty.security.oidcclientcore.token.TokenResponse;
+import io.openliberty.security.oidcclientcore.userinfo.UserInfoHandler;
 import jakarta.json.JsonObject;
 import jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdConstant;
 import jakarta.security.enterprise.credential.Credential;
@@ -39,6 +47,8 @@ import jakarta.servlet.http.HttpServletRequest;
  *
  */
 public class OidcIdentityStore implements IdentityStore {
+
+    public static final TraceComponent tc = Tr.register(OidcIdentityStore.class);
 
     public OidcIdentityStore() {
 
@@ -62,13 +72,14 @@ public class OidcIdentityStore implements IdentityStore {
                     long tokenMinValidityInMillis = oidcClientConfig.getTokenMinValidity();
                     AccessToken accessToken = createAccessTokenFromTokenResponse(tokenMinValidityInMillis, tokenResponse);
                     IdentityToken identityToken = createIdentityTokenFromTokenResponse(tokenMinValidityInMillis, tokenResponse, idTokenClaims);
-                    OpenIdClaims userinfoClaims = createOpenIdClaimsFromUserInfoResponse(); // TODO: Use this interface when creating the CredentialValidationResult
+                    OpenIdClaims userInfoClaims = createOpenIdClaimsFromUserInfoResponse(oidcClientConfig, accessToken);
 
-                    CredentialValidationResult credentialValidationResult = createCredentialValidationResult(client.getOidcClientConfig(), accessToken, idTokenClaims);
+                    CredentialValidationResult credentialValidationResult = createCredentialValidationResult(client.getOidcClientConfig(), accessToken, idTokenClaims,
+                                                                                                             userInfoClaims);
 
                     JsonObject providerMetadata = getProviderMetadataAsJsonObject();
 
-                    OpenIdContext openIdContext = createOpenIdContext(credentialValidationResult.getCallerUniqueId(), tokenResponse, accessToken, identityToken, userinfoClaims,
+                    OpenIdContext openIdContext = createOpenIdContext(credentialValidationResult.getCallerUniqueId(), tokenResponse, accessToken, identityToken, userInfoClaims,
                                                                       providerMetadata, request.getParameter(OpenIdConstant.STATE), oidcClientConfig.isUseSession());
 
                     castCredential.setOpenIdContext(openIdContext);
@@ -117,9 +128,23 @@ public class OidcIdentityStore implements IdentityStore {
         return new IdentityTokenImpl(tokenResponse.getIdTokenString(), idTokenClaims.getClaimsMap(), tokenMinValidityInMillis);
     }
 
-    private OpenIdClaims createOpenIdClaimsFromUserInfoResponse() {
-        // TODO Auto-generated method stub
-        return null;
+    private OpenIdClaims createOpenIdClaimsFromUserInfoResponse(OidcClientConfig oidcClientConfig, AccessToken accessToken) {
+        UserInfoHandler userInfoHandler = getUserInfoHandler();
+        Map<String, Object> userInfoClaims = null;
+        try {
+            userInfoClaims = userInfoHandler.getUserInfoClaims(oidcClientConfig, accessToken.getToken());
+        } catch (UserInfoResponseException e) {
+            Tr.warning(tc, e.toString());
+            return null;
+        }
+        if (userInfoClaims == null) {
+            return null;
+        }
+        return new OpenIdClaimsImpl(userInfoClaims);
+    }
+
+    UserInfoHandler getUserInfoHandler() {
+        return new UserInfoHandler();
     }
 
     /**
@@ -131,13 +156,14 @@ public class OidcIdentityStore implements IdentityStore {
      * <li>Caller Groups: OpenIdAuthenticationMechanismDefinition.claimsDefinition.callerGroupsClaim</li>
      * </ul>
      */
-    CredentialValidationResult createCredentialValidationResult(OidcClientConfig clientConfig, AccessToken accessToken, JwtClaims idTokenClaims) throws MalformedClaimException {
-        String issuer = getIssuer(clientConfig, accessToken, idTokenClaims); //realm
-        String caller = getCallerName(clientConfig, accessToken, idTokenClaims);
+    CredentialValidationResult createCredentialValidationResult(OidcClientConfig clientConfig, AccessToken accessToken, JwtClaims idTokenClaims,
+                                                                OpenIdClaims userInfoClaims) throws MalformedClaimException {
+        String issuer = getIssuer(clientConfig, accessToken, idTokenClaims, userInfoClaims); //realm
+        String caller = getCallerName(clientConfig, accessToken, idTokenClaims, userInfoClaims);
         if (caller == null) {
             return CredentialValidationResult.INVALID_RESULT;
         }
-        Set<String> groups = getCallerGroups(clientConfig, accessToken, idTokenClaims);
+        Set<String> groups = getCallerGroups(clientConfig, accessToken, idTokenClaims, userInfoClaims);
         return new CredentialValidationResult(issuer, caller, null, caller, groups);
     }
 
@@ -153,8 +179,8 @@ public class OidcIdentityStore implements IdentityStore {
      * @return
      * @throws MalformedClaimException
      */
-    String getIssuer(OidcClientConfig clientConfig, AccessToken accessToken, JwtClaims idTokenClaims) throws MalformedClaimException {
-        String issuer = getClaimValueFromTokens(OpenIdConstant.ISSUER_IDENTIFIER, accessToken, idTokenClaims, String.class);
+    String getIssuer(OidcClientConfig clientConfig, AccessToken accessToken, JwtClaims idTokenClaims, OpenIdClaims userInfoClaims) throws MalformedClaimException {
+        String issuer = getClaimValueFromTokens(OpenIdConstant.ISSUER_IDENTIFIER, accessToken, idTokenClaims, userInfoClaims, String.class);
         if (issuer == null || issuer.isEmpty()) {
             issuer = issuerFromProviderMetadata(clientConfig);
         }
@@ -169,21 +195,22 @@ public class OidcIdentityStore implements IdentityStore {
         return clientConfig.getProviderMetadata().getIssuer(); //TODO: use discovery data
     }
 
-    String getCallerName(OidcClientConfig clientConfig, AccessToken accessToken, JwtClaims idTokenClaims) throws MalformedClaimException {
+    String getCallerName(OidcClientConfig clientConfig, AccessToken accessToken, JwtClaims idTokenClaims, OpenIdClaims userInfoClaims) throws MalformedClaimException {
         String callerNameClaim = getCallerNameClaim(clientConfig);
         if (callerNameClaim == null || callerNameClaim.isEmpty()) {
             return null;
         }
-        return getClaimValueFromTokens(callerNameClaim, accessToken, idTokenClaims, String.class);
+        return getClaimValueFromTokens(callerNameClaim, accessToken, idTokenClaims, userInfoClaims, String.class);
     }
 
     @SuppressWarnings("unchecked")
-    Set<String> getCallerGroups(OidcClientConfig clientConfig, AccessToken accessToken, JwtClaims idTokenClaims) throws MalformedClaimException {
+    Set<String> getCallerGroups(OidcClientConfig clientConfig, AccessToken accessToken, JwtClaims idTokenClaims, OpenIdClaims userInfoClaims) throws MalformedClaimException {
         String callerGroupClaim = getCallerGroupsClaim(clientConfig);
         if (callerGroupClaim == null || callerGroupClaim.isEmpty()) {
             return null;
         }
-        return getClaimValueFromTokens(callerGroupClaim, accessToken, idTokenClaims, Set.class);
+        List<String> groups = getClaimValueFromTokens(callerGroupClaim, accessToken, idTokenClaims, userInfoClaims, List.class);
+        return Set.copyOf(groups);
     }
 
     String getCallerNameClaim(OidcClientConfig clientConfig) {
@@ -211,7 +238,7 @@ public class OidcIdentityStore implements IdentityStore {
      * <li>If not resolved yet, and the specified claim exists and has a non-empty value in the User Info Token, this User Info Token claim value is taken.
      * </ul>
      */
-    <T> T getClaimValueFromTokens(String claim, AccessToken accessToken, JwtClaims idTokenClaims, Class<T> claimType) throws MalformedClaimException {
+    <T> T getClaimValueFromTokens(String claim, AccessToken accessToken, JwtClaims idTokenClaims, OpenIdClaims userInfoClaims, Class<T> claimType) throws MalformedClaimException {
         T claimValue = getClaimFromAccessToken(accessToken, claim);
         if (valueExistsAndIsNotEmpty(claimValue, claimType)) {
             return claimValue;
@@ -220,7 +247,10 @@ public class OidcIdentityStore implements IdentityStore {
         if (valueExistsAndIsNotEmpty(claimValue, claimType)) {
             return claimValue;
         }
-        // TODO - get claimValue from User Info
+        claimValue = getClaimFromUserInfo(userInfoClaims, claim, claimType);
+        if (valueExistsAndIsNotEmpty(claimValue, claimType)) {
+            return claimValue;
+        }
         return null;
     }
 
@@ -236,6 +266,25 @@ public class OidcIdentityStore implements IdentityStore {
         return idTokenClaims.getClaimValue(claim, claimType);
     }
 
+    @SuppressWarnings("unchecked")
+    <T> T getClaimFromUserInfo(OpenIdClaims userInfoClaims, String claim, Class<T> claimType) {
+        if (userInfoClaims == null) {
+            return null;
+        }
+        if (claimType.equals(String.class)) {
+            Optional<String> claimValue = userInfoClaims.getStringClaim(claim);
+            if (claimValue.isPresent()) {
+                return (T) claimValue.get();
+            }
+            return null;
+        }
+        if (claimType.equals(List.class)) {
+            return (T) userInfoClaims.getArrayStringClaim(claim);
+        }
+        // Other types can be supported later if needed
+        return null;
+    }
+
     @SuppressWarnings("rawtypes")
     <T> boolean valueExistsAndIsNotEmpty(T claimValue, Class<T> claimType) {
         if (claimValue == null) {
@@ -245,6 +294,9 @@ public class OidcIdentityStore implements IdentityStore {
             return false;
         }
         if (claimType.equals(Set.class) && ((Set) claimValue).isEmpty()) {
+            return false;
+        }
+        if (claimType.equals(List.class) && ((List) claimValue).isEmpty()) {
             return false;
         }
         return true;

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/identitystore/OidcIdentityStoreTest.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/identitystore/OidcIdentityStoreTest.java
@@ -11,8 +11,17 @@
 package io.openliberty.security.jakartasec.identitystore;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.jmock.Expectations;
@@ -26,10 +35,11 @@ import org.junit.Test;
 
 import com.ibm.ws.security.test.common.CommonTestClass;
 
+import io.openliberty.security.jakartasec.tokens.OpenIdClaimsImpl;
 import io.openliberty.security.oidcclientcore.client.ClaimsMappingConfig;
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
-import io.openliberty.security.oidcclientcore.token.TokenResponse;
 import jakarta.security.enterprise.identitystore.openid.AccessToken;
+import jakarta.security.enterprise.identitystore.openid.OpenIdClaims;
 import test.common.SharedOutputManager;
 
 public class OidcIdentityStoreTest extends CommonTestClass {
@@ -38,9 +48,9 @@ public class OidcIdentityStoreTest extends CommonTestClass {
 
     private final OidcClientConfig config = mockery.mock(OidcClientConfig.class);
     private final ClaimsMappingConfig claimsMappingConfig = mockery.mock(ClaimsMappingConfig.class);
-    private final TokenResponse tokenResponse = mockery.mock(TokenResponse.class);
     private final AccessToken accessToken = mockery.mock(AccessToken.class);
     private final JwtClaims idTokenClaims = mockery.mock(JwtClaims.class);
+    private final OpenIdClaims userInfoClaims = mockery.mock(OpenIdClaims.class);
 
     private OidcIdentityStore identityStore;
 
@@ -57,6 +67,7 @@ public class OidcIdentityStoreTest extends CommonTestClass {
     @After
     public void tearDown() {
         outputMgr.resetStreams();
+        mockery.assertIsSatisfied();
     }
 
     @AfterClass
@@ -75,7 +86,7 @@ public class OidcIdentityStoreTest extends CommonTestClass {
                 will(returnValue(null));
             }
         });
-        String result = identityStore.getCallerName(config, accessToken, idTokenClaims);
+        String result = identityStore.getCallerName(config, accessToken, idTokenClaims, userInfoClaims);
         assertNull("Result should have been null but was [" + result + "].", result);
     }
 
@@ -89,7 +100,7 @@ public class OidcIdentityStoreTest extends CommonTestClass {
                 will(returnValue(null));
             }
         });
-        Set<String> result = identityStore.getCallerGroups(config, accessToken, idTokenClaims);
+        Set<String> result = identityStore.getCallerGroups(config, accessToken, idTokenClaims, userInfoClaims);
         assertNull("Result should have been null but was [" + result + "].", result);
     }
 
@@ -176,11 +187,276 @@ public class OidcIdentityStoreTest extends CommonTestClass {
         String result = identityStore.getCallerGroupsClaim(config);
         assertEquals(claim, result);
     }
-    
 
-    // TODO - getClaimValueFromTokens
+    @Test
+    public void test_getClaimValueFromTokens_string_claimInAccessToken() throws MalformedClaimException {
+        String claim = "myClaim";
+        String value = "the expected value";
+        mockery.checking(new Expectations() {
+            {
+                one(accessToken).isJWT();
+                will(returnValue(true));
+                one(accessToken).getClaim(claim);
+                will(returnValue(value));
+            }
+        });
+
+        String result = identityStore.getClaimValueFromTokens(claim, accessToken, idTokenClaims, userInfoClaims, String.class);
+        assertEquals(value, result);
+    }
+
+    @Test
+    public void test_getClaimValueFromTokens_string_claimInIdToken() throws MalformedClaimException {
+        String claim = "myClaim";
+        String value = "the expected value";
+        mockery.checking(new Expectations() {
+            {
+                one(accessToken).isJWT();
+                will(returnValue(true));
+                one(accessToken).getClaim(claim);
+                will(returnValue(null));
+                one(idTokenClaims).getClaimValue(claim, String.class);
+                will(returnValue(value));
+            }
+        });
+
+        String result = identityStore.getClaimValueFromTokens(claim, accessToken, idTokenClaims, userInfoClaims, String.class);
+        assertEquals(value, result);
+    }
+
+    @Test
+    public void test_getClaimValueFromTokens_string_claimInUserInfo() throws MalformedClaimException {
+        String claim = "myClaim";
+        String value = "the expected value";
+        Map<String, Object> userInfoClaimsMap = new HashMap<String, Object>();
+        userInfoClaimsMap.put(claim, value);
+        OpenIdClaims userInfoClaims = new OpenIdClaimsImpl(userInfoClaimsMap);
+        mockery.checking(new Expectations() {
+            {
+                one(accessToken).isJWT();
+                will(returnValue(true));
+                one(accessToken).getClaim(claim);
+                will(returnValue(null));
+                one(idTokenClaims).getClaimValue(claim, String.class);
+                will(returnValue(null));
+            }
+        });
+
+        String result = identityStore.getClaimValueFromTokens(claim, accessToken, idTokenClaims, userInfoClaims, String.class);
+        assertEquals(value, result);
+    }
+
+    @Test
+    public void test_getClaimValueFromTokens_string_claimMissing() throws MalformedClaimException {
+        String claim = "myClaim";
+        Map<String, Object> userInfoClaimsMap = new HashMap<String, Object>();
+        OpenIdClaims userInfoClaims = new OpenIdClaimsImpl(userInfoClaimsMap);
+        mockery.checking(new Expectations() {
+            {
+                one(accessToken).isJWT();
+                will(returnValue(true));
+                one(accessToken).getClaim(claim);
+                will(returnValue(null));
+                one(idTokenClaims).getClaimValue(claim, String.class);
+                will(returnValue(null));
+            }
+        });
+
+        String result = identityStore.getClaimValueFromTokens(claim, accessToken, idTokenClaims, userInfoClaims, String.class);
+        assertNull("Result should have been null but was [" + result + "].", result);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void test_getClaimValueFromTokens_list_claimEmptyInAccessToken_claimNonEmptyElsewhere() throws MalformedClaimException {
+        String claim = "myClaim";
+        Map<String, Object> userInfoClaimsMap = new HashMap<String, Object>();
+        List<String> value = List.of("one", "two", "three");
+        userInfoClaimsMap.put(claim, value);
+        OpenIdClaims userInfoClaims = new OpenIdClaimsImpl(userInfoClaimsMap);
+        mockery.checking(new Expectations() {
+            {
+                one(accessToken).isJWT();
+                will(returnValue(true));
+                one(accessToken).getClaim(claim);
+                will(returnValue(List.of()));
+                one(idTokenClaims).getClaimValue(claim, List.class);
+                will(returnValue(null));
+            }
+        });
+
+        List result = identityStore.getClaimValueFromTokens(claim, accessToken, idTokenClaims, userInfoClaims, List.class);
+        assertEquals(value, result);
+    }
+
     // TODO - getClaimFromAccessToken
+
     // TODO - getClaimFromIdToken
-    // TODO - valueExistsAndIsNotEmpty
+
+    @Test
+    public void test_getClaimFromUserInfo_nullClaims() {
+        String claim = "myClaim";
+        String result = identityStore.getClaimFromUserInfo(null, claim, String.class);
+        assertNull("Result should have been null but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_getClaimFromUserInfo_string_missing() {
+        String claim = "myClaim";
+        Map<String, Object> claimsMap = new HashMap<String, Object>();
+        OpenIdClaims claims = new OpenIdClaimsImpl(claimsMap);
+
+        String result = identityStore.getClaimFromUserInfo(claims, claim, String.class);
+        assertNull("Result should have been null but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_getClaimFromUserInfo_string_wrongType() {
+        String claim = "myClaim";
+        Map<String, Object> claimsMap = new HashMap<String, Object>();
+        claimsMap.put(claim, 112358);
+        OpenIdClaims claims = new OpenIdClaimsImpl(claimsMap);
+
+        try {
+            String result = identityStore.getClaimFromUserInfo(claims, claim, String.class);
+            fail("Should have thrown an exception but got [" + result + "].");
+        } catch (ClassCastException e) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void test_getClaimFromUserInfo_string() {
+        String claim = "myClaim";
+        String value = "the expected value";
+        Map<String, Object> claimsMap = new HashMap<String, Object>();
+        claimsMap.put(claim, value);
+        OpenIdClaims claims = new OpenIdClaimsImpl(claimsMap);
+
+        String result = identityStore.getClaimFromUserInfo(claims, claim, String.class);
+        assertEquals(value, result);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void test_getClaimFromUserInfo_list_missing() {
+        String claim = "myClaim";
+        Map<String, Object> claimsMap = new HashMap<String, Object>();
+        OpenIdClaims claims = new OpenIdClaimsImpl(claimsMap);
+
+        List result = identityStore.getClaimFromUserInfo(claims, claim, List.class);
+        assertEquals(List.of(), result);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void test_getClaimFromUserInfo_list_rawString() {
+        String claim = "myClaim";
+        Map<String, Object> claimsMap = new HashMap<String, Object>();
+        String value = "some claim value";
+        claimsMap.put(claim, value);
+        OpenIdClaims claims = new OpenIdClaimsImpl(claimsMap);
+
+        List result = identityStore.getClaimFromUserInfo(claims, claim, List.class);
+        assertEquals(List.of(value), result);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void test_getClaimFromUserInfo_list_wrongType() {
+        String claim = "myClaim";
+        Map<String, Object> claimsMap = new HashMap<String, Object>();
+        boolean value = true;
+        claimsMap.put(claim, value);
+        OpenIdClaims claims = new OpenIdClaimsImpl(claimsMap);
+
+        try {
+            List result = identityStore.getClaimFromUserInfo(claims, claim, List.class);
+            fail("Should have thrown an exception but got [" + result + "].");
+        } catch (IllegalArgumentException e) {
+            // Expected
+        }
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void test_getClaimFromUserInfo_list() {
+        String claim = "myClaim";
+        List<Object> value = Arrays.asList("group1", 1234);
+        Map<String, Object> claimsMap = new HashMap<String, Object>();
+        claimsMap.put(claim, value);
+        OpenIdClaims claims = new OpenIdClaimsImpl(claimsMap);
+
+        List result = identityStore.getClaimFromUserInfo(claims, claim, List.class);
+        assertEquals(value, result);
+    }
+
+    @Test
+    public void test_getClaimFromUserInfo_unsupportedType() {
+        String claim = "myClaim";
+        Map<String, Object> claimsMap = new HashMap<String, Object>();
+        String value = "some claim value";
+        claimsMap.put(claim, value);
+        OpenIdClaims claims = new OpenIdClaimsImpl(claimsMap);
+
+        Long result = identityStore.getClaimFromUserInfo(claims, claim, Long.class);
+        assertNull("Result should have been null but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_valueExistsAndIsNotEmpty_null() {
+        String claim = null;
+        assertFalse(identityStore.valueExistsAndIsNotEmpty(claim, String.class));
+    }
+
+    @Test
+    public void test_valueExistsAndIsNotEmpty_string_empty() {
+        String claim = "";
+        assertFalse(identityStore.valueExistsAndIsNotEmpty(claim, String.class));
+    }
+
+    @Test
+    public void test_valueExistsAndIsNotEmpty_string_nonEmpty() {
+        String claim = " ";
+        assertTrue(identityStore.valueExistsAndIsNotEmpty(claim, String.class));
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void test_valueExistsAndIsNotEmpty_set_empty() {
+        Set claim = new HashSet<>();
+        assertFalse(identityStore.valueExistsAndIsNotEmpty(claim, Set.class));
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Test
+    public void test_valueExistsAndIsNotEmpty_set_nonEmpty() {
+        Set claim = new HashSet<>();
+        claim.add("test");
+        claim.add(123);
+        assertTrue(identityStore.valueExistsAndIsNotEmpty(claim, Set.class));
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void test_valueExistsAndIsNotEmpty_list_empty() {
+        List claim = new ArrayList<>();
+        assertFalse(identityStore.valueExistsAndIsNotEmpty(claim, List.class));
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Test
+    public void test_valueExistsAndIsNotEmpty_list_nonEmpty() {
+        List claim = new ArrayList<>();
+        claim.add("group");
+        assertTrue(identityStore.valueExistsAndIsNotEmpty(claim, List.class));
+    }
+
+    @Test
+    public void test_valueExistsAndIsNotEmpty_otherType() {
+        Long claim = 0L;
+        // Anything other than String and Set will just return true
+        assertTrue(identityStore.valueExistsAndIsNotEmpty(claim, Long.class));
+    }
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
+++ b/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
@@ -91,3 +91,10 @@ TOKEN_ENDPOINT_MISSING=CWWKS2417E: The {0} OpenID Connect client cannot find a v
 TOKEN_ENDPOINT_MISSING.explanation=The token endpoint URL is missing from the OpenID Connect provider metadata and the OpenID Connect client configuration.
 TOKEN_ENDPOINT_MISSING.useraction=Verify that the OpenID Connect provider metadata contains a token_endpoint value. A token endpoint can also be specified in the OpenID Connect client configuration.
 
+USERINFO_RESPONSE_ERROR=CWWKS2418W: The OpenID Connect client encountered the following error while sending a request to the [{0}] User Info URL of the OpenID Connect provider: {1}
+USERINFO_RESPONSE_ERROR.explanation=The User Info response from the OpenID Connect provider might be malformed or missing information, or the OpenID Connect provider encountered an error while handling the request.
+USERINFO_RESPONSE_ERROR.useraction=See the error in the message for more information. Verify that the User Info URL for the OpenID Connect provider is correct.
+
+USERINFO_RESPONSE_NOT_200=CWWKS2419W: The request to the [{0}] User Info URL of the OpenID Connect provider returned a {1} HTTP status code. The OpenID Connect provider returned the following response: {2}
+USERINFO_RESPONSE_NOT_200.explanation=The OpenID Connect client did not receive a successful response from the OpenID Connect provider.
+USERINFO_RESPONSE_NOT_200.useraction=See the status code and error response in the message for more information.

--- a/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
+++ b/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
@@ -91,10 +91,10 @@ TOKEN_ENDPOINT_MISSING=CWWKS2417E: The {0} OpenID Connect client cannot find a v
 TOKEN_ENDPOINT_MISSING.explanation=The token endpoint URL is missing from the OpenID Connect provider metadata and the OpenID Connect client configuration.
 TOKEN_ENDPOINT_MISSING.useraction=Verify that the OpenID Connect provider metadata contains a token_endpoint value. A token endpoint can also be specified in the OpenID Connect client configuration.
 
-USERINFO_RESPONSE_ERROR=CWWKS2418W: The OpenID Connect client encountered the following error while sending a request to the [{0}] User Info URL of the OpenID Connect provider: {1}
-USERINFO_RESPONSE_ERROR.explanation=The User Info response from the OpenID Connect provider might be malformed or missing information, or the OpenID Connect provider encountered an error while handling the request.
-USERINFO_RESPONSE_ERROR.useraction=See the error in the message for more information. Verify that the User Info URL for the OpenID Connect provider is correct.
+USERINFO_RESPONSE_ERROR=CWWKS2418W: The OpenID Connect client encountered the following error when it sent a request to the [{0}] User Info URL of the OpenID Connect provider: {1}
+USERINFO_RESPONSE_ERROR.explanation=The User Info response from the OpenID Connect provider might be malformed or missing information, or the OpenID Connect provider encountered an error when it handled the request.
+USERINFO_RESPONSE_ERROR.useraction=For more information, see the error in the message. Verify that the User Info URL for the OpenID Connect provider is correct.
 
 USERINFO_RESPONSE_NOT_200=CWWKS2419W: The request to the [{0}] User Info URL of the OpenID Connect provider returned a {1} HTTP status code. The OpenID Connect provider returned the following response: {2}
 USERINFO_RESPONSE_NOT_200.explanation=The OpenID Connect client did not receive a successful response from the OpenID Connect provider.
-USERINFO_RESPONSE_NOT_200.useraction=See the status code and error response in the message for more information.
+USERINFO_RESPONSE_NOT_200.useraction=For more information, see the status code and error response in the message.

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/discovery/OidcDiscoveryConstants.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/discovery/OidcDiscoveryConstants.java
@@ -14,6 +14,7 @@ public class OidcDiscoveryConstants {
 
     public static final String METADATA_KEY_AUTHORIZATION_ENDPOINT = "authorization_endpoint";
     public static final String METADATA_KEY_TOKEN_ENDPOINT = "token_endpoint";
+    public static final String METADATA_KEY_USERINFO_ENDPOINT = "userinfo_endpoint";
 
     public static final String WELL_KNOWN_SUFFIX = ".well-known/openid-configuration";
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/UserInfoEndpointNotHttpsException.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/UserInfoEndpointNotHttpsException.java
@@ -13,20 +13,14 @@ package io.openliberty.security.oidcclientcore.exceptions;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 
-public class UserInfoEndpointNotHttpsException extends Exception {
+public class UserInfoEndpointNotHttpsException extends UserInfoResponseException {
 
     public static final TraceComponent tc = Tr.register(UserInfoEndpointNotHttpsException.class);
 
     private static final long serialVersionUID = 1L;
 
-    private final String userInfoEndpoint;
-
     public UserInfoEndpointNotHttpsException(String userInfoEndpoint) {
-        this.userInfoEndpoint = userInfoEndpoint;
-    }
-
-    public String getUserInfoEndpoint() {
-        return userInfoEndpoint;
+        super(userInfoEndpoint, Tr.formatMessage(tc, "URL_NOT_HTTPS", userInfoEndpoint));
     }
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/UserInfoResponseException.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/UserInfoResponseException.java
@@ -19,8 +19,27 @@ public class UserInfoResponseException extends Exception {
 
     private static final long serialVersionUID = 1L;
 
-    public UserInfoResponseException(Exception e) {
-        super(e);
+    protected final String userInfoEndpoint;
+    protected final String errorMsg;
+
+    public UserInfoResponseException(String userInfoEndpoint, String errorMsg) {
+        this.userInfoEndpoint = userInfoEndpoint;
+        this.errorMsg = errorMsg;
+    }
+
+    public UserInfoResponseException(String userInfoEndpoint, Exception cause) {
+        super(cause);
+        this.userInfoEndpoint = userInfoEndpoint;
+        this.errorMsg = cause.toString();
+    }
+
+    public String getUserInfoEndpoint() {
+        return userInfoEndpoint;
+    }
+
+    @Override
+    public String getMessage() {
+        return Tr.formatMessage(tc, "USERINFO_RESPONSE_ERROR", userInfoEndpoint, errorMsg);
     }
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/UserInfoResponseNot200Exception.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/UserInfoResponseNot200Exception.java
@@ -13,24 +13,19 @@ package io.openliberty.security.oidcclientcore.exceptions;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 
-public class UserInfoResponseNot200Exception extends Exception {
+public class UserInfoResponseNot200Exception extends UserInfoResponseException {
 
     public static final TraceComponent tc = Tr.register(UserInfoResponseNot200Exception.class);
 
     private static final long serialVersionUID = 1L;
 
-    private final String userInfoEndpoint;
     private final String statusCode;
     private final String responseStr;
 
     public UserInfoResponseNot200Exception(String userInfoEndpoint, String statusCode, String responseStr) {
-        this.userInfoEndpoint = userInfoEndpoint;
+        super(userInfoEndpoint, Tr.formatMessage(tc, "USERINFO_RESPONSE_NOT_200", userInfoEndpoint, statusCode, responseStr));
         this.statusCode = statusCode;
         this.responseStr = responseStr;
-    }
-
-    public String getUserInfoEndpoint() {
-        return userInfoEndpoint;
     }
 
     public String getStatusCode() {

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/userinfo/UserInfoHandler.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/userinfo/UserInfoHandler.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oidcclientcore.userinfo;
+
+import java.util.Map;
+
+import com.ibm.json.java.JSONObject;
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
+import io.openliberty.security.oidcclientcore.client.OidcProviderMetadata;
+import io.openliberty.security.oidcclientcore.discovery.OidcDiscoveryConstants;
+import io.openliberty.security.oidcclientcore.exceptions.UserInfoResponseException;
+import io.openliberty.security.oidcclientcore.http.EndpointRequest;
+import io.openliberty.security.oidcclientcore.userinfo.UserInfoRequestor.Builder;
+
+public class UserInfoHandler extends EndpointRequest {
+
+    public static final TraceComponent tc = Tr.register(UserInfoHandler.class);
+
+    public Map<String, Object> getUserInfoClaims(OidcClientConfig oidcClientConfig, String accessToken) throws UserInfoResponseException {
+        String userInfoEndpoint = getUserInfoEndpoint(oidcClientConfig);
+        if (userInfoEndpoint == null || userInfoEndpoint.isEmpty()) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Failed to find a UserInfo endpoint in the client configuration or discovery data");
+            }
+            return null;
+        }
+        UserInfoRequestor userInfoRequester = createUserInfoRequestor(userInfoEndpoint, accessToken);
+        UserInfoResponse userInfoResponse = userInfoRequester.requestUserInfo();
+        if (userInfoResponse != null) {
+            return userInfoResponse.asMap();
+        }
+        return null;
+    }
+
+    String getUserInfoEndpoint(OidcClientConfig oidcClientConfig) {
+        String userInfoEndpoint = getUserInfoEndpointFromProviderMetadata(oidcClientConfig);
+        if (userInfoEndpoint == null) {
+            userInfoEndpoint = getUserInfoEndpointFromDiscoveryMetadata(oidcClientConfig);
+        }
+        return userInfoEndpoint;
+    }
+
+    String getUserInfoEndpointFromProviderMetadata(OidcClientConfig oidcClientConfig) {
+        OidcProviderMetadata providerMetadata = oidcClientConfig.getProviderMetadata();
+        if (providerMetadata != null) {
+            // Provider metadata overrides properties discovered via providerUri
+            String userInfoEndpoint = providerMetadata.getUserinfoEndpoint();
+            if (userInfoEndpoint != null && !userInfoEndpoint.isEmpty()) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "UserInfo endpoint found in the provider metadata: [" + userInfoEndpoint + "]");
+                }
+                return userInfoEndpoint;
+            }
+        }
+        return null;
+    }
+
+    String getUserInfoEndpointFromDiscoveryMetadata(OidcClientConfig oidcClientConfig) {
+        String userInfoEndpoint = null;
+        JSONObject discoveryData = getProviderDiscoveryMetadata(oidcClientConfig);
+        if (discoveryData != null) {
+            userInfoEndpoint = (String) discoveryData.get(OidcDiscoveryConstants.METADATA_KEY_USERINFO_ENDPOINT);
+        }
+        return userInfoEndpoint;
+    }
+
+    UserInfoRequestor createUserInfoRequestor(String userInfoEndpoint, String accessToken) {
+        Builder builder = new UserInfoRequestor.Builder(userInfoEndpoint, accessToken, getSSLSocketFactory());
+        return builder.build();
+    }
+
+}

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/userinfo/UserInfoRequestor.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/userinfo/UserInfoRequestor.java
@@ -55,7 +55,7 @@ public class UserInfoRequestor {
         this.params = new ArrayList<NameValuePair>();
     }
 
-    public UserInfoResponse requestUserInfo() throws Exception {
+    public UserInfoResponse requestUserInfo() throws UserInfoResponseException {
         if (!userInfoEndpoint.toLowerCase().startsWith(HttpConstants.HTTPS_SCHEME)) {
             throw new UserInfoEndpointNotHttpsException(userInfoEndpoint);
         }
@@ -71,7 +71,7 @@ public class UserInfoRequestor {
             claims = extractClaimsFromResponse(response);
             statusCode = getStatusCodeFromResponse(response);
         } catch (Exception e) {
-            throw new UserInfoResponseException(e);
+            throw new UserInfoResponseException(userInfoEndpoint, e);
         }
 
         if (statusCode != 200) {

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/userinfo/UserInfoHandlerTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/userinfo/UserInfoHandlerTest.java
@@ -1,0 +1,219 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oidcclientcore.userinfo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.jmock.Expectations;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.json.java.JSONObject;
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
+import io.openliberty.security.oidcclientcore.client.OidcProviderMetadata;
+import io.openliberty.security.oidcclientcore.discovery.DiscoveryHandler;
+import io.openliberty.security.oidcclientcore.discovery.OidcDiscoveryConstants;
+import io.openliberty.security.oidcclientcore.exceptions.UserInfoResponseException;
+import test.common.SharedOutputManager;
+
+public class UserInfoHandlerTest extends CommonTestClass {
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+
+    public static final String CWWKS2418W_USERINFO_RESPONSE_ERROR = "CWWKS2418W";
+
+    private final OidcClientConfig oidcClientConfig = mockery.mock(OidcClientConfig.class);
+    private final OidcProviderMetadata providerMetadata = mockery.mock(OidcProviderMetadata.class);
+    private final DiscoveryHandler discoveryHandler = mockery.mock(DiscoveryHandler.class);
+    private final UserInfoRequestor userInfoRequestor = mockery.mock(UserInfoRequestor.class);
+    private final UserInfoResponse userInfoResponse = mockery.mock(UserInfoResponse.class);
+
+    private final String clientId = "myClientId";
+    private final String discoveryUrl = "https://localhost/OP/" + OidcDiscoveryConstants.WELL_KNOWN_SUFFIX;
+    private final String userInfoEndpoint = "https://localhost/OP/userinfo";
+    private final String accessToken = "qOuZdH6Anmxclul5d71AXoDbFVmRG2dPnHn9moaw";
+
+    UserInfoHandler handler;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void setUp() {
+        mockery.checking(new Expectations() {
+            {
+                allowing(oidcClientConfig).getProviderURI();
+                will(returnValue(discoveryUrl));
+                allowing(oidcClientConfig).getClientId();
+                will(returnValue(clientId));
+            }
+        });
+        handler = new UserInfoHandler() {
+            @Override
+            public DiscoveryHandler getDiscoveryHandler() {
+                return discoveryHandler;
+            }
+
+            @Override
+            UserInfoRequestor createUserInfoRequestor(String userInfoEndpoint, String accessToken) {
+                return userInfoRequestor;
+            }
+        };
+    }
+
+    @After
+    public void tearDown() {
+        outputMgr.resetStreams();
+        mockery.assertIsSatisfied();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    @Test
+    public void test_getUserInfoClaims_noUserInfoEndpoint() throws Exception {
+        mockery.checking(new Expectations() {
+            {
+                one(oidcClientConfig).getProviderMetadata();
+                will(returnValue(null));
+                one(discoveryHandler).fetchDiscoveryDataJson(discoveryUrl, clientId);
+                will(returnValue(new JSONObject()));
+            }
+        });
+        Map<String, Object> result = handler.getUserInfoClaims(oidcClientConfig, accessToken);
+        assertNull("Result should have been null but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_getUserInfoClaims_requestThrowsException() throws Exception {
+        JSONObject discoveryData = new JSONObject();
+        discoveryData.put(OidcDiscoveryConstants.METADATA_KEY_USERINFO_ENDPOINT, userInfoEndpoint);
+        mockery.checking(new Expectations() {
+            {
+                one(oidcClientConfig).getProviderMetadata();
+                will(returnValue(null));
+                one(discoveryHandler).fetchDiscoveryDataJson(discoveryUrl, clientId);
+                will(returnValue(discoveryData));
+                one(userInfoRequestor).requestUserInfo();
+                will(throwException(new UserInfoResponseException(userInfoEndpoint, new Exception(defaultExceptionMsg))));
+            }
+        });
+        try {
+            Map<String, Object> result = handler.getUserInfoClaims(oidcClientConfig, accessToken);
+            fail("Should have thrown an exception but got: [" + result + "].");
+        } catch (UserInfoResponseException e) {
+            verifyException(e, CWWKS2418W_USERINFO_RESPONSE_ERROR + ".+" + Pattern.quote(defaultExceptionMsg));
+        }
+    }
+
+    @Test
+    public void test_getUserInfoClaims() throws Exception {
+        JSONObject discoveryData = new JSONObject();
+        discoveryData.put(OidcDiscoveryConstants.METADATA_KEY_USERINFO_ENDPOINT, userInfoEndpoint);
+        mockery.checking(new Expectations() {
+            {
+                one(oidcClientConfig).getProviderMetadata();
+                will(returnValue(null));
+                one(discoveryHandler).fetchDiscoveryDataJson(discoveryUrl, clientId);
+                will(returnValue(discoveryData));
+                one(userInfoRequestor).requestUserInfo();
+                will(returnValue(userInfoResponse));
+                one(userInfoResponse).asMap();
+            }
+        });
+        Map<String, Object> result = handler.getUserInfoClaims(oidcClientConfig, accessToken);
+        assertNotNull("Should have gotten back a non-null map.", result);
+    }
+
+    @Test
+    public void test_getUserInfoEndpointFromProviderMetadata_noProviderMetadata() {
+        mockery.checking(new Expectations() {
+            {
+                one(oidcClientConfig).getProviderMetadata();
+                will(returnValue(null));
+            }
+        });
+        String result = handler.getUserInfoEndpointFromProviderMetadata(oidcClientConfig);
+        assertNull("Result should have been null but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_getUserInfoEndpointFromProviderMetadata_emptyValue() {
+        mockery.checking(new Expectations() {
+            {
+                one(oidcClientConfig).getProviderMetadata();
+                will(returnValue(providerMetadata));
+                one(providerMetadata).getUserinfoEndpoint();
+                will(returnValue(""));
+            }
+        });
+        String result = handler.getUserInfoEndpointFromProviderMetadata(oidcClientConfig);
+        assertNull("Result should have been null but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_getUserInfoEndpointFromProviderMetadata() {
+        mockery.checking(new Expectations() {
+            {
+                one(oidcClientConfig).getProviderMetadata();
+                will(returnValue(providerMetadata));
+                one(providerMetadata).getUserinfoEndpoint();
+                will(returnValue(userInfoEndpoint));
+            }
+        });
+        String result = handler.getUserInfoEndpointFromProviderMetadata(oidcClientConfig);
+        assertEquals(userInfoEndpoint, result);
+    }
+
+    @Test
+    public void test_getUserInfoEndpointFromDiscoveryMetadata_missingUserInfoEndpoint() throws Exception {
+        JSONObject discoveryData = new JSONObject();
+        mockery.checking(new Expectations() {
+            {
+                one(discoveryHandler).fetchDiscoveryDataJson(discoveryUrl, clientId);
+                will(returnValue(discoveryData));
+            }
+        });
+        String result = handler.getUserInfoEndpointFromDiscoveryMetadata(oidcClientConfig);
+        assertNull("Result should have been null but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_getUserInfoEndpointFromDiscoveryMetadata() throws Exception {
+        JSONObject discoveryData = new JSONObject();
+        discoveryData.put(OidcDiscoveryConstants.METADATA_KEY_USERINFO_ENDPOINT, userInfoEndpoint);
+        mockery.checking(new Expectations() {
+            {
+                one(discoveryHandler).fetchDiscoveryDataJson(discoveryUrl, clientId);
+                will(returnValue(discoveryData));
+            }
+        });
+        String result = handler.getUserInfoEndpointFromDiscoveryMetadata(oidcClientConfig);
+        assertEquals(userInfoEndpoint, result);
+    }
+
+}


### PR DESCRIPTION
Adds logic to call the OP's UserInfo endpoint when we're building the `CredentialValidationResult` in the `OidcIdentityStore`.

For #21171