### PR TITLE
Comments explaining why TCKs require servlet

### DIFF
--- a/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/publish/servers/FATServer/server.xml
+++ b/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/publish/servers/FATServer/server.xml
@@ -17,6 +17,7 @@
         <feature>mpRestClient-3.0</feature>
         <feature>arquillian-support-jakarta-2.1</feature>
         <feature>ssl-1.0</feature>
+        <!-- Servlet required due to https://github.com/OpenLiberty/open-liberty/issues/22280 -->
         <feature>servlet-5.0</feature>
     </featureManager>
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat_tck/publish/servers/Telemetry10TCKServer/server.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat_tck/publish/servers/Telemetry10TCKServer/server.xml
@@ -17,6 +17,8 @@
         <feature>mpRestClient-3.0</feature>
         <feature>arquillian-support-jakarta-2.1</feature>
         <feature>ssl-1.0</feature>
+        <!-- Servlet required since we cannot use rest protocol because rest requests create spans which results in more spans than the tests expect -->
+        <!-- See https://github.com/eclipse/microprofile-telemetry/issues/72 -->
         <feature>servlet-6.0</feature>
         <feature>mpTelemetry-1.0</feature>
     </featureManager>


### PR DESCRIPTION
MP 6.0 depends on Jakarta EE Core which does not include servlet. Therefore, we should be able to run all the MP 6.0 TCKs without servlet.

However, some TCKs do not work when switching the arquillian test protocol from "servlet" to "rest" and so servlet is still required to run the TCK.

Add comments to the relevant server.xmls pointing to why servlet is still required.

Fixes #22348