### PR TITLE
upgrade graphql-java

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -164,12 +164,12 @@
     <dependency>
       <groupId>com.graphql-java</groupId>
       <artifactId>graphql-java</artifactId>
-      <version>16.2</version>
+      <version>19.2</version>
     </dependency>
     <dependency>
       <groupId>com.graphql-java</groupId>
       <artifactId>java-dataloader</artifactId>
-      <version>2.2.3</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>com.hazelcast</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -28,8 +28,8 @@ com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java-util:3.19.2
 com.google.protobuf:protobuf-java:3.19.2
 com.googlecode.json-simple:json-simple:1.1.1
-com.graphql-java:graphql-java:16.2
-com.graphql-java:java-dataloader:2.2.3
+com.graphql-java:graphql-java:19.2
+com.graphql-java:java-dataloader:3.2.0
 com.hazelcast:hazelcast-client:3.12.12
 com.hazelcast:hazelcast:3.12.12
 com.hazelcast:hazelcast:5.1.3

--- a/dev/com.ibm.ws.com.graphql.java/bnd.bnd
+++ b/dev/com.ibm.ws.com.graphql.java/bnd.bnd
@@ -17,16 +17,18 @@ bVersion=1.0
 
 
 -includeresource: \
-  @${repo;com.graphql-java:graphql-java;16.2},\
-  @${repo;com.graphql-java:java-dataloader;2.2.3},\
+  @${repo;com.graphql-java:graphql-java;19.2},\
+  @${repo;com.graphql-java:java-dataloader;3.2.0},\
   @${repo;org.antlr:antlr4-runtime;4.8}
-  
+
 Export-Package: \
-  graphql.*;version=16.2,\
-  org.dataloader.*;version=2.2.3
+  graphql.*;version=19.2,\
+  org.dataloader.*;version=3.2.0
 
 Import-Package: \
   !com.google.errorprone.*,\
   !org.checkerframework.checker.nullness.qual.*,\
+  !javax.annotation.meta,\
+  !sun.misc,\
   *
- 
+

--- a/dev/com.ibm.ws.io.smallrye.graphql/bnd.bnd
+++ b/dev/com.ibm.ws.io.smallrye.graphql/bnd.bnd
@@ -54,7 +54,7 @@ Export-Package: \
 
 src: src/
 
--cdiannotations: 
+-cdiannotations:
 
 -dsannotations: com.ibm.ws.io.smallrye.graphql.component.*
 
@@ -89,7 +89,7 @@ Service-Component: \
   io.smallrye:smallrye-graphql-schema-builder;strategy=exact;version=${smallryeGraphQLVersion},\
   io.smallrye:smallrye-graphql-schema-model;strategy=exact;version=${smallryeGraphQLVersion},\
   io.smallrye:smallrye-graphql-servlet;strategy=exact;version=${smallryeGraphQLVersion},\
-  com.ibm.websphere.javaee.annotation.1.3;version=latest, \
+  com.ibm.websphere.javaee.annotation.1.3;version=latest,\
   com.ibm.websphere.javaee.cdi.2.0;version=latest,\
   com.ibm.websphere.javaee.interceptor.1.2;version=latest,\
   com.ibm.websphere.javaee.jsonp.1.1;version=latest,\
@@ -105,5 +105,6 @@ Service-Component: \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
   com.ibm.ws.org.jboss.jandex;version=latest,\
   com.ibm.ws.org.jboss.logging;version=latest,\
-  com.ibm.ws.webcontainer;version=latest
-
+  com.ibm.ws.webcontainer;version=latest,\
+  com.ibm.websphere.javaee.jsonb.1.0;version=latest,\
+  com.ibm.ws.logging.core;version=latest

