### PR TITLE
Update mpMetrics-5.0 to not depend on servlet feature

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.adminSecurity-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.adminSecurity-1.0.feature
@@ -2,7 +2,7 @@
 symbolicName=com.ibm.websphere.appserver.adminSecurity-1.0
 WLP-DisableAllFeatures-OnConflict: false
 singleton=true
--features=com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0", \
+-features=io.openliberty.servlet.internal-3.0; ibm.tolerates:="3.1,4.0", \
   com.ibm.websphere.appserver.distributedMap-1.0, \
   com.ibm.websphere.appserver.security-1.0, \
   com.ibm.websphere.appserver.authFilter-1.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.adminSecurity-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.adminSecurity-2.0.feature
@@ -1,7 +1,7 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.adminSecurity-2.0
 singleton=true
--features=com.ibm.websphere.appserver.servlet-5.0; ibm.tolerates:="6.0", \
+-features=io.openliberty.servlet.internal-5.0; ibm.tolerates:="6.0", \
   com.ibm.websphere.appserver.distributedMap-1.0, \
   com.ibm.websphere.appserver.security-1.0
 -bundles=com.ibm.websphere.security, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.restHandler.internal-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.restHandler.internal-1.0.feature
@@ -1,0 +1,18 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.restHandler.internal-1.0
+WLP-DisableAllFeatures-OnConflict: false
+visibility=private
+IBM-App-ForceRestart: uninstall, \
+ install
+-features=com.ibm.websphere.appserver.json-1.0, \
+  io.openliberty.webBundleSecurity.internal-1.0, \
+  io.openliberty.webBundle.internal-1.0, \
+  com.ibm.websphere.appserver.ssl-1.0, \
+  io.openliberty.servlet.internal-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0", \
+  io.openliberty.restHandler1.0.internal.ee-6.0; ibm.tolerates:="9.0, 10.0", \
+  com.ibm.websphere.appserver.httptransport-1.0
+-bundles=com.ibm.ws.org.joda.time.1.6.2, \
+ com.ibm.websphere.jsonsupport, \
+ com.ibm.websphere.rest.handler
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.restHandler1.0.internal.ee-10.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.restHandler1.0.internal.ee-10.0.feature
@@ -1,0 +1,16 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+
+symbolicName = io.openliberty.restHandler1.0.internal.ee-10.0
+singleton=true
+visibility = private
+
+-features=\
+  io.openliberty.servlet.internal-6.0, \
+  com.ibm.websphere.appserver.adminSecurity-2.0, \
+  io.openliberty.securityAPI.jakarta-1.0
+
+-bundles= com.ibm.ws.rest.handler.jakarta
+
+kind=beta
+edition=core
+

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.restHandler1.0.internal.ee-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.restHandler1.0.internal.ee-6.0.feature
@@ -5,10 +5,18 @@ singleton=true
 WLP-DisableAllFeatures-OnConflict: false
 visibility = private
 
+IBM-SPI-Package: com.ibm.wsspi.rest.handler; type="ibm-spi", \
+ com.ibm.wsspi.rest.handler.helper; type="ibm-spi"
+
 -features=\
-  com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0"
+  io.openliberty.servlet.internal-3.0; ibm.tolerates:="3.1,4.0", \
+  com.ibm.websphere.appserver.adminSecurity-1.0, \
+  io.openliberty.securityAPI.javaee-1.0
 
 -bundles= com.ibm.ws.rest.handler
+
+-jars=com.ibm.websphere.appserver.spi.restHandler; location:=dev/spi/ibm/
+-files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.restHandler_2.0-javadoc.zip
 
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.restHandler1.0.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.restHandler1.0.internal.ee-9.0.feature
@@ -4,10 +4,18 @@ symbolicName = io.openliberty.restHandler1.0.internal.ee-9.0
 singleton=true
 visibility = private
 
+IBM-SPI-Package: com.ibm.wsspi.rest.handler; type="ibm-spi", \
+ com.ibm.wsspi.rest.handler.helper; type="ibm-spi"
+
 -features=\
-  com.ibm.websphere.appserver.servlet-5.0; ibm.tolerates:="6.0"
+  io.openliberty.servlet.internal-5.0, \
+  com.ibm.websphere.appserver.adminSecurity-2.0, \
+  io.openliberty.securityAPI.jakarta-1.0
 
 -bundles= com.ibm.ws.rest.handler.jakarta
