### PR TITLE
Security 3.0: Add OpenIdContext getClaimsJson support

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal/resources/io/openliberty/security/jakartasec/internal/resources/JakartaSecurity30Messages.nlsprops
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/resources/io/openliberty/security/jakartasec/internal/resources/JakartaSecurity30Messages.nlsprops
@@ -31,10 +31,14 @@ JAKARTASEC_WARNING_LOGOUT_DEF_CONFIG=CWWKS2502W: The Expression Language (EL) ex
 JAKARTASEC_WARNING_LOGOUT_DEF_CONFIG.explanation=The attribute cannot be resolved as an expression. The EL result and the expected attribute value type might be mismatched. For example, if the expected attribute type is String, then the EL result must be a String.
 JAKARTASEC_WARNING_LOGOUT_DEF_CONFIG.useraction=Make sure that the annotation contains a valid configuration value. Ensure that the EL expressions are valid, that any referenced beans in the expression are resolvable, and that the type of the result corresponds with the attribute.
 
-JAKARTASEC_WARNING_PROV_METADATA_CONFIG=CWWKS2502W: The Expression Language (EL) expression for the {0} attribute of the OpenID provider metadata annotation cannot be resolved to a valid value. The value provided was ''{1}''. Ensure that the EL expression and the result are valid and ensure that any referenced beans that are used in the expression are resolvable. The default attribute value of ''{2}'' is used.
+JAKARTASEC_WARNING_PROV_METADATA_CONFIG=CWWKS2503W: The Expression Language (EL) expression for the {0} attribute of the OpenID provider metadata annotation cannot be resolved to a valid value. The value provided was ''{1}''. Ensure that the EL expression and the result are valid and ensure that any referenced beans that are used in the expression are resolvable. The default attribute value of ''{2}'' is used.
 JAKARTASEC_WARNING_PROV_METADATA_CONFIG.explanation=The attribute cannot be resolved as an expression. The EL result and the expected attribute value type might be mismatched. For example, if the expected attribute type is String, then the EL result must be a String.
 JAKARTASEC_WARNING_PROV_METADATA_CONFIG.useraction=Make sure that the annotation contains a valid configuration value. Ensure that the EL expressions are valid, that any referenced beans in the expression are resolvable, and that the type of the result corresponds with the attribute.
 
-CREDENTIAL_VALIDATION_ERROR=CWWKS2503E: The {0} OpenID Connect client encountered the following error while validating the credential for the authenticated user: {1}
+CREDENTIAL_VALIDATION_ERROR=CWWKS2504E: The {0} OpenID Connect client encountered the following error while validating the credential for the authenticated user: {1}
 CREDENTIAL_VALIDATION_ERROR.explanation=The OpenID Connect client encountered an error while validating the tokens that were returned from the OpenID Connect provider, or an error occurred while using the information in the tokens to build the credential.
 CREDENTIAL_VALIDATION_ERROR.useraction=For more information, see the error in the message.
+
+JAKARTASEC_WARNING_MISSING_SUBJECT_CLAIMS=CWWKS2505W: The claims JSON object in the OpenIdContext bean cannot add the subject value for client {0} because subject value is missing from the OpenIdClaims object. 
+JAKARTASEC_WARNING_MISSING_SUBJECT_CLAIMS.explanation=The OpenIdClaims object on the OpenIdContext bean is missing the required subject value. Therefore, the subject value of the claims JSON object cannot be set.  
+JAKARTASEC_WARNING_MISSING_SUBJECT_CLAIMS.useraction=Review the logs for earlier errors related to OpenID authentication.

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
@@ -82,7 +82,8 @@ public class OidcIdentityStore implements IdentityStore {
                     JsonObject providerMetadata = getProviderMetadataAsJsonObject();
 
                     OpenIdContext openIdContext = createOpenIdContext(credentialValidationResult.getCallerUniqueId(), tokenResponse, accessToken, identityToken, userInfoClaims,
-                                                                      providerMetadata, request.getParameter(OpenIdConstant.STATE), oidcClientConfig.isUseSession());
+                                                                      providerMetadata, request.getParameter(OpenIdConstant.STATE), oidcClientConfig.isUseSession(),
+                                                                      client.getOidcClientConfig().getClientId());
 
                     castCredential.setOpenIdContext(openIdContext);
 
