### PR TITLE
Set application metadata on thread during JPA server start

### DIFF
--- a/dev/com.ibm.ws.jpa.container/src/com/ibm/ws/jpa/container/osgi/internal/ApplicationComponentMetaData.java
+++ b/dev/com.ibm.ws.jpa.container/src/com/ibm/ws/jpa/container/osgi/internal/ApplicationComponentMetaData.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jpa.container.osgi.internal;
+
+import com.ibm.websphere.csi.J2EEName;
+import com.ibm.ws.container.service.metadata.extended.IdentifiableComponentMetaData;
+import com.ibm.ws.runtime.metadata.ApplicationMetaData;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.runtime.metadata.MetaDataImpl;
+import com.ibm.ws.runtime.metadata.ModuleMetaData;
+
+public class ApplicationComponentMetaData extends MetaDataImpl implements ComponentMetaData, IdentifiableComponentMetaData {
+
+    private final ModuleMetaData module;
+
+    public ApplicationComponentMetaData(ModuleMetaData module) {
+        super(0);
+        this.module = module;
+    }
+
+    public ApplicationComponentMetaData(ApplicationMetaData app) {
+        this(new ApplicationModuleMetaData(app));
+    }
+
+    @Override
+    public ModuleMetaData getModuleMetaData() {
+        return module;
+    }
+
+    @Override
+    public J2EEName getJ2EEName() {
+        return module.getJ2EEName();
+    }
+
+    @Override
+    public String getName() {
+        return module.getName();
+    }
+
+    @Override
+    public String getPersistentIdentifier() {
+        return "JPA#" + module.getName();
+    }
+}

