### PR TITLE
change default authMethod from basic to post

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/AuthorizationCodeHandler.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/AuthorizationCodeHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -110,8 +110,8 @@ public class AuthorizationCodeHandler {
         try {
             oidcResult = sendTokenRequestAndValidateResult(oidcClientRequest, sslSocketFactory, authzCode, responseState, redirectUrl);
         } catch (BadPostRequestException e) {
-            Tr.error(tc, "OIDC_CLIENT_TOKEN_REQUEST_FAILURE", new Object[] { e.getErrorMessage(), clientId, clientConfig.getTokenEndpointUrl() });
-            sendErrorJSON(e.getStatusCode(), "invalid_request", e.getErrorMessage());
+            Tr.error(tc, "OIDC_CLIENT_TOKEN_REQUEST_FAILURE", new Object[] { e.getMessage(), clientId, clientConfig.getTokenEndpointUrl() });
+            sendErrorJSON(e.getStatusCode(), "invalid_request", e.getMessage());
             return new ProviderAuthenticationResult(AuthResult.FAILURE, e.getStatusCode());
         } catch (Exception e) {
             Tr.error(tc, "OIDC_CLIENT_TOKEN_REQUEST_FAILURE", new Object[] { e.getLocalizedMessage(), clientId, clientConfig.getTokenEndpointUrl() });

--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanism.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanism.java
@@ -23,6 +23,8 @@ import java.util.regex.Pattern;
 
 import javax.security.auth.Subject;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.context.SubjectManager;
 import com.ibm.ws.security.javaeesec.JavaEESecConstants;
@@ -69,6 +71,8 @@ import jakarta.servlet.http.HttpServletResponse;
 @Default
 @ApplicationScoped
 public class OidcHttpAuthenticationMechanism implements HttpAuthenticationMechanism {
+
+    private static final TraceComponent tc = Tr.register(OidcHttpAuthenticationMechanism.class);
 
     @Inject
     IdentityStoreHandler identityStoreHandler;
@@ -237,6 +241,7 @@ public class OidcHttpAuthenticationMechanism implements HttpAuthenticationMechan
             ProviderAuthenticationResult providerAuthenticationResult = client.continueFlow(request, response);
             status = processContinueFlowResult(providerAuthenticationResult, httpMessageContext, request, response, client);
         } catch (AuthenticationResponseException | TokenRequestException e) {
+            Tr.error(tc, e.getMessage());
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         }
         if (status == AuthenticationStatus.SUCCESS && originalResourceRequest.isPresent()) {

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationTests.java
@@ -303,14 +303,14 @@ public class ConfigurationTests extends CommonAnnotatedSecurityTests {
      *
      * @throws Exception
      */
-    @ExpectedFFDC({ "java.io.IOException", "io.openliberty.security.oidcclientcore.exceptions.TokenRequestException" })
+    @ExpectedFFDC({ "io.openliberty.security.oidcclientcore.http.BadPostRequestException", "io.openliberty.security.oidcclientcore.exceptions.TokenRequestException" })
     @Test
     public void ConfigurationTests_badClientSecret() throws Exception {
 
         WebClient webClient = getAndSaveWebClient();
 
         String app = "GenericOIDCAuthMechanism";
-        String url = rpHttpsBase + "/omittedClientSecret/" + app;
+        String url = rpHttpsBase + "/badClientSecret/" + app;
 
         Page response = invokeAppReturnLoginPage(webClient, url);
         response = actions.doFormLogin(response, Constants.TESTUSER, Constants.TESTUSERPWD);
@@ -332,7 +332,7 @@ public class ConfigurationTests extends CommonAnnotatedSecurityTests {
      *
      * @throws Exception
      */
-    @ExpectedFFDC({ "java.io.IOException", "io.openliberty.security.oidcclientcore.exceptions.TokenRequestException" })
+    @ExpectedFFDC({ "io.openliberty.security.oidcclientcore.http.BadPostRequestException", "io.openliberty.security.oidcclientcore.exceptions.TokenRequestException" })
     @Test
     public void ConfigurationTests_omittedClientSecret() throws Exception {
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/http/BadPostRequestException.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/http/BadPostRequestException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,8 @@ public class BadPostRequestException extends Exception {
     /**
      * @return the errorMessage
      */
-    public String getErrorMessage() {
+    @Override
+    public String getMessage() {
         return errorMessage;
     }
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenRequestor.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenRequestor.java
@@ -155,7 +155,7 @@ public class TokenRequestor {
         private String refreshToken = null;
         private SSLSocketFactory sslSocketFactory = null;
         private boolean isHostnameVerification = false;
-        private String authMethod = TokenConstants.METHOD_BASIC;
+        private String authMethod = TokenConstants.METHOD_POST;
         private String resources = null;
         private HashMap<String, String> customParams = null;
         private boolean useSystemPropertiesForHttpClientConnections = false;


### PR DESCRIPTION
for #23223 

- change default authMethod from basic to post
    - this will make sure the client id and client secret are passed in the form data in the token request (for both `authorization_code` and `refresh_token` grant types)
        - this will fix a failure in the jakarta security 3.0 tck where the op's token endpoint is looking to validate the client id and client secret from the form params
    - had to update the expected ffdc in some fat tests from `java.io.IOException` to `io.openliberty.security.oidcclientcore.http.BadPostRequestException`
    - fixed a typo in the `ConfigurationTests_badClientSecret` test  where it was using `/omittedClientSecret` instead of `/badClientSecret`
    - logged the error caught in `OidcHttpAuthenticationMechanism#processCallback`, so it gets printed in the messages.log file
