### PR TITLE
Create holder for OpenIdAuthenticationMechanismDefinition instance for issue #21155

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanism.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanism.java
@@ -26,6 +26,7 @@ import com.ibm.ws.webcontainer.security.AuthResult;
 import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 
 import io.openliberty.security.jakartasec.JakartaSec30Constants;
+import io.openliberty.security.jakartasec.OpenIdAuthenticationMechanismDefinitionHolder;
 import io.openliberty.security.jakartasec.OpenIdAuthenticationMechanismDefinitionWrapper;
 import io.openliberty.security.jakartasec.credential.OidcTokensCredential;
 import io.openliberty.security.oidcclientcore.authentication.AuthorizationRequestUtils;
@@ -44,7 +45,6 @@ import jakarta.security.enterprise.AuthenticationException;
 import jakarta.security.enterprise.AuthenticationStatus;
 import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
 import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
 import jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdConstant;
 import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
 import jakarta.security.enterprise.identitystore.openid.IdentityToken;
@@ -76,7 +76,8 @@ public class OidcHttpAuthenticationMechanism implements HttpAuthenticationMechan
          * Build the baseURL from the incoming HttpRequest as the redirectURL may contain baseURL variable, such as ${baseURL}/Callback
          */
         String baseURL = requestUtils.getBaseURL(request);
-        return new OpenIdAuthenticationMechanismDefinitionWrapper((OpenIdAuthenticationMechanismDefinition) props.get(JakartaSec30Constants.OIDC_ANNOTATION), baseURL);
+        OpenIdAuthenticationMechanismDefinitionHolder openIdAuthenticationMechanismDefinitionHolder = (OpenIdAuthenticationMechanismDefinitionHolder) props.get(JakartaSec30Constants.OIDC_ANNOTATION);
+        return new OpenIdAuthenticationMechanismDefinitionWrapper(openIdAuthenticationMechanismDefinitionHolder.getOpenIdAuthenticationMechanismDefinition(), baseURL);
     }
 
     @SuppressWarnings("unchecked")

--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/extensions/JakartaSecurity30CDIExtension.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/extensions/JakartaSecurity30CDIExtension.java
@@ -27,6 +27,7 @@ import com.ibm.ws.security.javaeesec.cdi.extensions.HttpAuthenticationMechanisms
 import com.ibm.ws.security.javaeesec.cdi.extensions.PrimarySecurityCDIExtension;
 
 import io.openliberty.security.jakartasec.JakartaSec30Constants;
+import io.openliberty.security.jakartasec.OpenIdAuthenticationMechanismDefinitionHolder;
 import io.openliberty.security.jakartasec.cdi.beans.OidcHttpAuthenticationMechanism;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
@@ -88,7 +89,7 @@ public class JakartaSecurity30CDIExtension implements Extension {
 
     private void addOidcHttpAuthenticationMechanismBean(Annotation annotation, Class<?> annotatedClass) {
         Properties props = new Properties();
-        props.put(JakartaSec30Constants.OIDC_ANNOTATION, annotation);
+        props.put(JakartaSec30Constants.OIDC_ANNOTATION, new OpenIdAuthenticationMechanismDefinitionHolder((OpenIdAuthenticationMechanismDefinition) annotation));
         primarySecurityCDIExtension.addAuthMech(applicationName, annotatedClass, OidcHttpAuthenticationMechanism.class, props);
     }
 

--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/test/io/openliberty/security/jakartasec/cdi/extensions/JakartaSecurity30CDIExtensionTest.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/test/io/openliberty/security/jakartasec/cdi/extensions/JakartaSecurity30CDIExtensionTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import com.ibm.ws.security.javaeesec.cdi.extensions.PrimarySecurityCDIExtension;
 
 import io.openliberty.security.jakartasec.JakartaSec30Constants;
+import io.openliberty.security.jakartasec.OpenIdAuthenticationMechanismDefinitionHolder;
 import io.openliberty.security.jakartasec.cdi.beans.OidcHttpAuthenticationMechanism;
 import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
 import jakarta.enterprise.inject.spi.AnnotatedType;
@@ -102,7 +103,7 @@ public class JakartaSecurity30CDIExtensionTest {
     private void withAnnotatedClassEvent() {
         event = mockery.mock(ProcessAnnotatedType.class);
         annotatedType = mockery.mock(AnnotatedType.class);
-        oidcAnnotation = mockery.mock(Annotation.class);
+        oidcAnnotation = mockery.mock(OpenIdAuthenticationMechanismDefinition.class);
 
         mockery.checking(new Expectations() {
             {
@@ -153,7 +154,8 @@ public class JakartaSecurity30CDIExtensionTest {
         public boolean matches(Object arg0) {
             boolean result = false;
             if (arg0 instanceof Properties) {
-                Annotation annotation = (Annotation) ((Properties) arg0).get(JakartaSec30Constants.OIDC_ANNOTATION);
+                OpenIdAuthenticationMechanismDefinitionHolder holder = (OpenIdAuthenticationMechanismDefinitionHolder) ((Properties) arg0).get(JakartaSec30Constants.OIDC_ANNOTATION);
+                Annotation annotation = holder.getOpenIdAuthenticationMechanismDefinition();
                 result = oidcAnnotation == annotation;
             }
             return result;

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/OpenIdAuthenticationMechanismDefinitionHolder.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/OpenIdAuthenticationMechanismDefinitionHolder.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.jakartasec;
+
+import com.ibm.websphere.ras.annotation.Sensitive;
+
+import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
+
+/**
+ * Temporarily holds the OpenIdAuthenticationMechanismDefinition instance to prevent tracing its secrets.
+ */
+public class OpenIdAuthenticationMechanismDefinitionHolder {
+
+    @Sensitive
+    private final OpenIdAuthenticationMechanismDefinition oidcMechanismDefinition;
+
+    @Sensitive
+    public OpenIdAuthenticationMechanismDefinitionHolder(OpenIdAuthenticationMechanismDefinition oidcMechanismDefinition) {
+        this.oidcMechanismDefinition = oidcMechanismDefinition;
+    }
+
+    @Sensitive
+    public OpenIdAuthenticationMechanismDefinition getOpenIdAuthenticationMechanismDefinition() {
+        return oidcMechanismDefinition;
+    }
+
+}


### PR DESCRIPTION
For issue #21155

Creates a OpenIdAuthenticationMechanismDefinition holder to prevent tracing the OpenIdAuthenticationMechanismDefinition in certain components.