### PR TITLE
Address Pages 3.1 TCK failures

### DIFF
--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/JspVisitor.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/JspVisitor.java
@@ -290,14 +290,48 @@ public abstract class JspVisitor {
                     visitJspParamEnd(jspElement);
                 }
                 else if (jspElementType.equals(Constants.JSP_PARAMS_TYPE)) {
-                    visitJspParamsStart(jspElement);
-                    processChildren(jspElement);
-                    visitJspParamsEnd(jspElement);
+                    if(PagesVersionHandler.isPages30OrLowerLoaded()){
+                        visitJspParamsStart(jspElement);
+                        processChildren(jspElement);
+                        visitJspParamsEnd(jspElement);
+                    } else {
+                        // Changed for Page 3.1. jsp:params is a no-op (as it must be a child of jsp:plugin)
+                        // JSP must still valid contents/syntax within (3.1 Spec, section 5.8 <jsp:params>)
+                        if(this.getClass().equals(com.ibm.ws.jsp.translator.visitor.validator.ValidateJspVisitor.class)){
+                            if(com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)){
+                                logger.logp(Level.FINEST, CLASS_NAME, "processJspElement","Processing Validation for the jsp:params element");
+                            }
+                            visitJspParamsStart(jspElement);
+                            processChildren(jspElement);
+                            visitJspParamsEnd(jspElement);    
+                        } else {
+                            if(com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)){
+                                logger.logp(Level.FINEST, CLASS_NAME, "processJspElement","Skipping the jsp:params element as it is a no operation for Pages 3.1+");
+                            }
+                        }
+                    }
                 }
                 else if (jspElementType.equals(Constants.JSP_FALLBACK_TYPE)) {
-                    visitJspFallbackStart(jspElement);
-                    processChildren(jspElement);
-                    visitJspFallbackEnd(jspElement);
+                    if(PagesVersionHandler.isPages30OrLowerLoaded()){
+                        visitJspFallbackStart(jspElement);
+                        processChildren(jspElement);
+                        visitJspFallbackEnd(jspElement);
+                    } else {
+                        // Changed for Page 3.1. jsp:fallback is a no-op (as it must be a child of jsp:plugin)
+                        // JSP must still valid contents/syntax within (3.1 Spec, section 5.9 <jsp:fallback>)
+                        if(this.getClass().equals(com.ibm.ws.jsp.translator.visitor.validator.ValidateJspVisitor.class)){
+                            if(com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)){
+                                logger.logp(Level.FINEST, CLASS_NAME, "processJspElement","Processing Validation for the jsp:fallback element");
+                            }
+                            visitJspFallbackStart(jspElement);
+                            processChildren(jspElement);
+                            visitJspFallbackEnd(jspElement);    
+                        } else {
+                            if(com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)){
+                                logger.logp(Level.FINEST, CLASS_NAME, "processJspElement","Skipping the jsp:fallback element as it is a no operation for Pages 3.1+");
+                            }
+                        }
+                    }
                 }
                 else if (jspElementType.equals(Constants.JSP_INCLUDE_TYPE)) {
                     visitJspIncludeStart(jspElement);
@@ -330,8 +364,18 @@ public abstract class JspVisitor {
                         processChildren(jspElement);
                         visitJspPluginEnd(jspElement);
                     } else {
-                        if(com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)){
-                            logger.logp(Level.FINEST, CLASS_NAME, "processJspElement","Skipping the jsp:plugin element as it is a no operation for Pages 3.1+");
+                        // Changed for Page 3.1. jsp:plugin is a no-op, but JSP must still valid contents within (3.1 Spec, section 5.7 <jsp:plugin>)
+                        if(this.getClass().equals(com.ibm.ws.jsp.translator.visitor.validator.ValidateJspVisitor.class)){
+                            if(com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)){
+                                logger.logp(Level.FINEST, CLASS_NAME, "processJspElement","Processing Validation for the jsp:plugin element");
+                            }
+                            visitJspPluginStart(jspElement);
+                            processChildren(jspElement);
+                            visitJspPluginEnd(jspElement);      
+                        } else {
+                            if(com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINEST)){
+                                logger.logp(Level.FINEST, CLASS_NAME, "processJspElement","Skipping the jsp:plugin element as it is a no operation for Pages 3.1+");
+                            }
                         }
                     }
                 }

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/GenerateTagFileVisitor.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/GenerateTagFileVisitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2020 IBM Corporation and others.
+ * Copyright (c) 1997, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.jsp.translator.visitor.generator;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.logging.Level;
@@ -215,14 +216,28 @@ public class GenerateTagFileVisitor extends GenerateVisitor {
     protected void generateClassSection(ValidateTagFileResult validatorResult) {
         writer.println();
         writer.print("public class " + tagFileFiles.getClassName() + " extends javax.servlet.jsp.tagext.SimpleTagSupport");
+        
+        ArrayList<String> implementingInterfaces = new ArrayList<String>();
+
         if(PagesVersionHandler.isPages31OrHigherLoaded()){
-            writer.print(" implements com.ibm.ws.jsp.runtime.JspDirectiveInfo");
+            implementingInterfaces.add("com.ibm.ws.jsp.runtime.JspDirectiveInfo");
         }
+
         TagFileInfo tfi = (TagFileInfo)inputMap.get("TagFileInfo");
         TagInfo ti = tfi.getTagInfo();
         if (ti.hasDynamicAttributes()) {
-            writer.println();
-            writer.print(" implements javax.servlet.jsp.tagext.DynamicAttributes");
+            implementingInterfaces.add("javax.servlet.jsp.tagext.DynamicAttributes");
+        }
+
+        if(implementingInterfaces.size() > 0){
+            writer.print(" implements");
+            int size = implementingInterfaces.size();
+            for(int i = 0; i < size; i++){
+                writer.print(" " + implementingInterfaces.get(i));
+                if(i < size -1 ){
+                    writer.print(",");
+                }
+            }
         }
         
         writer.println(" {");


### PR DESCRIPTION
for #22747


1) Compilation issue: 
```
public class _positiveDuplicateAttributes extends jakarta.servlet.jsp.tagext.SimpleTagSupport implements com.ibm.ws.jsp.runtime.JspDirectiveInfo
 implements jakarta.servlet.jsp.tagext.DynamicAttributes
 ```
 
 2) Children of jsp:plugin should still have validation run on them (but they shouldn't generate any code) 
 
 3) ` jsp:params` and` jsp:fallback` are also deprecated  (I handle them the same as jsp:plugin) Validation occurs with the start methods of the ValidateJspVisitor class (i.e [ValidateVistor#visitJspParamsStart](https://github.com/OpenLiberty/open-liberty/blob/3edb9b2001d38ac8be95922d9ba466374c331e5b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/validator/ValidateVisitor.java#L199) and[ concrete validator class here](https://github.com/OpenLiberty/open-liberty/blob/53a015064ac381fa75a1333e9c7aa3f43abaddd6/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/validator/ValidateJspVisitor.java) ) 
 
 
 May need better log strings / comments, but need to verify the TCK passes first.