### PR TITLE
wsSecurity-1.1 regression: Failed to parse Created TimeStamp in UsernameTokenValidator

### DIFF
--- a/dev/com.ibm.ws.wssecurity.3.4.1/.classpath
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" output="bin" path="src"/>
+	<classpathentry kind="src" output="bin_test" path="test"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.wssecurity.3.4.1/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/bnd.bnd
@@ -133,5 +133,19 @@ instrument.classesExcludes: com/ibm/ws/wssecurity/resources/*.class
 	com.ibm.ws.org.ehcache.ehcache.107.3.8.1,\
 	io.openliberty.wssecurity;version=latest,\
 	org.apache.wss4j.wss4j-ws-security-common
+	
+-testpath: \
+	../build.sharedResources/lib/junit/old/junit.jar;version=file,\
+	com.ibm.ws.junit.extensions;version=latest,\
+	org.jmock:jmock-legacy;version='2.5.0',\
+	org.jmock:jmock-junit4;strategy=exact;version='2.5.1',\
+	org.jmock:jmock;strategy=exact;version='2.5.1',\
+	com.ibm.ws.org.objenesis:objenesis;version='1.0',\
+	cglib:cglib-nodep;version='3.3.0',\
+	org.hamcrest:hamcrest-all;version='1.3',\
+	com.ibm.ws.kernel.boot;version=latest, \
+	com.ibm.ws.componenttest.2.0,\
+	com.ibm.ws.junit.extensions,\
+	com.ibm.ws.componenttest.2.0
 
 

--- a/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/cxf/validator/UsernameTokenValidator.java
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/cxf/validator/UsernameTokenValidator.java
@@ -61,13 +61,13 @@ public class UsernameTokenValidator implements Validator {
     /**
      * Validate the credential argument. It must contain a non-null UsernameToken. A
      * CallbackHandler implementation is also required to be set.
-     * 
+     *
      * If the password type is either digest or plaintext, it extracts a password from the
      * CallbackHandler and then compares the passwords appropriately.
-     * 
+     *
      * If the password is null it queries a hook to allow the user to validate UsernameTokens
      * of this type.
-     * 
+     *
      * @param credential the Credential to be validated
      * @param data the RequestData associated with the request
      * @throws WSSecurityException on a failed validation
@@ -96,7 +96,7 @@ public class UsernameTokenValidator implements Validator {
             handleCustomPasswordTypes = data.isHandleCustomPasswordTypes();//wssConfig.getHandleCustomPasswordTypes();
             //passwordsAreEncoded = wssConfig.getPasswordsAreEncoded();
             passwordsAreEncoded = data.isEncodePasswords();
-            //requiredPasswordType = wssConfig.getRequiredPasswordType();        
+            //requiredPasswordType = wssConfig.getRequiredPasswordType();
             requiredPasswordType = data.getRequiredPasswordType();
         }
 
@@ -146,7 +146,7 @@ public class UsernameTokenValidator implements Validator {
      * This method currently uses the same logic as the verifyPlaintextPassword case, but it in
      * a separate protected method to allow users to override the validation of the custom
      * password type specific case.
-     * 
+     *
      * @param usernameToken The UsernameToken instance to verify
      * @throws WSSecurityException on a failed authentication.
      */
@@ -162,7 +162,7 @@ public class UsernameTokenValidator implements Validator {
      * This method currently uses the same logic as the verifyDigestPassword case, but it in
      * a separate protected method to allow users to override the validation of the plaintext
      * password specific case.
-     * 
+     *
      * @param usernameToken The UsernameToken instance to verify
      * @throws WSSecurityException on a failed authentication.
      */
@@ -238,7 +238,7 @@ public class UsernameTokenValidator implements Validator {
             throw new WSSecurityException(WSSecurityException.ErrorCode.FAILED_AUTHENTICATION, e);
         }
 
-        // Let's validate the user and 
+        // Let's validate the user and
         if (authnPrincipal == null) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "User " + user + " could not be validated.");
