### PR TITLE
Update server.xml

### DIFF
--- a/dev/com.ibm.ws.microprofile.openapi_fat/publish/servers/FilterServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/publish/servers/FilterServer/server.xml
@@ -20,6 +20,4 @@
     <feature>jaxrs-2.0</feature> <!-- EE feature to ensure we get the expected EE version -->
   </featureManager>
 
-  <keyStore id="defaultKeyStore" password="password" />
-
 </server>


### PR DESCRIPTION
Removed the keyStore entry from server.xml, as the test cases do not require this. Also it was unable to delete when repeating test cases, as when deleting the liberty server, the keystore creation process had not yet finished
