### PR TITLE
Allow validate OR provide_group in EL string expression

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/extensions/DatabaseIdentityStoreBean.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/extensions/DatabaseIdentityStoreBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.Set;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
@@ -48,8 +49,12 @@ public class DatabaseIdentityStoreBean implements Bean<IdentityStore> {
     public DatabaseIdentityStoreBean(BeanManager beanManager, DatabaseIdentityStoreDefinition dbIdentityStoreDefinition) {
         databaseIdentityStoreDefinition = dbIdentityStoreDefinition;
         qualifiers = new HashSet<Annotation>();
-        qualifiers.add(new AnnotationLiteral<Default>() {});
-        type = new TypeLiteral<IdentityStore>() {}.getType();
+        qualifiers.add(new AnnotationLiteral<Default>() {
+        });
+        qualifiers.add(new AnnotationLiteral<Any>() {
+        });
+        type = new TypeLiteral<IdentityStore>() {
+        }.getType();
         types = Collections.singleton(type);
         name = this.getClass().getName() + "@" + this.hashCode() + "[" + type + "]";
         id = beanManager.hashCode() + "#" + this.name;

--- a/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/extensions/IdentityStoreHandlerBean.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/extensions/IdentityStoreHandlerBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.Set;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
@@ -42,9 +43,13 @@ public class IdentityStoreHandlerBean implements Bean<IdentityStoreHandler>, Pas
 
     public IdentityStoreHandlerBean(BeanManager beanManager) {
         qualifiers = new HashSet<Annotation>();
-        qualifiers.add(new AnnotationLiteral<Default>() {});
+        qualifiers.add(new AnnotationLiteral<Default>() {
+        });
+        qualifiers.add(new AnnotationLiteral<Any>() {
+        });
 
-        type = new TypeLiteral<IdentityStoreHandler>() {}.getType();
+        type = new TypeLiteral<IdentityStoreHandler>() {
+        }.getType();
         types = Collections.singleton(type);
         name = this.getClass().getName() + "[" + type + "]";
         id = beanManager.hashCode() + "#" + this.name;
@@ -66,7 +71,8 @@ public class IdentityStoreHandlerBean implements Bean<IdentityStoreHandler>, Pas
      * @see javax.enterprise.context.spi.Contextual#destroy(java.lang.Object, javax.enterprise.context.spi.CreationalContext)
      */
     @Override
-    public void destroy(IdentityStoreHandler arg0, CreationalContext<IdentityStoreHandler> arg1) {}
+    public void destroy(IdentityStoreHandler arg0, CreationalContext<IdentityStoreHandler> arg1) {
+    }
 
     /*
      * (non-Javadoc)

--- a/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/extensions/LdapIdentityStoreBean.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/extensions/LdapIdentityStoreBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.Set;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
@@ -48,9 +49,13 @@ public class LdapIdentityStoreBean implements Bean<IdentityStore>, PassivationCa
     public LdapIdentityStoreBean(BeanManager beanManager, LdapIdentityStoreDefinition ldapIdentityStoreDefinition) {
         this.ldapIdentityStoreDefinition = ldapIdentityStoreDefinition;
         qualifiers = new HashSet<Annotation>();
-        qualifiers.add(new AnnotationLiteral<Default>() {});
+        qualifiers.add(new AnnotationLiteral<Default>() {
+        });
+        qualifiers.add(new AnnotationLiteral<Any>() {
+        });
 
-        type = new TypeLiteral<IdentityStore>() {}.getType();
+        type = new TypeLiteral<IdentityStore>() {
+        }.getType();
         types = Collections.singleton(type);
         name = this.getClass().getName() + "@" + this.hashCode() + "[" + type + "]";
         id = beanManager.hashCode() + "#" + this.name;

--- a/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/extensions/ModulePropertiesProviderBean.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/extensions/ModulePropertiesProviderBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import java.util.Set;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
@@ -49,8 +50,12 @@ public class ModulePropertiesProviderBean<T> implements Bean<ModulePropertiesPro
     public ModulePropertiesProviderBean(BeanManager beanManager, Map<String, ModuleProperties> moduleMap) {
         this.moduleMap = moduleMap;
         qualifiers = new HashSet<Annotation>();
-        qualifiers.add(new AnnotationLiteral<Default>() {});
-        type = new TypeLiteral<ModulePropertiesProvider>() {}.getType();
+        qualifiers.add(new AnnotationLiteral<Default>() {
+        });
+        qualifiers.add(new AnnotationLiteral<Any>() {
+        });
+        type = new TypeLiteral<ModulePropertiesProvider>() {
+        }.getType();
         types = Collections.singleton(type);
         name = this.getClass().getName() + "[" + type + "]";
         id = beanManager.hashCode() + "#" + this.name;

--- a/dev/com.ibm.ws.security.javaeesec.cdi/test/com/ibm/ws/security/javaeesec/cdi/extensions/IdentityStoreHandlerBeanTest.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/test/com/ibm/ws/security/javaeesec/cdi/extensions/IdentityStoreHandlerBeanTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,10 +17,12 @@ import static org.junit.Assert.assertTrue;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Iterator;
 import java.util.Set;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.util.AnnotationLiteral;
@@ -53,7 +55,8 @@ public class IdentityStoreHandlerBeanTest {
     private final CreationalContext<IdentityStoreHandler> cc = context.mock(CreationalContext.class, "cc1");
 
     @Before
-    public void setUp() {}
+    public void setUp() {
+    }
 
     @After
     public void tearDown() throws Exception {
@@ -77,9 +80,13 @@ public class IdentityStoreHandlerBeanTest {
     public void getQualifiers() {
         IdentityStoreHandlerBean ishb = new IdentityStoreHandlerBean(bm);
         Set<Annotation> output = ishb.getQualifiers();
+        Iterator<Annotation> it = output.iterator();
         System.out.println("getQualifiers: " + output);
-        assertEquals("getQualifiers returns incorrect number of elements.", 1, output.size());
-        assertEquals("getQualifiers returns incorrect value.", new AnnotationLiteral<Default>() {}.toString(), output.iterator().next().toString());
+        assertEquals("getQualifiers returns incorrect number of elements.", 2, output.size());
+        assertEquals("getQualifiers returns incorrect value.", new AnnotationLiteral<Default>() {
+        }.toString(), it.next().toString());
+        assertEquals("getQualifiers returns incorrect value.", new AnnotationLiteral<Any>() {
+        }.toString(), it.next().toString());
     }
 
     @Test
@@ -102,7 +109,8 @@ public class IdentityStoreHandlerBeanTest {
         Set<Type> output = ishb.getTypes();
         System.out.println("getTypess: " + output);
         assertEquals("getTypes returns incorrect number of elements.", 1, output.size());
-        assertEquals("getTypes returns incorrect value.", new TypeLiteral<IdentityStoreHandler>() {}.getType().toString(), output.iterator().next().toString());
+        assertEquals("getTypes returns incorrect value.", new TypeLiteral<IdentityStoreHandler>() {
+        }.getType().toString(), output.iterator().next().toString());
     }
 
     @Test

--- a/dev/com.ibm.ws.security.javaeesec.cdi/test/com/ibm/ws/security/javaeesec/cdi/extensions/ModulePropertiesProviderBeanTest.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/test/com/ibm/ws/security/javaeesec/cdi/extensions/ModulePropertiesProviderBeanTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,17 +17,16 @@ import static org.junit.Assert.assertTrue;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Iterator;
 import java.util.Set;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.util.AnnotationLiteral;
 import javax.enterprise.util.TypeLiteral;
-import com.ibm.ws.security.javaeesec.properties.ModuleProperties;
-import com.ibm.ws.security.javaeesec.properties.ModulePropertiesProvider;
-import com.ibm.ws.security.javaeesec.properties.ModulePropertiesProviderImpl;
 
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JUnit4Mockery;
@@ -37,8 +36,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 
-import test.common.SharedOutputManager;
+import com.ibm.ws.security.javaeesec.properties.ModulePropertiesProvider;
 
+import test.common.SharedOutputManager;
 
 public class ModulePropertiesProviderBeanTest {
     static final SharedOutputManager outputMgr = SharedOutputManager.getInstance();
@@ -56,7 +56,8 @@ public class ModulePropertiesProviderBeanTest {
     private final CreationalContext<ModulePropertiesProvider> cc = context.mock(CreationalContext.class, "cc1");
 
     @Before
-    public void setUp() {}
+    public void setUp() {
+    }
 
     @After
     public void tearDown() throws Exception {
@@ -80,9 +81,13 @@ public class ModulePropertiesProviderBeanTest {
     public void getQualifiers() {
         ModulePropertiesProviderBean mppb = new ModulePropertiesProviderBean(bm, null);
         Set<Annotation> output = mppb.getQualifiers();
+        Iterator<Annotation> it = output.iterator();
         System.out.println("getQualifiers: " + output);
-        assertEquals("getQualifiers returns incorrect number of elements.", 1, output.size());
-        assertEquals("getQualifiers returns incorrect value.", new AnnotationLiteral<Default>() {}.toString(), output.iterator().next().toString());
+        assertEquals("getQualifiers returns incorrect number of elements.", 2, output.size());
+        assertEquals("getQualifiers returns incorrect value.", new AnnotationLiteral<Default>() {
+        }.toString(), it.next().toString());
+        assertEquals("getQualifiers returns incorrect value.", new AnnotationLiteral<Any>() {
+        }.toString(), it.next().toString());
     }
 
     @Test
@@ -105,7 +110,8 @@ public class ModulePropertiesProviderBeanTest {
         Set<Type> output = mppb.getTypes();
         System.out.println("getTypess: " + output);
         assertEquals("getTypes returns incorrect number of elements.", 1, output.size());
-        assertEquals("getTypes returns incorrect value.", new TypeLiteral<ModulePropertiesProvider>() {}.getType().toString(), output.iterator().next().toString());
+        assertEquals("getTypes returns incorrect value.", new TypeLiteral<ModulePropertiesProvider>() {
+        }.getType().toString(), output.iterator().next().toString());
     }
 
     @Test

--- a/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/ELHelper.java
+++ b/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/ELHelper.java
@@ -569,13 +569,21 @@ public class ELHelper {
 
             } else if (obj instanceof String) {
                 Tr.debug(tc, "processUseFor (String): " + (String) obj);
-                ValidationType[] types = new ValidationType[2];
                 String validation = ((String) obj).toLowerCase();
-                if (validation.contains("validate")) {
+                ValidationType[] types = null;
+                if (validation.contains("validate") && validation.contains("provide_groups")) {
+                    types = new ValidationType[2];
                     types[0] = ValidationType.VALIDATE;
-                }
-                if (validation.contains("provide_groups")) {
                     types[1] = ValidationType.PROVIDE_GROUPS;
+                } else if (validation.contains("validate")) {
+                    types = new ValidationType[1];
+                    types[0] = ValidationType.VALIDATE;
+                } else if (validation.contains("provide_groups")) {
+                    types = new ValidationType[1];
+                    types[0] = ValidationType.PROVIDE_GROUPS;
+                } else {
+                    Tr.debug(tc, "processUseFor result does not contain validate or provide_groups");
+                    throw new IllegalArgumentException("The identity store must be configured with at least one ValidationType.");
                 }
                 result = EnumSet.copyOf(Arrays.asList(types));
                 immediate = isImmediateExpression(useForExpression);

--- a/dev/com.ibm.ws.security.javaeesec/test/com/ibm/ws/security/javaeesec/identitystore/LdapIdentityStoreDefinitionsWrapperTest.java
+++ b/dev/com.ibm.ws.security.javaeesec/test/com/ibm/ws/security/javaeesec/identitystore/LdapIdentityStoreDefinitionsWrapperTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -424,6 +424,21 @@ public class LdapIdentityStoreDefinitionsWrapperTest {
          */
         Map<String, Object> overrides = new HashMap<String, Object>();
         overrides.put("useForExpression", "{ValidationType.VALIDATE}");
+
+        LdapIdentityStoreDefinition idStoreDefinition = getInstanceofAnnotation(overrides);
+        LdapIdentityStoreDefinitionWrapper wrapper = new LdapIdentityStoreDefinitionWrapper(idStoreDefinition);
+
+        assertFalse(wrapper.getUseFor().contains(ValidationType.PROVIDE_GROUPS));
+        assertTrue(wrapper.getUseFor().contains(ValidationType.VALIDATE));
+    }
+
+    @Test
+    public void useFor_EL_String() {
+        /*
+         * Override the useFor with the useForExpression setting.
+         */
+        Map<String, Object> overrides = new HashMap<String, Object>();
+        overrides.put("useForExpression", "#{'VALIDATE'}");
 
         LdapIdentityStoreDefinition idStoreDefinition = getInstanceofAnnotation(overrides);
         LdapIdentityStoreDefinitionWrapper wrapper = new LdapIdentityStoreDefinitionWrapper(idStoreDefinition);


### PR DESCRIPTION
In LdapIdentityStoreDefinition, useForExpression = "#{'VALIDATE'}" was causing an NPE because we were mishandling the case where useForExpression evaluates to a string with only one of validate OR provide_groups. This fix will allow EL expressions in useForExpression to provide only one of validate/provide_groups.