### PR TITLE
Get the microProfile Config object only once

### DIFF
--- a/dev/com.ibm.ws.security.mp.jwt.1.1.config/src/com/ibm/ws/security/mp/jwt/v11/config/impl/MpConfigProxyServiceImpl.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1.config/src/com/ibm/ws/security/mp/jwt/v11/config/impl/MpConfigProxyServiceImpl.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.security.mp.jwt.v11.config.impl;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -77,6 +79,19 @@ public class MpConfigProxyServiceImpl implements MpConfigProxyService {
         return null;
     }
 
+    /** return */
+    @Sensitive
+    @Override
+    public <T> List<T> getConfigValues(ClassLoader cl, Set<String> propertyNames, Class<T> propertyType) throws IllegalArgumentException {
+        Config config = getConfig(cl);
+        List<T> list = new ArrayList<T>();
+
+        for (String propertyName : propertyNames) {
+            list.add(getValue(config, propertyName, propertyType));
+        }
+        return list;
+    }
+
     @Override
     public Set<String> getSupportedConfigPropertyNames() {
         return MpConfigProperties.acceptableMpConfigPropNames11;
@@ -88,5 +103,20 @@ public class MpConfigProxyServiceImpl implements MpConfigProxyService {
         } else {
             return ConfigProvider.getConfig();
         }
+    }
+
+    /**
+     * @return
+     */
+    @Sensitive
+    private <T> T getValue(Config config, String propertyName, Class<T> propertyType) {
+        if (isAcceptableMpConfigProperty(propertyName)) {
+            Optional<T> value = config.getOptionalValue(propertyName, propertyType);
+            if (value != null && value.isPresent()) {
+                return value.get();
+            }
+            return null;
+        }
+        return null;
     }
 }

--- a/dev/com.ibm.ws.security.mp.jwt.1.1.config/test/com/ibm/ws/security/mp/jwt/v11/config/impl/MpConfigProxyServiceImplTest.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1.config/test/com/ibm/ws/security/mp/jwt/v11/config/impl/MpConfigProxyServiceImplTest.java
@@ -14,7 +14,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
 
 import org.eclipse.microprofile.config.Config;
 import org.jmock.Expectations;
@@ -199,6 +202,75 @@ public class MpConfigProxyServiceImplTest {
 
         String output = (String) mpConfigProxyServiceImpl.getConfigValue(cl, NAME, CLAZZ);
         assertEquals("the expected value should be returned", VALUE, output);
+    }
+
+    @Test
+    public void testGetConfigValuesNoClassLoader() {
+        MpConfigProxyServiceImpl mpConfigProxyServiceImpl = new MpConfigProxyServiceImplDouble();
+        Set<String> properties = new TreeSet<>();
+        properties.add(MpConfigProperties.PUBLIC_KEY);
+        properties.add(MpConfigProperties.ISSUER);
+        Class CLAZZ = String.class;
+        String VALUE = "value";
+
+        mockery.checking(new Expectations() {
+            {
+                one(configNoCL).getOptionalValue(MpConfigProperties.PUBLIC_KEY, CLAZZ);
+                will(returnValue(Optional.of(VALUE)));
+                one(configNoCL).getOptionalValue(MpConfigProperties.ISSUER, CLAZZ);
+                will(returnValue(Optional.of(VALUE)));
+            }
+        });
+
+        List<String> output = mpConfigProxyServiceImpl.getConfigValues(null, properties, CLAZZ);
+        assertEquals("the list should be 2 items.", 2, output.size());
+    }
+
+    @Test
+    public void testGetConfigValuesClassLoader() {
+        MpConfigProxyServiceImpl mpConfigProxyServiceImpl = new MpConfigProxyServiceImplDouble();
+        Set<String> properties = new TreeSet<>();
+        properties.add(MpConfigProperties.PUBLIC_KEY);
+        properties.add(MpConfigProperties.ISSUER);
+        Class CLAZZ = String.class;
+        String VALUE = "value";
+
+        mockery.checking(new Expectations() {
+            {
+                one(configCL).getOptionalValue(MpConfigProperties.PUBLIC_KEY, CLAZZ);
+                will(returnValue(Optional.of(VALUE)));
+                one(configCL).getOptionalValue(MpConfigProperties.ISSUER, CLAZZ);
+                will(returnValue(Optional.of(VALUE)));
+            }
+        });
+
+        List<String> output = mpConfigProxyServiceImpl.getConfigValues(cl, properties, CLAZZ);
+        assertEquals("the list should be 2 items.", 2, output.size());
+    }
+
+    @Test
+    public void testGetConfigValuesClassLoader_unknownMpJwtConfigProperty() {
+        MpConfigProxyServiceImpl mpConfigProxyServiceImpl = new MpConfigProxyServiceImplDouble();
+        Set<String> properties = new TreeSet<>();
+        properties.add(MpConfigProperties.PUBLIC_KEY);
+        properties.add(MpConfigProperties.ISSUER);
+        properties.add("Unknown");
+
+        Class CLAZZ = String.class;
+        String VALUE = "value";
+
+        mockery.checking(new Expectations() {
+            {
+                one(configCL).getOptionalValue(MpConfigProperties.PUBLIC_KEY, CLAZZ);
+                will(returnValue(Optional.of(VALUE)));
+                one(configCL).getOptionalValue(MpConfigProperties.ISSUER, CLAZZ);
+                will(returnValue(Optional.of(VALUE)));
+                never(configCL).getOptionalValue("Unknown", CLAZZ);
+            }
+        });
+
+        List<String> output = mpConfigProxyServiceImpl.getConfigValues(cl, properties, CLAZZ);
+        assertEquals("the list should be 3 items.", 3, output.size());
     }
 
     class MpConfigProxyServiceImplDouble extends MpConfigProxyServiceImpl {

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/MpConfigProxyService.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/MpConfigProxyService.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.security.mp.jwt;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
@@ -31,6 +32,8 @@ public interface MpConfigProxyService {
      * @return
      */
     public <T> T getConfigValue(ClassLoader cl, String propertyName, Class<T> propertyType) throws IllegalArgumentException, NoSuchElementException;
+
+    public <T> List<T> getConfigValues(ClassLoader cl, Set<String> propertyNames, Class<T> propertyType) throws IllegalArgumentException;
 
     public Set<String> getSupportedConfigPropertyNames();
 

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/MpConfigProxyService.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/MpConfigProxyService.java
@@ -10,9 +10,10 @@
  *******************************************************************************/
 package com.ibm.ws.security.mp.jwt;
 
-import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
+
+import com.ibm.ws.security.jwt.config.MpConfigProperties;
 
 public interface MpConfigProxyService {
 
@@ -33,7 +34,7 @@ public interface MpConfigProxyService {
      */
     public <T> T getConfigValue(ClassLoader cl, String propertyName, Class<T> propertyType) throws IllegalArgumentException, NoSuchElementException;
 
-    public <T> List<T> getConfigValues(ClassLoader cl, Set<String> propertyNames, Class<T> propertyType) throws IllegalArgumentException;
+    public MpConfigProperties getConfigProperties(ClassLoader cl);
 
     public Set<String> getSupportedConfigPropertyNames();
 

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/config/MpConfigUtil.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/config/MpConfigUtil.java
@@ -10,9 +10,6 @@
  *******************************************************************************/
 package com.ibm.ws.security.mp.jwt.config;
 
-import java.util.List;
-import java.util.Set;
-
 import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
@@ -47,7 +44,7 @@ public class MpConfigUtil {
 
     public MpConfigProperties getMpConfig(HttpServletRequest req) {
         if (mpConfigProxyService != null) {
-            return getMpConfigMap(mpConfigProxyService, getApplicationClassloader(req));
+            return mpConfigProxyService.getConfigProperties(getApplicationClassloader(req));
         } else {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "MP JWT feature is not enabled.");
@@ -58,30 +55,5 @@ public class MpConfigUtil {
 
     protected ClassLoader getApplicationClassloader(HttpServletRequest req) {
         return req != null ? req.getServletContext().getClassLoader() : null;
-    }
-
-    // no null check other than cl. make sure that the caller sets non null objects.
-    protected MpConfigProperties getMpConfigMap(MpConfigProxyService service, ClassLoader cl) {
-
-        Set<String> supportedMpConfigPropNames = service.getSupportedConfigPropertyNames();
-        List<String> values = service.getConfigValues(cl, supportedMpConfigPropNames, String.class);
-
-        MpConfigProperties map = new MpConfigProperties();
-        int i = 0;
-        for (String propertyName : supportedMpConfigPropNames) {
-            String value = values.get(i);
-            if (value != null) {
-                value = value.trim();
-            }
-            if (value != null && !value.isEmpty()) {
-                map.put(propertyName, value);
-            } else {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, propertyName + " is empty or null. Ignore it.");
-                }
-            }
-            i++;
-        }
-        return map;
     }
 }

--- a/dev/com.ibm.ws.security.mp.jwt/test/com/ibm/ws/security/mp/jwt/config/MpConfigUtilTest.java
+++ b/dev/com.ibm.ws.security.mp.jwt/test/com/ibm/ws/security/mp/jwt/config/MpConfigUtilTest.java
@@ -13,11 +13,7 @@ package com.ibm.ws.security.mp.jwt.config;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -122,10 +118,8 @@ public class MpConfigUtilTest {
                 will(returnValue(servletCtx));
                 one(servletCtx).getClassLoader();
                 will(returnValue(null));
-                one(mpConfigProxyService).getSupportedConfigPropertyNames();
-                will(returnValue(getSupportedMpConfigProps()));
-                one(mpConfigProxyService).getConfigValues(null, getSupportedMpConfigProps(), String.class);
-                will(returnValue(getConfigValues("value_" + MpConfigProperties.ISSUER, "value_" + MpConfigProperties.PUBLIC_KEY, "value_" + MpConfigProperties.KEY_LOCATION)));
+                one(mpConfigProxyService).getConfigProperties(null);
+                will(returnValue(getConfigProperties()));
             }
         });
         Map<String, String> map = mpConfigUtil.getMpConfig(req);
@@ -150,10 +144,8 @@ public class MpConfigUtilTest {
                 will(returnValue(servletCtx));
                 one(servletCtx).getClassLoader();
                 will(returnValue(cl));
-                one(mpConfigProxyService).getSupportedConfigPropertyNames();
-                will(returnValue(getSupportedMpConfigProps()));
-                one(mpConfigProxyService).getConfigValues(cl, getSupportedMpConfigProps(), String.class);
-                will(returnValue(getConfigValues("value_" + MpConfigProperties.ISSUER, "value_" + MpConfigProperties.PUBLIC_KEY, "value_" + MpConfigProperties.KEY_LOCATION)));
+                one(mpConfigProxyService).getConfigProperties(cl);
+                will(returnValue(getConfigProperties()));
             }
         });
         Map<String, String> map = mpConfigUtil.getMpConfig(srtReq);
