### PR TITLE
add missing allowedffdc annotations

### DIFF
--- a/dev/com.ibm.ws.jca_fat_regr/fat/src/suite/r80/base/jca16/ann/AdministeredObjectValidatorTest.java
+++ b/dev/com.ibm.ws.jca_fat_regr/fat/src/suite/r80/base/jca16/ann/AdministeredObjectValidatorTest.java
@@ -26,6 +26,7 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
@@ -127,6 +128,7 @@ public class AdministeredObjectValidatorTest {
      *                                  when the test case fails.
      */
     @Test
+    @AllowedFFDC({ "java.lang.IllegalStateException", "com.ibm.ws.container.service.state.StateChangeException" })
     public void testValidationOfEmptyInterfaceList() throws Throwable {
         if (LOGGER.isLoggable(Level.FINER)) {
             LOGGER.entering(CLASSNAME, "testValidationOfEmptyInterfaceList");
@@ -161,6 +163,7 @@ public class AdministeredObjectValidatorTest {
      *                                  when the test case fails.
      */
     @Test
+    @AllowedFFDC({ "java.lang.IllegalStateException", "com.ibm.ws.container.service.state.StateChangeException" })
     public void testValidationOfUnspecifiedInterface() throws Throwable {
 
         if (LOGGER.isLoggable(Level.FINER)) {
@@ -194,6 +197,7 @@ public class AdministeredObjectValidatorTest {
      *                                  when the test case fails.
      */
     @Test
+    @AllowedFFDC({ "java.lang.IllegalStateException", "com.ibm.ws.container.service.state.StateChangeException" })
     public void testValidationOfAOSuperClass() throws Throwable {
         if (LOGGER.isLoggable(Level.FINER)) {
             LOGGER.entering(CLASSNAME, "testValidationOfAOSuperClass");


### PR DESCRIPTION
Address defect 292812. Even though the ffdcs were thrown in the setup() method, due to the delay in ffdcs being produced, they sometimes came out when the test was running due to slow systems and/or timing windows and were caught by the test framework and caused the test to fail.