--- a/dev/com.ibm.ws.jpa.container/src/com/ibm/ws/jpa/container/osgi/internal/ApplicationModuleMetaData.java
+++ b/dev/com.ibm.ws.jpa.container/src/com/ibm/ws/jpa/container/osgi/internal/ApplicationModuleMetaData.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jpa.container.osgi.internal;
+
+import com.ibm.websphere.csi.J2EEName;
+import com.ibm.ws.runtime.metadata.ApplicationMetaData;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.runtime.metadata.MetaDataSlot;
+import com.ibm.ws.runtime.metadata.ModuleMetaData;
+
+public class ApplicationModuleMetaData implements ModuleMetaData {
+
+    private final ApplicationMetaData application;
+
+    public ApplicationModuleMetaData(ApplicationMetaData application) {
+        this.application = application;
+    }
+
+    @Override
+    public void setMetaData(MetaDataSlot slot, Object metadata) {
+    }
+
+    @Override
+    public void release() {
+    }
+
+    @Override
+    public String getName() {
+        return application.getName();
+    }
+
+    @Override
+    public Object getMetaData(MetaDataSlot slot) {
+        return null;
+    }
+
+    @Override
+    public J2EEName getJ2EEName() {
+        return application.getJ2EEName();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ApplicationMetaData getApplicationMetaData() {
+        return application;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ComponentMetaData[] getComponentMetaDatas() {
+        return null;
+    }
+
+}

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/.classpath
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/.classpath
@@ -2,6 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/jpaContainerApp/src"/>
+	<classpathentry kind="src" path="test-applications/jpaDataSourceApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -14,7 +14,8 @@ bVersion=1.0
 
 src: \
     fat/src,\
-    test-applications/jpaContainerApp/src
+    test-applications/jpaContainerApp/src,\
+    test-applications/jpaDataSourceApp/src
 
 fat.project: true
 #tested.features: el-3.0, persistence-3.0, servlet-5.0, cdi-3.0, beanValidation-3.0, enterprisebeanslite-4.0
@@ -27,4 +28,7 @@ fat.project: true
     com.ibm.websphere.javaee.servlet.3.1;version=latest,\
     com.ibm.websphere.javaee.persistence.2.1;version=latest,\
     com.ibm.websphere.javaee.transaction.1.2;version=latest,\
-    com.ibm.websphere.appserver.thirdparty.eclipselink;version=latest
+    com.ibm.websphere.appserver.thirdparty.eclipselink;version=latest,\
+    io.openliberty.org.testcontainers;version=latest,\
+    org.jboss.shrinkwrap:shrinkwrap-impl-base;version=latest,\
+    org.jboss.shrinkwrap:shrinkwrap-spi;version=latest

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,11 +11,19 @@
 
 configurations {
   eclipselink26WAS
+  jpaFatTools
 }
 
 dependencies {
+  jpaFatTools project(':com.ibm.ws.jpa_testframework')
   eclipselink26WAS project(':com.ibm.websphere.appserver.thirdparty.eclipselink')
+}
 
+task addJPAFATTools (type: Copy) {
+  mustRunAfter jar
+  from configurations.jpaFatTools
+  include "**/com.ibm.ws.jpa_testframework.jar"
+  into new File(autoFvtDir, 'lib')
 }
 
 task addECL26WAS (type: Copy) {
@@ -26,8 +34,8 @@ task addECL26WAS (type: Copy) {
   into new File(autoFvtDir, 'publish/shared/resources/ecl')
 }
 
-
 addRequiredLibraries {
   dependsOn addDerby
   dependsOn addECL26WAS
+  dependsOn addJPAFATTools
 }

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/fat/src/com/ibm/ws/jpaContainer/fat/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/fat/src/com/ibm/ws/jpaContainer/fat/AbstractFATSuite.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpaContainer.fat;
+
+import org.junit.ClassRule;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
+
+import componenttest.containers.TestContainerSuite;
+import componenttest.topology.database.container.DatabaseContainerFactory;
+
+public class AbstractFATSuite extends TestContainerSuite {
+    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+
+    @ClassRule
+    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+
+    public static String repeatPhase = "";
+
+    public static JPAPersistenceProvider provider = JPAPersistenceProvider.DEFAULT;
+}

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/fat/src/com/ibm/ws/jpaContainer/fat/JPADataSourceModifyConfigTest_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/fat/src/com/ibm/ws/jpaContainer/fat/JPADataSourceModifyConfigTest_EJB.java
@@ -1,0 +1,215 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jpaContainer.fat;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.Application;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.websphere.simplicity.config.dsprops.Properties_derby_embedded;
+import com.ibm.ws.testtooling.vehicle.web.JPAFATServletClient;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+
+@RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
+public class JPADataSourceModifyConfigTest_EJB extends JPAFATServletClient {
+
+    private final static String RESOURCE_ROOT = "test-applications/jpaDataSourceApp/";
+    private final static String appFolder = "ejb";
+    private final static String appName = "jpadatasourceEjb";
+    private final static String appNameEar = appName + ".ear";
+    private final static String MSG_APP_START = "CWWKZ0001I.*" + appName;
+    private final static String MSG_APP_RESTART = "CWWKZ0003I.*" + appName;
+
+    private final static String EJB_SF_SERVLET_NAME = "TestDataSource_EJB_SF_Servlet";
+    private final static String EJB_SFEX_SERVLET_NAME = "TestDataSource_EJB_SFEx_Servlet";
+    private final static String EJB_SL_SERVLET_NAME = "TestDataSource_EJB_SL_Servlet";
+
+    @Server("DataSourceServer")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        int appStartTimeout = server.getAppStartTimeout();
+        if (appStartTimeout < (120 * 1000)) {
+            server.setAppStartTimeout(120 * 1000);
+        }
+
+        int configUpdateTimeout = server.getConfigUpdateTimeout();
+        if (configUpdateTimeout < (120 * 1000)) {
+            server.setConfigUpdateTimeout(120 * 1000);
+        }
+
+        setupTestApplication();
+    }
+
+    private static void setupTestApplication() throws Exception {
+        JavaArchive ejbApp = ShrinkWrap.create(JavaArchive.class, appName + ".jar");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.datasource.ejblocal");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.datasource.model");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.datasource.testlogic");
+        ShrinkHelper.addDirectory(ejbApp, RESOURCE_ROOT + appFolder + "/" + appName + ".jar");
+
+        WebArchive webApp = ShrinkWrap.create(WebArchive.class, appName + ".war");
+        webApp.addPackages(true, "com.ibm.ws.jpa.datasource.ejb");
+        ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + appFolder + "/" + appName + ".war");
+
+        final JavaArchive testApiJar = buildTestAPIJar();
+
+        final EnterpriseArchive app = ShrinkWrap.create(EnterpriseArchive.class, appNameEar);
+        app.addAsModule(ejbApp);
+        app.addAsModule(webApp);
+        app.addAsLibrary(testApiJar);
+        ShrinkHelper.addDirectory(app, RESOURCE_ROOT + appFolder, new org.jboss.shrinkwrap.api.Filter<ArchivePath>() {
+            @Override
+            public boolean include(ArchivePath arg0) {
+                if (arg0.get().startsWith("/META-INF/")) {
+                    return true;
+                }
+                return false;
+            }
+        });
+
+        ShrinkHelper.exportToServer(server, "apps", app);
+
+        Application appRecord = new Application();
+        appRecord.setLocation(appNameEar);
+        appRecord.setName(appName);
+
+        ServerConfiguration sc = server.getServerConfiguration();
+        sc.getApplications().add(appRecord);
+        server.updateServerConfiguration(sc);
+    }
+
+    @Test
+    public void jpa_datasource_testModifyDataSource_EJB_SF_AMJTA_Web() throws Exception {
+        final String resourceType = "SF_AMJTA";
+        final String dataSource1 = "JPA_AMJTA_DS1";
+        final String dataSource2 = "JPA_AMJTA_DS2";
+        testModifyDataSource(EJB_SF_SERVLET_NAME, resourceType, dataSource1, dataSource2);
+    }
+
+    @Test
+    public void jpa_datasource_testModifyDataSource_EJB_SF_AMRL_Web() throws Exception {
+        final String resourceType = "SF_AMRL";
+        final String dataSource1 = "JPA_AMRL_DS1";
+        final String dataSource2 = "JPA_AMRL_DS2";
+        testModifyDataSource(EJB_SF_SERVLET_NAME, resourceType, dataSource1, dataSource2);
+    }
+
+    @Test
+    public void jpa_datasource_testModifyDataSource_EJB_SF_CMTS_Web() throws Exception {
+        final String resourceType = "SF_CMTS";
+        final String dataSource1 = "JPA_CMTS_DS1";
+        final String dataSource2 = "JPA_CMTS_DS2";
+        testModifyDataSource(EJB_SF_SERVLET_NAME, resourceType, dataSource1, dataSource2);
+    }
+
+    @Test
+    public void jpa_datasource_testModifyDataSource_EJB_SFEx_CMEX_Web() throws Exception {
+        final String resourceType = "SFEx_CMEX";
+        final String dataSource1 = "JPA_AMJTA_DS1";
+        final String dataSource2 = "JPA_AMJTA_DS2";
+        testModifyDataSource(EJB_SFEX_SERVLET_NAME, resourceType, dataSource1, dataSource2);
+    }
+
+    @Test
+    public void jpa_datasource_testModifyDataSource_EJB_SL_AMJTA_Web() throws Exception {
+        final String resourceType = "SL_AMJTA";
+        final String dataSource1 = "JPA_AMJTA_DS1";
+        final String dataSource2 = "JPA_AMJTA_DS2";
+        testModifyDataSource(EJB_SL_SERVLET_NAME, resourceType, dataSource1, dataSource2);
+    }
+
+    @Test
+    public void jpa_datasource_testModifyDataSource_EJB_SL_AMRL_Web() throws Exception {
+        final String resourceType = "SL_AMRL";
+        final String dataSource1 = "JPA_AMRL_DS1";
+        final String dataSource2 = "JPA_AMRL_DS2";
+        testModifyDataSource(EJB_SL_SERVLET_NAME, resourceType, dataSource1, dataSource2);
+    }
+
+    @Test
+    public void jpa_datasource_testModifyDataSource_EJB_SL_CMTS_Web() throws Exception {
+        final String resourceType = "SL_CMTS";
+        final String dataSource1 = "JPA_CMTS_DS1";
+        final String dataSource2 = "JPA_CMTS_DS2";
+        testModifyDataSource(EJB_SL_SERVLET_NAME, resourceType, dataSource1, dataSource2);
+    }
+
+    /**
+     * Test that modifying the data source, while the server is running, prompts the application to restart.
+     * Validate that after the application restarts, the JPA provider switches to using the new data source.
+     */
+    private void testModifyDataSource(String servletName, String resourceType, String dataSource1, String dataSource2) throws Exception {
+        Assert.assertFalse("Server is already started!", server.isStarted());
+
+        try {
+            // Start the server
+            server.startServer();
+            assertNotNull(appName + " was expected to start, but did not", server.waitForStringInLogUsingMark(MSG_APP_START));
+            server.setMarkToEndOfLog();
+
+            // Save the configuration to the default
+            server.saveServerConfiguration();
+
+            // Using the default data source, insert values into the database
+            runTest(server, appName + '/' + servletName, "insert_" + resourceType);
+
+            try {
+                // Using the default data source, validate that the value previously inserted exists
+                runTest(server, appName + '/' + servletName, "exists_" + resourceType);
+
+                // Modify the data source to point to a new data source; save the configuration
+                ServerConfiguration sc = server.getServerConfiguration();
+                com.ibm.websphere.simplicity.config.DataSource d1 = sc.getDataSources().getById(dataSource1);
+                com.ibm.websphere.simplicity.config.DataSource d2 = sc.getDataSources().getById(dataSource2);
+
+                Properties_derby_embedded newProps = (Properties_derby_embedded) d2.getProperties_derby_embedded().get(0).clone();
+                d1.replaceDatasourceProperties(newProps);
+                server.setMarkToEndOfLog();
+                server.updateServerConfiguration(sc);
+                assertNotNull(appName + " was expected to restart, but did not", server.waitForStringInLogUsingMark(MSG_APP_RESTART));
+
+                // Using the new data source, validate that the value previously inserted no longer exists
+                runTest(server, appName + '/' + servletName, "notExists_" + resourceType);
+            } finally {
+                // Restore the configuration to the default
+                server.setMarkToEndOfLog();
+                server.restoreServerConfiguration();
+                assertNotNull(appName + " was expected to restart, but did not", server.waitForStringInLogUsingMark(MSG_APP_RESTART));
+
+                // Using the default data source, cleanup the database
+                runTest(server, appName + '/' + servletName, "remove_" + resourceType);
+            }
+        } finally {
+            server.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
+                              "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
+            );
+        }
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/fat/src/com/ibm/ws/jpaContainer/fat/JPADataSourceModifyConfigTest_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/fat/src/com/ibm/ws/jpaContainer/fat/JPADataSourceModifyConfigTest_Web.java
@@ -1,0 +1,176 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jpaContainer.fat;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.Application;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.websphere.simplicity.config.dsprops.Properties_derby_embedded;
+import com.ibm.ws.testtooling.vehicle.web.JPAFATServletClient;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+
+@RunWith(FATRunner.class)
+@Mode(TestMode.LITE)
+public class JPADataSourceModifyConfigTest_Web extends JPAFATServletClient {
+
+    private final static String RESOURCE_ROOT = "test-applications/jpaDataSourceApp/";
+    private final static String appFolder = "web";
+    private final static String appName = "jpadatasourceWeb";
+    private final static String appNameEar = appName + ".ear";
+    private final static String MSG_APP_START = "CWWKZ0001I.*" + appName;
+    private final static String MSG_APP_RESTART = "CWWKZ0003I.*" + appName;
+
+    private final static String SERVLET_NAME = "TestDataSourceServlet";
+
+    @Server("DataSourceServer")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        int appStartTimeout = server.getAppStartTimeout();
+        if (appStartTimeout < (120 * 1000)) {
+            server.setAppStartTimeout(120 * 1000);
+        }
+
+        int configUpdateTimeout = server.getConfigUpdateTimeout();
+        if (configUpdateTimeout < (120 * 1000)) {
+            server.setConfigUpdateTimeout(120 * 1000);
+        }
+
+        setupTestApplication();
+    }
+
+    private static void setupTestApplication() throws Exception {
+        WebArchive webApp = ShrinkWrap.create(WebArchive.class, appName + ".war");
+        webApp.addPackages(true, "com.ibm.ws.jpa.datasource.model");
+        webApp.addPackages(true, "com.ibm.ws.jpa.datasource.testlogic");
+        webApp.addPackages(true, "com.ibm.ws.jpa.datasource.web");
+        ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + appFolder + "/" + appName + ".war");
+
+        final JavaArchive testApiJar = buildTestAPIJar();
+
+        final EnterpriseArchive app = ShrinkWrap.create(EnterpriseArchive.class, appNameEar);
+        app.addAsModule(webApp);
+        app.addAsLibrary(testApiJar);
+        ShrinkHelper.addDirectory(app, RESOURCE_ROOT + appFolder, new org.jboss.shrinkwrap.api.Filter<ArchivePath>() {
+            @Override
+            public boolean include(ArchivePath arg0) {
+                if (arg0.get().startsWith("/META-INF/")) {
+                    return true;
+                }
+                return false;
+            }
+        });
+
+        ShrinkHelper.exportToServer(server, "apps", app);
+
+        Application appRecord = new Application();
+        appRecord.setLocation(appNameEar);
+        appRecord.setName(appName);
+
+        ServerConfiguration sc = server.getServerConfiguration();
+        sc.getApplications().add(appRecord);
+        server.updateServerConfiguration(sc);
+    }
+
+    @Test
+    public void jpa_datasource_testModifyDataSource_AMJTA_Web() throws Exception {
+        final String resourceType = "AMJTA";
+        final String dataSource1 = "JPA_AMJTA_DS1";
+        final String dataSource2 = "JPA_AMJTA_DS2";
+        testModifyDataSource(resourceType, dataSource1, dataSource2);
+    }
+
+    @Test
+    public void jpa_datasource_testModifyDataSource_AMRL_Web() throws Exception {
+        final String resourceType = "AMRL";
+        final String dataSource1 = "JPA_AMRL_DS1";
+        final String dataSource2 = "JPA_AMRL_DS2";
+        testModifyDataSource(resourceType, dataSource1, dataSource2);
+    }
+
+    @Test
+    public void jpa_datasource_testModifyDataSource_CMTS_Web() throws Exception {
+        final String resourceType = "CMTS";
+        final String dataSource1 = "JPA_CMTS_DS1";
+        final String dataSource2 = "JPA_CMTS_DS2";
+        testModifyDataSource(resourceType, dataSource1, dataSource2);
+    }
+
+    /**
+     * Test that modifying the data source, while the server is running, prompts the application to restart.
+     * Validate that after the application restarts, the JPA provider switches to using the new data source.
+     */
+    private void testModifyDataSource(String resourceType, String dataSource1, String dataSource2) throws Exception {
+        Assert.assertFalse("Server is already started!", server.isStarted());
+
+        try {
+            // Start the server
+            server.startServer();
+            assertNotNull(appName + " was expected to start, but did not", server.waitForStringInLogUsingMark(MSG_APP_START));
+            server.setMarkToEndOfLog();
+
+            // Save the configuration to the default
+            server.saveServerConfiguration();
+
+            // Using the default data source, insert values into the database
+            runTest(server, appName + '/' + SERVLET_NAME, "insert_" + resourceType);
+
+            try {
+                // Using the default data source, validate that the value previously inserted exists
+                runTest(server, appName + '/' + SERVLET_NAME, "exists_" + resourceType);
+
+                // Modify the data source to point to a new data source; save the configuration
+                ServerConfiguration sc = server.getServerConfiguration();
+                com.ibm.websphere.simplicity.config.DataSource d1 = sc.getDataSources().getById(dataSource1);
+                com.ibm.websphere.simplicity.config.DataSource d2 = sc.getDataSources().getById(dataSource2);
+
+                Properties_derby_embedded newProps = (Properties_derby_embedded) d2.getProperties_derby_embedded().get(0).clone();
+                d1.replaceDatasourceProperties(newProps);
+                server.setMarkToEndOfLog();
+                server.updateServerConfiguration(sc);
+                assertNotNull(appName + " was expected to restart, but did not", server.waitForStringInLogUsingMark(MSG_APP_RESTART));
+
+                // Using the new data source, validate that the value previously inserted no longer exists
+                runTest(server, appName + '/' + SERVLET_NAME, "notExists_" + resourceType);
+            } finally {
+                // Restore the configuration to the default
+                server.setMarkToEndOfLog();
+                server.restoreServerConfiguration();
+                assertNotNull(appName + " was expected to restart, but did not", server.waitForStringInLogUsingMark(MSG_APP_RESTART));
+
+                // Using the default data source, cleanup the database
+                runTest(server, appName + '/' + SERVLET_NAME, "remove_" + resourceType);
+            }
+        } finally {
+            server.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
+                              "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
+            );
+        }
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/publish/servers/DataSourceServer/bootstrap.properties
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/publish/servers/DataSourceServer/bootstrap.properties
@@ -1,0 +1,6 @@
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:Bell=all:JPA=all
+com.ibm.ws.logging.max.file.size=0
+ds.loglevel=debug
+# Exempt from java 2 security because this FAT does dynamic config
+websphere.java.security.exempt=true

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/publish/servers/DataSourceServer/server.xml
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/publish/servers/DataSourceServer/server.xml
@@ -1,0 +1,68 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="DataSource Swapping Test Server">
+    <include location="../fatTestPorts.xml" />
+
+    <featureManager>
+        <feature>ejblite-3.2</feature>
+        <feature>servlet-3.1</feature>
+        <feature>jpa-2.1</feature>
+        <feature>componenttest-1.0</feature>
+    </featureManager>
+
+    <!-- Default database -->
+    <dataSource id="JPA_AMJTA_DS1" jndiName="jdbc/JPA_AMJTA_JTA_DS">
+        <jdbcDriver libraryRef="derbylib"/>
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    <!-- Backup database for swap testing -->
+    <dataSource id="JPA_AMJTA_DS2" jndiName="jdbc/JPA_AMJTA_JTA_DS2">
+        <jdbcDriver libraryRef="derbylib"/>
+        <properties.derby.embedded databaseName="memory:ds2" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+
+    <!-- Default database -->
+    <dataSource id="JPA_AMRL_DS1" jndiName="jdbc/JPA_AMRL_NJTA_DS" transactional="false">
+        <jdbcDriver libraryRef="derbylib"/>
+        <properties.derby.embedded databaseName="memory:ds3" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    <!-- Backup database for swap testing -->
+    <dataSource id="JPA_AMRL_DS2" jndiName="jdbc/JPA_AMRL_NJTA_DS2" transactional="false">
+        <jdbcDriver libraryRef="derbylib"/>
+        <properties.derby.embedded databaseName="memory:ds4" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+
+    <!-- Default database -->
+    <dataSource id="JPA_CMTS_DS1" jndiName="jdbc/JPA_CMTS_JTA_DS">
+        <jdbcDriver libraryRef="derbylib"/>
+        <properties.derby.embedded databaseName="memory:ds5" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    <!-- Backup database for swap testing -->
+    <dataSource id="JPA_CMTS_DS2" jndiName="jdbc/JPA_CMTS_JTA_DS2">
+        <jdbcDriver libraryRef="derbylib"/>
+        <properties.derby.embedded databaseName="memory:ds6" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+
+    <library id="derbylib">
+        <file name="${shared.resource.dir}/derby/derby.jar"/>
+    </library>
+
+    <!-- File read write permissions -->
+    <javaPermission className="java.util.PropertyPermission" name="user.dir" actions="read"/>
+    <javaPermission className="java.io.FilePermission" name="files/timertestoutput.txt" actions="read,write"/>
+    <javaPermission className="java.io.FilePermission" name="files" actions="write"/>
+
+    <!--<logging  traceSpecification="JPA=all=enabled:EJBContainer=all=enabled"
+              traceFileName="trace.log"
+              maxFileSize="2000"
+              maxFiles="10"
+              traceFormat="BASIC" />-->
+</server>

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/ejb/META-INF/application.xml
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/ejb/META-INF/application.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<application xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd"
+    id="Application_ID">
+
+    <display-name>JPADataSource_EJB</display-name>
+    <module id="EjbModule_1"> 
+        <ejb>jpadatasourceEjb.jar</ejb>
+    </module>
+    <module id="WebModule_1">
+        <web>
+            <web-uri>jpadatasourceEjb.war</web-uri>
+            <context-root>jpadatasourceEjb</context-root>
+        </web>
+    </module>
+</application>

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/ejb/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/ejb/META-INF/permissions.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd" 
+             version="7">
+   <permission>
+      <class-name>java.lang.reflect.ReflectPermission</class-name>
+      <name>suppressAccessChecks</name>
+   </permission>
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>getClassLoader</name>
+   </permission>
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>accessDeclaredMembers</name>
+   </permission>
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>createClassLoader</name>
+   </permission>
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>accessClassInPackage.com.sun.org.apache.xerces.internal.dom</name>
+   </permission>
+   <permission>
+      <class-name>java.io.FilePermission</class-name>
+      <name>-</name>
+      <actions>read</actions>
+   </permission>
+   <permission>
+      <class-name>java.net.URLPermission</class-name>
+      <name>http://localhost:*/DatabaseManagement/DMS</name>
+      <actions>GET</actions>
+   </permission>
+   <permission>
+      <class-name>javax.management.MBeanServerPermission</class-name>
+      <name>newMBeanServer</name>
+   </permission>
+   <permission>
+      <class-name>javax.management.MBeanServerPermission</class-name>
+      <name>createMBeanServer</name>
+   </permission>
+
+</permissions>

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/ejb/jpadatasourceEjb.jar/META-INF/ejb-jar.xml
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/ejb/jpadatasourceEjb.jar/META-INF/ejb-jar.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<ejb-jar id="ejb-jar_id" xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_0.xsd"
+    metadata-complete="false" version="3.0">
+
+    <enterprise-beans>
+        <!-- Stateful Session Bean, PC: AM-JTA, AM-RL, CM-TS -->
+        <session>
+            <ejb-name>DataSourceSFEJB</ejb-name>
+            <business-local>com.ibm.ws.jpa.datasource.ejblocal.DataSourceSFEJBLocal</business-local>
+            <ejb-class>com.ibm.ws.testtooling.vehicle.ejb.BMTEJBTestVehicle</ejb-class>
+            <session-type>Stateful</session-type>
+            <remove-method>
+                <bean-method>
+                    <method-name>release</method-name>
+                </bean-method>
+            </remove-method>
+            <transaction-type>Bean</transaction-type>
+            <resource-ref>
+                <res-ref-name>jdbc/JPA_CMTS_JTA_DS</res-ref-name>
+                <res-type>javax.sql.DataSource</res-type>
+                <res-auth>Container</res-auth>
+                <res-sharing-scope>Shareable</res-sharing-scope>
+            </resource-ref>
+            <resource-ref>
+                <res-ref-name>jdbc/JPA_AMJTA_JTA_DS</res-ref-name>
+                <res-type>javax.sql.DataSource</res-type>
+                <res-auth>Container</res-auth>
+                <res-sharing-scope>Shareable</res-sharing-scope>
+            </resource-ref>
+            <resource-ref>
+                <res-ref-name>jdbc/JPA_AMRL_NJTA_DS</res-ref-name>
+                <res-type>javax.sql.DataSource</res-type>
+                <res-auth>Container</res-auth>
+                <res-sharing-scope>Shareable</res-sharing-scope>
+            </resource-ref>
+
+            <!-- Persistence Context Definitions -->
+            <persistence-context-ref>
+                <description>Transaction-Scoped Persistence Context</description>
+                <persistence-context-ref-name>jpa/CMTS_DATASOURCE_JTA</persistence-context-ref-name>
+                <persistence-unit-name>CMTS_DATASOURCE_JTA</persistence-unit-name>
+                <persistence-context-type>Transaction</persistence-context-type>
+            </persistence-context-ref>
+
+            <persistence-unit-ref>
+                <description>Application-Managed RL-Tran Persistence Context</description>
+                <persistence-unit-ref-name>jpa/AMJTA_DATASOURCE_JTA</persistence-unit-ref-name>
+                <persistence-unit-name>AMJTA_DATASOURCE_JTA</persistence-unit-name>
+            </persistence-unit-ref>
+
+            <persistence-unit-ref>
+                <description>Application-Managed RL-Tran Persistence Context</description>
+                <persistence-unit-ref-name>jpa/AMRL_DATASOURCE_RL</persistence-unit-ref-name>
+                <persistence-unit-name>AMRL_DATASOURCE_RL</persistence-unit-name>
+            </persistence-unit-ref>
+        </session>
+
+        <!-- Stateful Session Bean, PC: CM-ES -->
+        <session>
+            <ejb-name>DataSourceSFExEJB</ejb-name>
+            <business-local>com.ibm.ws.jpa.datasource.ejblocal.DataSourceSFExEJBLocal</business-local>
+            <ejb-class>com.ibm.ws.testtooling.vehicle.ejb.BMTEJBTestVehicle</ejb-class>
+            <session-type>Stateful</session-type>
+            <remove-method>
+                <bean-method>
+                    <method-name>release</method-name>
+                </bean-method>
+            </remove-method>
+            <transaction-type>Bean</transaction-type>
+            <resource-ref>
+                <res-ref-name>jdbc/JPA_AMJTA_JTA_DS</res-ref-name>
+                <res-type>javax.sql.DataSource</res-type>
+                <res-auth>Container</res-auth>
+                <res-sharing-scope>Shareable</res-sharing-scope>
+            </resource-ref>
+
+            <!-- Persistence Context Definitions -->
+            <persistence-context-ref>
+                <persistence-context-ref-name>jpa/CMEX_DATASOURCE_JTA</persistence-context-ref-name>
+                <persistence-unit-name>AMJTA_DATASOURCE_JTA</persistence-unit-name>
+                <persistence-context-type>Extended</persistence-context-type>
+            </persistence-context-ref>
+        </session>
+
+        <!-- Stateless Session Bean, PC: AM-JTA, AM-RL, CM-TS -->
+        <session>
+            <ejb-name>DataSourceSLEJB</ejb-name>
+            <business-local>com.ibm.ws.jpa.datasource.ejblocal.DataSourceSLEJBLocal</business-local>
+            <ejb-class>com.ibm.ws.testtooling.vehicle.ejb.BMTEJBTestVehicle</ejb-class>
+            <session-type>Stateless</session-type>
+            <transaction-type>Bean</transaction-type>
+            <resource-ref>
+                <res-ref-name>jdbc/JPA_CMTS_JTA_DS</res-ref-name>
+                <res-type>javax.sql.DataSource</res-type>
+                <res-auth>Container</res-auth>
+                <res-sharing-scope>Shareable</res-sharing-scope>
+            </resource-ref>
+            <resource-ref>
+                <res-ref-name>jdbc/JPA_AMJTA_JTA_DS</res-ref-name>
+                <res-type>javax.sql.DataSource</res-type>
+                <res-auth>Container</res-auth>
+                <res-sharing-scope>Shareable</res-sharing-scope>
+            </resource-ref>
+            <resource-ref>
+                <res-ref-name>jdbc/JPA_AMRL_NJTA_DS</res-ref-name>
+                <res-type>javax.sql.DataSource</res-type>
+                <res-auth>Container</res-auth>
+                <res-sharing-scope>Shareable</res-sharing-scope>
+            </resource-ref>
+
+            <!-- Persistence Context Definitions -->
+            <persistence-context-ref>
+                <description>Transaction-Scoped Persistence Context</description>
+                <persistence-context-ref-name>jpa/CMTS_DATASOURCE_JTA</persistence-context-ref-name>
+                <persistence-unit-name>CMTS_DATASOURCE_JTA</persistence-unit-name>
+                <persistence-context-type>Transaction</persistence-context-type>
+            </persistence-context-ref>
+
+            <persistence-unit-ref>
+                <description>Application-Managed JTA-Tran Persistence Context</description>
+                <persistence-unit-ref-name>jpa/AMJTA_DATASOURCE_JTA</persistence-unit-ref-name>
+                <persistence-unit-name>AMJTA_DATASOURCE_JTA</persistence-unit-name>
+            </persistence-unit-ref>
+
+            <persistence-unit-ref>
+                <description>Application-Managed RL-Tran Persistence Context</description>
+                <persistence-unit-ref-name>jpa/AMRL_DATASOURCE_RL</persistence-unit-ref-name>
+                <persistence-unit-name>AMRL_DATASOURCE_RL</persistence-unit-name>
+            </persistence-unit-ref>
+        </session>
+    </enterprise-beans>
+</ejb-jar>

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/ejb/jpadatasourceEjb.jar/META-INF/ibm-ejb-jar-bnd.xml
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/ejb/jpadatasourceEjb.jar/META-INF/ibm-ejb-jar-bnd.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<ejb-jar-bnd xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-ejb-jar-bnd_1_0.xsd"
+    version="1.0">
+    <session name="DataSourceSFEJB">
+        <resource-ref name="jdbc/JPA_CMTS_JTA_DS"  binding-name="jdbc/JPA_CMTS_JTA_DS" />
+        <resource-ref name="jdbc/JPA_AMJTA_JTA_DS" binding-name="jdbc/JPA_AMJTA_JTA_DS" />
+        <resource-ref name="jdbc/JPA_AMRL_NJTA_DS" binding-name="jdbc/JPA_AMRL_NJTA_DS" />
+    </session>
+    <session name="DataSourceSFExEJB">
+        <resource-ref name="jdbc/JPA_CMTS_JTA_DS"  binding-name="jdbc/JPA_CMTS_JTA_DS" />
+        <resource-ref name="jdbc/JPA_AMJTA_JTA_DS" binding-name="jdbc/JPA_AMJTA_JTA_DS" />
+        <resource-ref name="jdbc/JPA_AMRL_NJTA_DS" binding-name="jdbc/JPA_AMRL_NJTA_DS" />
+    </session>
+    <session name="DataSourceSLEJB">
+        <resource-ref name="jdbc/JPA_CMTS_JTA_DS"  binding-name="jdbc/JPA_CMTS_JTA_DS" />
+        <resource-ref name="jdbc/JPA_AMJTA_JTA_DS" binding-name="jdbc/JPA_AMJTA_JTA_DS" />
+        <resource-ref name="jdbc/JPA_AMRL_NJTA_DS" binding-name="jdbc/JPA_AMRL_NJTA_DS" />
+    </session>
+</ejb-jar-bnd>

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/ejb/jpadatasourceEjb.jar/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/ejb/jpadatasourceEjb.jar/META-INF/persistence.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+    version="2.0">
+
+    <persistence-unit name="CMTS_DATASOURCE_JTA">
+        <jta-data-source>jdbc/JPA_CMTS_JTA_DS</jta-data-source>
+        <properties>
+            <property name="javax.persistence.schema-generation.database.action" value="create"/>
+            <property name="jakarta.persistence.schema-generation.database.action" value="create"/>
+        </properties>
+    </persistence-unit>
+
+    <persistence-unit name="AMJTA_DATASOURCE_JTA">
+        <jta-data-source>jdbc/JPA_AMJTA_JTA_DS</jta-data-source>
+        <properties>
+            <property name="javax.persistence.schema-generation.database.action" value="create"/>
+            <property name="jakarta.persistence.schema-generation.database.action" value="create"/>
+        </properties>
+    </persistence-unit>
+
+    <persistence-unit name="AMRL_DATASOURCE_RL" transaction-type="RESOURCE_LOCAL">
+        <non-jta-data-source>jdbc/JPA_AMRL_NJTA_DS</non-jta-data-source>
+        <properties>
+            <property name="javax.persistence.schema-generation.database.action" value="create"/>
+            <property name="jakarta.persistence.schema-generation.database.action" value="create"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/ejb/jpadatasourceEjb.war/WEB-INF/ibm-web-bnd.xml
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/ejb/jpadatasourceEjb.war/WEB-INF/ibm-web-bnd.xml
@@ -1,5 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,18 +10,12 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+-->
+<web-bnd xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-bnd_1_0.xsd"
+    version="1.0">
 
