### PR TITLE
Add data-1.0 back in the java levels file.

### DIFF
--- a/dev/build.featureStart.base/resources/feature-java-levels.properties
+++ b/dev/build.featureStart.base/resources/feature-java-levels.properties
@@ -5,6 +5,7 @@ batch-2.1=11
 cdi-4.0=11
 concurrent-3.0=11
 connectors-2.1=11
+data-1.0=11
 expressionLanguage-5.0=11
 faces-4.0=11
 facesContainer-4.0=11


### PR DESCRIPTION
When the restructure of the feature start tests was done the data-1.0 change to start with Java 11 was lost.