+
+-jars=com.ibm.websphere.appserver.spi.restHandler; location:=dev/spi/ibm/
+-files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.restHandler_2.0-javadoc.zip
 
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.restHandler-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.restHandler-1.0.feature
@@ -6,19 +6,12 @@ IBM-App-ForceRestart: uninstall, \
  install
 IBM-SPI-Package: com.ibm.wsspi.rest.handler; type="ibm-spi", \
  com.ibm.wsspi.rest.handler.helper; type="ibm-spi"
--features=com.ibm.websphere.appserver.json-1.0, \
+-features=io.openliberty.restHandler.internal-1.0, \
   com.ibm.wsspi.appserver.webBundleSecurity-1.0, \
   com.ibm.wsspi.appserver.webBundle-1.0, \
-  com.ibm.websphere.appserver.ssl-1.0, \
   com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0", \
-  com.ibm.websphere.appserver.adminSecurity-1.0; ibm.tolerates:="2.0", \
   io.openliberty.securityAPI.javaee-1.0, \
-  io.openliberty.securityAPI.jakarta-1.0, \
-  io.openliberty.restHandler1.0.internal.ee-6.0; ibm.tolerates:="9.0", \
-  com.ibm.websphere.appserver.httptransport-1.0
--bundles=com.ibm.ws.org.joda.time.1.6.2, \
- com.ibm.websphere.jsonsupport, \
- com.ibm.websphere.rest.handler
+  io.openliberty.securityAPI.jakarta-1.0
 -jars=com.ibm.websphere.appserver.spi.restHandler; location:=dev/spi/ibm/
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.restHandler_2.0-javadoc.zip
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-6.0/io.openliberty.microProfile-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-6.0/io.openliberty.microProfile-6.0.feature
@@ -7,13 +7,11 @@ IBM-App-ForceRestart: install, \
 IBM-ShortName: microProfile-6.0
 Subsystem-Name: MicroProfile 6.0
 -features=\
-  io.openliberty.noShip-1.0, \
   io.openliberty.cdi-4.0, \
   io.openliberty.jsonb-3.0, \
   io.openliberty.jsonp-2.1, \
   io.openliberty.restfulWS-3.1, \
   io.openliberty.restfulWSClient-3.1, \
-  com.ibm.websphere.appserver.servlet-6.0, \
   io.openliberty.mpCompatible-6.0, \
   io.openliberty.mpConfig-3.0, \
   io.openliberty.mpHealth-4.0, \
@@ -23,5 +21,5 @@ Subsystem-Name: MicroProfile 6.0
   io.openliberty.mpMetrics-5.0, \
   io.openliberty.mpRestClient-3.0, \
   io.openliberty.mpTelemetry-1.0
-kind=noship
-edition=full
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-5.0/io.openliberty.mpMetrics-5.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-5.0/io.openliberty.mpMetrics-5.0.feature
@@ -6,10 +6,10 @@ IBM-API-Package: org.eclipse.microprofile.metrics.annotation;  type="stable", \
  org.eclipse.microprofile.metrics; type="stable"
 IBM-ShortName: mpMetrics-5.0
 Subsystem-Name: MicroProfile Metrics 5.0
--features=com.ibm.websphere.appserver.restHandler-1.0, \
+-features=io.openliberty.restHandler.internal-1.0, \
   io.openliberty.mpConfig-3.0, \
   io.openliberty.jakarta.annotation-2.1,\
-  com.ibm.websphere.appserver.servlet-6.0, \
+  io.openliberty.servlet.internal-6.0, \
   io.openliberty.mpCompatible-6.0, \
   io.openliberty.cdi-4.0, \
   io.openliberty.org.eclipse.microprofile.metrics-5.0, \

--- a/dev/io.openliberty.microprofile.metrics.internal.5.0_fat_tck/publish/servers/MetricsTCKServer/server.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.0_fat_tck/publish/servers/MetricsTCKServer/server.xml
@@ -6,6 +6,7 @@
         <feature>localConnector-1.0</feature>
         <feature>ssl-1.0</feature>
         <feature>arquillian-support-jakarta-2.1</feature>
+        <feature>servlet-6.0</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml" />


### PR DESCRIPTION
Part of https://github.com/OpenLiberty/open-liberty/issues/19980
- Create internal restHandler feature that does not expose the servlet public feature when doing EE6.  Update the protected restHandle feature to depend on the internal feature
- Update mpMetrics-5.0 to use the new internal restHandler feature
- Change microProfile-6.0 feature to beta.
