### PR TITLE
Don't expose 3rd party Weld packages that don't exist

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-2.0/com.ibm.websphere.appserver.cdi-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-2.0/com.ibm.websphere.appserver.cdi-2.0.feature
@@ -31,9 +31,7 @@ IBM-API-Package: javax.decorator;  type="spec", \
  org.jboss.weld.serialization.spi; type="internal", \
  org.jboss.weld.context;type="third-party", \
  org.jboss.weld.context.api;type="third-party", \
- org.jboss.weld.context.beanstore;type="third-party", \
- org.jboss.weld.context.bound;type="third-party", \
- org.jboss.weld.context.conversation;type="third-party"
+ org.jboss.weld.context.bound;type="third-party"
 IBM-SPI-Package: io.openliberty.cdi.spi;type="ibm-spi"
 IBM-ShortName: cdi-2.0
 Subsystem-Name: Contexts and Dependency Injection 2.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-3.0/io.openliberty.cdi-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-3.0/io.openliberty.cdi-3.0.feature
@@ -30,9 +30,7 @@ IBM-API-Package: jakarta.decorator;  type="spec", \
  org.jboss.weld.serialization.spi; type="internal", \
  org.jboss.weld.context;type="third-party", \
  org.jboss.weld.context.api;type="third-party", \
- org.jboss.weld.context.beanstore;type="third-party", \
- org.jboss.weld.context.bound;type="third-party", \
- org.jboss.weld.context.conversation;type="third-party"
+ org.jboss.weld.context.bound;type="third-party"
 IBM-SPI-Package: io.openliberty.cdi.spi;type="ibm-spi"
 IBM-ShortName: cdi-3.0
 Subsystem-Name: Jakarta Contexts and Dependency Injection 3.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-4.0/io.openliberty.cdi-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-4.0/io.openliberty.cdi-4.0.feature
@@ -34,9 +34,7 @@ IBM-API-Package: jakarta.decorator;  type="spec", \
  org.jboss.weld.serialization.spi; type="internal", \
  org.jboss.weld.context;type="third-party", \
  org.jboss.weld.context.api;type="third-party", \
- org.jboss.weld.context.beanstore;type="third-party", \
- org.jboss.weld.context.bound;type="third-party", \
- org.jboss.weld.context.conversation;type="third-party"
+ org.jboss.weld.context.bound;type="third-party"
 IBM-SPI-Package: io.openliberty.cdi.spi;type="ibm-spi"
 IBM-ShortName: cdi-4.0
 Subsystem-Name: Jakarta Contexts and Dependency Injection 4.0


### PR DESCRIPTION
`org.jboss.weld.context.beanstore` and `org.jboss.weld.context.conversation` do not exist any more. They were renamed in Weld 3 but since no one has requested them, there is no reason to expose the newer packages.

fixes #22748 
#build