### PR TITLE
Improve FAT leaked server cleanup 2

### DIFF
--- a/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
@@ -367,7 +367,15 @@
 				</junit>
 			</sequential>
 			<finally>
-				<!-- If the tests timeout, attempt to copy logs from zombie servers -->
+				<!-- If the tests timeout, wait 30 seconds for leaked servers to finish starting/stopping -->
+				<fileset dir="${basedir}/output" includes="*.mrk" id="markfiles" />
+				<foreach param="serverFile" in="markfiles">
+					<echo>Waiting 30 seconds in case the server has not finished starting or stopping : ${serverFile}</echo>
+					<sleep seconds="30"/>
+				</foreach>
+				
+				<!-- If the tests timeout, attempt to stop and copy logs from zombie/leaked servers -->
+				<!-- Obtain the set of mark files again, in case any servers stopped during above wait -->
 				<fileset dir="${basedir}/output" includes="*.mrk" id="markfiles" />
 				<foreach param="serverFile" in="markfiles">
 					<echo>Failure running ${test.bucket.name}, attempting to stop servers that did not stop properly : ${serverFile}</echo>
@@ -380,8 +388,6 @@
 						<istrue value="${is.windows.platform}" />
 					</condition>
 
-					<echo>Waiting 30 seconds in case the server has not finished starting...</echo>
-					<sleep seconds="30"/>
 					<echo>Executing ${libertyInstallPath}/bin/${script.exec} ${script.cmd} stop ${serverDir}</echo>
 					<exec failonerror="false" executable="${script.exec}" dir="${libertyInstallPath}/bin" timeout="300000">
 						<arg line="${script.cmd}" />

--- a/dev/com.ibm.ws.jmx_fat/override/autoFVT/src/ant/launch.xml
+++ b/dev/com.ibm.ws.jmx_fat/override/autoFVT/src/ant/launch.xml
@@ -553,7 +553,15 @@
 				</junit>
 			</sequential>
 			<finally>
-				<!-- If the tests timeout, attempt to copy logs from zombie servers -->
+				<!-- If the tests timeout, wait 30 seconds for leaked servers to finish starting/stopping -->
+				<fileset dir="${basedir}/output" includes="*.mrk" id="markfiles" />
+				<foreach param="serverFile" in="markfiles">
+					<echo>Waiting 30 seconds in case the server has not finished starting or stopping : ${serverFile}</echo>
+					<sleep seconds="30"/>
+				</foreach>
+				
+				<!-- If the tests timeout, attempt to stop and copy logs from zombie/leaked servers -->
+				<!-- Obtain the set of mark files again, in case any servers stopped during above wait -->
 				<fileset dir="${basedir}/output" includes="*.mrk" id="markfiles" />
 				<foreach param="serverFile" in="markfiles">
 					<echo>Failure running ${test.bucket.name}, attempting to stop servers that did not stop properly : ${serverFile}</echo>
@@ -566,8 +574,6 @@
 						<istrue value="${is.windows.platform}" />
 					</condition>
 
-					<echo>Waiting 30 seconds in case the server has not finished starting...</echo>
-					<sleep seconds="30"/>
 					<echo>Executing ${libertyInstallPath}/bin/${script.exec} ${script.cmd} stop ${serverDir}</echo>
 					<exec failonerror="false" executable="${script.exec}" dir="${libertyInstallPath}/bin" timeout="300000">
 						<arg line="${script.cmd}" />

--- a/dev/com.ibm.ws.kernel.boot_fat/override/autoFVT/src/ant/launch.xml
+++ b/dev/com.ibm.ws.kernel.boot_fat/override/autoFVT/src/ant/launch.xml
@@ -553,7 +553,15 @@
 				</junit>
 			</sequential>
 			<finally>
-				<!-- If the tests timeout, attempt to copy logs from zombie servers -->
+				<!-- If the tests timeout, wait 30 seconds for leaked servers to finish starting/stopping -->
+				<fileset dir="${basedir}/output" includes="*.mrk" id="markfiles" />
+				<foreach param="serverFile" in="markfiles">
+					<echo>Waiting 30 seconds in case the server has not finished starting or stopping : ${serverFile}</echo>
+					<sleep seconds="30"/>
+				</foreach>
+				
+				<!-- If the tests timeout, attempt to stop and copy logs from zombie/leaked servers -->
+				<!-- Obtain the set of mark files again, in case any servers stopped during above wait -->
 				<fileset dir="${basedir}/output" includes="*.mrk" id="markfiles" />
 				<foreach param="serverFile" in="markfiles">
 					<echo>Failure running ${test.bucket.name}, attempting to stop servers that did not stop properly : ${serverFile}</echo>
@@ -566,8 +574,6 @@
 						<istrue value="${is.windows.platform}" />
 					</condition>
 
-					<echo>Waiting 30 seconds in case the server has not finished starting...</echo>
-					<sleep seconds="30"/>
 					<echo>Executing ${libertyInstallPath}/bin/${script.exec} ${script.cmd} stop ${serverDir}</echo>
 					<exec failonerror="false" executable="${script.exec}" dir="${libertyInstallPath}/bin" timeout="300000">
 						<arg line="${script.cmd}" />

--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -531,7 +531,15 @@
 				</junit>
 			</sequential>
 			<finally>
-				<!-- If the tests timeout, attempt to copy logs from zombie servers -->
+				<!-- If the tests timeout, wait 30 seconds for leaked servers to finish starting/stopping -->
+				<fileset dir="${basedir}/output" includes="*.mrk" id="markfiles" />
+				<foreach param="serverFile" in="markfiles">
+					<echo>Waiting 30 seconds in case the server has not finished starting or stopping : ${serverFile}</echo>
+					<sleep seconds="30"/>
+				</foreach>
+				
+				<!-- If the tests timeout, attempt to stop and copy logs from zombie/leaked servers -->
+				<!-- Obtain the set of mark files again, in case any servers stopped during above wait -->
 				<fileset dir="${basedir}/output" includes="*.mrk" id="markfiles" />
 				<foreach param="serverFile" in="markfiles">
 					<echo>Failure running ${test.bucket.name}, attempting to stop servers that did not stop properly : ${serverFile}</echo>
@@ -544,8 +552,6 @@
 						<istrue value="${is.windows.platform}" />
 					</condition>
 
-					<echo>Waiting 30 seconds in case the server has not finished starting...</echo>
-					<sleep seconds="30"/>
 					<echo>Executing ${libertyInstallPath}/bin/${script.exec} ${script.cmd} stop ${serverDir}</echo>
 					<exec failonerror="false" executable="${script.exec}" dir="${libertyInstallPath}/bin" timeout="300000">
 						<arg line="${script.cmd}" />


### PR DESCRIPTION
- do not try to stop servers that were stopping at time of FAT timeout/exit
- obtain list of server files again after waiting for them to finish start/stop