@@ -166,146 +158,13 @@ public class MpConfigUtilTest {
         assertTrue("the map should contain the value" + MpConfigProperties.KEY_LOCATION, map.get(MpConfigProperties.KEY_LOCATION).equals("value_" + MpConfigProperties.KEY_LOCATION));
     }
 
-    /**
-     * Tests getMpConfig method with the config proxy service is available.
-     * The MpConfigProperties.ISSUER does not exist.
-     */
-    @Test
-    public void getMpConfigWithConfigProxyServiceSrtReqNoIssuer() {
-        mockery.checking(new Expectations() {
-            {
-                one(srtReq).getServletContext();
-                will(returnValue(servletCtx));
-                one(servletCtx).getClassLoader();
-                will(returnValue(cl));
-                one(mpConfigProxyService).getSupportedConfigPropertyNames();
-                will(returnValue(getSupportedMpConfigProps()));
-                one(mpConfigProxyService).getConfigValues(cl, getSupportedMpConfigProps(), String.class);
-                will(returnValue(getConfigValues(null, "value_" + MpConfigProperties.PUBLIC_KEY, "value_" + MpConfigProperties.KEY_LOCATION)));
-            }
-        });
-        Map<String, String> map = mpConfigUtil.getMpConfig(srtReq);
-        assertEquals("the map should be 2 items.", 2, map.size());
-        assertTrue("the map should contain the key " + MpConfigProperties.PUBLIC_KEY, map.containsKey(MpConfigProperties.PUBLIC_KEY));
-        assertTrue("the map should contain the key " + MpConfigProperties.KEY_LOCATION, map.containsKey(MpConfigProperties.KEY_LOCATION));
-        assertTrue("the map should contain the value " + MpConfigProperties.PUBLIC_KEY, map.get(MpConfigProperties.PUBLIC_KEY).equals("value_" + MpConfigProperties.PUBLIC_KEY));
-        assertTrue("the map should contain the value" + MpConfigProperties.KEY_LOCATION, map.get(MpConfigProperties.KEY_LOCATION).equals("value_" + MpConfigProperties.KEY_LOCATION));
-    }
+    private MpConfigProperties getConfigProperties() {
 
-    /**
-     * Tests getMpConfig method with the config proxy service is available.
-     * The MpConfigProperties.PUBLIC_KEY does not exist.
-     */
-    @Test
-    public void getMpConfigWithConfigProxyServiceSrtReqNoPublicKey() {
-        mockery.checking(new Expectations() {
-            {
-                one(srtReq).getServletContext();
-                will(returnValue(servletCtx));
-                one(servletCtx).getClassLoader();
-                will(returnValue(cl));
-                one(mpConfigProxyService).getSupportedConfigPropertyNames();
-                will(returnValue(getSupportedMpConfigProps()));
-                one(mpConfigProxyService).getConfigValues(cl, getSupportedMpConfigProps(), String.class);
-                will(returnValue(getConfigValues("value_" + MpConfigProperties.ISSUER, null, "value_" + MpConfigProperties.KEY_LOCATION)));
-            }
-        });
-        Map<String, String> map = mpConfigUtil.getMpConfig(srtReq);
-        assertEquals("the map should be 2 items.", 2, map.size());
-        assertTrue("the map should contain the key " + MpConfigProperties.ISSUER, map.containsKey(MpConfigProperties.ISSUER));
-        assertTrue("the map should contain the key " + MpConfigProperties.KEY_LOCATION, map.containsKey(MpConfigProperties.KEY_LOCATION));
-        assertTrue("the map should contain the value " + MpConfigProperties.ISSUER, map.get(MpConfigProperties.ISSUER).equals("value_" + MpConfigProperties.ISSUER));
-        assertTrue("the map should contain the value" + MpConfigProperties.KEY_LOCATION, map.get(MpConfigProperties.KEY_LOCATION).equals("value_" + MpConfigProperties.KEY_LOCATION));
-    }
-
-    /**
-     * Tests getMpConfig method with the config proxy service is available.
-     * The MpConfigProperties.KEY_LOCATION does not exist.
-     */
-    @Test
-    public void getMpConfigWithConfigProxyServiceSrtReqNoKeyLocation() {
-        mockery.checking(new Expectations() {
-            {
-                one(srtReq).getServletContext();
-                will(returnValue(servletCtx));
-                one(servletCtx).getClassLoader();
-                will(returnValue(cl));
-                one(mpConfigProxyService).getSupportedConfigPropertyNames();
-                will(returnValue(getSupportedMpConfigProps()));
-                one(mpConfigProxyService).getConfigValues(cl, getSupportedMpConfigProps(), String.class);
-                will(returnValue(getConfigValues("value_" + MpConfigProperties.ISSUER, "value_" + MpConfigProperties.PUBLIC_KEY, null)));
-            }
-        });
-        Map<String, String> map = mpConfigUtil.getMpConfig(srtReq);
-        assertEquals("the map should be 2 items.", 2, map.size());
-        assertTrue("the map should contain the key " + MpConfigProperties.ISSUER, map.containsKey(MpConfigProperties.ISSUER));
-        assertTrue("the map should contain the key " + MpConfigProperties.PUBLIC_KEY, map.containsKey(MpConfigProperties.PUBLIC_KEY));
-        assertTrue("the map should contain the value " + MpConfigProperties.ISSUER, map.get(MpConfigProperties.ISSUER).equals("value_" + MpConfigProperties.ISSUER));
-        assertTrue("the map should contain the value " + MpConfigProperties.PUBLIC_KEY, map.get(MpConfigProperties.PUBLIC_KEY).equals("value_" + MpConfigProperties.PUBLIC_KEY));
-    }
-
-    /**
-     * Tests getMpConfig method with the config proxy service is available.
-     * No data exists.
-     */
-    @Test
-    public void getMpConfigWithConfigProxyServiceSrtReqNoProperties() {
-        mockery.checking(new Expectations() {
-            {
-                one(srtReq).getServletContext();
-                will(returnValue(servletCtx));
-                one(servletCtx).getClassLoader();
-                will(returnValue(cl));
-                one(mpConfigProxyService).getSupportedConfigPropertyNames();
-                will(returnValue(getSupportedMpConfigProps()));
-                one(mpConfigProxyService).getConfigValues(cl, getSupportedMpConfigProps(), String.class);
-                will(returnValue(getConfigValues(null, null, null)));
-            }
-        });
-        Map<String, String> map = mpConfigUtil.getMpConfig(srtReq);
-        assertTrue("the map should be empty when none of the properties is available.", map.isEmpty());
-    }
-
-    /**
-     * Tests getMpConfig method with the config proxy service is available.
-     * make sure that empty data (after trim) is not put.
-     */
-    @Test
-    public void getMpConfigWithConfigProxyServiceSrtReqTrim() {
-        mockery.checking(new Expectations() {
-            {
-                one(srtReq).getServletContext();
-                will(returnValue(servletCtx));
-                one(servletCtx).getClassLoader();
-                will(returnValue(cl));
-                one(mpConfigProxyService).getSupportedConfigPropertyNames();
-                will(returnValue(getSupportedMpConfigProps()));
-                one(mpConfigProxyService).getConfigValues(cl, getSupportedMpConfigProps(), String.class);
-                will(returnValue(getConfigValues("\t\t\t\n", "               ", "     value_" + MpConfigProperties.KEY_LOCATION + "          ")));
-            }
-        });
-        Map<String, String> map = mpConfigUtil.getMpConfig(srtReq);
-        assertEquals("the map should be 1 item.", 1, map.size());
-        assertTrue("the map should contain the value" + MpConfigProperties.KEY_LOCATION, map.get(MpConfigProperties.KEY_LOCATION).equals("value_" + MpConfigProperties.KEY_LOCATION));
-    }
-
-    private Set<String> getSupportedMpConfigProps() {
-        Set<String> supportedMpConfigProps = new TreeSet<String>();
-        supportedMpConfigProps.add(MpConfigProperties.ISSUER);
-        supportedMpConfigProps.add(MpConfigProperties.PUBLIC_KEY);
-        supportedMpConfigProps.add(MpConfigProperties.KEY_LOCATION);
-        return supportedMpConfigProps;
-    }
-
-    /**
-     * @return
-     */
-    private List<String> getConfigValues(String issuer, String publicKey, String keyLocation) {
-        List<String> list = new ArrayList<String>();
-        list.add(issuer);
-        list.add(publicKey);
-        list.add(keyLocation);
-        return list;
+        MpConfigProperties configProps = new MpConfigProperties();
+        configProps.put(MpConfigProperties.ISSUER, "value_" + MpConfigProperties.ISSUER);
+        configProps.put(MpConfigProperties.PUBLIC_KEY, "value_" + MpConfigProperties.PUBLIC_KEY);
+        configProps.put(MpConfigProperties.KEY_LOCATION, "value_" + MpConfigProperties.KEY_LOCATION);
+        return configProps;
     }
 
 }

