### PR TITLE
Add multipart spec tests

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -4427,11 +4427,6 @@
       <version>3.17.200</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse</groupId>
-      <artifactId>yasson</artifactId>
-      <version>1.0.8</version>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.classfilewriter</groupId>
       <artifactId>jboss-classfilewriter</artifactId>
       <version>1.2.5.Final</version>

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/restfulWSClient-3.1/io.openliberty.restfulWSClient-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/restfulWSClient-3.1/io.openliberty.restfulWSClient-3.1.feature
@@ -12,6 +12,7 @@ IBM-API-Package: jakarta.ws.rs; type="spec", \
  org.jboss.resteasy.annotations; type="internal", \
  org.jboss.resteasy.client.jaxrs; type="internal", \
  org.jboss.resteasy.client.jaxrs.internal; type="internal", \
+ org.jboss.resteasy.plugins.providers.multipart; type="internal", \
  org.jboss.resteasy.plugins.providers.sse.client; type="internal", \
  org.jboss.resteasy.plugins.providers.sse; type="internal", \
  org.jboss.resteasy.plugins.providers; type="internal", \

--- a/dev/io.openliberty.org.jboss.resteasy.common.ee10/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.common.ee10/bnd.bnd
@@ -158,6 +158,7 @@ Private-Package: \
 
 instrument.ffdc: false
 instrument.classesExcludes: \
+  io/openliberty/restfulWS/utils/RestfulWSUtils.class, \
   org/jboss/resteasy/client/jaxrs/internal/ClientConfiguration.class, \
   org/jboss/resteasy/client/jaxrs/internal/ClientInvocationBuilder.class, \
   org/jboss/resteasy/client/jaxrs/internal/ClientWebTarget.class, \
@@ -168,6 +169,7 @@ instrument.classesExcludes: \
   org/jboss/resteasy/core/ResteasyContext.class, \
   org/jboss/resteasy/plugins/delegates/CookieHeaderDelegate.class, \
   org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegate.class, \
+  org/jboss/resteasy/plugins/providers/multipart/IAttachmentImpl.class, \
   org/jboss/resteasy/specimpl/MultivaluedTreeMap.class, \
   org/jboss/resteasy/spi/EntityOutputStream.class, \
   org/jboss/resteasy/util/snapshot/SnapshotMap.class, \

