### PR TITLE
Revert "Use staged MP OpenAPI 3.1 API and TCK"

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2514,7 +2514,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.openapi</groupId>
       <artifactId>microprofile-openapi-api</artifactId>
-      <version>3.1</version>
+      <version>3.1-RC2</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.opentracing</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -498,7 +498,7 @@ org.eclipse.microprofile.openapi:microprofile-openapi-api:1.0.1
 org.eclipse.microprofile.openapi:microprofile-openapi-api:1.1.1
 org.eclipse.microprofile.openapi:microprofile-openapi-api:2.0
 org.eclipse.microprofile.openapi:microprofile-openapi-api:3.0
-org.eclipse.microprofile.openapi:microprofile-openapi-api:3.1
+org.eclipse.microprofile.openapi:microprofile-openapi-api:3.1-RC2
 org.eclipse.microprofile.opentracing:microprofile-opentracing-api:1.0.1
 org.eclipse.microprofile.opentracing:microprofile-opentracing-api:1.1
 org.eclipse.microprofile.opentracing:microprofile-opentracing-api:1.2

--- a/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -8,16 +8,9 @@
     <packaging>jar</packaging>
 
     <name>MicroProfile OpenAPI TCK Runner</name>
-    
-    <repositories>
-        <repository>
-            <id>eclipse-staging</id>
-            <url>https://oss.sonatype.org/content/repositories/orgeclipsemicroprofile-1611</url>
-        </repository>
-    </repositories>
-    
+
     <properties>
-        <microprofile.openapi.version>3.1</microprofile.openapi.version>
+        <microprofile.openapi.version>3.1-RC3</microprofile.openapi.version>
 
         <surefire.version>2.17</surefire.version> <!-- Any changes to the surefire version must be tested against ZOS-->
 


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#22826

It broke external builds as the dependency was added to the wrong file.

The file is available on DHE, but we won't look for it there for dependencies in oss_dependencies.