### PR TITLE
Fix OpenTelemetry SecurityManager and disposal issues

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat_tck/fat/src/io/openliberty/microprofile/telemetry/internal_fat_tck/Telemetry10TCKLauncher.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat_tck/fat/src/io/openliberty/microprofile/telemetry/internal_fat_tck/Telemetry10TCKLauncher.java
@@ -51,7 +51,7 @@ public class Telemetry10TCKLauncher {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWWKZ0002E", "CWOWB1018W");
+        server.stopServer();
     }
 
     @Test

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat_tck/publish/servers/Telemetry10TCKServer/server.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat_tck/publish/servers/Telemetry10TCKServer/server.xml
@@ -21,9 +21,21 @@
         <feature>mpTelemetry-1.0</feature>
     </featureManager>
 
-    <!--Java2 security-->
-    <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
-
+    <!-- Required by Arquillian ServletTestRunner -->
+    <javaPermission className="java.lang.RuntimePermission" name="getClassLoader" />
+    <javaPermission className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks" />
+    <javaPermission className="java.util.PropertyPermission" name="*" actions="read" />
+    <javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers" />
+    <javaPermission className="java.lang.RuntimePermission" name="accessClassInPackage.sun.reflect.annotation" />
+    
+    <!-- Required by Awaitility -->
+    <javaPermission className="java.lang.RuntimePermission" name="setDefaultUncaughtExceptionHandler" />
+    <javaPermission className="java.lang.RuntimePermission" name="modifyThread" />
+    
+    <!-- Required by Tests -->
+    <!-- Test makes requests to localhost using HttpUrlConnection -->
+    <javaPermission className="java.net.URLPermission" name="http://localhost:*/-" actions="*" />
+    
     <include location="../fatTestPorts.xml" />
 
 </server>


### PR DESCRIPTION
- Use a privileged action for creation of the OpenTelemetry object
- Add disposal method for the OpenTelemetry bean instead of using shutdown hooks
- Reduce permissions granted to Telemetry TCK
- Remove warnings allowed by Telemetry TCK

For #22689
Fixes #23145