### PR TITLE
Split out OIDC FAT test cases for discovery errors into their own classes

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/FATSuite.java
@@ -21,6 +21,10 @@ import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientBasicTests;
 import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientConsentTests;
 import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientCookieVerificationTests;
 import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientDiscoveryBasicTests;
+import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientDiscoveryErrorBadOpTrustStoreTests;
+import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientDiscoveryErrorBadRpTrustStoreTests;
+import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientDiscoveryErrorNoOpTrustStoreTests;
+import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientDiscoveryErrorNoRpTrustStoreTests;
 import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientDiscoveryErrorTests;
 import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientDiscoveryJVMPropsTests;
 import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientDiscoveryJWTBasicTests;
@@ -38,10 +42,14 @@ import componenttest.rules.repeater.RepeatTests;
         OidcClientConsentTests.class,
         OidcClientDiscoveryBasicTests.class,
         OidcClientDiscoveryErrorTests.class,
+        OidcClientDiscoveryErrorBadOpTrustStoreTests.class,
+        OidcClientDiscoveryErrorBadRpTrustStoreTests.class,
+        OidcClientDiscoveryErrorNoOpTrustStoreTests.class,
+        OidcClientDiscoveryErrorNoRpTrustStoreTests.class,
         OidcClientDiscoveryJVMPropsTests.class,
         OidcClientDiscoveryJWTBasicTests.class,
         OidcClientCookieVerificationTests.class,
-        // OidcCertificationRPBasicProfileTests.class,
+// OidcCertificationRPBasicProfileTests.class,
 
 })
 /**

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorBadOpTrustStoreTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorBadOpTrustStoreTests.java
@@ -1,0 +1,176 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.security.openidconnect.client.fat.IBM;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonTest;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonTestHelpers;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.Constants;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.DiscoveryUtils;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.TestSettings;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.ValidationData.validationData;
+import com.ibm.ws.security.openidconnect.client.fat.CommonTests.GenericOidcClientTests;
+import com.meterware.httpunit.WebConversation;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+
+/**
+ * This is the test class that will run error scenarios with OpenID Connect RP tests with an RP configuration (using access token
+ * and X509 cert) which includes discovery of OP endpoints.
+ * Discovery of OP endpoints is configured in the openidConnectClient section in server.xml by specifying the discoveryEndpointUrl
+ * instead of configuring
+ * each individual OP endpoint URL (such as authorizationEndpointUrl and tokenEndpointUrl) separately. This line below is used to
+ * configure RP discovery:
+ *
+ * discoveryEndpointUrl="https://localhost:${bvt.prop.OP_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
+ *
+ * With discovery, all the discovered endpoints are HTTPS. Any endpoints which are specified in the configuration will be ignored
+ * and the
+ * discovered endpoints will be used instead.
+ *
+ * This test configures the sslRef as part of the openidConnectClient configuration so that the SSL processing is handled by the
+ * client rather than
+ * outside this configuration.
+ *
+ **/
+
+@Mode(TestMode.FULL)
+@AllowedFFDC({ "org.apache.http.NoHttpResponseException", "java.security.cert.CertPathBuilderException", "sun.security.validator.ValidatorException", "javax.net.ssl.SSLHandshakeException", "com.ibm.websphere.ssl.SSLException", "java.lang.Exception" })
+@RunWith(FATRunner.class)
+public class OidcClientDiscoveryErrorBadOpTrustStoreTests extends CommonTest {
+    public static Class<?> thisClass = GenericOidcClientTests.class;
+    public static HashMap<String, Integer> defRespStatusMap = null;
+
+    public static String[] test_GOOD_LOGIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT;
+    public static String[] test_GOOD_POST_LOGIN_ACTIONS = Constants.GOOD_OIDC_POST_LOGIN_ACTIONS_SKIP_CONSENT;
+    public static String[] test_GOOD_LOGIN_AGAIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_AGAIN_ACTIONS;
+    public static String[] test_LOGIN_PAGE_ONLY = Constants.GET_LOGIN_PAGE_ONLY;
+    public static String test_FinalAction = Constants.LOGIN_USER;
+    protected static String hostName = "localhost";
+
+    @SuppressWarnings("serial")
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        thisClass = OidcClientDiscoveryErrorBadOpTrustStoreTests.class;
+
+        List<String> apps = new ArrayList<String>() {
+            {
+                add(Constants.OPENID_APP);
+            }
+        };
+
+        testSettings = new TestSettings();
+
+        // Set config parameters for Access token with X509 Certificate
+        String tokenType = Constants.ACCESS_TOKEN_KEY;
+        String certType = Constants.X509_CERT;
+
+        // Start the OIDC OP server
+        testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.op", "op_server_ssl_bad_truststore_clientAuth.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+
+        DiscoveryUtils.waitForOPDiscoveryToBeReady(testSettings);
+
+        //Start the OIDC RP server and setup default values
+        testRPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.rpd", "rp_server_orig.xml", Constants.OIDC_RP, apps, Constants.DO_NOT_USE_DERBY,
+                Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+
+        testOPServer.addIgnoredServerException("CWOAU0039W"); // Ignore errors from the malformed discovery url
+        testOPServer.addIgnoredServerException("CWWKO0801E");
+        testRPServer.addIgnoredServerException("CWWKS1859E"); //Ignore exceptions from bad client secret test
+        testRPServer.addIgnoredServerException("SRVE8094W");
+        testRPServer.addIgnoredServerException("SRVE0190E");
+        testRPServer.addIgnoredServerException("CWWKS1741W"); // Ignore from sigAlgMismatch2 - message is not always logged
+        testRPServer.addIgnoredServerException("SRVE8115W"); // Ignore setStatus WARNING
+        testRPServer.addIgnoredServerException("CWWKS1521W"); // Ignore message indicating conflicting configured endpoints are ignored
+        testRPServer.addIgnoredServerException("CWWKS1524E"); // Ignore message indicating unsuccessful response from endpoint
+        testRPServer.addIgnoredServerException("CWWKS1525E"); // Ignore message indicating discovery failed
+        testRPServer.addIgnoredServerException("CWWKS1522W"); // Ignore message indicating conflicting endpoints for issuer identifier
+        testRPServer.addIgnoredServerException("CWPKI0022E"); // Ignore message indicating conflicting configured endpoints are ignored
+        testRPServer.addIgnoredServerException("CWWKG0058E"); // Ignore SSL failure message
+
+        // override actions that generic tests should use - Need to skip consent form as httpunit
+        // cannot process the form because of embedded javascript
+
+        test_GOOD_LOGIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT;
+        test_GOOD_POST_LOGIN_ACTIONS = Constants.GOOD_OIDC_POST_LOGIN_ACTIONS_SKIP_CONSENT;
+        test_GOOD_LOGIN_AGAIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_AGAIN_ACTIONS;
+        test_FinalAction = Constants.LOGIN_USER;
+        testSettings.setFlowType(Constants.RP_FLOW);
+
+        // Force discovery to run to access login page so that the discovery service is active. Then, in the actual tests the reconfig will initiate discovery and cause the
+        // error messages to be generated on discovery failures during the reconfig (rather than waiting until the first authorization request in the runtime).
+        CommonTestHelpers helpers = new CommonTestHelpers();
+
+        // try to wait for discovery to have populated the RP config
+        // Don't stop if this fails (there is a chance it could be ready by the time the tests actually run
+        DiscoveryUtils.waitForRPDiscoveryToBeReady(testSettings);
+
+    }
+
+    /**
+     * Test Purpose:
+     * <OL>
+     * <LI>With discovery configured at the RP, attempt to access a test servlet specifying valid OP url with bad OP trust store
+     * <LI>results in 401 error with messages logged.
+     * <LI>In this scenario, the consent form is disabled in OP by setting the oauthProvider attribute
+     * <LI>in server.xml as: autoAuthorize="true". The OP truststore is missing the certificate for RP.
+     * <LI>clientAuthentication is set to "true" for OP server.
+     * </OL>
+     * <P>
+     * Expected Results:
+     * <OL>
+     * <LI>The discovery should be attempted and should fail with 401 when the RP tries process the first authentication request
+     * and the following messages should be logged
+     * <LI>CWWKS1525E: A successful response was not returned from the URL <discovery endpoint>
+     * <LI>CWWKS1524E: The OpenID Connect client failed to obtain OpenID Connect Provider information through the discovery
+     * endpoint...
+     * </OL>
+     */
+    // different versions of java issue different exceptions - allow appropriate exceptions from any of our supported java versions
+    @AllowedFFDC({ "java.net.SocketException", "javax.net.ssl.SSLHandshakeException", "javax.net.ssl.SSLException", "javax.net.ssl.SSLProtocolException" })
+    @Test
+    public void OidcClientDiscoverySSLTest_BadOPTrustStoreWithClientAuth() throws Exception {
+
+        TestSettings updatedTestSettings = testSettings.copyTestSettings();
+        updatedTestSettings.setScope("openid profile");
+        updatedTestSettings.setTestURL(updatedTestSettings.getTestURL().replace(Constants.DEFAULT_SERVLET, "simple/goodSSL"));
+
+        List<validationData> expectations = vData.addSuccessStatusCodes(null);
+
+        WebConversation wc = new WebConversation();
+
+        try {
+            genericRP(_testName, wc, updatedTestSettings, test_LOGIN_PAGE_ONLY, expectations);
+        } catch (Exception e) {
+            // there can be one of multiple exceptions thrown for this erroneous
+            // condition - the exceptions vary by JDK - validating the exception
+            // here allows the test to handle instances where we can get one of
+            // multiple possible error better than using an expectation.
+            msgUtils.assertTrueAndLog(_testName, "Expected one of the following in the exception: javax.net.ssl.SSLException, javax.net.ssl.SSLHandshakeException, java.net.SocketException actually received: " + e,
+                    validationTools.foundOneErrorInException(e, "javax.net.ssl.SSLException", "javax.net.ssl.SSLHandshakeException", "java.net.SocketException", "java.io.IOException"));
+
+        }
+
+    }
+
+}

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorBadOpTrustStoreTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorBadOpTrustStoreTests.java
@@ -12,7 +12,7 @@
 package com.ibm.ws.security.openidconnect.client.fat.IBM;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.BeforeClass;
