### PR TITLE
Restore MP JWT 1.2 and 2.0 TCK except failing test on Java 19

### DIFF
--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/FATSuite.java
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/FATSuite.java
@@ -14,8 +14,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import componenttest.annotation.MaximumJavaLevel;
-
 @RunWith(Suite.class)
 @SuiteClasses({
                 Mpjwt12TCKLauncher_aud_env.class,
@@ -26,6 +24,5 @@ import componenttest.annotation.MaximumJavaLevel;
                 DummyForQuarantine.class
 })
 
-@MaximumJavaLevel(javaLevel = 18)
 public class FATSuite {
 }

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/Mpjwt12TCKLauncher_aud_env.java
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/Mpjwt12TCKLauncher_aud_env.java
@@ -16,7 +16,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import componenttest.annotation.AllowedFFDC;
-import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -27,7 +26,6 @@ import componenttest.topology.utils.tck.TCKUtils;
  * This is a test class that runs a whole Maven TCK as one test FAT test. *
  */
 //@Mode(TestMode.QUARANTINE)
-@MaximumJavaLevel(javaLevel = 18)
 @RunWith(FATRunner.class)
 public class Mpjwt12TCKLauncher_aud_env {
 

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/Mpjwt12TCKLauncher_aud_noenv.java
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/Mpjwt12TCKLauncher_aud_noenv.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import componenttest.annotation.AllowedFFDC;
-import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -31,7 +30,6 @@ import componenttest.topology.utils.tck.TCKUtils;
  *
  */
 //@Mode(TestMode.QUARANTINE)
-@MaximumJavaLevel(javaLevel = 18)
 @RunWith(FATRunner.class)
 public class Mpjwt12TCKLauncher_aud_noenv {
 

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/Mpjwt12TCKLauncher_aud_noenv2.java
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/Mpjwt12TCKLauncher_aud_noenv2.java
@@ -18,7 +18,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -30,7 +29,6 @@ import componenttest.topology.utils.tck.TCKUtils;
  *
  */
 //@Mode(TestMode.QUARANTINE)
-@MaximumJavaLevel(javaLevel = 18)
 @RunWith(FATRunner.class)
 public class Mpjwt12TCKLauncher_aud_noenv2 {
 

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/Mpjwt12TCKLauncher_noaud_env.java
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/Mpjwt12TCKLauncher_noaud_env.java
@@ -16,7 +16,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import componenttest.annotation.AllowedFFDC;
-import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -27,7 +26,6 @@ import componenttest.topology.utils.tck.TCKUtils;
  * This is a test class that runs a whole Maven TCK as one test FAT test. *
  */
 //@Mode(TestMode.QUARANTINE)
-@MaximumJavaLevel(javaLevel = 18)
 @RunWith(FATRunner.class)
 public class Mpjwt12TCKLauncher_noaud_env {
 

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/Mpjwt12TCKLauncher_noaud_noenv.java
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/Mpjwt12TCKLauncher_noaud_noenv.java
@@ -15,9 +15,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.tck.TCKResultsInfo.Type;
 import componenttest.topology.utils.tck.TCKUtils;
@@ -26,7 +26,6 @@ import componenttest.topology.utils.tck.TCKUtils;
  * This is a test class that runs a whole Maven TCK as one test FAT test. *
  */
 //@Mode(TestMode.QUARANTINE)
-@MaximumJavaLevel(javaLevel = 18)
 @RunWith(FATRunner.class)
 public class Mpjwt12TCKLauncher_noaud_noenv {
 
@@ -50,7 +49,7 @@ public class Mpjwt12TCKLauncher_noaud_noenv {
     @Test
     //@AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchMpjwt12TCK_noaud_noenv() throws Exception {
-        String suiteName = "tck_suite_noaud_noenv.xml";
+        String suiteName = JavaInfo.JAVA_VERSION < 19 ? "tck_suite_noaud_noenv.xml" : "tck_suite_noaud_noenv_java19.xml";
         String bucketName = "io.openliberty.microprofile.jwt.1.2.internal_fat_tck";
         String testName = this.getClass() + ":launchMpjwt12TCK_noaud_noenv";
         Type type = Type.MICROPROFILE;

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/tck_suite_noaud_noenv_java19.xml
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/tck_suite_noaud_noenv_java19.xml
@@ -1,0 +1,51 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="microprofile-jwt-auth-BaseTCK" verbose="1" preserve-order="true" configfailurepolicy="continue" >
+
+    <!-- The required base JAX-RS and CDI based tests that all MP-JWT implementations
+    must pass.
+    -->
+    <test name="base-tests" verbose="10">
+        <groups>
+            <define name="base-groups">
+                <include name="arquillian" description="Arquillian internal"/>
+                <include name="utils" description="Utility tests"/>
+                <include name="jwt" description="Base JsonWebToken tests"/>
+                <include name="jaxrs" description="JAX-RS invocation tests"/>
+                <include name="cdi" description="Base CDI injection of ClaimValues"/>
+                <include name="cdi-json" description="CDI injection of JSON-P values"/>
+                <include name="cdi-provider" description="CDI injection of javax.inject.Provider values"/>
+                <include name="config" description="Validate configuration using MP-config"/>
+            </define>
+            <define name="excludes">
+                <include name="debug" description="Internal debugging tests" />
+            </define>
+            <run>
+                <include name="base-groups" />
+                <exclude name="excludes" />
+            </run>
+        </groups>
+        <classes>
+
+              <!-- MP JWT 1.1 - These tests do not require an audience defined in the server.xml -->
+              <class name="org.eclipse.microprofile.jwt.tck.config.IssValidationFailTest" />  
+              
+              <!--  MP JWT 1.2 jaxrs tests  -->
+              <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudArrayValidationTest" />
+              <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationBadAudTest" />
+              <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationMissingAudTest" />
+              <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationTest" />
+
+             <!--  MP JWT 1.2 utils tests -->
+             <class name="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest">
+                <methods>
+	                  <!-- Test currently fails at Java 19+ (291095) -->
+	                  <exclude name="testFailAlgorithm" />
+                </methods>
+             </class>
+             <class name="org.eclipse.microprofile.jwt.tck.util.TokenUtilsExtraTest" />
+             <class name="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" />
+             
+        </classes>
+    </test>
+
+</suite>

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/Mpjwt20TCKLauncher_aud_env.java
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/Mpjwt20TCKLauncher_aud_env.java
@@ -16,7 +16,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import componenttest.annotation.AllowedFFDC;
-import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -27,7 +26,6 @@ import componenttest.topology.utils.tck.TCKUtils;
  * This is a test class that runs a whole Maven TCK as one test FAT test. *
  */
 //@Mode(TestMode.QUARANTINE)
-@MaximumJavaLevel(javaLevel = 18)
 @RunWith(FATRunner.class)
 public class Mpjwt20TCKLauncher_aud_env {
 

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/Mpjwt20TCKLauncher_aud_noenv.java
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/Mpjwt20TCKLauncher_aud_noenv.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import componenttest.annotation.AllowedFFDC;
-import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -31,7 +30,6 @@ import componenttest.topology.utils.tck.TCKUtils;
  *
  */
 //@Mode(TestMode.QUARANTINE)
-@MaximumJavaLevel(javaLevel = 18)
 @RunWith(FATRunner.class)
 public class Mpjwt20TCKLauncher_aud_noenv {
 

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/Mpjwt20TCKLauncher_aud_noenv2.java
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/Mpjwt20TCKLauncher_aud_noenv2.java
@@ -18,7 +18,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -30,7 +29,6 @@ import componenttest.topology.utils.tck.TCKUtils;
  *
  */
 //@Mode(TestMode.QUARANTINE)
-@MaximumJavaLevel(javaLevel = 18)
 @RunWith(FATRunner.class)
 public class Mpjwt20TCKLauncher_aud_noenv2 {
 

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/Mpjwt20TCKLauncher_noaud_env.java
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/Mpjwt20TCKLauncher_noaud_env.java
@@ -16,7 +16,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import componenttest.annotation.AllowedFFDC;
-import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -27,7 +26,6 @@ import componenttest.topology.utils.tck.TCKUtils;
  * This is a test class that runs a whole Maven TCK as one test FAT test. *
  */
 //@Mode(TestMode.QUARANTINE)
-@MaximumJavaLevel(javaLevel = 18)
 @RunWith(FATRunner.class)
 public class Mpjwt20TCKLauncher_noaud_env {
 

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/Mpjwt20TCKLauncher_noaud_noenv.java
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/Mpjwt20TCKLauncher_noaud_noenv.java
@@ -15,9 +15,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.tck.TCKResultsInfo.Type;
 import componenttest.topology.utils.tck.TCKUtils;
@@ -26,7 +26,6 @@ import componenttest.topology.utils.tck.TCKUtils;
  * This is a test class that runs a whole Maven TCK as one test FAT test. *
  */
 //@Mode(TestMode.QUARANTINE)
-@MaximumJavaLevel(javaLevel = 18)
 @RunWith(FATRunner.class)
 public class Mpjwt20TCKLauncher_noaud_noenv {
 
@@ -50,7 +49,7 @@ public class Mpjwt20TCKLauncher_noaud_noenv {
     @Test
     //@AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchMpjwt20TCK_noaud_noenv() throws Exception {
-        String suiteName = "tck_suite_noaud_noenv.xml";
+        String suiteName = JavaInfo.JAVA_VERSION < 19 ? "tck_suite_noaud_noenv.xml" : "tck_suite_noaud_noenv_java19.xml";
         String bucketName = "io.openliberty.microprofile.jwt.2.0.internal_fat_tck";
         String testName = this.getClass() + ":launchMpjwt20TCK_noaud_noenv";
         Type type = Type.MICROPROFILE;

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/publish/tckRunner/tck/tck_suite_noaud_noenv_java19.xml
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/publish/tckRunner/tck/tck_suite_noaud_noenv_java19.xml
@@ -1,0 +1,51 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="microprofile-jwt-auth-BaseTCK" verbose="1" preserve-order="true" configfailurepolicy="continue" >
+
+    <!-- The required base JAX-RS and CDI based tests that all MP-JWT implementations
+    must pass.
+    -->
+    <test name="base-tests" verbose="10">
+        <groups>
+            <define name="base-groups">
+                <include name="arquillian" description="Arquillian internal"/>
+                <include name="utils" description="Utility tests"/>
+                <include name="jwt" description="Base JsonWebToken tests"/>
+                <include name="jaxrs" description="JAX-RS invocation tests"/>
+                <include name="cdi" description="Base CDI injection of ClaimValues"/>
+                <include name="cdi-json" description="CDI injection of JSON-P values"/>
+                <include name="cdi-provider" description="CDI injection of javax.inject.Provider values"/>
+                <include name="config" description="Validate configuration using MP-config"/>
+            </define>
+            <define name="excludes">
+                <include name="debug" description="Internal debugging tests" />
+            </define>
+            <run>
+                <include name="base-groups" />
+                <exclude name="excludes" />
+            </run>
+        </groups>
+        <classes>
+
+              <!-- MP JWT 1.1 - These tests do not require an audience defined in the server.xml -->
+              <class name="org.eclipse.microprofile.jwt.tck.config.IssValidationFailTest" />  
+              
+              <!--  MP JWT 1.2 jaxrs tests  -->
+              <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudArrayValidationTest" />
+              <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationBadAudTest" />
+              <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationMissingAudTest" />
+              <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationTest" />
+
+             <!--  MP JWT 1.2 utils tests -->
+             <class name="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest">
+                <methods>
+	                  <!-- Test currently fails at Java 19+ (291095) -->
+	                  <exclude name="testFailAlgorithm" />
+                </methods>
+             </class>
+             <class name="org.eclipse.microprofile.jwt.tck.util.TokenUtilsExtraTest" />
+             <class name="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" />
+             
+        </classes>
+    </test>
+
+</suite>


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/open-liberty/issues/22933