### PR TITLE
Update processing for Prompt and Display attributes

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/ELHelper.java
+++ b/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/ELHelper.java
@@ -55,7 +55,7 @@ public class ELHelper {
      * @return The evaluated expression.
      */
     @Trivial
-    protected Object evaluateElExpression(String expression) {
+    public Object evaluateElExpression(String expression) {
         return evaluateElExpression(expression, false);
     }
 
@@ -165,7 +165,7 @@ public class ELHelper {
      * @return True if the expression is an immediate EL expression.
      */
     @Trivial
-    static boolean isImmediateExpression(String expression) {
+    public static boolean isImmediateExpression(String expression) {
         return isImmediateExpression(expression, false);
     }
 

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/OpenIdAuthenticationMechanismDefinitionWrapperTest.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/test/io/openliberty/security/jakartasec/OpenIdAuthenticationMechanismDefinitionWrapperTest.java
@@ -314,7 +314,72 @@ public class OpenIdAuthenticationMechanismDefinitionWrapperTest {
         assertEquals(EMPTY_DEFAULT, wrapper.getPromptParameter());
     }
 
-    // TODO: Unit test getPromptParameter with EL expression
+    @Test
+    public void testGetPromptParameterWithLogin() {
+        overrides.put(PROMPT, new PromptType[] { PromptType.LOGIN });
+        OpenIdAuthenticationMechanismDefinition oidcMechanismDefinition = getInstanceofAnnotation(overrides);
+        OpenIdAuthenticationMechanismDefinitionWrapper wrapper = new OpenIdAuthenticationMechanismDefinitionWrapper(oidcMechanismDefinition, constructedBaseURL);
+
+        assertEquals("login", wrapper.getPromptParameter());
+    }
+
+    @Test
+    public void testGetPromptParameterWithConsent() {
+        overrides.put(PROMPT, new PromptType[] { PromptType.CONSENT });
+        OpenIdAuthenticationMechanismDefinition oidcMechanismDefinition = getInstanceofAnnotation(overrides);
+        OpenIdAuthenticationMechanismDefinitionWrapper wrapper = new OpenIdAuthenticationMechanismDefinitionWrapper(oidcMechanismDefinition, constructedBaseURL);
+
+        assertEquals("consent", wrapper.getPromptParameter());
+    }
+
+    @Test
+    public void testGetPromptParameterWithSelectAccount() {
+        overrides.put(PROMPT, new PromptType[] { PromptType.SELECT_ACCOUNT });
+        OpenIdAuthenticationMechanismDefinition oidcMechanismDefinition = getInstanceofAnnotation(overrides);
+        OpenIdAuthenticationMechanismDefinitionWrapper wrapper = new OpenIdAuthenticationMechanismDefinitionWrapper(oidcMechanismDefinition, constructedBaseURL);
+
+        assertEquals("select_account", wrapper.getPromptParameter());
+    }
+
+    @Test
+    public void testGetPromptParameterWithNone() {
+        overrides.put(PROMPT, new PromptType[] { PromptType.NONE });
+        OpenIdAuthenticationMechanismDefinition oidcMechanismDefinition = getInstanceofAnnotation(overrides);
+        OpenIdAuthenticationMechanismDefinitionWrapper wrapper = new OpenIdAuthenticationMechanismDefinitionWrapper(oidcMechanismDefinition, constructedBaseURL);
+
+        assertEquals("none", wrapper.getPromptParameter());
+    }
+
+    @Test
+    public void testGetPromptParameterWithLoginAndConsent() {
+        overrides.put(PROMPT, new PromptType[] { PromptType.LOGIN, PromptType.CONSENT });
+        OpenIdAuthenticationMechanismDefinition oidcMechanismDefinition = getInstanceofAnnotation(overrides);
+        OpenIdAuthenticationMechanismDefinitionWrapper wrapper = new OpenIdAuthenticationMechanismDefinitionWrapper(oidcMechanismDefinition, constructedBaseURL);
+
+        boolean matches = "login consent".equals(wrapper.getPromptParameter()) || "consent login".equals(wrapper.getPromptParameter());
+        assertTrue("Prompt did not match either `login consent` or `consent login`, but was " + wrapper.getPromptParameter(), matches);
+    }
+
+    @Test
+    public void testGetPromptParameterEL() {
+        overrides.put(PROMPT_EXPRESSION, "#{'Log'.concat('in')}");
+
+        OpenIdAuthenticationMechanismDefinition oidcMechanismDefinition = getInstanceofAnnotation(overrides);
+        OpenIdAuthenticationMechanismDefinitionWrapper wrapper = new OpenIdAuthenticationMechanismDefinitionWrapper(oidcMechanismDefinition, constructedBaseURL);
+
+        assertEquals("login", wrapper.getPromptParameter());
+    }
+
+    @Test
+    public void testGetPromptParameterEL2() {
+        overrides.put(PROMPT_EXPRESSION, "#{'Login'.concat(' consent')}");
+
+        OpenIdAuthenticationMechanismDefinition oidcMechanismDefinition = getInstanceofAnnotation(overrides);
+        OpenIdAuthenticationMechanismDefinitionWrapper wrapper = new OpenIdAuthenticationMechanismDefinitionWrapper(oidcMechanismDefinition, constructedBaseURL);
+
+        boolean matches = "login consent".equals(wrapper.getPromptParameter()) || "consent login".equals(wrapper.getPromptParameter());
+        assertTrue("Prompt did not match either `login consent` or `consent login`, but was " + wrapper.getPromptParameter(), matches);
+    }
 
     @Test
     public void testGetDisplayParameter() {
@@ -325,9 +390,48 @@ public class OpenIdAuthenticationMechanismDefinitionWrapperTest {
     }
 
     @Test
-    @Ignore("This will fail until the EL implementation can handle inner enums.")
+    public void testGetDisplayParameterWithPopup() {
+        overrides.put(DISPLAY, DisplayType.POPUP);
+
+        OpenIdAuthenticationMechanismDefinition oidcMechanismDefinition = getInstanceofAnnotation(overrides);
+        OpenIdAuthenticationMechanismDefinitionWrapper wrapper = new OpenIdAuthenticationMechanismDefinitionWrapper(oidcMechanismDefinition, constructedBaseURL);
+
+        assertEquals("popup", wrapper.getDisplayParameter());
+    }
+
+    @Test
+    public void testGetDisplayParameterWithPage() {
+        overrides.put(DISPLAY, DisplayType.PAGE);
+
+        OpenIdAuthenticationMechanismDefinition oidcMechanismDefinition = getInstanceofAnnotation(overrides);
+        OpenIdAuthenticationMechanismDefinitionWrapper wrapper = new OpenIdAuthenticationMechanismDefinitionWrapper(oidcMechanismDefinition, constructedBaseURL);
+
+        assertEquals("page", wrapper.getDisplayParameter());
+    }
+
+    @Test
+    public void testGetDisplayParameterWithTouch() {
+        overrides.put(DISPLAY, DisplayType.TOUCH);
+
+        OpenIdAuthenticationMechanismDefinition oidcMechanismDefinition = getInstanceofAnnotation(overrides);
+        OpenIdAuthenticationMechanismDefinitionWrapper wrapper = new OpenIdAuthenticationMechanismDefinitionWrapper(oidcMechanismDefinition, constructedBaseURL);
+
+        assertEquals("touch", wrapper.getDisplayParameter());
+    }
+
+    @Test
+    public void testGetDisplayParameterWithWap() {
+        overrides.put(DISPLAY, DisplayType.WAP);
+
+        OpenIdAuthenticationMechanismDefinition oidcMechanismDefinition = getInstanceofAnnotation(overrides);
+        OpenIdAuthenticationMechanismDefinitionWrapper wrapper = new OpenIdAuthenticationMechanismDefinitionWrapper(oidcMechanismDefinition, constructedBaseURL);
+
+        assertEquals("wap", wrapper.getDisplayParameter());
+    }
+
+    @Test
     public void testGetDisplayParameter_EL() {
-        overrides.put(DISPLAY_EXPRESSION, "DisplayType.POPUP");
+        overrides.put(DISPLAY_EXPRESSION, "#{'pop'.concat('up')}");
 
         OpenIdAuthenticationMechanismDefinition oidcMechanismDefinition = getInstanceofAnnotation(overrides);
         OpenIdAuthenticationMechanismDefinitionWrapper wrapper = new OpenIdAuthenticationMechanismDefinitionWrapper(oidcMechanismDefinition, constructedBaseURL);


### PR DESCRIPTION
Fixes #23180

The Prompt and Display attributes were not getting their enums or potential EL values processed correctly.

- Processed both the prompt and display options, either fetch the enum or resolve the EL and match up the potential PromptType and DisplayType enums.

- Added Unit tests for both Prompt and Display, both for the Prompt/Display and the PromptExpression and DisplayExpression

- Updated some of the ElHelper methods to be public, so I didn't push jakarta references into the `com.ibm.ws.security.javaeesec` project.

- Display was logging the incorrect default to be used in case of an error.

- Updated the returned Prompt string to lowercase the attributes, per https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