--- a/dev/com.ibm.ws.security.mp.jwt/test/com/ibm/ws/security/mp/jwt/config/MpConfigUtilTest.java
+++ b/dev/com.ibm.ws.security.mp.jwt/test/com/ibm/ws/security/mp/jwt/config/MpConfigUtilTest.java
@@ -13,10 +13,11 @@ package com.ibm.ws.security.mp.jwt.config;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.TreeSet;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -123,12 +124,8 @@ public class MpConfigUtilTest {
                 will(returnValue(null));
                 one(mpConfigProxyService).getSupportedConfigPropertyNames();
                 will(returnValue(getSupportedMpConfigProps()));
-                one(mpConfigProxyService).getConfigValue(null, MpConfigProperties.ISSUER, String.class);
-                will(returnValue("value_" + MpConfigProperties.ISSUER));
-                one(mpConfigProxyService).getConfigValue(null, MpConfigProperties.PUBLIC_KEY, String.class);
-                will(returnValue("value_" + MpConfigProperties.PUBLIC_KEY));
-                one(mpConfigProxyService).getConfigValue(null, MpConfigProperties.KEY_LOCATION, String.class);
-                will(returnValue("value_" + MpConfigProperties.KEY_LOCATION));
+                one(mpConfigProxyService).getConfigValues(null, getSupportedMpConfigProps(), String.class);
+                will(returnValue(getConfigValues("value_" + MpConfigProperties.ISSUER, "value_" + MpConfigProperties.PUBLIC_KEY, "value_" + MpConfigProperties.KEY_LOCATION)));
             }
         });
         Map<String, String> map = mpConfigUtil.getMpConfig(req);
