### PR TITLE
Update DB IdentityStore to process string array on HashParams

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/DatabaseIdentityStoreDefinitionWrapper.java
+++ b/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/DatabaseIdentityStoreDefinitionWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -283,9 +283,11 @@ public class DatabaseIdentityStoreDefinitionWrapper {
         } else {
             if (rawArray != null && rawArray.length > 0) {
                 for (int idx = 0; idx < rawArray.length; idx++) {
-                    String value = elHelper.processString("hashAlgorithmParameters[" + idx + "]", rawArray[idx], false);
-                    if (value != null && !value.isEmpty()) {
-                        parameters.add(value);
+                    List<String> value = elHelper.processStringOrStringArray("hashAlgorithmParameters[" + idx + "]", rawArray[idx], false, false);
+                    if (value != null) {
+                        for (String innerValue : value) {
+                            parameters.add(innerValue);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The `app-db` tck test was failing to process an array of hashAlgorithmParameters with a member that evaluated to another String[], resulting in `java.lang.IllegalArgumentException: Expected 'hashAlgorithmParameters[1]' to evaluate to a String value.`

Example:
```
...
    hashAlgorithmParameters = {
        "Pbkdf2PasswordHash.Iterations=3072",
        "${applicationConfig.dyna}"
    } // just for test / example
)
@ApplicationScoped
@Named
public class ApplicationConfig {

    public String[] getDyna() {
        return new String[]{"Pbkdf2PasswordHash.Algorithm=PBKDF2WithHmacSHA512", "Pbkdf2PasswordHash.SaltSizeBytes=64"};
    }
```

- Added a new method to ELHelper to process a String that could contain a String or String[] (built off of `ElHelper.processString`). I did not add recursive support. That could be added in the future.