### PR TITLE
Reduce calls to getHeader in WebRequestImpl.determineIfRequestHasAuthenticationData

### DIFF
--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
@@ -28,7 +28,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import io.openliberty.jcache.CacheService;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 
@@ -102,6 +101,8 @@ import com.ibm.wsspi.webcontainer.servlet.IExtendedRequest;
 import com.ibm.wsspi.webcontainer.servlet.IServletContext;
 import com.ibm.wsspi.webcontainer.webapp.WebAppConfig;
 
+import io.openliberty.jcache.CacheService;
+
 public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborator, WebAppAuthorizationHelper {
     private static final TraceComponent tc = Tr.register(WebAppSecurityCollaboratorImpl.class);
 
@@ -167,8 +168,6 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
     private boolean isJaspiEnabled = false;
     private Subject savedSubject = null;
     private boolean isActive = false;
-
-    private final Map<String, Boolean> appsWithAuthentication = new HashMap<String, Boolean>();
 
     /**
      * Zero length constructor required by DS.
@@ -838,29 +837,9 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
         if (result != null) {
             return result.booleanValue();
         }
-        String mapKey = webRequest.getApplicationName() + webRequest.getHttpServletRequest().getRequestURI();
-        Boolean hasAuth = appsWithAuthentication.get(mapKey);
-
-        if (hasAuth != null) {
-            return hasAuth.booleanValue();
-        } else if (webRequest.hasAuthenticationData()) {
-            Tr.debug(tc, "Appname not in apps and has authentication = true");
-            appsWithAuthentication.put(mapKey, Boolean.TRUE);
+        if (webRequest.hasAuthenticationData())
             return true;
-        } else {
-            Tr.debug(tc, "Appname not in apps and has authentication = false");
-            //for (Entry<String, Boolean> entry : appsWithAuthentication.entrySet())
-            //    Tr.debug(tc, "appsWithAuthentication key = " + entry.getKey() + " value = " + entry.getValue() + "App name = " + webRequest.getApplicationName());
-            appsWithAuthentication.put(mapKey, Boolean.FALSE);
-            //Tr.debug(tc, "appsWithAutbentication size = " + appsWithAuthentication.size());
-        }
-        if (isUnprotectedResourceAuthenRequired(webRequest)) {
-            appsWithAuthentication.put(mapKey, Boolean.TRUE);
-            return true;
-        } else {
-            appsWithAuthentication.put(mapKey, Boolean.FALSE);
-            return false;
-        }
+        return isUnprotectedResourceAuthenRequired(webRequest);
     }
 
     private WebReply unprotectedResource(WebRequest webRequest) {

--- a/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/internal/WebRequestImplTest.java
+++ b/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/internal/WebRequestImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -190,8 +190,6 @@ public class WebRequestImplTest {
 
     @Test
     public void hasAuthenticationData_Bearer() {
-        withCertificates(null);
-        withCookies(new Cookie[] {});
         withAuthorizationHeader("Bearer value");
 
         assertTrue("The Bearer token must be found in the request.", webRequest.hasAuthenticationData());


### PR DESCRIPTION
Performance improvement by reducing calls to getHeader in WebRequestImpl.determineIfRequestHasAuthenticationData

