### PR TITLE
Fix java.lang.NoClassDefFoundError: jakarta.json.JsonObject for issue #21163

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/bnd.bnd
@@ -54,6 +54,7 @@ src: src, resources
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	io.openliberty.jakarta.authentication.3.0;version=latest,\
 	io.openliberty.jakarta.cdi.4.0,\
+	io.openliberty.jakarta.jsonp.2.1,\
 	io.openliberty.jakarta.security.3.0,\
 	io.openliberty.jakarta.servlet.6.0,\
 	io.openliberty.security.jakartasec.2.0.internal,\

--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/extensions/OpenIdContextBean.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/extensions/OpenIdContextBean.java
@@ -35,6 +35,7 @@ import jakarta.enterprise.inject.spi.InjectionPoint;
 import jakarta.enterprise.inject.spi.PassivationCapable;
 import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.enterprise.util.TypeLiteral;
+import jakarta.json.JsonObject;
 import jakarta.security.enterprise.identitystore.openid.OpenIdContext;
 
 public class OpenIdContextBean implements Bean<OpenIdContext>, PassivationCapable {
@@ -183,5 +184,10 @@ public class OpenIdContextBean implements Bean<OpenIdContext>, PassivationCapabl
          * TODO: Could be returning null here -- do we want to return an empty or dummy openIdContext or stay with null if not found?
          */
         return openIdContext;
+    }
+
+    // Workaround for CDI proxy dependency on jakarta.json classes.
+    private JsonObject getJsonObject() {
+        return null;
     }
 }


### PR DESCRIPTION
For issue #21163

This fixes java.lang.NoClassDefFoundError: jakarta.json.JsonObject when the CDI proxy for the OpenIdContext is called to return the JsonObject. 