--- a/dev/com.ibm.ws.io.smallrye.graphql/src/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/dev/com.ibm.ws.io.smallrye.graphql/src/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -1,0 +1,746 @@
+// https://github.com/smallrye/smallrye-graphql/blob/e6685d6b9a51db7674f2610e20aa0ff3f75ef69f/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+// With changes from https://github.com/smallrye/smallrye-graphql/commit/4a47a2da6e4f4b4a6aedf2fc6464510737fe4c52#diff-3de1c8e86a52a96e30384e8fdc4cd85b3f0526c456ef2158c9220ff6b5ec2fde
+// Apache v2.0 licensed - https://github.com/smallrye/smallrye-graphql/blob/1.0.9/LICENSE
+package io.smallrye.graphql.bootstrap;
+
+import static graphql.schema.visibility.DefaultGraphqlFieldVisibility.DEFAULT_FIELD_VISIBILITY;
+import static graphql.schema.visibility.NoIntrospectionGraphqlFieldVisibility.NO_INTROSPECTION_FIELD_VISIBILITY;
+import static io.smallrye.graphql.SmallRyeGraphQLServerLogging.log;
+
+import java.io.StringReader;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.json.Json;
+import javax.json.JsonReader;
+import javax.json.JsonReaderFactory;
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.FieldCoordinates;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLCodeRegistry;
+import graphql.schema.GraphQLEnumType;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLInputObjectField;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLInputType;
+import graphql.schema.GraphQLInterfaceType;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLScalarType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLTypeReference;
+import graphql.schema.visibility.BlockedFields;
+import graphql.schema.visibility.GraphqlFieldVisibility;
+import io.smallrye.graphql.execution.Classes;
+import io.smallrye.graphql.execution.context.SmallRyeContext;
+import io.smallrye.graphql.execution.datafetcher.BatchDataFetcher;
+import io.smallrye.graphql.execution.datafetcher.CollectionCreator;
+import io.smallrye.graphql.execution.datafetcher.PropertyDataFetcher;
+import io.smallrye.graphql.execution.error.ErrorInfoMap;
+import io.smallrye.graphql.execution.event.EventEmitter;
+import io.smallrye.graphql.execution.resolver.InterfaceOutputRegistry;
+import io.smallrye.graphql.execution.resolver.InterfaceResolver;
+import io.smallrye.graphql.json.JsonBCreator;
+import io.smallrye.graphql.json.JsonInputRegistry;
+import io.smallrye.graphql.scalar.GraphQLScalarTypes;
+import io.smallrye.graphql.schema.model.Argument;
+import io.smallrye.graphql.schema.model.EnumType;
+import io.smallrye.graphql.schema.model.Field;
+import io.smallrye.graphql.schema.model.Group;
+import io.smallrye.graphql.schema.model.InputType;
+import io.smallrye.graphql.schema.model.InterfaceType;
+import io.smallrye.graphql.schema.model.Operation;
+import io.smallrye.graphql.schema.model.Reference;
+import io.smallrye.graphql.schema.model.ReferenceType;
+import io.smallrye.graphql.schema.model.Schema;
+import io.smallrye.graphql.schema.model.Type;
+import io.smallrye.graphql.schema.model.Wrapper;
+import io.smallrye.graphql.spi.ClassloadingService;
+
+/**
+ * Bootstrap MicroProfile GraphQL
+ * This create a graphql-java model from the smallrye model
+ *
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public class Bootstrap {
+
+    private final Schema schema;
+    private final Config config;
+    private final EventEmitter eventEmitter;
+    private final DataFetcherFactory dataFetcherFactory;
+    private final Map<String, GraphQLEnumType> enumMap = new HashMap<>();
+    private final Map<String, GraphQLInterfaceType> interfaceMap = new HashMap<>();
+    private final Map<String, GraphQLInputObjectType> inputMap = new HashMap<>();
+    private final Map<String, GraphQLObjectType> typeMap = new HashMap<>();
+
+    private GraphQLSchema graphQLSchema;
+    private final GraphQLCodeRegistry.Builder codeRegistryBuilder = GraphQLCodeRegistry.newCodeRegistry();
+
+    private final ClassloadingService classloadingService = ClassloadingService.get();
+
+    public static GraphQLSchema bootstrap(Schema schema) {
+        return bootstrap(schema, null);
+    }
+
+    public static GraphQLSchema bootstrap(Schema schema, Config config) {
+        if (schema != null && (schema.hasOperations())) {
+            Bootstrap bootstrap = new Bootstrap(schema, config);
+            bootstrap.generateGraphQLSchema();
+            return bootstrap.graphQLSchema;
+        } else {
+            log.emptyOrNullSchema();
+            return null;
+        }
+    }
+
+    private Bootstrap(Schema schema, Config config) {
+        this.schema = schema;
+        this.config = config;
+        this.dataFetcherFactory = new DataFetcherFactory(config);
+        this.eventEmitter = EventEmitter.getInstance(config);
+        SmallRyeContext.setSchema(schema);
+    }
+
+    private void generateGraphQLSchema() {
+        GraphQLSchema.Builder schemaBuilder = GraphQLSchema.newSchema();
+
+        createGraphQLEnumTypes();
+        createGraphQLInterfaceTypes();
+        createGraphQLObjectTypes();
+        createGraphQLInputObjectTypes();
+
+        addQueries(schemaBuilder);
+        addMutations(schemaBuilder);
+
+        schemaBuilder.additionalTypes(new HashSet<>(enumMap.values()));
+        schemaBuilder.additionalTypes(new HashSet<>(interfaceMap.values()));
+        schemaBuilder.additionalTypes(new HashSet<>(typeMap.values()));
+        schemaBuilder.additionalTypes(new HashSet<>(inputMap.values()));
+
+        this.codeRegistryBuilder.fieldVisibility(getGraphqlFieldVisibility());
+        schemaBuilder = schemaBuilder.codeRegistry(codeRegistryBuilder.build());
+
+        // register error info
+        ErrorInfoMap.register(schema.getErrors());
+
+        // Allow custom extension
+        schemaBuilder = eventEmitter.fireBeforeSchemaBuild(schemaBuilder);
+
+        this.graphQLSchema = schemaBuilder.build();
+    }
+
+    private void addQueries(GraphQLSchema.Builder schemaBuilder) {
+        GraphQLObjectType.Builder queryBuilder = GraphQLObjectType.newObject()
+                .name(QUERY)
+                .description(QUERY_DESCRIPTION);
+
+        if (schema.hasQueries()) {
+            addRootObject(queryBuilder, schema.getQueries(), QUERY);
+        }
+        if (schema.hasGroupedQueries()) {
+            addGroupedRootObject(queryBuilder, schema.getGroupedQueries(), QUERY);
+        }
+
+        GraphQLObjectType query = queryBuilder.build();
+        schemaBuilder.query(query);
+    }
+
+    private void addMutations(GraphQLSchema.Builder schemaBuilder) {
+        GraphQLObjectType.Builder mutationBuilder = GraphQLObjectType.newObject()
+                .name(MUTATION)
+                .description(MUTATION_DESCRIPTION);
+
+        if (schema.hasMutations()) {
+            addRootObject(mutationBuilder, schema.getMutations(), MUTATION);
+        }
+        if (schema.hasGroupedMutations()) {
+            addGroupedRootObject(mutationBuilder, schema.getGroupedMutations(), MUTATION);
+        }
+
+        GraphQLObjectType mutation = mutationBuilder.build();
+        if (mutation.getFieldDefinitions() != null && !mutation.getFieldDefinitions().isEmpty()) {
+            schemaBuilder.mutation(mutation);
+        }
+    }
+
+    private void addRootObject(GraphQLObjectType.Builder rootBuilder, Set<Operation> operations,
+            String rootName) {
+
+        for (Operation operation : operations) {
+            operation = eventEmitter.fireCreateOperation(operation);
+            GraphQLFieldDefinition graphQLFieldDefinition = createGraphQLFieldDefinitionFromOperation(rootName,
+                    operation);
+            rootBuilder.field(graphQLFieldDefinition);
+        }
+    }
+
+    private void addGroupedRootObject(GraphQLObjectType.Builder rootBuilder,
+            Map<Group, Set<Operation>> operationMap, String rootName) {
+        Set<Map.Entry<Group, Set<Operation>>> operationsSet = operationMap.entrySet();
+
+        for (Map.Entry<Group, Set<Operation>> operationsEntry : operationsSet) {
+            Group group = operationsEntry.getKey();
+            Set<Operation> operations = operationsEntry.getValue();
+
+            GraphQLObjectType namedType = createNamedType(rootName, group, operations);
+
+            GraphQLFieldDefinition.Builder graphQLFieldDefinitionBuilder = GraphQLFieldDefinition.newFieldDefinition()
+                    .name(group.getName()).description(group.getDescription());
+
+            graphQLFieldDefinitionBuilder.type(namedType);
+
+            // DataFetcher (Just a dummy)
+            DataFetcher datafetcher = new DataFetcher() {
+                @Override
+                public Object get(DataFetchingEnvironment dfe) throws Exception {
+                    return namedType.getName();
+                }
+            };
+
+            GraphQLFieldDefinition namedField = graphQLFieldDefinitionBuilder.build();
+
+            this.codeRegistryBuilder.dataFetcherIfAbsent(
+                    FieldCoordinates.coordinates(rootName, namedField.getName()),
+                    datafetcher);
+
+            rootBuilder.field(namedField);
+        }
+    }
+
+    private GraphQLObjectType createNamedType(String parent, Group group, Set<Operation> operations) {
+        String namedTypeName = group.getName() + parent;
+        GraphQLObjectType.Builder objectTypeBuilder = GraphQLObjectType.newObject()
+                .name(namedTypeName)
+                .description(group.getDescription());
+
+        // Operations
+        for (Operation operation : operations) {
+            operation = eventEmitter.fireCreateOperation(operation);
+
+            GraphQLFieldDefinition graphQLFieldDefinition = createGraphQLFieldDefinitionFromOperation(namedTypeName,
+                    operation);
+            objectTypeBuilder = objectTypeBuilder.field(graphQLFieldDefinition);
+        }
+
+        GraphQLObjectType graphQLObjectType = objectTypeBuilder.build();
+
+        return graphQLObjectType;
+
+    }
+
+    // Create all enums and map them
+    private void createGraphQLEnumTypes() {
+        if (schema.hasEnums()) {
+            for (EnumType enumType : schema.getEnums().values()) {
+                createGraphQLEnumType(enumType);
+            }
+        }
+    }
+
+    private void createGraphQLEnumType(EnumType enumType) {
+        GraphQLEnumType.Builder enumBuilder = GraphQLEnumType.newEnum()
+                .name(enumType.getName())
+                .description(enumType.getDescription());
+        // Values
+        for (String value : enumType.getValues()) {
+            enumBuilder = enumBuilder.value(value);
+        }
+        GraphQLEnumType graphQLEnumType = enumBuilder.build();
+        enumMap.put(enumType.getClassName(), graphQLEnumType);
+    }
+
+    private void createGraphQLInterfaceTypes() {
+        if (schema.hasInterfaces()) {
+            for (InterfaceType interfaceType : schema.getInterfaces().values()) {
+                createGraphQLInterfaceType(interfaceType);
+            }
+        }
+    }
+
+    private void createGraphQLInterfaceType(InterfaceType interfaceType) {
+        GraphQLInterfaceType.Builder interfaceTypeBuilder = GraphQLInterfaceType.newInterface()
+                .name(interfaceType.getName())
+                .description(interfaceType.getDescription());
+
+        // Fields
+        if (interfaceType.hasFields()) {
+            interfaceTypeBuilder = interfaceTypeBuilder
+                    .fields(createGraphQLFieldDefinitionsFromFields(interfaceType.getName(),
+                            interfaceType.getFields().values()));
+        }
+
+        // Interfaces
+        if (interfaceType.hasInterfaces()) {
+            Set<Reference> interfaces = interfaceType.getInterfaces();
+            for (Reference i : interfaces) {
+                interfaceTypeBuilder = interfaceTypeBuilder.withInterface(GraphQLTypeReference.typeRef(i.getName()));
+            }
+        }
+
+        GraphQLInterfaceType graphQLInterfaceType = interfaceTypeBuilder.build();
+        // To resolve the concrete class
+        this.codeRegistryBuilder.typeResolver(graphQLInterfaceType, new InterfaceResolver(interfaceType));
+        this.interfaceMap.put(interfaceType.getName(), graphQLInterfaceType);
+    }
+
+    private void createGraphQLInputObjectTypes() {
+        if (schema.hasInputs()) {
+            for (InputType inputType : schema.getInputs().values()) {
+                createGraphQLInputObjectType(inputType);
+            }
+        }
+    }
+
+    private void createGraphQLInputObjectType(InputType inputType) {
+        GraphQLInputObjectType.Builder inputObjectTypeBuilder = GraphQLInputObjectType.newInputObject()
+                .name(inputType.getName())
+                .description(inputType.getDescription());
+
+        // Fields
+        if (inputType.hasFields()) {
+            inputObjectTypeBuilder = inputObjectTypeBuilder
+                    .fields(createGraphQLInputObjectFieldsFromFields(inputType.getFields().values()));
+            // Register this input for posible JsonB usage
+            JsonInputRegistry.register(inputType);
+        }
+
+        GraphQLInputObjectType graphQLInputObjectType = inputObjectTypeBuilder.build();
+        inputMap.put(inputType.getName(), graphQLInputObjectType);
+    }
+
+    private void createGraphQLObjectTypes() {
+        if (schema.hasTypes()) {
+            for (Type type : schema.getTypes().values()) {
+                createGraphQLObjectType(type);
+            }
+        }
+    }
+
+    private void createGraphQLObjectType(Type type) {
+        GraphQLObjectType.Builder objectTypeBuilder = GraphQLObjectType.newObject()
+                .name(type.getName())
+                .description(type.getDescription());
+
+        // Fields
+        if (type.hasFields()) {
+            objectTypeBuilder = objectTypeBuilder
+                    .fields(createGraphQLFieldDefinitionsFromFields(type.getName(), type.getFields().values()));
+        }
+
+        // Operations
+        if (type.hasOperations()) {
+            for (Operation operation : type.getOperations().values()) {
+                String name = operation.getName();
+                if (!type.hasBatchOperation(name)) {
+                    operation = eventEmitter.fireCreateOperation(operation);
+
+                    GraphQLFieldDefinition graphQLFieldDefinition = createGraphQLFieldDefinitionFromOperation(type.getName(),
+                            operation);
+                    objectTypeBuilder = objectTypeBuilder.field(graphQLFieldDefinition);
+                } else {
+                    log.duplicateOperation(operation.getName());
+                }
+            }
+        }
+
+        // Batch Operations
+        if (type.hasBatchOperations()) {
+            for (Operation operation : type.getBatchOperations().values()) {
+                operation = eventEmitter.fireCreateOperation(operation);
+
+                GraphQLFieldDefinition graphQLFieldDefinition = createGraphQLFieldDefinitionFromBatchOperation(type.getName(),
+                        operation);
+                objectTypeBuilder = objectTypeBuilder.field(graphQLFieldDefinition);
+            }
+        }
+
+        // Interfaces
+        if (type.hasInterfaces()) {
+            Set<Reference> interfaces = type.getInterfaces();
+            for (Reference i : interfaces) {
+                if (interfaceMap.containsKey(i.getName())) {
+                    GraphQLInterfaceType graphQLInterfaceType = interfaceMap.get(i.getName());
+                    objectTypeBuilder = objectTypeBuilder.withInterface(graphQLInterfaceType);
+                }
+            }
+        }
+
+        GraphQLObjectType graphQLObjectType = objectTypeBuilder.build();
+        typeMap.put(type.getName(), graphQLObjectType);
+
+        // Register this output for interface type resolving
+        InterfaceOutputRegistry.register(type, graphQLObjectType);
+    }
+
+    private GraphQLFieldDefinition createGraphQLFieldDefinitionFromBatchOperation(String operationTypeName,
+            Operation operation) {
+        // Fields
+        GraphQLFieldDefinition.Builder fieldBuilder = GraphQLFieldDefinition.newFieldDefinition()
+                .name(operation.getName())
+                .description(operation.getDescription());
+
+        // Return field
+        fieldBuilder = fieldBuilder.type(createGraphQLOutputType(operation, true));
+
+        // Arguments
+        if (operation.hasArguments()) {
+            fieldBuilder = fieldBuilder.arguments(createGraphQLArguments(operation.getArguments()));
+        }
+
+        DataFetcher<?> datafetcher = new BatchDataFetcher<>(operation, config);
+        GraphQLFieldDefinition graphQLFieldDefinition = fieldBuilder.build();
+
+        this.codeRegistryBuilder.dataFetcher(FieldCoordinates.coordinates(operationTypeName, graphQLFieldDefinition.getName()),
+                datafetcher);
+
+        return graphQLFieldDefinition;
+    }
+
+    private GraphQLFieldDefinition createGraphQLFieldDefinitionFromOperation(String operationTypeName, Operation operation) {
+        // Fields
+        GraphQLFieldDefinition.Builder fieldBuilder = GraphQLFieldDefinition.newFieldDefinition()
+                .name(operation.getName())
+                .description(operation.getDescription());
+
+        // Return field
+        fieldBuilder = fieldBuilder.type(createGraphQLOutputType(operation, false));
+
+        // Arguments
+        if (operation.hasArguments()) {
+            fieldBuilder = fieldBuilder.arguments(createGraphQLArguments(operation.getArguments()));
+        }
+
+        GraphQLFieldDefinition graphQLFieldDefinition = fieldBuilder.build();
+
+        // DataFetcher
+        DataFetcher<?> datafetcher = dataFetcherFactory.getDataFetcher(operation);
+
+        this.codeRegistryBuilder.dataFetcher(FieldCoordinates.coordinates(operationTypeName, graphQLFieldDefinition.getName()),
+                datafetcher);
+
+        return graphQLFieldDefinition;
+    }
+
+    private List<GraphQLFieldDefinition> createGraphQLFieldDefinitionsFromFields(String ownerName, Collection<Field> fields) {
+        List<GraphQLFieldDefinition> graphQLFieldDefinitions = new ArrayList<>();
+        for (Field field : fields) {
+            graphQLFieldDefinitions.add(createGraphQLFieldDefinitionFromField(ownerName, field));
+        }
+        return graphQLFieldDefinitions;
+    }
+
+    private GraphQLFieldDefinition createGraphQLFieldDefinitionFromField(String ownerName, Field field) {
+        GraphQLFieldDefinition.Builder fieldBuilder = GraphQLFieldDefinition.newFieldDefinition()
+                .name(field.getName())
+                .description(field.getDescription());
+
+        // Type
+        fieldBuilder = fieldBuilder.type(createGraphQLOutputType(field, false));
+
+        GraphQLFieldDefinition graphQLFieldDefinition = fieldBuilder.build();
+
+        // DataFetcher
+        PropertyDataFetcher datafetcher = new PropertyDataFetcher(field);
+        this.codeRegistryBuilder.dataFetcher(FieldCoordinates.coordinates(ownerName, graphQLFieldDefinition.getName()),
+                datafetcher);
+
+        return graphQLFieldDefinition;
+    }
+
+    private List<GraphQLInputObjectField> createGraphQLInputObjectFieldsFromFields(Collection<Field> fields) {
+        List<GraphQLInputObjectField> graphQLInputObjectFields = new ArrayList<>();
+        for (Field field : fields) {
+            graphQLInputObjectFields.add(createGraphQLInputObjectFieldFromField(field));
+        }
+        return graphQLInputObjectFields;
+    }
+
+    private GraphQLInputObjectField createGraphQLInputObjectFieldFromField(Field field) {
+        GraphQLInputObjectField.Builder inputFieldBuilder = GraphQLInputObjectField.newInputObjectField()
+                .name(field.getName())
+                .description(field.getDescription());
+
+        // Type
+        inputFieldBuilder = inputFieldBuilder.type(createGraphQLInputType(field));
+
+        // Default value (on method)
+        // Liberty Change - Start
+        if (field.hasDefaultValue()) {
+            inputFieldBuilder = inputFieldBuilder.defaultValue(sanitizeDefaultValue(field));
+        }
+        // Liberty Change - End
+
+        return inputFieldBuilder.build();
+    }
+
+    private GraphQLInputType createGraphQLInputType(Field field) {
+
+        GraphQLInputType graphQLInputType = referenceGraphQLInputType(field);
+
+        Wrapper wrapper = dataFetcherFactory.unwrap(field, false);
+
+        // Collection
+        if (wrapper != null && wrapper.isCollectionOrArray()) {
+            // Mandatory in the collection
+            if (wrapper.isNotEmpty()) {
+                graphQLInputType = GraphQLNonNull.nonNull(graphQLInputType);
+            }
+            // Collection depth
+            do {
+                if (wrapper.isCollectionOrArray()) {
+                    graphQLInputType = GraphQLList.list(graphQLInputType);
+                    wrapper = wrapper.getWrapper();
+                } else {
+                    wrapper = null;
+                }
+            } while (wrapper != null);
+        }
+
+        // Mandatory
+        if (field.isNotNull()) {
+            graphQLInputType = GraphQLNonNull.nonNull(graphQLInputType);
+        }
+
+        return graphQLInputType;
+    }
+
+    private GraphQLOutputType createGraphQLOutputType(Field field, boolean isBatch) {
+        GraphQLOutputType graphQLOutputType = referenceGraphQLOutputType(field);
+
+        Wrapper wrapper = dataFetcherFactory.unwrap(field, isBatch);
+
+        // Collection
+        if (wrapper != null && wrapper.isCollectionOrArray()) {
+            // Mandatory in the collection
+            if (wrapper.isNotEmpty()) {
+                graphQLOutputType = GraphQLNonNull.nonNull(graphQLOutputType);
+            }
+            // Collection depth
+            do {
+                if (wrapper.isCollectionOrArray()) {
+                    graphQLOutputType = GraphQLList.list(graphQLOutputType);
+                    wrapper = wrapper.getWrapper();
+                } else {
+                    wrapper = null;
+                }
+            } while (wrapper != null);
+        }
+
+        // Mandatory
+        if (field.isNotNull()) {
+            graphQLOutputType = GraphQLNonNull.nonNull(graphQLOutputType);
+        }
+
+        return graphQLOutputType;
+    }
+
+    private GraphQLOutputType referenceGraphQLOutputType(Field field) {
+        Reference reference = getCorrectFieldReference(field);
+        ReferenceType type = reference.getType();
+        String className = reference.getClassName();
+        String name = reference.getName();
+        switch (type) {
+            case SCALAR:
+                return getCorrectScalarType(reference);
+            case ENUM:
+                return enumMap.get(className);
+            default:
+                return GraphQLTypeReference.typeRef(name);
+        }
+    }
+
+    private GraphQLInputType referenceGraphQLInputType(Field field) {
+        Reference reference = getCorrectFieldReference(field);
+        ReferenceType type = reference.getType();
+        String className = reference.getClassName();
+        String name = reference.getName();
+        switch (type) {
+            case SCALAR:
+                return getCorrectScalarType(reference);
+            case ENUM:
+                return enumMap.get(className);
+            default:
+                return GraphQLTypeReference.typeRef(name);
+        }
+    }
+
+    private Reference getCorrectFieldReference(Field field) {
+        // First check if this is mapped to some other type
+
+        if (field.getReference().hasMapping()) { // Global
+            return field.getReference().getMapping().getReference();
+        } else if (field.hasMapping()) { // Per field
+            return field.getMapping().getReference();
+        } else {
+            return field.getReference();
+        }
+    }
+
+    private GraphQLScalarType getCorrectScalarType(Reference fieldReference) {
+        return GraphQLScalarTypes.getScalarByName(fieldReference.getName());
+    }
+
+    private List<GraphQLArgument> createGraphQLArguments(List<Argument> arguments) {
+        List<GraphQLArgument> graphQLArguments = new ArrayList<>();
+        for (Argument argument : arguments) {
+            if (!argument.isSourceArgument() && !argument.getReference().getClassName().equals(CONTEXT)) {
+                graphQLArguments.add(createGraphQLArgument(argument));
+            }
+        }
+        return graphQLArguments;
+    }
+
+    private GraphQLArgument createGraphQLArgument(Argument argument) {
+        GraphQLArgument.Builder argumentBuilder = GraphQLArgument.newArgument()
+                .name(argument.getName())
+                .description(argument.getDescription());
+
+        // Liberty Change - Start
+        if (argument.hasDefaultValue()) {
+            argumentBuilder = argumentBuilder.defaultValue(sanitizeDefaultValue(argument));
+        }
+        // Liberty Change - End
+
+        GraphQLInputType graphQLInputType = referenceGraphQLInputType(argument);
+
+        Wrapper wrapper = dataFetcherFactory.unwrap(argument, false);
+
+        // Collection
+        if (wrapper != null && wrapper.isCollectionOrArray()) {
+            // Mandatory in the collection
+            if (wrapper.isNotEmpty()) {
+                graphQLInputType = GraphQLNonNull.nonNull(graphQLInputType);
+            }
+            // Collection depth
+            do {
+                if (wrapper.isCollectionOrArray()) {
+                    graphQLInputType = GraphQLList.list(graphQLInputType);
+                    wrapper = wrapper.getWrapper();
+                } else {
+                    wrapper = null;
+                }
+            } while (wrapper != null);
+        }
+
+        // Mandatory
+        if (argument.isNotNull()) {
+            graphQLInputType = GraphQLNonNull.nonNull(graphQLInputType);
+        }
+
+        argumentBuilder = argumentBuilder.type(graphQLInputType);
+
+        return argumentBuilder.build();
+
+    }
+
+    private Object sanitizeDefaultValue(Field field) {
+        String jsonString = field.getDefaultValue();
+
+        if (jsonString == null) {
+            return null;
+        }
+
+        if (isJsonString(jsonString)) {
+            Class<?> type;
+            Wrapper wrapper = dataFetcherFactory.unwrap(field, false);
+
+            if (wrapper != null && wrapper.isCollectionOrArray()) {
+                type = classloadingService.loadClass(field.getWrapper().getWrapperClassName());
+                if (Collection.class.isAssignableFrom(type)) {
+                    type = CollectionCreator.newCollection(field.getWrapper().getWrapperClassName()).getClass();
+                }
+            } else {
+                type = classloadingService.loadClass(field.getReference().getClassName());
+            }
+            Jsonb jsonB = JsonBCreator.getJsonB(type.getName());
+
+            Reference reference = getCorrectFieldReference(field);
+            ReferenceType referenceType = reference.getType();
+
+            if (referenceType.equals(referenceType.INPUT) || referenceType.equals(ReferenceType.TYPE)) { // Complex type
+                return jsonB.fromJson(jsonString, Map.class);
+            } else { // Basic Type
+                return jsonB.fromJson(jsonString, type);
+            }
+        }
+
+        if (Classes.isNumberLikeType(field.getReference().getGraphQlClassName())) {
+            return new BigDecimal(jsonString);
+        }
+
+        if (Classes.isBoolean(field.getReference().getGraphQlClassName())) {
+            return Boolean.parseBoolean(jsonString);
+        }
+
+        return jsonString;
+    }
+
+    @FFDCIgnore(value = { Exception.class }) // Liberty Change
+    private boolean isJsonString(String string) {
+        if (string != null && !string.isEmpty() && (string.contains("{") || string.contains("["))) {
+            try (StringReader stringReader = new StringReader(string);
+                    JsonReader jsonReader = jsonReaderFactory.createReader(stringReader)) {
+
+                jsonReader.readValue();
+                return true;
+            } catch (Exception ex) {
+                // Not a valid json
+            }
+        }
+        return false;
+    }
+
+    /**
+     * This can hide certain fields in the schema (for security purposes)
+     *
+     * @return The visibility
+     * @see www.graphql-java.com/documentation/v15/fieldvisibility/
+     */
+    private GraphqlFieldVisibility getGraphqlFieldVisibility() {
+        if (config != null) {
+            String fieldVisibility = config.getFieldVisibility();
+            if (fieldVisibility != null && !fieldVisibility.isEmpty()) {
+
+                if (fieldVisibility.equals(Config.FIELD_VISIBILITY_NO_INTROSPECTION)) {
+                    return NO_INTROSPECTION_FIELD_VISIBILITY;
+                } else {
+                    String[] patterns = fieldVisibility.split(COMMA);
+                    BlockedFields.Builder blockedFields = BlockedFields.newBlock();
+                    for (String pattern : patterns) {
+                        blockedFields = blockedFields.addPattern(pattern);
+                    }
+                    return blockedFields.build();
+                }
+            }
+        }
+        return DEFAULT_FIELD_VISIBILITY;
+    }
+
+    private static final String QUERY = "Query";
+    private static final String QUERY_DESCRIPTION = "Query root";
+
+    private static final String MUTATION = "Mutation";
+    private static final String MUTATION_DESCRIPTION = "Mutation root";
+
+    private static final String COMMA = ",";
+
+    private static final Jsonb JSONB = JsonbBuilder.create();
+    private static final JsonReaderFactory jsonReaderFactory = Json.createReaderFactory(null);
+
+    private static final String CONTEXT = "io.smallrye.graphql.api.Context";
+}

