### PR TITLE
Servlet 6.0 Request Cookie Header with dollar sign

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/cookies/CookieUtils.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/cookies/CookieUtils.java
@@ -335,7 +335,9 @@ public class CookieUtils {
         int expires = cookie.getMaxAge();
         if (-1 < expires) {
             if (0 == expires) {
-                if (!isRFC1123DateEnabled) {
+                if (HttpDispatcher.useEE10Cookies()) { //Since Servlet 6.0 - RFC 6265
+                    buffer.append("; max-age=0");
+                } else if (!isRFC1123DateEnabled) {
                     buffer.append(longAgo);
                 } else {
                     buffer.append(longAgoRFC1123);

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/ee/behaviors/HttpBehavior.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/ee/behaviors/HttpBehavior.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.wsspi.http.ee.behaviors;
+
+/**
+ * Create a generic configure class for WebContainer/others to pass down any configuration
+ */
+public class HttpBehavior {
+
+    /*
+     * Since Servlet 6.0 (EE10):
+     * Follows RFC 6265.
+     * Attributes are no longer accepted from the request Cookie header (section 4.2.2)
+     * $ is used only for $Versions in the request Cookie; prefix any other will be treated as new cookie ($ is part of a cookie name)
+     */
+    public static final String USE_EE10_COOKIES = "useEE10Cookies";
+}

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/ee/behaviors/package-info.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/ee/behaviors/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0.16
+ */
+@org.osgi.annotation.versioning.Version("1.0.16")
+package com.ibm.wsspi.http.ee.behaviors;

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletRequest.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletRequest.java
@@ -1721,6 +1721,10 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
             _srtRequestHelper._cookiesParsed = true;
         }
 
+        if (TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) { 
+             displayCookies(_srtRequestHelper._cookies);
+        }
+        
         return _srtRequestHelper._cookies;
     }
 
@@ -4388,5 +4392,13 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
             threadData = localThreadData;
         }
         return localThreadData;
+    }
+    
+    protected void displayCookies(Cookie[] cookie) {
+        if (cookie == null)
+            return;
+
+        for (int i = 0; i < cookie.length; i++)
+            logger.logp(Level.FINE, CLASS_NAME,"displayCookies", " " + cookie[i]);
     }
 }

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal.factories/bnd.bnd
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal.factories/bnd.bnd
@@ -44,7 +44,11 @@ Service-Component: \
   com.ibm.ws.webcontainer.v60.httpProtocolBehavior; \
     implementation:=com.ibm.wsspi.channelfw.HttpProtocolBehavior; \
     provide:=com.ibm.wsspi.channelfw.HttpProtocolBehavior; \
-    properties:="httpVersionSetting:String=2.0_Optional_On"
+    properties:="httpVersionSetting:String=2.0_Optional_On", \
+  com.ibm.ws.webcontainer.v60.httpBehavior; \
+    implementation:=com.ibm.wsspi.http.ee.behaviors.HttpBehavior; \
+    provide:=com.ibm.wsspi.http.ee.behaviors.HttpBehavior; \
+    properties:="useEE10Cookies:Boolean=true"
 
 # For each exported package, create (in that package) a package-info.java
 # file, and place an @version javadoc tag in package-level javadoc. 

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal_fat/bnd.bnd
@@ -17,7 +17,8 @@ src: \
     test-applications/GetRealPathTest.war/src,\
     test-applications/CookieSetAttributeTest.war/src,\
     test-applications/RequestConnectionTest.war/src,\
-    test-applications/SessionCookieConfigSCI.jar/src
+    test-applications/SessionCookieConfigSCI.jar/src,\
+    test-applications/RequestCookieHeaderTest.war/src
 
 fat.project: true
 

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal_fat/fat/src/io/openliberty/webcontainer/servlet60/fat/FATSuite.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal_fat/fat/src/io/openliberty/webcontainer/servlet60/fat/FATSuite.java
@@ -17,6 +17,7 @@ import org.junit.runners.Suite.SuiteClasses;
 import io.openliberty.webcontainer.servlet60.fat.tests.Servlet60CookieSetAttributeTest;
 import io.openliberty.webcontainer.servlet60.fat.tests.Servlet60GetRealPathTest;
 import io.openliberty.webcontainer.servlet60.fat.tests.Servlet60RequestConnectionTest;
