### PR TITLE
Force @Interceptors instances to never be CDI Beans

### DIFF
--- a/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/apps/interceptors/Interceptor9.java
+++ b/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/apps/interceptors/Interceptor9.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.ejb.apps.interceptors;
+
+import javax.interceptor.AroundConstruct;
+import javax.interceptor.InvocationContext;
+
+public class Interceptor9 extends InterceptorBase {
+
+    @AroundConstruct
+    private void aroundConstruct(InvocationContext ic) {
+        System.out.println(">Interceptor9 aroundConstruct - " + this.hashCode());
+        try {
+            ic.proceed();
+        } catch (Exception e) {
+            // TODO Auto-generated catch block
+            // Do you need FFDC here? Remember FFDC instrumentation and @FFDCIgnore
+            // https://websphere.pok.ibm.com/~liberty/secure/docs/dev/API/com.ibm.ws.ras/com/ibm/ws/ffdc/annotation/FFDCIgnore.html
+            e.printStackTrace();
+        }
+        System.out.println("<Interceptor9 aroundConstruct - " + this.hashCode());
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/apps/interceptors/InterceptorA.java
+++ b/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/apps/interceptors/InterceptorA.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.ejb.apps.interceptors;
+
+import javax.interceptor.AroundConstruct;
+import javax.interceptor.InvocationContext;
+
+public class InterceptorA extends Interceptor9 {
+
+    @AroundConstruct
+    private void aroundConstruct(InvocationContext ic) {
+        System.out.println(">InterceptorA aroundConstruct - " + this.hashCode());
+        try {
+            ic.proceed();
+        } catch (Exception e) {
+            // TODO Auto-generated catch block
+            // Do you need FFDC here? Remember FFDC instrumentation and @FFDCIgnore
+            // https://websphere.pok.ibm.com/~liberty/secure/docs/dev/API/com.ibm.ws.ras/com/ibm/ws/ffdc/annotation/FFDCIgnore.html
+            e.printStackTrace();
+        }
+        System.out.println("<InterceptorA aroundConstruct - " + this.hashCode());
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/apps/interceptors/InterceptorBase.java
+++ b/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/apps/interceptors/InterceptorBase.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.ejb.apps.interceptors;
+
+import javax.annotation.PostConstruct;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.InvocationContext;
+
+abstract class InterceptorBase {
+
+    @PostConstruct
+    private void postConstruct(InvocationContext ic) {
+        System.out.println(">InterceptorBase postConstruct - " + this.hashCode());
+        try {
+            ic.proceed();
+        } catch (Exception e) {
+            // TODO Auto-generated catch block
+            // Do you need FFDC here? Remember FFDC instrumentation and @FFDCIgnore
+            // https://websphere.pok.ibm.com/~liberty/secure/docs/dev/API/com.ibm.ws.ras/com/ibm/ws/ffdc/annotation/FFDCIgnore.html
+            e.printStackTrace();
+        }
+        System.out.println("<InterceptorBase postConstruct - " + this.hashCode());
+    }
+
+    @AroundInvoke
+    private Object aroundInvoke(InvocationContext ic) {
+        System.out.println(">InterceptorBase aroundInvoke - " + this.hashCode());
+        Object res;
+        try {
+            res = ic.proceed();
+        } catch (Exception e) {
+            res = e;
+            e.printStackTrace();
+        }
+        System.out.println("<InterceptorBase aroundInvoke - " + this.hashCode());
+        return res;
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/apps/interceptors/InterceptorsTestServlet.java
+++ b/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/apps/interceptors/InterceptorsTestServlet.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.ejb.apps.interceptors;
+
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@WebServlet("/")
+public class InterceptorsTestServlet extends FATServlet {
+
+    @Inject
+    private RequestScopedBean bean;
+
+    @Test
+    public void testEJB() {
+        bean.message();
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/apps/interceptors/RequestScopedBean.java
+++ b/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/apps/interceptors/RequestScopedBean.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.ejb.apps.interceptors;
+
+import javax.ejb.EJB;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Named;
+
+@Named("RequestScopedBean")
+@RequestScoped
+public class RequestScopedBean {
+
+    @EJB
+    SingletonEJB ejb;
+
+    public String message() {
+        return ejb.message();
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/apps/interceptors/SingletonEJB.java
+++ b/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/apps/interceptors/SingletonEJB.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.ejb.apps.interceptors;
+
+import javax.ejb.Singleton;
+import javax.interceptor.Interceptors;
+
+@Singleton
+@Interceptors({ InterceptorA.class, Interceptor9.class })
+public class SingletonEJB {
+
+    public SingletonEJB() {
+        System.out.println("SingletonEJB xtor");
+    }
+
+    public String message() {
+        System.out.println("SingletonEJB message - " + this.hashCode());
+        return "Hello";
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/FATSuite.java
+++ b/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/FATSuite.java
@@ -30,6 +30,7 @@ import com.ibm.ws.fat.util.FatLogHandler;
                 EjbScopeTest.class,
                 EjbTimerTest.class,
                 InjectParameterTest.class,
+                InterceptorsTest.class,
                 MultipleNamedEJBTest.class,
                 StatefulSessionBeanInjectionTest.class,
 })

--- a/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/InterceptorsTest.java
+++ b/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/InterceptorsTest.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.ejb.tests;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.CDIArchiveHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+import com.ibm.websphere.simplicity.beansxml.BeansAsset.DiscoveryMode;
+import com.ibm.ws.cdi.ejb.apps.interceptors.InterceptorsTestServlet;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.annotation.TestServlets;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.EERepeatActions;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+/**
+ * Testing that interceptors bound with an @Interceptors annotation on an ejb can be resolved
+ * even when they have a common type. In this case we force them not to be CDI beans.
+ */
+@RunWith(FATRunner.class)
+public class InterceptorsTest extends FATServletClient {
+
+    public static final String INTERCEPTORS_APP_NAME = "interceptorsApp";
+    public static final String SERVER_NAME = "interceptorsServer";
+
+    //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
+    @ClassRule
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE7, EERepeatActions.EE9);
+
+    @Server(SERVER_NAME)
+    @TestServlets({
+                    @TestServlet(servlet = InterceptorsTestServlet.class, contextRoot = INTERCEPTORS_APP_NAME)
+    })
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        WebArchive interceptorsApp = ShrinkWrap.create(WebArchive.class, INTERCEPTORS_APP_NAME + ".war")
+                                               .addPackages(true, InterceptorsTestServlet.class.getPackage());
+        CDIArchiveHelper.addBeansXML(interceptorsApp, DiscoveryMode.ALL);
+
+        ShrinkHelper.exportDropinAppToServer(server, interceptorsApp, DeployOptions.SERVER_ONLY);
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.ejb_fat/publish/servers/interceptorsServer/bootstrap.properties
+++ b/dev/com.ibm.ws.cdi.ejb_fat/publish/servers/interceptorsServer/bootstrap.properties
@@ -1,0 +1,2 @@
+bootstrap.include=../testports.properties
+osgi.console=7777

--- a/dev/com.ibm.ws.cdi.ejb_fat/publish/servers/interceptorsServer/server.xml
+++ b/dev/com.ibm.ws.cdi.ejb_fat/publish/servers/interceptorsServer/server.xml
@@ -1,0 +1,16 @@
+<server description="Server for testing EJB on CDI">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>osgiconsole-1.0</feature>
+        <feature>cdi-1.2</feature>
+        <feature>ejbLite-3.2</feature>
+        <feature>servlet-3.1</feature>
+        <feature>componentTest-1.0</feature>
+        <feature>jsf-2.2</feature>
+    </featureManager>
+<!--  
+    <logging traceSpecification="**=info:JCDI=all:com.ibm.ws.cdi*=all:com.ibm.ws.weld*=all:org.jboss.*=all:Injection=all"/>
+-->    
+</server>

--- a/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/managedobject/CDIInterceptorManagedObjectFactoryImpl.java
+++ b/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/managedobject/CDIInterceptorManagedObjectFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2018 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@
 package com.ibm.ws.cdi.impl.managedobject;
 
 import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.InjectionTarget;
 
 import org.jboss.weld.construction.api.WeldCreationalContext;
@@ -42,7 +43,8 @@ public class CDIInterceptorManagedObjectFactoryImpl<T> extends AbstractManagedOb
 
         @SuppressWarnings("unchecked")
         WeldCreationalContext<T> creationalContext = managedObjectContext.getContextData(WeldCreationalContext.class);
-        creationalContext = CreationalContextResolver.resolve(creationalContext, getBean());
+        Bean<T> bean = getBean();
+        creationalContext = CreationalContextResolver.resolve(creationalContext, bean);
 
         return creationalContext;
     }
@@ -73,6 +75,13 @@ public class CDIInterceptorManagedObjectFactoryImpl<T> extends AbstractManagedOb
         }
 
         return injectionTarget;
+    }
+
+    @Override
+    protected synchronized Bean<T> getBean() throws ManagedObjectException {
+        //in theory this MOF is only used with the @Interceptors annotation
+        //such interceptors are never CDI beans
+        return null;
     }
 
     @Override


### PR DESCRIPTION
When an interceptor class is declared via the @Interceptors annotation on an EJB, it should never be treated as a CDI Bean ... even if discovery-mode=all

#build
