### PR TITLE
Additional check for empty beans.xml and set version on internal beans.xml

### DIFF
--- a/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/weld/WebSphereCDIDeploymentImpl.java
+++ b/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/weld/WebSphereCDIDeploymentImpl.java
@@ -733,14 +733,24 @@ public class WebSphereCDIDeploymentImpl implements WebSphereCDIDeployment {
                 continue;
             }
             //check if the file is really empty ... just whitespace like a single space would cause Weld to complain anyway
-            try (InputStream is = parsedURL.openStream()) {
+            InputStream is = null;
+            try {
+                is = parsedURL.openStream();
                 if (is.available() == 0) {
                     //file is empty
                     continue;
                 }
-            } catch (IOException e) {
+            } catch (IOException e1) {
                 //could not read the file, assume it is empty
                 continue;
+            } finally {
+                if (is != null) {
+                    try {
+                        is.close();
+                    } catch (IOException e) {
+                        //FFDC and ignore
+                    }
+                }
             }
 
             //if the beans.xml was not an empty file then check if the version was set or not

--- a/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/weld/WebSphereCDIDeploymentImpl.java
+++ b/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/weld/WebSphereCDIDeploymentImpl.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.cdi.impl.weld;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -725,9 +727,19 @@ public class WebSphereCDIDeploymentImpl implements WebSphereCDIDeployment {
             }
 
             URL parsedURL = beansXml.getUrl();
-            //if the URL is null then that means it was an empty beans.xml file
+            //if the URL is null then this may mean it was an empty beans.xml file
             //note that this may be an undocumented "feature" of the Weld SPI
             if (parsedURL == null) {
+                continue;
+            }
+            //check if the file is really empty ... just whitespace like a single space would cause Weld to complain anyway
+            try (InputStream is = parsedURL.openStream()) {
+                if (is.available() == 0) {
+                    //file is empty
+                    continue;
+                }
+            } catch (IOException e) {
+                //could not read the file, assume it is empty
                 continue;
             }
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0.cdi/resources/META-INF/beans.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0.cdi/resources/META-INF/beans.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+    version="2.0" bean-discovery-mode="all">
+
+    <scan>
+        <exclude
+            name="com.ibm.ws.microprofile.faulttolerance.cdi20.*" />
+    </scan>
+
+</beans>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi20/FaultToleranceCDI20Extension.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi20/FaultToleranceCDI20Extension.java
@@ -12,7 +12,9 @@ package com.ibm.ws.microprofile.faulttolerance.cdi20;
 
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.AnnotatedType;
 import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.BeforeBeanDiscovery;
 import javax.enterprise.inject.spi.Extension;
 import javax.enterprise.inject.spi.ProcessAnnotatedType;
 
@@ -26,6 +28,11 @@ import com.ibm.ws.microprofile.faulttolerance.cdi.FaultToleranceInterceptor;
  */
 @Component(service = WebSphereCDIExtension.class, immediate = true)
 public class FaultToleranceCDI20Extension implements WebSphereCDIExtension, Extension {
+
+    public void addAsyncRequestContextController(@Observes BeforeBeanDiscovery bbd, BeanManager bm) {
+        AnnotatedType<AsyncRequestContextControllerImpl> annotatedType = bm.createAnnotatedType(AsyncRequestContextControllerImpl.class);
+        bbd.addAnnotatedType(annotatedType, AsyncRequestContextControllerImpl.class.getName());
+    }
 
     public void removeInterceptorType(@Observes ProcessAnnotatedType<FaultToleranceInterceptor> event) {
         // Veto the type, so that CDI doesn't discover that it's a bean

--- a/dev/com.ibm.ws.security.jaspic/resources/META-INF/beans.xml
+++ b/dev/com.ibm.ws.security.jaspic/resources/META-INF/beans.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    Copyright (c) 2017 IBM Corporation and others.
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
-    which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
- -->
+<!-- Copyright (c) 2017 IBM Corporation and others. All rights reserved. 
+    This program and the accompanying materials are made available under the 
+    terms of the Eclipse Public License v1.0 which accompanies this distribution, 
+    and is available at http://www.eclipse.org/legal/epl-v10.html Contributors: 
+    IBM Corporation - initial API and implementation -->
 
-<beans xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-xmlns="http://xmlns.jcp.org/xml/ns/javaee" bean-discovery-mode="all"> </beans>
+<beans
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee" bean-discovery-mode="all"
+    version="1.1">
+</beans>

--- a/dev/io.openliberty.org.jboss.resteasy.cdi.ee10/resources/META-INF/beans.xml
+++ b/dev/io.openliberty.org.jboss.resteasy.cdi.ee10/resources/META-INF/beans.xml
@@ -2,5 +2,6 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
         https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
-       bean-discovery-mode="annotated">
+       bean-discovery-mode="annotated"
+       version="4.0">
 </beans>

--- a/dev/io.openliberty.org.jboss.resteasy.cdi/resources/META-INF/beans.xml
+++ b/dev/io.openliberty.org.jboss.resteasy.cdi/resources/META-INF/beans.xml
@@ -2,5 +2,6 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee 
         http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-       bean-discovery-mode="annotated">
+       bean-discovery-mode="annotated"
+       version="1.1">
 </beans>

--- a/dev/io.openliberty.org.jboss.resteasy.common.ee10/resources/META-INF/beans.xml
+++ b/dev/io.openliberty.org.jboss.resteasy.common.ee10/resources/META-INF/beans.xml
@@ -2,5 +2,6 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
         https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
-       bean-discovery-mode="annotated">
+       bean-discovery-mode="annotated"
+       version="4.0">
 </beans>

--- a/dev/io.openliberty.org.jboss.resteasy.common/resources/META-INF/beans.xml
+++ b/dev/io.openliberty.org.jboss.resteasy.common/resources/META-INF/beans.xml
@@ -2,5 +2,6 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee 
         http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-       bean-discovery-mode="annotated">
+       bean-discovery-mode="annotated"
+       version="1.1">
 </beans>


### PR DESCRIPTION
1. Add extra check for an empty beans.xml in case the undocumented Weld SPI function is not enough
2. Make sure that the version is properly set on all internal bundle beans.xml files

#build