### PR TITLE
Fix intermittent NPE in RESTEasy client code.

### DIFF
--- a/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/io/openliberty/org/jboss/resteasy/common/client/OsgiFacade.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/io/openliberty/org/jboss/resteasy/common/client/OsgiFacade.java
@@ -16,10 +16,10 @@ import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -30,7 +30,7 @@ import org.osgi.framework.ServiceReference;
 
 class OsgiFacade {
     private static final boolean isSecurityManagerPresent = null != System.getSecurityManager();
-    private static final Map<Integer, Tuple<?>> tupleMap = new HashMap<>();
+    private static final Map<Integer, Tuple<?>> tupleMap = new ConcurrentHashMap<>();
     private static final AtomicInteger counter = new AtomicInteger(0);
 
     static Optional<OsgiFacade> instance() {

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/client/OsgiFacade.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/client/OsgiFacade.java
@@ -16,10 +16,10 @@ import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -30,7 +30,7 @@ import org.osgi.framework.ServiceReference;
 
 class OsgiFacade {
     private static final boolean isSecurityManagerPresent = null != System.getSecurityManager();
-    private static final Map<Integer, Tuple<?>> tupleMap = new HashMap<>();
+    private static final Map<Integer, Tuple<?>> tupleMap = new ConcurrentHashMap<>();
     private static final AtomicInteger counter = new AtomicInteger(0);
 
     static Optional<OsgiFacade> instance() {


### PR DESCRIPTION
Under heavy load, I see this NPE (it is rare). Switching to a ConcurrentHashMap seems to fix it.

```
java.lang.NullPointerException
	at io.openliberty.org.jboss.resteasy.common.client.OsgiFacade.invoke(OsgiFacade.java:95)
	at io.openliberty.org.jboss.resteasy.common.client.LibertyResteasyClientBuilderImpl.lambda$build$3(LibertyResteasyClientBuilderImpl.java:86)
	at java.base/java.util.Optional.ifPresent(Optional.java:183)
	at io.openliberty.org.jboss.resteasy.common.client.LibertyResteasyClientBuilderImpl.lambda$build$4(LibertyResteasyClientBuilderImpl.java:85)
	at java.base/java.util.Optional.ifPresent(Optional.java:183)
	at io.openliberty.org.jboss.resteasy.common.client.LibertyResteasyClientBuilderImpl.build(LibertyResteasyClientBuilderImpl.java:85)
	at io.openliberty.org.jboss.resteasy.common.client.LibertyResteasyClientBuilderImpl.build(LibertyResteasyClientBuilderImpl.java:35)
```