### PR TITLE
Added maven deps to MP Health 2.x TCKs

### DIFF
--- a/dev/com.ibm.ws.microprofile.health.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2019, 2021 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2019, 2022 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -121,6 +121,13 @@
             <artifactId>jackson-annotations</artifactId>
             <version>2.9.5</version>
         </dependency>
+        
+        <dependency>
+            <groupId>com.github.fge</groupId>
+            <artifactId>btf</artifactId>
+            <version>1.2</version>
+        </dependency>
+        
     </dependencies>
 
     <build>

--- a/dev/com.ibm.ws.microprofile.health.2.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2020, 2021 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2020, 2022 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -115,6 +115,13 @@
             <artifactId>jackson-annotations</artifactId>
             <version>2.9.5</version>
         </dependency>
+        
+        <dependency>
+            <groupId>com.github.fge</groupId>
+            <artifactId>btf</artifactId>
+            <version>1.2</version>
+        </dependency>
+        
     </dependencies>
 
     <build>


### PR DESCRIPTION
fixes #22517
- Added `com.github.fge.btf` of maven dependency for the MP Health 2.1 and 2.2 TCKs.