### PR TITLE
PR for Issue 22726: Update custom cache key used in Jakarta Security 3.0

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/bnd.bnd
@@ -64,7 +64,8 @@ src: src, resources
 	com.ibm.ws.cdi.interfaces.jakarta;version=latest,\
 	io.openliberty.webcontainer.security.internal;version=latest,\
 	com.ibm.ws.security;version=latest,\
-	com.ibm.websphere.security;version=latest
+	com.ibm.websphere.security;version=latest,\
+	com.ibm.ws.security.token;version=latest
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file,\

--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanism.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanism.java
@@ -24,6 +24,7 @@ import com.ibm.ws.security.javaeesec.cdi.beans.Utils;
 import com.ibm.ws.security.javaeesec.properties.ModulePropertiesProvider;
 import com.ibm.ws.webcontainer.security.AuthResult;
 import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
+import com.ibm.wsspi.security.token.AttributeNameConstants;
 
 import io.openliberty.security.jakartasec.JakartaSec30Constants;
 import io.openliberty.security.jakartasec.OpenIdAuthenticationMechanismDefinitionWrapper;
@@ -272,6 +273,13 @@ public class OidcHttpAuthenticationMechanism implements HttpAuthenticationMechan
     private void setOpenIdContextInSubject(Subject clientSubject, OpenIdContext openIdContext) {
         if (openIdContext != null) {
             clientSubject.getPrivateCredentials().add(openIdContext);
+            Hashtable<String, Object> hashtable = utils.getSubjectExistingHashtable(clientSubject);
+            if (hashtable != null) {
+                IdentityToken idToken = openIdContext.getIdentityToken();
+                if (idToken != null) {
+                    hashtable.put(AttributeNameConstants.WSCREDENTIAL_CACHE_KEY, String.valueOf(idToken.hashCode()));
+                }
+            }
         }
     }
 

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/SimpleServlet.war/src/oidc/client/base/utils/OpenIdContextLogger.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/SimpleServlet.war/src/oidc/client/base/utils/OpenIdContextLogger.java
@@ -50,6 +50,7 @@ public class OpenIdContextLogger {
             return;
 
         }
+        printLine(ps, caller, "OpenIdContext: " + context);
 
         /*
          * // Method descriptor #18 ()Ljakarta/json/JsonObject;


### PR DESCRIPTION
We were finding that the custom cache key we were generating as part of the Jakarta Security 3.0 flow was not unique between two different test scenarios. These changes update the custom cache key to be the hash code of the ID token since the ID token should be unique.

Resolves #22726