--- a/dev/com.ibm.ws.io.smallrye.graphql/src/io/smallrye/graphql/execution/ExecutionService.java
+++ b/dev/com.ibm.ws.io.smallrye.graphql/src/io/smallrye/graphql/execution/ExecutionService.java
@@ -1,0 +1,245 @@
+// https://github.com/smallrye/smallrye-graphql/blob/1e1000a4b8aba36b180f8ceedb4c2357e0df974c/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
+// Apache v2.0 licensed - https://github.com/smallrye/smallrye-graphql/blob/1.0.9/LICENSE
+// Liberty Change - Recompiling with graphql-java 19.2 APIs
+package io.smallrye.graphql.execution;
+
+import static io.smallrye.graphql.SmallRyeGraphQLServerLogging.log;
+
+import java.io.StringReader;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonReader;
+import javax.json.JsonReaderFactory;
+import javax.json.JsonValue;
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+import javax.json.bind.JsonbConfig;
+
+import org.dataloader.BatchLoaderWithContext;
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderOptions;
+import org.dataloader.DataLoaderRegistry;
+
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
+import graphql.ExecutionInput;
+import graphql.ExecutionInput.Builder;
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.GraphQLContext;
+import graphql.GraphQLError;
+import graphql.execution.ExecutionId;
+import graphql.schema.GraphQLSchema;
+import io.smallrye.graphql.api.Context;
+import io.smallrye.graphql.bootstrap.Config;
+import io.smallrye.graphql.bootstrap.DataFetcherFactory;
+import io.smallrye.graphql.execution.context.SmallRyeBatchLoaderContextProvider;
+import io.smallrye.graphql.execution.context.SmallRyeContext;
+import io.smallrye.graphql.execution.datafetcher.helper.BatchLoaderHelper;
+import io.smallrye.graphql.execution.error.ExceptionHandler;
+import io.smallrye.graphql.execution.error.ExecutionErrorsService;
+import io.smallrye.graphql.execution.event.EventEmitter;
+import io.smallrye.graphql.schema.model.Operation;
+
+/**
+ * Executing the GraphQL request
+ *
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public class ExecutionService {
+
+    private static final JsonBuilderFactory jsonObjectFactory = Json.createBuilderFactory(null);
+    private static final JsonReaderFactory jsonReaderFactory = Json.createReaderFactory(null);
+    private static final Jsonb jsonB = JsonbBuilder.create(new JsonbConfig()
+            .withNullValues(Boolean.TRUE)
+            .withFormatting(Boolean.TRUE));
+
+    private final String executionIdPrefix;
+    private final AtomicLong executionId = new AtomicLong();
+
+    private final ExecutionErrorsService errorsService = new ExecutionErrorsService();
+
+    private final Config config;
+
+    private final GraphQLSchema graphQLSchema;
+
+    private final BatchLoaderHelper batchLoaderHelper = new BatchLoaderHelper();
+    private final DataFetcherFactory dataFetcherFactory;
+    private final List<Operation> batchOperations;
+
+    private final EventEmitter eventEmitter;
+
+    private GraphQL graphQL;
+
+    public ExecutionService(Config config, GraphQLSchema graphQLSchema, List<Operation> batchOperations) {
+        this.config = config;
+        this.graphQLSchema = graphQLSchema;
+        this.dataFetcherFactory = new DataFetcherFactory(config);
+        this.batchOperations = batchOperations;
+        this.eventEmitter = EventEmitter.getInstance(config);
+        // use schema's hash as prefix to differentiate between multiple apps
+        this.executionIdPrefix = Integer.toString(Objects.hashCode(graphQLSchema));
+    }
+
+    @FFDCIgnore(value = { Throwable.class }) // Liberty Change
+    public JsonObject execute(JsonObject jsonInput) {
+        SmallRyeContext context = new SmallRyeContext(jsonInput);
+
+        // ExecutionId
+        ExecutionId finalExecutionId = ExecutionId.from(executionIdPrefix + executionId.getAndIncrement());
+
+        try {
+            String query = context.getQuery();
+
+            if (config.logPayload()) {
+                log.payloadIn(query);
+            }
+
+            GraphQL g = getGraphQL();
+            if (g != null) {
+                // Query
+                Builder executionBuilder = ExecutionInput.newExecutionInput()
+                        .query(query)
+                        .executionId(finalExecutionId);
+
+                // Variables
+                context.getVariables().ifPresent(executionBuilder::variables);
+
+                // Operation name
+                context.getOperationName().ifPresent(executionBuilder::operationName);
+
+                // Context
+                executionBuilder.context(toGraphQLContext(context));
+
+                // DataLoaders
+                if (batchOperations != null && !batchOperations.isEmpty()) {
+                    DataLoaderRegistry dataLoaderRegistry = getDataLoaderRegistry(batchOperations);
+                    executionBuilder.dataLoaderRegistry(dataLoaderRegistry);
+                }
+
+                ExecutionInput executionInput = executionBuilder.build();
+
+                // Update context with execution data
+                context = context.withDataFromExecution(executionInput);
+                ((GraphQLContext) executionInput.getContext()).put("context", context);
+
+                // Notify before
+                eventEmitter.fireBeforeExecute(context);
+                // Execute
+                ExecutionResult executionResult = g.execute(executionInput);
+                // Notify after
+                eventEmitter.fireAfterExecute(context);
+
+                JsonObjectBuilder returnObjectBuilder = jsonObjectFactory.createObjectBuilder();
+
+                // Errors
+                returnObjectBuilder = addErrorsToResponse(returnObjectBuilder, executionResult);
+                // Data
+                returnObjectBuilder = addDataToResponse(returnObjectBuilder, executionResult);
+
+                JsonObject jsonResponse = returnObjectBuilder.build();
+
+                if (config.logPayload()) {
+                    log.payloadOut(jsonResponse.toString());
+                }
+
+                return jsonResponse;
+            } else {
+                log.noGraphQLMethodsFound();
+                return null;
+            }
+        } catch (Throwable t) {
+            eventEmitter.fireOnExecuteError(finalExecutionId.toString(), t);
+            throw t; // TODO: can I remove that?
+        }
+    }
+
+    private <K, T> DataLoaderRegistry getDataLoaderRegistry(List<Operation> operations) {
+        DataLoaderRegistry dataLoaderRegistry = new DataLoaderRegistry();
+        for (Operation operation : operations) {
+            BatchLoaderWithContext<K, T> batchLoader = dataFetcherFactory.getSourceBatchLoader(operation);
+            SmallRyeBatchLoaderContextProvider ctxProvider = new SmallRyeBatchLoaderContextProvider();
+            DataLoaderOptions options = DataLoaderOptions.newOptions()
+                    .setBatchLoaderContextProvider(ctxProvider);
+            DataLoader<K, T> dataLoader = DataLoader.newDataLoader(batchLoader, options);
+            ctxProvider.setDataLoader(dataLoader);
+            dataLoaderRegistry.register(batchLoaderHelper.getName(operation), dataLoader);
+        }
+        return dataLoaderRegistry;
+    }
+
+    private GraphQLContext toGraphQLContext(Context context) {
+        GraphQLContext.Builder builder = GraphQLContext.newContext();
+        builder = builder.of("context", context);
+        return builder.build();
+    }
+
+    private JsonObjectBuilder addDataToResponse(JsonObjectBuilder returnObjectBuilder, ExecutionResult executionResult) {
+        Object pojoData = executionResult.getData();
+        return addDataToResponse(returnObjectBuilder, pojoData);
+    }
+
+    private JsonObjectBuilder addDataToResponse(JsonObjectBuilder returnObjectBuilder, Object pojoData) {
+        if (pojoData != null) {
+            JsonValue data = toJsonValue(pojoData);
+            return returnObjectBuilder.add(DATA, data);
+        } else {
+            return returnObjectBuilder.addNull(DATA);
+        }
+    }
+
+    private JsonObjectBuilder addErrorsToResponse(JsonObjectBuilder returnObjectBuilder, ExecutionResult executionResult) {
+        List<GraphQLError> errors = executionResult.getErrors();
+        if (errors != null) {
+            JsonArray jsonArray = errorsService.toJsonErrors(errors);
+            if (!jsonArray.isEmpty()) {
+                returnObjectBuilder = returnObjectBuilder.add(ERRORS, jsonArray);
+            }
+            return returnObjectBuilder;
+        } else {
+            return returnObjectBuilder;
+        }
+
+    }
+
+    private JsonValue toJsonValue(Object pojo) {
+        String json = jsonB.toJson(pojo);
+        try (StringReader sr = new StringReader(json); JsonReader reader = jsonReaderFactory.createReader(sr)) {
+            return reader.readValue();
+        }
+    }
+
+    private GraphQL getGraphQL() {
+        if (this.graphQL == null) {
+            ExceptionHandler exceptionHandler = new ExceptionHandler(config);
+            if (graphQLSchema != null) {
+                QueryCache queryCache = new QueryCache();
+
+                GraphQL.Builder graphqlBuilder = GraphQL.newGraphQL(graphQLSchema);
+
+                graphqlBuilder = graphqlBuilder.defaultDataFetcherExceptionHandler(exceptionHandler);
+                graphqlBuilder = graphqlBuilder.instrumentation(queryCache);
+                graphqlBuilder = graphqlBuilder.preparsedDocumentProvider(queryCache);
+
+                // Allow custom extension
+                graphqlBuilder = eventEmitter.fireBeforeGraphQLBuild(graphqlBuilder);
+
+                this.graphQL = graphqlBuilder.build();
+            } else {
+                log.noGraphQLMethodsFound();
+            }
+        }
+        return this.graphQL;
+
+    }
+
+    private static final String DATA = "data";
+    private static final String ERRORS = "errors";
+}

--- a/dev/com.ibm.ws.io.smallrye.graphql/src/io/smallrye/graphql/execution/context/SmallRyeContext.java
+++ b/dev/com.ibm.ws.io.smallrye.graphql/src/io/smallrye/graphql/execution/context/SmallRyeContext.java
@@ -1,0 +1,371 @@
+// https://github.com/smallrye/smallrye-graphql/blob/4a47a2da6e4f4b4a6aedf2fc6464510737fe4c52/server/implementation/src/main/java/io/smallrye/graphql/execution/context/SmallRyeContext.java
+// Apache v2.0 licensed - https://github.com/smallrye/smallrye-graphql/blob/1.0.9/LICENSE
+package io.smallrye.graphql.execution.context;
+
+import static io.smallrye.graphql.SmallRyeGraphQLServerMessages.msg;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+
+import graphql.ExecutionInput;
+import graphql.ParseAndValidate;
+import graphql.ParseAndValidateResult;
+import graphql.execution.preparsed.PreparsedDocumentEntry;
+import graphql.language.Document;
+import graphql.language.OperationDefinition;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingFieldSelectionSet;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLNamedType;
+import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLScalarType;
+import graphql.schema.GraphQLType;
+import graphql.schema.SelectedField;
+import io.smallrye.graphql.api.Context;
+import io.smallrye.graphql.execution.QueryCache;
+import io.smallrye.graphql.schema.model.Field;
+import io.smallrye.graphql.schema.model.ReferenceType;
+import io.smallrye.graphql.schema.model.Schema;
+import io.smallrye.graphql.schema.model.Type;
+
+/**
+ * Implements the Context from MicroProfile API.
+ *
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public class SmallRyeContext implements Context {
+    private static Schema schema;
+
+    private static final InheritableThreadLocal<SmallRyeContext> current = new InheritableThreadLocal<>();
+
+    public static void register(JsonObject jsonInput) {
+        SmallRyeContext registry = new SmallRyeContext(jsonInput);
+        current.set(registry);
+    }
+
+    public static void setSchema(Schema schema) {
+        SmallRyeContext.schema = schema;
+    }
+
+    public static SmallRyeContext getContext() {
+        return current.get();
+    }
+
+    public static void setContext(SmallRyeContext context) {
+        current.set(context);
+    }
+
+    public SmallRyeContext withDataFromExecution(ExecutionInput executionInput) {
+        return new SmallRyeContext(this.jsonObject, this.dfe, executionInput, this.queryCache, this.field);
+    }
+
+    public SmallRyeContext withDataFromExecution(ExecutionInput executionInput, QueryCache queryCache) {
+        return new SmallRyeContext(this.jsonObject, this.dfe, executionInput, queryCache, this.field);
+    }
+
+    public SmallRyeContext withDataFromFetcher(DataFetchingEnvironment dfe, Field field) {
+        return new SmallRyeContext(this.jsonObject, dfe, this.executionInput, this.queryCache, field);
+    }
+
+    public static void remove() {
+        current.remove();
+    }
+
+    @Override
+    public JsonObject getRequest() {
+        return jsonObject;
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> wrappedType) {
+        // We only support DataFetchingEnvironment, ExecutionInput and Document at this point
+        if (wrappedType.equals(DataFetchingEnvironment.class)) {
+            return (T) this.dfe;
+        } else if (wrappedType.equals(ExecutionInput.class)) {
+            return (T) this.executionInput;
+        } else if (wrappedType.equals(Document.class)) {
+            return documentSupplier != null ? (T) documentSupplier.get() : null;
+        }
+        throw msg.unsupportedWrappedClass(wrappedType.getName());
+    }
+
+    @Override
+    public Boolean hasArgument(String name) {
+        if (dfe != null) {
+            return dfe.containsArgument(name);
+        }
+        return null;
+    }
+
+    @Override
+    public <T> T getArgument(String name) {
+        if (dfe != null) {
+            return dfe.getArgument(name);
+        }
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> getArguments() {
+        if (dfe != null) {
+            return dfe.getArguments();
+        }
+        return null;
+    }
+
+    @Override
+    public String getPath() {
+        if (dfe != null) {
+            return dfe.getExecutionStepInfo().getPath().toString();
+        }
+        return null;
+    }
+
+    @Override
+    public String getExecutionId() {
+        if (dfe != null) {
+            return dfe.getExecutionId().toString();
+        } else if (executionInput != null) {
+            return executionInput.getExecutionId().toString();
+        }
+        return null;
+    }
+
+    @Override
+    public String getFieldName() {
+        if (dfe != null) {
+            return dfe.getField().getName();
+        }
+        return null;
+    }
+
+    @Override
+    public <T> T getSource() {
+        if (dfe != null) {
+            return dfe.getSource();
+        }
+        return null;
+    }
+
+    @Override
+    public JsonArray getSelectedFields(boolean includeSourceFields) {
+        if (dfe != null) {
+            DataFetchingFieldSelectionSet selectionSet = dfe.getSelectionSet();
+            //Related to #713 - java-graphql #2275 repectively
+            Set<SelectedField> fields = new LinkedHashSet<>(selectionSet.getFields());
+            return toJsonArrayBuilder(fields, includeSourceFields).build();
+        }
+        return null;
+    }
+
+    @Override
+    public String getOperationType() {
+        if (dfe != null) {
+            return getOperationTypeFromDefinition(dfe.getOperationDefinition());
+        }
+        return null;
+    }
+
+    @Override
+    public List<String> getRequestedOperationTypes() {
+        List<String> allRequestedTypes = new ArrayList<>();
+
+        if (documentSupplier != null) {
+            Document document = documentSupplier.get();
+            List<OperationDefinition> definitions = document.getDefinitionsOfType(OperationDefinition.class);
+            for (OperationDefinition definition : definitions) {
+                String operationType = getOperationTypeFromDefinition(definition);
+                if (!allRequestedTypes.contains(operationType)) {
+                    allRequestedTypes.add(operationType);
+                }
+            }
+        }
+        return allRequestedTypes;
+    }
+
+    @Override
+    public Optional<String> getParentTypeName() {
+        if (dfe != null) {
+            return getName(dfe.getParentType());
+        }
+        return Optional.empty();
+    }
+
+    private Optional<String> getName(GraphQLType graphQLType) {
+        if (graphQLType instanceof GraphQLNamedType) {
+            return Optional.of(((GraphQLNamedType) graphQLType).getName());
+        } else if (graphQLType instanceof GraphQLNonNull) {
+            return getName(((GraphQLNonNull) graphQLType).getWrappedType());
+        } else if (graphQLType instanceof GraphQLList) {
+            return getName(((GraphQLList) graphQLType).getWrappedType());
+        }
+        return Optional.empty();
+    }
+
+    private String getOperationTypeFromDefinition(OperationDefinition definition) {
+        return definition.getOperation().toString();
+    }
+
+    private final JsonObject jsonObject;
+    private final DataFetchingEnvironment dfe;
+    private final ExecutionInput executionInput;
+    private final Supplier<Document> documentSupplier;
+    private final Field field;
+    private final QueryCache queryCache;
+
+    public SmallRyeContext(final JsonObject jsonObject) {
+        this.jsonObject = jsonObject;
+        this.dfe = null;
+        this.executionInput = null;
+        this.queryCache = null;
+        this.documentSupplier = null;
+        this.field = null;
+    }
+
+    public SmallRyeContext(JsonObject jsonObject,
+            DataFetchingEnvironment dfe,
+            ExecutionInput executionInput,
+            QueryCache queryCache,
+            Field field) {
+        this.jsonObject = jsonObject;
+        this.dfe = dfe;
+        this.field = field;
+        this.executionInput = executionInput;
+        this.queryCache = queryCache;
+        this.documentSupplier = new DocumentSupplier(executionInput, queryCache);
+    }
+
+    private JsonArrayBuilder toJsonArrayBuilder(Set<SelectedField> fields, boolean includeSourceFields) {
+        JsonArrayBuilder builder = jsonbuilder.createArrayBuilder();
+
+        for (SelectedField field : fields) {
+            if (!isFlattenScalar(field)) {
+                if (includeSourceFields || !isSourceField(field)) {
+                    if (isScalar(field)) {
+                        builder = builder.add(field.getName());
+                    } else {
+                        builder = builder.add(toJsonObjectBuilder(field, includeSourceFields));
+                    }
+                }
+            }
+        }
+
+        return builder;
+    }
+
+    private JsonObjectBuilder toJsonObjectBuilder(SelectedField selectedField, boolean includeSourceFields) {
+        JsonObjectBuilder builder = jsonbuilder.createObjectBuilder();
+        //Related to #713 - java-graphql #2275 repectively
+        Set<SelectedField> fields = new LinkedHashSet<>(selectedField.getSelectionSet().getFields());
+        builder = builder.add(selectedField.getName(),
+                toJsonArrayBuilder(fields, includeSourceFields));
+        return builder;
+    }
+
+    private boolean isSourceField(SelectedField selectedField) {
+        if (field.getReference().getType().equals(ReferenceType.TYPE)) {
+            Type type = schema.getTypes().get(field.getReference().getName());
+            return type.hasOperation(selectedField.getName());
+        }
+        return false; // Only Type has source field (for now)
+    }
+
+    private boolean isScalar(SelectedField field) {
+        List<GraphQLFieldDefinition> fieldDefinitions = field.getFieldDefinitions();
+        for (GraphQLFieldDefinition fieldDefinition : fieldDefinitions) {
+            GraphQLType graphQLType = unwrapGraphQLType(fieldDefinition.getType());
+            if (isScalar(graphQLType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isScalar(GraphQLType gqlt) {
+        return GraphQLScalarType.class.isAssignableFrom(gqlt.getClass());
+    }
+
+    private GraphQLType unwrapGraphQLType(GraphQLType gqlt) {
+        if (isNonNull(gqlt)) {
+            GraphQLNonNull graphQLNonNull = (GraphQLNonNull) gqlt;
+            return unwrapGraphQLType(graphQLNonNull.getWrappedType());
+        } else if (isList(gqlt)) {
+            GraphQLList graphQLList = (GraphQLList) gqlt;
+            return unwrapGraphQLType(graphQLList.getWrappedType());
+        }
+        return gqlt;
+    }
+
+    private boolean isNonNull(GraphQLType gqlt) {
+        return GraphQLNonNull.class.isAssignableFrom(gqlt.getClass());
+    }
+
+    private boolean isList(GraphQLType gqlt) {
+        return GraphQLList.class.isAssignableFrom(gqlt.getClass());
+    }
+
+    private boolean isFlattenScalar(SelectedField field) {
+        return field.getQualifiedName().contains("/");
+    }
+
+    @Override
+    public String toString() {
+        return "SmallRyeContext {\n"
+                + "executionId = " + getExecutionId() + ",\n"
+                + "request = " + getRequest() + ",\n"
+                + "operationName = " + getOperationName().orElse(null) + ",\n"
+                + "operationTypes = " + getRequestedOperationTypes() + ",\n"
+                + "parentTypeName = " + getParentTypeName().orElse(null) + ",\n"
+                + "variables = " + getVariables().orElse(null) + ",\n"
+                + "query = " + getQuery() + ",\n"
+                + "fieldName = " + getFieldName() + ",\n"
+                + "selectedFields = " + getSelectedFields() + ",\n"
+                + "source = " + getSource() + ",\n"
+                + "arguments = " + getArguments() + ",\n"
+                + "fieldName = " + getFieldName() + ",\n"
+                + "path = " + getPath() + "\n"
+                + "}";
+    }
+
+    private static final JsonBuilderFactory jsonbuilder = Json.createBuilderFactory(null);
+
+    private static class DocumentSupplier implements Supplier<Document> {
+
+        private final ExecutionInput executionInput;
+        private final QueryCache queryCache;
+
+        public DocumentSupplier(ExecutionInput executionInput,
+                QueryCache queryCache) {
+            this.executionInput = executionInput;
+            this.queryCache = queryCache;
+        }
+
+        @Override
+        public Document get() {
+            if (queryCache == null) {
+                ParseAndValidateResult parse = ParseAndValidate.parse(executionInput);
+                return parse.isFailure() ? null : parse.getDocument();
+            } else {
+                PreparsedDocumentEntry documentEntry = queryCache.getDocument(executionInput, ei -> {
+                    ParseAndValidateResult parse = ParseAndValidate.parse(ei);
+                    return parse.isFailure() ? new PreparsedDocumentEntry(parse.getErrors())
+                            : new PreparsedDocumentEntry(parse.getDocument());
+                });
+                return documentEntry.hasErrors() ? null : documentEntry.getDocument();
+            }
+        }
+    }
+}

--- a/dev/com.ibm.ws.io.smallrye.graphql/src/io/smallrye/graphql/execution/datafetcher/AbstractDataFetcher.java
+++ b/dev/com.ibm.ws.io.smallrye.graphql/src/io/smallrye/graphql/execution/datafetcher/AbstractDataFetcher.java
@@ -1,0 +1,119 @@
+// https://github.com/smallrye/smallrye-graphql/blob/1e1000a4b8aba36b180f8ceedb4c2357e0df974c/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/AbstractDataFetcher.java
+// Apache v2.0 licensed - https://github.com/smallrye/smallrye-graphql/blob/1.0.9/LICENSE
+// Liberty Change - Recompiling with graphql-java 19.2 APIs
+package io.smallrye.graphql.execution.datafetcher;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionException;
+
+import org.dataloader.BatchLoaderWithContext;
+import org.eclipse.microprofile.graphql.GraphQLException;
+
+import graphql.GraphQLContext;
+import graphql.execution.DataFetcherResult;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import io.smallrye.graphql.bootstrap.Config;
+import io.smallrye.graphql.execution.context.SmallRyeContext;
+import io.smallrye.graphql.execution.datafetcher.helper.ArgumentHelper;
+import io.smallrye.graphql.execution.datafetcher.helper.BatchLoaderHelper;
+import io.smallrye.graphql.execution.datafetcher.helper.FieldHelper;
+import io.smallrye.graphql.execution.datafetcher.helper.PartialResultHelper;
+import io.smallrye.graphql.execution.datafetcher.helper.ReflectionHelper;
+import io.smallrye.graphql.execution.event.EventEmitter;
+import io.smallrye.graphql.schema.model.Operation;
+import io.smallrye.graphql.transformation.AbstractDataFetcherException;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
+/**
+ * The abstract data fetcher
+ *
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ * @param <K>
+ * @param <T>
+ */
+public abstract class AbstractDataFetcher<K, T> implements DataFetcher<T>, BatchLoaderWithContext<K, T> {
+
+    protected Operation operation;
+    protected FieldHelper fieldHelper;
+    protected ReflectionHelper reflectionHelper;
+    protected PartialResultHelper partialResultHelper;
+    protected ArgumentHelper argumentHelper;
+    protected EventEmitter eventEmitter;
+    protected BatchLoaderHelper batchLoaderHelper;
+    protected List<String> unwrapExceptions = new ArrayList<>();
+
+    public AbstractDataFetcher(Operation operation, Config config) {
+        this.operation = operation;
+        this.eventEmitter = EventEmitter.getInstance(config);
+        this.fieldHelper = new FieldHelper(operation);
+        this.reflectionHelper = new ReflectionHelper(operation, eventEmitter);
+        this.argumentHelper = new ArgumentHelper(operation.getArguments());
+        this.partialResultHelper = new PartialResultHelper();
+        this.batchLoaderHelper = new BatchLoaderHelper();
+        if (config != null && config.getUnwrapExceptions().isPresent()) {
+            this.unwrapExceptions.addAll(config.getUnwrapExceptions().get());
+        }
+        this.unwrapExceptions.addAll(DEFAULT_EXCEPTION_UNWRAP);
+    }
+
+    @FFDCIgnore(value = { AbstractDataFetcherException.class, GraphQLException.class, IllegalArgumentException.class }) // Liberty Change
+    @Override
+    public T get(final DataFetchingEnvironment dfe) throws Exception {
+        // update the context
+        GraphQLContext graphQLContext = dfe.getContext();
+        SmallRyeContext context = ((SmallRyeContext) graphQLContext.get("context")).withDataFromFetcher(dfe, operation);
+        graphQLContext.put("context", context);
+
+        final DataFetcherResult.Builder<Object> resultBuilder = DataFetcherResult.newResult().localContext(graphQLContext);
+
+        eventEmitter.fireBeforeDataFetch(context);
+
+        try {
+            Object[] transformedArguments = argumentHelper.getArguments(dfe);
+
+            return invokeAndTransform(dfe, resultBuilder, transformedArguments);
+        } catch (AbstractDataFetcherException abstractDataFetcherException) {
+            //Arguments or result couldn't be transformed
+            abstractDataFetcherException.appendDataFetcherResult(resultBuilder, dfe);
+            eventEmitter.fireOnDataFetchError(dfe.getExecutionId().toString(), abstractDataFetcherException);
+        } catch (GraphQLException graphQLException) {
+            partialResultHelper.appendPartialResult(resultBuilder, dfe, graphQLException);
+            eventEmitter.fireOnDataFetchError(dfe.getExecutionId().toString(), graphQLException);
+        } catch (SecurityException | IllegalAccessException | IllegalArgumentException ex) {
+            //m.invoke failed
+            eventEmitter.fireOnDataFetchError(dfe.getExecutionId().toString(), ex);
+            throw ex;
+        } finally {
+            eventEmitter.fireAfterDataFetch(context);
+        }
+
+        return invokeFailure(resultBuilder);
+    }
+
+    protected abstract <T> T invokeAndTransform(DataFetchingEnvironment dfe, DataFetcherResult.Builder<Object> resultBuilder,
+            Object[] transformedArguments) throws AbstractDataFetcherException, Exception;
+
+    protected abstract <T> T invokeFailure(DataFetcherResult.Builder<Object> resultBuilder);
+
+    protected Throwable unwrapThrowable(Throwable t) {
+        if (shouldUnwrapThrowable(t)) {
+            t = t.getCause();
+            return unwrapThrowable(t);
+        }
+        return t;
+    }
+
+    private boolean shouldUnwrapThrowable(Throwable t) {
+        return unwrapExceptions.contains(t.getClass().getName()) && t.getCause() != null;
+    }
+
+    private static final List<String> DEFAULT_EXCEPTION_UNWRAP = new ArrayList<>();
+
+    static {
+        DEFAULT_EXCEPTION_UNWRAP.add(CompletionException.class.getName());
+        DEFAULT_EXCEPTION_UNWRAP.add("javax.ejb.EJBException");
+        DEFAULT_EXCEPTION_UNWRAP.add("jakarta.ejb.EJBException");
+    }
+}

