### PR TITLE
Ignore Deployment Restriction for WebSocket 2.1,  Added websocket deployment tests

### DIFF
--- a/dev/com.ibm.ws.wsoc/src/com/ibm/ws/wsoc/servercontainer/ServerContainerExt.java
+++ b/dev/com.ibm.ws.wsoc/src/com/ibm/ws/wsoc/servercontainer/ServerContainerExt.java
@@ -32,6 +32,7 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.wsoc.AnnotatedEndpoint;
 import com.ibm.ws.wsoc.EndpointHelper;
 import com.ibm.ws.wsoc.EndpointManager;
+import com.ibm.ws.wsoc.WebSocketVersionServiceManager;
 import com.ibm.ws.wsoc.external.WebSocketContainerExt;
 import com.ibm.ws.wsoc.external.WsocHandlerImpl;
 
@@ -165,8 +166,9 @@ public abstract class ServerContainerExt extends WebSocketContainerExt {
     }
 
     public void setNoMoreAddEndpointsAllowed() {
-        noMoreAdds = true;
-
+        // This restriction to add endpoints after initialization/deployment is removed in 2.1 https://github.com/jakartaee/websocket/issues/211
+        if(!WebSocketVersionServiceManager.isWsoc21OrHigher())
+            noMoreAdds = true;
     }
 
     @FFDCIgnore({ IllegalStateException.class })

