### PR TITLE
disable ir cookie creation to prevent the buildup of cookies if required

### DIFF
--- a/dev/com.ibm.ws.security.saml.websso.2.0/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021,2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -133,6 +133,9 @@ nameIDFormat.CUSTOMIZE=Customized Name ID Format.
 
 customizeNameIDFormat=Customized XML name space of name id format
 customizeNameIDFormat.desc=Specifies the customized URI reference corresponding to a name identifier format that is not defined in the SAML core specification.
+
+disableIRCookie=Disable initial request cookie creation
+disableIRCookie.desc=When too many authentication requests are created by Service Provider and redirected to IdP due to the application SSO setup, set this attribute to true to prevent creation of the initial request cookie. The default is false.
 
 disableLtpaCookie=Disable LTPA token
 disableLtpaCookie.desc=Do not create an LTPA Token during processing of the SAML Assertion. Create a cookie of the specific Service Provider instead.

--- a/dev/com.ibm.ws.security.saml.websso.2.0/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021,2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -108,6 +108,8 @@
         <AD id="authFilterRef" name="%authFilterRef" description="%authFilterRef.desc" 
              ibm:type="pid" ibm:reference="com.ibm.ws.security.authentication.filter"
              required="false" type="String"  />
+        <AD id="disableInitialRequestCookie" name="%disableIRCookie" description="%disableIRCookie.desc"
+            required="false" type="Boolean" default="false"/>
         <AD id="disableLtpaCookie" name ="%disableLtpaCookie" description="%disableLtpaCookie.desc"
             required="false" type="Boolean" default="true"/>
         <AD id="spCookieName" name="%spCookieName" description="%spCookieName.desc"

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/SsoConfig.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/SsoConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -108,6 +108,8 @@ public interface SsoConfig {
     public Constants.MapToUserRegistry getMapToUserRegistry();
 
     public String getSignatureMethodAlgorithm();
+    
+    public boolean isDisableInitialRequestCookie();
 
     public boolean isDisableLtpaCookie();
 

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/binding/BasicMessageContext.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/binding/BasicMessageContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -284,7 +284,9 @@ public class BasicMessageContext<InboundMessageType extends SAMLObject, Outbound
                 //             The same request may have been sent more than once. It is a potential hack attack.
                 //Tr.error(tc, "SAML20_POTENTIAL_REPLAY_ATTACK", new Object[] { externalRelayState });
                 try {
-                    cachedRequestInfo = irUtil.recreateHttpRequestInfo(externalRelayState, this.request, this.response, this.ssoService);
+                    if (!(ssoService.getConfig().isDisableInitialRequestCookie())) {
+                        cachedRequestInfo = irUtil.recreateHttpRequestInfo(externalRelayState, this.request, this.response, this.ssoService);
+                    }  
                 } catch (SamlException e) {
                     Tr.debug(tc, "cannot recreate HttpRequestInfo using InitialRequest cookie", e.getMessage());
                     throw e;

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/SsoConfigImpl.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/SsoConfigImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -85,6 +85,7 @@ public class SsoConfigImpl extends PkixTrustEngineConfig implements SsoConfig, F
     static final String KEY_realmIdentifier = "realmIdentifier";
     static final String KEY_includeTokenInSubject = "includeTokenInSubject";
     static final String KEY_mapToUserRegistry = "mapToUserRegistry";
+    static final String KEY_disableInitialRequestCookie = "disableInitialRequestCookie";
     static final String KEY_disableLtpaCookie = "disableLtpaCookie";
     static final String KEY_spCookieName = "spCookieName";
     static final String KEY_realmName = "realmName";
@@ -161,6 +162,7 @@ public class SsoConfigImpl extends PkixTrustEngineConfig implements SsoConfig, F
     boolean allowCustomCacheKey = true; // default is allowCustomCacheKey
 
     Constants.MapToUserRegistry mapToUserRegistry = Constants.MapToUserRegistry.No;
+    boolean disableInitialRequestCookie = false;
     boolean disableLtpaCookie = true;
     String spCookieName = null;
     String spHostAndPort = null;
@@ -270,6 +272,7 @@ public class SsoConfigImpl extends PkixTrustEngineConfig implements SsoConfig, F
         realmIdentifier = trim((String) props.get(KEY_realmIdentifier));
         includeTokenInSubject = (Boolean) props.get(KEY_includeTokenInSubject);
         mapToUserRegistry = Constants.MapToUserRegistry.valueOf((String) props.get(KEY_mapToUserRegistry));
+        disableInitialRequestCookie = (Boolean) props.get(KEY_disableInitialRequestCookie);
         disableLtpaCookie = (Boolean) props.get(KEY_disableLtpaCookie);
         spCookieName = trim((String) props.get(KEY_spCookieName));
         realmName = trim((String) props.get(KEY_realmName));
@@ -546,6 +549,7 @@ public class SsoConfigImpl extends PkixTrustEngineConfig implements SsoConfig, F
                      + "\nrealmIdentifier:" + realmIdentifier
                      + "\nincludeTokenInSubject:" + includeTokenInSubject
                      + "\nmapToUserRegistry:" + mapToUserRegistry
+                     + "\ndisableInitialRequestCookie:" + disableInitialRequestCookie
                      + "\ndisableLtpaCookie:" + disableLtpaCookie
                      + "\nspCookieName:" + spCookieName
                      + "\nrealmName:" + realmName
@@ -927,6 +931,11 @@ public class SsoConfigImpl extends PkixTrustEngineConfig implements SsoConfig, F
     @Override
     public boolean isServletRequestLogoutPerformsSamlLogout() {
         return servletRequestLogoutPerformsSamlLogout;
+    }
+    
+    @Override
+    public boolean isDisableInitialRequestCookie() {  
+        return this.disableInitialRequestCookie;
     }
 
 }

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/rs/RsSamlConfigImpl.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/rs/RsSamlConfigImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -825,6 +825,11 @@ public class RsSamlConfigImpl extends PkixTrustEngineConfig implements SsoConfig
     @Override
     public boolean isServletRequestLogoutPerformsSamlLogout() {
         return servletRequestLogoutPerformsSamlLogout;
+    }
+
+    @Override
+    public boolean isDisableInitialRequestCookie() {
+        return unexpectedCall(false);
     }
 
 }

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/sp/Solicited.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/sp/Solicited.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -132,7 +132,9 @@ public class Solicited {
         }
         String relayState = Constants.SP_INITAL + shortRelayState;
         RequestUtil.cacheRequestInfo(shortRelayState, ssoService, cachingRequestInfo); // cache with shorRelayState
