### PR TITLE
Allow thread pool controller to shrink pool under heavy load

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ThreadPoolController.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ThreadPoolController.java
@@ -1247,7 +1247,7 @@ public final class ThreadPoolController {
 
         if (poolAdjustment != 0) {
             // don't shrink too far
-            if (poolAdjustment < 0 && newPoolSize >= Math.max(activeThreads, currentMinimumPoolSize)) {
+            if (poolAdjustment < 0 && newPoolSize >= currentMinimumPoolSize) {
                 lastAction = LastAction.SHRINK;
                 setPoolSize(newPoolSize);
             } else if (poolAdjustment > 0 && newPoolSize <= maxThreads) {


### PR DESCRIPTION
In an OCP environment, with a small CPU allocation and under heavy load, the thread pool does not find the optimal size, staying larger than it should. This PR is to address that issue.