+import io.openliberty.webcontainer.servlet60.fat.tests.Servlet60RequestCookieHeaderTest;
 import io.openliberty.webcontainer.servlet60.fat.tests.Servlet60SessionCookieConfigSCITest;
 import io.openliberty.webcontainer.servlet60.fat.tests.Servlet60SessionCookieConfigXMLTest;
 import io.openliberty.webcontainer.servlet60.fat.tests.Servlet60XPoweredByHeaderTest;
@@ -28,7 +29,8 @@ import io.openliberty.webcontainer.servlet60.fat.tests.Servlet60XPoweredByHeader
                 Servlet60CookieSetAttributeTest.class,
                 Servlet60RequestConnectionTest.class,
                 Servlet60SessionCookieConfigXMLTest.class,
-                Servlet60SessionCookieConfigSCITest.class
+                Servlet60SessionCookieConfigSCITest.class,
+                Servlet60RequestCookieHeaderTest.class
 })
 public class FATSuite {
 

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal_fat/fat/src/io/openliberty/webcontainer/servlet60/fat/tests/Servlet60RequestCookieHeaderTest.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal_fat/fat/src/io/openliberty/webcontainer/servlet60/fat/tests/Servlet60RequestCookieHeaderTest.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.webcontainer.servlet60.fat.tests;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.logging.Logger;
+
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * Test Request Cookie header according to RFC 6265:
+ * 1. Except $version, $ prefix any name will be part of the new cookie name (including $ sign).
+ * That also applies to those special attributes like Domain, Path
+ * 2. max-age=0 set by the application is expecting explicitly in the response Set-Cookie header
+ *
+ * request URL: /TestRequestCookieHeader?testName=xyz
+ */
+@RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
+public class Servlet60RequestCookieHeaderTest {
+    private static final Logger LOG = Logger.getLogger(Servlet60RequestCookieHeaderTest.class.getName());
+    private static final String TEST_APP_NAME = "RequestCookieHeaderTest";
+
+    @Server("servlet60_requestCookieHeaderTest")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultDropinApp(server, TEST_APP_NAME + ".war", "requestcookieheader.servlets");
+
+        server.startServer(Servlet60RequestCookieHeaderTest.class.getSimpleName() + ".log");
+    }
+
+    @AfterClass
+    public static void testCleanup() throws Exception {
+        LOG.info("testCleanUp : stop server");
+
+        // Stop the server
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    /**
+     * Test combination of COOKIE header with mix name.
+     * Request sends the following header to application:
+     * Cookie: $Version=1; name1=value1; $Path=/Dollar_Path; $Domain=localhost; $NAME2=DollarNameValue; Domain=DomainValue
+     *
+     * Main data are in the response's headers
+     *
+     */
+    @Test
+    public void test_MixCookieNameWithDollarSigns() throws Exception {
+        String url = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/" + TEST_APP_NAME + "/TestRequestCookieHeader?testName=MixCookieNames";
+        LOG.info("\n Sending Request [" + url + "]");
+        HttpGet getMethod = new HttpGet(url);
+
+        //Set request header COOKIE
+        //server is expecting to parse this header into 5 separate cookies
+        getMethod.addHeader("Cookie", "$Version=1; name1=value1; $Path=/Dollar_Path; $Domain=localhost; $NAME2=DollarNameValue; Domain=DomainValue");
+
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            try (CloseableHttpResponse response = client.execute(getMethod)) {
+                String responseText = EntityUtils.toString(response.getEntity());
+                LOG.info("\n" + "Response Text: [" + responseText + "]");
+
+                String headerValue = response.getHeader("TestResult").getValue();
+
+                LOG.info("\n TestResult : " + headerValue);
+
+                assertTrue("The response does not contain Result [PASS]. TestResult header [" + headerValue + "]", headerValue.contains("Result [PASS]"));
+
+            }
+        }
+    }
+
+    @Test
+    public void test_MaxAgeZero() throws Exception {
+        String url = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/" + TEST_APP_NAME + "/TestRequestCookieHeader?testName=MaxAgeZero";
+        LOG.info("\n Sending Request [" + url + "]");
+        HttpGet getMethod = new HttpGet(url);
+
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            try (CloseableHttpResponse response = client.execute(getMethod)) {
+                String responseText = EntityUtils.toString(response.getEntity());
+                LOG.info("\n" + "Response Text: [" + responseText + "]");
+
+                String headerValue = response.getHeader("Set-Cookie").getValue();
+
+                LOG.info("\n TestResult : " + headerValue);
+
+                assertTrue("The Set-Cookie response header does not contain [max-age=0]. TestResult header [" + headerValue + "]", headerValue.contains("max-age=0"));
+            }
+        }
+    }
+}

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal_fat/publish/servers/servlet60_requestCookieHeaderTest/bootstrap.properties
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal_fat/publish/servers/servlet60_requestCookieHeaderTest/bootstrap.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+osgi.console=7777
+com.ibm.ws.logging.trace.specification=*=info=enabled:io.openliberty.webcontainer*=all:com.ibm.ws.webcontainer*=all:com.ibm.wsspi.webcontainer*=all:HTTPChannel=all:GenericBNF=all:HTTPDispatcher=all:com.ibm.ws.http*=all
+com.ibm.ws.logging.max.file.size=20
+com.ibm.ws.logging.max.files=10
+com.ibm.ws.logging.trace.format=BASIC

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal_fat/publish/servers/servlet60_requestCookieHeaderTest/server.xml
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal_fat/publish/servers/servlet60_requestCookieHeaderTest/server.xml
@@ -1,0 +1,21 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Server for testing servlet request COOKIE header with dollar sign name">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>servlet-6.0</feature>
+    </featureManager>
+    
+    <applicationManager autoExpand="true"/>
+
+</server>

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal_fat/test-applications/RequestCookieHeaderTest.war/src/requestcookieheader/servlets/TestRequestCookieHeader.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal_fat/test-applications/RequestCookieHeaderTest.war/src/requestcookieheader/servlets/TestRequestCookieHeader.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package requestcookieheader.servlets;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Test Request Cookie header according to RFC 6265:
+ * 1. Except $version, $ prefix any name will be part of the new cookie name (including $ sign).
+ *      That also applies to those special attributes like Domain, Path
+ * 2. Max-Age - if set to 0, it should include in the Set-Cookie 
+ * 
+ * request URL: /TestRequestCookieHeader
+ */
+@WebServlet("/TestRequestCookieHeader")
+public class TestRequestCookieHeader extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+    private static final String CLASS_NAME = TestRequestCookieHeader.class.getName();
+    private static final Logger LOG = Logger.getLogger(CLASS_NAME);
+
+    public TestRequestCookieHeader() {
+        super();
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String testName = request.getParameter("testName");
+
+        if (testName == null) {
+            return;
+        }
+        else if (testName.equalsIgnoreCase("MixCookieNames")) {
+            testMixCookieNamesWithDollarSign(request,  response);
+        }
+        else if (testName.equalsIgnoreCase("MaxAgeZero")) {
+            testMaxAgeZero(request, response); 
+        }
+    }
+
+    /*
+     * Request with header:
+     * Cookie: $Version=1; name1=value1; $Path=/Dollar_Path; $Domain=localhost; $NAME2=DollarNameValue; Domain=DomainValue
+     * Expecting 5 cookies
+     */
+    private void testMixCookieNamesWithDollarSign(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        LOG.info("Test testMixCookieNamesWithDollarSign");
+        Cookie[] cookie = request.getCookies();
+        int i = cookie.length;
+        boolean testPass = true;
+        StringBuilder sBuilderResponse = new StringBuilder("TEST testMixDollarSigns . Message [[[--");
+        
+        //Test number of found cookies
+        if (i != 5) {
+            testPass = false;
+            sBuilderResponse.append(" FAIL test number of cookies, expecting 5 cookies , found [" + i + "] . Test is not complete.  Check the test case and trace |");
+            LOG.info("Test number of cookies FAIL");
+
+            sBuilderResponse.append(" --]]] Result [FAIL]");
+            response.setHeader("TestResult", sBuilderResponse.toString());  
+            
+            return; //do not continue as it will mess up later tests index
+        }
+        else
+            sBuilderResponse.append(" test number of cookies, found ["+i+"] cookies. PASS |");
+
+        //Cookies should be in order showing in the request header
+
+        //1st cookie, expecting cookie name1=value1
+        if (!(cookie[0].toString().contains("name1=value1"))) {
+            testPass = false;
+            sBuilderResponse.append(" FAIL , expecting [name1=value1] cookie. Actual [" + cookie[0] + "] |");
+            LOG.info("Test [name1=value1] cookie FAIL");
+        }
+        else 
+            sBuilderResponse.append(" Test [name1=value1] cookie  PASS |");
+        
+        //2nd cookie, expecting cookie $Path=/Dollar_Path
+        if (!(cookie[1].toString().contains("$Path=/Dollar_Path"))) {
+            testPass = false;
+            sBuilderResponse.append(" FAIL , expecting [$Path=/Dollar_Path] cookie. Actual [" + cookie[1] + "] |");
+            LOG.info("Test [name1=value1] cookie FAIL");
+        }
+        else 
+            sBuilderResponse.append(" Test [$Path=/Dollar_Path] cookie  PASS |");
+
+        //3rd, expecting cookie $Domain=localhost
+        if (!(cookie[2].toString().contains("$Domain=localhost"))) {
+            testPass = false;
+            sBuilderResponse.append(" FAIL , expecting [$Domain=localhost] cookie. Actual [" + cookie[2] + "] |");
+            LOG.info("Test [name1=value1] cookie FAIL");
+        }
+        else 
+            sBuilderResponse.append(" Test [$Domain=localhost] cookie  PASS |");
+        
+        //4th, expecting cookie $NAME2=DollarNameValue"
+        if (!(cookie[3].toString().contains("$NAME2=DollarNameValue"))) {
+            testPass = false;
+            sBuilderResponse.append(" FAIL , expecting [$NAME2=DollarNameValue] cookie. Actual [" + cookie[3] + "] |");
+            LOG.info("Test [name1=value1] cookie FAIL");
+        }
+        else 
+            sBuilderResponse.append(" Test [$NAME2=DollarNameValue] cookie  PASS |");
+        
+        //5th, expecting cookie Domain=DomainValue
+        if (!(cookie[4].toString().contains("Domain=DomainValue"))) {
+            testPass = false;
+            sBuilderResponse.append(" FAIL , expecting [Domain=DomainValue] cookie. Actual [" + cookie[4] + "] |");
+            LOG.info("Test [name1=value1] cookie FAIL");
+        }
+        else 
+            sBuilderResponse.append(" Test [Domain=DomainValue] cookie  PASS |");
+
+
+        //Final result - any of the above tests fail will make test fail
+        if (testPass)
+            sBuilderResponse.append(" --]]] Result [PASS]");
+        else
+            sBuilderResponse.append(" --]]] Result [FAIL]");
+       
+       
+        //Client check this header.
+        response.setHeader("TestResult", sBuilderResponse.toString());   
+    }
+    
+    private void testMaxAgeZero(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        LOG.info("Test testMaxAgeZero");
+
+        ServletOutputStream sos = response.getOutputStream();
+        sos.println("Hello World from TestRequestCookieHeader.testMaxAgeZero");
+        
+        Cookie testCookie = new Cookie("cookieName", "cookieValue");
+        testCookie.setVersion(0);
+
+        testCookie.setMaxAge(0);
+        response.addCookie(testCookie);
+        
+        
+        
+    }
+
+}


### PR DESCRIPTION
for #20415

Servlet 6.0 follows RFC 6265 which has the following rules:

1. Agent (i.e browser) does not send attributes back to the server.
2. With the exception to Version, $ prefix is part of the cookie name. i.e $Domain and Domain are 2 different cookies.  (Previous servlets treat $Domain, in Cookie header, as an attribute).