### PR TITLE
Rename registerPreSnapshotHook to registerPreCheckpointHook

### DIFF
--- a/dev/io.openliberty.checkpoint/src/io/openliberty/checkpoint/internal/openj9/ExecuteCRIU_OpenJ9.java
+++ b/dev/io.openliberty.checkpoint/src/io/openliberty/checkpoint/internal/openj9/ExecuteCRIU_OpenJ9.java
@@ -33,10 +33,14 @@ public class ExecuteCRIU_OpenJ9 implements ExecuteCRIU {
     }
 
     @Override
-    @FFDCIgnore({ JVMCheckpointException.class, SystemCheckpointException.class, RestoreException.class, JVMCRIUException.class, RuntimeException.class })
+    @FFDCIgnore({ JVMCheckpointException.class, SystemCheckpointException.class, RestoreException.class, JVMCRIUException.class, RuntimeException.class, NoSuchMethodError.class })
     public void dump(Runnable prepare, Runnable restore, File imageDir, String logFileName, File workDir, File envProps, boolean unprivileged) throws CheckpointFailedException {
         CRIUSupport criuSupport = new CRIUSupport(imageDir.toPath());
-        criuSupport.registerPreSnapshotHook(prepare);
+        try {
+            criuSupport.registerPreCheckpointHook(prepare);
+        } catch (NoSuchMethodError e) {
+            criuSupport.registerPreSnapshotHook(prepare);
+        }
         criuSupport.registerPostRestoreHook(restore);
         criuSupport.setShellJob(true);
         criuSupport.setFileLocks(true);

--- a/dev/io.openliberty.org.eclipse.openj9.criu/src/org/eclipse/openj9/criu/CRIUSupport.java
+++ b/dev/io.openliberty.org.eclipse.openj9.criu/src/org/eclipse/openj9/criu/CRIUSupport.java
@@ -260,6 +260,10 @@ public final class CRIUSupport {
 		return this;
 	}
 
+	public CRIUSupport registerPreSnapshotHook(Runnable hook) {
+		return this;
+	}
+
 	/**
 	 * User hook that is run after restoring a checkpoint image.
 	 *
@@ -273,8 +277,7 @@ public final class CRIUSupport {
 	 *
 	 * TODO: Additional JVM capabilities will be added to prevent certain deadlock scenarios
 	 */
-	public CRIUSupport registerPreSnapshotHook(Runnable hook) {
-
+	public CRIUSupport registerPreCheckpointHook(Runnable hook) {
 		return this;
 	}
 


### PR DESCRIPTION
Rename registerPreSnapshotHook to registerPreCheckpointHook

Based on changes in OpenJ9
https://github.com/eclipse-openj9/openj9/pull/16116

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>

