### PR TITLE
Fix scanning order of CDI archives

### DIFF
--- a/dev/com.ibm.ws.cdi.visibility_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.visibility_fat/bnd.bnd
@@ -37,7 +37,9 @@ tested.features:\
 	cdi-4.0,\
 	connectors-2.1,\
 	jakartaee-10.0,\
-	servlet-6.0
+	servlet-6.0,\
+	mpConfig-3.0,\
+	mpFaultTolerance-4.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.ejb.3.2;version=latest,\

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/ejb/EJBVisibilityTests.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/ejb/EJBVisibilityTests.java
@@ -37,7 +37,7 @@ import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.EERepeatActions;
+import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -49,7 +49,7 @@ public class EJBVisibilityTests extends FATServletClient {
     public static final String SERVER_NAME = "cdi12EJBServer";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7);
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP60, MicroProfileActions.MP14, MicroProfileActions.MP50);
 
     public static final String MASKED_CLASS_APP_NAME = "maskedClassWeb";
 

--- a/dev/com.ibm.ws.cdi.visibility_fat/publish/servers/cdi12EJBServer/server.xml
+++ b/dev/com.ibm.ws.cdi.visibility_fat/publish/servers/cdi12EJBServer/server.xml
@@ -10,6 +10,9 @@
         <feature>localConnector-1.0</feature>
         <feature>appClientSupport-1.0</feature>
         <feature>componentTest-1.0</feature>
+        <!-- Fault Tolerance included as a feature with CDI extension which can see application BDAs -->
+        <!-- which caused issues with masked classes -->
+        <feature>mpFaultTolerance-1.1</feature>
     </featureManager>
     
     <orb id="defaultOrb" orbSSLInitTimeout="60"/>

--- a/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/weld/BeanDeploymentArchiveImpl.java
+++ b/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/weld/BeanDeploymentArchiveImpl.java
@@ -255,10 +255,14 @@ public class BeanDeploymentArchiveImpl implements WebSphereBeanDeploymentArchive
             //mark as scanned up front to prevent loops
             this.scanned = true;
 
-            //scan the children
-            for (WebSphereBeanDeploymentArchive child : accessibleBDAs) {
-                if (!child.hasBeenScanned()) {
-                    child.scan();
+            // Scan any accessible BDAs first to ensure we scan more visible things (shared libs, ear libs) before less visible things (war classes, war libs)
+            // This helps to make sure that the later call to isAccessibleBean works
+            // Don't scan accessible BDAs of runtime extensions because they sit outside the hierarchy and some of them need to see everything
+            if (getType() != ArchiveType.RUNTIME_EXTENSION) {
+                for (WebSphereBeanDeploymentArchive child : accessibleBDAs) {
+                    if (!child.hasBeenScanned()) {
+                        child.scan();
+                    }
                 }
             }
 


### PR DESCRIPTION
When we scan CDI archives, we try to scan all the visible archives
first. This should make sure we scan things which are more widely
visible (like shared libs) before things which aren't (like wars).

However, runtime extensions can break this as some of them have
visibility of all BDAs.

Fixes #23252