### PR TITLE
Add repeats to the rest 3.1 TCK FAT

### DIFF
--- a/dev/io.openliberty.jakarta.rest.3.1.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.jakarta.rest.3.1.internal_fat_tck/bnd.bnd
@@ -15,6 +15,8 @@ bVersion=1.0
 src: \
 	fat/src
 
+tested.features=webprofile-10.0
+
 fat.project: true
 
 

--- a/dev/io.openliberty.jakarta.rest.3.1.internal_fat_tck/fat/src/io/openliberty/jakarta/rest31/tck/JakartaRest31TckPackageTest.java
+++ b/dev/io.openliberty.jakarta.rest.3.1.internal_fat_tck/fat/src/io/openliberty/jakarta/rest31/tck/JakartaRest31TckPackageTest.java
@@ -12,9 +12,12 @@ package io.openliberty.jakarta.rest31.tck;
 
 
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -23,6 +26,9 @@ import com.ibm.websphere.simplicity.log.Log;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.RepeatTestFilter;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.tck.TCKUtils;
 import componenttest.topology.utils.tck.TCKResultsInfo.Type;
@@ -33,6 +39,18 @@ import componenttest.topology.utils.tck.TCKResultsInfo.Type;
  */
 @RunWith(FATRunner.class)
 public class JakartaRest31TckPackageTest {
+
+    private static final Set<String> featuresToRemove = new HashSet<>();
+    static {
+        featuresToRemove.add("appSecurity-5.0");
+        featuresToRemove.add("xmlBinding-4.0");
+        featuresToRemove.add("webProfile-10.0");
+    }
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.withoutModification().
+        andWith(new FeatureReplacementAction().removeFeatures(featuresToRemove).addFeature("webProfile-10.0").withID("webProfile").fullFATOnly()).
+        andWith(new FeatureReplacementAction().removeFeatures(featuresToRemove).withID("coreProfile").fullFATOnly());
 
     @Server("FATServer")
     public static LibertyServer server;
@@ -59,7 +77,13 @@ public class JakartaRest31TckPackageTest {
         HashMap<String, String> props = new HashMap<String, String>(); 
         // The Java Se Bootstrap API added in EE10 is optional and not supported by Open Liberty.   So the 
         // following property is being added to exclude those tests.
-        props.put("excludedGroups","se_bootstrap");
+        if (RepeatTestFilter.isRepeatActionActive("webProfile")) {
+            props.put("excludedGroups","se_bootstrap,xml_binding");
+        } else if (RepeatTestFilter.isRepeatActionActive("coreProfile")) {
+            props.put("excludedGroups","se_bootstrap,xml_binding,servlet,security");
+        } else {
+            props.put("excludedGroups","se_bootstrap");
+        }
         
         String bucketName = "io.openliberty.jakarta.rest.3.1.internal_fat_tck";
         String testName = this.getClass() + ":testJakarta31RestTck";

--- a/dev/io.openliberty.jakarta.rest.3.1.internal_fat_tck/publish/tckRunner/tck/src/main/resources/arquillian.xml
+++ b/dev/io.openliberty.jakarta.rest.3.1.internal_fat_tck/publish/tckRunner/tck/src/main/resources/arquillian.xml
@@ -27,6 +27,7 @@
             <property name="failSafeUndeployment">${tck_failSafeUndeployment}</property>
             <property name="appUndeployTimeout">120</property>
             <property name="javaVmArguments">-Dcom.ibm.tools.attach.enable=yes</property> <!-- this goes here because this tck project asks arquillian to start the server -->
+            <property name="testProtocol">rest</property>
         </configuration>
     </container>
 </arquillian>


### PR DESCRIPTION
- Add repeats for web profile and core profile
- Run the TCK with the rest testProtocol