@@ -155,12 +152,8 @@ public class MpConfigUtilTest {
                 will(returnValue(cl));
                 one(mpConfigProxyService).getSupportedConfigPropertyNames();
                 will(returnValue(getSupportedMpConfigProps()));
-                one(mpConfigProxyService).getConfigValue(cl, MpConfigProperties.ISSUER, String.class);
-                will(returnValue("value_" + MpConfigProperties.ISSUER));
-                one(mpConfigProxyService).getConfigValue(cl, MpConfigProperties.PUBLIC_KEY, String.class);
-                will(returnValue("value_" + MpConfigProperties.PUBLIC_KEY));
-                one(mpConfigProxyService).getConfigValue(cl, MpConfigProperties.KEY_LOCATION, String.class);
-                will(returnValue("value_" + MpConfigProperties.KEY_LOCATION));
+                one(mpConfigProxyService).getConfigValues(cl, getSupportedMpConfigProps(), String.class);
+                will(returnValue(getConfigValues("value_" + MpConfigProperties.ISSUER, "value_" + MpConfigProperties.PUBLIC_KEY, "value_" + MpConfigProperties.KEY_LOCATION)));
             }
         });
         Map<String, String> map = mpConfigUtil.getMpConfig(srtReq);
@@ -187,12 +180,8 @@ public class MpConfigUtilTest {
                 will(returnValue(cl));
                 one(mpConfigProxyService).getSupportedConfigPropertyNames();
                 will(returnValue(getSupportedMpConfigProps()));
-                one(mpConfigProxyService).getConfigValue(cl, MpConfigProperties.ISSUER, String.class);
-                will(throwException(new NoSuchElementException()));
-                one(mpConfigProxyService).getConfigValue(cl, MpConfigProperties.PUBLIC_KEY, String.class);
-                will(returnValue("value_" + MpConfigProperties.PUBLIC_KEY));
-                one(mpConfigProxyService).getConfigValue(cl, MpConfigProperties.KEY_LOCATION, String.class);
-                will(returnValue("value_" + MpConfigProperties.KEY_LOCATION));
+                one(mpConfigProxyService).getConfigValues(cl, getSupportedMpConfigProps(), String.class);
+                will(returnValue(getConfigValues(null, "value_" + MpConfigProperties.PUBLIC_KEY, "value_" + MpConfigProperties.KEY_LOCATION)));
             }
         });
         Map<String, String> map = mpConfigUtil.getMpConfig(srtReq);
@@ -217,12 +206,8 @@ public class MpConfigUtilTest {
                 will(returnValue(cl));
                 one(mpConfigProxyService).getSupportedConfigPropertyNames();
                 will(returnValue(getSupportedMpConfigProps()));
-                one(mpConfigProxyService).getConfigValue(cl, MpConfigProperties.ISSUER, String.class);
-                will(returnValue("value_" + MpConfigProperties.ISSUER));
-                one(mpConfigProxyService).getConfigValue(cl, MpConfigProperties.PUBLIC_KEY, String.class);
-                will(throwException(new NoSuchElementException()));
-                one(mpConfigProxyService).getConfigValue(cl, MpConfigProperties.KEY_LOCATION, String.class);
-                will(returnValue("value_" + MpConfigProperties.KEY_LOCATION));
+                one(mpConfigProxyService).getConfigValues(cl, getSupportedMpConfigProps(), String.class);
+                will(returnValue(getConfigValues("value_" + MpConfigProperties.ISSUER, null, "value_" + MpConfigProperties.KEY_LOCATION)));
             }
         });
         Map<String, String> map = mpConfigUtil.getMpConfig(srtReq);
@@ -247,12 +232,8 @@ public class MpConfigUtilTest {
                 will(returnValue(cl));
                 one(mpConfigProxyService).getSupportedConfigPropertyNames();
                 will(returnValue(getSupportedMpConfigProps()));
-                one(mpConfigProxyService).getConfigValue(cl, MpConfigProperties.ISSUER, String.class);
-                will(returnValue("value_" + MpConfigProperties.ISSUER));
-                one(mpConfigProxyService).getConfigValue(cl, MpConfigProperties.PUBLIC_KEY, String.class);
-                will(returnValue("value_" + MpConfigProperties.PUBLIC_KEY));
-                one(mpConfigProxyService).getConfigValue(cl, MpConfigProperties.KEY_LOCATION, String.class);
-                will(throwException(new NoSuchElementException()));
+                one(mpConfigProxyService).getConfigValues(cl, getSupportedMpConfigProps(), String.class);
+                will(returnValue(getConfigValues("value_" + MpConfigProperties.ISSUER, "value_" + MpConfigProperties.PUBLIC_KEY, null)));
             }
         });
         Map<String, String> map = mpConfigUtil.getMpConfig(srtReq);
