### PR TITLE
Ensure DB Rotation replaces Username and Password

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_fat.common/publish/servers/JPA10RelationshipsEJBServer/server.xml
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_fat.common/publish/servers/JPA10RelationshipsEJBServer/server.xml
@@ -23,15 +23,15 @@
 
     <dataSource id="jdbc/JPA_JTA_DS" jndiName="jdbc/JPA_JTA_DS" fat.modify="true">
         <jdbcDriver libraryRef="AnonymousJDBCLib"/>
-        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" />
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
 
     <dataSource id="jdbc/JPA_NJTA_DS" jndiName="jdbc/JPA_NJTA_DS" fat.modify="true" transactional="false">
         <jdbcDriver libraryRef="AnonymousJDBCLib"/>
-        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" />
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
 
-    <library id="AnonymousJDBCLib" fat.modify="true">
+    <library id="AnonymousJDBCLib">
         <fileset dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>
     </library>
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_fat.common/publish/servers/JPA10RelationshipsWebServer/server.xml
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_fat.common/publish/servers/JPA10RelationshipsWebServer/server.xml
@@ -23,15 +23,15 @@
 
     <dataSource id="jdbc/JPA_JTA_DS" jndiName="jdbc/JPA_JTA_DS" fat.modify="true">
         <jdbcDriver libraryRef="AnonymousJDBCLib"/>
-        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" />
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
 
     <dataSource id="jdbc/JPA_NJTA_DS" jndiName="jdbc/JPA_NJTA_DS" fat.modify="true" transactional="false">
         <jdbcDriver libraryRef="AnonymousJDBCLib"/>
-        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" />
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
 
-    <library id="AnonymousJDBCLib" fat.modify="true">
+    <library id="AnonymousJDBCLib">
         <fileset dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>
     </library>
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_fat.common/publish/servers/JPA10RelationshipsEJBServer/server.xml
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_fat.common/publish/servers/JPA10RelationshipsEJBServer/server.xml
@@ -23,15 +23,15 @@
 
     <dataSource id="jdbc/JPA_JTA_DS" jndiName="jdbc/JPA_JTA_DS" fat.modify="true">
         <jdbcDriver libraryRef="AnonymousJDBCLib"/>
-        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" />
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
 
     <dataSource id="jdbc/JPA_NJTA_DS" jndiName="jdbc/JPA_NJTA_DS" fat.modify="true" transactional="false">
         <jdbcDriver libraryRef="AnonymousJDBCLib"/>
-        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" />
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
 
-    <library id="AnonymousJDBCLib" fat.modify="true">
+    <library id="AnonymousJDBCLib" >
         <fileset dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>
     </library>
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_fat.common/publish/servers/JPA10RelationshipsWebServer/server.xml
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_fat.common/publish/servers/JPA10RelationshipsWebServer/server.xml
@@ -23,15 +23,15 @@
 
     <dataSource id="jdbc/JPA_JTA_DS" jndiName="jdbc/JPA_JTA_DS" fat.modify="true">
         <jdbcDriver libraryRef="AnonymousJDBCLib"/>
-        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" />
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
 
     <dataSource id="jdbc/JPA_NJTA_DS" jndiName="jdbc/JPA_NJTA_DS" fat.modify="true" transactional="false">
         <jdbcDriver libraryRef="AnonymousJDBCLib"/>
-        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" />
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
 
-    <library id="AnonymousJDBCLib" fat.modify="true">
+    <library id="AnonymousJDBCLib">
         <fileset dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>
     </library>
 


### PR DESCRIPTION
Database rotation cannot assume where a test wants the username/password to be modified. 
Therefore, these servers need to be updated to have a username and password set for derby.