--- a/dev/com.ibm.ws.io.smallrye.graphql/src/io/smallrye/graphql/execution/datafetcher/PropertyDataFetcher.java
+++ b/dev/com.ibm.ws.io.smallrye.graphql/src/io/smallrye/graphql/execution/datafetcher/PropertyDataFetcher.java
@@ -1,0 +1,48 @@
+// https://github.com/smallrye/smallrye-graphql/blob/1e1000a4b8aba36b180f8ceedb4c2357e0df974c/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/PropertyDataFetcher.java
+// Apache v2.0 licensed - https://github.com/smallrye/smallrye-graphql/blob/1.0.9/LICENSE
+// Liberty Change - Recompiling with graphql-java 19.2 APIs
+package io.smallrye.graphql.execution.datafetcher;
+
+import static io.smallrye.graphql.SmallRyeGraphQLServerLogging.log;
+
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
+import graphql.GraphQLContext;
+import graphql.schema.DataFetchingEnvironment;
+import io.smallrye.graphql.execution.context.SmallRyeContext;
+import io.smallrye.graphql.execution.datafetcher.helper.FieldHelper;
+import io.smallrye.graphql.schema.model.Field;
+import io.smallrye.graphql.transformation.AbstractDataFetcherException;
+
+/**
+ * Extending the default property data fetcher to intercept the result for some manipulation
+ *
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public class PropertyDataFetcher extends graphql.schema.PropertyDataFetcher {
+
+    private final FieldHelper fieldHelper;
+    private final Field field;
+
+    public PropertyDataFetcher(Field field) {
+        super(field.getPropertyName());
+        this.field = field;
+        this.fieldHelper = new FieldHelper(field);
+    }
+
+    @FFDCIgnore(value = { AbstractDataFetcherException.class }) // Liberty Change
+    @Override
+    public Object get(DataFetchingEnvironment dfe) {
+        GraphQLContext graphQLContext = dfe.getContext();
+        graphQLContext.put("context", ((SmallRyeContext) graphQLContext.get("context")).withDataFromFetcher(dfe, field));
+
+        Object resultFromMethodCall = super.get(dfe);
+        try {
+            // See if we need to transform
+            return fieldHelper.transformResponse(resultFromMethodCall);
+        } catch (AbstractDataFetcherException ex) {
+            log.transformError(ex);
+            return resultFromMethodCall;
+        }
+    }
+}

--- a/dev/com.ibm.ws.io.smallrye.graphql/src/io/smallrye/graphql/scalar/AbstractScalar.java
+++ b/dev/com.ibm.ws.io.smallrye.graphql/src/io/smallrye/graphql/scalar/AbstractScalar.java
@@ -1,0 +1,52 @@
+// https://github.com/smallrye/smallrye-graphql/blob/4a47a2da6e4f4b4a6aedf2fc6464510737fe4c52/server/implementation/src/main/java/io/smallrye/graphql/scalar/AbstractScalar.java
+// Apache v2.0 licensed - https://github.com/smallrye/smallrye-graphql/blob/1.0.9/LICENSE
+package io.smallrye.graphql.scalar;
+
+import java.util.Arrays;
+import java.util.List;
+
+import graphql.schema.Coercing;
+import graphql.schema.GraphQLScalarType;
+
+/**
+ * Base Scalar for all of our own scalars
+ *
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public abstract class AbstractScalar {
+
+    private final String name;
+    private final Coercing coercing;
+    private final List<Class> supportedTypes;
+    private final GraphQLScalarType graphQLScalarType;
+
+    public AbstractScalar(String name,
+            Coercing coercing,
+            Class... supportedTypes) {
+
+        this.name = name;
+        this.coercing = coercing;
+        this.supportedTypes = Arrays.asList(supportedTypes);
+        this.graphQLScalarType = GraphQLScalarType.newScalar()
+                .name(name)
+                .description("Scalar for " + name)
+                .coercing(coercing)
+                .build();
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public Coercing getCoercing() {
+        return this.coercing;
+    }
+
+    public List<Class> getSupportedClasses() {
+        return this.supportedTypes;
+    }
+
+    public GraphQLScalarType getScalarType() {
+        return graphQLScalarType;
+    }
+}

--- a/dev/com.ibm.ws.io.smallrye.graphql/src/io/smallrye/graphql/scalar/GraphQLScalarTypes.java
+++ b/dev/com.ibm.ws.io.smallrye.graphql/src/io/smallrye/graphql/scalar/GraphQLScalarTypes.java
@@ -1,0 +1,94 @@
+// https://github.com/smallrye/smallrye-graphql/blob/4a47a2da6e4f4b4a6aedf2fc6464510737fe4c52/server/implementation/src/main/java/io/smallrye/graphql/scalar/GraphQLScalarTypes.java
+// Apache v2.0 licensed - https://github.com/smallrye/smallrye-graphql/blob/1.0.9/LICENSE
+package io.smallrye.graphql.scalar;
+
+import java.net.URI;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import graphql.Scalars;
+import graphql.schema.GraphQLScalarType;
+import io.smallrye.graphql.scalar.number.BigDecimalScalar;
+import io.smallrye.graphql.scalar.number.BigIntegerScalar;
+import io.smallrye.graphql.scalar.number.FloatScalar;
+import io.smallrye.graphql.scalar.number.IntegerScalar;
+import io.smallrye.graphql.scalar.time.DateScalar;
+import io.smallrye.graphql.scalar.time.DateTimeScalar;
+import io.smallrye.graphql.scalar.time.DurationScalar;
+import io.smallrye.graphql.scalar.time.PeriodScalar;
+import io.smallrye.graphql.scalar.time.TimeScalar;
+
+/**
+ * Here we keep all the graphql-java scalars
+ * mapped by classname
+ *
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public class GraphQLScalarTypes {
+
+    private GraphQLScalarTypes() {
+    }
+
+    public static Map<String, GraphQLScalarType> getScalarMap() {
+        return SCALAR_MAP;
+    }
+
+    public static GraphQLScalarType getScalarByName(String name) {
+        return SCALARS_BY_NAME.get(name);
+    }
+
+    public static GraphQLScalarType getScalarByClassName(String className) {
+        return SCALAR_MAP.get(className);
+    }
+
+    public static boolean isGraphQLScalarType(String className) {
+        return SCALAR_MAP.containsKey(className);
+    }
+
+    // Scalar map we can just create now.
+    private static final Map<String, GraphQLScalarType> SCALAR_MAP = new HashMap<>();
+
+    /**
+     * Maps scalar-name to scalar-type.
+     */
+    private static final Map<String, GraphQLScalarType> SCALARS_BY_NAME = new HashMap<>();
+    private static final String ID = "ID";
+
+    static {
+        SCALAR_MAP.put(ID, Scalars.GraphQLID);
+
+        SCALAR_MAP.put(Boolean.class.getName(), Scalars.GraphQLBoolean);
+        SCALAR_MAP.put(boolean.class.getName(), Scalars.GraphQLBoolean);
+
+        SCALAR_MAP.put(char.class.getName(), Scalars.GraphQLString);
+        SCALAR_MAP.put(Character.class.getName(), Scalars.GraphQLString);
+
+        SCALAR_MAP.put(String.class.getName(), Scalars.GraphQLString);
+        SCALAR_MAP.put(UUID.class.getName(), Scalars.GraphQLString);
+        SCALAR_MAP.put(URL.class.getName(), Scalars.GraphQLString);
+        SCALAR_MAP.put(URI.class.getName(), Scalars.GraphQLString);
+
+        mapType(new IntegerScalar()); // AtomicInteger, OptionalInt, Integer, int, Short, short, Byte, byte
+        mapType(new FloatScalar()); // OptionalDouble, Float, float, Double, double
+        mapType(new BigIntegerScalar()); // AtomicLong, OptionalLong, BigInteger, Long, long
+        mapType(new BigDecimalScalar()); // BigDecimal
+        mapType(new DateScalar()); // LocalDate, java.sql.Date
+        mapType(new TimeScalar()); // LocalTime, java.sql.Time, OffsetTime
+        mapType(new DateTimeScalar()); // LocalDateTime, Date, java.sql.Timestamp, ZonedDateTime, OffsetDateTime
+
+        mapType(new PeriodScalar());
+        mapType(new DurationScalar());
+
+        for (final GraphQLScalarType value : SCALAR_MAP.values()) {
+            SCALARS_BY_NAME.put(value.getName(), value);
+        }
+    }
+
+    private static void mapType(AbstractScalar abstractScalar) {
+        for (Class c : abstractScalar.getSupportedClasses()) {
+            SCALAR_MAP.put(c.getName(), abstractScalar.getScalarType());
+        }
+    }
+}

