### PR TITLE
Issue 22765: Fix test logic to wait for J2CA7001I every time J2CA7009I occurrs in the logs.

### DIFF
--- a/dev/com.ibm.ws.jca_fat_bval/fat/src/com/ibm/ws/jca/fat/bval/BeanValidationTest.java
+++ b/dev/com.ibm.ws.jca_fat_bval/fat/src/com/ibm/ws/jca/fat/bval/BeanValidationTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.fail;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.AfterClass;
@@ -70,7 +71,9 @@ public class BeanValidationTest extends FATServletClient {
         else
             server.waitForConfigUpdateInLogUsingMark(appNames);
 
-        assertNotNull(server.waitForStringInLog("J2CA7001I.*" + BVAL_RAR));
+        //Match the number of RAR installed (J2CA7001I) messages to the number of RAR uninstalled messages.
+        List<String> rarUninstallMessages = server.findStringsInLogs("J2CA7009I.*");
+        server.waitForMultipleStringsInLogUsingMark(rarUninstallMessages.size() + 1, "J2CA7001I.*" + BVAL_RAR);
     }
 
     @AfterClass


### PR DESCRIPTION
fixes #22765
Fix test logic to wait for J2CA7001I every time J2CA7009I occurrs in the logs.

Previously the tests would always find the first instance of J2CA7001I from server startup and not always wait for the bval RAR to be started.

