### PR TITLE
Update MP Health 4.0 API and TCK to 4.0.1

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2414,7 +2414,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.health</groupId>
       <artifactId>microprofile-health-api</artifactId>
-      <version>4.0</version>
+      <version>4.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.jwt</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -478,7 +478,7 @@ org.eclipse.microprofile.health:microprofile-health-api:2.1
 org.eclipse.microprofile.health:microprofile-health-api:2.2
 org.eclipse.microprofile.health:microprofile-health-api:3.0
 org.eclipse.microprofile.health:microprofile-health-api:3.1
-org.eclipse.microprofile.health:microprofile-health-api:4.0
+org.eclipse.microprofile.health:microprofile-health-api:4.0.1
 org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:1.0
 org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:1.2
 org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:2.0

--- a/dev/io.openliberty.microprofile.health.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.health.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2021 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2021, 2022 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -17,7 +17,7 @@
     <name>MicroProfile Health 4.0 TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.health.version>4.0</microprofile.health.version>
+        <microprofile.health.version>4.0.1</microprofile.health.version>
         <arquillian.version>1.7.0.Alpha12</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->

--- a/dev/io.openliberty.org.eclipse.microprofile/health.4.0.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile/health.4.0.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -21,6 +21,6 @@ Export-Package: org.eclipse.microprofile.health;version=4.0, \
                 org.eclipse.microprofile.health.spi;version=4.0
 
 Include-Resource: \
-  @${repo;org.eclipse.microprofile.health:microprofile-health-api;4.0;EXACT}
+  @${repo;org.eclipse.microprofile.health:microprofile-health-api;4.0.1;EXACT}
 
 WS-TraceGroup: HEALTH


### PR DESCRIPTION
fixes #22850
- Updates the MicroProfile Health 4.0 API and TCK binaries to 4.0.1.