-        irUtil.handleSerializingInitialRequest(req, resp, Constants.SP_INITAL, shortRelayState, cachingRequestInfo, ssoService);
+        if (!(ssoService.getConfig().isDisableInitialRequestCookie())) {
+            irUtil.handleSerializingInitialRequest(req, resp, Constants.SP_INITAL, shortRelayState, cachingRequestInfo, ssoService);
+        }       
         TAIResult result = postIdp(req, resp, strAuthnRequest, relayState, idpUrl, cachingRequestInfo); // send out with the long relayState
         return result;
     }

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/sp/Unsolicited.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/sp/Unsolicited.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -70,7 +70,9 @@ public class Unsolicited {
         String targetId = SamlUtil.generateRandom(); // no need to Base64 encode
         HttpRequestInfo cachingRequestInfo = new HttpRequestInfo(req);
         RequestUtil.cacheRequestInfo(targetId, ssoService, cachingRequestInfo);
-        irUtil.handleSerializingInitialRequest(req, resp, Constants.IDP_INITAL, targetId, cachingRequestInfo, ssoService);
+        if (!(ssoService.getConfig().isDisableInitialRequestCookie())) {
+            irUtil.handleSerializingInitialRequest(req, resp, Constants.IDP_INITAL, targetId, cachingRequestInfo, ssoService);
+        }   
         TAIResult result = redirectToUserDefinedLoginPageURL(req, resp, targetId, decodedLoginPageUrl, cachingRequestInfo);
         return result;
     }

--- a/dev/com.ibm.ws.security.saml.websso.2.0/test/com/ibm/ws/security/saml/sso20/binding/BasicMessageContextTest.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/test/com/ibm/ws/security/saml/sso20/binding/BasicMessageContextTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -434,6 +434,12 @@ public class BasicMessageContextTest {
                 one(cache).get(CACHE_VALUE);
                 will(returnValue(null));
                 
+                one(ssoService).getConfig();
+                will(returnValue(ssoConfig));
+                
+                one(ssoConfig).isDisableInitialRequestCookie();
+                will(returnValue(false));
+                
                 one(irutil).recreateHttpRequestInfo(RELAY_STATE, null, null, ssoService);
                 will(throwException(new SamlException("")));
                              
@@ -444,7 +450,7 @@ public class BasicMessageContextTest {
     }
 
     @Test
-    public void getChachedInfoRequestInfo() {
+    public void getCachedInfoRequestInfo() {
         instance.getCachedRequestInfo();
     }
 

--- a/dev/com.ibm.ws.security.saml.websso.2.0/test/com/ibm/ws/security/saml/sso20/internal/SsoConfigImplTest.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/test/com/ibm/ws/security/saml/sso20/internal/SsoConfigImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -144,6 +144,7 @@ public class SsoConfigImplTest {
         SAML_CONFIG_PROPS.put(SsoConfigImpl.KEY_realmIdentifier, "realmIdentifier");
         SAML_CONFIG_PROPS.put(SsoConfigImpl.KEY_includeTokenInSubject, true);
         SAML_CONFIG_PROPS.put(SsoConfigImpl.KEY_mapToUserRegistry, "User");
+        SAML_CONFIG_PROPS.put(SsoConfigImpl.KEY_disableInitialRequestCookie, false);
         SAML_CONFIG_PROPS.put(SsoConfigImpl.KEY_disableLtpaCookie, true);
         SAML_CONFIG_PROPS.put(SsoConfigImpl.CFG_KEY_AUTH_FILTER_REF, "authFilterRef");
         SAML_CONFIG_PROPS.put(SsoConfigImpl.KEY_authnRequestTime, Long.valueOf(600000L));


### PR DESCRIPTION
Provide an option to disable initial request cookie creation 
too many authentication requests (this may happen due to how the saml SP and auth filter is setup to achieve SSO with the provider) from SP to IdP may result in the build up of the cookies. 

