### PR TITLE
Make fattest.simplicity depend on Jackson bundle

### DIFF
--- a/dev/fattest.simplicity/bnd.bnd
+++ b/dev/fattest.simplicity/bnd.bnd
@@ -103,4 +103,5 @@ fat.test.container.images: testcontainers/ryuk:0.3.4, testcontainers/sshd:1.1.0,
 	io.openliberty.jakarta.cdi.3.0;version=latest,\
 	com.ibm.ws.kernel.boot;version=latest,\
 	io.openliberty.org.eclipse.openj9.criu;version=latest,\
-	com.ibm.ws.org.slf4j.api;version=latest
+	com.ibm.ws.org.slf4j.api;version=latest,\
+	io.openliberty.com.fasterxml.jackson;version=latest


### PR DESCRIPTION
This ensures that the Jackson bundle is included as a dependency when building any FAT project which means it will be available to be copied into the autoFVT zip.

Without this change the build works as long as the Jackson bundle is included in the list of projects to build. However, if you try to buildandrun a FAT test alone, gradle cannot find the Jackson project.
