### PR TITLE
Add issuerIdentifier to OIDC OP config to fix BCL beta behavior

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.2/publish/files/serversettings/oauthProvider_1.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat.2/publish/files/serversettings/oauthProvider_1.xml
@@ -15,7 +15,10 @@
 		scope="myScopeSample"
 		jwkEnabled="${oidcJWKEnabled}"
 		signatureAlgorithm="${oidcSignAlg}"
-		oauthProviderRef="OAuthConfigSample" />
+		oauthProviderRef="OAuthConfigSample"
+		issuerIdentifier="http://localhost:${bvt.prop.security_1_HTTP_default}/oidc/endpoint/OidcConfigSample"
+	/>
+	<!-- TODO: remove issuerIdentifier when back-channel logout beta is removed -->
 
 	<oauthProvider
 		id="OAuthConfigSample"


### PR DESCRIPTION
Back-channel logout tokens that are created based on the ID token provided in the end_session request in some FATs will have an `"iss"` claim value that will not match the expected issuer. The ID tokens are created with `"http://localhost:8910/oidc/endpoint/OidcConfigSample"` as the issuer (HTTP), but the logout token creation code expects the issuer to be `"https://localhost:8920/oidc/endpoint/OidcConfigSample"` (with HTTPS).

This updates the code so the issuer will always be the HTTP version, making the GA and beta versions of the tests happy.

**Note: ** As the comment suggests, this should be removed or at least revisited when back-channel logout code is moved to GA.