### PR TITLE
Security 3.0: Create correct access token type from OidcIdentityStore

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/JakartaSec30Constants.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/JakartaSec30Constants.java
@@ -42,4 +42,6 @@ public class JakartaSec30Constants extends JavaEESecConstants {
 
     public static final String JWT_ID_IDENTIFIER = "jti";
 
+    public static final String DELIMITER = ".";
+
 }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
@@ -10,10 +10,12 @@
  *******************************************************************************/
 package io.openliberty.security.jakartasec.identitystore;
 
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.MalformedClaimException;
@@ -22,6 +24,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
+import io.openliberty.security.jakartasec.JakartaSec30Constants;
 import io.openliberty.security.jakartasec.credential.OidcTokensCredential;
 import io.openliberty.security.jakartasec.tokens.AccessTokenImpl;
 import io.openliberty.security.jakartasec.tokens.IdentityTokenImpl;
@@ -88,6 +91,12 @@ public class OidcIdentityStore implements IdentityStore {
 
                     return credentialValidationResult;
                 } catch (Exception e) {
+                    /*
+                     * Optionally provide the stack in trace, since we're ignoring the FFDC here.
+                     */
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "validate", "Exception occurred for client " + client.getOidcClientConfig().getClientId(), e);
+                    }
                     Tr.error(tc, "CREDENTIAL_VALIDATION_ERROR", client.getOidcClientConfig().getClientId(), e.toString());
                     return CredentialValidationResult.INVALID_RESULT;
                 }
@@ -116,15 +125,59 @@ public class OidcIdentityStore implements IdentityStore {
         return openIdContext;
     }
 
-    private AccessToken createAccessTokenFromTokenResponse(long tokenMinValidityInMillis, TokenResponse tokenResponse) {
+    @FFDCIgnore({ Exception.class })
+    protected AccessToken createAccessTokenFromTokenResponse(long tokenMinValidityInMillis, TokenResponse tokenResponse) {
+        final String METHODNAME = "createAccessTokenFromTokenResponse";
+
         Map<String, String> tokenResponseRawMap = tokenResponse.asMap();
         long expiresIn = 0L;
-        if (tokenResponseRawMap.containsKey(OpenIdConstant.EXPIRES_IN)) {
+        if (tokenResponseRawMap != null && tokenResponseRawMap.containsKey(OpenIdConstant.EXPIRES_IN)) {
             expiresIn = Long.parseLong(tokenResponseRawMap.get(OpenIdConstant.EXPIRES_IN));
         }
 
-        // TODO: Determine if this is a JWT Access Token and use proper constructor.
-        return new AccessTokenImpl(tokenResponse.getAccessTokenString(), tokenResponse.getResponseGenerationTime(), expiresIn, tokenMinValidityInMillis);
+        String accessTokenString = tokenResponse.getAccessTokenString();
+
+        boolean isJWT = false;
+        Map<String, Object> jwtClaims = null;
+
+        String[] parts = accessTokenString.split(Pattern.quote(JakartaSec30Constants.DELIMITER)); // split out the "parts" (header, payload and signature)
+
+        if (parts.length > 1) {
+            try {
+                try {
+                    String claimsAsJsonString = new String(Base64.getDecoder().decode(parts[0]), "UTF-8");
+                    org.jose4j.jwt.JwtClaims.parse(claimsAsJsonString).getClaimsMap();
+                    isJWT = true;
+                } catch (Exception e1) {
+                    String claimsAsJsonString = new String(Base64.getDecoder().decode(parts[1]), "UTF-8");
+                    jwtClaims = org.jose4j.jwt.JwtClaims.parse(claimsAsJsonString).getClaimsMap();
+                    isJWT = true;
+                }
+            } catch (Exception e2) {
+                // do nothing
+            }
+        } else {
+            // do nothing
+        }
+
+        if (isJWT) {
+            if (jwtClaims == null) { // grab the claims map if we haven't already
+                try {
+                    String claimsAsJsonString = new String(Base64.getDecoder().decode(parts[1]), "UTF-8");
+                    jwtClaims = org.jose4j.jwt.JwtClaims.parse(claimsAsJsonString).getClaimsMap();
+                } catch (Exception e1) {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, METHODNAME, "The tokenResponse accessTokenString was parsable for the first part, but couldn't parse out a claimsMap.", e1);
+                    }
+                }
+            }
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, METHODNAME, "Creating a jwt access token based on the tokenResponse accessTokenString");
+            }
+            return new AccessTokenImpl(accessTokenString, jwtClaims, tokenResponse.getResponseGenerationTime(), expiresIn, tokenMinValidityInMillis);
+        }
+
+        return new AccessTokenImpl(accessTokenString, tokenResponse.getResponseGenerationTime(), expiresIn, tokenMinValidityInMillis);
     }
 
     private IdentityToken createIdentityTokenFromTokenResponse(long tokenMinValidityInMillis, TokenResponse tokenResponse, JwtClaims idTokenClaims) {

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/tokens/AccessTokenImpl.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/tokens/AccessTokenImpl.java
@@ -48,8 +48,8 @@ public class AccessTokenImpl implements AccessToken, Serializable {
     public AccessTokenImpl(String tokenString, Map<String, Object> accessTokenClaimsMap, Instant responseGenerationTime, Long expirationTimeInSeconds,
                            Long tokenMinValidityInMillis) {
         this(tokenString, responseGenerationTime, expirationTimeInSeconds, tokenMinValidityInMillis);
-        this.accessTokenClaimsMap = accessTokenClaimsMap;
-        jwtClaims = new JwtClaimsImpl(accessTokenClaimsMap);
+        this.accessTokenClaimsMap = accessTokenClaimsMap == null ? Collections.emptyMap() : accessTokenClaimsMap;
+        jwtClaims = accessTokenClaimsMap == null ? JwtClaims.NONE : new JwtClaimsImpl(accessTokenClaimsMap);
         type = Type.BEARER;
     }
 


### PR DESCRIPTION
Check for token type and call appropriate constructor for `AccessToken` from `OidcIdentityStore`

Added unit tests for OidcIdentityStore.createAccessTokenFromTokenResponse

Follow up to #21171