### PR TITLE
Retry port opens in basic recovery FATs

### DIFF
--- a/dev/com.ibm.ws.transaction.recovery_fat.1/publish/servers/recovery/server.xml
+++ b/dev/com.ibm.ws.transaction.recovery_fat.1/publish/servers/recovery/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -10,7 +10,14 @@
  -->
 <server>
 
-    <include location="../fatTestPorts.xml"/>
+	<include location="../fatTestCommon.xml" />
+
+    <httpEndpoint id="defaultHttpEndpoint"
+                  host="*"
+                  httpPort="${bvt.prop.HTTP_default}"
+                  httpsPort="${bvt.prop.HTTP_default.secure}">
+		<tcpOptions portOpenRetries="100000"/>
+    </httpEndpoint>
     
     <featureManager>
       <feature>servlet-3.1</feature>


### PR DESCRIPTION
#build
#spawn.fullfat.buckets=com.ibm.ws.transaction.recovery_fat.1,com.ibm.ws.transaction.recovery_fat.2,com.ibm.ws.transaction.recovery_fat.3