### PR TITLE
upgrade Jackson 1x to io.openliberty.org.codehaus.jackson 1.9.13.1

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -42,13 +42,9 @@ com.ibm.ws.org.apache.yoko:yoko-spec-corba:1.5.0.48b8f2f105
 com.ibm.ws.org.apache.yoko:yoko-util:1.5.0.48b8f2f105
 com.ibm.ws.org.apache:xalan:2.7.2
 com.ibm.ws.org.codehaus.jackson:jackson-core-asl:1.6.2.1
-com.ibm.ws.org.codehaus.jackson:jackson-core-asl:1.9.13
 com.ibm.ws.org.codehaus.jackson:jackson-jaxrs:1.6.2.1
-com.ibm.ws.org.codehaus.jackson:jackson-jaxrs:1.9.13
 com.ibm.ws.org.codehaus.jackson:jackson-mapper-asl:1.6.2.1
-com.ibm.ws.org.codehaus.jackson:jackson-mapper-asl:1.9.13
 com.ibm.ws.org.codehaus.jackson:jackson-xc:1.6.2.1
-com.ibm.ws.org.codehaus.jackson:jackson-xc:1.9.13
 com.ibm.ws.org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.1.20200728.204607-6
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.antlr:2.6.10.WAS-3707413
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.core:2.6.10.WAS-3707413
@@ -59,6 +55,10 @@ com.ibm.ws.org.objenesis:objenesis:1.0
 com.ibm.ws:geronimo-validation:1.1
 com.ibm.ws:nekohtml:1.9.18
 io.openliberty.jakarta.ws.rs:jakarta-restful-ws-tck:3.1.2
+io.openliberty.org.codehaus.jackson:jackson-core-asl:1.9.13.1
+io.openliberty.org.codehaus.jackson:jackson-jaxrs:1.9.13.1
+io.openliberty.org.codehaus.jackson:jackson-mapper-asl:1.9.13.1
+io.openliberty.org.codehaus.jackson:jackson-xc:1.9.13.1
 net.sf.jtidy:jtidy:9.3.8
 org.apache.aries.blueprint:org.apache.aries.blueprint:1.3.0-ibm-s20170710-0926
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0

--- a/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2021 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -134,10 +134,10 @@ Private-Package:\
    com.ibm.ws.jaxrs20.*
 
 Include-Resource: \
-  @${repo;com.ibm.ws.org.codehaus.jackson:jackson-xc;1.9.13}, \
-  @${repo;com.ibm.ws.org.codehaus.jackson:jackson-mapper-asl;1.9.13}, \
-  @${repo;com.ibm.ws.org.codehaus.jackson:jackson-jaxrs;1.9.13}, \
-  @${repo;com.ibm.ws.org.codehaus.jackson:jackson-core-asl;1.9.13}, \
+  @${repo;io.openliberty.org.codehaus.jackson:jackson-xc;1.9.13.1}, \
+  @${repo;io.openliberty.org.codehaus.jackson:jackson-mapper-asl;1.9.13.1}, \
+  @${repo;io.openliberty.org.codehaus.jackson:jackson-jaxrs;1.9.13.1}, \
+  @${repo;io.openliberty.org.codehaus.jackson:jackson-core-asl;1.9.13.1}, \
   @${repo;org.apache.cxf.cxf-rt-rs-service-description;3.1.18;EXACT}, \
   @${repo;org.apache.cxf.cxf-tools-wadlto-jaxrs;3.1.18;EXACT}, \
   @${repo;org.apache.cxf.cxf-tools-common;3.1.18;EXACT}, \
@@ -155,8 +155,6 @@ Include-Resource: \
  	com.ibm.ws.jaxrs20.providers.security.SecurityAnnoProviderRegister, \
  	com.ibm.ws.cxf.jaxrs20.client.component.*
 
--dependson: com.ibm.ws.org.codehaus.jackson
-
 instrument.ffdc: false
 instrument.classesExcludes: com/ibm/ws/jaxrs20/internal/resources/*.class, \
 	org/apache/cxf/common/util/UrlUtils.class
@@ -170,7 +168,10 @@ instrument.classesExcludes: com/ibm/ws/jaxrs20/internal/resources/*.class, \
 	org.apache.cxf.cxf-tools-common;strategy=exact;version=3.1.18,\
 	org.apache.cxf.cxf-tools-wadlto-jaxrs;strategy=exact;version=3.1.18,\
 	org.apache.cxf.cxf-rt-rs-service-description;strategy=exact;version=3.1.18,\
-	com.ibm.ws.org.codehaus.jackson.1.6.2;version=latest,\
+	io.openliberty.org.codehaus.jackson:jackson-core-asl;strategy=exact;version=1.9.13.1, \
+	io.openliberty.org.codehaus.jackson:jackson-jaxrs;strategy=exact;version=1.9.13.1, \
+	io.openliberty.org.codehaus.jackson:jackson-mapper-asl;strategy=exact;version=1.9.13.1, \
+	io.openliberty.org.codehaus.jackson:jackson-xc;strategy=exact;version=1.9.13.1,\
 	com.ibm.ws.adaptable.module;version=latest,\
 	com.ibm.ws.anno;version=latest,\
 	com.ibm.ws.artifact;version=latest,\

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019,2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
+apply from: '../wlp-gradle/subprojects/repos.gradle'
 
 configurations {
   cxf
@@ -30,10 +30,10 @@ dependencies {
     'org.apache.cxf:cxf-rt-rs-client:3.1.18',
     'org.apache.cxf:cxf-rt-rs-extension-providers:3.1.18',
     'org.apache.cxf:cxf-rt-transports-http:3.1.18'
-  jackson1x 'org.codehaus.jackson:jackson-core-asl:1.6.2',
-    'org.codehaus.jackson:jackson-jaxrs:1.6.2',
-    'org.codehaus.jackson:jackson-mapper-asl:1.6.2',
-    'org.codehaus.jackson:jackson-xc:1.6.2'
+  jackson1x 'io.openliberty.org.codehaus.jackson:jackson-core-asl:1.9.13.1',
+    'io.openliberty.org.codehaus.jackson:jackson-jaxrs:1.9.13.1',
+    'io.openliberty.org.codehaus.jackson:jackson-mapper-asl:1.9.13.1',
+    'io.openliberty.org.codehaus.jackson:jackson-xc:1.9.13.1'
   jackson2x project(':io.openliberty.com.fasterxml.jackson'),
     project(':io.openliberty.com.fasterxml.jackson.jaxrs')
   jersey 'org.glassfish.hk2.external:aopalliance-repackaged:2.3.0-b10',
@@ -93,7 +93,7 @@ task addJersey(type: Copy) {
 
 task addJersey2(type: Copy) {
   from configurations.jersey
-  into "${buildDir}/autoFVT/appLibs/jerseywithinjection/"  
+  into "${buildDir}/autoFVT/appLibs/jerseywithinjection/"
 }
 
 task addJson(type: Copy) {


### PR DESCRIPTION
Jackson 1.9.13 is the last release of Jackson 1.X. Jackson has stated that they will never make another 1.X release.
However, they have backported several fixes without creating a new release. We want those fixes as well as the ability to maintain Jackson ourselves going forward.

Jackson's offical 1.X repo: https://github.com/FasterXML/jackson-1
IBM's fork: https://github.com/OpenLiberty/jackson-1

I created 1.9.13.1 from our fork with the backported fixes and this PR updates Open Liberty to use the IBM Jackson jars with the fixes.