### PR TITLE
refresh some grpc libraries

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -149,12 +149,12 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <version>3.19.2</version>
+      <version>3.19.6</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.19.2</version>
+      <version>3.19.6</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -25,8 +25,8 @@ com.google.errorprone:error_prone_annotations:2.4.0
 com.google.guava:guava:30.1-android
 com.google.inject:guice:2.0
 com.google.j2objc:j2objc-annotations:1.1
-com.google.protobuf:protobuf-java-util:3.19.2
-com.google.protobuf:protobuf-java:3.19.2
+com.google.protobuf:protobuf-java-util:3.19.6
+com.google.protobuf:protobuf-java:3.19.6
 com.googlecode.json-simple:json-simple:1.1.1
 com.graphql-java:graphql-java:19.2
 com.graphql-java:java-dataloader:3.2.0

--- a/dev/com.ibm.ws.grpc_fat/bnd.bnd
+++ b/dev/com.ibm.ws.grpc_fat/bnd.bnd
@@ -81,8 +81,8 @@ tested.features:\
     org.brotli:dec;version=0.1.2,\
     net.sourceforge.htmlunit:htmlunit-cssparser;version=1.6.0,\
     xml-apis:xml-apis;version=1.4.01,\
-    com.google.protobuf:protobuf-java;version=3.19.2, \
-    com.google.protobuf:protobuf-java-util;version=3.19.2, \
+    com.google.protobuf:protobuf-java;version=3.19.6, \
+    com.google.protobuf:protobuf-java-util;version=3.19.6, \
     com.ibm.websphere.javaee.jaxrs.2.1,\
     com.ibm.websphere.javaee.cdi.2.0,\
     com.ibm.websphere.appserver.api.distributedMap;version=latest,\

--- a/dev/com.ibm.ws.grpc_fat/build.gradle
+++ b/dev/com.ibm.ws.grpc_fat/build.gradle
@@ -40,7 +40,7 @@ plugins {
 }
 
 def grpcVersion = '1.43.2'
-def protocVersion = '3.19.2'
+def protocVersion = '3.19.6'
 
 // only run the protobuf compilation plugin if the build is run with "-PcompileProtobufs"
 // this will allow us to avoid recompiling the protobuf stubs on every build, and additionally
@@ -123,7 +123,7 @@ configurations {
 dependencies {
 
     // Adding libraries the application to run in FAT
-    storeAppWarLibs 'com.google.protobuf:protobuf-java-util:3.19.2',
+    storeAppWarLibs 'com.google.protobuf:protobuf-java-util:3.19.6',
     project(':io.openliberty.com.google.gson'),
     'com.google.guava:guava:30.1-android',
     'com.google.errorprone:error_prone_annotations:2.4.0',
@@ -140,7 +140,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     //
-    implementation 'com.google.protobuf:protobuf-java-util:3.19.2'
+    implementation 'com.google.protobuf:protobuf-java-util:3.19.6'
     // @jar is needed since some of the dependencies of java-util were overwritten
     providedCompile 'io.grpc:grpc-protobuf:' + grpcVersion + '@jar'
     compileOnly 'io.grpc:grpc-stub:' + grpcVersion
@@ -150,7 +150,7 @@ dependencies {
     implementation 'com.ibm.websphere.appserver.api:com.ibm.websphere.appserver.api.distributedMap:2.0.37'
 
     // provided
-    providedCompile 'com.google.protobuf:protobuf-java:3.19.2'
+    providedCompile 'com.google.protobuf:protobuf-java:3.19.6'
     providedCompile 'javax.annotation:javax.annotation-api:1.2'
     providedCompile 'jakarta.platform:jakarta.jakartaee-api:8.0.0'
     providedCompile 'org.eclipse.microprofile:microprofile:3.2'
@@ -177,8 +177,8 @@ dependencies {
       'io.grpc:grpc-stub:' + grpcVersion,
       'io.grpc:grpc-protobuf:' + grpcVersion,
       'io.grpc:grpc-netty:' + grpcVersion,
-      'com.google.protobuf:protobuf-java:3.19.2',
-      'com.google.protobuf:protobuf-java-util:3.19.2'
+      'com.google.protobuf:protobuf-java:3.19.6',
+      'com.google.protobuf:protobuf-java-util:3.19.6'
 }
 
 

--- a/dev/io.openliberty.grpc.1.0.internal.client.monitor/bnd.bnd
+++ b/dev/io.openliberty.grpc.1.0.internal.client.monitor/bnd.bnd
@@ -53,7 +53,7 @@ instrument.disabled: true
     com.google.guava:failureaccess;version=1.0.1,\
     com.google.guava:guava;version=30.1, \
     com.google.j2objc:j2objc-annotations;version=1.1, \
-    com.google.protobuf:protobuf-java;version=3.19.2, \
+    com.google.protobuf:protobuf-java;version=3.19.6, \
     org.checkerframework:checker-compat-qual;version=2.5.2,\
     io.openliberty.grpc.1.0.internal.common;version=latest,\
     io.openliberty.grpc.1.0.internal.client;version=latest,\

--- a/dev/io.openliberty.grpc.1.0.internal.common/bnd.bnd
+++ b/dev/io.openliberty.grpc.1.0.internal.common/bnd.bnd
@@ -66,7 +66,7 @@ instrument.disabled: true
   com.google.guava:failureaccess;version=1.0.1,\
   com.google.guava:guava;version=30.1, \
   com.google.j2objc:j2objc-annotations;version=1.1, \
-  com.google.protobuf:protobuf-java;version=3.19.2, \
+  com.google.protobuf:protobuf-java;version=3.19.6, \
   io.grpc:grpc-census;version=${grpcVersion}, \
   io.grpc:grpc-context;version=${grpcVersion}, \
   io.grpc:grpc-core;version=${grpcVersion}, \

--- a/dev/io.openliberty.grpc.1.0.internal.monitor/bnd.bnd
+++ b/dev/io.openliberty.grpc.1.0.internal.monitor/bnd.bnd
@@ -53,7 +53,7 @@ instrument.disabled: true
     com.google.guava:failureaccess;version=1.0.1,\
     com.google.guava:guava;version=30.1, \
     com.google.j2objc:j2objc-annotations;version=1.1, \
-    com.google.protobuf:protobuf-java;version=3.19.2, \
+    com.google.protobuf:protobuf-java;version=3.19.6, \
     org.checkerframework:checker-compat-qual;version=2.5.2,\
     io.openliberty.grpc.1.0.internal.common;version=latest,\
     io.openliberty.grpc.1.0.internal;version=latest,\


### PR DESCRIPTION
Refresh some gRPC dependencies.

I have verified that these libs are not in git@github.ibm.com:websphere/oss-build-from-source.git
and that it is ok to refresh them in artifactory as jars. Both jars have been uploaded using the uploader tool. 

Signed-off-by: Gordon Hutchison <gordon.hutchison@gmail.com>
