### PR TITLE
Issue 21120: Adding routing for rest handle schema for config and validation to be accessible under the /ibm/api context root.

### DIFF
--- a/dev/com.ibm.ws.rest.handler.config.openapi/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.config.openapi/bnd.bnd
@@ -28,13 +28,14 @@ Private-Package:\
 -dsannotations:\
   com.ibm.ws.rest.handler.config.openapi.ConfigSchemaRESTHandler
 
--buildpath:\
-  com.ibm.websphere.appserver.spi.logging,\
-  com.ibm.websphere.org.osgi.core,\
-  com.ibm.websphere.rest.handler;version=latest,\
-  com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-  com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
-  com.ibm.ws.microprofile.openapi;version=latest,\
-  com.ibm.websphere.org.eclipse.microprofile.openapi.1.0;version=latest,\
-  io.openliberty.com.fasterxml.jackson;version=latest,\
-  com.ibm.ws.logging;version=latest
+-buildpath: \
+	com.ibm.websphere.appserver.spi.logging,\
+	com.ibm.websphere.org.osgi.core,\
+	com.ibm.websphere.rest.handler;version=latest,\
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+	com.ibm.ws.microprofile.openapi;version=latest,\
+	com.ibm.websphere.org.eclipse.microprofile.openapi.1.0;version=latest,\
+	io.openliberty.com.fasterxml.jackson;version=latest,\
+	com.ibm.ws.logging;version=latest,\
+	com.ibm.ws.kernel.boot

--- a/dev/com.ibm.ws.rest.handler.config.openapi/src/com/ibm/ws/rest/handler/config/openapi/ConfigSchemaRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.config.openapi/src/com/ibm/ws/rest/handler/config/openapi/ConfigSchemaRESTHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,6 +38,7 @@ import com.ibm.wsspi.rest.handler.RESTResponse;
            configurationPolicy = ConfigurationPolicy.IGNORE,
            service = { RESTHandler.class },
            property = { RESTHandler.PROPERTY_REST_HANDLER_CONTEXT_ROOT + "=/openapi/platform",
+                        RESTHandler.PROPERTY_REST_HANDLER_CONTEXT_ROOT + "=/ibm/api/platform",
                         RESTHandler.PROPERTY_REST_HANDLER_ROOT + "=/config" })
 public class ConfigSchemaRESTHandler implements RESTHandler {
     private static final TraceComponent tc = Tr.register(ConfigSchemaRESTHandler.class);

--- a/dev/com.ibm.ws.rest.handler.config.openapi/src/com/ibm/ws/rest/handler/config/openapi/ConfigSchemaRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.config.openapi/src/com/ibm/ws/rest/handler/config/openapi/ConfigSchemaRESTHandler.java
@@ -22,6 +22,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.ws.microprofile.openapi.Constants;
 import com.ibm.ws.microprofile.openapi.impl.core.util.Json;
 import com.ibm.ws.microprofile.openapi.impl.core.util.Yaml;
@@ -57,6 +58,14 @@ public class ConfigSchemaRESTHandler implements RESTHandler {
             }
             response.setResponseHeader("Accept", "GET");
             response.sendError(405); // Method Not Allowed
+            return;
+        }
+
+        // Delete once feature 18696 is GA.
+        // Remove com.ibm.ws.kernel.boot from bnd buildpath once the Beta check is no longer needed.
+        if (!ProductInfo.getBetaEdition() && request.getContextPath().contains("/ibm/api")) {
+            response.setResponseHeader("Accept", "GET");
+            response.sendError(404); // Not Found
             return;
         }
 

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigOpenApiSchemaTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigOpenApiSchemaTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -66,12 +66,29 @@ public class ConfigOpenApiSchemaTest extends FATServletClient {
     }
 
     /**
+     * Test the config schema is available under the ibm/api/platform/config endpoint, and
+     * honors both the "format=json" query parameter and "Accept application/json" http header.
+     */
+    @Test
+    public void testConfigOpenAPIAsJSON_ibmApi() throws Exception {
+        testConfigOpenAPIAsJSON("/ibm/api");
+    }
+
+    /**
      * Test the config schema is available under the openapi/platform/config endpoint, and
      * honors both the "format=json" query parameter and "Accept application/json" http header.
      */
     @Test
