### PR TITLE
Use staged MP OpenAPI 3.1 API and TCK

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2512,11 +2512,6 @@
       <version>3.0</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.microprofile.openapi</groupId>
-      <artifactId>microprofile-openapi-api</artifactId>
-      <version>3.1-RC2</version>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.microprofile.opentracing</groupId>
       <artifactId>microprofile-opentracing-api</artifactId>
       <version>1.0.1</version>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -498,7 +498,6 @@ org.eclipse.microprofile.openapi:microprofile-openapi-api:1.0.1
 org.eclipse.microprofile.openapi:microprofile-openapi-api:1.1.1
 org.eclipse.microprofile.openapi:microprofile-openapi-api:2.0
 org.eclipse.microprofile.openapi:microprofile-openapi-api:3.0
-org.eclipse.microprofile.openapi:microprofile-openapi-api:3.1-RC2
 org.eclipse.microprofile.opentracing:microprofile-opentracing-api:1.0.1
 org.eclipse.microprofile.opentracing:microprofile-opentracing-api:1.1
 org.eclipse.microprofile.opentracing:microprofile-opentracing-api:1.2

--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -63,6 +63,7 @@ org.apache.aries.blueprint:org.apache.aries.blueprint:1.3.0-ibm-s20170710-0926
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0
 org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.0-20191203
 org.eclipse.microprofile.graphql:microprofile-graphql-tck:1.0.0-20191203
+org.eclipse.microprofile.openapi:microprofile-openapi-api:3.1
 org.eclipse.microprofile.rest.client:microprofile-rest-client-tck:1.2.2-20210215
 org.eclipse.microprofile.rest.client:microprofile-rest-client-tck:1.3.5-20210215
 org.eclipse.microprofile.rest.client:microprofile-rest-client-tck:1.4.2-20210215

--- a/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -8,9 +8,16 @@
     <packaging>jar</packaging>
 
     <name>MicroProfile OpenAPI TCK Runner</name>
-
+    
+    <repositories>
+        <repository>
+            <id>eclipse-staging</id>
+            <url>https://oss.sonatype.org/content/repositories/orgeclipsemicroprofile-1611</url>
+        </repository>
+    </repositories>
+    
     <properties>
-        <microprofile.openapi.version>3.1-RC3</microprofile.openapi.version>
+        <microprofile.openapi.version>3.1</microprofile.openapi.version>
 
         <surefire.version>2.17</surefire.version> <!-- Any changes to the surefire version must be tested against ZOS-->
 


### PR DESCRIPTION
The final API and TCK artifacts have been staged pending release.

As they're not on maven central yet, they must be added to oss_ibm and uploaded to DHE to avoid breaking the build for external developers.

Fixes #22853