--- a/dev/com.ibm.ws.io.smallrye.graphql/src/io/smallrye/graphql/scalar/number/BigDecimalScalar.java
+++ b/dev/com.ibm.ws.io.smallrye.graphql/src/io/smallrye/graphql/scalar/number/BigDecimalScalar.java
@@ -1,0 +1,33 @@
+// https://github.com/smallrye/smallrye-graphql/blob/4a47a2da6e4f4b4a6aedf2fc6464510737fe4c52/server/implementation/src/main/java/io/smallrye/graphql/scalar/number/BigDecimalScalar.java
+// Apache v2.0 licensed - https://github.com/smallrye/smallrye-graphql/blob/1.0.9/LICENSE
+package io.smallrye.graphql.scalar.number;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * Scalar for BigDecimal.
+ * Based on graphql-java's Scalars.GraphQLBigDecimal
+ *
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public class BigDecimalScalar extends AbstractNumberScalar {
+
+    public BigDecimalScalar() {
+
+        super("BigDecimal",
+                new Converter() {
+                    @Override
+                    public Object fromBigDecimal(BigDecimal bigDecimal) {
+                        return bigDecimal;
+                    }
+
+                    @Override
+                    public Object fromBigInteger(BigInteger bigInteger) {
+                        return new BigDecimal(bigInteger);
+                    }
+                },
+                BigDecimal.class);
+    }
+
+}

