### PR TITLE
Jakarta Security: Use JWK timeout config attributes

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal/resources/io/openliberty/security/jakartasec/internal/resources/JakartaSecurity30Messages.nlsprops
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/resources/io/openliberty/security/jakartasec/internal/resources/JakartaSecurity30Messages.nlsprops
@@ -34,3 +34,7 @@ JAKARTASEC_WARNING_LOGOUT_DEF_CONFIG.useraction=Make sure that the annotation co
 JAKARTASEC_WARNING_PROV_METADATA_CONFIG=CWWKS2502W: The Expression Language (EL) expression for the {0} attribute of the OpenID provider metadata annotation cannot be resolved to a valid value. The value provided was ''{1}''. Ensure that the EL expression and the result are valid and ensure that any referenced beans that are used in the expression are resolvable. The default attribute value of ''{2}'' is used.
 JAKARTASEC_WARNING_PROV_METADATA_CONFIG.explanation=The attribute cannot be resolved as an expression. The EL result and the expected attribute value type might be mismatched. For example, if the expected attribute type is String, then the EL result must be a String.
 JAKARTASEC_WARNING_PROV_METADATA_CONFIG.useraction=Make sure that the annotation contains a valid configuration value. Ensure that the EL expressions are valid, that any referenced beans in the expression are resolvable, and that the type of the result corresponds with the attribute.
+
+CREDENTIAL_VALIDATION_ERROR=CWWKS2503E: The {0} OpenID Connect client encountered the following error while validating the credential for the authenticated user: {1}
+CREDENTIAL_VALIDATION_ERROR.explanation=The OpenID Connect client encountered an error while validating the tokens that were returned from the OpenID Connect provider, or an error occurred while using the information in the tokens to build the credential.
+CREDENTIAL_VALIDATION_ERROR.useraction=For more information, see the error in the message.

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
@@ -20,6 +20,7 @@ import org.jose4j.jwt.MalformedClaimException;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 import io.openliberty.security.jakartasec.credential.OidcTokensCredential;
 import io.openliberty.security.jakartasec.tokens.AccessTokenImpl;
@@ -55,6 +56,7 @@ public class OidcIdentityStore implements IdentityStore {
     }
 
     @Override
