### PR TITLE
reduce tracing in the com.ibm.ws.jaxrs.2.1.sse_fat bucket

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/publish/servers/com.ibm.ws.jaxrs21.sse.basic/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/publish/servers/com.ibm.ws.jaxrs21.sse.basic/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -8,8 +8,8 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all:org.apache.cxf.*=all:org.jboss.resteasy.*=all:com.ibm.ws.jaxrs*=all:com.ibm.websphere.jaxrs*=all
-com.ibm.ws.logging.max.file.size=0
-osgi.console=5678
-ds.loglevel=debug
+#com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all:org.apache.cxf.*=all:org.jboss.resteasy.*=all:com.ibm.ws.jaxrs*=all:com.ibm.websphere.jaxrs*=all
+#com.ibm.ws.logging.max.file.size=0
+#osgi.console=5678
+#ds.loglevel=debug
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/publish/servers/com.ibm.ws.jaxrs21.sse.delay/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/publish/servers/com.ibm.ws.jaxrs21.sse.delay/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -8,8 +8,8 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all:org.apache.cxf.*=all:org.jboss.resteasy.*=all:com.ibm.ws.jaxrs*=all:com.ibm.websphere.jaxrs*=all
-com.ibm.ws.logging.max.file.size=0
-osgi.console=5678
-ds.loglevel=debug
+#com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all:org.apache.cxf.*=all:org.jboss.resteasy.*=all:com.ibm.ws.jaxrs*=all:com.ibm.websphere.jaxrs*=all
+#com.ibm.ws.logging.max.file.size=0
+#osgi.console=5678
+#ds.loglevel=debug
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/publish/servers/com.ibm.ws.jaxrs21.sse.jaxb/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/publish/servers/com.ibm.ws.jaxrs21.sse.jaxb/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -8,8 +8,8 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all:org.apache.cxf.*=all:org.jboss.resteasy.*=all:com.ibm.ws.jaxrs*=all:com.ibm.websphere.jaxrs*=all
-com.ibm.ws.logging.max.file.size=0
-osgi.console=5678
-ds.loglevel=debug
+#com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all:org.apache.cxf.*=all:org.jboss.resteasy.*=all:com.ibm.ws.jaxrs*=all:com.ibm.websphere.jaxrs*=all
+#com.ibm.ws.logging.max.file.size=0
+#osgi.console=5678
+#ds.loglevel=debug
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/publish/servers/com.ibm.ws.jaxrs21.sse.jsonb/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/publish/servers/com.ibm.ws.jaxrs21.sse.jsonb/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -8,8 +8,8 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all:org.apache.cxf.*=all:org.jboss.resteasy.*=all:com.ibm.ws.jaxrs*=all:com.ibm.websphere.jaxrs*=all
-com.ibm.ws.logging.max.file.size=0
-osgi.console=5678
-ds.loglevel=debug
+#com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all:org.apache.cxf.*=all:org.jboss.resteasy.*=all:com.ibm.ws.jaxrs*=all:com.ibm.websphere.jaxrs*=all
+#com.ibm.ws.logging.max.file.size=0
+#osgi.console=5678
+#ds.loglevel=debug
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/publish/servers/io.openliberty.sse.broadcaster/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/publish/servers/io.openliberty.sse.broadcaster/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -8,8 +8,8 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all:org.apache.cxf.*=all:org.jboss.resteasy.*=all:com.ibm.ws.jaxrs*=all:com.ibm.websphere.jaxrs*=all
-com.ibm.ws.logging.max.file.size=0
-osgi.console=5678
-ds.loglevel=debug
+#com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all:org.apache.cxf.*=all:org.jboss.resteasy.*=all:com.ibm.ws.jaxrs*=all:com.ibm.websphere.jaxrs*=all
+#com.ibm.ws.logging.max.file.size=0
+#osgi.console=5678
+#ds.loglevel=debug
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/publish/servers/io.openliberty.sse.clientbehavior/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/publish/servers/io.openliberty.sse.clientbehavior/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -8,8 +8,8 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all:org.apache.cxf.*=all:org.jboss.resteasy.*=all:com.ibm.ws.jaxrs*=all:com.ibm.websphere.jaxrs*=all
-com.ibm.ws.logging.max.file.size=0
-osgi.console=5678
-ds.loglevel=debug
+#com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all:org.apache.cxf.*=all:org.jboss.resteasy.*=all:com.ibm.ws.jaxrs*=all:com.ibm.websphere.jaxrs*=all
+#com.ibm.ws.logging.max.file.size=0
+#osgi.console=5678
+#ds.loglevel=debug
 bootstrap.include=../testports.properties


### PR DESCRIPTION
The `https://github.com/WhiteCat22/open-liberty/pull/new/reduce_sse_trace` test bucket is currently producing over 4GB of unused/unneeded trace. This is causing problems with our build infrastructure.
