### PR TITLE
infer more from parameterized types

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -17,17 +17,51 @@ class QueryInfo {
         COUNT, DELETE, EXISTS, MERGE, SELECT, UPDATE
     }
 
+    /**
+     * Information about the type of entity to which the query pertains.
+     */
     final EntityInfo entityInfo;
+
+    /**
+     * Generated JPQL for the query. Null if a save operation.
+     */
     final String jpql;
+
+    /**
+     * Array element type if the repository method returns an array, such as,
+     * <code>Product[] findByNameLike(String namePattern);</code>
+     * or if its parameterized type is an array, such as,
+     * <code>CompletableFuture&lt;Product[]&gt; findByNameLike(String namePattern);</code>
+     * Otherwise null.
+     */
     final Class<?> returnArrayType;
+
+    /**
+     * Type parameter of the repository method return value.
+     * Null if the return type is not parameterized or is generic.
+     * This is useful in cases such as
+     * <code>&#64;Query(...) Optional&lt;Float&gt; priceOf(String productId)</code>
+     * and
+     * <code>CompletableFuture&lt;Stream&lt;Product&gt&gt; findByNameLike(String namePattern)</code>
+     */
+    final Class<?> returnTypeParam;
+
+    /**
+     * Type of the first parameter to a save operation. Null if not a save operation.
+     */
     final Class<?> saveParamType;
+
+    /**
+     * Categorization of query type.
+     */
     final Type type;
 
     QueryInfo(Type type, String jpql, EntityInfo entityInfo,
-              Class<?> saveParamType, Class<?> returnArrayType) {
+              Class<?> saveParamType, Class<?> returnArrayType, Class<?> returnParamType) {
         this.jpql = jpql;
         this.entityInfo = entityInfo;
         this.returnArrayType = returnArrayType;
+        this.returnTypeParam = returnParamType;
         this.saveParamType = saveParamType;
 
         if (type == null) {

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/DataExtension.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/DataExtension.java
@@ -186,9 +186,9 @@ public class DataExtension implements Extension, PrivilegedAction<DataExtensionM
             if (interfaceType instanceof ParameterizedType) {
                 ParameterizedType parameterizedType = (ParameterizedType) interfaceType;
                 if (parameterizedType.getRawType().getTypeName().startsWith(DataRepository.class.getPackageName())) {
-                    Type paramTypes[] = parameterizedType.getActualTypeArguments();
-                    if (paramTypes.length == 2 && paramTypes[0] instanceof Class) {
-                        entityClass = (Class<?>) paramTypes[0];
+                    Type typeParams[] = parameterizedType.getActualTypeArguments();
+                    if (typeParams.length == 2 && typeParams[0] instanceof Class) {
+                        entityClass = (Class<?>) typeParams[0];
                     }
                 }
             }
@@ -197,16 +197,24 @@ public class DataExtension implements Extension, PrivilegedAction<DataExtensionM
         if (entityClass == null) {
             for (Method method : repositoryInterface.getMethods())
                 if (method.getParameterCount() == 1 && "save".equals(method.getName())) {
-                    Class<?> paramType = method.getParameterTypes()[0];
-                    if (paramType.isArray())
-                        paramType = paramType.getComponentType();
-                    String packageName = paramType.getPackageName();
-                    if (!paramType.isPrimitive() &&
-                        !paramType.isInterface() &&
-                        !packageName.startsWith("java") &&
-                        !packageName.startsWith("jakarta")) {
-                        entityClass = paramType;
-                        break;
+                    Type type = method.getGenericParameterTypes()[0];
+                    if (type instanceof ParameterizedType) {
+                        Type[] typeParams = ((ParameterizedType) type).getActualTypeArguments();
+                        if (typeParams.length == 1) // for example, List<Product> vs. Map<Long, String>
+                            type = typeParams[0];
+                    }
+                    if (type instanceof Class) {
+                        Class<?> paramClass = (Class<?>) type;
+                        if (paramClass.isArray())
+                            paramClass = paramClass.getComponentType();
+                        String packageName = paramClass.getPackageName();
+                        if (!paramClass.isPrimitive() &&
+                            !paramClass.isInterface() &&
+                            !packageName.startsWith("java") &&
+                            !packageName.startsWith("jakarta")) {
+                            entityClass = paramClass;
+                            break;
+                        }
                     }
                 }
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/PersonRepo.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/PersonRepo.java
@@ -16,12 +16,14 @@ import jakarta.data.Query;
 import jakarta.data.repository.Repository;
 
 /**
- *
+ * This example only references the entity class as a parameterized type.
+ * Do not add methods or inheritance that would allow the entity class
+ * to be discovered another way.
  */
 @Repository
 public interface PersonRepo {
     @Query("SELECT o FROM Person o WHERE o.lastName=?1")
     List<Person> find(String lastName);
 
-    void save(Person p);
+    void save(List<Person> people);
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Personnel.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Personnel.java
@@ -15,10 +15,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 import java.util.stream.Collector;
+import java.util.stream.Stream;
 
 import jakarta.data.Delete;
-import jakarta.data.Limit;
 import jakarta.data.Paginated;
+import jakarta.data.Query;
 import jakarta.data.Select;
 import jakarta.data.Update;
 import jakarta.data.Where;
@@ -36,7 +37,7 @@ public interface Personnel {
     @Asynchronous
     @Update("o.lastName = ?2")
     @Where("o.lastName = ?1 AND o.ssn IN ?3")
-    CompletionStage<Long> changeSurnames(String oldSurname, String newSurname, List<Long> ssnList);
+    CompletionStage<Integer> changeSurnames(String oldSurname, String newSurname, List<Long> ssnList);
 
     @Asynchronous
     CompletionStage<List<Person>> findByLastNameOrderByFirstName(String lastName);
@@ -50,8 +51,15 @@ public interface Personnel {
     CompletableFuture<Void> findByOrderBySsnDesc(Consumer<Person> callback);
 
     @Asynchronous
-    @Limit(1) // indicates single result (rather than list) for the completion stage
     CompletableFuture<Person> findBySsn(long ssn);
+
+    @Asynchronous
+    @Query("SELECT o.firstName FROM Person o WHERE o.lastName=?1 ORDER BY o.firstName")
+    CompletableFuture<Stream<String>> firstNames(String lastName);
+
+    @Asynchronous
+    @Query("SELECT DISTINCT o.lastName FROM Person o ORDER BY o.lastName")
+    CompletionStage<String[]> lastNames();
 
     @Asynchronous
     @Select("firstName")
@@ -78,5 +86,5 @@ public interface Personnel {
     @Asynchronous
     @Update("o.lastName = ?1")
     @Where("o.ssn = ?2")
-    CompletableFuture<Long> setSurnameAsync(String newSurname, long ssn);
+    CompletableFuture<Boolean> setSurnameAsync(String newSurname, long ssn);
 }


### PR DESCRIPTION
With the decision not to have an annotation for limit, it needs to be possible to infer when there is a singular result from the result type, which might be parameterized.  This pull experiments with that, as well as with a number of other scenarios where we could use the parameterized type information to correctly infer how to form the result that the application wants to receive.