### PR TITLE
Update Health Center message in logging FAT

### DIFF
--- a/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/HealthCenterTest.java
+++ b/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/HealthCenterTest.java
@@ -53,7 +53,7 @@ public class HealthCenterTest {
     @Test
     public void testHealthCenterInfo() throws Exception {
         Assert.assertFalse("Expected healthcenter INFO message",
-                           server.findStringsInLogs("^INFO:.*com\\.ibm\\.java\\.diagnostics\\.healthcenter\\.agent\\.iiop\\.port",
+                           server.findStringsInLogs("INFO:.*Health Center agent started on port",
                                                     server.getConsoleLogFile()).isEmpty());
     }
 


### PR DESCRIPTION
fixes #23215
- The Health Center IIOP message (`INFO: IIOP will be listening on the next available system assigned port. Use com.ibm.java.diagnostics.healthcenter.agent.iiop.port to specify a port`) that we used to test the Health Center in the logging FAT does not appear in Java 11 for z/OS. 
- Replaced the message to look for in the test cases with a more generic message (`INFO: Health Center agent started on port`)