+    @FFDCIgnore(Exception.class)
     public CredentialValidationResult validate(Credential credential) {
         // Use OidcTokensCredential to validate
         if (!(credential instanceof OidcTokensCredential)) {
@@ -86,6 +88,7 @@ public class OidcIdentityStore implements IdentityStore {
 
                     return credentialValidationResult;
                 } catch (Exception e) {
+                    Tr.error(tc, "CREDENTIAL_VALIDATION_ERROR", client.getOidcClientConfig().getClientId(), e.toString());
                     return CredentialValidationResult.INVALID_RESULT;
                 }
             }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/package-info.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/package-info.java
@@ -12,4 +12,9 @@
  * @version 1.0.0
  */
 @org.osgi.annotation.versioning.Version("1.0.0")
+@TraceOptions(traceGroup = TraceConstants.TRACE_GROUP, messageBundle = TraceConstants.MESSAGE_BUNDLE)
 package io.openliberty.security.jakartasec.identitystore;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;
+
+import io.openliberty.security.jakartasec.TraceConstants;

--- a/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
+++ b/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
@@ -98,3 +98,17 @@ USERINFO_RESPONSE_ERROR.useraction=For more information, see the error in the me
 USERINFO_RESPONSE_NOT_200=CWWKS2419W: The request to the [{0}] User Info URL of the OpenID Connect provider returned a {1} HTTP status code. The OpenID Connect provider returned the following response: {2}
 USERINFO_RESPONSE_NOT_200.explanation=The OpenID Connect client did not receive a successful response from the OpenID Connect provider.
 USERINFO_RESPONSE_NOT_200.useraction=For more information, see the status code and error response in the message.
+
+VERIFICATION_KEY_ERROR=CWWKS2420E: The {0} OpenID Connect client encountered the following error while getting the key to verify the identity token from the OpenID Connect provider: {1}
+VERIFICATION_KEY_ERROR.explanation=The verification key might be missing, the OpenID Connect client encountered an error while fetching the key from the OpenID Connect provider, or another error occurred.
+VERIFICATION_KEY_ERROR.useraction=For more information, see the error in the message.
+
+# Do not translate "jwksConnectTimeout"
+JWK_CONNECTION_TIMED_OUT=CWWKS2421E: The OpenID Connect client failed to connect to the [{0}] JWK URI of the OpenID Connect provider within {1} milliseconds. Consider updating the jwksConnectTimeout property in the OpenID Connect client configuration.
+JWK_CONNECTION_TIMED_OUT.explanation=The OpenID Connect client cannot establish a connection with the JWK URI within the configured time frame.
+JWK_CONNECTION_TIMED_OUT.useraction=Update the jwksConnectTimeout property in the OpenID Connect client configuration. Verify that the OpenID Connect provider is reachable.
+
+# Do not translate "jwksReadTimeout"
+JWK_READ_TIMED_OUT=CWWKS2422E: The OpenID Connect client failed to read data from the [{0}] JWK URI of the OpenID Connect provider within {1} milliseconds. Consider updating the jwksReadTimeout property in the OpenID Connect client configuration.
+JWK_READ_TIMED_OUT.explanation=The OpenID Connect client cannot read the JWK data from the JWK URI within the configured time frame.
+JWK_READ_TIMED_OUT.useraction=Update the jwksReadTimeout property in the OpenID Connect client configuration. Verify that the OpenID Connect provider is reachable.

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/VerificationKeyException.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/exceptions/VerificationKeyException.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oidcclientcore.exceptions;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+public class VerificationKeyException extends Exception {
+
+    public static final TraceComponent tc = Tr.register(VerificationKeyException.class);
+
+    private static final long serialVersionUID = 1L;
+
+    private final String clientId;
+    private final String nlsMessage;
+
+    public VerificationKeyException(String clientId, String nlsMessage) {
+        this.clientId = clientId;
+        this.nlsMessage = nlsMessage;
+    }
+
+    @Override
+    public String getMessage() {
+        return Tr.formatMessage(tc, "VERIFICATION_KEY_ERROR", clientId, nlsMessage);
+    }
+
+}

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenResponseValidator.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenResponseValidator.java
@@ -27,6 +27,7 @@ import com.ibm.json.java.JSONObject;
 import com.ibm.websphere.ras.ProtectedString;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.common.jwk.impl.JWKSet;
 import com.ibm.wsspi.ssl.SSLSupport;
 
@@ -61,7 +62,7 @@ public class TokenResponseValidator {
     private Storage storage;
 
     public TokenResponseValidator() {
-        
+
     }
 
     /**
@@ -70,7 +71,7 @@ public class TokenResponseValidator {
     public TokenResponseValidator(OidcClientConfig oidcClientConfig) {
         this.clientConfig = oidcClientConfig;
     }
-    
+
     /**
      * @param oidcClientConfig
      */
@@ -80,7 +81,7 @@ public class TokenResponseValidator {
         } else {
             this.storage = new CookieBasedStorage(this.request, this.response);
         }
-        
+
     }
 
     @Reference(name = KEY_SSL_SUPPORT, policy = ReferencePolicy.DYNAMIC)
@@ -104,6 +105,7 @@ public class TokenResponseValidator {
     /**
      * @param tokenResponse
      */
+    @FFDCIgnore(Exception.class)
     public JwtClaims validate(TokenResponse tokenResponse) throws TokenValidationException {
         String idtoken = null;
 
@@ -136,11 +138,11 @@ public class TokenResponseValidator {
                 }
                 if (jwtClaims.getExpirationTime() == null) {
                     throw new TokenValidationException(this.clientConfig.getClientId(), "token is missing required exp claim");
-                }           
+                }
                 TokenValidator tokenValidator = new IdTokenValidator(clientConfig);
                 issuerconfigured = getIssuer();
                 tokenValidator.issuer(jwtClaims.getIssuer()).subject(jwtClaims.getSubject()).audiences(jwtClaims.getAudience()).azp(((String) jwtClaims.getClaimValue("azp"))).iat(jwtClaims.getIssuedAt()).exp(jwtClaims.getExpirationTime()).nbf(jwtClaims.getNotBefore()).issuerconfigured(issuerconfigured);
-                if (this.clientConfig.isUseNonce()) {  
+                if (this.clientConfig.isUseNonce()) {
                     ((IdTokenValidator) tokenValidator).nonce(((String) jwtClaims.getClaimValue("nonce")));
                     ((IdTokenValidator) tokenValidator).state(getStateParameter());
                     ((IdTokenValidator) tokenValidator).secret(clientSecret);
@@ -161,11 +163,13 @@ public class TokenResponseValidator {
                 }
                 TokenSignatureValidationBuilder tokenSignatureValidationBuilder = jose4jutil.signaturevalidationbuilder();
                 String jwkuri = getJwkUri();
-                tokenSignatureValidationBuilder.signature(jsonStruct).sslsupport(sslSupport).issuer(issuerconfigured).jwkuri(jwkuri)
-                                .clientid(clientConfig.getClientId());
+                tokenSignatureValidationBuilder.signature(jsonStruct).sslsupport(sslSupport).issuer(issuerconfigured).jwkuri(jwkuri).clientid(clientConfig.getClientId());
 
                 tokenSignatureValidationBuilder.clientsecret(clientSecret);
                 tokenSignatureValidationBuilder.jwkset(jwkset);
+                tokenSignatureValidationBuilder.jwksConnectTimeout(clientConfig.getJwksConnectTimeout());
+                tokenSignatureValidationBuilder.jwksReadTimeout(clientConfig.getJwksReadTimeout());
+
                 return tokenSignatureValidationBuilder.parseJwtWithValidation(idtoken);
             } catch (Exception e) {
                 throw new TokenValidationException(this.clientConfig.getClientId(), e.getMessage());
@@ -173,7 +177,7 @@ public class TokenResponseValidator {
         }
         throw new TokenValidationException(this.clientConfig.getClientId(), "not a valid token to continue the flow");
     }
-    
+
     /**
      * @param clientConfig
      * @return
@@ -182,11 +186,10 @@ public class TokenResponseValidator {
         String issuer = null;
         issuer = clientConfig.getProviderMetadata().getIssuer();
         if ((issuer == null || issuer.isEmpty()) && getProviderDiscoveryMetadadata() != null) {
-            return ((String)this.discoveredProviderMetadata.get("issuer"));
+            return ((String) this.discoveredProviderMetadata.get("issuer"));
         }
         return issuer;
     }
-
 
     /**
      * @return
@@ -205,35 +208,35 @@ public class TokenResponseValidator {
         String jwkuri = null;
         jwkuri = clientConfig.getProviderMetadata().getJwksURI();
         if ((jwkuri == null || jwkuri.isEmpty()) && getProviderDiscoveryMetadadata() != null) {
-            jwkuri = (String)(this.discoveredProviderMetadata.get("jwks_uri"));
+            jwkuri = (String) (this.discoveredProviderMetadata.get("jwks_uri"));
         }
         return jwkuri;
     }
 
     public String getStateParameter() {
         return request.getParameter(AuthorizationRequestParameters.STATE);
-      //TODO: maybe throw an exception right here if this state is not valid
+        //TODO: maybe throw an exception right here if this state is not valid
     }
 
     /**
      * @param jwkSet
      */
     public void setJwkSet(JWKSet jwkSet) {
-        this.jwkset = jwkSet;    
+        this.jwkset = jwkSet;
     }
 
     /**
      * @param request
      */
     public void setRequest(HttpServletRequest request) {
-        this.request = request;       
+        this.request = request;
     }
 
     /**
      * @param response
      */
     public void setResponse(HttpServletResponse response) {
-        this.response = response;        
+        this.response = response;
     }
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/utils/CommonJose4jUtils.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/utils/CommonJose4jUtils.java
@@ -10,13 +10,14 @@
  *******************************************************************************/
 package io.openliberty.security.oidcclientcore.utils;
 
-
-import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.security.Key;
-import java.security.KeyStoreException;
-import java.security.PrivilegedActionException;
 import java.util.List;
 
+import org.apache.http.NameValuePair;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.conn.ConnectTimeoutException;
 import org.jose4j.jws.JsonWebSignature;
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.consumer.JwtConsumer;
@@ -28,34 +29,33 @@ import org.jose4j.keys.HmacKey;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.security.common.http.HttpUtils;
 import com.ibm.ws.security.common.jwk.impl.JWKSet;
 import com.ibm.ws.security.common.jwk.impl.JwKRetriever;
 import com.ibm.wsspi.ssl.SSLSupport;
 
+import io.openliberty.security.oidcclientcore.exceptions.VerificationKeyException;
 
 /**
  *
  */
 public class CommonJose4jUtils {
-    
+
     public static final TraceComponent tc = Tr.register(CommonJose4jUtils.class);
     TokenSignatureValidationBuilder tokenSignatureValidationBuilder = new TokenSignatureValidationBuilder();
+
     public CommonJose4jUtils() {
-        
+
     }
-    
+
     //Just parse without validation for now
     public static JwtContext parseJwtWithoutValidation(String jwtString) throws Exception {
-        JwtConsumer firstPassJwtConsumer = new JwtConsumerBuilder()
-                .setSkipAllValidators()
-                .setDisableRequireSignature()
-                .setSkipSignatureVerification()
-                .build();
+        JwtConsumer firstPassJwtConsumer = new JwtConsumerBuilder().setSkipAllValidators().setDisableRequireSignature().setSkipSignatureVerification().build();
 
         return firstPassJwtConsumer.process(jwtString);
     }
-    
-    
+
     public JsonWebStructure getJsonWebStructureFromJwtContext(JwtContext jwtContext) throws Exception {
         List<JsonWebStructure> jsonStructures = jwtContext.getJoseObjects();
         if (jsonStructures == null || jsonStructures.isEmpty()) {
@@ -71,12 +71,12 @@ public class CommonJose4jUtils {
         }
         return jsonStruct;
     }
-    
+
     public TokenSignatureValidationBuilder signaturevalidationbuilder() {
         return this.tokenSignatureValidationBuilder;
     }
-    
-  //TODO: use this in regular OIDC flow to do token signature validation
+
+    //TODO: use this in regular OIDC flow to do token signature validation
 
     public static class TokenSignatureValidationBuilder {
 
@@ -87,6 +87,8 @@ public class CommonJose4jUtils {
         private String clientsecret;
         private JWKSet jwkset;
         private String issuerconfigured;
+        private int jwksConnectTimeout = 500;
+        private int jwksReadTimeout = 500;
 
         private TokenSignatureValidationBuilder() {
 
@@ -140,25 +142,26 @@ public class CommonJose4jUtils {
             this.issuerconfigured = issuerFromProviderMetadata;
             return this;
         }
-        
 
         /**
          * @param jwkset
          */
         public TokenSignatureValidationBuilder jwkset(JWKSet jwkset) {
-           this.jwkset = jwkset;
-           return this; 
+            this.jwkset = jwkset;
+            return this;
         }
 
-        /**
-         * @return
-         * @throws Exception
-         * @throws InterruptedException
-         * @throws IOException
-         * @throws PrivilegedActionException
-         * @throws KeyStoreException
-         */
-        public Key getVerificationKey() throws KeyStoreException, PrivilegedActionException, IOException, InterruptedException, Exception {
+        public TokenSignatureValidationBuilder jwksConnectTimeout(int jwksConnectTimeout) {
+            this.jwksConnectTimeout = jwksConnectTimeout;
+            return this;
+        }
+
+        public TokenSignatureValidationBuilder jwksReadTimeout(int jwksReadTimeout) {
+            this.jwksReadTimeout = jwksReadTimeout;
+            return this;
+        }
+
+        public Key getVerificationKey() throws Exception {
             if (getSignatureAlgorithm() != null && getSignatureAlgorithm().startsWith("HS")) {
                 return new HmacKey(clientsecret.getBytes("UTF-8"));
             }
@@ -167,10 +170,6 @@ public class CommonJose4jUtils {
             return createJwkRetriever().getPublicKeyFromJwk(kid, x5t, "sig", false);
         }
 
-        /**
-         * @return
-         * @throws Exception
-         */
         private String getSignatureAlgorithm() throws Exception {
             String algorithm = null;
             if (this.signature != null && this.signature instanceof JsonWebSignature) {
@@ -188,20 +187,32 @@ public class CommonJose4jUtils {
         private JwKRetriever createJwkRetriever() throws Exception {
 
             String algorithm = getSignatureAlgorithm();
-            return new JwKRetriever(this.clientid, null, this.jwkuri, this.jwkset, this.sslsupport, false, null, null, algorithm);
+            JwKRetriever jwkRetriever = new JwKRetriever(this.clientid, null, this.jwkuri, this.jwkset, this.sslsupport, false, null, null, algorithm);
+            // Override the retriever's HttpUtils member so we can set connection and read timeouts
+            jwkRetriever.httpUtils = new HttpUtils() {
+                @Override
+                public HttpGet createHttpGetMethod(String url, final List<NameValuePair> commonHeaders) {
+                    HttpGet request = super.createHttpGetMethod(url, commonHeaders);
+                    RequestConfig requestConfig = RequestConfig.custom().setConnectTimeout(jwksConnectTimeout).setSocketTimeout(jwksReadTimeout).build();
+                    request.setConfig(requestConfig);
+                    return request;
+                }
+            };
+            return jwkRetriever;
         }
 
-        /**
-         * @throws Exception
-         * @throws InterruptedException
-         * @throws IOException
-         * @throws PrivilegedActionException
-         * @throws KeyStoreException
-         *
-         */
-        public JwtClaims parseJwtWithValidation(String jwtString) throws KeyStoreException, PrivilegedActionException, IOException, InterruptedException, Exception {
-            Key key = getVerificationKey();
+        @FFDCIgnore({ ConnectTimeoutException.class, SocketTimeoutException.class })
+        public JwtClaims parseJwtWithValidation(String jwtString) throws Exception {
+            Key key = null;
+            try {
+                key = getVerificationKey();
+            } catch (ConnectTimeoutException e) {
+                throw new VerificationKeyException(clientid, Tr.formatMessage(tc, "JWK_CONNECTION_TIMED_OUT", jwkuri, jwksConnectTimeout));
+            } catch (SocketTimeoutException e) {
+                throw new VerificationKeyException(clientid, Tr.formatMessage(tc, "JWK_READ_TIMED_OUT", jwkuri, jwksReadTimeout));
+            }
             if (key == null) {
+                // TODO - NLS message
                 throw new Exception("error getting verification key");
             }
             JwtConsumerBuilder builder = new JwtConsumerBuilder();


### PR DESCRIPTION
Adds support for the `jwksConnectTimeout` and `jwksReadTimeout` attributes in the `@OpenIdAuthenticationMechanismDefinition` configuration. Support includes a few new NLS messages for error scenarios involving validating the credential and timing out while connecting to/reading from the JWK endpoint.