--- a/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/org/jboss/resteasy/plugins/providers/multipart/ResteasyEntityPartBuilder.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/org/jboss/resteasy/plugins/providers/multipart/ResteasyEntityPartBuilder.java
@@ -1,0 +1,255 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.plugins.providers.multipart;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.lang.annotation.Annotation;
+import java.util.Objects;
+import java.util.Optional;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.EntityPart;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.Providers;
+
+import org.jboss.resteasy.core.ResteasyContext;
+import org.jboss.resteasy.spi.EntityOutputStream;
+import org.jboss.resteasy.plugins.providers.multipart.i18n.Messages;
+import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
+import org.jboss.resteasy.specimpl.UnmodifiableMultivaluedMap;
+
+/**
+ * An implementation of the {@link EntityPart.Builder}.
+ * <p>
+ * This is not intended for direct usage. Use the {@link EntityPart#withName(String)} instead.
+ * </p>
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class ResteasyEntityPartBuilder implements EntityPart.Builder {
+    private static final Annotation[] ANNOTATIONS = {};
+    private final String name;
+    private final MultivaluedMap<String, String> headers;
+    private MediaType mediaType;
+    private String fileName;
+    private Content content;
+
+
+    /**
+     * Creates a new builder with the part name.
+     *
+     * @param name the part name
+     */
+    public ResteasyEntityPartBuilder(final String name) {
+        this.name = name;
+        headers = new MultivaluedHashMap<>();
+    }
+
+    @Override
+    public EntityPart.Builder mediaType(final MediaType mediaType) throws IllegalArgumentException {
+        this.mediaType = mediaType;
+        return this;
+    }
+
+    @Override
+    public EntityPart.Builder mediaType(final String mediaTypeString) throws IllegalArgumentException {
+        this.mediaType = mediaTypeString == null ? null : MediaType.valueOf(mediaTypeString);
+        return this;
+    }
+
+    @Override
+    public EntityPart.Builder header(final String headerName, final String... headerValues)
+            throws IllegalArgumentException {
+        headers.addAll(headerName, headerValues);
+        return this;
+    }
+
+    @Override
+    public EntityPart.Builder headers(final MultivaluedMap<String, String> newHeaders) throws IllegalArgumentException {
+        headers.putAll(newHeaders);
+        return this;
+    }
+
+    @Override
+    public EntityPart.Builder fileName(final String fileName) throws IllegalArgumentException {
+        this.fileName = fileName;
+        return this;
+    }
+
+    @Override
+    public EntityPart.Builder content(final InputStream content) throws IllegalArgumentException {
+        this.content = new Content(GenericType.forInstance(
+                Objects.requireNonNull(content, Messages.MESSAGES.nullParameter("content"))), content);
+        return this;
+    }
+
+    @Override
+    public <T> EntityPart.Builder content(final T content, final Class<? extends T> type)
+            throws IllegalArgumentException {
+        this.content = new Content(new GenericType<>(Objects.requireNonNull(type, Messages.MESSAGES.nullParameter("type"))),
+                Objects.requireNonNull(content, Messages.MESSAGES.nullParameter("content")));
+        return this;
+    }
+
+    @Override
+    public EntityPart.Builder content(final Object content) throws IllegalArgumentException {
+        return content(Objects.requireNonNull(content, Messages.MESSAGES.nullParameter("content")), content.getClass());
+    }
+
+    @Override
+    public <T> EntityPart.Builder content(final T content, final GenericType<T> type) throws IllegalArgumentException {
+        this.content = new Content(Objects.requireNonNull(type, Messages.MESSAGES.nullParameter("type")),
+                Objects.requireNonNull(content, Messages.MESSAGES.nullParameter("content")));
+        return this;
+    }
+
+    @Override
+    public EntityPart build() throws IllegalStateException, IOException, WebApplicationException {
+        //Liberty change start
+        // Per RFC 7578 ( https://tools.ietf.org/html/rfc7578#section-4.4 ) default to text/plain if not a file
+        // or application/octet-stream if it is.
+        if (this.mediaType == null) {
+            if (this.fileName == null) {
+                mediaType = MediaType.TEXT_PLAIN_TYPE;
+            } else {
+                mediaType = MediaType.APPLICATION_OCTET_STREAM_TYPE;
+            }
+        }
+        //Liberty change end
+
+        return new EntityPartImpl(name, headers, mediaType, fileName, content);
+    }
+
+    private static class EntityPartImpl implements EntityPart {
+        private final String name;
+        private final MultivaluedMap<String, String> headers;
+        private final MediaType mediaType;
+        private final String fileName;
+        private final Content content;
+
+        private EntityPartImpl(final String name, final MultivaluedMap<String, String> headers,
+                               final MediaType mediaType, final String fileName, final Content content) {
+            this.name = name;
+            this.headers = new UnmodifiableMultivaluedMap<>(new MultivaluedHashMap<>(headers));
+            this.mediaType = mediaType;
+            this.fileName = fileName;
+            this.content = content;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public Optional<String> getFileName() {
+            return Optional.ofNullable(fileName);
+        }
+
+        @Override
+        public InputStream getContent() {
+            try {
+                return content.getInputStream(mediaType, headers);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public <T> T getContent(final Class<T> type)
+                throws IllegalArgumentException, IllegalStateException, IOException, WebApplicationException {
+            return getContent(new GenericType<>(type));
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getContent(final GenericType<T> type)
+                throws IllegalArgumentException, IllegalStateException, IOException, WebApplicationException {
+            final Providers providers = ResteasyContext.getRequiredContextData(Providers.class);
+            final MessageBodyReader<T> reader = (MessageBodyReader<T>) providers.getMessageBodyReader(type.getRawType(), type.getType(), ANNOTATIONS, mediaType);
+            if (reader == null) {
+                throw new RuntimeException(Messages.MESSAGES.unableToFindMessageBodyReader(mediaType, type.getRawType()
+                        .getName()));
+            }
+            LogMessages.LOGGER.debugf("MessageBodyReader: %s", reader.getClass().getName());
+
+            return reader.readFrom((Class<T>) type.getRawType(), type.getType(), ANNOTATIONS, mediaType, headers, getContent());
+        }
+
+        @Override
+        public MultivaluedMap<String, String> getHeaders() {
+            return headers;
+        }
+
+        @Override
+        public MediaType getMediaType() {
+            return mediaType;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("EntityPart[name=%s, fileName=%s, mediaType=%s, headers=%s, content=%s]", name, fileName, mediaType, headers, content);
+        }
+    }
+
+    private static class Content {
+        final GenericType<?> genericType;
+        final Object content;
+        final InputPart inputPart;
+
+        private Content(final GenericType<?> genericType, final Object content) {
+            this.genericType = genericType;
+            this.content = content;
+            this.inputPart = null;
+        }
+
+        InputStream getInputStream(final MediaType mediaType,
+                                   final MultivaluedMap<String, String> headers) throws IOException {
+            if (content instanceof InputStream) {
+                return (InputStream) content;
+            }
+            if (content instanceof EntityPart) {
+                return ((EntityPart) content).getContent();
+            }
+            if (content instanceof InputPart) {
+                return ((InputPart) content).getBody();
+            }
+            try (EntityOutputStream out = new EntityOutputStream()) {
+                final Providers providers = ResteasyContext.getRequiredContextData(Providers.class);
+                @SuppressWarnings("unchecked")
+                final MessageBodyWriter<Object> messageBodyWriter = providers.getMessageBodyWriter((Class<Object>) genericType.getRawType(), genericType.getType(), ANNOTATIONS, mediaType);
+                messageBodyWriter.writeTo(content, genericType.getRawType(), genericType.getType(), ANNOTATIONS, mediaType, new MultivaluedHashMap<>(headers), out);
+                return out.toInputStream();
+            }
+        }
+
+        @Override
+        public String toString() {
+            return String.format("Content[content=%s, genericType=%s]", content, genericType);
+        }
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.1_fat/fat/src/io/openliberty/restfulWS31/fat/FATSuite.java
+++ b/dev/io.openliberty.restfulWS.3.1_fat/fat/src/io/openliberty/restfulWS31/fat/FATSuite.java
@@ -16,7 +16,8 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-    JavaSeBootstrapContainerTest.class
+    JavaSeBootstrapContainerTest.class,
+    MultipartTest.class
 })
 public class FATSuite {
 }

--- a/dev/io.openliberty.restfulWS.3.1_fat/fat/src/io/openliberty/restfulWS31/fat/MultipartTest.java
+++ b/dev/io.openliberty.restfulWS.3.1_fat/fat/src/io/openliberty/restfulWS31/fat/MultipartTest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS31.fat;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import io.openliberty.restfulWS31.fat.multipart.MultipartTestServlet;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+@RunWith(FATRunner.class)
+public class MultipartTest extends FATServletClient {
+    private static final String war = "multipart";
+
+    @Server("multipart")
+    @TestServlet(servlet = MultipartTestServlet.class, contextRoot = war)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultDropinApp(server, war, "io.openliberty.restfulWS31.fat.multipart")
+                    .addAsWebInfResource(new StringAsset("This is a resource file that is part of the app"),
+                                         "resource.txt");
+
+        // Make sure we don't fail because we try to start an
+        // already started server
+        try {
+            server.startServer(true);
+        } catch (Exception e) {
+            System.out.println(e.toString());
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer(/*"CWWKW0101W", "CWWKW0102W", "SRVE8052E", "SRVE0276E", "SRVE0190E"*/);
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.1_fat/fat/src/io/openliberty/restfulWS31/fat/multipart/MultipartResource.java
+++ b/dev/io.openliberty.restfulWS.3.1_fat/fat/src/io/openliberty/restfulWS31/fat/multipart/MultipartResource.java
@@ -1,0 +1,288 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS31.fat.multipart;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.List;
+import java.util.Optional;
+
+import com.ibm.websphere.jaxrs20.multipart.IAttachment;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.EntityPart;
+import jakarta.ws.rs.core.Response;
+
+@ApplicationPath("/app")
+@Path("/multi")
+public class MultipartResource extends Application {
+   
+    @POST
+    @Path("/iAttachments")
+    @Consumes("multipart/form-data")
+    public Response postMultipartIAttachments(List <IAttachment> attachments) throws IOException{
+        String[] contentTypeArray = {"text/plain","*/*","application/xml"};
+        String[] fileArray =  {"fileid","description","person.xml"};
+        String[] contentArray = {"person1234","XML file about person1234",
+                                 "<person>    <name>Chris</name>    <position>laying</position>    <temperature>99.9</temperature></person>"};
+        InputStream stream = null;
+        for (IAttachment attachment : attachments) {
+            if (attachment == null) {
+                fail("No IAttachments sent to Post method.");
+            }
+            int i = getIndex(attachment.getDataHandler().getName(), fileArray);
+            String contentType = attachment.getDataHandler().getContentType();;
+            assertEquals(contentTypeArray[i], contentType);
+  
+            String name = attachment.getDataHandler().getName();
+            
+            if (name != null) {
+                File tempFile = new File(name);
+                assertEquals(fileArray[i],tempFile.getPath());
+            } else {
+                fail("Expected fileName, " + fileArray[i] + ", not present.");
+            }
+            
+            stream = attachment.getDataHandler().getInputStream();
+            if (stream != null) {
+                StringBuilder sb = new StringBuilder();
+                BufferedReader br = new BufferedReader(new InputStreamReader(stream));
+                String line = null;
+                try {
+                    while ((line = br.readLine()) != null) {
+                        sb.append(line);
+                    }
+                } catch (IOException e) {
+                    fail("Unexpected exception: " + e);
+                } finally {
+                    if (br != null) {
+                        try {
+                            br.close();
+                        } catch (IOException e) {
+                            fail("Unexpected exception: " + e);
+                        }
+                    }
+                }
+                assertEquals(contentArray[i],sb.toString());
+
+                stream.close();
+            } else {
+               fail("Expected content, " + contentArray[i] + ", not present."); 
+            }
+            i++;
+        }
+        return Response.ok("SUCCESS").build();
+    }
+
+    @POST
+    @Path("/iAttachmentsWithDefaults")
+    @Consumes("multipart/form-data")
+    public Response postMultipartIAttachmentsWithDefaultMediaType(List <IAttachment> attachments) throws IOException{
+        String[] contentTypeArray = {"text/plain","text/plain","application/octet-stream"};
+        String[] fileArray =  {"fileid","description","person.xml"};
+        String[] contentArray = {"person1234","XML file about person1234",
+                                 "<person>    <name>Chris</name>    <position>laying</position>    <temperature>99.9</temperature></person>"};
+        InputStream stream = null;
+        for (IAttachment attachment : attachments) {
+            if (attachment == null) {
+                fail("No IAttachments sent to Post method.");
+            }
+            int i = getIndex(attachment.getDataHandler().getName(), fileArray);
+            String contentType = attachment.getDataHandler().getContentType();;
+            assertEquals(contentTypeArray[i], contentType);
+  
+            String name = attachment.getDataHandler().getName();
+            
+            if (name != null) {
+                File tempFile = new File(name);
+                assertEquals(fileArray[i],tempFile.getPath());
+            } else {
+                fail("Expected fileName, " + fileArray[i] + ", not present.");
+            }
+            
+            stream = attachment.getDataHandler().getInputStream();
+            if (stream != null) {
+                StringBuilder sb = new StringBuilder();
+                BufferedReader br = new BufferedReader(new InputStreamReader(stream));
+                String line = null;
+                try {
+                    while ((line = br.readLine()) != null) {
+                        sb.append(line);
+                    }
+                } catch (IOException e) {
+                    fail("Unexpected exception: " + e);
+                } finally {
+                    if (br != null) {
+                        try {
+                            br.close();
+                        } catch (IOException e) {
+                            fail("Unexpected exception: " + e);
+                        }
+                    }
+                }
+                assertEquals(contentArray[i],sb.toString());
+
+                stream.close();
+            } else {
+               fail("Expected content, " + contentArray[i] + ", not present."); 
+            }
+            i++;
+        }
+        return Response.ok("SUCCESS").build();
+    }
+
+    @POST
+    @Path("/entityParts")
+    @Consumes("multipart/form-data")
+    public Response postMultipartEntityParts(List <EntityPart> parts) throws IOException{
+        String[] contentTypeArray = {"text/plain;charset=us-ascii","*/*","application/xml"};
+        String[] nameArray =  {"fileid","description","thefile"};
+        String[] fileArray =  {null,null,"person.xml"};
+        String[] contentArray = {"person1234","XML file about person1234",
+                                 "<person>    <name>Chris</name>    <position>laying</position>    <temperature>99.9</temperature></person>"};
+        InputStream stream = null;
+
+        for (EntityPart part : parts) {
+            if (part == null) {
+                fail("No EntityPart objects sent to POST method.");
+            }
+            String name = part.getName();
+            int i = getIndex(name, nameArray);
+            
+            assertEquals(nameArray[i], part.getName());
+            assertEquals(contentTypeArray[i], part.getMediaType().toString());
+  
+            Optional<String> fileName = part.getFileName();
+            
+            if (fileName.isPresent()) {
+                File tempFile = new File(fileName.get());
+                assertEquals(fileArray[i],tempFile.getPath());
+            } else {
+                assertEquals(fileArray[i],null);
+            }
+            
+            stream = part.getContent();
+            if (stream != null) {
+                StringBuilder sb = new StringBuilder();
+                BufferedReader br = new BufferedReader(new InputStreamReader(stream));
+                String line = null;
+                try {
+                    while ((line = br.readLine()) != null) {
+                        sb.append(line);
+                    }
+                } catch (IOException e) {
+                    fail("Unexpected exception: " + e);
+                } finally {
+                    if (br != null) {
+                        try {
+                            br.close();
+                        } catch (IOException e) {
+                            fail("Unexpected exception: " + e);
+                        }
+                    }
+                }
+                assertEquals(contentArray[i],sb.toString());
+
+                stream.close();
+            } else {
+               fail("Expected content, " + contentArray[i] + ", not present."); 
+            }
+            i++;
+        }
+        return Response.ok("SUCCESS").build();
+    }
+    
+    @POST
+    @Path("/entityPartsWithDefaults")
+    @Consumes("multipart/form-data")
+    public Response postMultipartEntityPartsWithDefaultMediaType(List <EntityPart> parts) throws IOException{
+        String[] contentTypeArray = {"text/plain;charset=us-ascii","text/plain;charset=us-ascii","application/octet-stream"};
+        String[] nameArray =  {"fileid","description","thefile"};
+        String[] fileArray =  {null,null,"person.xml"};
+        String[] contentArray = {"person1234","XML file about person1234",
+                                 "<person>    <name>Chris</name>    <position>laying</position>    <temperature>99.9</temperature></person>"};
+        InputStream stream = null;
+
+        for (EntityPart part : parts) {
+            if (part == null) {
+                fail("No EntityPart objects sent to POST method.");
+            }
+            String name = part.getName();
+            int i = getIndex(name, nameArray);
+            
+            assertEquals(nameArray[i], part.getName());
+            assertEquals(contentTypeArray[i], part.getMediaType().toString());
+  
+            Optional<String> fileName = part.getFileName();
+            
+            if (fileName.isPresent()) {
+                File tempFile = new File(fileName.get());
+                assertEquals(fileArray[i],tempFile.getPath());
+            } else {
+                assertEquals(fileArray[i],null);
+            }
+            
+            stream = part.getContent();
+            if (stream != null) {
+                StringBuilder sb = new StringBuilder();
+                BufferedReader br = new BufferedReader(new InputStreamReader(stream));
+                String line = null;
+                try {
+                    while ((line = br.readLine()) != null) {
+                        sb.append(line);
+                    }
+                } catch (IOException e) {
+                    fail("Unexpected exception: " + e);
+                } finally {
+                    if (br != null) {
+                        try {
+                            br.close();
+                        } catch (IOException e) {
+                            fail("Unexpected exception: " + e);
+                        }
+                    }
+                }
+                assertEquals(contentArray[i],sb.toString());
+
+                stream.close();
+            } else {
+               fail("Expected content, " + contentArray[i] + ", not present."); 
+            }
+            i++;
+        }
+        return Response.ok("SUCCESS").build();
+    }
+    
+    private int getIndex(String name, String[] nameArray) {
+        int returnVal = -1;
+        for (int i = 0; i < nameArray.length; i++) {
+            if (name.equals(nameArray[i])) {
+                returnVal = i;
+                break;
+            } 
+        }
+        if (returnVal == -1) {
+            fail("Part/Attachment not found: " + name);
+        }
+        return returnVal;
+    }    
+
+}

--- a/dev/io.openliberty.restfulWS.3.1_fat/fat/src/io/openliberty/restfulWS31/fat/multipart/MultipartTestServlet.java
+++ b/dev/io.openliberty.restfulWS.3.1_fat/fat/src/io/openliberty/restfulWS31/fat/multipart/MultipartTestServlet.java
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS31.fat.multipart;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.resteasy.plugins.providers.multipart.ResteasyEntityPartBuilder;
+import org.junit.After;
+import org.junit.Test;
+
+import com.ibm.websphere.jaxrs20.multipart.AttachmentBuilder;
+import com.ibm.websphere.jaxrs20.multipart.IAttachment;
+
+import componenttest.app.FATServlet;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.EntityPart;
+import jakarta.ws.rs.core.GenericEntity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@WebServlet(urlPatterns = "/MultipartTestServlet")
+public class MultipartTestServlet extends FATServlet {
+    private static final long serialVersionUID = 4563445834756294836L;
+
+    final static String URI_CONTEXT_ROOT = "http://localhost:" + Integer.getInteger("bvt.prop.HTTP_default") + "/multipart/";
+
+    private Client client;
+
+    @Override
+    public void init() throws ServletException {
+        client = ClientBuilder.newClient();
+    }
+
+    @After
+    private void teardown() {
+        client.close();
+    }
+
+    @Test
+    public void testMultipartRequestIAttachment() throws Exception {
+        testIAttachmentMultipartRequest("/app/multi/iAttachments", false);
+    }
+    @Test
+    public void testMultipartRequestIAttachmentWithDefaultMediaType() throws Exception {
+        testIAttachmentMultipartRequest("/app/multi/iAttachmentsWithDefaults",true);
+    }
+    @Test
+    public void testMultipartRequestEntityPart() throws Exception {
+        testEntityPartMultipartRequest("/app/multi/entityParts",false);
+    }
+    @Test
+    public void testMultipartRequestEntityPartWithDefaultMediaType() throws Exception {
+        testEntityPartMultipartRequest("/app/multi/entityPartsWithDefaults",true);
+    }
+
+        
+    private void testIAttachmentMultipartRequest(String path, boolean useDefault) {
+        List<IAttachment> attachments = new ArrayList<>();
+
+        // MediaType will be defaulted if not provided, so test both.
+        try {
+            if (useDefault) {
+                attachments.add(AttachmentBuilder.newBuilder("fileid")
+                                .inputStream(new ByteArrayInputStream("person1234".getBytes()))
+                                .build());
+                attachments.add(AttachmentBuilder.newBuilder("description")
+                                .inputStream(new ByteArrayInputStream("XML file about person1234".getBytes()))
+                                .build());
+                
+                File file = new File("./person.xml");
+                attachments.add(AttachmentBuilder.newBuilder("thefile")
+                                .inputStream("person.xml",new FileInputStream(file))
+                                .build());
+
+
+            } else {
+                attachments.add(AttachmentBuilder.newBuilder("fileid")
+                                .inputStream(new ByteArrayInputStream("person1234".getBytes()))
+                                .contentType(MediaType.TEXT_PLAIN)
+                                .build());
+                attachments.add(AttachmentBuilder.newBuilder("description")
+                                .inputStream(new ByteArrayInputStream("XML file about person1234".getBytes()))
+                                .contentType(MediaType.WILDCARD)
+                                .build());
+                
+                File file = new File("./person.xml");
+                attachments.add(AttachmentBuilder.newBuilder("thefile")
+                                .inputStream("person.xml",new FileInputStream(file))
+                                .contentType(MediaType.APPLICATION_XML_TYPE)
+                                .build());
+            }
+
+        } catch (IOException e) {
+            e.printStackTrace();
+            fail("Exception caught: " + e);
+        }
+        System.out.println("testMultipartRequest - sending  " + attachments);
+        Response response = client.target(URI_CONTEXT_ROOT)
+                        .path(path)
+                        .request(MediaType.TEXT_PLAIN)
+                        .post(Entity.entity(attachments, MediaType.MULTIPART_FORM_DATA));
+        
+        assertEquals(200, response.getStatus());
+        assertEquals("SUCCESS", response.readEntity(String.class));
+          
+    }
+    
+    private void testEntityPartMultipartRequest(String path, boolean useDefault) {
+        List<EntityPart> parts = new ArrayList<>();
+
+        try {
+            if (useDefault) {
+                ResteasyEntityPartBuilder builder = new ResteasyEntityPartBuilder("fileid");
+                parts.add(builder.content(new ByteArrayInputStream("person1234".getBytes()))
+                                .build());
+
+                builder = new ResteasyEntityPartBuilder("description");
+                parts.add(builder.content(new ByteArrayInputStream("XML file about person1234".getBytes()))
+                                .build());
+
+                File file = new File("./person.xml");
+                builder = new ResteasyEntityPartBuilder("thefile");
+                parts.add(builder.fileName("person.xml")
+                                .content("person.xml",new FileInputStream(file))
+                                .build());
+                
+                
+            } else {
+                ResteasyEntityPartBuilder builder = new ResteasyEntityPartBuilder("fileid");
+                parts.add(builder.content(new ByteArrayInputStream("person1234".getBytes()))
+                                .mediaType(MediaType.TEXT_PLAIN)
+                                .build());
+
+                builder = new ResteasyEntityPartBuilder("description");
+                parts.add(builder.content(new ByteArrayInputStream("XML file about person1234".getBytes()))
+                                .mediaType(MediaType.WILDCARD)
+                                .build());
+
+                File file = new File("./person.xml");
+                builder = new ResteasyEntityPartBuilder("thefile");
+                parts.add(builder.fileName("person.xml")
+                                .content("person.xml",new FileInputStream(file))
+                                .mediaType(MediaType.APPLICATION_XML_TYPE)
+                                .build());
+                
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+            fail("Exception caught: " + e);
+        }
+        
+        System.out.println("testMultipartRequest - sending  " + parts);
+        Response response = client.target(URI_CONTEXT_ROOT)
+                        .path(path)
+                        .request(MediaType.TEXT_PLAIN)
+                        .post(Entity.entity(new GenericEntity<List<EntityPart>>(parts){}, MediaType.MULTIPART_FORM_DATA));
+        
+        assertEquals(200, response.getStatus());
+        assertEquals("SUCCESS", response.readEntity(String.class));
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.1_fat/publish/servers/multipart/bootstrap.properties
+++ b/dev/io.openliberty.restfulWS.3.1_fat/publish/servers/multipart/bootstrap.properties
@@ -1,0 +1,4 @@
+com.ibm.ws.logging.trace.specification=*=info
+com.ibm.ws.logging.max.file.size=0
+
+bootstrap.include=../testports.properties

--- a/dev/io.openliberty.restfulWS.3.1_fat/publish/servers/multipart/jvm.options
+++ b/dev/io.openliberty.restfulWS.3.1_fat/publish/servers/multipart/jvm.options
@@ -1,0 +1,1 @@
+-Dorg.jboss.resteasy.plugins.providers.multipart.memoryThreshold=2048

--- a/dev/io.openliberty.restfulWS.3.1_fat/publish/servers/multipart/person.xml
+++ b/dev/io.openliberty.restfulWS.3.1_fat/publish/servers/multipart/person.xml
@@ -1,0 +1,5 @@
+<person>
+    <name>Chris</name>
+    <position>laying</position>
+    <temperature>99.9</temperature>
+</person>

--- a/dev/io.openliberty.restfulWS.3.1_fat/publish/servers/multipart/server.xml
+++ b/dev/io.openliberty.restfulWS.3.1_fat/publish/servers/multipart/server.xml
@@ -1,0 +1,14 @@
+<server>
+    <featureManager>
+        <feature>componenttest-2.0</feature>
+        <feature>restfulWS-3.1</feature>
+        <feature>servlet-6.0</feature>
+    </featureManager>
+    
+ 
+  	<include location="../fatTestPorts.xml"/>
+  	<javaPermission className="java.util.PropertyPermission" name="bvt.prop.HTTP_default" actions="read"/>
+
+    <javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
+    <javaPermission className="java.io.FilePermission" name="&lt;&lt;ALL FILES&gt;&gt;" actions="read"/>
+</server>


### PR DESCRIPTION
Fixes #22884
Add test to confirm that multi-part function continue to works for the previous IBM-only APIs and the new Spec APIs (ie. EntityPart).