### PR TITLE
Fix jsp:plugin test

### DIFF
--- a/dev/io.openliberty.pages.3.1.internal_fat/test-applications/Misc.war/resources/jspPlugin.jsp
+++ b/dev/io.openliberty.pages.3.1.internal_fat/test-applications/Misc.war/resources/jspPlugin.jsp
@@ -18,7 +18,7 @@
 
     <p> Verify jsp:plugin logging occurs in trace </p>
 
-     Nothing should be generated <jsp:plugin /> in between. 
+     Nothing should be generated <jsp:plugin type="bean" code="bar.class" codebase="/" ></jsp:plugin> in between. 
     
 </body>
 </html>


### PR DESCRIPTION
Validation processing was added back in for the jsp:plugin to address TCK failures.

FULL mode for this this must have never run prior. 

related to #22747  (TCK fixes introduced this failure.  Previously  the jsp:plugin validation was skipped, but then it was then added back in. ) 