### PR TITLE
Avoid timing issues with failover after application stops

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/fat/src/com/ibm/ws/concurrent/persistent/fat/failovertimers/FailoverTimersTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/fat/src/com/ibm/ws/concurrent/persistent/fat/failovertimers/FailoverTimersTest.java
@@ -328,6 +328,7 @@ public class FailoverTimersTest extends FATServletClient {
             newConfig.getApplications().removeBy("location", "failoverTimersApp.war");
             serverOnWhichToStopApp.setMarkToEndOfLog();
             serverOnWhichToStopApp.updateServerConfiguration(newConfig);
+            serverOnWhichToStopApp.waitForStringInTraceUsingMark("CWWKC1556W"); // CWWKC1556W: Execution of tasks from application failoverTimersApp is deferred until the application and modules that scheduled the tasks are available.
             try {
                 String nameOfServerForFailover = serverOnWhichToStopApp == serverA ? SERVER_B_NAME : SERVER_A_NAME;
                 LibertyServer serverForFailover = serverOnWhichToStopApp == serverA ? serverB : serverA;


### PR DESCRIPTION
On slow test infrastructure it is possible for the following sequence of events to happen: 

The test testSingletonTimerFailsOverWhenAppStops starts:
```
[08/23/2022 21:06:12:524 PDT] 001 FATRunner                      evaluate                       I entering com.ibm.ws.concurrent.persistent.fat.failovertimers.FailoverTimersTest.testSingletonTimerFailsOverWhenAppStops
```

ServerA is already running, ServerB is started.
```
[08/23/2022 21:06:12:524 PDT] 197 LibertyServer                  startServerWithArgs            I >>> STARTING SERVER: com.ibm.ws.concurrent.persistent.fat.failovertimers.serverB
[08/23/2022 21:07:11:568 PDT] 197 LibertyServer                  validateServerStarted          I Waiting up to 120 seconds for server confirmation:  CWWKF0011I to be found in C:/Users/jazz_build/Build/jazz-build-engines/wasrtc/EBCPROD/build/dev/image/output/wlp/usr/servers/com.ibm.ws.concurrent.persistent.fat.failovertimers.serverB/logs/testSingletonTimerFailsOverWhenAppStops.log
```

We confirm that ServerB was the last one to run the singleton timer. 
```
[08/23/2022 21:07:11:584 PDT] 001 FailoverTimersTest             (null)                         I URL is http://localhost:8010/failoverTimersApp/FailoverTimersTestServlet?testMethod=findServerWhereTimerRuns&timer=AutomaticCountingSingletonTimer&test=testSingletonTimerFailsOverWhenAppStops[1]
[08/23/2022 21:07:11:600 PDT] 001 FailoverTimersTest             runInServlet                   I Timer last ran on server: com.ibm.ws.concurrent.persistent.fat.failovertimers.serverB.
[08/23/2022 21:07:11:600 PDT] 001 FailoverTimersTest             runInServlet                   I SUCCESS
```

This is confirmed by looking at ServerB trace:
```
[8/23/22, 21:07:12:037 PDT] 00000092 SystemOut                                                    O Running timer AutomaticCountingSingletonTimer on com.ibm.ws.concurrent.persistent.fat.failovertimers.serverB
```

The application on ServerB is stopped.  Notice the time!!!:
```
[8/23/22, 21:07:22:350 PDT] 0000008f com.ibm.ws.app.manager.AppMessageHelper                      A CWWKZ0009I: The application failoverTimersApp has stopped successfully.
[8/23/22, 21:07:24:037 PDT] 0000008f com.ibm.ws.concurrent.persistent.internal.ApplicationTracker W CWWKC1556W: Execution of tasks from application failoverTimersApp is deferred until the application and modules that scheduled the tasks are available.
```

While that was happening the test then queries ServerA to ensure the timer is now running there:
```
[08/23/2022 21:07:21:647 PDT] 001 HttpUtils                      getHttpResponseAsString        I url = http://localhost:8010/failoverTimersApp/FailoverTimersTestServlet?testMethod=testTimerFailover&timer=AutomaticCountingSingletonTimer&server=com.ibm.ws.concurrent.persistent.fat.failovertimers.serverA&test=testSingletonTimerFailsOverWhenAppStops[2]
```

ServerA gets the call and responds that the last time the timer ran was on ServerB (AssertionError)
```
[8/23/22, 21:07:21:662 PDT] 0000008d SystemOut                                                    O Request URL: http://localhost:8010/failoverTimersApp/FailoverTimersTestServlet?testMethod=testTimerFailover&timer=AutomaticCountingSingletonTimer&server=com.ibm.ws.concurrent.persistent.fat.failovertimers.serverA&test=testSingletonTimerFailsOverWhenAppStops[2]
[8/23/22, 21:09:21:787 PDT] 0000008d SystemErr                                                    R java.lang.AssertionError: Timer last ran on server: com.ibm.ws.concurrent.persistent.fat.failovertimers.serverB
```

We do see a few seconds later that the timer DOES start running on ServerA.
``` 
[8/23/22, 21:09:26:615 PDT] 0000008d SystemOut                                                    O Running timer AutomaticCountingSingletonTimer on com.ibm.ws.concurrent.persistent.fat.failovertimers.serverA
```


This is a timing issue, where the test has confirmed that the configuration on ServerB was completed, but due to slow infrastructure it takes a while for the application to be fully removed, and therefore the timers haven't failed over yet.
There is a warning produced that we can wait for to avoid this: `CWWKC1556W`