@@ -97,7 +98,7 @@ public class OidcIdentityStore implements IdentityStore {
     }
 
     private OpenIdContext createOpenIdContext(String subjectIdentifier, TokenResponse tokenResponse, AccessToken accessToken, IdentityToken identityToken,
-                                              OpenIdClaims userinfoClaims, JsonObject providerMetadata, String state, boolean useSession) {
+                                              OpenIdClaims userinfoClaims, JsonObject providerMetadata, String state, boolean useSession, String clientId) {
         Map<String, String> tokenResponseRawMap = tokenResponse.asMap();
         // TODO: Move getting expires_in to TokenResponse
         long expiresIn = 0L;
@@ -105,7 +106,7 @@ public class OidcIdentityStore implements IdentityStore {
             expiresIn = Long.parseLong(tokenResponseRawMap.get(OpenIdConstant.EXPIRES_IN));
         }
 
-        OpenIdContextImpl openIdContext = new OpenIdContextImpl(subjectIdentifier, tokenResponseRawMap.get(OpenIdConstant.TOKEN_TYPE), accessToken, identityToken, userinfoClaims, providerMetadata, state, useSession);
+        OpenIdContextImpl openIdContext = new OpenIdContextImpl(subjectIdentifier, tokenResponseRawMap.get(OpenIdConstant.TOKEN_TYPE), accessToken, identityToken, userinfoClaims, providerMetadata, state, useSession, clientId);
         openIdContext.setExpiresIn(expiresIn);
 
         String refreshTokenString = tokenResponse.getRefreshTokenString();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OpenIdContextImpl.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OpenIdContextImpl.java
@@ -13,12 +13,16 @@ package io.openliberty.security.jakartasec.identitystore;
 import java.io.StringReader;
 import java.util.Optional;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
 import io.openliberty.security.oidcclientcore.storage.CookieBasedStorage;
 import io.openliberty.security.oidcclientcore.storage.OidcStorageUtils;
 import io.openliberty.security.oidcclientcore.storage.SessionBasedStorage;
 import io.openliberty.security.oidcclientcore.storage.Storage;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
 import jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdConstant;
 import jakarta.security.enterprise.identitystore.openid.AccessToken;
 import jakarta.security.enterprise.identitystore.openid.IdentityToken;
@@ -35,20 +39,24 @@ public class OpenIdContextImpl implements OpenIdContext {
 
     private static final long serialVersionUID = 1L;
 
+    private static final TraceComponent tc = Tr.register(OpenIdContextImpl.class);
+
     private final String subjectIdentifier;
     private final String tokenType;
     private final AccessToken accessToken;
     private final IdentityToken identityToken;
     private final OpenIdClaims userinfoClaims;
+    private JsonObject userinfoClaimsAsJson = null;
     private final JsonObject providerMetadata; // TODO: Store JSON String instead for serialization
     private final String state; // TODO: Determine if storage values can be obtained without relying on state.
     private final boolean useSession;
+    private final String clientId;
 
     private RefreshToken refreshToken;
     private Long expiresIn;
 
     public OpenIdContextImpl(String subjectIdentifier, String tokenType, AccessToken accessToken, IdentityToken identityToken, OpenIdClaims userinfoClaims,
-                             JsonObject providerMetadata, String state, boolean useSession) {
+                             JsonObject providerMetadata, String state, boolean useSession, String clientId) {
         this.subjectIdentifier = subjectIdentifier;
         this.tokenType = tokenType;
         this.accessToken = accessToken;
@@ -57,6 +65,7 @@ public class OpenIdContextImpl implements OpenIdContext {
         this.providerMetadata = providerMetadata;
         this.state = state;
         this.useSession = useSession;
+        this.clientId = clientId;
     }
 
     public void setRefreshToken(RefreshToken refreshToken) {
@@ -105,8 +114,97 @@ public class OpenIdContextImpl implements OpenIdContext {
 
     @Override
     public JsonObject getClaimsJson() {
-        // TODO Auto-generated method stub
-        return null;
+        if (userinfoClaimsAsJson == null) {
+            userinfoClaimsAsJson = createClaimsJson();
+        }
+        return userinfoClaimsAsJson;
+    }
+
+    /**
+     * Create a JsonObject with the data available in the OpenIdClaims object.
+     *
+     * @return
+     */
+    private JsonObject createClaimsJson() {
+        JsonObjectBuilder builder = Json.createObjectBuilder();
+
+        if (userinfoClaims == null) {
+            return null;
+        }
+
+        try {
+            if (userinfoClaims.getSubject() != null && !userinfoClaims.getSubject().isEmpty()) {
+                builder.add(OpenIdConstant.SUBJECT_IDENTIFIER, userinfoClaims.getSubject());
+            } else {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isWarningEnabled()) {
+                    Tr.warning(tc, "JAKARTASEC_WARNING_MISSING_SUBJECT_CLAIMS", new Object[] { clientId });
+                }
+            }
+        } catch (IllegalArgumentException iae) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isWarningEnabled()) {
+                Tr.warning(tc, "JAKARTASEC_WARNING_MISSING_SUBJECT_CLAIMS", new Object[] { clientId });
+            }
+        }
+        if (userinfoClaims.getAddress().isPresent()) {
+            builder.add(OpenIdConstant.ADDRESS, userinfoClaims.getAddress().get());
+        }
+        if (userinfoClaims.getBirthdate().isPresent()) {
+            builder.add(OpenIdConstant.BIRTHDATE, userinfoClaims.getBirthdate().get());
+        }
+        if (userinfoClaims.getEmail().isPresent()) {
+            builder.add(OpenIdConstant.EMAIL, userinfoClaims.getEmail().get());
+        }
+        if (userinfoClaims.getEmailVerified().isPresent()) {
+            builder.add(OpenIdConstant.EMAIL_VERIFIED, userinfoClaims.getEmailVerified().get());
+        }
+        if (userinfoClaims.getFamilyName().isPresent()) {
+            builder.add(OpenIdConstant.FAMILY_NAME, userinfoClaims.getFamilyName().get());
+        }
+        if (userinfoClaims.getGender().isPresent()) {
+            builder.add(OpenIdConstant.GENDER, userinfoClaims.getGender().get());
+        }
+        if (userinfoClaims.getGivenName().isPresent()) {
+            builder.add(OpenIdConstant.GIVEN_NAME, userinfoClaims.getGivenName().get());
+        }
+        if (userinfoClaims.getLocale().isPresent()) {
+            builder.add(OpenIdConstant.LOCALE, userinfoClaims.getLocale().get());
+        }
+        if (userinfoClaims.getMiddleName().isPresent()) {
+            builder.add(OpenIdConstant.MIDDLE_NAME, userinfoClaims.getMiddleName().get());
+        }
+        if (userinfoClaims.getName().isPresent()) {
+            builder.add(OpenIdConstant.NAME, userinfoClaims.getName().get());
+        }
+        if (userinfoClaims.getNickname().isPresent()) {
+            builder.add(OpenIdConstant.NICKNAME, userinfoClaims.getNickname().get());
+        }
+        if (userinfoClaims.getPhoneNumber().isPresent()) {
+            builder.add(OpenIdConstant.PHONE_NUMBER, userinfoClaims.getPhoneNumber().get());
+        }
+        if (userinfoClaims.getPhoneNumberVerified().isPresent()) {
+            builder.add(OpenIdConstant.PHONE_NUMBER_VERIFIED, userinfoClaims.getPhoneNumberVerified().get());
+        }
+        if (userinfoClaims.getPicture().isPresent()) {
+            builder.add(OpenIdConstant.PICTURE, userinfoClaims.getPicture().get());
+        }
+        if (userinfoClaims.getPreferredUsername().isPresent()) {
+            builder.add(OpenIdConstant.PREFERRED_USERNAME, userinfoClaims.getPreferredUsername().get());
+        }
+        if (userinfoClaims.getProfile().isPresent()) {
+            builder.add(OpenIdConstant.PROFILE, userinfoClaims.getProfile().get());
+        }
+        if (userinfoClaims.getUpdatedAt().isPresent()) {
+            builder.add(OpenIdConstant.UPDATED_AT, userinfoClaims.getUpdatedAt().get());
+        }
+        if (userinfoClaims.getWebsite().isPresent()) {
+            builder.add(OpenIdConstant.WEBSITE, userinfoClaims.getWebsite().get());
+        }
+        if (userinfoClaims.getZoneinfo().isPresent()) {
+            builder.add(OpenIdConstant.ZONEINFO, userinfoClaims.getZoneinfo().get());
+        }
+
+        JsonObject json = builder.build();
+        return json;
     }
 
     @Override

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/identitystore/OpenIdContextImplTest.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/identitystore/OpenIdContextImplTest.java
@@ -12,7 +12,11 @@ package io.openliberty.security.jakartasec.identitystore;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import org.jmock.Expectations;
@@ -22,8 +26,11 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
+import io.openliberty.security.jakartasec.tokens.OpenIdClaimsImpl;
 import io.openliberty.security.oidcclientcore.storage.OidcStorageUtils;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
@@ -36,6 +43,7 @@ import jakarta.security.enterprise.identitystore.openid.RefreshToken;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import test.common.SharedOutputManager;
 
 public class OpenIdContextImplTest {
 
@@ -44,6 +52,7 @@ public class OpenIdContextImplTest {
     private static final String TOKEN_TYPE_MAC = "MAC";
     private static final Long ONE_HOUR = Long.valueOf(3600);
     private static final String STATE = "1234567890";
+    private static final String clientID = "myClient";
 
     private final Mockery mockery = new JUnit4Mockery();
 
@@ -56,6 +65,10 @@ public class OpenIdContextImplTest {
     private OpenIdContext openIdContext;
     private HttpServletRequest request;
     private HttpServletResponse response;
+
+    SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("*=all");
+    @Rule
+    public TestRule outputRule = outputMgr;
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
@@ -73,7 +86,7 @@ public class OpenIdContextImplTest {
         userinfoClaims = mockery.mock(OpenIdClaims.class);
         providerMetadata = Json.createObjectBuilder().add(OpenIdConstant.ISSUER, "https://localhost:9443/oidc/endpoint/OP/authorize").build();
 
-        openIdContext = new OpenIdContextImpl(SUBJECT_IN_ID_TOKEN, TOKEN_TYPE_BEARER, accessToken, identityToken, userinfoClaims, providerMetadata, STATE, true);
+        openIdContext = new OpenIdContextImpl(SUBJECT_IN_ID_TOKEN, TOKEN_TYPE_BEARER, accessToken, identityToken, userinfoClaims, providerMetadata, STATE, true, clientID);
     }
 
     @After
@@ -130,12 +143,133 @@ public class OpenIdContextImplTest {
         assertEquals("The 'expires in' must be set.", ONE_HOUR, optionalExpiresIn.get());
     }
 
-//
-//    @Test
-//    public void testGetClaimsJson() {
-//        fail("Not yet implemented");
-//    }
-//
+    /**
+     * Set all the OpenIdClaims variables and verify we get a JsonObject back containing them.
+     */
+    @Test
+    public void testGetClaimsJson() {
+
+        Map<String, Object> claimsMap = new HashMap<String, Object>();
+        claimsMap.put(OpenIdConstant.ADDRESS, "123 This Street");
+        claimsMap.put(OpenIdConstant.BIRTHDATE, "01/01/2021");
+        claimsMap.put(OpenIdConstant.EMAIL, "myemailaddress@ibm.com");
+        claimsMap.put(OpenIdConstant.EMAIL_VERIFIED, "true");
+        claimsMap.put(OpenIdConstant.FAMILY_NAME, "myfamilyname");
+        claimsMap.put(OpenIdConstant.GENDER, "Non-binary");
+        claimsMap.put(OpenIdConstant.GIVEN_NAME, "mygivenname");
+        claimsMap.put(OpenIdConstant.LOCALE, "US_EN");
+        claimsMap.put(OpenIdConstant.MIDDLE_NAME, "mymiddlename");
+        claimsMap.put(OpenIdConstant.NAME, "myname");
+        claimsMap.put(OpenIdConstant.NICKNAME, "mynickname");
+        claimsMap.put(OpenIdConstant.PHONE_NUMBER, "555-555-5555");
+        claimsMap.put(OpenIdConstant.PHONE_NUMBER_VERIFIED, "true");
+        claimsMap.put(OpenIdConstant.PICTURE, "myphoto.jpg");
+        claimsMap.put(OpenIdConstant.PREFERRED_USERNAME, "myusername");
+        claimsMap.put(OpenIdConstant.PROFILE, "myprofile");
+        claimsMap.put(OpenIdConstant.SUBJECT_IDENTIFIER, "mySubject");
+        claimsMap.put(OpenIdConstant.UPDATED_AT, "12:00AM");
+        claimsMap.put(OpenIdConstant.WEBSITE, "www.my.claims.website");
+        claimsMap.put(OpenIdConstant.ZONEINFO, "CST");
+        OpenIdClaims userinfo = new OpenIdClaimsImpl(claimsMap);
+
+        OpenIdContext openIdContextWithUserInfo = new OpenIdContextImpl(SUBJECT_IN_ID_TOKEN, TOKEN_TYPE_BEARER, accessToken, identityToken, userinfo, providerMetadata, STATE, true, clientID);
+
+        JsonObject json = openIdContextWithUserInfo.getClaimsJson();
+
+        assertNotNull("The userinfo claims as Json must be set on the OpenIdContext.", json);
+        assertEquals("Street should match", "123 This Street", json.getString(OpenIdConstant.ADDRESS));
+        assertEquals("Birthday should match", "01/01/2021", json.getString(OpenIdConstant.BIRTHDATE));
+        assertEquals("Email address should match", "myemailaddress@ibm.com", json.getString(OpenIdConstant.EMAIL));
+        assertEquals("Email address verified should match", "true", json.getString(OpenIdConstant.EMAIL_VERIFIED));
+        assertEquals("Family name should match", "myfamilyname", json.getString(OpenIdConstant.FAMILY_NAME));
+        assertEquals("Gender should match", "Non-binary", json.getString(OpenIdConstant.GENDER));
+        assertEquals("Given name should match", "mygivenname", json.getString(OpenIdConstant.GIVEN_NAME));
+        assertEquals("Locale should match", "US_EN", json.getString(OpenIdConstant.LOCALE));
+        assertEquals("Middle name should match", "mymiddlename", json.getString(OpenIdConstant.MIDDLE_NAME));
+        assertEquals("Name should match", "myname", json.getString(OpenIdConstant.NAME));
+        assertEquals("Nickname should match", "mynickname", json.getString(OpenIdConstant.NICKNAME));
+        assertEquals("Phone number should match", "555-555-5555", json.getString(OpenIdConstant.PHONE_NUMBER));
+        assertEquals("Phone number verifed should match", "true", json.getString(OpenIdConstant.PHONE_NUMBER_VERIFIED));
+        assertEquals("Picture should match", "myphoto.jpg", json.getString(OpenIdConstant.PICTURE));
+        assertEquals("Preferred username should match", "myusername", json.getString(OpenIdConstant.PREFERRED_USERNAME));
+        assertEquals("Profile should match", "myprofile", json.getString(OpenIdConstant.PROFILE));
+        assertEquals("Subject should match", "mySubject", json.getString(OpenIdConstant.SUBJECT_IDENTIFIER));
+        assertEquals("Updated at should match", "12:00AM", json.getString(OpenIdConstant.UPDATED_AT));
+        assertEquals("Website should match", "www.my.claims.website", json.getString(OpenIdConstant.WEBSITE));
+        assertEquals("Zone info at should match", "CST", json.getString(OpenIdConstant.ZONEINFO));
+
+    }
+
+    /**
+     * Do not set the optional variables on OpenIdClaims and verify they are not present on the JsonObject
+     */
+    @Test
+    public void testGetClaimsJson_empty() {
+        Map<String, Object> claimsMap = new HashMap<String, Object>();
+        // Subject is required
+        claimsMap.put(OpenIdConstant.SUBJECT_IDENTIFIER, "mySubject");
+
+        OpenIdClaims userinfo = new OpenIdClaimsImpl(claimsMap);
+
+        OpenIdContext openIdContextWithUserInfo = new OpenIdContextImpl(SUBJECT_IN_ID_TOKEN, TOKEN_TYPE_BEARER, accessToken, identityToken, userinfo, providerMetadata, STATE, true, clientID);
+        JsonObject json = openIdContextWithUserInfo.getClaimsJson();
+
+        assertNotNull("The userinfo claims as Json must be set on the OpenIdContext.", json);
+
+        assertEquals("Subject should match", "mySubject", json.getString(OpenIdConstant.SUBJECT_IDENTIFIER));
+
+        assertFalse("Street should not be set", json.containsKey(OpenIdConstant.ADDRESS));
+        assertFalse("Birthday should not be set", json.containsKey(OpenIdConstant.BIRTHDATE));
+        assertFalse("Email address should not be set", json.containsKey(OpenIdConstant.EMAIL));
+        assertFalse("Email address verified should not be set", json.containsKey(OpenIdConstant.EMAIL_VERIFIED));
+        assertFalse("Family name should not be set", json.containsKey(OpenIdConstant.FAMILY_NAME));
+        assertFalse("Gender should not be set", json.containsKey(OpenIdConstant.GENDER));
+        assertFalse("Given name should not be set", json.containsKey(OpenIdConstant.GIVEN_NAME));
+        assertFalse("Locale should not be set", json.containsKey(OpenIdConstant.LOCALE));
+        assertFalse("Middle name should not be set", json.containsKey(OpenIdConstant.MIDDLE_NAME));
+        assertFalse("Name should not be set", json.containsKey(OpenIdConstant.NAME));
+        assertFalse("Nickname should not be set", json.containsKey(OpenIdConstant.NICKNAME));
+        assertFalse("Phone number should not be set", json.containsKey(OpenIdConstant.PHONE_NUMBER));
+        assertFalse("Phone number verifed should not be set", json.containsKey(OpenIdConstant.PHONE_NUMBER_VERIFIED));
+        assertFalse("Picture should not be set", json.containsKey(OpenIdConstant.PICTURE));
+        assertFalse("Preferred username should not be set", json.containsKey(OpenIdConstant.PREFERRED_USERNAME));
+        assertFalse("Profile should not be set", json.containsKey(OpenIdConstant.PROFILE));
+        assertFalse("Updated at should not be set", json.containsKey(OpenIdConstant.UPDATED_AT));
+        assertFalse("Website should not be set", json.containsKey(OpenIdConstant.WEBSITE));
+        assertFalse("Zone info at should not be set", json.containsKey(OpenIdConstant.ZONEINFO));
+
+    }
+
+    /**
+     * Send in a null OpenIdClaims, make sure we don't fail when the claimsJson String is requested.
+     */
+    @Test
+    public void testGetClaimsJson_null() {
+
+        OpenIdContext openIdContextWithUserInfo = new OpenIdContextImpl(SUBJECT_IN_ID_TOKEN, TOKEN_TYPE_BEARER, accessToken, identityToken, null, providerMetadata, STATE, true, clientID);
+        JsonObject json = openIdContextWithUserInfo.getClaimsJson();
+
+        assertNull("The userinfo was null, json request will be null.", json);
+    }
+
+    /**
+     * Send in an empty OpenIdClaims object, make sure we handle the IllegalArgumentException from OpenIdClaims.getSubject()
+     */
+    @Test
+    public void testGetClaimsJson_missing_subject() {
+
+        Map<String, Object> claimsMap = new HashMap<String, Object>();
+
+        OpenIdClaims userinfo = new OpenIdClaimsImpl(claimsMap);
+
+        OpenIdContext openIdContextWithUserInfo = new OpenIdContextImpl(SUBJECT_IN_ID_TOKEN, TOKEN_TYPE_BEARER, accessToken, identityToken, userinfo, providerMetadata, STATE, true, clientID);
+        JsonObject json = openIdContextWithUserInfo.getClaimsJson();
+
+        assertNotNull("The userinfo claims as Json must be set on the OpenIdContext.", json);
+
+        assertFalse("Subject should not be set", json.containsKey(OpenIdConstant.SUBJECT_IDENTIFIER));
+    }
+
     @Test
     public void testGetClaims() {
         assertEquals("The userinfo claims must be set.", userinfoClaims, openIdContext.getClaims());


### PR DESCRIPTION
Add support for OpenIdContext.getClaimsJson()

- Added JsonObject creation for getClaimsJson()
- Updated unit test
- Fixed the numbering in the nlsprops file (had accidentally assigned the same number to 2 messages)
- Passed along clientId so we could use it for logging purposes.

Follow up for #21175