@@ -277,12 +258,8 @@ public class MpConfigUtilTest {
                 will(returnValue(cl));
                 one(mpConfigProxyService).getSupportedConfigPropertyNames();
                 will(returnValue(getSupportedMpConfigProps()));
-                one(mpConfigProxyService).getConfigValue(cl, MpConfigProperties.ISSUER, String.class);
-                will(throwException(new NoSuchElementException()));
-                one(mpConfigProxyService).getConfigValue(cl, MpConfigProperties.PUBLIC_KEY, String.class);
-                will(throwException(new NoSuchElementException()));
-                one(mpConfigProxyService).getConfigValue(cl, MpConfigProperties.KEY_LOCATION, String.class);
-                will(throwException(new NoSuchElementException()));
+                one(mpConfigProxyService).getConfigValues(cl, getSupportedMpConfigProps(), String.class);
+                will(returnValue(getConfigValues(null, null, null)));
             }
         });
         Map<String, String> map = mpConfigUtil.getMpConfig(srtReq);
@@ -303,12 +280,8 @@ public class MpConfigUtilTest {
                 will(returnValue(cl));
                 one(mpConfigProxyService).getSupportedConfigPropertyNames();
                 will(returnValue(getSupportedMpConfigProps()));
-                one(mpConfigProxyService).getConfigValue(cl, MpConfigProperties.ISSUER, String.class);
-                will(returnValue("\t\t\t\n"));
-                one(mpConfigProxyService).getConfigValue(cl, MpConfigProperties.PUBLIC_KEY, String.class);
-                will(returnValue("               "));
-                one(mpConfigProxyService).getConfigValue(cl, MpConfigProperties.KEY_LOCATION, String.class);
-                will(returnValue("     value_" + MpConfigProperties.KEY_LOCATION + "          "));
+                one(mpConfigProxyService).getConfigValues(cl, getSupportedMpConfigProps(), String.class);
+                will(returnValue(getConfigValues("\t\t\t\n", "               ", "     value_" + MpConfigProperties.KEY_LOCATION + "          ")));
             }
         });
         Map<String, String> map = mpConfigUtil.getMpConfig(srtReq);
@@ -317,11 +290,22 @@ public class MpConfigUtilTest {
     }
 
     private Set<String> getSupportedMpConfigProps() {
-        Set<String> supportedMpConfigProps = new HashSet<String>();
+        Set<String> supportedMpConfigProps = new TreeSet<String>();
         supportedMpConfigProps.add(MpConfigProperties.ISSUER);
         supportedMpConfigProps.add(MpConfigProperties.PUBLIC_KEY);
         supportedMpConfigProps.add(MpConfigProperties.KEY_LOCATION);
         return supportedMpConfigProps;
+    }
+
+    /**
+     * @return
+     */
+    private List<String> getConfigValues(String issuer, String publicKey, String keyLocation) {
+        List<String> list = new ArrayList<String>();
+        list.add(issuer);
+        list.add(publicKey);
+        list.add(keyLocation);
+        return list;
     }
 
 }

--- a/dev/io.openliberty.security.mp.jwt.1.2.config/src/io/openliberty/security/mp/jwt/v12/config/impl/MpConfigProxyServiceImpl.java
+++ b/dev/io.openliberty.security.mp.jwt.1.2.config/src/io/openliberty/security/mp/jwt/v12/config/impl/MpConfigProxyServiceImpl.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package io.openliberty.security.mp.jwt.v12.config.impl;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -75,6 +77,19 @@ public class MpConfigProxyServiceImpl implements MpConfigProxyService {
         return null;
     }
 
+    /** return */
+    @Sensitive
+    @Override
+    public <T> List<T> getConfigValues(ClassLoader cl, Set<String> propertyNames, Class<T> propertyType) throws IllegalArgumentException {
+        Config config = getConfig(cl);
+        List<T> list = new ArrayList<T>();
+
+        for (String propertyName : propertyNames) {
+            list.add(getValue(config, propertyName, propertyType));
+        }
+        return list;
+    }
+
     @Override
     public Set<String> getSupportedConfigPropertyNames() {
         return MpConfigProperties.acceptableMpConfigPropNames12;
@@ -86,5 +101,20 @@ public class MpConfigProxyServiceImpl implements MpConfigProxyService {
         } else {
             return ConfigProvider.getConfig();
         }
+    }
+
+    /**
+     * @return
+     */
+    @Sensitive
+    private <T> T getValue(Config config, String propertyName, Class<T> propertyType) {
+        if (isAcceptableMpConfigProperty(propertyName)) {
+            Optional<T> value = config.getOptionalValue(propertyName, propertyType);
+            if (value != null && value.isPresent()) {
+                return value.get();
+            }
+            return null;
+        }
+        return null;
     }
 }

--- a/dev/io.openliberty.security.mp.jwt.1.2.config/src/io/openliberty/security/mp/jwt/v12/config/impl/MpConfigProxyServiceImpl.java
+++ b/dev/io.openliberty.security.mp.jwt.1.2.config/src/io/openliberty/security/mp/jwt/v12/config/impl/MpConfigProxyServiceImpl.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package io.openliberty.security.mp.jwt.v12.config.impl;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -80,14 +78,31 @@ public class MpConfigProxyServiceImpl implements MpConfigProxyService {
     /** return */
     @Sensitive
     @Override
-    public <T> List<T> getConfigValues(ClassLoader cl, Set<String> propertyNames, Class<T> propertyType) throws IllegalArgumentException {
+    public MpConfigProperties getConfigProperties(ClassLoader cl) {
         Config config = getConfig(cl);
-        List<T> list = new ArrayList<T>();
+        Set<String> propertyNames = getSupportedConfigPropertyNames();
+        MpConfigProperties mpConfigProps = new MpConfigProperties();
 
         for (String propertyName : propertyNames) {
-            list.add(getValue(config, propertyName, propertyType));
+            Optional<String> value = config.getOptionalValue(propertyName, String.class);
+            if (value != null && value.isPresent()) {
+                String valueString = value.get().trim();
+                if (!valueString.isEmpty()) {
+                    mpConfigProps.put(propertyName, valueString);
+                } else {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, propertyName + " is empty. Ignore it.");
+                    }
+
+                }
+            } else {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, propertyName + " is not in mpConfig.");
+                }
+            }
         }
-        return list;
+
+        return mpConfigProps;
     }
 
     @Override
@@ -101,20 +116,5 @@ public class MpConfigProxyServiceImpl implements MpConfigProxyService {
         } else {
             return ConfigProvider.getConfig();
         }
-    }
-
-    /**
-     * @return
-     */
-    @Sensitive
-    private <T> T getValue(Config config, String propertyName, Class<T> propertyType) {
-        if (isAcceptableMpConfigProperty(propertyName)) {
-            Optional<T> value = config.getOptionalValue(propertyName, propertyType);
-            if (value != null && value.isPresent()) {
-                return value.get();
-            }
-            return null;
-        }
-        return null;
     }
 }