-    public void testConfigOpenAPIAsJSON() throws Exception {
-        HttpsRequest request = new HttpsRequest(server, "/openapi/platform/config?format=json");
+    public void testConfigOpenAPIAsJSON_openApi() throws Exception {
+        testConfigOpenAPIAsJSON("/openapi");
+    }
+
+    /**
+     * Test the config schema is available under the ${contextRoot}/platform/config endpoint, and
+     * honors both the "format=json" query parameter and "Accept application/json" http header.
+     */
+    private void testConfigOpenAPIAsJSON(String contextRoot) throws Exception {
+        HttpsRequest request = new HttpsRequest(server, contextRoot + "/platform/config?format=json");
         JsonObject json = request.run(JsonObject.class);
         String err = "Unexpected json response: " + json.toString();
         JsonObject paths = json.getJsonObject("paths");
@@ -83,7 +100,7 @@ public class ConfigOpenApiSchemaTest extends FATServletClient {
         assertTrue(err, paths.size() == 3);
 
         //test again with json specified in the header
-        request = new HttpsRequest(server, "/openapi/platform/config");
+        request = new HttpsRequest(server, contextRoot + "/platform/config");
         json = request.requestProp("Accept", "application/json").run(JsonObject.class);
         err = "Unexpected json response: " + json.toString();
         paths = json.getJsonObject("paths");
@@ -96,12 +113,29 @@ public class ConfigOpenApiSchemaTest extends FATServletClient {
     }
 
     /**
+     * Test the config schema is available under the ibm/api/platform/config endpoint, and
+     * is returned as YAML by default.
+     */
+    @Test
+    public void testConfigOpenAPIAsYAML_ibmApi() throws Exception {
+        testConfigOpenAPIAsYAML("/ibm/api");
+    }
+
+    /**
      * Test the config schema is available under the openapi/platform/config endpoint, and
      * is returned as YAML by default.
      */
     @Test
-    public void testConfigOpenAPIAsYAML() throws Exception {
-        HttpsRequest request = new HttpsRequest(server, "/openapi/platform/config");
+    public void testConfigOpenAPIAsYAML_openApi() throws Exception {
+        testConfigOpenAPIAsYAML("/openapi");
+    }
+
+    /**
+     * Test the config schema is available under the ${contextRoot}/platform/config endpoint, and
+     * is returned as YAML by default.
+     */
+    private void testConfigOpenAPIAsYAML(String contextRoot) throws Exception {
+        HttpsRequest request = new HttpsRequest(server, contextRoot + "/platform/config");
         String yaml = request.run(String.class);
         SwaggerParseResult result = new OpenAPIParser().readContents(yaml, null, null, null);
         assertNotNull(result);

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigOpenApiSchemaTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigOpenApiSchemaTest.java
@@ -37,7 +37,6 @@ import componenttest.topology.utils.HttpsRequest;
 
 @RunWith(FATRunner.class)
 public class ConfigOpenApiSchemaTest extends FATServletClient {
-
     /**  */
     private static final String SERVER_NAME = "com.ibm.ws.rest.handler.config.openapi.fat";
 
@@ -47,6 +46,9 @@ public class ConfigOpenApiSchemaTest extends FATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         FATSuite.setupServerSideAnnotations(server);
+
+        // Delete once feature 18696 is GA.
+        server.setJvmOptions(Arrays.asList("-Dcom.ibm.ws.beta.edition=true"));
 
         server.startServer();
 

--- a/dev/com.ibm.ws.rest.handler.validator.openapi/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.validator.openapi/bnd.bnd
@@ -41,4 +41,5 @@ Include-Resource: \
 	com.ibm.websphere.org.osgi.core,\
 	com.ibm.ws.microprofile.openapi,\
 	io.openliberty.com.fasterxml.jackson;version=latest,\
-	com.ibm.websphere.org.eclipse.microprofile.openapi.1.0
+	com.ibm.websphere.org.eclipse.microprofile.openapi.1.0,\
+	com.ibm.ws.kernel.boot

--- a/dev/com.ibm.ws.rest.handler.validator.openapi/src/com/ibm/ws/rest/handler/validator/openapi/ValidatorSchemaRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.validator.openapi/src/com/ibm/ws/rest/handler/validator/openapi/ValidatorSchemaRESTHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -51,6 +51,7 @@ import com.ibm.wsspi.validator.Validator;
            configurationPolicy = ConfigurationPolicy.IGNORE,
            service = { RESTHandler.class },
            property = { RESTHandler.PROPERTY_REST_HANDLER_CONTEXT_ROOT + "=/openapi/platform",
+                        RESTHandler.PROPERTY_REST_HANDLER_CONTEXT_ROOT + "=/ibm/api/platform",
                         RESTHandler.PROPERTY_REST_HANDLER_ROOT + "=/validation" })
 public class ValidatorSchemaRESTHandler implements RESTHandler {
     private static final TraceComponent tc = Tr.register(ValidatorSchemaRESTHandler.class);

--- a/dev/com.ibm.ws.rest.handler.validator.openapi/src/com/ibm/ws/rest/handler/validator/openapi/ValidatorSchemaRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.validator.openapi/src/com/ibm/ws/rest/handler/validator/openapi/ValidatorSchemaRESTHandler.java
@@ -34,6 +34,7 @@ import org.osgi.service.component.annotations.Deactivate;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.ws.microprofile.openapi.Constants;
 import com.ibm.ws.microprofile.openapi.impl.core.util.Json;
 import com.ibm.ws.microprofile.openapi.impl.core.util.Yaml;
@@ -72,6 +73,14 @@ public class ValidatorSchemaRESTHandler implements RESTHandler {
             }
             response.setResponseHeader("Accept", "GET");
             response.sendError(405); // Method Not Allowed
+            return;
+        }
+
+        // Delete once feature 18696 is GA.
+        // Remove com.ibm.ws.kernel.boot from bnd buildpath once the Beta check is no longer needed.
+        if (!ProductInfo.getBetaEdition() && request.getContextPath().contains("/ibm/api")) {
+            response.setResponseHeader("Accept", "GET");
+            response.sendError(404); // Not Found
             return;
         }
 
@@ -127,16 +136,16 @@ public class ValidatorSchemaRESTHandler implements RESTHandler {
         try {
             cloudantEnabled = getServiceReferences(context.getBundleContext(), Validator.class,
                                                    "(component.name=com.ibm.ws.rest.handler.validator.cloudant.CloudantDatabaseValidator)")
-                                                                   .iterator()
-                                                                   .hasNext();
+                            .iterator()
+                            .hasNext();
             jcaEnabled = getServiceReferences(context.getBundleContext(), Validator.class,
                                               "(component.name=com.ibm.ws.rest.handler.validator.jca.ConnectionFactoryValidator)")
-                                                              .iterator()
-                                                              .hasNext();
+                            .iterator()
+                            .hasNext();
             jdbcEnabled = getServiceReferences(context.getBundleContext(), Validator.class,
                                                "(component.name=com.ibm.ws.rest.handler.validator.jdbc.DataSourceValidator)")
-                                                               .iterator()
-                                                               .hasNext();
+                            .iterator()
+                            .hasNext();
         } catch (InvalidSyntaxException e) {
             //Should never happen.
             e.printStackTrace();

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateOpenApiSchemaTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateOpenApiSchemaTest.java
@@ -73,6 +73,9 @@ public class ValidateOpenApiSchemaTest extends FATServletClient {
         jar.addPackage("com.ibm.ws.rest.handler.validator.loginmodule");
         ShrinkHelper.exportToServer(server, "/", jar, SERVER_ONLY);
 
+        // Delete once feature 18696 is GA.
+        server.setJvmOptions(Arrays.asList("-Dcom.ibm.ws.beta.edition=true"));
+
         server.startServer();
 
         // Wait for the API to become available

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateOpenApiSchemaTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateOpenApiSchemaTest.java
@@ -52,7 +52,6 @@ import componenttest.topology.utils.HttpsRequest;
 
 @RunWith(FATRunner.class)
 public class ValidateOpenApiSchemaTest extends FATServletClient {
-
     @Server("com.ibm.ws.rest.handler.validator.openapi.fat")
     public static LibertyServer server;
 
@@ -93,12 +92,29 @@ public class ValidateOpenApiSchemaTest extends FATServletClient {
     }
 
     /**
+     * Test the validation schema is available under the ibm/api/platform/vaidation endpoint and
+     * honors the format=json parameter.
+     */
+    @Test
+    public void testAllValidatorsAsJSON_ibmApi() throws Exception {
+        testAllValidatorsAsJSON("/ibm/api");
+    }
+
+    /**
      * Test the validation schema is available under the openapi/platform/vaidation endpoint and
      * honors the format=json parameter.
      */
     @Test
-    public void testAllValidatorsAsJSON() throws Exception {
-        HttpsRequest request = new HttpsRequest(server, "/openapi/platform/validation?format=json");
+    public void testAllValidatorsAsJSON_openApi() throws Exception {
+        testAllValidatorsAsJSON("/openapi");
+    }
+
+    /**
+     * Test the validation schema is available under the ${contextRoot}/platform/vaidation endpoint and
+     * honors the format=json parameter.
+     */
+    private void testAllValidatorsAsJSON(String contextRoot) throws Exception {
+        HttpsRequest request = new HttpsRequest(server, contextRoot + "/platform/validation?format=json");
         JsonObject json = request.run(JsonObject.class);
         String err = "Unexpected json response: " + json.toString();
         JsonObject paths = json.getJsonObject("paths");
@@ -120,12 +136,29 @@ public class ValidateOpenApiSchemaTest extends FATServletClient {
     }
 
     /**
+     * Test the validation schema is available under the ibm/api/platform/vaidation endpoint and
+     * is returned in YAML format by default.
+     */
+    @Test
+    public void testAllValidatorsAsYAML_ibmApi() throws Exception {
+        testAllValidatorsAsYAML("/ibm/api");
+    }
+
+    /**
      * Test the validation schema is available under the openapi/platform/vaidation endpoint and
      * is returned in YAML format by default.
      */
     @Test
-    public void testAllValidatorsAsYAML() throws Exception {
-        HttpsRequest request = new HttpsRequest(server, "/openapi/platform/validation");
+    public void testAllValidatorsAsYAML_openApi() throws Exception {
+        testAllValidatorsAsYAML("/openapi");
+    }
+
+    /**
+     * Test the validation schema is available under the ${contextRoot}/platform/vaidation endpoint and
+     * is returned in YAML format by default.
+     */
+    private void testAllValidatorsAsYAML(String contextRoot) throws Exception {
+        HttpsRequest request = new HttpsRequest(server, contextRoot + "/platform/validation");
         String yaml = request.run(String.class);
         SwaggerParseResult result = new OpenAPIParser().readContents(yaml, null, null, null);
         assertNotNull(result);
@@ -198,12 +231,29 @@ public class ValidateOpenApiSchemaTest extends FATServletClient {
      * doesn't return cloudant API data when cloudant isn't enabled.
      */
     @Test
-    public void testDisableCloudantValidator() throws Exception {
+    public void testDisableCloudantValidator_ibmApi() throws Exception {
+        testDisableCloudantValidator("/ibm/api");
+    }
+
+    /**
+     * Test the validation OpenAPI endpoint honors the Accept header of application/json and
+     * doesn't return cloudant API data when cloudant isn't enabled.
+     */
+    @Test
+    public void testDisableCloudantValidator_openApi() throws Exception {
+        testDisableCloudantValidator("/openapi");
+    }
+
+    /**
+     * Test the validation OpenAPI endpoint honors the Accept header of application/json and
+     * doesn't return cloudant API data when cloudant isn't enabled.
+     */
+    private void testDisableCloudantValidator(String contextRoot) throws Exception {
         //Disable cloudant.
         try (AutoCloseable x = withoutFeatures("cloudant-1.0")) {
 
             //Test that cloudant elements have been removed from the OpenAPI document.
-            HttpsRequest request = new HttpsRequest(server, "/openapi/platform/validation");
+            HttpsRequest request = new HttpsRequest(server, contextRoot + "/platform/validation");
             JsonObject json = request.requestProp("Accept", "application/json").run(JsonObject.class);
             String err = "Unexpected json response: " + json.toString();
             JsonObject paths = json.getJsonObject("paths");
@@ -229,13 +279,28 @@ public class ValidateOpenApiSchemaTest extends FATServletClient {
      * Test the validation OpenAPI doesn't return JCA or JMS API data when JCA isn't enabled in the server.
      */
     @Test
-    public void testDisableJCAValidator() throws Exception {
+    public void testDisableJCAValidator_ibmApi() throws Exception {
+        testDisableJCAValidator("/ibm/api");
+    }
+
+    /**
+     * Test the validation OpenAPI doesn't return JCA or JMS API data when JCA isn't enabled in the server.
+     */
+    @Test
+    public void testDisableJCAValidator_openApi() throws Exception {
+        testDisableJCAValidator("/openapi");
+    }
+
+    /**
+     * Test the validation OpenAPI doesn't return JCA or JMS API data when JCA isn't enabled in the server.
+     */
+    private void testDisableJCAValidator(String contextRoot) throws Exception {
         //Disable JCA (JMS 2.0 implicitly enabled it).
         try (AutoCloseable x = withoutFeatures("jca", "jms", "wasjmsclient", "wasjmsserver",
                                                "connectors", "messaging", "messagingClient", "messagingServer")) {
 
             //Test that JCA and JMS elements have been removed from the OpenAPI document.
-            HttpsRequest request = new HttpsRequest(server, "/openapi/platform/validation");
+            HttpsRequest request = new HttpsRequest(server, contextRoot + "/platform/validation");
             String yaml = request.run(String.class);
             SwaggerParseResult result = new OpenAPIParser().readContents(yaml, null, null, null);
             assertNotNull(result);
@@ -265,11 +330,26 @@ public class ValidateOpenApiSchemaTest extends FATServletClient {
      * Test the validation OpenAPI doesn't return JDBC API data when JDBC isn't enabled in the server.
      */
     @Test
-    public void testDisableJDBCValidator() throws Exception {
+    public void testDisableJDBCValidator_ibmApi() throws Exception {
+        testDisableJDBCValidator("/ibm/api");
+    }
+
+    /**
+     * Test the validation OpenAPI doesn't return JDBC API data when JDBC isn't enabled in the server.
+     */
+    @Test
+    public void testDisableJDBCValidator_openApi() throws Exception {
+        testDisableJDBCValidator("/openapi");
+    }
+
+    /**
+     * Test the validation OpenAPI doesn't return JDBC API data when JDBC isn't enabled in the server.
+     */
+    private void testDisableJDBCValidator(String contextRoot) throws Exception {
         //Disable JDBC.
         try (AutoCloseable x = withoutFeatures("jdbc")) {
             //Test that JDBC elements have been removed from the OpenAPI document.
-            HttpsRequest request = new HttpsRequest(server, "/openapi/platform/validation");
+            HttpsRequest request = new HttpsRequest(server, contextRoot + "/platform/validation");
             String yaml = request.run(String.class);
             SwaggerParseResult result = new OpenAPIParser().readContents(yaml, null, null, null);
             assertNotNull(result);
@@ -299,12 +379,27 @@ public class ValidateOpenApiSchemaTest extends FATServletClient {
      * Test the validation OpenAPI doesn't return JMS API data when JMS isn't enabled in the server.
      */
     @Test
-    public void testDisableJMSValidator() throws Exception {
+    public void testDisableJMSValidator_ibmApi() throws Exception {
+        testDisableJMSValidator("/ibm/api");
+    }
+
+    /**
+     * Test the validation OpenAPI doesn't return JMS API data when JMS isn't enabled in the server.
+     */
+    @Test
+    public void testDisableJMSValidator_openApi() throws Exception {
+        testDisableJMSValidator("/openapi");
+    }
+
+    /**
+     * Test the validation OpenAPI doesn't return JMS API data when JMS isn't enabled in the server.
+     */
+    private void testDisableJMSValidator(String contextRoot) throws Exception {
         // Remove JMS
         try (AutoCloseable x = withoutFeatures("jms", "wasjmsclient", "wasjmsserver",
                                                "messaging", "messagingClient", "messagingServer")) {
             //Test that JMS elements have been removed from the OpenAPI document.
-            HttpsRequest request = new HttpsRequest(server, "/openapi/platform/validation");
+            HttpsRequest request = new HttpsRequest(server, contextRoot + "/platform/validation");
             String yaml = request.run(String.class);
             SwaggerParseResult result = new OpenAPIParser().readContents(yaml, null, null, null);
             assertNotNull(result);

--- a/dev/io.openliberty.rest.handler.config.openapi.2.0/bnd.bnd
+++ b/dev/io.openliberty.rest.handler.config.openapi.2.0/bnd.bnd
@@ -33,12 +33,13 @@ Private-Package:\
   io.openliberty.rest.handler.config.openapi20.ConfigSchemaRESTHandler
 
 -buildpath: \
-    com.ibm.websphere.appserver.spi.logging,\
-    com.ibm.websphere.rest.handler;version=latest,\
-    com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-    com.ibm.wsspi.org.osgi.service.component.annotations,\
-    com.ibm.ws.rest.handler.validator,\
-    com.ibm.websphere.org.osgi.service.component,\
-    com.ibm.websphere.org.osgi.core,\
-    io.openliberty.io.smallrye.openapi.core,\
-    io.openliberty.org.eclipse.microprofile.openapi.2.0
+	com.ibm.websphere.appserver.spi.logging,\
+	com.ibm.websphere.rest.handler;version=latest,\
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+	com.ibm.wsspi.org.osgi.service.component.annotations,\
+	com.ibm.ws.rest.handler.validator,\
+	com.ibm.websphere.org.osgi.service.component,\
+	com.ibm.websphere.org.osgi.core,\
+	io.openliberty.io.smallrye.openapi.core,\
+	io.openliberty.org.eclipse.microprofile.openapi.2.0,\
+	com.ibm.ws.kernel.boot

--- a/dev/io.openliberty.rest.handler.config.openapi.2.0/src/io/openliberty/rest/handler/config/openapi20/ConfigSchemaRESTHandler.java
+++ b/dev/io.openliberty.rest.handler.config.openapi.2.0/src/io/openliberty/rest/handler/config/openapi20/ConfigSchemaRESTHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,6 +34,7 @@ import io.smallrye.openapi.runtime.io.OpenApiSerializer;
 @Component(configurationPolicy = ConfigurationPolicy.IGNORE,
            service = { RESTHandler.class },
            property = { RESTHandler.PROPERTY_REST_HANDLER_CONTEXT_ROOT + "=/openapi/platform",
+                        RESTHandler.PROPERTY_REST_HANDLER_CONTEXT_ROOT + "=/ibm/api/platform",
                         RESTHandler.PROPERTY_REST_HANDLER_ROOT + "=/config" })
 public class ConfigSchemaRESTHandler implements RESTHandler {
     private static final TraceComponent tc = Tr.register(ConfigSchemaRESTHandler.class);

--- a/dev/io.openliberty.rest.handler.config.openapi.2.0/src/io/openliberty/rest/handler/config/openapi20/ConfigSchemaRESTHandler.java
+++ b/dev/io.openliberty.rest.handler.config.openapi.2.0/src/io/openliberty/rest/handler/config/openapi20/ConfigSchemaRESTHandler.java
@@ -19,6 +19,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.wsspi.rest.handler.RESTHandler;
 import com.ibm.wsspi.rest.handler.RESTRequest;
 import com.ibm.wsspi.rest.handler.RESTResponse;
@@ -53,6 +54,14 @@ public class ConfigSchemaRESTHandler implements RESTHandler {
             }
             response.setResponseHeader("Accept", "GET");
             response.sendError(405); // Method Not Allowed
+            return;
+        }
+
+        // Delete once feature 18696 is GA.
+        // Remove com.ibm.ws.kernel.boot from bnd buildpath once the Beta check is no longer needed.
+        if (!ProductInfo.getBetaEdition() && request.getContextPath().contains("/ibm/api")) {
+            response.setResponseHeader("Accept", "GET");
+            response.sendError(404); // Not Found
             return;
         }
 

--- a/dev/io.openliberty.rest.handler.config.openapi.common/bnd.bnd
+++ b/dev/io.openliberty.rest.handler.config.openapi.common/bnd.bnd
@@ -19,6 +19,7 @@ bVersion=1.0
 
 WS-TraceGroup: rest.config
 
+Web-ContextPath: ibm/api/platform
 Web-ContextPath: openapi/platform
 OL-VirtualHost: ${admin.virtual.host}
 

--- a/dev/io.openliberty.rest.handler.config.openapi.common/resources/WEB-INF/web.xml
+++ b/dev/io.openliberty.rest.handler.config.openapi.common/resources/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2019, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -71,6 +71,48 @@
       <transport-guarantee>CONFIDENTIAL</transport-guarantee>
     </user-data-constraint>
   </security-constraint>
+  
+  <security-constraint id="SecurityConstraint_4">
+    <display-name>ibm/api/platform REST Security Constraint - Administrator Role</display-name>
+    <web-resource-collection id="WebResourceCollection_4">
+      <web-resource-name>/ibm/api/platform REST URL</web-resource-name>
+      <url-pattern>/*</url-pattern>
+    </web-resource-collection>
+    <auth-constraint>
+      <role-name>allAuthenticatedUsers</role-name>
+      <role-name>Administrator</role-name>
+    </auth-constraint>
+    <user-data-constraint id="UserDataConstraint_4">
+      <transport-guarantee>CONFIDENTIAL</transport-guarantee>
+    </user-data-constraint>
+  </security-constraint>
+
+  <security-constraint id="SecurityConstraint_5">
+    <display-name>ibm/api/platform REST Security Constraint - OPTIONS</display-name>
+    <web-resource-collection id="WebResourceCollection_5">
+      <web-resource-name>ibm/api/platform REST URL</web-resource-name>
+      <url-pattern>/*</url-pattern>
+      <http-method>OPTIONS</http-method>
+    </web-resource-collection>
+    <user-data-constraint id="UserDataConstraint_5">
+      <transport-guarantee>CONFIDENTIAL</transport-guarantee>
+    </user-data-constraint>
+  </security-constraint>
+
+  <security-constraint id="SecurityConstraint_6">
+    <display-name>ibm/api/platform REST Security Constraint - Viewer Role</display-name>
+    <web-resource-collection id="WebResourceCollection_6">
+      <web-resource-name>ibm/api/platform REST URL</web-resource-name>
+      <url-pattern>/*</url-pattern>
+      <http-method>GET</http-method>
+    </web-resource-collection>
+    <auth-constraint>
+      <role-name>Viewer</role-name>
+    </auth-constraint>
+    <user-data-constraint id="UserDataConstraint_6">
+      <transport-guarantee>CONFIDENTIAL</transport-guarantee>
+    </user-data-constraint>
+  </security-constraint>
 
   <security-role id="SecurityRole_1">
     <description>Any Role</description>
@@ -90,7 +132,8 @@
   <login-config id="LoginConfig_1">
   	<auth-method>CLIENT_CERT</auth-method>
     <realm-name>openapi/platform</realm-name>
-  </login-config>  
+    <realm-name>ibm/api/platform</realm-name>
+  </login-config>
 
 </web-app>
   

--- a/dev/io.openliberty.rest.handler.validator.openapi.2.0/bnd.bnd
+++ b/dev/io.openliberty.rest.handler.validator.openapi.2.0/bnd.bnd
@@ -38,12 +38,13 @@ Include-Resource: \
   io.openliberty.rest.handler.validator.openapi20.ValidatorSchemaRESTHandler
 
 -buildpath: \
-    com.ibm.websphere.appserver.spi.logging,\
-    com.ibm.websphere.rest.handler;version=latest,\
-    com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-    com.ibm.wsspi.org.osgi.service.component.annotations,\
-    com.ibm.ws.rest.handler.validator,\
-    com.ibm.websphere.org.osgi.service.component,\
-    com.ibm.websphere.org.osgi.core,\
-    io.openliberty.io.smallrye.openapi.core,\
-    io.openliberty.org.eclipse.microprofile.openapi.2.0
+	com.ibm.websphere.appserver.spi.logging,\
+	com.ibm.websphere.rest.handler;version=latest,\
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+	com.ibm.wsspi.org.osgi.service.component.annotations,\
+	com.ibm.ws.rest.handler.validator,\
+	com.ibm.websphere.org.osgi.service.component,\
+	com.ibm.websphere.org.osgi.core,\
+	io.openliberty.io.smallrye.openapi.core,\
+	io.openliberty.org.eclipse.microprofile.openapi.2.0,\
+	com.ibm.ws.kernel.boot

--- a/dev/io.openliberty.rest.handler.validator.openapi.2.0/src/io/openliberty/rest/handler/validator/openapi20/ValidatorSchemaRESTHandler.java
+++ b/dev/io.openliberty.rest.handler.validator.openapi.2.0/src/io/openliberty/rest/handler/validator/openapi20/ValidatorSchemaRESTHandler.java
@@ -44,10 +44,11 @@ import io.smallrye.openapi.runtime.io.OpenApiSerializer;
 /**
  * Displays validation schema
  */
-@Component(configurationPolicy = ConfigurationPolicy.IGNORE, service = { RESTHandler.class }, property = { RESTHandler.PROPERTY_REST_HANDLER_CONTEXT_ROOT
-                                                                                                           + "=/openapi/platform",
-                                                                                                           RESTHandler.PROPERTY_REST_HANDLER_ROOT
-                                                                                                                                   + "=/validation" })
+@Component(configurationPolicy = ConfigurationPolicy.IGNORE, 
+           service = { RESTHandler.class }, 
+           property = { RESTHandler.PROPERTY_REST_HANDLER_CONTEXT_ROOT + "=/openapi/platform",
+                        RESTHandler.PROPERTY_REST_HANDLER_CONTEXT_ROOT + "=/ibm/api/platform",
+                        RESTHandler.PROPERTY_REST_HANDLER_ROOT + "=/validation" })
 public class ValidatorSchemaRESTHandler implements RESTHandler {
     private static final TraceComponent tc = Tr.register(ValidatorSchemaRESTHandler.class);
 

--- a/dev/io.openliberty.rest.handler.validator.openapi.2.0/src/io/openliberty/rest/handler/validator/openapi20/ValidatorSchemaRESTHandler.java
+++ b/dev/io.openliberty.rest.handler.validator.openapi.2.0/src/io/openliberty/rest/handler/validator/openapi20/ValidatorSchemaRESTHandler.java
@@ -31,6 +31,7 @@ import org.osgi.service.component.annotations.Deactivate;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.wsspi.rest.handler.RESTHandler;
 import com.ibm.wsspi.rest.handler.RESTRequest;
 import com.ibm.wsspi.rest.handler.RESTResponse;
@@ -44,11 +45,9 @@ import io.smallrye.openapi.runtime.io.OpenApiSerializer;
 /**
  * Displays validation schema
  */
-@Component(configurationPolicy = ConfigurationPolicy.IGNORE, 
-           service = { RESTHandler.class }, 
-           property = { RESTHandler.PROPERTY_REST_HANDLER_CONTEXT_ROOT + "=/openapi/platform",
-                        RESTHandler.PROPERTY_REST_HANDLER_CONTEXT_ROOT + "=/ibm/api/platform",
-                        RESTHandler.PROPERTY_REST_HANDLER_ROOT + "=/validation" })
+@Component(configurationPolicy = ConfigurationPolicy.IGNORE, service = { RESTHandler.class }, property = { RESTHandler.PROPERTY_REST_HANDLER_CONTEXT_ROOT + "=/openapi/platform",
+                                                                                                           RESTHandler.PROPERTY_REST_HANDLER_CONTEXT_ROOT + "=/ibm/api/platform",
+                                                                                                           RESTHandler.PROPERTY_REST_HANDLER_ROOT + "=/validation" })
 public class ValidatorSchemaRESTHandler implements RESTHandler {
     private static final TraceComponent tc = Tr.register(ValidatorSchemaRESTHandler.class);
 
@@ -68,6 +67,14 @@ public class ValidatorSchemaRESTHandler implements RESTHandler {
             }
             response.setResponseHeader("Accept", "GET");
             response.sendError(405); // Method Not Allowed
+            return;
+        }
+
+        // Delete once feature 18696 is GA.
+        // Remove com.ibm.ws.kernel.boot from bnd buildpath once the Beta check is no longer needed.
+        if (!ProductInfo.getBetaEdition() && request.getContextPath().contains("/ibm/api")) {
+            response.setResponseHeader("Accept", "GET");
+            response.sendError(404); // Not Found
             return;
         }
 


### PR DESCRIPTION
Adding routing for rest handle schema for config and validation to be accessible under the /ibm/api context root.

Routing has been added to duplicate the /openapi/platform/config and /openapi/platform/validation endpoints to also be available at /ibm/api/platform/config and /ibm/api/platform/validation. 

Updates to FAT tests have been made to verify the new endpoints of /ibm/api/plaform/config and /ibm/api/platform/validation.