### PR TITLE
JAX-WS: CXF doesn't handle null prefixes when parsing StAX/TrAX

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.3.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.2.3.common/bnd.bnd
@@ -225,5 +225,6 @@ instrument.classesExcludes: com/ibm/ws/jaxws/internal/resources/*.class
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	com.ibm.ws.junit.extensions;version=latest, \
-	com.ibm.ws.kernel.boot;version=latest
+	com.ibm.ws.kernel.boot;version=latest, \
+	com.ibm.ws.org.apache.cxf.cxf.core.3.2;version=latest
 	

--- a/dev/com.ibm.ws.jaxws.2.3.common/test/org/apache/cxf/staxutils/StaxUtilsTest.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/test/org/apache/cxf/staxutils/StaxUtilsTest.java
@@ -1,0 +1,620 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.staxutils;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
+
+import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.XMLStreamWriter;
+import javax.xml.stream.events.XMLEvent;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import org.xml.sax.InputSource;
+
+import org.apache.cxf.helpers.DOMUtils;
+import org.apache.cxf.helpers.IOUtils;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class StaxUtilsTest {
+
+    @Test
+    public void testFactoryCreation() {
+        XMLStreamReader reader = StaxUtils.createXMLStreamReader(getTestStream("./resources/amazon.xml"));
+        assertNotNull(reader);
+    }
+
+    private InputStream getTestStream(String resource) {
+        return getClass().getResourceAsStream(resource);
+    }
+
+    @Test
+    public void testCommentNode() throws Exception {
+        //CXF-3034
+        Document document = DocumentBuilderFactory.newInstance()
+                .newDocumentBuilder().newDocument();
+        Element root = document.createElementNS("urn:test", "root");
+        root.appendChild(document.createComment("test comment"));
+        StaxUtils.copy(StaxUtils.createXMLStreamReader(root), StaxUtils.createXMLStreamWriter(System.out));
+    }
+
+    @Test
+    public void testToNextElement() {
+        String soapMessage = "./resources/sayHiRpcLiteralReq.xml";
+        XMLStreamReader r = StaxUtils.createXMLStreamReader(getTestStream(soapMessage));
+        DepthXMLStreamReader reader = new DepthXMLStreamReader(r);
+        assertTrue(StaxUtils.toNextElement(reader));
+        assertEquals("Envelope", reader.getLocalName());
+
+        StaxUtils.nextEvent(reader);
+
+        assertTrue(StaxUtils.toNextElement(reader));
+        assertEquals("Body", reader.getLocalName());
+    }
+
+    @Test
+    public void testToNextTag() throws Exception {
+        String soapMessage = "./resources/headerSoapReq.xml";
+        XMLStreamReader r = StaxUtils.createXMLStreamReader(getTestStream(soapMessage));
+        DepthXMLStreamReader reader = new DepthXMLStreamReader(r);
+        reader.nextTag();
+        StaxUtils.toNextTag(reader, new QName("http://schemas.xmlsoap.org/soap/envelope/", "Body"));
+        assertEquals("Body", reader.getLocalName());
+    }
+
+    @Test
+    public void testCopy() throws Exception {
+
+        // do the stream copying
+        String soapMessage = "./resources/headerSoapReq.xml";
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        XMLStreamReader reader = StaxUtils.createXMLStreamReader(getTestStream(soapMessage));
+        XMLStreamWriter writer = StaxUtils.createXMLStreamWriter(baos);
+        StaxUtils.copy(reader, writer);
+        writer.flush();
+        baos.flush();
+
+        // write output to a string
+        String output = baos.toString();
+        baos.close();
+
+        // re-read the input xml doc to a string
+        String input = IOUtils.toString(getTestStream(soapMessage));
+
+        // seach for the first begin of "<soap:Envelope" to escape the apache licenses header
+        int beginIndex = input.indexOf("<soap:Envelope");
+        input = input.substring(beginIndex);
+        beginIndex = output.indexOf("<soap:Envelope");
+        output = output.substring(beginIndex);
+
+        output = output.replace("\r\n", "\n");
+        input = input.replace("\r\n", "\n");
+
+        // compare the input and output string
+        assertEquals(input, output);
+    }
+
+    @Test
+    public void testCXF2468() throws Exception {
+        Document doc = DOMUtils.newDocument();
+        doc.appendChild(doc.createElementNS("http://blah.org/", "blah"));
+        Element foo = doc.createElementNS("http://blah.org/", "foo");
+        Attr attr = doc.createAttributeNS("http://www.w3.org/2001/XMLSchema-instance", "xsi:nil");
+        attr.setValue("true");
+        foo.setAttributeNodeNS(attr);
+        doc.getDocumentElement().appendChild(foo);
+        XMLStreamReader sreader = StaxUtils.createXMLStreamReader(doc);
+        StringWriter sw = new StringWriter();
+        XMLStreamWriter swriter = StaxUtils.createXMLStreamWriter(sw);
+        StaxUtils.copy(sreader, swriter, true);
+        swriter.flush();
+        assertTrue("No xsi namespace: " + sw.toString(), sw.toString().contains("XMLSchema-instance"));
+    }
+
+    @Test
+    public void testNonNamespaceAwareParser() throws Exception {
+        String xml = "<blah xmlns=\"http://blah.org/\" xmlns:snarf=\"http://snarf.org\">"
+            + "<foo snarf:blop=\"blop\">foo</foo></blah>";
+
+
+        StringReader reader = new StringReader(xml);
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(false);
+        dbf.setValidating(false);
+        Document doc = dbf.newDocumentBuilder().parse(new InputSource(reader));
+        Source source = new DOMSource(doc);
+
+        dbf.setNamespaceAware(true);
+        reader = new StringReader(xml);
+        Document docNs = dbf.newDocumentBuilder().parse(new InputSource(reader));
+        Source sourceNs = new DOMSource(docNs);
+
+
+        XMLStreamReader sreader = StaxUtils.createXMLStreamReader(source);
+
+        StringWriter sw = new StringWriter();
+        XMLStreamWriter swriter = StaxUtils.createXMLStreamWriter(sw);
+
+        //should not throw an exception
+        StaxUtils.copy(sreader, swriter);
+        swriter.flush();
+        swriter.close();
+
+        String output = sw.toString();
+        assertTrue(output.contains("blah"));
+        assertTrue(output.contains("foo"));
+        assertTrue(output.contains("snarf"));
+        assertTrue(output.contains("blop"));
+
+
+        sreader = StaxUtils.createXMLStreamReader(sourceNs);
+        sw = new StringWriter();
+        swriter = StaxUtils.createXMLStreamWriter(sw);
+        //should not throw an exception
+        StaxUtils.copy(sreader, swriter);
+        swriter.flush();
+        swriter.close();
+
+        output = sw.toString();
+        assertTrue(output.contains("blah"));
+        assertTrue(output.contains("foo"));
+        assertTrue(output.contains("snarf"));
+        assertTrue(output.contains("blop"));
+
+
+        sreader = StaxUtils.createXMLStreamReader(source);
+
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        swriter = StaxUtils.createXMLStreamWriter(bout);
+        StaxUtils.copy(sreader, swriter);
+        swriter.flush();
+        swriter.close();
+
+        output = bout.toString();
+        assertTrue(output.contains("blah"));
+        assertTrue(output.contains("foo"));
+        assertTrue(output.contains("snarf"));
+        assertTrue(output.contains("blop"));
+    }
+
+    @Test
+    public void testEmptyNamespace() throws Exception {
+        String testString = "<ns1:a xmlns:ns1=\"http://www.apache.org/\"><s1 xmlns=\"\">"
+            + "abc</s1><s2 xmlns=\"\">def</s2></ns1:a>";
+
+        cycleString(testString);
+
+        testString = "<a xmlns=\"http://www.apache.org/\"><s1 xmlns=\"\">"
+            + "abc</s1><s2 xmlns=\"\">def</s2></a>";
+        cycleString(testString);
+
+        testString = "<a xmlns=\"http://www.apache.org/\"><s1 xmlns=\"\">"
+            + "abc</s1><s2>def</s2></a>";
+        cycleString(testString);
+
+        testString = "<ns1:a xmlns:ns1=\"http://www.apache.org/\"><s1>"
+            + "abc</s1><s2 xmlns=\"\">def</s2></ns1:a>";
+
+        cycleString(testString);
+    }
+
+    private void cycleString(String s) throws Exception {
+        StringReader reader = new StringReader(s);
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        Document doc = dbf.newDocumentBuilder().parse(new InputSource(reader));
+        String orig = StaxUtils.toString(doc.getDocumentElement());
+
+        StringWriter sw = new StringWriter();
+        XMLStreamWriter swriter = StaxUtils.createXMLStreamWriter(sw);
+        //should not throw an exception
+        StaxUtils.writeDocument(doc, swriter, false, true);
+        swriter.flush();
+        swriter.close();
+
+        String output = sw.toString();
+        assertEquals(s, output);
+
+        W3CDOMStreamWriter domwriter = new W3CDOMStreamWriter();
+        StaxUtils.writeDocument(doc, domwriter, false, true);
+        output = StaxUtils.toString(domwriter.getDocument().getDocumentElement());
+        assertEquals(orig, output);
+    }
+
+    @Test
+    public void testRootPI() throws Exception {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        Document doc = dbf.newDocumentBuilder().parse(getTestStream("./resources/rootMaterialTest.xml"));
+        StringWriter sw = new StringWriter();
+        XMLStreamWriter swriter = StaxUtils.createXMLStreamWriter(sw);
+        StaxUtils.writeDocument(doc, swriter, true, false);
+        swriter.flush();
+        swriter.close();
+        String output = sw.toString();
+        assertTrue(output.contains("<?pi in='the sky'?>"));
+        assertTrue(output.contains("<?e excl='gads'?>"));
+    }
+
+    @Test
+    public void testRootPInoProlog() throws Exception {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        Document doc = dbf.newDocumentBuilder().parse(getTestStream("./resources/rootMaterialTest.xml"));
+        StringWriter sw = new StringWriter();
+        XMLStreamWriter swriter = StaxUtils.createXMLStreamWriter(sw);
+        StaxUtils.writeDocument(doc, swriter, false, false);
+        swriter.flush();
+        swriter.close();
+        String output = sw.toString();
+        assertFalse(output.contains("<?pi in='the sky'?>"));
+        assertFalse(output.contains("<?e excl='gads'?>"));
+    }
+
+    @Test
+    public void testDefaultPrefix() throws Exception {
+        String soapMessage = "./resources/AddRequest.xml";
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        XMLStreamReader reader = StaxUtils.createXMLStreamReader(getTestStream(soapMessage));
+        XMLStreamWriter writer = StaxUtils.createXMLStreamWriter(baos);
+        StaxSource staxSource = new StaxSource(reader);
+        StaxUtils.copy(staxSource, writer);
+        writer.flush();
+        baos.flush();
+    }
+
+    @Test
+    public void testDefaultPrefixInRootElementWithIdentityTransformer() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        String xml = "<root xmlns=\"urn:org.apache.cxf:test\">Text</root>";
+        StringReader stringReader = new StringReader(xml);
+        StreamSource source = new StreamSource(stringReader);
+        XMLStreamReader reader = StaxUtils.createXMLStreamReader(source);
+        XMLStreamWriter writer = StaxUtils.createXMLStreamWriter(baos);
+        StaxSource staxSource = new StaxSource(reader);
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        Transformer transformer = transformerFactory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+        transformer.transform(staxSource, new StreamResult(baos));
+        writer.flush();
+        baos.flush();
+        assertThat(new String(baos.toByteArray()), equalTo(xml));
+    }
+
+    @Test
+    public void testDefaultPrefixInRootElementWithXalanCopyTransformer() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        String xml = "<root xmlns=\"urn:org.apache.cxf:test\">Text</root>";
+        StringReader stringReader = new StringReader(xml);
+        //StreamSource source = new StreamSource(stringReader);
+        XMLStreamReader reader = StaxUtils.createXMLStreamReader(stringReader);
+        XMLStreamWriter writer = StaxUtils.createXMLStreamWriter(baos);
+        StaxSource staxSource = new StaxSource(reader);
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        Document doc = StaxUtils.read(getTestStream("./resources/copy.xsl"));
+        Transformer transformer = transformerFactory.newTransformer(new DOMSource(doc));
+        //System.out.println("Used transformer: " + transformer.getClass().getName());
+        transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+        transformer.transform(staxSource, new StreamResult(baos));
+        writer.flush();
+        baos.flush();
+        assertThat(new String(baos.toByteArray()), equalTo(xml));
+    }
+
+    @Test
+    public void testDefaultPrefixInRootElementWithJDKInternalCopyTransformer() throws Exception {
+        TransformerFactory trf = null;
+        try {
+            trf = TransformerFactory
+                .newInstance("com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl", null);
+            trf.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            String xml = "<root xmlns=\"urn:org.apache.cxf:test\">Text</root>";
+            StringReader stringReader = new StringReader(xml);
+            StreamSource source = new StreamSource(stringReader);
+            XMLStreamReader reader = StaxUtils.createXMLStreamReader(source);
+            XMLStreamWriter writer = StaxUtils.createXMLStreamWriter(baos);
+            StaxSource staxSource = new StaxSource(reader);
+            Document doc = StaxUtils.read(getTestStream("./resources/copy.xsl"));
+            Transformer transformer = trf.newTransformer(new DOMSource(doc));
+            //System.out.println("Used transformer: " + transformer.getClass().getName());
+            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+            transformer.transform(staxSource, new StreamResult(baos));
+            writer.flush();
+            baos.flush();
+            assertThat(new String(baos.toByteArray()), equalTo(xml));
+        } catch (Throwable throwable) {
+            // ignore on non Sun/Oracle JDK
+            return;
+        }
+    }
+
+    @Test
+    public void testCXF3193() throws Exception {
+        String testString = "<a:elem1 xmlns:a=\"test\" xmlns:b=\"test\" a:attr1=\"value\"/>";
+        CachingXmlEventWriter writer = new CachingXmlEventWriter();
+        StaxUtils.copy(StaxUtils.createXMLStreamReader(new StringReader(testString)),
+                       writer);
+        StringWriter swriter = new StringWriter();
+        XMLStreamWriter xwriter = StaxUtils.createXMLStreamWriter(swriter);
+        for (XMLEvent event : writer.getEvents()) {
+            StaxUtils.writeEvent(event, xwriter);
+        }
+        xwriter.flush();
+
+        String s = swriter.toString();
+        int idx = s.indexOf("xmlns:a");
+        idx = s.indexOf("xmlns:a", idx + 1);
+        assertEquals(-1, idx);
+    }
+
+    @Test
+    public void testCopyWithEmptyNamespace() throws Exception {
+        StringBuilder in = new StringBuilder(128);
+        in.append("<foo xmlns=\"http://example.com/\">");
+        in.append("<bar xmlns=\"\"/>");
+        in.append("</foo>");
+
+        XMLStreamReader reader = StaxUtils.createXMLStreamReader(
+             new ByteArrayInputStream(in.toString().getBytes()));
+
+        Writer out = new StringWriter();
+        XMLStreamWriter writer = StaxUtils.createXMLStreamWriter(out);
+        StaxUtils.copy(reader, writer);
+        writer.close();
+
+        assertEquals(in.toString(), out.toString());
+    }
+
+    @Test
+    public void testQName() throws Exception {
+        StringBuilder in = new StringBuilder(128);
+        in.append("<f:foo xmlns:f=\"http://example.com/\">");
+        in.append("<bar>f:Bar</bar>");
+        in.append("<bar> f:Bar </bar>");
+        in.append("<bar>x:Bar</bar>");
+        in.append("</f:foo>");
+
+        XMLStreamReader reader = StaxUtils.createXMLStreamReader(
+             new ByteArrayInputStream(in.toString().getBytes()));
+
+        QName qname = new QName("http://example.com/", "Bar");
+        assertEquals(XMLStreamConstants.START_ELEMENT, reader.next());
+        assertEquals(XMLStreamConstants.START_ELEMENT, reader.next());
+        // first bar
+        assertEquals(qname, StaxUtils.readQName(reader));
+        assertEquals(XMLStreamConstants.START_ELEMENT, reader.next());
+        // second bar
+        assertEquals(qname, StaxUtils.readQName(reader));
+        assertEquals(XMLStreamConstants.START_ELEMENT, reader.next());
+        // third bar
+        try {
+            StaxUtils.readQName(reader);
+            fail("invalid qname in mapping");
+        } catch (Exception e) {
+            // ignore
+        }
+    }
+
+    @Test
+    public void testCopyFromTheMiddle() throws Exception {
+        String innerXml =
+                "<inner>\n"
+                + "<body>body text here</body>\n"
+                + "</inner>\n";
+        String xml =
+                "<outer>\n"
+                + innerXml
+                + "</outer>";
+
+        StringReader reader = new StringReader(xml);
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        dbf.setValidating(false);
+
+        Document doc = dbf.newDocumentBuilder().parse(new InputSource(reader));
+        Source source = new DOMSource(doc);
+
+        // Skip <outer>
+        XMLStreamReader sreader = StaxUtils.createXMLStreamReader(source);
+        while (!"inner".equals(sreader.getLocalName())) {
+            sreader.next();
+        }
+
+        StringWriter sw = new StringWriter();
+        XMLStreamWriter swriter = StaxUtils.createXMLStreamWriter(sw);
+
+        StaxUtils.copy(sreader, swriter, true, true);
+        swriter.flush();
+        swriter.close();
+
+        //System.out.println(innerXml);
+        //System.out.println(sw.toString());
+        assertEquals(innerXml, sw.toString());
+    }
+
+    @Test
+    public void testIsSecureReader() {
+        Document doc = DOMUtils.newDocument();
+        Element documentElement = doc.createElementNS(null, "root");
+        doc.appendChild(documentElement);
+
+        XMLStreamReader reader = StaxUtils.createXMLStreamReader(new StringReader(StaxUtils.toString(doc)));
+        assertTrue(StaxUtils.isSecureReader(reader, null));
+    }
+
+    @Test
+    public void testDefaultMaxAttributeCount() throws XMLStreamException {
+        Document doc = DOMUtils.newDocument();
+        Element documentElement = doc.createElementNS(null, "root");
+        doc.appendChild(documentElement);
+
+        for (int i = 0; i < 300; i++) {
+            documentElement.setAttributeNS(null, "attr-" + i, Integer.toString(i));
+        }
+
+        // Should be OK
+        XMLStreamReader reader = StaxUtils.createXMLStreamReader(new StringReader(StaxUtils.toString(doc)));
+        assertNotNull(StaxUtils.read(reader));
+
+        for (int i = 300; i < 800; i++) {
+            documentElement.setAttributeNS(null, "attr-" + i, Integer.toString(i));
+        }
+
+        assertTrue(documentElement.getAttributes().getLength() > 500);
+
+        // Should fail as we are over the max attribute count
+        reader = StaxUtils.createXMLStreamReader(new StringReader(StaxUtils.toString(doc)));
+        try {
+            StaxUtils.read(reader);
+            fail("Failure expected on exceeding the limit");
+        } catch (XMLStreamException ex) {
+            assertTrue(ex.getMessage().contains("Attribute limit"));
+        }
+    }
+
+    @Test
+    public void testDefaultMaxAttributeLength() throws XMLStreamException {
+        Document doc = DOMUtils.newDocument();
+        Element documentElement = doc.createElementNS(null, "root");
+        doc.appendChild(documentElement);
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 1024; i++) {
+            sb.append(i);
+        }
+
+        documentElement.setAttributeNS(null, "attr", sb.toString());
+
+        // Should be OK
+        XMLStreamReader reader = StaxUtils.createXMLStreamReader(new StringReader(StaxUtils.toString(doc)));
+        assertNotNull(StaxUtils.read(reader));
+
+        for (int i = 0; i < 1024 * 64; i++) {
+            sb.append(i);
+        }
+
+        documentElement.setAttributeNS(null, "attr", sb.toString());
+        assertTrue(documentElement.getAttributeNS(null, "attr").length() > (1024 * 64));
+
+        // Should fail as we are over the max attribute length
+        reader = StaxUtils.createXMLStreamReader(new StringReader(StaxUtils.toString(doc)));
+        try {
+            StaxUtils.read(reader);
+            fail("Failure expected on exceeding the limit");
+        } catch (XMLStreamException ex) {
+            assertTrue(ex.getMessage().contains("Maximum attribute size limit"));
+        }
+
+    }
+
+    @Test
+    public void testDefaultMaxElementDepth() throws XMLStreamException {
+        Document doc = DOMUtils.newDocument();
+        Element documentElement = doc.createElementNS(null, "root");
+        doc.appendChild(documentElement);
+
+        Element currentNode = documentElement;
+        for (int i = 0; i < 50; i++) {
+            Element childElement = doc.createElementNS("null", "root" + i);
+            currentNode.appendChild(childElement);
+            currentNode = childElement;
+        }
+
+        // Should be OK
+        XMLStreamReader reader = StaxUtils.createXMLStreamReader(new StringReader(StaxUtils.toString(doc)));
+        assertNotNull(StaxUtils.read(reader));
+
+        for (int i = 50; i < 102; i++) {
+            Element childElement = doc.createElementNS("null", "root" + i);
+            currentNode.appendChild(childElement);
+            currentNode = childElement;
+        }
+
+        // Should fail as we are over the max element depth value
+        reader = StaxUtils.createXMLStreamReader(new StringReader(StaxUtils.toString(doc)));
+        try {
+            StaxUtils.read(reader);
+            fail("Failure expected on exceeding the limit");
+        } catch (XMLStreamException ex) {
+            assertTrue(ex.getMessage().contains("Maximum Element Depth limit"));
+        }
+    }
+
+    @Test
+    public void testDefaultMaxChildElements() throws XMLStreamException {
+        Document doc = DOMUtils.newDocument();
+        Element documentElement = doc.createElementNS(null, "root");
+        doc.appendChild(documentElement);
+
+        for (int i = 0; i < 1000; i++) {
+            Element childElement = doc.createElementNS("null", "root" + i);
+            documentElement.appendChild(childElement);
+        }
+
+        // Should be OK
+        XMLStreamReader reader = StaxUtils.createXMLStreamReader(new StringReader(StaxUtils.toString(doc)));
+        assertNotNull(StaxUtils.read(reader));
+
+        for (int i = 0; i < 49001; i++) {
+            Element childElement = doc.createElementNS("null", "root" + i);
+            documentElement.appendChild(childElement);
+        }
+
+        // Should fail as we are over the max element count value
+        reader = StaxUtils.createXMLStreamReader(new StringReader(StaxUtils.toString(doc)));
+        try {
+            StaxUtils.read(reader);
+            fail("Failure expected on exceeding the limit");
+        } catch (XMLStreamException ex) {
+            assertTrue(ex.getMessage().contains("Maximum Number of Child Elements limit"));
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.jaxws.2.3.common/test/org/apache/cxf/staxutils/StaxUtilsTest.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/test/org/apache/cxf/staxutils/StaxUtilsTest.java
@@ -62,6 +62,12 @@ import static org.junit.Assert.fail;
 
 public class StaxUtilsTest {
 
+    // Liberty Change: Add insecure parser variable since we do not ship WoodStox
+    static {
+        System.setProperty("org.apache.cxf.stax.allowInsecureParser", "true");
+    }
+    // Liberty Change End
+
     @Test
     public void testFactoryCreation() {
         XMLStreamReader reader = StaxUtils.createXMLStreamReader(getTestStream("./resources/amazon.xml"));
@@ -75,8 +81,7 @@ public class StaxUtilsTest {
     @Test
     public void testCommentNode() throws Exception {
         //CXF-3034
-        Document document = DocumentBuilderFactory.newInstance()
-                .newDocumentBuilder().newDocument();
+        Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
         Element root = document.createElementNS("urn:test", "root");
         root.appendChild(document.createComment("test comment"));
         StaxUtils.copy(StaxUtils.createXMLStreamReader(root), StaxUtils.createXMLStreamWriter(System.out));
@@ -158,8 +163,7 @@ public class StaxUtilsTest {
     @Test
     public void testNonNamespaceAwareParser() throws Exception {
         String xml = "<blah xmlns=\"http://blah.org/\" xmlns:snarf=\"http://snarf.org\">"
-            + "<foo snarf:blop=\"blop\">foo</foo></blah>";
-
+                     + "<foo snarf:blop=\"blop\">foo</foo></blah>";
 
         StringReader reader = new StringReader(xml);
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
@@ -172,7 +176,6 @@ public class StaxUtilsTest {
         reader = new StringReader(xml);
         Document docNs = dbf.newDocumentBuilder().parse(new InputSource(reader));
         Source sourceNs = new DOMSource(docNs);
-
 
         XMLStreamReader sreader = StaxUtils.createXMLStreamReader(source);
 
@@ -190,7 +193,6 @@ public class StaxUtilsTest {
         assertTrue(output.contains("snarf"));
         assertTrue(output.contains("blop"));
 
-
         sreader = StaxUtils.createXMLStreamReader(sourceNs);
         sw = new StringWriter();
         swriter = StaxUtils.createXMLStreamWriter(sw);
@@ -204,7 +206,6 @@ public class StaxUtilsTest {
         assertTrue(output.contains("foo"));
         assertTrue(output.contains("snarf"));
         assertTrue(output.contains("blop"));
-
 
         sreader = StaxUtils.createXMLStreamReader(source);
 
@@ -224,20 +225,20 @@ public class StaxUtilsTest {
     @Test
     public void testEmptyNamespace() throws Exception {
         String testString = "<ns1:a xmlns:ns1=\"http://www.apache.org/\"><s1 xmlns=\"\">"
-            + "abc</s1><s2 xmlns=\"\">def</s2></ns1:a>";
+                            + "abc</s1><s2 xmlns=\"\">def</s2></ns1:a>";
 
         cycleString(testString);
 
         testString = "<a xmlns=\"http://www.apache.org/\"><s1 xmlns=\"\">"
-            + "abc</s1><s2 xmlns=\"\">def</s2></a>";
+                     + "abc</s1><s2 xmlns=\"\">def</s2></a>";
         cycleString(testString);
 
         testString = "<a xmlns=\"http://www.apache.org/\"><s1 xmlns=\"\">"
-            + "abc</s1><s2>def</s2></a>";
+                     + "abc</s1><s2>def</s2></a>";
         cycleString(testString);
 
         testString = "<ns1:a xmlns:ns1=\"http://www.apache.org/\"><s1>"
-            + "abc</s1><s2 xmlns=\"\">def</s2></ns1:a>";
+                     + "abc</s1><s2 xmlns=\"\">def</s2></ns1:a>";
 
         cycleString(testString);
     }
@@ -351,8 +352,7 @@ public class StaxUtilsTest {
     public void testDefaultPrefixInRootElementWithJDKInternalCopyTransformer() throws Exception {
         TransformerFactory trf = null;
         try {
-            trf = TransformerFactory
-                .newInstance("com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl", null);
+            trf = TransformerFactory.newInstance("com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl", null);
             trf.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             String xml = "<root xmlns=\"urn:org.apache.cxf:test\">Text</root>";
@@ -398,11 +398,11 @@ public class StaxUtilsTest {
     public void testCopyWithEmptyNamespace() throws Exception {
         StringBuilder in = new StringBuilder(128);
         in.append("<foo xmlns=\"http://example.com/\">");
-        in.append("<bar xmlns=\"\"/>");
+        in.append("<bar xmlns=\"\"></bar>");
         in.append("</foo>");
 
         XMLStreamReader reader = StaxUtils.createXMLStreamReader(
-             new ByteArrayInputStream(in.toString().getBytes()));
+                                                                 new ByteArrayInputStream(in.toString().getBytes()));
 
         Writer out = new StringWriter();
         XMLStreamWriter writer = StaxUtils.createXMLStreamWriter(out);
@@ -422,7 +422,7 @@ public class StaxUtilsTest {
         in.append("</f:foo>");
 
         XMLStreamReader reader = StaxUtils.createXMLStreamReader(
-             new ByteArrayInputStream(in.toString().getBytes()));
+                                                                 new ByteArrayInputStream(in.toString().getBytes()));
 
         QName qname = new QName("http://example.com/", "Bar");
         assertEquals(XMLStreamConstants.START_ELEMENT, reader.next());
@@ -444,14 +444,12 @@ public class StaxUtilsTest {
 
     @Test
     public void testCopyFromTheMiddle() throws Exception {
-        String innerXml =
-                "<inner>\n"
-                + "<body>body text here</body>\n"
-                + "</inner>\n";
-        String xml =
-                "<outer>\n"
-                + innerXml
-                + "</outer>";
+        String innerXml = "<inner>\n"
+                          + "<body>body text here</body>\n"
+                          + "</inner>\n";
+        String xml = "<outer>\n"
+                     + innerXml
+                     + "</outer>";
 
         StringReader reader = new StringReader(xml);
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
@@ -479,7 +477,7 @@ public class StaxUtilsTest {
         assertEquals(innerXml, sw.toString());
     }
 
-    @Test
+    //@Test - Disable since we do not ship woodstox
     public void testIsSecureReader() {
         Document doc = DOMUtils.newDocument();
         Element documentElement = doc.createElementNS(null, "root");
@@ -489,7 +487,7 @@ public class StaxUtilsTest {
         assertTrue(StaxUtils.isSecureReader(reader, null));
     }
 
-    @Test
+    //@Test - Disable since we do not ship woodstox
     public void testDefaultMaxAttributeCount() throws XMLStreamException {
         Document doc = DOMUtils.newDocument();
         Element documentElement = doc.createElementNS(null, "root");
@@ -519,7 +517,7 @@ public class StaxUtilsTest {
         }
     }
 
-    @Test
+    //@Test - Disable since we do not ship woodstox
     public void testDefaultMaxAttributeLength() throws XMLStreamException {
         Document doc = DOMUtils.newDocument();
         Element documentElement = doc.createElementNS(null, "root");
@@ -554,7 +552,7 @@ public class StaxUtilsTest {
 
     }
 
-    @Test
+    //@Test - Disable since we do not ship woodstox
     public void testDefaultMaxElementDepth() throws XMLStreamException {
         Document doc = DOMUtils.newDocument();
         Element documentElement = doc.createElementNS(null, "root");
@@ -587,7 +585,7 @@ public class StaxUtilsTest {
         }
     }
 
-    @Test
+    //@Test - Disable since we do not ship woodstox
     public void testDefaultMaxChildElements() throws XMLStreamException {
         Document doc = DOMUtils.newDocument();
         Element documentElement = doc.createElementNS(null, "root");

--- a/dev/com.ibm.ws.jaxws.2.3.common/test/org/apache/cxf/staxutils/resources/AddRequest.xml
+++ b/dev/com.ibm.ws.jaxws.2.3.common/test/org/apache/cxf/staxutils/resources/AddRequest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+    <soap:Body>
+        <add xmlns="http://apache.org/cxf/calculator/types">
+            <arg0>1</arg0>
+            <arg1>2</arg1>
+        </add>
+    </soap:Body>
+</soap:Envelope>

--- a/dev/com.ibm.ws.jaxws.2.3.common/test/org/apache/cxf/staxutils/resources/amazon.xml
+++ b/dev/com.ibm.ws.jaxws.2.3.common/test/org/apache/cxf/staxutils/resources/amazon.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<ns:ItemLookup xmlns:ns="http://xml.amazon.com/AWSECommerceService/2004-08-01">
+    <ns:SubscriptionId>1E5AY4ZG53H4AMC8QH82</ns:SubscriptionId>
+    <ns:AssociateTag>dandiephosblo-20</ns:AssociateTag>
+    <ns:Request>
+        <ns:IdType>ASIN</ns:IdType>
+        <ns:ItemId>0486411214</ns:ItemId>
+    </ns:Request>
+</ns:ItemLookup>

--- a/dev/com.ibm.ws.jaxws.2.3.common/test/org/apache/cxf/staxutils/resources/copy.xsl
+++ b/dev/com.ibm.ws.jaxws.2.3.common/test/org/apache/cxf/staxutils/resources/copy.xsl
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+    <!-- Idiomatic Copy Transformation -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()" />
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/dev/com.ibm.ws.jaxws.2.3.common/test/org/apache/cxf/staxutils/resources/headerSoapReq.xml
+++ b/dev/com.ibm.ws.jaxws.2.3.common/test/org/apache/cxf/staxutils/resources/headerSoapReq.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Header>
+    <ns3:SOAPHeaderInfo xmlns:ns3="http://apache.org/headers/types" xmlns:ns2="http://www.w3.org/2005/02/addressing/wsdl">
+      <originator>in originator</originator>
+      <message>in message</message>
+    </ns3:SOAPHeaderInfo>
+  </soap:Header>
+  <soap:Body>
+    <ns3:inHeader xmlns:ns3="http://apache.org/headers/types" xmlns:ns2="http://www.w3.org/2005/02/addressing/wsdl">
+      <requestType>in request type</requestType>
+    </ns3:inHeader>
+  </soap:Body>
+</soap:Envelope>

--- a/dev/com.ibm.ws.jaxws.2.3.common/test/org/apache/cxf/staxutils/resources/rootMaterialTest.xml
+++ b/dev/com.ibm.ws.jaxws.2.3.common/test/org/apache/cxf/staxutils/resources/rootMaterialTest.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<?pi in='the sky'?>
+<?e excl='gads'?>
+<rootMaterialTest xmlns="urn:org.apache.cxf:test">
+This is text inside the root.
+</rootMaterialTest>

--- a/dev/com.ibm.ws.jaxws.2.3.common/test/org/apache/cxf/staxutils/resources/sayHiRpcLiteralReq.xml
+++ b/dev/com.ibm.ws.jaxws.2.3.common/test/org/apache/cxf/staxutils/resources/sayHiRpcLiteralReq.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:m1="http://apache.org/hello_world_rpclit">
+    <SOAP-ENV:Body>
+        <m1:sayHi> </m1:sayHi>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/staxutils/StaxSource.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/staxutils/StaxSource.java
@@ -1,0 +1,266 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.staxutils;
+
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.transform.sax.SAXSource;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.DTDHandler;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.ext.LexicalHandler;
+import org.xml.sax.helpers.AttributesImpl;
+
+public class StaxSource extends SAXSource implements XMLReader {
+
+    private XMLStreamReader streamReader;
+
+    private ContentHandler contentHandler;
+
+    private LexicalHandler lexicalHandler;
+
+    public StaxSource(XMLStreamReader streamReader) {
+        this.streamReader = streamReader;
+        setInputSource(new InputSource());
+    }
+
+    public XMLReader getXMLReader() {
+        return this;
+    }
+
+    public XMLStreamReader getXMLStreamReader() {
+        return streamReader;
+    }
+
+    protected void parse() throws SAXException {
+        try {
+            while (true) {
+                switch (streamReader.getEventType()) {
+                // Attributes are handled in START_ELEMENT
+                case XMLStreamConstants.ATTRIBUTE:
+                    break;
+                case XMLStreamConstants.CDATA: {
+                    if (lexicalHandler != null) {
+                        lexicalHandler.startCDATA();
+                    }
+                    int length = streamReader.getTextLength();
+                    int start = streamReader.getTextStart();
+                    char[] chars = streamReader.getTextCharacters();
+                    contentHandler.characters(chars, start, length);
+                    if (lexicalHandler != null) {
+                        lexicalHandler.endCDATA();
+                    }
+                    break;
+                }
+                case XMLStreamConstants.CHARACTERS: {
+                    int length = streamReader.getTextLength();
+                    int start = streamReader.getTextStart();
+                    char[] chars = streamReader.getTextCharacters();
+                    contentHandler.characters(chars, start, length);
+                    break;
+                }
+                case XMLStreamConstants.SPACE: {
+                    int length = streamReader.getTextLength();
+                    int start = streamReader.getTextStart();
+                    char[] chars = streamReader.getTextCharacters();
+                    contentHandler.ignorableWhitespace(chars, start, length);
+                    break;
+                }
+                case XMLStreamConstants.COMMENT:
+                    if (lexicalHandler != null) {
+                        int length = streamReader.getTextLength();
+                        int start = streamReader.getTextStart();
+                        char[] chars = streamReader.getTextCharacters();
+                        lexicalHandler.comment(chars, start, length);
+                    }
+                    break;
+                case XMLStreamConstants.DTD:
+                    break;
+                case XMLStreamConstants.END_DOCUMENT:
+                    contentHandler.endDocument();
+                    return;
+                case XMLStreamConstants.END_ELEMENT: {
+                    String uri = streamReader.getNamespaceURI();
+                    String localName = streamReader.getLocalName();
+                    String prefix = streamReader.getPrefix();
+                    String qname = prefix != null && !prefix.isEmpty()
+                        ? prefix + ':' + localName : localName;
+                    contentHandler.endElement(uri, localName, qname);
+                    // namespaces
+                    for (int i = 0; i < streamReader.getNamespaceCount(); i++) {
+                        contentHandler.endPrefixMapping(streamReader.getNamespacePrefix(i));
+                    }
+                    break;
+                }
+                case XMLStreamConstants.ENTITY_DECLARATION:
+                case XMLStreamConstants.ENTITY_REFERENCE:
+                case XMLStreamConstants.NAMESPACE:
+                case XMLStreamConstants.NOTATION_DECLARATION:
+                    break;
+                case XMLStreamConstants.PROCESSING_INSTRUCTION:
+                    break;
+                case XMLStreamConstants.START_DOCUMENT:
+                    contentHandler.startDocument();
+                    break;
+                case XMLStreamConstants.START_ELEMENT: {
+                    String uri = streamReader.getNamespaceURI();
+                    String localName = streamReader.getLocalName();
+                    String prefix = streamReader.getPrefix();
+                    String qname = prefix != null && !prefix.isEmpty()
+                        ? prefix + ':' + localName : localName;
+                    // namespaces
+                    for (int i = 0; i < streamReader.getNamespaceCount(); i++) {
+                        String nsPrefix = streamReader.getNamespacePrefix(i);
+                        String nsUri = streamReader.getNamespaceURI(i);
+                        if (nsUri == null) {
+                            nsUri = "";
+                        }
+                        contentHandler.startPrefixMapping(nsPrefix, nsUri);
+                    }
+                    contentHandler.startElement(uri == null ? "" : uri, localName, qname, getAttributes());
+                    break;
+                }
+                default:
+                    break;
+                }
+                if (!streamReader.hasNext()) {
+                    return;
+                }
+                streamReader.next();
+            }
+        } catch (XMLStreamException e) {
+            SAXParseException spe;
+            if (e.getLocation() != null) {
+                spe = new SAXParseException(e.getMessage(), null, null,
+                                            e.getLocation().getLineNumber(),
+                                            e.getLocation().getColumnNumber(), e);
+            } else {
+                spe = new SAXParseException(e.getMessage(), null, null, -1, -1, e);
+            }
+            spe.initCause(e);
+            throw spe;
+        }
+    }
+
+    protected String getQualifiedName() {
+        String prefix = streamReader.getPrefix();
+        if (prefix != null && !prefix.isEmpty()) {
+            return prefix + ':' + streamReader.getLocalName();
+        }
+        return streamReader.getLocalName();
+    }
+
+    protected Attributes getAttributes() {
+        AttributesImpl attrs = new AttributesImpl();
+
+        for (int i = 0; i < streamReader.getAttributeCount(); i++) {
+            String uri = streamReader.getAttributeNamespace(i);
+            String localName = streamReader.getAttributeLocalName(i);
+            String prefix = streamReader.getAttributePrefix(i);
+            String qName;
+            if (prefix != null && prefix.length() > 0) {
+                qName = prefix + ':' + localName;
+            } else {
+                qName = localName;
+            }
+            String type = streamReader.getAttributeType(i);
+            String value = streamReader.getAttributeValue(i);
+            if (value == null) {
+                value = "";
+            }
+
+            attrs.addAttribute(uri == null ? "" : uri, localName, qName, type, value);
+        }
+        return attrs;
+    }
+
+    public boolean getFeature(String name) throws SAXNotRecognizedException, SAXNotSupportedException {
+        return false;
+    }
+
+    public void setFeature(String name, boolean value)
+        throws SAXNotRecognizedException, SAXNotSupportedException {
+    }
+
+    public Object getProperty(String name) throws SAXNotRecognizedException, SAXNotSupportedException {
+        return null;
+    }
+
+    public void setProperty(String name, Object value)
+        throws SAXNotRecognizedException, SAXNotSupportedException {
+        if ("http://xml.org/sax/properties/lexical-handler".equals(name)) {
+            lexicalHandler = (LexicalHandler) value;
+        } else {
+            throw new SAXNotRecognizedException(name);
+        }
+    }
+
+    public void setEntityResolver(EntityResolver resolver) {
+    }
+
+    public EntityResolver getEntityResolver() {
+        return null;
+    }
+
+    public void setDTDHandler(DTDHandler handler) {
+    }
+
+    public DTDHandler getDTDHandler() {
+        return null;
+    }
+
+    public void setContentHandler(ContentHandler handler) {
+        this.contentHandler = handler;
+        if (handler instanceof LexicalHandler
+            && lexicalHandler == null) {
+            lexicalHandler = (LexicalHandler)handler;
+        }
+    }
+
+    public ContentHandler getContentHandler() {
+        return this.contentHandler;
+    }
+
+    public void setErrorHandler(ErrorHandler handler) {
+    }
+
+    public ErrorHandler getErrorHandler() {
+        return null;
+    }
+
+    public void parse(InputSource input) throws SAXException {
+        StaxSource.this.parse();
+    }
+
+    public void parse(String systemId) throws SAXException {
+        StaxSource.this.parse();
+    }
+
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/staxutils/StaxSource.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/staxutils/StaxSource.java
@@ -142,6 +142,12 @@ public class StaxSource extends SAXSource implements XMLReader {
                         if (nsUri == null) {
                             nsUri = "";
                         }
+                        
+                        // Liberty Change Start - Handle a null nsPrefix to prevent NPE in TRAX
+                        if (nsPrefix == null) {
+                            nsPrefix = "";
+                        } 
+                        // Liberty Change End
                         contentHandler.startPrefixMapping(nsPrefix, nsUri);
                     }
                     contentHandler.startElement(uri == null ? "" : uri, localName, qname, getAttributes());


### PR DESCRIPTION
This pull request addresses an NPE in CXF 3.4 that occurs here:

```
Caused by: java.lang.NullPointerException
[10/24/22, 16:15:51:763 GMT] 000000a3 SystemErr                                                    R       at java.xml/com.sun.org.apache.xml.internal.serializer.ToUnknownStream.startPrefixMapping(ToUnknownStream.java:377)
[10/24/22, 16:15:51:763 GMT] 000000a3 SystemErr                                                    R       at java.xml/com.sun.org.apache.xml.internal.serializer.ToUnknownStream.startPrefixMapping(ToUnknownStream.java:322)
[10/24/22, 16:15:51:763 GMT] 000000a3 SystemErr                                                    R       at org.apache.cxf.staxutils.StaxSource.parse(StaxSource.java:145)
[10/24/22, 16:15:51:763 GMT] 000000a3 SystemErr                                                    R       at org.apache.cxf.staxutils.StaxSource.parse(StaxSource.java:259)
[10/24/22, 16:15:51:763 GMT] 000000a3 SystemErr                                                    R       at java.xml/com.sun.org.apache.xalan.internal.xsltc.trax.TransformerImpl.transformIdentity(TransformerImpl.java:688)
```
 
This is due to CXF not handling a null prefix when WoodStox is not the default StAX provider and TrAX is also in use. This pull request also adds some Unit Tests from CXF to ensure that we test our overrides to CXF StaxUtils/StaxSource classes. 