### PR TITLE
hide http header and param value traces

### DIFF
--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/OriginalResourceRequest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/OriginalResourceRequest.java
@@ -28,6 +28,9 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 
+import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.websphere.ras.annotation.Trivial;
+
 import io.openliberty.security.oidcclientcore.storage.Storage;
 import io.openliberty.security.oidcclientcore.storage.StorageFactory;
 import io.openliberty.security.oidcclientcore.utils.Utils;
@@ -135,6 +138,7 @@ public class OriginalResourceRequest extends HttpServletRequestWrapper {
         this.params = params;
     }
 
+    @Trivial
     private String getAndRemoveFromStorage(String key) {
         String value = storage.get(key);
         if (value != null) {
@@ -154,6 +158,7 @@ public class OriginalResourceRequest extends HttpServletRequestWrapper {
     }
 
     @Override
+    @Sensitive
     public String getHeader(String name) {
         List<String> headerValues = headers.get(name);
         if (headerValues == null || headerValues.size() == 0) {
@@ -168,6 +173,7 @@ public class OriginalResourceRequest extends HttpServletRequestWrapper {
     }
 
     @Override
+    @Sensitive
     public Enumeration<String> getHeaders(String name) {
         List<String> headerValues = headers.get(name);
         if (headerValues == null) {
@@ -177,6 +183,7 @@ public class OriginalResourceRequest extends HttpServletRequestWrapper {
     }
 
     @Override
+    @Sensitive
     public int getIntHeader(String name) {
         String header = getHeader(name);
         if (header == null) {
@@ -186,6 +193,7 @@ public class OriginalResourceRequest extends HttpServletRequestWrapper {
     }
 
     @Override
+    @Sensitive
     public String getParameter(String name) {
         String[] paramValues = params.get(name);
         if (paramValues == null || paramValues.length == 0) {
@@ -195,6 +203,7 @@ public class OriginalResourceRequest extends HttpServletRequestWrapper {
     }
 
     @Override
+    @Sensitive
     public Map<String, String[]> getParameterMap() {
         return new HashMap<String, String[]>(params);
     }
@@ -205,6 +214,7 @@ public class OriginalResourceRequest extends HttpServletRequestWrapper {
     }
 
     @Override
+    @Sensitive
     public String[] getParameterValues(String name) {
         return params.get(name);
     }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/CookieBasedStorage.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/CookieBasedStorage.java
@@ -58,6 +58,7 @@ public class CookieBasedStorage implements Storage {
     }
 
     @Override
+    @Sensitive
     public String get(String name) {
         Cookie[] cookies = request.getCookies();
         for (Cookie c : cookies) {

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/SessionBasedStorage.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/SessionBasedStorage.java
@@ -15,6 +15,7 @@ import javax.servlet.http.HttpSession;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Sensitive;
 
 public class SessionBasedStorage implements Storage {
 
@@ -27,12 +28,12 @@ public class SessionBasedStorage implements Storage {
     }
 
     @Override
-    public void store(String name, String value) {
+    public void store(String name, @Sensitive String value) {
         store(name, value, null);
     }
 
     @Override
-    public void store(String name, String value, StorageProperties properties) {
+    public void store(String name, @Sensitive String value, StorageProperties properties) {
         // ignore storage properties, since http session attributes
         // can't set properties (e.g., expiration time) like cookies can
         HttpSession session = request.getSession();
@@ -40,6 +41,7 @@ public class SessionBasedStorage implements Storage {
     }
 
     @Override
+    @Sensitive
     public String get(String name) {
         HttpSession session = request.getSession();
         Object value = session.getAttribute(name);


### PR DESCRIPTION
for #21164 

- hide http header and param value traces in-case they contain sensitive information.
    - added `@Sensitive` and `@Trivial` annotations to methods which might return sensitive info in OriginalResourceRequest
    - added `@Sensitive` to `get` method in CookieBasedStorage (we already use `@Sensitve` on the value in the `store` method) and mirrored these annotations onto the SessionBasedStorage methods
