### PR TITLE
Ensure tracer error doesn't prevent DataSource injection

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
@@ -1124,9 +1124,16 @@ public class WSManagedConnectionFactoryImpl extends WSManagedConnectionFactory i
         for (Class<?> cl = d.getClass(); cl != null; cl = cl.getSuperclass())
             classes.addAll(Arrays.asList(cl.getInterfaces()));
         
-        return Proxy.newProxyInstance(jdbcDriverLoader,
-                                      classes.toArray(new Class[classes.size()]),
-                                      tracer);
+        try {
+            return Proxy.newProxyInstance(jdbcDriverLoader,
+                                          classes.toArray(new Class[classes.size()]),
+                                          tracer);
+        } catch (IllegalArgumentException e) {
+            //Creating a proxy can fail based on jdbc driver restrictions.
+            //Throw a resource exception and let caller handle it. 
+            throw new ResourceException(e);
+        } //TODO handle security exceptions
+        
     }
 
     /**


### PR DESCRIPTION
As part of our trace enablement, we attempt to create a proxy to the DataSource object so that we can trace method entries and exits.  However, it is possible for jdbc drivers to restrict access to certain classes/methods which would result in an IllegalArgumentException.

As it is today, the IllegalArgumentException is never caught and therefore will prevent DataSource injection.  
We should instead handle this exception case and log it as this should not prevent DataSource useage. 

This happens when using `WAS.database=all` trace. 