### PR TITLE
reprocess redirectUri if it returns another EL expression containing baseURL

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/SimplestAnnotatedWithEL.war/src/oidc/client/withEL/servlets/OidcAnnotatedServletWithEL.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/SimplestAnnotatedWithEL.war/src/oidc/client/withEL/servlets/OidcAnnotatedServletWithEL.java
@@ -22,7 +22,7 @@ import oidc.client.base.servlets.BaseServlet;
 @WebServlet("/OidcAnnotatedServletWithEL")
 @OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1", clientId = "${openIdConfig.clientId}",
                                          clientSecret = "${openIdConfig.clientSecret}",
-                                         redirectURI = "${baseURL}/Callback",
+                                         redirectURI = "${openIdConfig.redirectURI}",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "${openIdConfig.callerNameClaim}",
                                                                               callerGroupsClaim = "${openIdConfig.callerGroupsClaim}"),
                                          providerMetadata = @OpenIdProviderMetadata(authorizationEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/authorize",


### PR DESCRIPTION
for #23091

- reprocess redirectUri if it returns another EL expression containing `baseURL`
    - i do the reprocess if the redirectUri just contains `baseURL` and not `${baseURL}` in-case they have some other variation, e.g., `${baseURL += oidcConfig.redirectCallback}`
    - an edge case would be if they had something like `https://example.com/baseURL`, which would cause the reprocessing to happen again, but should just resolve to itself, since it doesn't contain any EL expressions
- updated the redirectURI in the EL fat test to the EL expression `${openIdConfig.redirectUri}` which returns `${baseURL}/Callback` to test this scenerio in the fat test
- `java.net.URISyntaxException: Illegal character in path at index 1: ${baseURL}/Callback?&state=001666275185866OzcznVYdZ&code=sample_auth_code` error in the jakarta security 3.0 tck no longer appears