-package com.ibm.ws.jpaContainer.fat;
+    <virtual-host name="default_host" />
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
-
-@RunWith(Suite.class)
-@SuiteClasses({
-                JPAContainerModifyConfigTest.class,
-                JPADataSourceModifyConfigTest_EJB.class,
-                JPADataSourceModifyConfigTest_Web.class
-})
-public class FATSuite {
-}
+</web-bnd>

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/ejb/jpadatasourceEjb.war/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/ejb/jpadatasourceEjb.war/WEB-INF/web.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+    version="2.5">
+
+    <!-- EJB References -->
+    <ejb-local-ref>
+        <ejb-ref-name>ejb/DataSourceSFEJB</ejb-ref-name>
+        <local>com.ibm.ws.jpa.datasource.ejblocal.DataSourceSFEJBLocal</local>
+        <ejb-link>DataSourceSFEJB</ejb-link>
+    </ejb-local-ref>
+    <ejb-local-ref>
+        <ejb-ref-name>ejb/DataSourceSFExEJB</ejb-ref-name>
+        <local>com.ibm.ws.jpa.datasource.ejblocal.DataSourceSFExEJBLocal</local>
+        <ejb-link>DataSourceSFExEJB</ejb-link>
+    </ejb-local-ref>
+    <ejb-local-ref>
+        <ejb-ref-name>ejb/DataSourceSLEJB</ejb-ref-name>
+        <local>com.ibm.ws.jpa.datasource.ejblocal.DataSourceSLEJBLocal</local>
+        <ejb-link>DataSourceSLEJB</ejb-link>
+    </ejb-local-ref>
+</web-app>

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/src/com/ibm/ws/jpa/datasource/ejb/TestDataSource_EJB_SFEx_Servlet.java
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/src/com/ibm/ws/jpa/datasource/ejb/TestDataSource_EJB_SFEx_Servlet.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.datasource.ejb;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.annotation.WebServlet;
+
+import com.ibm.ws.jpa.datasource.testlogic.DataSourceLogic;
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext;
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext.PersistenceContextType;
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext.PersistenceInjectionType;
+import com.ibm.ws.testtooling.vehicle.web.EJBTestVehicleServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/TestDataSource_EJB_SFEx_Servlet")
+public class TestDataSource_EJB_SFEx_Servlet extends EJBTestVehicleServlet {
+
+    @PostConstruct
+    private void initFAT() {
+        testClassName = DataSourceLogic.class.getName();
+        ejbJNDIName = "ejb/DataSourceSFExEJB";
+
+        jpaPctxMap.put("test-jpa-resource-cmex",
+                       new JPAPersistenceContext("test-jpa-resource-cmex", PersistenceContextType.CONTAINER_MANAGED_ES, PersistenceInjectionType.JNDI, "java:comp/env/jpa/CMEX_DATASOURCE_JTA"));
+    }
+
+    // testInsert Test
+    public void insert_SFEx_CMEX() throws Exception {
+        final String testName = "insert_SFEx_CMEX";
+        final String testMethod = "testInsert";
+        final String testResource = "test-jpa-resource-cmex";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    // testFindExists Test
+    public void exists_SFEx_CMEX() throws Exception {
+        final String testName = "exists_SFEx_CMEX";
+        final String testMethod = "testFindExists";
+        final String testResource = "test-jpa-resource-cmex";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    // testFindExists Test
+    public void notExists_SFEx_CMEX() throws Exception {
+        final String testName = "notExists_SFEx_CMEX";
+        final String testMethod = "testFindNotExists";
+        final String testResource = "test-jpa-resource-cmex";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    // testRemove Test
+    public void remove_SFEx_CMEX() throws Exception {
+        final String testName = "remove_SFEx_CMEX";
+        final String testMethod = "testRemove";
+        final String testResource = "test-jpa-resource-cmex";
+        executeTest(testName, testMethod, testResource);
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/src/com/ibm/ws/jpa/datasource/ejb/TestDataSource_EJB_SF_Servlet.java
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/src/com/ibm/ws/jpa/datasource/ejb/TestDataSource_EJB_SF_Servlet.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.datasource.ejb;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.annotation.WebServlet;
+
+import com.ibm.ws.jpa.datasource.testlogic.DataSourceLogic;
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext;
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext.PersistenceContextType;
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext.PersistenceInjectionType;
+import com.ibm.ws.testtooling.vehicle.web.EJBTestVehicleServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/TestDataSource_EJB_SF_Servlet")
+public class TestDataSource_EJB_SF_Servlet extends EJBTestVehicleServlet {
+
+    @PostConstruct
+    private void initFAT() {
+        testClassName = DataSourceLogic.class.getName();
+        ejbJNDIName = "ejb/DataSourceSFEJB";
+
+        jpaPctxMap.put("test-jpa-resource-amjta",
+                       new JPAPersistenceContext("test-jpa-resource-amjta", PersistenceContextType.APPLICATION_MANAGED_JTA, PersistenceInjectionType.JNDI, "java:comp/env/jpa/AMJTA_DATASOURCE_JTA"));
+        jpaPctxMap.put("test-jpa-resource-amrl",
+                       new JPAPersistenceContext("test-jpa-resource-amrl", PersistenceContextType.APPLICATION_MANAGED_RL, PersistenceInjectionType.JNDI, "java:comp/env/jpa/AMRL_DATASOURCE_RL"));
+        jpaPctxMap.put("test-jpa-resource-cmts",
+                       new JPAPersistenceContext("test-jpa-resource-cmts", PersistenceContextType.CONTAINER_MANAGED_TS, PersistenceInjectionType.JNDI, "java:comp/env/jpa/CMTS_DATASOURCE_JTA"));
+    }
+
+    // testInsert Test
+    public void insert_SF_AMJTA() throws Exception {
+        final String testName = "insert_SF_AMJTA";
+        final String testMethod = "testInsert";
+        final String testResource = "test-jpa-resource-amjta";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void insert_SF_AMRL() throws Exception {
+        final String testName = "insert_SF_AMRL";
+        final String testMethod = "testInsert";
+        final String testResource = "test-jpa-resource-amrl";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void insert_SF_CMTS() throws Exception {
+        final String testName = "insert_SF_CMTS";
+        final String testMethod = "testInsert";
+        final String testResource = "test-jpa-resource-cmts";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    // testFindExists Test
+    public void exists_SF_AMJTA() throws Exception {
+        final String testName = "exists_SF_AMJTA";
+        final String testMethod = "testFindExists";
+        final String testResource = "test-jpa-resource-amjta";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void exists_SF_AMRL() throws Exception {
+        final String testName = "exists_SF_AMRL";
+        final String testMethod = "testFindExists";
+        final String testResource = "test-jpa-resource-amrl";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void exists_SF_CMTS() throws Exception {
+        final String testName = "exists_SF_CMTS";
+        final String testMethod = "testFindExists";
+        final String testResource = "test-jpa-resource-cmts";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    // testFindExists Test
+    public void notExists_SF_AMJTA() throws Exception {
+        final String testName = "notExists_SF_AMJTA";
+        final String testMethod = "testFindNotExists";
+        final String testResource = "test-jpa-resource-amjta";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void notExists_SF_AMRL() throws Exception {
+        final String testName = "notExists_SF_AMRL";
+        final String testMethod = "testFindNotExists";
+        final String testResource = "test-jpa-resource-amrl";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void notExists_SF_CMTS() throws Exception {
+        final String testName = "notExists_SF_CMTS";
+        final String testMethod = "testFindNotExists";
+        final String testResource = "test-jpa-resource-cmts";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    // testRemove Test
+    public void remove_SF_AMJTA() throws Exception {
+        final String testName = "remove_SF_AMJTA";
+        final String testMethod = "testRemove";
+        final String testResource = "test-jpa-resource-amjta";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void remove_SF_AMRL() throws Exception {
+        final String testName = "remove_SF_AMRL";
+        final String testMethod = "testRemove";
+        final String testResource = "test-jpa-resource-amrl";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void remove_SF_CMTS() throws Exception {
+        final String testName = "remove_SF_CMTS";
+        final String testMethod = "testRemove";
+        final String testResource = "test-jpa-resource-cmts";
+        executeTest(testName, testMethod, testResource);
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/src/com/ibm/ws/jpa/datasource/ejb/TestDataSource_EJB_SL_Servlet.java
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/src/com/ibm/ws/jpa/datasource/ejb/TestDataSource_EJB_SL_Servlet.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.datasource.ejb;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.annotation.WebServlet;
+
+import com.ibm.ws.jpa.datasource.testlogic.DataSourceLogic;
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext;
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext.PersistenceContextType;
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext.PersistenceInjectionType;
+import com.ibm.ws.testtooling.vehicle.web.EJBTestVehicleServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/TestDataSource_EJB_SL_Servlet")
+public class TestDataSource_EJB_SL_Servlet extends EJBTestVehicleServlet {
+
+    @PostConstruct
+    private void initFAT() {
+        testClassName = DataSourceLogic.class.getName();
+        ejbJNDIName = "ejb/DataSourceSLEJB";
+
+        jpaPctxMap.put("test-jpa-resource-amjta",
+                       new JPAPersistenceContext("test-jpa-resource-amjta", PersistenceContextType.APPLICATION_MANAGED_JTA, PersistenceInjectionType.JNDI, "java:comp/env/jpa/AMJTA_DATASOURCE_JTA"));
+        jpaPctxMap.put("test-jpa-resource-amrl",
+                       new JPAPersistenceContext("test-jpa-resource-amrl", PersistenceContextType.APPLICATION_MANAGED_RL, PersistenceInjectionType.JNDI, "java:comp/env/jpa/AMRL_DATASOURCE_RL"));
+        jpaPctxMap.put("test-jpa-resource-cmts",
+                       new JPAPersistenceContext("test-jpa-resource-cmts", PersistenceContextType.CONTAINER_MANAGED_TS, PersistenceInjectionType.JNDI, "java:comp/env/jpa/CMTS_DATASOURCE_JTA"));
+    }
+
+    // testInsert Test
+    public void insert_SL_AMJTA() throws Exception {
+        final String testName = "insert_SL_AMJTA";
+        final String testMethod = "testInsert";
+        final String testResource = "test-jpa-resource-amjta";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void insert_SL_AMRL() throws Exception {
+        final String testName = "insert_SL_AMRL";
+        final String testMethod = "testInsert";
+        final String testResource = "test-jpa-resource-amrl";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void insert_SL_CMTS() throws Exception {
+        final String testName = "insert_SL_CMTS";
+        final String testMethod = "testInsert";
+        final String testResource = "test-jpa-resource-cmts";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    // testFindExists Test
+    public void exists_SL_AMJTA() throws Exception {
+        final String testName = "exists_SL_AMJTA";
+        final String testMethod = "testFindExists";
+        final String testResource = "test-jpa-resource-amjta";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void exists_SL_AMRL() throws Exception {
+        final String testName = "exists_SL_AMRL";
+        final String testMethod = "testFindExists";
+        final String testResource = "test-jpa-resource-amrl";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void exists_SL_CMTS() throws Exception {
+        final String testName = "exists_SL_CMTS";
+        final String testMethod = "testFindExists";
+        final String testResource = "test-jpa-resource-cmts";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    // testFindExists Test
+    public void notExists_SL_AMJTA() throws Exception {
+        final String testName = "notExists_SL_AMJTA";
+        final String testMethod = "testFindNotExists";
+        final String testResource = "test-jpa-resource-amjta";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void notExists_SL_AMRL() throws Exception {
+        final String testName = "notExists_SL_AMRL";
+        final String testMethod = "testFindNotExists";
+        final String testResource = "test-jpa-resource-amrl";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void notExists_SL_CMTS() throws Exception {
+        final String testName = "notExists_SL_CMTS";
+        final String testMethod = "testFindNotExists";
+        final String testResource = "test-jpa-resource-cmts";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    // testRemove Test
+    public void remove_SL_AMJTA() throws Exception {
+        final String testName = "remove_SL_AMJTA";
+        final String testMethod = "testRemove";
+        final String testResource = "test-jpa-resource-amjta";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void remove_SL_AMRL() throws Exception {
+        final String testName = "remove_SL_AMRL";
+        final String testMethod = "testRemove";
+        final String testResource = "test-jpa-resource-amrl";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void remove_SL_CMTS() throws Exception {
+        final String testName = "remove_SL_CMTS";
+        final String testMethod = "testRemove";
+        final String testResource = "test-jpa-resource-cmts";
+        executeTest(testName, testMethod, testResource);
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/src/com/ibm/ws/jpa/datasource/ejblocal/DataSourceSFEJBLocal.java
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/src/com/ibm/ws/jpa/datasource/ejblocal/DataSourceSFEJBLocal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,17 +9,10 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpaContainer.fat;
+package com.ibm.ws.jpa.datasource.ejblocal;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import com.ibm.ws.testtooling.vehicle.ejb.EJBTestVehicle;
 
-@RunWith(Suite.class)
-@SuiteClasses({
-                JPAContainerModifyConfigTest.class,
-                JPADataSourceModifyConfigTest_EJB.class,
-                JPADataSourceModifyConfigTest_Web.class
-})
-public class FATSuite {
+public interface DataSourceSFEJBLocal extends EJBTestVehicle {
+
 }

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/src/com/ibm/ws/jpa/datasource/ejblocal/DataSourceSFExEJBLocal.java
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/src/com/ibm/ws/jpa/datasource/ejblocal/DataSourceSFExEJBLocal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,17 +9,10 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpaContainer.fat;
+package com.ibm.ws.jpa.datasource.ejblocal;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import com.ibm.ws.testtooling.vehicle.ejb.EJBTestVehicle;
 
-@RunWith(Suite.class)
-@SuiteClasses({
-                JPAContainerModifyConfigTest.class,
-                JPADataSourceModifyConfigTest_EJB.class,
-                JPADataSourceModifyConfigTest_Web.class
-})
-public class FATSuite {
+public interface DataSourceSFExEJBLocal extends EJBTestVehicle {
+
 }

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/src/com/ibm/ws/jpa/datasource/ejblocal/DataSourceSLEJBLocal.java
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/src/com/ibm/ws/jpa/datasource/ejblocal/DataSourceSLEJBLocal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,17 +9,10 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpaContainer.fat;
+package com.ibm.ws.jpa.datasource.ejblocal;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import com.ibm.ws.testtooling.vehicle.ejb.EJBTestVehicle;
 
-@RunWith(Suite.class)
-@SuiteClasses({
-                JPAContainerModifyConfigTest.class,
-                JPADataSourceModifyConfigTest_EJB.class,
-                JPADataSourceModifyConfigTest_Web.class
-})
-public class FATSuite {
+public interface DataSourceSLEJBLocal extends EJBTestVehicle {
+
 }

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/src/com/ibm/ws/jpa/datasource/model/SimpleDataSourceEntity.java
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/src/com/ibm/ws/jpa/datasource/model/SimpleDataSourceEntity.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jpa.datasource.model;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Version;
+
+@Entity
+public class SimpleDataSourceEntity {
+
+    @Id
+    private int id;
+
+    @Version
+    private int version;
+
+    private String name;
+
+    public SimpleDataSourceEntity() {
+    }
+
+    public SimpleDataSourceEntity(int id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/src/com/ibm/ws/jpa/datasource/testlogic/DataSourceLogic.java
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/src/com/ibm/ws/jpa/datasource/testlogic/DataSourceLogic.java
@@ -1,0 +1,261 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.datasource.testlogic;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+
+import org.junit.Assert;
+
+import com.ibm.ws.jpa.datasource.model.SimpleDataSourceEntity;
+import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
+import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
+import com.ibm.ws.testtooling.tranjacket.TransactionJacket;
+import com.ibm.ws.testtooling.vehicle.resources.JPAResource;
+import com.ibm.ws.testtooling.vehicle.resources.TestExecutionResources;
+
+public class DataSourceLogic extends AbstractTestLogic {
+
+    public void testInsert(TestExecutionContext testExecCtx, TestExecutionResources testExecResources,
+                           Object managedComponentObject) throws Throwable {
+        final String testName = getTestName();
+
+        // Verify parameters
+        if (testExecCtx == null || testExecResources == null) {
+            Assert.fail(testName + ": Missing context and/or resources.  Cannot execute the test.");
+            return;
+        }
+
+        final JPAResource jpaResource = testExecResources.getJpaResourceMap().get("test-jpa-resource");
+        if (jpaResource == null) {
+            Assert.fail("Missing JPAResource 'test-jpa-resource').  Cannot execute the test.");
+            return;
+        }
+
+        // Process Test Properties
+        final Map<String, Serializable> testProps = testExecCtx.getProperties();
+        if (testProps != null) {
+            for (String key : testProps.keySet()) {
+                System.out.println("Test Property: " + key + " = " + testProps.get(key));
+            }
+        }
+
+        // Execute Test Case
+        try {
+            EntityManager em = jpaResource.getEm();
+            TransactionJacket tj = jpaResource.getTj();
+
+            int id = 99;
+            String value = "InsertEntity";
+
+            em.clear();
+
+            System.out.println("Beginning new transaction...");
+            tj.beginTransaction();
+            if (tj.isApplicationManaged()) {
+                System.out.println("Joining entitymanager to JTA transaction...");
+                em.joinTransaction();
+            }
+
+            SimpleDataSourceEntity s = new SimpleDataSourceEntity(id, value);
+
+            System.out.println("Persisting " + s);
+            em.persist(s);
+
+            System.out.println("Committing transaction...");
+            tj.commitTransaction();
+        } catch (AssertionError ae) {
+            throw ae;
+        } catch (Throwable t) {
+            t.printStackTrace();
+            throw new RuntimeException(t);
+        } finally {
+            System.out.println(testName + ": End");
+        }
+    }
+
+    public void testFindExists(TestExecutionContext testExecCtx, TestExecutionResources testExecResources,
+                               Object managedComponentObject) throws Throwable {
+        final String testName = getTestName();
+
+        // Verify parameters
+        if (testExecCtx == null || testExecResources == null) {
+            Assert.fail(testName + ": Missing context and/or resources.  Cannot execute the test.");
+            return;
+        }
+
+        final JPAResource jpaResource = testExecResources.getJpaResourceMap().get("test-jpa-resource");
+        if (jpaResource == null) {
+            Assert.fail("Missing JPAResource 'test-jpa-resource').  Cannot execute the test.");
+            return;
+        }
+
+        // Process Test Properties
+        final Map<String, Serializable> testProps = testExecCtx.getProperties();
+        if (testProps != null) {
+            for (String key : testProps.keySet()) {
+                System.out.println("Test Property: " + key + " = " + testProps.get(key));
+            }
+        }
+
+        // Execute Test Case
+        try {
+            EntityManager em = jpaResource.getEm();
+            TransactionJacket tj = jpaResource.getTj();
+
+            int id = 99;
+
+            em.clear();
+
+            System.out.println("Beginning new transaction...");
+            tj.beginTransaction();
+            if (tj.isApplicationManaged()) {
+                System.out.println("Joining entitymanager to JTA transaction...");
+                em.joinTransaction();
+            }
+
+            System.out.println("Finding " + SimpleDataSourceEntity.class.getSimpleName() + " (id=" + id + ")...");
+            SimpleDataSourceEntity find_entity = em.find(SimpleDataSourceEntity.class, id);
+            System.out.println("Object returned by find: " + find_entity);
+            Assert.assertNotNull("Expected that the find operation would return null", find_entity);
+
+            System.out.println("Rollback transaction...");
+            tj.rollbackTransaction();
+        } catch (AssertionError ae) {
+            throw ae;
+        } catch (Throwable t) {
+            t.printStackTrace();
+            throw new RuntimeException(t);
+        } finally {
+            System.out.println(testName + ": End");
+        }
+    }
+
+    public void testFindNotExists(TestExecutionContext testExecCtx, TestExecutionResources testExecResources,
+                                  Object managedComponentObject) throws Throwable {
+        final String testName = getTestName();
+
+        // Verify parameters
+        if (testExecCtx == null || testExecResources == null) {
+            Assert.fail(testName + ": Missing context and/or resources.  Cannot execute the test.");
+            return;
+        }
+
+        final JPAResource jpaResource = testExecResources.getJpaResourceMap().get("test-jpa-resource");
+        if (jpaResource == null) {
+            Assert.fail("Missing JPAResource 'test-jpa-resource').  Cannot execute the test.");
+            return;
+        }
+
+        // Process Test Properties
+        final Map<String, Serializable> testProps = testExecCtx.getProperties();
+        if (testProps != null) {
+            for (String key : testProps.keySet()) {
+                System.out.println("Test Property: " + key + " = " + testProps.get(key));
+            }
+        }
+
+        // Execute Test Case
+        try {
+            EntityManager em = jpaResource.getEm();
+            TransactionJacket tj = jpaResource.getTj();
+
+            int id = 99;
+
+            em.clear();
+
+            System.out.println("Beginning new transaction...");
+            tj.beginTransaction();
+            if (tj.isApplicationManaged()) {
+                System.out.println("Joining entitymanager to JTA transaction...");
+                em.joinTransaction();
+            }
+
+            System.out.println("Finding " + SimpleDataSourceEntity.class.getSimpleName() + " (id=" + id + ")...");
+            SimpleDataSourceEntity find_entity = em.find(SimpleDataSourceEntity.class, id);
+            System.out.println("Object returned by find: " + find_entity);
+            Assert.assertNull("Expected that the find operation would return null", find_entity);
+
+            System.out.println("Rollback transaction...");
+            tj.rollbackTransaction();
+        } catch (AssertionError ae) {
+            throw ae;
+        } catch (Throwable t) {
+            t.printStackTrace();
+            throw new RuntimeException(t);
+        } finally {
+            System.out.println(testName + ": End");
+        }
+    }
+
+    public void testRemove(TestExecutionContext testExecCtx, TestExecutionResources testExecResources,
+                           Object managedComponentObject) throws Throwable {
+        final String testName = getTestName();
+
+        // Verify parameters
+        if (testExecCtx == null || testExecResources == null) {
+            Assert.fail(testName + ": Missing context and/or resources.  Cannot execute the test.");
+            return;
+        }
+
+        final JPAResource jpaResource = testExecResources.getJpaResourceMap().get("test-jpa-resource");
+        if (jpaResource == null) {
+            Assert.fail("Missing JPAResource 'test-jpa-resource').  Cannot execute the test.");
+            return;
+        }
+
+        // Process Test Properties
+        final Map<String, Serializable> testProps = testExecCtx.getProperties();
+        if (testProps != null) {
+            for (String key : testProps.keySet()) {
+                System.out.println("Test Property: " + key + " = " + testProps.get(key));
+            }
+        }
+
+        // Execute Test Case
+        try {
+            EntityManager em = jpaResource.getEm();
+            TransactionJacket tj = jpaResource.getTj();
+
+            int id = 99;
+
+            em.clear();
+
+            System.out.println("Beginning new transaction...");
+            tj.beginTransaction();
+            if (tj.isApplicationManaged()) {
+                System.out.println("Joining entitymanager to JTA transaction...");
+                em.joinTransaction();
+            }
+
+            System.out.println("Finding " + SimpleDataSourceEntity.class.getSimpleName() + " (id=" + id + ")...");
+            SimpleDataSourceEntity find_remove_entity = em.find(SimpleDataSourceEntity.class, id);
+            System.out.println("Object returned by find: " + find_remove_entity);
+            Assert.assertNotNull("Expected that the find operation would not return null", find_remove_entity);
+
+            System.out.println("Removing entity...");
+            em.remove(find_remove_entity);
+
+            System.out.println("Commit transaction...");
+            tj.commitTransaction();
+        } catch (AssertionError ae) {
+            throw ae;
+        } catch (Throwable t) {
+            t.printStackTrace();
+            throw new RuntimeException(t);
+        } finally {
+            System.out.println(testName + ": End");
+        }
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/src/com/ibm/ws/jpa/datasource/web/TestDataSourceServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/src/com/ibm/ws/jpa/datasource/web/TestDataSourceServlet.java
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.datasource.web;
+
+import javax.annotation.PostConstruct;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceContext;
+import javax.persistence.PersistenceUnit;
+import javax.servlet.annotation.WebServlet;
+
+import com.ibm.ws.jpa.datasource.testlogic.DataSourceLogic;
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext;
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext.PersistenceContextType;
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext.PersistenceInjectionType;
+import com.ibm.ws.testtooling.vehicle.web.JPATestServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/TestDataSourceServlet")
+public class TestDataSourceServlet extends JPATestServlet {
+
+    // Container Managed Transaction Scope
+    @PersistenceContext(unitName = "JPA_CMTS_DATASOURCE_JTA")
+    private EntityManager cmtsEm;
+
+    // Application Managed JTA
+    @PersistenceUnit(unitName = "JPA_AMJTA_DATASOURCE_JTA")
+    private EntityManagerFactory amjtaEmf;
+
+    // Application Managed Resource-Local
+    @PersistenceUnit(unitName = "JPA_AMRL_DATASOURCE_RL")
+    private EntityManagerFactory amrlEmf;
+
+    @PostConstruct
+    private void initFAT() {
+        testClassName = DataSourceLogic.class.getName();
+
+        jpaPctxMap.put("test-jpa-resource-amjta",
+                       new JPAPersistenceContext("test-jpa-resource-amjta", PersistenceContextType.APPLICATION_MANAGED_JTA, PersistenceInjectionType.FIELD, "amjtaEmf"));
+        jpaPctxMap.put("test-jpa-resource-amrl",
+                       new JPAPersistenceContext("test-jpa-resource-amrl", PersistenceContextType.APPLICATION_MANAGED_RL, PersistenceInjectionType.FIELD, "amrlEmf"));
+        jpaPctxMap.put("test-jpa-resource-cmts",
+                       new JPAPersistenceContext("test-jpa-resource-cmts", PersistenceContextType.CONTAINER_MANAGED_TS, PersistenceInjectionType.FIELD, "cmtsEm"));
+    }
+
+    // testInsert Test
+    public void insert_AMJTA() throws Exception {
+        final String testName = "insert_AMJTA";
+        final String testMethod = "testInsert";
+        final String testResource = "test-jpa-resource-amjta";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void insert_AMRL() throws Exception {
+        final String testName = "insert_AMRL";
+        final String testMethod = "testInsert";
+        final String testResource = "test-jpa-resource-amrl";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void insert_CMTS() throws Exception {
+        final String testName = "insert_CMTS";
+        final String testMethod = "testInsert";
+        final String testResource = "test-jpa-resource-cmts";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    // testFindExists Test
+    public void exists_AMJTA() throws Exception {
+        final String testName = "exists_AMJTA";
+        final String testMethod = "testFindExists";
+        final String testResource = "test-jpa-resource-amjta";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void exists_AMRL() throws Exception {
+        final String testName = "exists_AMRL";
+        final String testMethod = "testFindExists";
+        final String testResource = "test-jpa-resource-amrl";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void exists_CMTS() throws Exception {
+        final String testName = "exists_CMTS";
+        final String testMethod = "testFindExists";
+        final String testResource = "test-jpa-resource-cmts";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    // testFindExists Test
+    public void notExists_AMJTA() throws Exception {
+        final String testName = "notExists_AMJTA";
+        final String testMethod = "testFindNotExists";
+        final String testResource = "test-jpa-resource-amjta";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void notExists_AMRL() throws Exception {
+        final String testName = "notExists_AMRL";
+        final String testMethod = "testFindNotExists";
+        final String testResource = "test-jpa-resource-amrl";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void notExists_CMTS() throws Exception {
+        final String testName = "notExists_CMTS";
+        final String testMethod = "testFindNotExists";
+        final String testResource = "test-jpa-resource-cmts";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    // testRemove Test
+    public void remove_AMJTA() throws Exception {
+        final String testName = "remove_AMJTA";
+        final String testMethod = "testRemove";
+        final String testResource = "test-jpa-resource-amjta";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void remove_AMRL() throws Exception {
+        final String testName = "remove_AMRL";
+        final String testMethod = "testRemove";
+        final String testResource = "test-jpa-resource-amrl";
+        executeTest(testName, testMethod, testResource);
+    }
+
+    public void remove_CMTS() throws Exception {
+        final String testName = "remove_CMTS";
+        final String testMethod = "testRemove";
+        final String testResource = "test-jpa-resource-cmts";
+        executeTest(testName, testMethod, testResource);
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/web/META-INF/application.xml
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/web/META-INF/application.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<application xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd"
+    id="Application_ID">
+
+    <display-name>JPADataSource_WEB</display-name>
+    <module id="WebModule_1">
+        <web>
+            <web-uri>jpadatasourceWeb.war</web-uri>
+            <context-root>jpadatasourceWeb</context-root>
+        </web>
+    </module>
+</application>

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/web/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/web/META-INF/permissions.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd" 
+             version="7">
+   <permission>
+      <class-name>java.lang.reflect.ReflectPermission</class-name>
+      <name>suppressAccessChecks</name>
+   </permission>
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>getClassLoader</name>
+   </permission>
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>accessDeclaredMembers</name>
+   </permission>
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>createClassLoader</name>
+   </permission>
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>accessClassInPackage.com.sun.org.apache.xerces.internal.dom</name>
+   </permission>
+   <permission>
+      <class-name>java.io.FilePermission</class-name>
+      <name>-</name>
+      <actions>read</actions>
+   </permission>
+   <permission>
+      <class-name>java.net.URLPermission</class-name>
+      <name>http://localhost:*/DatabaseManagement/DMS</name>
+      <actions>GET</actions>
+   </permission>
+   <permission>
+      <class-name>javax.management.MBeanServerPermission</class-name>
+      <name>newMBeanServer</name>
+   </permission>
+   <permission>
+      <class-name>javax.management.MBeanServerPermission</class-name>
+      <name>createMBeanServer</name>
+   </permission>
+
+</permissions>

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/web/jpadatasourceWeb.war/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/web/jpadatasourceWeb.war/WEB-INF/classes/META-INF/persistence.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+    version="2.0">
+
+    <persistence-unit name="JPA_CMTS_DATASOURCE_JTA">
+        <jta-data-source>jdbc/JPA_CMTS_JTA_DS</jta-data-source>
+        <properties>
+            <property name="javax.persistence.schema-generation.database.action" value="create"/>
+            <property name="jakarta.persistence.schema-generation.database.action" value="create"/>
+        </properties>
+    </persistence-unit>
+
+    <persistence-unit name="JPA_AMJTA_DATASOURCE_JTA">
+        <jta-data-source>jdbc/JPA_AMJTA_JTA_DS</jta-data-source>
+        <properties>
+            <property name="javax.persistence.schema-generation.database.action" value="create"/>
+            <property name="jakarta.persistence.schema-generation.database.action" value="create"/>
+        </properties>
+    </persistence-unit>
+
+    <persistence-unit name="JPA_AMRL_DATASOURCE_RL" transaction-type="RESOURCE_LOCAL">
+        <non-jta-data-source>jdbc/JPA_AMRL_NJTA_DS</non-jta-data-source>
+        <properties>
+            <property name="javax.persistence.schema-generation.database.action" value="create"/>
+            <property name="jakarta.persistence.schema-generation.database.action" value="create"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/web/jpadatasourceWeb.war/WEB-INF/ibm-web-bnd.xml
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/web/jpadatasourceWeb.war/WEB-INF/ibm-web-bnd.xml
@@ -1,5 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,18 +10,12 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+-->
+<web-bnd xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-bnd_1_0.xsd"
+    version="1.0">
 
-package com.ibm.ws.jpaContainer.fat;
+    <virtual-host name="default_host" />
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
-
-@RunWith(Suite.class)
-@SuiteClasses({
-                JPAContainerModifyConfigTest.class,
-                JPADataSourceModifyConfigTest_EJB.class,
-                JPADataSourceModifyConfigTest_Web.class
-})
-public class FATSuite {
-}
+</web-bnd>

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/web/jpadatasourceWeb.war/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/test-applications/jpaDataSourceApp/web/jpadatasourceWeb.war/WEB-INF/web.xml
@@ -1,5 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,18 +10,10 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-
-package com.ibm.ws.jpaContainer.fat;
-
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
-
-@RunWith(Suite.class)
-@SuiteClasses({
-                JPAContainerModifyConfigTest.class,
-                JPADataSourceModifyConfigTest_EJB.class,
-                JPADataSourceModifyConfigTest_Web.class
-})
-public class FATSuite {
-}
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+    version="2.5">
+    
+</web-app>


### PR DESCRIPTION
fixes #22865

It appears that the `DataSourceService` is not refreshing the application because the application metadata is not available on the thread

```
java.lang.Exception: Stack trace
	at java.base/java.lang.Thread.dumpStack(Thread.java:1383)
	at com.ibm.ws.jca.cm.AbstractConnectionFactoryService.createResource(AbstractConnectionFactoryService.java:189)
	at com.ibm.ws.resource.internal.ResourceFactoryTrackerData$1.getService(ResourceFactoryTrackerData.java:120)
	at org.eclipse.osgi.internal.serviceregistry.ServiceFactoryUse$1.run(ServiceFactoryUse.java:220)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at org.eclipse.osgi.internal.serviceregistry.ServiceFactoryUse.factoryGetService(ServiceFactoryUse.java:217)
	at org.eclipse.osgi.internal.serviceregistry.ServiceFactoryUse.getService(ServiceFactoryUse.java:118)
	at org.eclipse.osgi.internal.serviceregistry.ServiceConsumer$2.getService(ServiceConsumer.java:48)
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistrationImpl.getService(ServiceRegistrationImpl.java:547)
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.getService(ServiceRegistry.java:533)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.getService(BundleContextImpl.java:655)
	at com.ibm.ws.jndi.internal.WSContextFactory.lambda$getService$0(WSContextFactory.java:81)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at com.ibm.ws.jndi.internal.WSContextFactory.lambda$getService$1(WSContextFactory.java:81)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1705)
	at com.ibm.ws.jndi.internal.WSContextFactory.getService(WSContextFactory.java:81)
	at com.ibm.ws.jndi.internal.WSContext.getReference(WSContext.java:520)
	at com.ibm.ws.jndi.internal.WSContext.resolveObject(WSContext.java:139)
	at com.ibm.ws.jndi.internal.WSContext.lookup(WSContext.java:309)
	at com.ibm.ws.jndi.WSContextBase.lookup(WSContextBase.java:61)
	at org.apache.aries.jndi.DelegateContext.lookup(DelegateContext.java:149)
	at java.naming/javax.naming.InitialContext.lookup(InitialContext.java:409)
	at com.ibm.ws.jpa.container.osgi.internal.OSGiJPAPUnitInfo.lookupDataSource(OSGiJPAPUnitInfo.java:317)
	at com.ibm.ws.jpa.management.JPAPUnitInfo.getJPADataSource(JPAPUnitInfo.java:338)
	at com.ibm.ws.jpa.management.JPAPUnitInfo.getJtaDataSource(JPAPUnitInfo.java:385)
	at com.ibm.ws.jpa.management.JPAPUnitInfo.initialize(JPAPUnitInfo.java:765)
	at com.ibm.ws.jpa.management.JPAPxmlInfo.extractPersistenceUnits(JPAPxmlInfo.java:182)
	at com.ibm.ws.jpa.management.JPAScopeInfo.processPersistenceUnit(JPAScopeInfo.java:88)
	at com.ibm.ws.jpa.management.JPAApplInfo.addPersistenceUnits(JPAApplInfo.java:119)
	at com.ibm.ws.jpa.container.osgi.internal.JPAComponentImpl.processLibraryJarPersistenceXml(JPAComponentImpl.java:528)
	at com.ibm.ws.jpa.container.osgi.internal.JPAComponentImpl.applicationStarting(JPAComponentImpl.java:317)
	at com.ibm.ws.container.service.state.internal.ApplicationStateManager.fireStarting(ApplicationStateManager.java:51)
	at com.ibm.ws.container.service.state.internal.StateChangeServiceImpl.fireApplicationStarting(StateChangeServiceImpl.java:50)
	at com.ibm.ws.app.manager.module.internal.SimpleDeployedAppInfoBase.preDeployApp(SimpleDeployedAppInfoBase.java:547)
	at com.ibm.ws.app.manager.module.internal.SimpleDeployedAppInfoBase.installApp(SimpleDeployedAppInfoBase.java:508)
	at com.ibm.ws.app.manager.module.internal.DeployedAppInfoBase.deployApp(DeployedAppInfoBase.java:349)
	at com.ibm.ws.app.manager.ear.internal.EARApplicationHandlerImpl.install(EARApplicationHandlerImpl.java:77)
	at com.ibm.ws.app.manager.internal.statemachine.StartAction.execute(StartAction.java:161)
	at com.ibm.ws.app.manager.internal.statemachine.ApplicationStateMachineImpl.enterState(ApplicationStateMachineImpl.java:1357)
	at com.ibm.ws.app.manager.internal.statemachine.ApplicationStateMachineImpl.run(ApplicationStateMachineImpl.java:901)
	at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:245)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>