### PR TITLE
Remove BND Builder since there is no bnd file

### DIFF
--- a/dev/cnf/gradle/replacement.project.templates/.project.template
+++ b/dev/cnf/gradle/replacement.project.templates/.project.template
@@ -10,14 +10,8 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>bndtools.core.bndbuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>bndtools.core.bndnature</nature>
 	</natures>
 </projectDescription>


### PR DESCRIPTION
The generated stub projects do not currently include a bnd file. Newer versions of the bnd builder fail to build anything if that file is missing. So for now (until a bnd file is added), remove the bnd builder from the template for the stub projects.
#build
