### PR TITLE
MP Metrics 5.0 TCK to use ssl-1.0 instead of appSecurity-5.0

### DIFF
--- a/dev/io.openliberty.microprofile.metrics.internal.5.0_fat_tck/publish/servers/MetricsTCKServer/server.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.0_fat_tck/publish/servers/MetricsTCKServer/server.xml
@@ -4,7 +4,7 @@
         <feature>restfulWS-3.1</feature>
     	<feature>mpMetrics-5.0</feature>
         <feature>localConnector-1.0</feature>
-        <feature>appSecurity-5.0</feature>
+        <feature>ssl-1.0</feature>
         <feature>arquillian-support-jakarta-2.1</feature>
     </featureManager>
 


### PR DESCRIPTION
#build