### PR TITLE
Update OIDC FATs to account for behavior in beta mode

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.1/publish/files/serversettings/oauthProvider_1.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/publish/files/serversettings/oauthProvider_1.xml
@@ -15,7 +15,9 @@
 		scope="myScopeSample"
 		jwkEnabled="${oidcJWKEnabled}"
 		signatureAlgorithm="${oidcSignAlg}"
+		issuerIdentifier="http://localhost:${bvt.prop.security_1_HTTP_default}/oidc/endpoint/OidcConfigSample"
 		oauthProviderRef="OAuthConfigSample" />
+	<!-- TODO: remove issuerIdentifier when back-channel logout beta is removed -->
 
 	<oauthProvider
 		id="OAuthConfigSample"


### PR DESCRIPTION
The OIDC back-channel logout support is still currently in beta mode. Back-channel logout tokens that are created based on the ID token provided in the end_session request in some FATs will have an "iss" claim value that will not match the expected issuer. The ID tokens are created with "http://localhost:8910/oidc/endpoint/OidcConfigSample" as the issuer (HTTP), but the logout token creation code expects the issuer to be "https://localhost:8920/oidc/endpoint/OidcConfigSample" (with HTTPS). This updates the code so the issuer will always be the HTTP version, making the GA and beta versions of the tests happy.

Beta mode also currently creates a WASOidcSession cookie for OIDC clients as part of the back-channel logout support. That cookie happens to be left around until the client performs a logout, which only some tests in this bucket do. So in the beta run of some tests, there will be an extra WASOidcSession cookie at the end of the login flow that isn't there in the GA version of the product.

Similar changes delivered here as in #23106 and #23108