@@ -281,7 +281,7 @@ public class UsernameTokenValidator implements Validator {
      * Verify a UsernameToken containing a password digest. It does this by querying a
      * CallbackHandler instance to obtain a password for the given username, and then comparing
      * it against the received password.
-     * 
+     *
      * @param usernameToken The UsernameToken instance to verify
      * @throws WSSecurityException on a failed authentication.
      */
@@ -305,7 +305,7 @@ public class UsernameTokenValidator implements Validator {
                 Tr.debug(tc, e.getMessage());
             }
             //new Exception(e,WSSecurityException.FAILED_AUTHENTICATION_ERR)
-            WSSecurityException wsse = new WSSecurityException(WSSecurityException.ErrorCode.FAILED_AUTHENTICATION/*, e*/);
+            WSSecurityException wsse = new WSSecurityException(WSSecurityException.ErrorCode.FAILED_AUTHENTICATION/* , e */);
         } catch (UnsupportedCallbackException e) {
             if (tc.isDebugEnabled()) {
                 Tr.debug(tc, e.getMessage());
@@ -342,7 +342,7 @@ public class UsernameTokenValidator implements Validator {
     /**
      * Verify a UsernameToken containing no password. This does nothing - but is in a separate
      * method to allow the end-user to override validation easily.
-     * 
+     *
      * @param usernameToken The UsernameToken instance to verify
      * @throws WSSecurityException on a failed authentication.
      */
@@ -395,7 +395,7 @@ public class UsernameTokenValidator implements Validator {
 
         // in the older cxf/wss4j versions we did not have ws-security.usernametoken.timeToLive option
         // so we depended on ws-security.timestamp.timeToLive for both timestamp and unt
-        // int timeStampTTL = 300; 
+        // int timeStampTTL = 300;
         // int futureTimeToLive = 300;
         int utTTL = 300;
         int utFutureTTL = 300;
@@ -408,8 +408,7 @@ public class UsernameTokenValidator implements Validator {
 
         boolean isValid = verifyCreated(created, utTTL, utFutureTTL);
         if (!isValid) {
-            throw new WSSecurityException(
-                            WSSecurityException.ErrorCode.MESSAGE_EXPIRED);
+            throw new WSSecurityException(WSSecurityException.ErrorCode.MESSAGE_EXPIRED);
             //"error.policy.invalidcreated",
             //new Object[] { "The security semantics of the message have expired" });
         }
@@ -448,12 +447,19 @@ public class UsernameTokenValidator implements Validator {
     }
 
     public static Date convertDate(String strTimeStamp) throws WSSecurityException {
+
         Date date;
         try {
-            //System.out.println("Original string: " + strTimeStamp);
 
-            // "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US);
+            //System.out.println("Original string: " + strTimeStamp);
+            String datePattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"; // default pattern
+
+            // Use correct date pattern if milliseconds is missing in timestamp
+            if (strTimeStamp.length() <= 20) { // 2020-06-08T12:40:10Z
+                datePattern = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+            }
+
+            SimpleDateFormat dateFormat = new SimpleDateFormat(datePattern, Locale.US);
             dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
             date = dateFormat.parse(strTimeStamp);
 
@@ -466,7 +472,7 @@ public class UsernameTokenValidator implements Validator {
                 Tr.debug(tc, "Caught exception while parse a timestamp as '" + strTimeStamp + "' : " + pe);
             }
             throw new WSSecurityException(WSSecurityException.ErrorCode.FAILURE, pe);
-        }
+            }
         return date;
     }
 

--- a/dev/com.ibm.ws.wssecurity.3.4.1/test/com/ibm/ws/wssecurity/cxf/validator/UsernameTokenValidatorTest.java
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/test/com/ibm/ws/wssecurity/cxf/validator/UsernameTokenValidatorTest.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.wssecurity.cxf.validator;
+
+import static org.junit.Assert.*;
+
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Date;
+import org.junit.rules.TestRule;
+import test.common.SharedOutputManager;
+
+/**
+ *
+ */
+public class UsernameTokenValidatorTest {
+    
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+
+    @Rule
+    public TestRule managerRule = outputMgr;
+
+    private final Mockery mock = new JUnit4Mockery();
+
+    UsernameTokenValidator unvalidator = new UsernameTokenValidator();
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.trace("*=all");
+    }
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.trace("*=all=disabled");
+    }
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @After
+    public void tearDown() throws Exception {
+        outputMgr.resetStreams();
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.wssecurity.cxf.validator.UsernameTokenValidator#verifyCreated(java.lang.String, int, int)}.
+     */
+    @Test
+    public void testVerifyCreated() {
+        //fail("Not yet implemented");
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.wssecurity.cxf.validator.UsernameTokenValidator#convertDate(java.lang.String)}.
+     */
+    @Test
+    public void testConvertDateMissingMonth() {
+        String strTimeStamp = "2016-14T20:40:43.883Z";
+
+        try {
+            Date date = UsernameTokenValidator.convertDate(strTimeStamp);
+            assertNull(date);
+
+        } catch (org.apache.wss4j.common.ext.WSSecurityException e) {
+          assertTrue("Exception as expected: ",
+                      e.getMessage().contains("Unparseable date: \"2016-14T20:40:43.883Z\""));
+        }
+
+    }
+    
+    @Test
+    public void testConvertDateSuccess() {
+        String strTimeStamp = "2016-12-14T20:40:43.883Z";
+
+        try {
+            Date date = unvalidator.convertDate(strTimeStamp);
+            assertNotNull(date);
+
+        } catch (org.apache.wss4j.common.ext.WSSecurityException e) {
+          assertFalse("Exception not expected: ",
+                      e.getMessage().contains("Unparseable date: \"2016-12-14T20:40:43.883Z\""));
+        }
+
+    }
+    
+    @Test
+    public void testConvertDateMissingMilliSeconds_shouldWork() {
+        String strTimeStamp = "2016-12-14T20:40:43Z";
+
+        try {
+            Date date = unvalidator.convertDate(strTimeStamp);
+            assertNotNull(date);
+
+        } catch (org.apache.wss4j.common.ext.WSSecurityException e) {
+          assertFalse("Exception not expected: ",
+                      e.getMessage().contains("Unparseable date: \"2016-12-14T20:40:43Z\""));
+        }
+
+    }
+}


### PR DESCRIPTION
This pull request:

- Applies the old version of CXF fix to address ##23031
- Add UnitTest for the behavior change to ensure this regression doesn't happen going forward. 