--- a/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/BasicTest.java
+++ b/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/BasicTest.java
@@ -37,7 +37,6 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
@@ -241,7 +240,7 @@ public class BasicTest {
         // This test causes SRVE0777E: Exception thrown by application class ServerContainerExt.addEndpoint which is expected
         // Also cause SRVE0315E An exception occurred: java.lang.Throwable: java.lang.IllegalStateException: endpoint.addsclosed also expected
         // and SRVE8094W WARNING: Cannot set header. Response already committed to show up
-        if(RepeatTestFilter.isRepeatActionActive(JakartaEE10Action.ID)){
+        if(JakartaEE10Action.isActive()){
             assertNotNull("Endpoint should have been added!", LS.waitForStringInLog("CWWKH0046I: Adding a WebSocket ServerEndpoint with the following URI: /newEchoEndpointAdded"));
         }else{
             assertNull("Endpoint should NOT have been added!", LS.waitForStringInLog("CWWKH0046I: Adding a WebSocket ServerEndpoint with the following URI: /newEchoEndpointAdded"));

--- a/dev/io.openliberty.wsoc.internal_fat/test-applications/basic.war/resources/WEB-INF/web.xml
+++ b/dev/io.openliberty.wsoc.internal_fat/test-applications/basic.war/resources/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2013, 2015 IBM Corporation and others.
+    Copyright (c) 2013, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -66,6 +66,17 @@
         <filter-name>UpgradeFilter</filter-name>
         <url-pattern>/pathUpgradeFilter/*</url-pattern>
     </filter-mapping>
+
+    <servlet>
+        <servlet-name>AddEndpointServlet</servlet-name>
+        <servlet-class>basic.war.servlet.AddEndpointServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>AddEndpointServlet</servlet-name>
+        <url-pattern>/addEndpoint</url-pattern>
+    </servlet-mapping>
     
     
     <absolute-ordering /> 

--- a/dev/io.openliberty.wsoc.internal_fat/test-applications/basic.war/src/basic/war/EchoServerEP.java
+++ b/dev/io.openliberty.wsoc.internal_fat/test-applications/basic.war/src/basic/war/EchoServerEP.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package basic.war;
+
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+
+/*
+* Echos messages sent to this endpoint.
+*/
+public class EchoServerEP {
+
+    public EchoServerEP(){
+
+    }
+
+    @OnOpen
+    public void onOpen(final Session session) {
+
+    }
+
+    @OnMessage
+    public String echo(String input) {
+        return input;
+    }
+
+}

--- a/dev/io.openliberty.wsoc.internal_fat/test-applications/basic.war/src/basic/war/servlet/AddEndpointServlet.java
+++ b/dev/io.openliberty.wsoc.internal_fat/test-applications/basic.war/src/basic/war/servlet/AddEndpointServlet.java
@@ -39,7 +39,9 @@ import basic.war.EchoServerEP;
  * be relaxed in a future version."
  * 
  * Before 2.1, endpoints can only registered during the deployment of the web application. Once a websocket request enters the webcontainer,
- * no more endpoints could be added with the API as stated in the spec "are only operational during the application deployment phase of an application. Specifically, as soon as any of the server endpoints within the application have accepted an opening handshake request, the apis may not longer be used. This restriction may be relaxed in a future version.". This restriction was removed in EE10 WebSocket 2.1
+ * no more endpoints could be added with the API as stated in the spec "are only operational during the application deployment phase of an application. 
+ * Specifically, as soon as any of the server endpoints within the application have accepted an opening handshake request, the apis may not
+ * longer be used. This restriction may be relaxed in a future version.". This restriction was removed in EE10 WebSocket 2.1
  */
 public class AddEndpointServlet extends HttpServlet {
 

--- a/dev/io.openliberty.wsoc.internal_fat/test-applications/basic.war/src/basic/war/servlet/AddEndpointServlet.java
+++ b/dev/io.openliberty.wsoc.internal_fat/test-applications/basic.war/src/basic/war/servlet/AddEndpointServlet.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package basic.war.servlet;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.websocket.server.ServerContainer;
+import javax.websocket.server.ServerEndpoint;
+import javax.websocket.server.ServerEndpointConfig;
+
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+import javax.websocket.DeploymentException;
+
+import com.ibm.websphere.wsoc.WsWsocServerContainer;
+import basic.war.EchoServerEP;
+
+/**
+ * Servlet for testing removed restriction when adding an endpoint in Websocket 2.1 with addEndpoint methods in ServerContainer https://github.com/jakartaee/websocket/issues/211
+ * As stated in the specification before 2.1, "These methods are only operational during the application deployment phase of an application. Specifically, as soon as any of the
+ * server endpoints within the application have accepted an opening handshake request, the APIs may not longer be used. This restriction may 
+ * be relaxed in a future version."
+ * 
+ * Before 2.1, endpoints can only registered during the deployment of the web application. Once a websocket request enters the webcontainer,
+ * no more endpoints could be added with the API as stated in the spec "are only operational during the application deployment phase of an application. Specifically, as soon as any of the server endpoints within the application have accepted an opening handshake request, the apis may not longer be used. This restriction may be relaxed in a future version.". This restriction was removed in EE10 WebSocket 2.1
+ */
+public class AddEndpointServlet extends HttpServlet {
+
+
+    /**
+     * Before 2.1, endpoints can only registered during the during the initialization phase of the application. Once a websocket request enters the webcontainer,
+     * no more endpoints could be added with the addEndpoint methods. This restriction was removed in EE10 WebSocket 2.1
+     */
+    @Override
+    public void doGet(HttpServletRequest req, HttpServletResponse resp)
+                    throws ServletException, IOException {
+        // Get websocket container from servlet context
+        ServerContainer container = (ServerContainer) req.getServletContext().getAttribute("javax.websocket.server.ServerContainer");
+
+        if (container instanceof WsWsocServerContainer) {
+            WsWsocServerContainer ws = (WsWsocServerContainer) container;
+            try{
+                // Upgrade request to websocket to hit the webcontainer and set restrictions. In essence, move out of web application deployment phase 
+                ws.doUpgrade(req, resp, ServerEndpointConfig.Builder.create(EchoServerEP.class, "/echo").build(), new HashMap<String, String>());
+                // Add a new endpoint to test restrictions
+                ws.addEndpoint(ServerEndpointConfig.Builder.create(EchoServerEP.class, "/newEchoEndpointAdded").build());
+            } catch(DeploymentException ex){
+                // Do nothing
+            }
+        }
+
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        doGet(request, response);
+    }
+
+}


### PR DESCRIPTION
- Made changes to include functionality to ignore restriction of adding endpoints after deployment
- Added test to verify deployment restrictions

fixes #22364 
