### PR TITLE
avoid map lookups to make getHttpAuthenticationMechanism faster

### DIFF
--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/metadata/WebModuleMetaDataImpl.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/metadata/WebModuleMetaDataImpl.java
@@ -37,6 +37,8 @@ public class WebModuleMetaDataImpl extends MetaDataImpl implements WebModuleMeta
     private BaseJspComponentMetaData jspComponentMetaData = null;
     private String sessionCookieNameInUse = null;
     public ServiceRegistration<?> mBeanServiceReg;
+    // Have 3 states to track: not checked (null), checked and doesn't have HAM (Boolean.FALSE), checked and has HAM (Boolean.TRUE)
+    private Boolean hasHAM = null;
 
     /**
      * @param slotCnt
@@ -169,4 +171,12 @@ public class WebModuleMetaDataImpl extends MetaDataImpl implements WebModuleMeta
         
     }
 
+    public boolean checkForHAM() {
+        // Only return false if it has been checked and found to be false.
+        return hasHAM != Boolean.FALSE;
+    }
+    
+    public void setHasHAM(boolean hamFound) {
+        hasHAM = (hamFound ? Boolean.TRUE : Boolean.FALSE);
+    }
 }


### PR DESCRIPTION
Map lookups are slow, compared to checking boolean fields. When the web module has no authentication mechanism, this change improves max tput by 0.5% using the MP-prim-ping workload.