### PR TITLE
Return OIDC client discovery code to parity between GA and beta mode

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rpd/bootstrap.properties
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rpd/bootstrap.properties
@@ -13,13 +13,10 @@ bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
 OpenIdConnect=all:\
-OPENIDCONNECT=all:\
-com.ibm.ws.security.oauth*=all=enabled:\
-com.ibm.ws.security.openidconnect*=all=enabled:\
-com.ibm.ws.security.jwt*=all=enabled:\
+OAUTH20=all:\
+JWTBUILDER=all:\
+SecurityCommon:\
 com.ibm.ws.webcontainer.security.*=all=enabled:\
-com.ibm.oauth.*=all=enabled:\
-com.ibm.wsspi.security.oauth20.*=all=enabled:\
 org.apache.http.client.*=all
 
 com.ibm.ws.logging.max.file.size=0


### PR DESCRIPTION
Ensures that the same NLS messages are being logged for OIDC discovery failures by the OIDC client in the GA and beta modes.