@@ -20,12 +20,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonTest;
-import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonTestHelpers;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.Constants;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.DiscoveryUtils;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.MessageConstants;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.TestSettings;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.ValidationData.validationData;
-import com.ibm.ws.security.openidconnect.client.fat.CommonTests.GenericOidcClientTests;
 import com.meterware.httpunit.WebConversation;
 
 import componenttest.annotation.AllowedFFDC;
@@ -34,44 +33,29 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
 /**
- * This is the test class that will run error scenarios with OpenID Connect RP tests with an RP configuration (using access token
- * and X509 cert) which includes discovery of OP endpoints.
- * Discovery of OP endpoints is configured in the openidConnectClient section in server.xml by specifying the discoveryEndpointUrl
- * instead of configuring
- * each individual OP endpoint URL (such as authorizationEndpointUrl and tokenEndpointUrl) separately. This line below is used to
- * configure RP discovery:
- *
- * discoveryEndpointUrl="https://localhost:${bvt.prop.OP_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
- *
- * With discovery, all the discovered endpoints are HTTPS. Any endpoints which are specified in the configuration will be ignored
- * and the
- * discovered endpoints will be used instead.
- *
- * This test configures the sslRef as part of the openidConnectClient configuration so that the SSL processing is handled by the
- * client rather than
- * outside this configuration.
- *
+ * Test Purpose:
+ * <OL>
+ * <LI>With discovery configured at the RP, attempt to access a test servlet specifying valid OP URL.
+ * <LI>The OP trust store is missing the SSL certificate for the RP.
+ * <LI>Results in 401 error with messages logged.
+ * </OL>
+ * <P>
+ * Expected Results:
+ * <OL>
+ * <LI>The discovery should be attempted and should fail with 401 when the RP tries process the authentication request.
+ * </OL>
  **/
