### PR TITLE
Allow previously skipped RestMetricsTest to run on EE10

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/RestMetricsTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/RestMetricsTest.java
@@ -39,10 +39,10 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.jaxrs.fat.restmetrics.MetricsUnmappedUncheckedException;
 
-import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.topology.impl.LibertyServer;
 
@@ -206,9 +206,8 @@ public class RestMetricsTest {
         ensureEmptyMonitorStats(ABORT_METHOD_INDEX);
     }
 
-    @SkipForRepeat("EE10_FEATURES") //Skipping until MP Metrics is upgraded for MP 6.0
     @Test
-    @AllowedFFDC({"org.apache.cxf.interceptor.Fault", "org.jboss.resteasy.spi.UnhandledException"})
+    @ExpectedFFDC(value={"org.apache.cxf.interceptor.Fault"},repeatAction={EmptyAction.ID,"JAXRS-2.1"})
     public void testCheckedExceptions() throws IOException {
 
 
@@ -225,9 +224,8 @@ public class RestMetricsTest {
         runCheckMonitorStats(200, CHECKED_METHOD_INDEX);
     }
 
-    @SkipForRepeat("EE10_FEATURES") //Skipping until MP Metrics is upgraded for MP 6.0
     @Test
-    @AllowedFFDC({"com.ibm.ws.jaxrs.fat.restmetrics.MetricsUnmappedUncheckedException", "org.jboss.resteasy.spi.UnhandledException"})
+    @ExpectedFFDC(value={"com.ibm.ws.jaxrs.fat.restmetrics.MetricsUnmappedUncheckedException"},repeatAction={EmptyAction.ID,"JAXRS-2.1"})
     public void testUncheckedExceptions() throws IOException {
 
         runGetUncheckedExceptionMethod(UNCHECKED_METHOD_INDEX, 200, "/restmetrics/rest/restmetrics/unchecked/mappedUnchecked", "Mapped Unchecked");

--- a/dev/com.ibm.ws.jaxrs.2.x.monitor/src/com/ibm/ws/jaxrs/monitor/JaxRsMonitorFilter.java
+++ b/dev/com.ibm.ws.jaxrs.2.x.monitor/src/com/ibm/ws/jaxrs/monitor/JaxRsMonitorFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -165,6 +165,10 @@ public class JaxRsMonitorFilter implements ContainerRequestFilter, ContainerResp
 			//Check for MP Metrics 30 header;
 			if (metricsHeader == null)
 				metricsHeader = respCtx.getHeaderString("io.openliberty.microprofile.metrics.internal.monitor.MetricsJaxRsEMCallbackImpl.Exception");
+
+			//Check for MP Metrics 31 header;
+			if (metricsHeader == null)
+				metricsHeader = respCtx.getHeaderString("io.openliberty.restfulws.mpmetrics.MetricsRestfulWsEMCallbackImpl.Exception");
 
 			// Save key in appMetricInfos for cleanup on application stop.
 			addKeyToMetricInfo(appName, key);


### PR DESCRIPTION
Fixes #22519 

The ContainerRequestsFilter/ContainerResponseFilter for MPMetrics (JaxRSMonitorFilter) has code in its `filter()` method to look for a header string of `com.ibm.ws.microprofile.metrics.monitor.MetricsJaxRsEMCallbackImpl.Exception` in EE8 and `io.openliberty.microprofile.metrics.internal.monitor.MetricsJaxRsEMCallbackImpl.Exception` in EE9.  It needed to also look for `io.openliberty.restfulws.mpmetrics.MetricsRestfulWsEMCallbackImpl.Exception` in EE10.