--- a/dev/io.openliberty.security.mp.jwt.1.2.config/test/io/openliberty/security/mp/jwt/v12/config/impl/MpConfigProxyServiceImplTest.java
+++ b/dev/io.openliberty.security.mp.jwt.1.2.config/test/io/openliberty/security/mp/jwt/v12/config/impl/MpConfigProxyServiceImplTest.java
@@ -14,10 +14,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.TreeSet;
 
 import org.eclipse.microprofile.config.Config;
 import org.jmock.Expectations;
@@ -173,70 +170,123 @@ public class MpConfigProxyServiceImplTest {
     @Test
     public void testGetConfigValuesNoClassLoader() {
         MpConfigProxyServiceImpl mpConfigProxyServiceImpl = new MpConfigProxyServiceImplDouble();
-        Set<String> properties = new TreeSet<>();
-        properties.add(MpConfigProperties.PUBLIC_KEY);
-        properties.add(MpConfigProperties.ISSUER);
         Class CLAZZ = String.class;
-        String VALUE = "value";
 
         mockery.checking(new Expectations() {
             {
-                one(configNoClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY, CLAZZ);
-                will(returnValue(Optional.of(VALUE)));
                 one(configNoClassLoader).getOptionalValue(MpConfigProperties.ISSUER, CLAZZ);
-                will(returnValue(Optional.of(VALUE)));
+                will(returnValue(Optional.of("value_" + MpConfigProperties.ISSUER)));
+                one(configNoClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.PUBLIC_KEY)));
+                one(configNoClassLoader).getOptionalValue(MpConfigProperties.KEY_LOCATION, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.KEY_LOCATION)));
+                one(configNoClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY_ALG, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.PUBLIC_KEY_ALG)));
+                one(configNoClassLoader).getOptionalValue(MpConfigProperties.DECRYPT_KEY_LOCATION, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.DECRYPT_KEY_LOCATION)));
+                one(configNoClassLoader).getOptionalValue(MpConfigProperties.VERIFY_AUDIENCES, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.VERIFY_AUDIENCES)));
+                one(configNoClassLoader).getOptionalValue(MpConfigProperties.TOKEN_HEADER, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.TOKEN_HEADER)));
+                one(configNoClassLoader).getOptionalValue(MpConfigProperties.TOKEN_COOKIE, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.TOKEN_COOKIE)));
             }
         });
 
-        List<String> output = mpConfigProxyServiceImpl.getConfigValues(null, properties, CLAZZ);
-        assertEquals("the list should be 2 items.", 2, output.size());
+        MpConfigProperties configProperties = mpConfigProxyServiceImpl.getConfigProperties(null);
+        assertEquals("the list should be 8 items.", 8, configProperties.size());
     }
 
     @Test
     public void testGetConfigValuesClassLoader() {
         MpConfigProxyServiceImpl mpConfigProxyServiceImpl = new MpConfigProxyServiceImplDouble();
-        Set<String> properties = new TreeSet<>();
-        properties.add(MpConfigProperties.PUBLIC_KEY);
-        properties.add(MpConfigProperties.ISSUER);
         Class CLAZZ = String.class;
-        String VALUE = "value";
 
         mockery.checking(new Expectations() {
             {
-                one(configClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY, CLAZZ);
-                will(returnValue(Optional.of(VALUE)));
                 one(configClassLoader).getOptionalValue(MpConfigProperties.ISSUER, CLAZZ);
-                will(returnValue(Optional.of(VALUE)));
+                will(returnValue(Optional.of("value_" + MpConfigProperties.ISSUER)));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.PUBLIC_KEY)));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.KEY_LOCATION, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.KEY_LOCATION)));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY_ALG, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.PUBLIC_KEY_ALG)));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.DECRYPT_KEY_LOCATION, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.DECRYPT_KEY_LOCATION)));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.VERIFY_AUDIENCES, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.VERIFY_AUDIENCES)));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.TOKEN_HEADER, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.TOKEN_HEADER)));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.TOKEN_COOKIE, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.TOKEN_COOKIE)));
             }
         });
 
-        List<String> output = mpConfigProxyServiceImpl.getConfigValues(cl, properties, CLAZZ);
-        assertEquals("the list should be 2 items.", 2, output.size());
+        MpConfigProperties configProperties = mpConfigProxyServiceImpl.getConfigProperties(cl);
+        assertEquals("the list should be 8 items.", 8, configProperties.size());
     }
 
     @Test
-    public void testGetConfigValuesClassLoader_unknownMpJwtConfigProperty() {
+    public void testGetConfigValuesClassLoader_noProperties() {
         MpConfigProxyServiceImpl mpConfigProxyServiceImpl = new MpConfigProxyServiceImplDouble();
-        Set<String> properties = new TreeSet<>();
-        properties.add(MpConfigProperties.PUBLIC_KEY);
-        properties.add(MpConfigProperties.ISSUER);
-        properties.add("Unknown");
-
         Class CLAZZ = String.class;
-        String VALUE = "value";
 
         mockery.checking(new Expectations() {
             {
-                one(configClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY, CLAZZ);
-                will(returnValue(Optional.of(VALUE)));
                 one(configClassLoader).getOptionalValue(MpConfigProperties.ISSUER, CLAZZ);
-                will(returnValue(Optional.of(VALUE)));
-                never(configClassLoader).getOptionalValue("Unknown", CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.KEY_LOCATION, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY_ALG, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.DECRYPT_KEY_LOCATION, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.VERIFY_AUDIENCES, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.TOKEN_HEADER, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.TOKEN_COOKIE, CLAZZ);
             }
         });
 
-        List<String> output = mpConfigProxyServiceImpl.getConfigValues(cl, properties, CLAZZ);
-        assertEquals("the list should be 3 items.", 3, output.size());
+        MpConfigProperties configProperties = mpConfigProxyServiceImpl.getConfigProperties(cl);
+        assertEquals("the list should be 0 items.", 0, configProperties.size());
+    }
+
+    @Test
+    public void testGetConfigValuesClassLoader_trim() {
+        MpConfigProxyServiceImpl mpConfigProxyServiceImpl = new MpConfigProxyServiceImplDouble();
+        Class CLAZZ = String.class;
+
+        mockery.checking(new Expectations() {
+            {
+                one(configClassLoader).getOptionalValue(MpConfigProperties.ISSUER, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.ISSUER + "         ")));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.PUBLIC_KEY + "\t\t\t\n")));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.KEY_LOCATION, CLAZZ);
+                will(returnValue(Optional.of("     ")));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY_ALG, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.DECRYPT_KEY_LOCATION, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.VERIFY_AUDIENCES, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.TOKEN_HEADER, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.TOKEN_COOKIE, CLAZZ);
+                will(returnValue(null));
+            }
+        });
+
+        MpConfigProperties configProperties = mpConfigProxyServiceImpl.getConfigProperties(cl);
+        assertEquals("the list should be 2 items.", 2, configProperties.size());
+        assertTrue("the map should contain value_" + MpConfigProperties.ISSUER, configProperties.get(MpConfigProperties.ISSUER).equals("value_" + MpConfigProperties.ISSUER));
+        assertTrue("the map should contain value_" + MpConfigProperties.PUBLIC_KEY, configProperties.get(MpConfigProperties.PUBLIC_KEY).equals("value_" + MpConfigProperties.PUBLIC_KEY));
+
     }
 
     class MpConfigProxyServiceImplDouble extends MpConfigProxyServiceImpl {

--- a/dev/io.openliberty.security.mp.jwt.2.1.config/src/io/openliberty/security/mp/jwt/v21/config/impl/MpConfigProxyServiceImpl.java
+++ b/dev/io.openliberty.security.mp.jwt.2.1.config/src/io/openliberty/security/mp/jwt/v21/config/impl/MpConfigProxyServiceImpl.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package io.openliberty.security.mp.jwt.v21.config.impl;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -74,6 +76,19 @@ public class MpConfigProxyServiceImpl implements MpConfigProxyService {
         return null;
     }
 
+    /** return */
+    @Sensitive
+    @Override
+    public <T> List<T> getConfigValues(ClassLoader cl, Set<String> propertyNames, Class<T> propertyType) throws IllegalArgumentException {
+        Config config = getConfig(cl);
+        List<T> list = new ArrayList<T>();
+
+        for (String propertyName : propertyNames) {
+            list.add(getValue(config, propertyName, propertyType));
+        }
+        return list;
+    }
+
     @Override
     public Set<String> getSupportedConfigPropertyNames() {
         return MpConfigProperties.acceptableMpConfigPropNames21;
@@ -86,4 +101,20 @@ public class MpConfigProxyServiceImpl implements MpConfigProxyService {
             return ConfigProvider.getConfig();
         }
     }
+
+    /**
+     * @return
+     */
+    @Sensitive
+    private <T> T getValue(Config config, String propertyName, Class<T> propertyType) {
+        if (isAcceptableMpConfigProperty(propertyName)) {
+            Optional<T> value = config.getOptionalValue(propertyName, propertyType);
+            if (value != null && value.isPresent()) {
+                return value.get();
+            }
+            return null;
+        }
+        return null;
+    }
+
 }

