### PR TITLE
Mp metrics50 beta

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.restfulWS3.1-mpMetrics-monitor1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.restfulWS3.1-mpMetrics-monitor1.0.feature
@@ -6,5 +6,5 @@ IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.restfulWS-3.1))"
 IBM-Install-Policy: when-satisfied
 -bundles=io.openliberty.restfulWS.mpMetrics.filter
-kind=noship
-edition=full
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.metrics-5.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.metrics-5.0.feature
@@ -1,9 +1,8 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.org.eclipse.microprofile.metrics-5.0
 singleton=true
--features=io.openliberty.mpCompatible-6.0, \
-  io.openliberty.noShip-1.0
+-features=io.openliberty.mpCompatible-6.0
 -bundles=io.openliberty.org.eclipse.microprofile.metrics.5.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.metrics:microprofile-metrics-api:5.0.0-RC3"
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-5.0/io.openliberty.mpMetrics-5.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-5.0/io.openliberty.mpMetrics-5.0.feature
@@ -22,5 +22,5 @@ Subsystem-Name: MicroProfile Metrics 5.0
  io.openliberty.microprofile.metrics.5.0.monitor.internal
 -jars=io.openliberty.smallrye.metrics; location:="lib/", \
  io.openliberty.micrometer; location:="lib/"
-kind=noship
-edition=full
+kind=beta
+edition=core


### PR DESCRIPTION
This is an updated version of https://github.com/OpenLiberty/open-liberty/pull/22860
Leaving out io.openliberty.mpFaultTolerance4.0-metrics5.0.feature because that causes a build problem