### PR TITLE
log nls messages when an issuer and/or jwks uri cannot be found

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/NoProviderURIInAnnotationWithProviderMetadata.war/src/oidc/client/noProviderURIInAnnotationWithProviderMetadata/servlets/NoProviderURIInAnnotationWithProviderMetadataServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/NoProviderURIInAnnotationWithProviderMetadata.war/src/oidc/client/noProviderURIInAnnotationWithProviderMetadata/servlets/NoProviderURIInAnnotationWithProviderMetadataServlet.java
@@ -29,7 +29,7 @@ import oidc.client.base.servlets.BaseServlet;
                                                                                     tokenEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/token",
                                                                                     issuer = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1",
                                                                                     idTokenSigningAlgorithmsSupported = "RS256",
-                                                                                    jwksURI = "",
+                                                                                    jwksURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/jwk",
                                                                                     responseTypeSupported = "code,id_token,token id_token",
                                                                                     subjectTypeSupported = "public",
                                                                                     userinfoEndpoint = ""))

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/discovery/OidcDiscoveryConstants.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/discovery/OidcDiscoveryConstants.java
@@ -15,6 +15,8 @@ public class OidcDiscoveryConstants {
     public static final String METADATA_KEY_AUTHORIZATION_ENDPOINT = "authorization_endpoint";
     public static final String METADATA_KEY_TOKEN_ENDPOINT = "token_endpoint";
     public static final String METADATA_KEY_USERINFO_ENDPOINT = "userinfo_endpoint";
+    public static final String METADATA_KEY_JWKS_URI = "jwks_uri";
+    public static final String METADATA_KEY_ISSUER = "issuer";
 
     public static final String WELL_KNOWN_SUFFIX = ".well-known/openid-configuration";
 


### PR DESCRIPTION
for #22634 

log nls messages when an issuer and/or jwks uri cannot be found in 1. provider metadata and 2. discovery metadata.

the issuer and jwks uri are required metadata values and now log nls messages when they are missing, similarly to what is logged when the auth or token endpoints are missing.

missing auth endpoint (existing):
```
[ERROR   ] CWWKS2401E: The configuration for the client_1 OpenID Connect client is not valid or is missing data. CWWKS2404E: The providerURI attribute for the client_1 OpenID Connect client is null or empty, and there is no metadata available for the OpenID Connect provider.
[ERROR   ] CWWKS2400E: The client_1 OpenID Connect client encountered an error while sending an authorization request to the OpenID Connect provider. CWWKS2403E: The client_1 OpenID Connect client encountered the following error during discovery of metadata for the OpenID Connect provider from the [] URL: CWWKS2405E: The OpenID Connect provider metadata is missing the required [authorization_endpoint] property.
```

missing issuer:
```
[ERROR   ] CWWKS2401E: The configuration for the client_1 OpenID Connect client is not valid or is missing data. CWWKS2404E: The providerURI attribute for the client_1 OpenID Connect client is null or empty, and there is no metadata available for the OpenID Connect provider.
[ERROR   ] CWWKS2504E: The client_1 OpenID Connect client encountered the following error while validating the credential for the authenticated user: io.openliberty.security.oidcclientcore.token.TokenValidationException: CWWKS2415E: The client_1 OpenID Connect client encountered the following error during validation of the token that was received from the OpenID Connect provider: CWWKS2403E: The client_1 OpenID Connect client encountered the following error during discovery of metadata for the OpenID Connect provider from the [] URL: CWWKS2405E: The OpenID Connect provider metadata is missing the required [issuer] property.
```

missing jwks uri:
```
[ERROR   ] CWWKS2401E: The configuration for the client_1 OpenID Connect client is not valid or is missing data. CWWKS2404E: The providerURI attribute for the client_1 OpenID Connect client is null or empty, and there is no metadata available for the OpenID Connect provider.
[ERROR   ] CWWKS2504E: The client_1 OpenID Connect client encountered the following error while validating the credential for the authenticated user: io.openliberty.security.oidcclientcore.token.TokenValidationException: CWWKS2415E: The client_1 OpenID Connect client encountered the following error during validation of the token that was received from the OpenID Connect provider: CWWKS2403E: The client_1 OpenID Connect client encountered the following error during discovery of metadata for the OpenID Connect provider from the [] URL: CWWKS2405E: The OpenID Connect provider metadata is missing the required [jwks_uri] property.
```