--- a/dev/io.openliberty.security.mp.jwt.2.1.config/src/io/openliberty/security/mp/jwt/v21/config/impl/MpConfigProxyServiceImpl.java
+++ b/dev/io.openliberty.security.mp.jwt.2.1.config/src/io/openliberty/security/mp/jwt/v21/config/impl/MpConfigProxyServiceImpl.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package io.openliberty.security.mp.jwt.v21.config.impl;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -79,14 +77,31 @@ public class MpConfigProxyServiceImpl implements MpConfigProxyService {
     /** return */
     @Sensitive
     @Override
-    public <T> List<T> getConfigValues(ClassLoader cl, Set<String> propertyNames, Class<T> propertyType) throws IllegalArgumentException {
+    public MpConfigProperties getConfigProperties(ClassLoader cl) {
         Config config = getConfig(cl);
-        List<T> list = new ArrayList<T>();
+        Set<String> propertyNames = getSupportedConfigPropertyNames();
+        MpConfigProperties mpConfigProps = new MpConfigProperties();
 
         for (String propertyName : propertyNames) {
-            list.add(getValue(config, propertyName, propertyType));
+            Optional<String> value = config.getOptionalValue(propertyName, String.class);
+            if (value != null && value.isPresent()) {
+                String valueString = value.get().trim();
+                if (!valueString.isEmpty()) {
+                    mpConfigProps.put(propertyName, valueString);
+                } else {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, propertyName + " is empty. Ignore it.");
+                    }
+
+                }
+            } else {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, propertyName + " is not in mpConfig.");
+                }
+            }
         }
-        return list;
+
+        return mpConfigProps;
     }
 
     @Override
@@ -101,20 +116,4 @@ public class MpConfigProxyServiceImpl implements MpConfigProxyService {
             return ConfigProvider.getConfig();
         }
     }
-
-    /**
-     * @return
-     */
-    @Sensitive
-    private <T> T getValue(Config config, String propertyName, Class<T> propertyType) {
-        if (isAcceptableMpConfigProperty(propertyName)) {
-            Optional<T> value = config.getOptionalValue(propertyName, propertyType);
-            if (value != null && value.isPresent()) {
-                return value.get();
-            }
-            return null;
-        }
-        return null;
-    }
-
 }

--- a/dev/io.openliberty.security.mp.jwt.2.1.config/test/io/openliberty/security/mp/jwt/v21/config/impl/MpConfigProxyServiceImplTest.java
+++ b/dev/io.openliberty.security.mp.jwt.2.1.config/test/io/openliberty/security/mp/jwt/v21/config/impl/MpConfigProxyServiceImplTest.java
@@ -14,10 +14,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.TreeSet;
 
 import org.eclipse.microprofile.config.Config;
 import org.jmock.Expectations;
@@ -173,70 +170,148 @@ public class MpConfigProxyServiceImplTest {
     @Test
     public void testGetConfigValuesNoClassLoader() {
         MpConfigProxyServiceImpl mpConfigProxyServiceImpl = new MpConfigProxyServiceImplDouble();
-        Set<String> properties = new TreeSet<>();
-        properties.add(MpConfigProperties.PUBLIC_KEY);
-        properties.add(MpConfigProperties.ISSUER);
         Class CLAZZ = String.class;
-        String VALUE = "value";
 
         mockery.checking(new Expectations() {
             {
-                one(configNoClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY, CLAZZ);
-                will(returnValue(Optional.of(VALUE)));
                 one(configNoClassLoader).getOptionalValue(MpConfigProperties.ISSUER, CLAZZ);
-                will(returnValue(Optional.of(VALUE)));
+                will(returnValue(Optional.of("value_" + MpConfigProperties.ISSUER)));
+                one(configNoClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.PUBLIC_KEY)));
+                one(configNoClassLoader).getOptionalValue(MpConfigProperties.KEY_LOCATION, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.KEY_LOCATION)));
+                one(configNoClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY_ALG, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.PUBLIC_KEY_ALG)));
+                one(configNoClassLoader).getOptionalValue(MpConfigProperties.DECRYPT_KEY_LOCATION, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.DECRYPT_KEY_LOCATION)));
+                one(configNoClassLoader).getOptionalValue(MpConfigProperties.VERIFY_AUDIENCES, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.VERIFY_AUDIENCES)));
+                one(configNoClassLoader).getOptionalValue(MpConfigProperties.TOKEN_HEADER, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.TOKEN_HEADER)));
+                one(configNoClassLoader).getOptionalValue(MpConfigProperties.TOKEN_COOKIE, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.TOKEN_COOKIE)));
+                one(configNoClassLoader).getOptionalValue(MpConfigProperties.TOKEN_AGE, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.TOKEN_AGE)));
+                one(configNoClassLoader).getOptionalValue(MpConfigProperties.CLOCK_SKEW, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.CLOCK_SKEW)));
+                one(configNoClassLoader).getOptionalValue(MpConfigProperties.DECRYPT_KEY_ALGORITHM, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.DECRYPT_KEY_ALGORITHM)));
             }
         });
 
