### PR TITLE
address issue passing wrong x5c params object while getting ec jwk instance

### DIFF
--- a/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/Jose4jEllipticCurveJWK.java
+++ b/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/Jose4jEllipticCurveJWK.java
@@ -127,7 +127,7 @@ public class Jose4jEllipticCurveJWK extends EllipticCurveJsonWebKey implements J
             if (tc.isDebugEnabled()) {
                 Tr.debug(tc, "Entry Key:" + entry.getKey() + " value:" + entry.getValue().toString());
             }
-            params.put(entry.getKey(), entry.getValue().toString());
+            params.put(entry.getKey(), entry.getValue());
         }
 
         Jose4jEllipticCurveJWK jwk = null;
@@ -136,7 +136,7 @@ public class Jose4jEllipticCurveJWK extends EllipticCurveJsonWebKey implements J
         } catch (JoseException e) {
             // TODO error handling
             if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "hit exception", e);
+                Tr.debug(tc, "hit exception = " + e.getMessage());
             }
         }
         return jwk;

--- a/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JwKRetriever.java
+++ b/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JwKRetriever.java
@@ -478,7 +478,7 @@ public class JwKRetriever {
         } catch (Exception e) {
             // could be ignored
             if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Fail to retrieve remote key: ", e.getCause());
+                Tr.debug(tc, "Fail to retrieve remote key: " + e.getMessage());
             }
         }
 

--- a/dev/com.ibm.ws.security.openidconnect.client/bnd.bnd
+++ b/dev/com.ibm.ws.security.openidconnect.client/bnd.bnd
@@ -116,12 +116,12 @@ Include-Resource: \
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file,\
 	com.ibm.ws.junit.extensions;version=latest,\
-	org.jmock:jmock-legacy;version=2.5.0,\
-	cglib:cglib-nodep;version=3.3.0,\
-	org.hamcrest:hamcrest-all;version=1.3,\
-	org.jmock:jmock-junit4;strategy=exact;version=2.5.1,\
-	org.jmock:jmock;strategy=exact;version=2.5.1,\
-	com.ibm.ws.org.objenesis:objenesis;version=1.0,\
+	org.jmock:jmock-legacy;version='2.5.0',\
+	cglib:cglib-nodep;version='3.3.0',\
+	org.hamcrest:hamcrest-all;version='1.3',\
+	org.jmock:jmock-junit4;strategy=exact;version='2.5.1',\
+	org.jmock:jmock;strategy=exact;version='2.5.1',\
+	com.ibm.ws.org.objenesis:objenesis;version='1.0',\
 	com.ibm.ws.kernel.boot;version=latest,\
 	com.ibm.ws.kernel.boot.core;version=latest,\
 	com.ibm.ws.org.jose4j;version=latest,\
@@ -137,12 +137,13 @@ Include-Resource: \
 	com.ibm.ws.container.service.compat;version=latest,\
 	com.ibm.ws.org.apache.commons.io;version=latest,\
 	com.ibm.ws.security.fat.common;version=latest,\
- 	com.ibm.ws.crypto.passwordutil;version=latest,\
+	com.ibm.ws.crypto.passwordutil;version=latest,\
 	joda-time;version=latest,\
 	com.ibm.ws.org.slf4j.api;version=latest,\
 	io.openliberty.org.apache.commons.codec;version=latest,\
 	com.ibm.ws.container.service;version=latest,\
 	com.ibm.ws.threading;version=latest,\
-	com.ibm.ws.injection.core;version=latest
+	com.ibm.ws.injection.core;version=latest,\
+	org.bitbucket.b_c.jose4j
 	
 instrument.classesExcludes: com/ibm/ws/security/openidconnect/client/internal/resources/OidcClientMessages*.class


### PR DESCRIPTION
- change the x5c params object from String to the expected type.
fixes #22298 