--- a/dev/com.ibm.ws.io.smallrye.graphql/src/io/smallrye/graphql/scalar/number/BigIntegerScalar.java
+++ b/dev/com.ibm.ws.io.smallrye.graphql/src/io/smallrye/graphql/scalar/number/BigIntegerScalar.java
@@ -1,0 +1,35 @@
+// https://github.com/smallrye/smallrye-graphql/blob/4a47a2da6e4f4b4a6aedf2fc6464510737fe4c52/server/implementation/src/main/java/io/smallrye/graphql/scalar/number/BigIntegerScalar.java
+// Apache v2.0 licensed - https://github.com/smallrye/smallrye-graphql/blob/1.0.9/LICENSE
+package io.smallrye.graphql.scalar.number;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Scalar for BigInteger.
+ * Based on graphql-java's Scalars.GraphQLBigInteger
+ *
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public class BigIntegerScalar extends AbstractNumberScalar {
+
+    public BigIntegerScalar() {
+
+        super("BigInteger",
+                new Converter() {
+                    @Override
+                    public Object fromBigDecimal(BigDecimal bigDecimal) {
+                        return bigDecimal.toBigIntegerExact();
+                    }
+
+                    @Override
+                    public Object fromBigInteger(BigInteger bigInteger) {
+                        return bigInteger;
+                    }
+
+                },
+                AtomicLong.class, OptionalLong.class, BigInteger.class, Long.class, long.class);
+    }
+}


### PR DESCRIPTION
Upgrade our GraphQL Java dependency to version 19.2.

I had to modify some of our SmallRye GraphQL classes for compatibility with the new version.

Fixes https://github.com/OpenLiberty/open-liberty/issues/23128