-        List<String> output = mpConfigProxyServiceImpl.getConfigValues(null, properties, CLAZZ);
-        assertEquals("the list should be 2 items.", 2, output.size());
+        MpConfigProperties configProperties = mpConfigProxyServiceImpl.getConfigProperties(null);
+        assertEquals("the list should be 11 items.", 11, configProperties.size());
     }
 
     @Test
     public void testGetConfigValuesClassLoader() {
         MpConfigProxyServiceImpl mpConfigProxyServiceImpl = new MpConfigProxyServiceImplDouble();
-        Set<String> properties = new TreeSet<>();
-        properties.add(MpConfigProperties.PUBLIC_KEY);
-        properties.add(MpConfigProperties.ISSUER);
         Class CLAZZ = String.class;
-        String VALUE = "value";
 
         mockery.checking(new Expectations() {
             {
-                one(configClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY, CLAZZ);
-                will(returnValue(Optional.of(VALUE)));
                 one(configClassLoader).getOptionalValue(MpConfigProperties.ISSUER, CLAZZ);
-                will(returnValue(Optional.of(VALUE)));
+                will(returnValue(Optional.of("value_" + MpConfigProperties.ISSUER)));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.PUBLIC_KEY)));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.KEY_LOCATION, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.KEY_LOCATION)));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY_ALG, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.PUBLIC_KEY_ALG)));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.DECRYPT_KEY_LOCATION, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.DECRYPT_KEY_LOCATION)));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.VERIFY_AUDIENCES, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.VERIFY_AUDIENCES)));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.TOKEN_HEADER, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.TOKEN_HEADER)));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.TOKEN_COOKIE, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.TOKEN_COOKIE)));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.TOKEN_AGE, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.TOKEN_AGE)));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.CLOCK_SKEW, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.CLOCK_SKEW)));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.DECRYPT_KEY_ALGORITHM, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.DECRYPT_KEY_ALGORITHM)));
             }
         });
 
-        List<String> output = mpConfigProxyServiceImpl.getConfigValues(cl, properties, CLAZZ);
-        assertEquals("the list should be 2 items.", 2, output.size());
+        MpConfigProperties configProperties = mpConfigProxyServiceImpl.getConfigProperties(cl);
+        assertEquals("the list should be 11 items.", 11, configProperties.size());
     }
 
     @Test
-    public void testGetConfigValuesClassLoader_unknownMpJwtConfigProperty() {
+    public void testGetConfigValuesClassLoader_noProperties() {
         MpConfigProxyServiceImpl mpConfigProxyServiceImpl = new MpConfigProxyServiceImplDouble();
-        Set<String> properties = new TreeSet<>();
-        properties.add(MpConfigProperties.PUBLIC_KEY);
-        properties.add(MpConfigProperties.ISSUER);
-        properties.add("Unknown");
-
         Class CLAZZ = String.class;
-        String VALUE = "value";
 
         mockery.checking(new Expectations() {
             {
-                one(configClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY, CLAZZ);
-                will(returnValue(Optional.of(VALUE)));
                 one(configClassLoader).getOptionalValue(MpConfigProperties.ISSUER, CLAZZ);
-                will(returnValue(Optional.of(VALUE)));
-                never(configClassLoader).getOptionalValue("Unknown", CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.KEY_LOCATION, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY_ALG, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.DECRYPT_KEY_LOCATION, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.VERIFY_AUDIENCES, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.TOKEN_HEADER, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.TOKEN_COOKIE, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.TOKEN_AGE, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.CLOCK_SKEW, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.DECRYPT_KEY_ALGORITHM, CLAZZ);
+                will(returnValue(null));
             }
         });
 
-        List<String> output = mpConfigProxyServiceImpl.getConfigValues(cl, properties, CLAZZ);
-        assertEquals("the list should be 3 items.", 3, output.size());
+        MpConfigProperties configProperties = mpConfigProxyServiceImpl.getConfigProperties(cl);
+        assertEquals("the list should be 0 items.", 0, configProperties.size());
+    }
+
+    @Test
+    public void testGetConfigValuesClassLoader_trim() {
+        MpConfigProxyServiceImpl mpConfigProxyServiceImpl = new MpConfigProxyServiceImplDouble();
+        Class CLAZZ = String.class;
+
+        mockery.checking(new Expectations() {
+            {
+                one(configClassLoader).getOptionalValue(MpConfigProperties.ISSUER, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.ISSUER + "         ")));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY, CLAZZ);
+                will(returnValue(Optional.of("value_" + MpConfigProperties.PUBLIC_KEY + "\t\t\t\n")));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.KEY_LOCATION, CLAZZ);
+                will(returnValue(Optional.of("     ")));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.PUBLIC_KEY_ALG, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.DECRYPT_KEY_LOCATION, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.VERIFY_AUDIENCES, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.TOKEN_HEADER, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.TOKEN_COOKIE, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.TOKEN_AGE, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.CLOCK_SKEW, CLAZZ);
+                will(returnValue(null));
+                one(configClassLoader).getOptionalValue(MpConfigProperties.DECRYPT_KEY_ALGORITHM, CLAZZ);
+                will(returnValue(null));
+            }
+        });
+
+        MpConfigProperties configProperties = mpConfigProxyServiceImpl.getConfigProperties(cl);
+        assertEquals("the list should be 2 items.", 2, configProperties.size());
+        assertTrue("the map should contain value_" + MpConfigProperties.ISSUER, configProperties.get(MpConfigProperties.ISSUER).equals("value_" + MpConfigProperties.ISSUER));
+        assertTrue("the map should contain value_" + MpConfigProperties.PUBLIC_KEY, configProperties.get(MpConfigProperties.PUBLIC_KEY).equals("value_" + MpConfigProperties.PUBLIC_KEY));
+
     }
 
     class MpConfigProxyServiceImplDouble extends MpConfigProxyServiceImpl {


### PR DESCRIPTION
Currently in our mpJwt code, we get a Microprofile Config object every time we look a property. This PR will change things to get the Config only once to look up all properties, which saves 2% of path length.
