### PR TITLE
XML WS 4.0: Make xmlWS-4.0 beta ready

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VisibilityTest.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VisibilityTest.java
@@ -393,18 +393,17 @@ public class VisibilityTest {
         expectedFailures.add("io.openliberty.jakarta.authentication-3.0");
         expectedFailures.add("io.openliberty.jakarta.authorization-2.1");
         expectedFailures.add("io.openliberty.jakarta.security.enterprise-3.0");
-        expectedFailures.add("io.openliberty.xmlws.common-4.0");
         expectedFailures.add("io.openliberty.org.eclipse.microprofile.jwt-2.1");
         expectedFailures.add("io.openliberty.persistentExecutor.internal.ee-10.0"); // the persistentExecutor feature is no ship
         expectedFailures.add("io.openliberty.socialLogin1.0.internal.ee-10.0");
         expectedFailures.add("io.openliberty.batch-2.1");
+        expectedFailures.add("io.openliberty.xmlWSClient-4.0");
 
         expectedFailures.add("io.openliberty.openidConnectClient1.0.internal.ee-10.0");
         expectedFailures.add("io.openliberty.adminCenter1.0.internal.ee-10.0");
         expectedFailures.add("io.openliberty.openidConnectServer1.0.internal.ee-10.0");
         expectedFailures.add("io.openliberty.webCache1.0.internal.ee-10.0");
         expectedFailures.add("io.openliberty.facesContainer-4.0");
-
 
         StringBuilder errorMessage = new StringBuilder();
         for (Entry<String, FeatureInfo> entry : features.entrySet()) {

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wsAtomicTransaction1.2.internal.ee-10.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wsAtomicTransaction1.2.internal.ee-10.0.feature
@@ -9,5 +9,5 @@ visibility = private
   com.ibm.ws.wsat.common.jakarta; start-phase:=CONTAINER_LATE, \
   com.ibm.ws.wsat.webclient.jakarta, \
   com.ibm.ws.wsat.webservice.jakarta
-kind=noship
-edition=full
+kind=beta
+edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlws.common-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlws.common-4.0.feature
@@ -54,6 +54,6 @@ IBM-API-Package:\
  com.ibm.ws.org.jvnet.mimepull, \
  io.openliberty.xmlWS.3.0.internal.tools, \
  io.openliberty.com.sun.xml.messaging.saaj.3.0
-kind=noship
-edition=full
+kind=beta
+edition=base
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWS-4.0/io.openliberty.xmlWS-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWS-4.0/io.openliberty.xmlWS-4.0.feature
@@ -31,7 +31,7 @@ IBM-API-Package: \
  dev/spi/ibm/javadoc/io.openliberty.globalhandler.spi_1.0-javadoc.zip
 -jars=\
   io.openliberty.globalhandler.spi; location:=dev/spi/ibm/
-kind=noship
-edition=full
+kind=beta
+edition=base
 WLP-AlsoKnownAs: jaxws-4.0
 WLP-Activation-Type: parallel


### PR DESCRIPTION
This pull requests puts xmlWS-4.0 into beta

A couple of things to note:
1. wsSecurity-1.1 cannot be switched to beta since it's dependent on other features not in beta.
2. xmlWSClient-4.0 not beta ready either since the convenience feature is not beta ready. 