### PR TITLE
Don't expose 3rd party Weld packages that don't exist

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-4.0/io.openliberty.cdi-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-4.0/io.openliberty.cdi-4.0.feature
@@ -34,9 +34,7 @@ IBM-API-Package: jakarta.decorator;  type="spec", \
  org.jboss.weld.serialization.spi; type="internal", \
  org.jboss.weld.context;type="third-party", \
  org.jboss.weld.context.api;type="third-party", \
- org.jboss.weld.context.beanstore;type="third-party", \
- org.jboss.weld.context.bound;type="third-party", \
- org.jboss.weld.context.conversation;type="third-party"
+ org.jboss.weld.context.bound;type="third-party"
 IBM-SPI-Package: io.openliberty.cdi.spi;type="ibm-spi"
 IBM-ShortName: cdi-4.0
 Subsystem-Name: Jakarta Contexts and Dependency Injection 4.0


### PR DESCRIPTION
org.jboss.weld.context.beanstore and org.jboss.weld.context.conversation do not exist any more. They were renamed in Weld 3 but since no one has requested them, there is no reason to expose the newer packages.

this is a partial CDI 4.0 fix for https://github.com/OpenLiberty/open-liberty/issues/22748
CDI 2.0 and 3.0 will be done under https://github.com/OpenLiberty/open-liberty/pull/22750
#build

