### PR TITLE
Remove trace from subset of MP JWT 2.1 FATs to have them run faster

### DIFF
--- a/dev/io.openliberty.microprofile.jwt.2.1.internal_fat_tck/publish/servers/jwt21tckAudEnv/server.xml
+++ b/dev/io.openliberty.microprofile.jwt.2.1.internal_fat_tck/publish/servers/jwt21tckAudEnv/server.xml
@@ -30,9 +30,6 @@
 
     <mpJwt groupNameAttribute="groups" id="myMpJwt" clockSkew="-1"/>
   
-    <!-- <logging maxFileSize="20" maxFiles="10" traceFileName="trace.log" traceSpecification="com.ibm.ws.jaxrs*=all:com.ibm.ws.webcontainer.security.*=all:com.ibm.ws.security.*=all:com.ibm.wsspi.webcontainer*=all"/>  --> 
-    <logging maxFileSize="20" maxFiles="10" traceFileName="trace.log" traceSpecification="*=info:com.ibm.websphere.security.*=all:com.ibm.ws.cdi*=all:com.ibm.ws.jaxrs*=all:com.ibm.ws.security.*=all:com.ibm.ws.webcontainer.security.*=all:com.ibm.ws.weld*=all:com.ibm.wsspi.webcontainer*=all" /> 
- 
     <keyStore id="defaultKeyStore" password="keyspass"/>
 	
 </server>


### PR DESCRIPTION
`ClaimValueInjectionTest.verifyInjectedIssuedAtStandard` configures a token lifetime of 4 seconds. Sometimes our test takes longer than that to start everything up and run the test, which means the token is expired by the time we get to the test. Removing trace should start the server up faster and mitigate the problem.