-
+// different versions of java issue different exceptions - allow appropriate exceptions from any of our supported java versions
 @Mode(TestMode.FULL)
 @AllowedFFDC({ "org.apache.http.NoHttpResponseException", "java.security.cert.CertPathBuilderException", "sun.security.validator.ValidatorException", "javax.net.ssl.SSLHandshakeException", "com.ibm.websphere.ssl.SSLException", "java.lang.Exception" })
 @RunWith(FATRunner.class)
 public class OidcClientDiscoveryErrorBadOpTrustStoreTests extends CommonTest {
-    public static Class<?> thisClass = GenericOidcClientTests.class;
-    public static HashMap<String, Integer> defRespStatusMap = null;
 
-    public static String[] test_GOOD_LOGIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT;
-    public static String[] test_GOOD_POST_LOGIN_ACTIONS = Constants.GOOD_OIDC_POST_LOGIN_ACTIONS_SKIP_CONSENT;
-    public static String[] test_GOOD_LOGIN_AGAIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_AGAIN_ACTIONS;
-    public static String[] test_LOGIN_PAGE_ONLY = Constants.GET_LOGIN_PAGE_ONLY;
-    public static String test_FinalAction = Constants.LOGIN_USER;
-    protected static String hostName = "localhost";
+    public static Class<?> thisClass = OidcClientDiscoveryErrorBadOpTrustStoreTests.class;
 
     @SuppressWarnings("serial")
     @BeforeClass
     public static void setUp() throws Exception {
-
-        thisClass = OidcClientDiscoveryErrorBadOpTrustStoreTests.class;
 
         List<String> apps = new ArrayList<String>() {
             {
@@ -81,94 +65,44 @@ public class OidcClientDiscoveryErrorBadOpTrustStoreTests extends CommonTest {
 
         testSettings = new TestSettings();
 
-        // Set config parameters for Access token with X509 Certificate
-        String tokenType = Constants.ACCESS_TOKEN_KEY;
-        String certType = Constants.X509_CERT;
-
         // Start the OIDC OP server
-        testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.op", "op_server_ssl_bad_truststore_clientAuth.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+        testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.op", "op_server_ssl_bad_truststore_clientAuth.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE);
 
         DiscoveryUtils.waitForOPDiscoveryToBeReady(testSettings);
 
         //Start the OIDC RP server and setup default values
-        testRPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.rpd", "rp_server_orig.xml", Constants.OIDC_RP, apps, Constants.DO_NOT_USE_DERBY,
-                Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+        testRPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.rpd", "rp_server_orig.xml", Constants.OIDC_RP, apps, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE);
 
-        testOPServer.addIgnoredServerException("CWOAU0039W"); // Ignore errors from the malformed discovery url
-        testOPServer.addIgnoredServerException("CWWKO0801E");
-        testRPServer.addIgnoredServerException("CWWKS1859E"); //Ignore exceptions from bad client secret test
-        testRPServer.addIgnoredServerException("SRVE8094W");
-        testRPServer.addIgnoredServerException("SRVE0190E");
+        testRPServer.addIgnoredServerException("CWWKS1859E"); // Ignore exceptions from bad client secret test
         testRPServer.addIgnoredServerException("CWWKS1741W"); // Ignore from sigAlgMismatch2 - message is not always logged
-        testRPServer.addIgnoredServerException("SRVE8115W"); // Ignore setStatus WARNING
-        testRPServer.addIgnoredServerException("CWWKS1521W"); // Ignore message indicating conflicting configured endpoints are ignored
         testRPServer.addIgnoredServerException("CWWKS1524E"); // Ignore message indicating unsuccessful response from endpoint
         testRPServer.addIgnoredServerException("CWWKS1525E"); // Ignore message indicating discovery failed
-        testRPServer.addIgnoredServerException("CWWKS1522W"); // Ignore message indicating conflicting endpoints for issuer identifier
-        testRPServer.addIgnoredServerException("CWPKI0022E"); // Ignore message indicating conflicting configured endpoints are ignored
-        testRPServer.addIgnoredServerException("CWWKG0058E"); // Ignore SSL failure message
-
-        // override actions that generic tests should use - Need to skip consent form as httpunit
-        // cannot process the form because of embedded javascript
-
-        test_GOOD_LOGIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT;
-        test_GOOD_POST_LOGIN_ACTIONS = Constants.GOOD_OIDC_POST_LOGIN_ACTIONS_SKIP_CONSENT;
-        test_GOOD_LOGIN_AGAIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_AGAIN_ACTIONS;
-        test_FinalAction = Constants.LOGIN_USER;
-        testSettings.setFlowType(Constants.RP_FLOW);
-
-        // Force discovery to run to access login page so that the discovery service is active. Then, in the actual tests the reconfig will initiate discovery and cause the
-        // error messages to be generated on discovery failures during the reconfig (rather than waiting until the first authorization request in the runtime).
-        CommonTestHelpers helpers = new CommonTestHelpers();
 
         // try to wait for discovery to have populated the RP config
         // Don't stop if this fails (there is a chance it could be ready by the time the tests actually run
         DiscoveryUtils.waitForRPDiscoveryToBeReady(testSettings);
-
     }
 
-    /**
-     * Test Purpose:
-     * <OL>
-     * <LI>With discovery configured at the RP, attempt to access a test servlet specifying valid OP url with bad OP trust store
-     * <LI>results in 401 error with messages logged.
-     * <LI>In this scenario, the consent form is disabled in OP by setting the oauthProvider attribute
-     * <LI>in server.xml as: autoAuthorize="true". The OP truststore is missing the certificate for RP.
-     * <LI>clientAuthentication is set to "true" for OP server.
-     * </OL>
-     * <P>
-     * Expected Results:
-     * <OL>
-     * <LI>The discovery should be attempted and should fail with 401 when the RP tries process the first authentication request
-     * and the following messages should be logged
-     * <LI>CWWKS1525E: A successful response was not returned from the URL <discovery endpoint>
-     * <LI>CWWKS1524E: The OpenID Connect client failed to obtain OpenID Connect Provider information through the discovery
-     * endpoint...
-     * </OL>
-     */
-    // different versions of java issue different exceptions - allow appropriate exceptions from any of our supported java versions
-    @AllowedFFDC({ "java.net.SocketException", "javax.net.ssl.SSLHandshakeException", "javax.net.ssl.SSLException", "javax.net.ssl.SSLProtocolException" })
     @Test
-    public void OidcClientDiscoverySSLTest_BadOPTrustStoreWithClientAuth() throws Exception {
+    public void test_discoveryError_BadOPTrustStoreWithClientAuth() throws Exception {
 
         TestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setScope("openid profile");
         updatedTestSettings.setTestURL(updatedTestSettings.getTestURL().replace(Constants.DEFAULT_SERVLET, "simple/goodSSL"));
 
-        List<validationData> expectations = vData.addSuccessStatusCodes(null);
+        List<validationData> expectations = validationTools.add401Responses(Constants.GET_LOGIN_PAGE);
+        validationTools.addMessageExpectation(testRPServer, expectations, Constants.GET_LOGIN_PAGE, Constants.MESSAGES_LOG, Constants.STRING_MATCHES, "Did not find CWWKS1534E message saying the authorization endpoint URL was missing.", MessageConstants.CWWKS1534E_MISSING_AUTH_ENDPOINT);
 
         WebConversation wc = new WebConversation();
 
         try {
-            genericRP(_testName, wc, updatedTestSettings, test_LOGIN_PAGE_ONLY, expectations);
+            genericRP(_testName, wc, updatedTestSettings, Constants.GET_LOGIN_PAGE_ONLY, expectations);
         } catch (Exception e) {
-            // there can be one of multiple exceptions thrown for this erroneous
-            // condition - the exceptions vary by JDK - validating the exception
-            // here allows the test to handle instances where we can get one of
-            // multiple possible error better than using an expectation.
-            msgUtils.assertTrueAndLog(_testName, "Expected one of the following in the exception: javax.net.ssl.SSLException, javax.net.ssl.SSLHandshakeException, java.net.SocketException actually received: " + e,
-                    validationTools.foundOneErrorInException(e, "javax.net.ssl.SSLException", "javax.net.ssl.SSLHandshakeException", "java.net.SocketException", "java.io.IOException"));
-
+            // there can be one of multiple exceptions thrown for this erroneous condition - the exceptions vary by JDK - validating the exception
+            // here allows the test to handle instances where we can get one of multiple possible error better than using an expectation.
+            String[] allowedExceptions = new String[] { "javax.net.ssl.SSLException", "javax.net.ssl.SSLHandshakeException", "java.net.SocketException", "java.io.IOException" };
+            msgUtils.assertTrueAndLog(_testName, "Expected one of the following in the exception: " + Arrays.toString(allowedExceptions) + ". Actually received: " + e,
+                    validationTools.foundOneErrorInException(e, allowedExceptions));
         }
 
     }

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorBadRpTrustStoreTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorBadRpTrustStoreTests.java
@@ -1,0 +1,172 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.security.openidconnect.client.fat.IBM;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonTest;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonTestHelpers;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.Constants;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.DiscoveryUtils;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.MessageConstants;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.TestSettings;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.ValidationData.validationData;
+import com.ibm.ws.security.openidconnect.client.fat.CommonTests.GenericOidcClientTests;
+import com.meterware.httpunit.WebConversation;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.ExpectedFFDC;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+
+/**
+ * This is the test class that will run error scenarios with OpenID Connect RP tests with an RP configuration (using access token
+ * and X509 cert) which includes discovery of OP endpoints.
+ * Discovery of OP endpoints is configured in the openidConnectClient section in server.xml by specifying the discoveryEndpointUrl
+ * instead of configuring
+ * each individual OP endpoint URL (such as authorizationEndpointUrl and tokenEndpointUrl) separately. This line below is used to
+ * configure RP discovery:
+ *
+ * discoveryEndpointUrl="https://localhost:${bvt.prop.OP_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
+ *
+ * With discovery, all the discovered endpoints are HTTPS. Any endpoints which are specified in the configuration will be ignored
+ * and the
+ * discovered endpoints will be used instead.
+ *
+ * This test configures the sslRef as part of the openidConnectClient configuration so that the SSL processing is handled by the
+ * client rather than
+ * outside this configuration.
+ *
+ **/
+
+@Mode(TestMode.FULL)
+@AllowedFFDC({ "org.apache.http.NoHttpResponseException", "java.security.cert.CertPathBuilderException", "sun.security.validator.ValidatorException", "javax.net.ssl.SSLHandshakeException", "com.ibm.websphere.ssl.SSLException", "java.lang.Exception" })
+@RunWith(FATRunner.class)
+public class OidcClientDiscoveryErrorBadRpTrustStoreTests extends CommonTest {
+    public static Class<?> thisClass = GenericOidcClientTests.class;
+    public static HashMap<String, Integer> defRespStatusMap = null;
+
+    public static String[] test_GOOD_LOGIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT;
+    public static String[] test_GOOD_POST_LOGIN_ACTIONS = Constants.GOOD_OIDC_POST_LOGIN_ACTIONS_SKIP_CONSENT;
+    public static String[] test_GOOD_LOGIN_AGAIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_AGAIN_ACTIONS;
+    public static String[] test_LOGIN_PAGE_ONLY = Constants.GET_LOGIN_PAGE_ONLY;
+    public static String test_FinalAction = Constants.LOGIN_USER;
+    protected static String hostName = "localhost";
+
+    @SuppressWarnings("serial")
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        thisClass = OidcClientDiscoveryErrorBadRpTrustStoreTests.class;
+
+        List<String> apps = new ArrayList<String>() {
+            {
+                add(Constants.OPENID_APP);
+            }
+        };
+
+        testSettings = new TestSettings();
+
+        // Set config parameters for Access token with X509 Certificate
+        String tokenType = Constants.ACCESS_TOKEN_KEY;
+        String certType = Constants.X509_CERT;
+
+        // Start the OIDC OP server
+        testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.op", "op_server_orig.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+
+        DiscoveryUtils.waitForOPDiscoveryToBeReady(testSettings);
+
+        //Start the OIDC RP server and setup default values
+        testRPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.rpd", "rp_server_basic_ssl_bad_truststore.xml", Constants.OIDC_RP, apps, Constants.DO_NOT_USE_DERBY,
+                Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+
+        testOPServer.addIgnoredServerException("CWOAU0039W"); // Ignore errors from the malformed discovery url
+        testOPServer.addIgnoredServerException("CWWKO0801E");
+        testRPServer.addIgnoredServerException("CWWKS1859E"); //Ignore exceptions from bad client secret test
+        testRPServer.addIgnoredServerException("SRVE8094W");
+        testRPServer.addIgnoredServerException("SRVE0190E");
+        testRPServer.addIgnoredServerException("CWWKS1741W"); // Ignore from sigAlgMismatch2 - message is not always logged
+        testRPServer.addIgnoredServerException("SRVE8115W"); // Ignore setStatus WARNING
+        testRPServer.addIgnoredServerException("CWWKS1521W"); // Ignore message indicating conflicting configured endpoints are ignored
+        testRPServer.addIgnoredServerException("CWWKS1524E"); // Ignore message indicating unsuccessful response from endpoint
+        testRPServer.addIgnoredServerException("CWWKS1525E"); // Ignore message indicating discovery failed
+        testRPServer.addIgnoredServerException("CWWKS1522W"); // Ignore message indicating conflicting endpoints for issuer identifier
+        testRPServer.addIgnoredServerException("CWPKI0022E"); // Ignore message indicating conflicting configured endpoints are ignored
+        testRPServer.addIgnoredServerException("CWWKG0058E"); // Ignore SSL failure message
+
+        // override actions that generic tests should use - Need to skip consent form as httpunit
+        // cannot process the form because of embedded javascript
+
+        test_GOOD_LOGIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT;
+        test_GOOD_POST_LOGIN_ACTIONS = Constants.GOOD_OIDC_POST_LOGIN_ACTIONS_SKIP_CONSENT;
+        test_GOOD_LOGIN_AGAIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_AGAIN_ACTIONS;
+        test_FinalAction = Constants.LOGIN_USER;
+        testSettings.setFlowType(Constants.RP_FLOW);
+
+        // Force discovery to run to access login page so that the discovery service is active. Then, in the actual tests the reconfig will initiate discovery and cause the
+        // error messages to be generated on discovery failures during the reconfig (rather than waiting until the first authorization request in the runtime).
+        CommonTestHelpers helpers = new CommonTestHelpers();
+
+        // try to wait for discovery to have populated the RP config
+        // Don't stop if this fails (there is a chance it could be ready by the time the tests actually run
+        DiscoveryUtils.waitForRPDiscoveryToBeReady(testSettings);
+
+    }
+
+    /**
+     * Test Purpose:
+     * <OL>
+     * <LI>With discovery enabled on the RP, attempt to access a test servlet specifying valid OP url. The RP
+     * <LI>trust store does not contain proper trust for discovery of the OP endpoints. The oidcClient
+     * <LI>In this scenario, the consent form is disabled in OP by setting the oauthProvider attribute
+     * <LI>in server.xml as: autoAuthorize="true". The RP truststore is missing the certificate for OP.
+     * <LI>The login attempt should fail with appropriate error.
+     * </OL>
+     * <P>
+     * Expected Results:
+     * <OL>
+     * <LI>The authentication request triggers the discovery process and discovery should fail and produce error messages.
+     * <LI>For serviceability, the following messages appear in the messages.log file:
+     * <LI>CWWKS1524E: The OpenID Connect client failed to obtain OpenID Connect Provider information through the discovery
+     * endpoint...
+     * </OL>
+     */
+    @Test
+    // TODO: (chc - enabling now that we have more ssl restart logic in the test framework - this may be ok now.)
+    // TODO: (maybe issue resolved) This test encounters an error when run with other tests as SSL update timing differs.
+    @ExpectedFFDC("javax.net.ssl.SSLHandshakeException")
+    @AllowedFFDC({ "java.security.cert.CertPathBuilderException", "sun.security.validator.ValidatorException", "com.ibm.security.cert.IBMCertPathBuilderException", "com.ibm.websphere.ssl.SSLException" })
+    public void OidcClientDiscoverySSLTest_BadRPTrustStore() throws Exception {
+
+        TestSettings updatedTestSettings = testSettings.copyTestSettings();
+        updatedTestSettings.setScope("openid profile");
+
+        List<validationData> expectations = validationTools.add401Responses(Constants.GET_LOGIN_PAGE);
+        expectations = validationTools.addMessageExpectation(testRPServer, expectations, Constants.GET_LOGIN_PAGE, Constants.MESSAGES_LOG, Constants.STRING_CONTAINS, "RP Server messages.log should contain msg indicating an SSL handshake error occurred.", "CWPKI0823E: SSL HANDSHAKE FAILURE.*");
+        expectations = validationTools.addMessageExpectation(testRPServer, expectations, Constants.GET_LOGIN_PAGE, Constants.MESSAGES_LOG, Constants.STRING_CONTAINS, "RP Server messages.log did not contain CWWKS1525E message indicating a successful response was not returned from the discovery endpoint.", MessageConstants.CWWKS1525E_SUCCESSFUL_RESPONSE_NOT_RETURNED);
+        expectations = validationTools.addMessageExpectation(testRPServer, expectations, Constants.GET_LOGIN_PAGE, Constants.MESSAGES_LOG, Constants.STRING_CONTAINS, "RP Server messages.log did not contain CWWKS1524E message saying we failed to obtain info from the OP.", MessageConstants.CWWKS1524E_DISCOVERY_FAILED_TO_RETURN_ENDPOINT);
+        expectations = validationTools.addMessageExpectation(testRPServer, expectations, Constants.GET_LOGIN_PAGE, Constants.MESSAGES_LOG, Constants.STRING_CONTAINS, "RP Server messages.log did not contain CWWKS1534E message saying the authorization endpoint URL is missing.", MessageConstants.CWWKS1534E_MISSING_AUTH_ENDPOINT);
+
+        WebConversation wc = new WebConversation();
+
+        genericRP(_testName, wc, updatedTestSettings, test_LOGIN_PAGE_ONLY, expectations);
+
+    }
+
+}

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorBadRpTrustStoreTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorBadRpTrustStoreTests.java
@@ -12,7 +12,6 @@
 package com.ibm.ws.security.openidconnect.client.fat.IBM;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 import org.junit.BeforeClass;
@@ -20,60 +19,40 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonTest;
-import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonTestHelpers;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.Constants;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.DiscoveryUtils;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.MessageConstants;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.TestSettings;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.ValidationData.validationData;
-import com.ibm.ws.security.openidconnect.client.fat.CommonTests.GenericOidcClientTests;
 import com.meterware.httpunit.WebConversation;
 
 import componenttest.annotation.AllowedFFDC;
-import componenttest.annotation.ExpectedFFDC;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
 /**
- * This is the test class that will run error scenarios with OpenID Connect RP tests with an RP configuration (using access token
- * and X509 cert) which includes discovery of OP endpoints.
- * Discovery of OP endpoints is configured in the openidConnectClient section in server.xml by specifying the discoveryEndpointUrl
- * instead of configuring
- * each individual OP endpoint URL (such as authorizationEndpointUrl and tokenEndpointUrl) separately. This line below is used to
- * configure RP discovery:
- *
- * discoveryEndpointUrl="https://localhost:${bvt.prop.OP_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
- *
- * With discovery, all the discovered endpoints are HTTPS. Any endpoints which are specified in the configuration will be ignored
- * and the
- * discovered endpoints will be used instead.
- *
- * This test configures the sslRef as part of the openidConnectClient configuration so that the SSL processing is handled by the
- * client rather than
- * outside this configuration.
- *
- **/
-
+ * Test Purpose:
+ * <OL>
+ * <LI>With discovery enabled on the RP, attempt to access a test servlet specifying valid OP url.
+ * <LI>The RP truststore is missing the certificate for OP.
+ * </OL>
+ * <P>
+ * Expected Results:
+ * <OL>
+ * <LI>The authentication request triggers the discovery process and discovery should fail and produce error messages.
+ * </OL>
+ */
 @Mode(TestMode.FULL)
-@AllowedFFDC({ "org.apache.http.NoHttpResponseException", "java.security.cert.CertPathBuilderException", "sun.security.validator.ValidatorException", "javax.net.ssl.SSLHandshakeException", "com.ibm.websphere.ssl.SSLException", "java.lang.Exception" })
+@AllowedFFDC({ "java.security.cert.CertPathBuilderException", "sun.security.validator.ValidatorException", "com.ibm.security.cert.IBMCertPathBuilderException", "com.ibm.websphere.ssl.SSLException" })
 @RunWith(FATRunner.class)
 public class OidcClientDiscoveryErrorBadRpTrustStoreTests extends CommonTest {
-    public static Class<?> thisClass = GenericOidcClientTests.class;
-    public static HashMap<String, Integer> defRespStatusMap = null;
 
-    public static String[] test_GOOD_LOGIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT;
-    public static String[] test_GOOD_POST_LOGIN_ACTIONS = Constants.GOOD_OIDC_POST_LOGIN_ACTIONS_SKIP_CONSENT;
-    public static String[] test_GOOD_LOGIN_AGAIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_AGAIN_ACTIONS;
-    public static String[] test_LOGIN_PAGE_ONLY = Constants.GET_LOGIN_PAGE_ONLY;
-    public static String test_FinalAction = Constants.LOGIN_USER;
-    protected static String hostName = "localhost";
+    public static Class<?> thisClass = OidcClientDiscoveryErrorBadRpTrustStoreTests.class;
 
     @SuppressWarnings("serial")
     @BeforeClass
     public static void setUp() throws Exception {
-
-        thisClass = OidcClientDiscoveryErrorBadRpTrustStoreTests.class;
 
         List<String> apps = new ArrayList<String>() {
             {
@@ -83,89 +62,36 @@ public class OidcClientDiscoveryErrorBadRpTrustStoreTests extends CommonTest {
 
         testSettings = new TestSettings();
 
-        // Set config parameters for Access token with X509 Certificate
-        String tokenType = Constants.ACCESS_TOKEN_KEY;
-        String certType = Constants.X509_CERT;
-
         // Start the OIDC OP server
-        testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.op", "op_server_orig.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+        testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.op", "op_server_orig.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE);
 
         DiscoveryUtils.waitForOPDiscoveryToBeReady(testSettings);
 
         //Start the OIDC RP server and setup default values
-        testRPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.rpd", "rp_server_basic_ssl_bad_truststore.xml", Constants.OIDC_RP, apps, Constants.DO_NOT_USE_DERBY,
-                Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+        testRPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.rpd", "rp_server_basic_ssl_bad_truststore.xml", Constants.OIDC_RP, apps, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE);
 
-        testOPServer.addIgnoredServerException("CWOAU0039W"); // Ignore errors from the malformed discovery url
-        testOPServer.addIgnoredServerException("CWWKO0801E");
-        testRPServer.addIgnoredServerException("CWWKS1859E"); //Ignore exceptions from bad client secret test
-        testRPServer.addIgnoredServerException("SRVE8094W");
-        testRPServer.addIgnoredServerException("SRVE0190E");
-        testRPServer.addIgnoredServerException("CWWKS1741W"); // Ignore from sigAlgMismatch2 - message is not always logged
-        testRPServer.addIgnoredServerException("SRVE8115W"); // Ignore setStatus WARNING
-        testRPServer.addIgnoredServerException("CWWKS1521W"); // Ignore message indicating conflicting configured endpoints are ignored
         testRPServer.addIgnoredServerException("CWWKS1524E"); // Ignore message indicating unsuccessful response from endpoint
         testRPServer.addIgnoredServerException("CWWKS1525E"); // Ignore message indicating discovery failed
-        testRPServer.addIgnoredServerException("CWWKS1522W"); // Ignore message indicating conflicting endpoints for issuer identifier
-        testRPServer.addIgnoredServerException("CWPKI0022E"); // Ignore message indicating conflicting configured endpoints are ignored
-        testRPServer.addIgnoredServerException("CWWKG0058E"); // Ignore SSL failure message
-
-        // override actions that generic tests should use - Need to skip consent form as httpunit
-        // cannot process the form because of embedded javascript
-
-        test_GOOD_LOGIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT;
-        test_GOOD_POST_LOGIN_ACTIONS = Constants.GOOD_OIDC_POST_LOGIN_ACTIONS_SKIP_CONSENT;
-        test_GOOD_LOGIN_AGAIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_AGAIN_ACTIONS;
-        test_FinalAction = Constants.LOGIN_USER;
-        testSettings.setFlowType(Constants.RP_FLOW);
-
-        // Force discovery to run to access login page so that the discovery service is active. Then, in the actual tests the reconfig will initiate discovery and cause the
-        // error messages to be generated on discovery failures during the reconfig (rather than waiting until the first authorization request in the runtime).
-        CommonTestHelpers helpers = new CommonTestHelpers();
+        testRPServer.addIgnoredServerException("CWPKI0823E"); // SSL HANDSHAKE FAILURE
+        testRPServer.addIgnoredServerException("CWWKS1534E");
 
         // try to wait for discovery to have populated the RP config
         // Don't stop if this fails (there is a chance it could be ready by the time the tests actually run
         DiscoveryUtils.waitForRPDiscoveryToBeReady(testSettings);
-
     }
 
-    /**
-     * Test Purpose:
-     * <OL>
-     * <LI>With discovery enabled on the RP, attempt to access a test servlet specifying valid OP url. The RP
-     * <LI>trust store does not contain proper trust for discovery of the OP endpoints. The oidcClient
-     * <LI>In this scenario, the consent form is disabled in OP by setting the oauthProvider attribute
-     * <LI>in server.xml as: autoAuthorize="true". The RP truststore is missing the certificate for OP.
-     * <LI>The login attempt should fail with appropriate error.
-     * </OL>
-     * <P>
-     * Expected Results:
-     * <OL>
-     * <LI>The authentication request triggers the discovery process and discovery should fail and produce error messages.
-     * <LI>For serviceability, the following messages appear in the messages.log file:
-     * <LI>CWWKS1524E: The OpenID Connect client failed to obtain OpenID Connect Provider information through the discovery
-     * endpoint...
-     * </OL>
-     */
     @Test
-    // TODO: (chc - enabling now that we have more ssl restart logic in the test framework - this may be ok now.)
-    // TODO: (maybe issue resolved) This test encounters an error when run with other tests as SSL update timing differs.
-    @ExpectedFFDC("javax.net.ssl.SSLHandshakeException")
-    @AllowedFFDC({ "java.security.cert.CertPathBuilderException", "sun.security.validator.ValidatorException", "com.ibm.security.cert.IBMCertPathBuilderException", "com.ibm.websphere.ssl.SSLException" })
-    public void OidcClientDiscoverySSLTest_BadRPTrustStore() throws Exception {
+    public void test_discoveryError_BadRPTrustStore() throws Exception {
 
         TestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setScope("openid profile");
 
         List<validationData> expectations = validationTools.add401Responses(Constants.GET_LOGIN_PAGE);
-        expectations = validationTools.addMessageExpectation(testRPServer, expectations, Constants.GET_LOGIN_PAGE, Constants.MESSAGES_LOG, Constants.STRING_CONTAINS, "RP Server messages.log should contain msg indicating an SSL handshake error occurred.", "CWPKI0823E: SSL HANDSHAKE FAILURE.*");
-        expectations = validationTools.addMessageExpectation(testRPServer, expectations, Constants.GET_LOGIN_PAGE, Constants.MESSAGES_LOG, Constants.STRING_CONTAINS, "RP Server messages.log did not contain CWWKS1525E message indicating a successful response was not returned from the discovery endpoint.", MessageConstants.CWWKS1525E_SUCCESSFUL_RESPONSE_NOT_RETURNED);
-        expectations = validationTools.addMessageExpectation(testRPServer, expectations, Constants.GET_LOGIN_PAGE, Constants.MESSAGES_LOG, Constants.STRING_CONTAINS, "RP Server messages.log did not contain CWWKS1524E message saying we failed to obtain info from the OP.", MessageConstants.CWWKS1524E_DISCOVERY_FAILED_TO_RETURN_ENDPOINT);
         expectations = validationTools.addMessageExpectation(testRPServer, expectations, Constants.GET_LOGIN_PAGE, Constants.MESSAGES_LOG, Constants.STRING_CONTAINS, "RP Server messages.log did not contain CWWKS1534E message saying the authorization endpoint URL is missing.", MessageConstants.CWWKS1534E_MISSING_AUTH_ENDPOINT);
 
         WebConversation wc = new WebConversation();
 
-        genericRP(_testName, wc, updatedTestSettings, test_LOGIN_PAGE_ONLY, expectations);
+        genericRP(_testName, wc, updatedTestSettings, Constants.GET_LOGIN_PAGE_ONLY, expectations);
 
     }
 

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorNoOpTrustStoreTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorNoOpTrustStoreTests.java
@@ -12,7 +12,6 @@
 package com.ibm.ws.security.openidconnect.client.fat.IBM;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 import org.junit.BeforeClass;
@@ -20,12 +19,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonTest;
-import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonTestHelpers;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.Constants;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.DiscoveryUtils;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.MessageConstants;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.TestSettings;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.ValidationData.validationData;
-import com.ibm.ws.security.openidconnect.client.fat.CommonTests.GenericOidcClientTests;
 import com.meterware.httpunit.WebConversation;
 
 import componenttest.annotation.AllowedFFDC;
@@ -34,44 +32,28 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
 /**
- * This is the test class that will run error scenarios with OpenID Connect RP tests with an RP configuration (using access token
- * and X509 cert) which includes discovery of OP endpoints.
- * Discovery of OP endpoints is configured in the openidConnectClient section in server.xml by specifying the discoveryEndpointUrl
- * instead of configuring
- * each individual OP endpoint URL (such as authorizationEndpointUrl and tokenEndpointUrl) separately. This line below is used to
- * configure RP discovery:
- *
- * discoveryEndpointUrl="https://localhost:${bvt.prop.OP_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
- *
- * With discovery, all the discovered endpoints are HTTPS. Any endpoints which are specified in the configuration will be ignored
- * and the
- * discovered endpoints will be used instead.
- *
- * This test configures the sslRef as part of the openidConnectClient configuration so that the SSL processing is handled by the
- * client rather than
- * outside this configuration.
- *
- **/
-
+ * Test Purpose:
+ * <OL>
+ * <LI>When the RP is configured with discovery, attempt to access a test servlet specifying valid OP url
+ * <LI>The OP keystore and truststore is not configured.
+ * </OL>
+ * <P>
+ * Expected Results:
+ * <OL>
+ * <LI>SSL connection from RP to OP is refused and the discovery process cannot complete.
+ * <LI>The login page cannot be displayed and returns 401.
+ * </OL>
+ */
 @Mode(TestMode.FULL)
-@AllowedFFDC({ "org.apache.http.NoHttpResponseException", "java.security.cert.CertPathBuilderException", "sun.security.validator.ValidatorException", "javax.net.ssl.SSLHandshakeException", "com.ibm.websphere.ssl.SSLException", "java.lang.Exception" })
+@AllowedFFDC({ "org.apache.http.conn.HttpHostConnectException", "javax.net.ssl.SSLException", "java.net.SocketException" })
 @RunWith(FATRunner.class)
 public class OidcClientDiscoveryErrorNoOpTrustStoreTests extends CommonTest {
-    public static Class<?> thisClass = GenericOidcClientTests.class;
-    public static HashMap<String, Integer> defRespStatusMap = null;
 
-    public static String[] test_GOOD_LOGIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT;
-    public static String[] test_GOOD_POST_LOGIN_ACTIONS = Constants.GOOD_OIDC_POST_LOGIN_ACTIONS_SKIP_CONSENT;
-    public static String[] test_GOOD_LOGIN_AGAIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_AGAIN_ACTIONS;
-    public static String[] test_LOGIN_PAGE_ONLY = Constants.GET_LOGIN_PAGE_ONLY;
-    public static String test_FinalAction = Constants.LOGIN_USER;
-    protected static String hostName = "localhost";
+    public static Class<?> thisClass = OidcClientDiscoveryErrorNoOpTrustStoreTests.class;
 
     @SuppressWarnings("serial")
     @BeforeClass
     public static void setUp() throws Exception {
-
-        thisClass = OidcClientDiscoveryErrorNoOpTrustStoreTests.class;
 
         List<String> apps = new ArrayList<String>() {
             {
@@ -81,91 +63,39 @@ public class OidcClientDiscoveryErrorNoOpTrustStoreTests extends CommonTest {
 
         testSettings = new TestSettings();
 
-        // Set config parameters for Access token with X509 Certificate
-        String tokenType = Constants.ACCESS_TOKEN_KEY;
-        String certType = Constants.X509_CERT;
-
         // Start the OIDC OP server
-        testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.op", "op_server_basic_ssl_no_truststore.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+        testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.op", "op_server_basic_ssl_no_truststore.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, false);
 
         DiscoveryUtils.waitForOPDiscoveryToBeReady(testSettings);
 
         //Start the OIDC RP server and setup default values
-        testRPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.rpd", "rp_server_orig.xml", Constants.OIDC_RP, apps, Constants.DO_NOT_USE_DERBY,
-                Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+        testRPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.rpd", "rp_server_orig.xml", Constants.OIDC_RP, apps, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE);
 
-        testOPServer.addIgnoredServerException("CWOAU0039W"); // Ignore errors from the malformed discovery url
-        testOPServer.addIgnoredServerException("CWWKO0801E");
-        testRPServer.addIgnoredServerException("CWWKS1859E"); //Ignore exceptions from bad client secret test
-        testRPServer.addIgnoredServerException("SRVE8094W");
-        testRPServer.addIgnoredServerException("SRVE0190E");
-        testRPServer.addIgnoredServerException("CWWKS1741W"); // Ignore from sigAlgMismatch2 - message is not always logged
-        testRPServer.addIgnoredServerException("SRVE8115W"); // Ignore setStatus WARNING
-        testRPServer.addIgnoredServerException("CWWKS1521W"); // Ignore message indicating conflicting configured endpoints are ignored
-        testRPServer.addIgnoredServerException("CWWKS1524E"); // Ignore message indicating unsuccessful response from endpoint
+        testOPServer.addIgnoredServerException("CWWKG0058E"); // Ignore SSL failure message
         testRPServer.addIgnoredServerException("CWWKS1525E"); // Ignore message indicating discovery failed
-        testRPServer.addIgnoredServerException("CWWKS1522W"); // Ignore message indicating conflicting endpoints for issuer identifier
-        testRPServer.addIgnoredServerException("CWPKI0022E"); // Ignore message indicating conflicting configured endpoints are ignored
-        testRPServer.addIgnoredServerException("CWWKG0058E"); // Ignore SSL failure message
-
-        // override actions that generic tests should use - Need to skip consent form as httpunit
-        // cannot process the form because of embedded javascript
-
-        test_GOOD_LOGIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT;
-        test_GOOD_POST_LOGIN_ACTIONS = Constants.GOOD_OIDC_POST_LOGIN_ACTIONS_SKIP_CONSENT;
-        test_GOOD_LOGIN_AGAIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_AGAIN_ACTIONS;
-        test_FinalAction = Constants.LOGIN_USER;
-        testSettings.setFlowType(Constants.RP_FLOW);
-
-        // Force discovery to run to access login page so that the discovery service is active. Then, in the actual tests the reconfig will initiate discovery and cause the
-        // error messages to be generated on discovery failures during the reconfig (rather than waiting until the first authorization request in the runtime).
-        CommonTestHelpers helpers = new CommonTestHelpers();
+        testRPServer.addIgnoredServerException("CWWKS1524E"); // Ignore message indicating unsuccessful response from endpoint
+        testRPServer.addIgnoredServerException("CWWKS1741W"); // Ignore from sigAlgMismatch2 - message is not always logged
+        testRPServer.addIgnoredServerException("CWWKS1859E"); // Ignore exceptions from bad client secret test
+        testRPServer.addIgnoredServerException("CWWKS1534E");
 
         // try to wait for discovery to have populated the RP config
         // Don't stop if this fails (there is a chance it could be ready by the time the tests actually run
         DiscoveryUtils.waitForRPDiscoveryToBeReady(testSettings);
-
     }
 
-    /**
-     * Test Purpose:
-     * <OL>
-     * <LI>When the RP is configured with discovery, attempt to access a test servlet specifying valid OP url
-     * <LI>In this scenario, the consent form is disabled in OP by setting the oauthProvider attribute
-     * <LI>in server.xml as: autoAuthorize="true". The OP keystore and truststore is not configured.
-     * <LI>SSL connection from RP to OP is refused and the discovery process cannot complete.
-     * </OL>
-     * <P>
-     * Expected Results:
-     * <OL>
-     * <LI>The login page cannot be displayed and returns 401
-     * <LI>Messages are logged to indicate that discovery did not complete:
-     * <LI>CWWKS1525E: A successful response was not returned from the URL
-     * [https://localhost:8947/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration]. This is the [404] response status
-     * and the [CWOAU0073E: An error was encountered while authenticating a user.
-     * Please try authenticating again, or contact the site administrator if the problem persists.] error from the discovery
-     * request.
-     * <LI>CWWKS1524E: The OpenID Connect client [client01] failed to obtain Open ID Connect Provider endpoint information through
-     * the discovery endpoint URL [https://localhost:8947/oidc/endpoint/OidcConfigSample/.mal-formed/openid-configuration].
-     * Update the configuration for the OpenID Connect client with the correct HTTPS discovery endpoint URL.
-     * </OL>
-     */
-    @AllowedFFDC({ "org.apache.http.conn.HttpHostConnectException", "javax.net.ssl.SSLException", "java.net.SocketException" })
     @Test
-    public void OidcClientDiscoverySSLTest_NoOPTrustStore() throws Exception {
+    public void test_discoveryError_NoOPTrustStore() throws Exception {
 
         TestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setScope("openid profile");
         updatedTestSettings.setTestURL(updatedTestSettings.getTestURL().replace(Constants.DEFAULT_SERVLET, "simple/goodSSL"));
 
-        List<validationData> expectations = vData.addSuccessStatusCodes(null);
+        List<validationData> expectations = validationTools.add401Responses(Constants.GET_LOGIN_PAGE);
+        validationTools.addMessageExpectation(testRPServer, expectations, Constants.GET_LOGIN_PAGE, Constants.MESSAGES_LOG, Constants.STRING_MATCHES, "Did not find CWWKS1534E message saying the authorization endpoint URL was missing.", MessageConstants.CWWKS1534E_MISSING_AUTH_ENDPOINT);
 
-        expectations = vData.addExpectation(expectations, Constants.GET_LOGIN_PAGE, Constants.EXCEPTION_MESSAGE, Constants.STRING_CONTAINS, "Should have received an exception for a connection refused exception", null, "java.net.ConnectException");
         WebConversation wc = new WebConversation();
 
-        testOPServer.addIgnoredServerException("CWWKG0058E");
-
-        genericRP(_testName, wc, updatedTestSettings, test_LOGIN_PAGE_ONLY, expectations);
+        genericRP(_testName, wc, updatedTestSettings, Constants.GET_LOGIN_PAGE_ONLY, expectations);
 
     }
 

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorNoOpTrustStoreTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorNoOpTrustStoreTests.java
@@ -1,0 +1,172 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.security.openidconnect.client.fat.IBM;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonTest;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonTestHelpers;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.Constants;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.DiscoveryUtils;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.TestSettings;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.ValidationData.validationData;
+import com.ibm.ws.security.openidconnect.client.fat.CommonTests.GenericOidcClientTests;
+import com.meterware.httpunit.WebConversation;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+
+/**
+ * This is the test class that will run error scenarios with OpenID Connect RP tests with an RP configuration (using access token
+ * and X509 cert) which includes discovery of OP endpoints.
+ * Discovery of OP endpoints is configured in the openidConnectClient section in server.xml by specifying the discoveryEndpointUrl
+ * instead of configuring
+ * each individual OP endpoint URL (such as authorizationEndpointUrl and tokenEndpointUrl) separately. This line below is used to
+ * configure RP discovery:
+ *
+ * discoveryEndpointUrl="https://localhost:${bvt.prop.OP_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
+ *
+ * With discovery, all the discovered endpoints are HTTPS. Any endpoints which are specified in the configuration will be ignored
+ * and the
+ * discovered endpoints will be used instead.
+ *
+ * This test configures the sslRef as part of the openidConnectClient configuration so that the SSL processing is handled by the
+ * client rather than
+ * outside this configuration.
+ *
+ **/
+
+@Mode(TestMode.FULL)
+@AllowedFFDC({ "org.apache.http.NoHttpResponseException", "java.security.cert.CertPathBuilderException", "sun.security.validator.ValidatorException", "javax.net.ssl.SSLHandshakeException", "com.ibm.websphere.ssl.SSLException", "java.lang.Exception" })
+@RunWith(FATRunner.class)
+public class OidcClientDiscoveryErrorNoOpTrustStoreTests extends CommonTest {
+    public static Class<?> thisClass = GenericOidcClientTests.class;
+    public static HashMap<String, Integer> defRespStatusMap = null;
+
+    public static String[] test_GOOD_LOGIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT;
+    public static String[] test_GOOD_POST_LOGIN_ACTIONS = Constants.GOOD_OIDC_POST_LOGIN_ACTIONS_SKIP_CONSENT;
+    public static String[] test_GOOD_LOGIN_AGAIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_AGAIN_ACTIONS;
+    public static String[] test_LOGIN_PAGE_ONLY = Constants.GET_LOGIN_PAGE_ONLY;
+    public static String test_FinalAction = Constants.LOGIN_USER;
+    protected static String hostName = "localhost";
+
+    @SuppressWarnings("serial")
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        thisClass = OidcClientDiscoveryErrorNoOpTrustStoreTests.class;
+
+        List<String> apps = new ArrayList<String>() {
+            {
+                add(Constants.OPENID_APP);
+            }
+        };
+
+        testSettings = new TestSettings();
+
+        // Set config parameters for Access token with X509 Certificate
+        String tokenType = Constants.ACCESS_TOKEN_KEY;
+        String certType = Constants.X509_CERT;
+
+        // Start the OIDC OP server
+        testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.op", "op_server_basic_ssl_no_truststore.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+
+        DiscoveryUtils.waitForOPDiscoveryToBeReady(testSettings);
+
+        //Start the OIDC RP server and setup default values
+        testRPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.rpd", "rp_server_orig.xml", Constants.OIDC_RP, apps, Constants.DO_NOT_USE_DERBY,
+                Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+
+        testOPServer.addIgnoredServerException("CWOAU0039W"); // Ignore errors from the malformed discovery url
+        testOPServer.addIgnoredServerException("CWWKO0801E");
+        testRPServer.addIgnoredServerException("CWWKS1859E"); //Ignore exceptions from bad client secret test
+        testRPServer.addIgnoredServerException("SRVE8094W");
+        testRPServer.addIgnoredServerException("SRVE0190E");
+        testRPServer.addIgnoredServerException("CWWKS1741W"); // Ignore from sigAlgMismatch2 - message is not always logged
+        testRPServer.addIgnoredServerException("SRVE8115W"); // Ignore setStatus WARNING
+        testRPServer.addIgnoredServerException("CWWKS1521W"); // Ignore message indicating conflicting configured endpoints are ignored
+        testRPServer.addIgnoredServerException("CWWKS1524E"); // Ignore message indicating unsuccessful response from endpoint
+        testRPServer.addIgnoredServerException("CWWKS1525E"); // Ignore message indicating discovery failed
+        testRPServer.addIgnoredServerException("CWWKS1522W"); // Ignore message indicating conflicting endpoints for issuer identifier
+        testRPServer.addIgnoredServerException("CWPKI0022E"); // Ignore message indicating conflicting configured endpoints are ignored
+        testRPServer.addIgnoredServerException("CWWKG0058E"); // Ignore SSL failure message
+
+        // override actions that generic tests should use - Need to skip consent form as httpunit
+        // cannot process the form because of embedded javascript
+
+        test_GOOD_LOGIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT;
+        test_GOOD_POST_LOGIN_ACTIONS = Constants.GOOD_OIDC_POST_LOGIN_ACTIONS_SKIP_CONSENT;
+        test_GOOD_LOGIN_AGAIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_AGAIN_ACTIONS;
+        test_FinalAction = Constants.LOGIN_USER;
+        testSettings.setFlowType(Constants.RP_FLOW);
+
+        // Force discovery to run to access login page so that the discovery service is active. Then, in the actual tests the reconfig will initiate discovery and cause the
+        // error messages to be generated on discovery failures during the reconfig (rather than waiting until the first authorization request in the runtime).
+        CommonTestHelpers helpers = new CommonTestHelpers();
+
+        // try to wait for discovery to have populated the RP config
+        // Don't stop if this fails (there is a chance it could be ready by the time the tests actually run
+        DiscoveryUtils.waitForRPDiscoveryToBeReady(testSettings);
+
+    }
+
+    /**
+     * Test Purpose:
+     * <OL>
+     * <LI>When the RP is configured with discovery, attempt to access a test servlet specifying valid OP url
+     * <LI>In this scenario, the consent form is disabled in OP by setting the oauthProvider attribute
+     * <LI>in server.xml as: autoAuthorize="true". The OP keystore and truststore is not configured.
+     * <LI>SSL connection from RP to OP is refused and the discovery process cannot complete.
+     * </OL>
+     * <P>
+     * Expected Results:
+     * <OL>
+     * <LI>The login page cannot be displayed and returns 401
+     * <LI>Messages are logged to indicate that discovery did not complete:
+     * <LI>CWWKS1525E: A successful response was not returned from the URL
+     * [https://localhost:8947/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration]. This is the [404] response status
+     * and the [CWOAU0073E: An error was encountered while authenticating a user.
+     * Please try authenticating again, or contact the site administrator if the problem persists.] error from the discovery
+     * request.
+     * <LI>CWWKS1524E: The OpenID Connect client [client01] failed to obtain Open ID Connect Provider endpoint information through
+     * the discovery endpoint URL [https://localhost:8947/oidc/endpoint/OidcConfigSample/.mal-formed/openid-configuration].
+     * Update the configuration for the OpenID Connect client with the correct HTTPS discovery endpoint URL.
+     * </OL>
+     */
+    @AllowedFFDC({ "org.apache.http.conn.HttpHostConnectException", "javax.net.ssl.SSLException", "java.net.SocketException" })
+    @Test
+    public void OidcClientDiscoverySSLTest_NoOPTrustStore() throws Exception {
+
+        TestSettings updatedTestSettings = testSettings.copyTestSettings();
+        updatedTestSettings.setScope("openid profile");
+        updatedTestSettings.setTestURL(updatedTestSettings.getTestURL().replace(Constants.DEFAULT_SERVLET, "simple/goodSSL"));
+
+        List<validationData> expectations = vData.addSuccessStatusCodes(null);
+
+        expectations = vData.addExpectation(expectations, Constants.GET_LOGIN_PAGE, Constants.EXCEPTION_MESSAGE, Constants.STRING_CONTAINS, "Should have received an exception for a connection refused exception", null, "java.net.ConnectException");
+        WebConversation wc = new WebConversation();
+
+        testOPServer.addIgnoredServerException("CWWKG0058E");
+
+        genericRP(_testName, wc, updatedTestSettings, test_LOGIN_PAGE_ONLY, expectations);
+
+    }
+
+}

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorNoRpTrustStoreTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorNoRpTrustStoreTests.java
@@ -12,7 +12,6 @@
 package com.ibm.ws.security.openidconnect.client.fat.IBM;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 import org.junit.BeforeClass;
@@ -20,12 +19,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonTest;
-import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonTestHelpers;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.Constants;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.DiscoveryUtils;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.TestSettings;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.ValidationData.validationData;
-import com.ibm.ws.security.openidconnect.client.fat.CommonTests.GenericOidcClientTests;
 import com.meterware.httpunit.WebConversation;
 
 import componenttest.annotation.AllowedFFDC;
@@ -34,44 +31,27 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
 /**
- * This is the test class that will run error scenarios with OpenID Connect RP tests with an RP configuration (using access token
- * and X509 cert) which includes discovery of OP endpoints.
- * Discovery of OP endpoints is configured in the openidConnectClient section in server.xml by specifying the discoveryEndpointUrl
- * instead of configuring
- * each individual OP endpoint URL (such as authorizationEndpointUrl and tokenEndpointUrl) separately. This line below is used to
- * configure RP discovery:
- *
- * discoveryEndpointUrl="https://localhost:${bvt.prop.OP_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
- *
- * With discovery, all the discovered endpoints are HTTPS. Any endpoints which are specified in the configuration will be ignored
- * and the
- * discovered endpoints will be used instead.
- *
- * This test configures the sslRef as part of the openidConnectClient configuration so that the SSL processing is handled by the
- * client rather than
- * outside this configuration.
- *
- **/
-
+ * Test Purpose:
+ * <OL>
+ * <LI>With discovery enabled on the RP, attempt to access a test servlet specifying valid OP url
+ * <LI>The RP keystore and truststore is not configured.
+ * </OL>
+ * <P>
+ * Expected Results:
+ * <OL>
+ * <LI>Client connection is refused as RP server is not listening on SSL port due to missing keystore and truststore.
+ * </OL>
+ */
 @Mode(TestMode.FULL)
-@AllowedFFDC({ "org.apache.http.NoHttpResponseException", "java.security.cert.CertPathBuilderException", "sun.security.validator.ValidatorException", "javax.net.ssl.SSLHandshakeException", "com.ibm.websphere.ssl.SSLException", "java.lang.Exception" })
+@AllowedFFDC({ "java.security.cert.CertPathBuilderException", "sun.security.validator.ValidatorException", "javax.net.ssl.SSLHandshakeException", "com.ibm.websphere.ssl.SSLException" })
 @RunWith(FATRunner.class)
 public class OidcClientDiscoveryErrorNoRpTrustStoreTests extends CommonTest {
-    public static Class<?> thisClass = GenericOidcClientTests.class;
-    public static HashMap<String, Integer> defRespStatusMap = null;
 
-    public static String[] test_GOOD_LOGIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT;
-    public static String[] test_GOOD_POST_LOGIN_ACTIONS = Constants.GOOD_OIDC_POST_LOGIN_ACTIONS_SKIP_CONSENT;
-    public static String[] test_GOOD_LOGIN_AGAIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_AGAIN_ACTIONS;
-    public static String[] test_LOGIN_PAGE_ONLY = Constants.GET_LOGIN_PAGE_ONLY;
-    public static String test_FinalAction = Constants.LOGIN_USER;
-    protected static String hostName = "localhost";
+    public static Class<?> thisClass = OidcClientDiscoveryErrorNoRpTrustStoreTests.class;
 
     @SuppressWarnings("serial")
     @BeforeClass
     public static void setUp() throws Exception {
-
-        thisClass = OidcClientDiscoveryErrorNoRpTrustStoreTests.class;
 
         List<String> apps = new ArrayList<String>() {
             {
@@ -81,71 +61,19 @@ public class OidcClientDiscoveryErrorNoRpTrustStoreTests extends CommonTest {
 
         testSettings = new TestSettings();
 
-        // Set config parameters for Access token with X509 Certificate
-        String tokenType = Constants.ACCESS_TOKEN_KEY;
-        String certType = Constants.X509_CERT;
-
         // Start the OIDC OP server
-        testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.op", "op_server_orig.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+        testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.op", "op_server_orig.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE);
 
         DiscoveryUtils.waitForOPDiscoveryToBeReady(testSettings);
 
         //Start the OIDC RP server and setup default values
-        testRPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.rpd", "rp_server_basic_ssl_no_truststore.xml", Constants.OIDC_RP, apps, Constants.DO_NOT_USE_DERBY,
-                Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+        testRPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.rpd", "rp_server_basic_ssl_no_truststore.xml", Constants.OIDC_RP, apps, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, false);
 
-        testOPServer.addIgnoredServerException("CWOAU0039W"); // Ignore errors from the malformed discovery url
-        testOPServer.addIgnoredServerException("CWWKO0801E");
-        testRPServer.addIgnoredServerException("CWWKS1859E"); //Ignore exceptions from bad client secret test
-        testRPServer.addIgnoredServerException("SRVE8094W");
-        testRPServer.addIgnoredServerException("SRVE0190E");
-        testRPServer.addIgnoredServerException("CWWKS1741W"); // Ignore from sigAlgMismatch2 - message is not always logged
-        testRPServer.addIgnoredServerException("SRVE8115W"); // Ignore setStatus WARNING
-        testRPServer.addIgnoredServerException("CWWKS1521W"); // Ignore message indicating conflicting configured endpoints are ignored
-        testRPServer.addIgnoredServerException("CWWKS1524E"); // Ignore message indicating unsuccessful response from endpoint
-        testRPServer.addIgnoredServerException("CWWKS1525E"); // Ignore message indicating discovery failed
-        testRPServer.addIgnoredServerException("CWWKS1522W"); // Ignore message indicating conflicting endpoints for issuer identifier
-        testRPServer.addIgnoredServerException("CWPKI0022E"); // Ignore message indicating conflicting configured endpoints are ignored
         testRPServer.addIgnoredServerException("CWWKG0058E"); // Ignore SSL failure message
-
-        // override actions that generic tests should use - Need to skip consent form as httpunit
-        // cannot process the form because of embedded javascript
-
-        test_GOOD_LOGIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT;
-        test_GOOD_POST_LOGIN_ACTIONS = Constants.GOOD_OIDC_POST_LOGIN_ACTIONS_SKIP_CONSENT;
-        test_GOOD_LOGIN_AGAIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_AGAIN_ACTIONS;
-        test_FinalAction = Constants.LOGIN_USER;
-        testSettings.setFlowType(Constants.RP_FLOW);
-
-        // Force discovery to run to access login page so that the discovery service is active. Then, in the actual tests the reconfig will initiate discovery and cause the
-        // error messages to be generated on discovery failures during the reconfig (rather than waiting until the first authorization request in the runtime).
-        CommonTestHelpers helpers = new CommonTestHelpers();
-
-        // try to wait for discovery to have populated the RP config
-        // Don't stop if this fails (there is a chance it could be ready by the time the tests actually run
-        DiscoveryUtils.waitForRPDiscoveryToBeReady(testSettings);
-
     }
 
-    /**
-     * Test Purpose:
-     * <OL>
-     * <LI>With discovery enabled on the RP, attempt to access a test servlet specifying valid OP url
-     * <LI>The RP keystore and truststore is not configured.
-     * <LI>The login attempt should fail with appropriate error.
-     * </OL>
-     * <P>
-     * Expected Results:
-     * <OL>
-     * <LI>Client connection is refused as RP server is not listening on SSL port
-     * <LI>due to missing keystore and truststore with the following message logged:
-     * <LI>CWWKS1524E: The OpenID Connect client failed to obtain OpenID Connect Provider information through the discovery
-     * endpoint...
-     * </OL>
-     */
     @Test
-    @AllowedFFDC({ "java.security.cert.CertPathBuilderException", "sun.security.validator.ValidatorException", "javax.net.ssl.SSLHandshakeException", "com.ibm.websphere.ssl.SSLException" })
-    public void OidcClientDiscoverySSLTest_NoRPTrustStore() throws Exception {
+    public void test_discoveryError_NoRPTrustStore() throws Exception {
 
         TestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setScope("openid profile");
@@ -154,10 +82,8 @@ public class OidcClientDiscoveryErrorNoRpTrustStoreTests extends CommonTest {
 
         expectations = vData.addExpectation(expectations, Constants.GET_LOGIN_PAGE, Constants.EXCEPTION_MESSAGE, Constants.STRING_CONTAINS, "Should have received an exception for a connection refused exception", null, "java.net.ConnectException");
 
-        testRPServer.addIgnoredServerExceptions("CWWKG0058E");
-
         WebConversation wc = new WebConversation();
-        genericRP(_testName, wc, updatedTestSettings, test_LOGIN_PAGE_ONLY, expectations);
+        genericRP(_testName, wc, updatedTestSettings, Constants.GET_LOGIN_PAGE_ONLY, expectations);
     }
 
 }

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorNoRpTrustStoreTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorNoRpTrustStoreTests.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.security.openidconnect.client.fat.IBM;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonTest;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.CommonTestHelpers;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.Constants;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.DiscoveryUtils;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.TestSettings;
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.ValidationData.validationData;
+import com.ibm.ws.security.openidconnect.client.fat.CommonTests.GenericOidcClientTests;
+import com.meterware.httpunit.WebConversation;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+
+/**
+ * This is the test class that will run error scenarios with OpenID Connect RP tests with an RP configuration (using access token
+ * and X509 cert) which includes discovery of OP endpoints.
+ * Discovery of OP endpoints is configured in the openidConnectClient section in server.xml by specifying the discoveryEndpointUrl
+ * instead of configuring
+ * each individual OP endpoint URL (such as authorizationEndpointUrl and tokenEndpointUrl) separately. This line below is used to
+ * configure RP discovery:
+ *
+ * discoveryEndpointUrl="https://localhost:${bvt.prop.OP_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
+ *
+ * With discovery, all the discovered endpoints are HTTPS. Any endpoints which are specified in the configuration will be ignored
+ * and the
+ * discovered endpoints will be used instead.
+ *
+ * This test configures the sslRef as part of the openidConnectClient configuration so that the SSL processing is handled by the
+ * client rather than
+ * outside this configuration.
+ *
+ **/
+
+@Mode(TestMode.FULL)
+@AllowedFFDC({ "org.apache.http.NoHttpResponseException", "java.security.cert.CertPathBuilderException", "sun.security.validator.ValidatorException", "javax.net.ssl.SSLHandshakeException", "com.ibm.websphere.ssl.SSLException", "java.lang.Exception" })
+@RunWith(FATRunner.class)
+public class OidcClientDiscoveryErrorNoRpTrustStoreTests extends CommonTest {
+    public static Class<?> thisClass = GenericOidcClientTests.class;
+    public static HashMap<String, Integer> defRespStatusMap = null;
+
+    public static String[] test_GOOD_LOGIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT;
+    public static String[] test_GOOD_POST_LOGIN_ACTIONS = Constants.GOOD_OIDC_POST_LOGIN_ACTIONS_SKIP_CONSENT;
+    public static String[] test_GOOD_LOGIN_AGAIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_AGAIN_ACTIONS;
+    public static String[] test_LOGIN_PAGE_ONLY = Constants.GET_LOGIN_PAGE_ONLY;
+    public static String test_FinalAction = Constants.LOGIN_USER;
+    protected static String hostName = "localhost";
+
+    @SuppressWarnings("serial")
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        thisClass = OidcClientDiscoveryErrorNoRpTrustStoreTests.class;
+
+        List<String> apps = new ArrayList<String>() {
+            {
+                add(Constants.OPENID_APP);
+            }
+        };
+
+        testSettings = new TestSettings();
+
+        // Set config parameters for Access token with X509 Certificate
+        String tokenType = Constants.ACCESS_TOKEN_KEY;
+        String certType = Constants.X509_CERT;
+
+        // Start the OIDC OP server
+        testOPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.op", "op_server_orig.xml", Constants.OIDC_OP, Constants.NO_EXTRA_APPS, Constants.DO_NOT_USE_DERBY, Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+
+        DiscoveryUtils.waitForOPDiscoveryToBeReady(testSettings);
+
+        //Start the OIDC RP server and setup default values
+        testRPServer = commonSetUp("com.ibm.ws.security.openidconnect.client-1.0_fat.rpd", "rp_server_basic_ssl_no_truststore.xml", Constants.OIDC_RP, apps, Constants.DO_NOT_USE_DERBY,
+                Constants.NO_EXTRA_MSGS, Constants.OPENID_APP, Constants.IBMOIDC_TYPE, true, true, tokenType, certType);
+
+        testOPServer.addIgnoredServerException("CWOAU0039W"); // Ignore errors from the malformed discovery url
+        testOPServer.addIgnoredServerException("CWWKO0801E");
+        testRPServer.addIgnoredServerException("CWWKS1859E"); //Ignore exceptions from bad client secret test
+        testRPServer.addIgnoredServerException("SRVE8094W");
+        testRPServer.addIgnoredServerException("SRVE0190E");
+        testRPServer.addIgnoredServerException("CWWKS1741W"); // Ignore from sigAlgMismatch2 - message is not always logged
+        testRPServer.addIgnoredServerException("SRVE8115W"); // Ignore setStatus WARNING
+        testRPServer.addIgnoredServerException("CWWKS1521W"); // Ignore message indicating conflicting configured endpoints are ignored
+        testRPServer.addIgnoredServerException("CWWKS1524E"); // Ignore message indicating unsuccessful response from endpoint
+        testRPServer.addIgnoredServerException("CWWKS1525E"); // Ignore message indicating discovery failed
+        testRPServer.addIgnoredServerException("CWWKS1522W"); // Ignore message indicating conflicting endpoints for issuer identifier
+        testRPServer.addIgnoredServerException("CWPKI0022E"); // Ignore message indicating conflicting configured endpoints are ignored
+        testRPServer.addIgnoredServerException("CWWKG0058E"); // Ignore SSL failure message
+
+        // override actions that generic tests should use - Need to skip consent form as httpunit
+        // cannot process the form because of embedded javascript
+
+        test_GOOD_LOGIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT;
+        test_GOOD_POST_LOGIN_ACTIONS = Constants.GOOD_OIDC_POST_LOGIN_ACTIONS_SKIP_CONSENT;
+        test_GOOD_LOGIN_AGAIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_AGAIN_ACTIONS;
+        test_FinalAction = Constants.LOGIN_USER;
+        testSettings.setFlowType(Constants.RP_FLOW);
+
+        // Force discovery to run to access login page so that the discovery service is active. Then, in the actual tests the reconfig will initiate discovery and cause the
+        // error messages to be generated on discovery failures during the reconfig (rather than waiting until the first authorization request in the runtime).
+        CommonTestHelpers helpers = new CommonTestHelpers();
+
+        // try to wait for discovery to have populated the RP config
+        // Don't stop if this fails (there is a chance it could be ready by the time the tests actually run
+        DiscoveryUtils.waitForRPDiscoveryToBeReady(testSettings);
+
+    }
+
+    /**
+     * Test Purpose:
+     * <OL>
+     * <LI>With discovery enabled on the RP, attempt to access a test servlet specifying valid OP url
+     * <LI>The RP keystore and truststore is not configured.
+     * <LI>The login attempt should fail with appropriate error.
+     * </OL>
+     * <P>
+     * Expected Results:
+     * <OL>
+     * <LI>Client connection is refused as RP server is not listening on SSL port
+     * <LI>due to missing keystore and truststore with the following message logged:
+     * <LI>CWWKS1524E: The OpenID Connect client failed to obtain OpenID Connect Provider information through the discovery
+     * endpoint...
+     * </OL>
+     */
+    @Test
+    @AllowedFFDC({ "java.security.cert.CertPathBuilderException", "sun.security.validator.ValidatorException", "javax.net.ssl.SSLHandshakeException", "com.ibm.websphere.ssl.SSLException" })
+    public void OidcClientDiscoverySSLTest_NoRPTrustStore() throws Exception {
+
+        TestSettings updatedTestSettings = testSettings.copyTestSettings();
+        updatedTestSettings.setScope("openid profile");
+
+        List<validationData> expectations = vData.addSuccessStatusCodes(null, Constants.GET_LOGIN_PAGE);
+
+        expectations = vData.addExpectation(expectations, Constants.GET_LOGIN_PAGE, Constants.EXCEPTION_MESSAGE, Constants.STRING_CONTAINS, "Should have received an exception for a connection refused exception", null, "java.net.ConnectException");
+
+        testRPServer.addIgnoredServerExceptions("CWWKG0058E");
+
+        WebConversation wc = new WebConversation();
+        genericRP(_testName, wc, updatedTestSettings, test_LOGIN_PAGE_ONLY, expectations);
+    }
+
+}


### PR DESCRIPTION
Splits up the `com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientDiscoveryErrorTests` class so that test cases that reconfigure the servers are put into their own classes. This should alleviate some build failures with FFDCs, timeouts, and error messages leaking between tests sometimes.