### PR TITLE
Update to Yasson 1.0.11 and 3.0.2

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2659,12 +2659,17 @@
     <dependency>
       <groupId>org.eclipse</groupId>
       <artifactId>yasson</artifactId>
+      <version>1.0.11</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse</groupId>
+      <artifactId>yasson</artifactId>
       <version>2.0.4</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse</groupId>
       <artifactId>yasson</artifactId>
-      <version>3.0.0</version>
+      <version>3.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.ehcache</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -527,8 +527,9 @@ org.eclipse.transformer:org.eclipse.transformer.bnd.analyzer:0.5.0
 org.eclipse.transformer:org.eclipse.transformer.cli:0.5.0
 org.eclipse.transformer:org.eclipse.transformer.jakarta:0.5.0
 org.eclipse.transformer:org.eclipse.transformer:0.5.0
+org.eclipse:yasson:1.0.11
 org.eclipse:yasson:2.0.4
-org.eclipse:yasson:3.0.0
+org.eclipse:yasson:3.0.2
 org.ehcache:ehcache:3.8.1
 org.ektorp:org.ektorp:1.5.0
 org.fusesource.jansi:jansi:1.18

--- a/dev/cnf/oss_source_dependencies.maven
+++ b/dev/cnf/oss_source_dependencies.maven
@@ -98,7 +98,6 @@ org.eclipse.platform:org.eclipse.equinox.coordinator:1.4.0
 org.eclipse.platform:org.eclipse.equinox.metatype:1.6.0
 org.eclipse.platform:org.eclipse.equinox.region:1.5.100
 org.eclipse.platform:org.eclipse.osgi:3.17.200
-org.eclipse:yasson:1.0.8
 org.jboss.classfilewriter:jboss-classfilewriter:1.2.5.Final
 org.jboss.jdeparser:jdeparser:1.0.0.Final
 org.jboss:jandex:2.4.3.Final

--- a/dev/com.ibm.ws.org.eclipse.yasson.1.0/bnd.bnd
+++ b/dev/com.ibm.ws.org.eclipse.yasson.1.0/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2020 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -8,19 +8,19 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
--include= jar:${fileuri;${repo;org.eclipse:yasson;1.0.8;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
+-include= jar:${fileuri;${repo;org.eclipse:yasson;1.0.11;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
 
 
 instrument.disabled: true
 
 -includeresource: \
-   @${repo;org.eclipse:yasson;1.0.8;EXACT}!/org/eclipse/yasson/*,\
-   @${repo;org.eclipse:yasson;1.0.8;EXACT}!/META-INF/services/javax.json.bind.spi.JsonbProvider,\
+   @${repo;org.eclipse:yasson;1.0.11;EXACT}!/org/eclipse/yasson/*,\
+   @${repo;org.eclipse:yasson;1.0.11;EXACT}!/META-INF/services/javax.json.bind.spi.JsonbProvider,\
    yasson-messages.properties=resources/yasson-messages.properties
 
 -buildpath: \
     com.ibm.websphere.javaee.jsonb.1.0;version=latest,\
-	org.eclipse:yasson;version=1.0.8
+	org.eclipse:yasson;version=1.0.11
 	
 -testpath: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.org.eclipse.yasson.1.0/bnd.overrides
+++ b/dev/com.ibm.ws.org.eclipse.yasson.1.0/bnd.overrides
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2020 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -14,7 +14,7 @@ bVersion=1.0
 Bundle-SymbolicName: com.ibm.ws.org.eclipse.yasson.1.0
 
 Export-Package: \
-  org.eclipse.yasson;version=1.0.8;thread-context=true
+  org.eclipse.yasson;version=1.0.11;thread-context=true
 
 Import-Package: \
   !javax.naming, \

--- a/dev/com.ibm.ws.org.eclipse.yasson.1.0/resources/yasson-messages.properties
+++ b/dev/com.ibm.ws.org.eclipse.yasson.1.0/resources/yasson-messages.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2022 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -50,6 +50,7 @@ dateTypeNotSupported=Date type not supported: {0}
 errorParsingDate=Error parsing {1} from value: {0}. Check your @JsonbDateFormat has all time units for {1} type, \
   or consider using org.eclipse.yasson.YassonConfig#ZERO_TIME_PARSE_DEFAULTING.
 noDefaultConstructor=Cannot create instance of a class: {0}, No default constructor found.
+recordMultipleConstructors=Cannot create instance of a record: {0}, Multiple constructors found.
 offsetDateTimeFromMillis=Parsing {0} from epoch millisecond, UTC zone offset will be used.
 timeToEpochMillisError=Cannot convert {0} to/from epoch milliseconds.
 configPropertyInvalidType=JsonbConfig property [{0}] must be of type [{1}].

--- a/dev/io.openliberty.org.eclipse.yasson.3.0/bnd.bnd
+++ b/dev/io.openliberty.org.eclipse.yasson.3.0/bnd.bnd
@@ -8,19 +8,19 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
--include= jar:${fileuri;${repo;org.eclipse:yasson;3.0.0;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
+-include= jar:${fileuri;${repo;org.eclipse:yasson;3.0.2;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
 
 instrument.disabled: true
 
 -includeresource: \
-   @${repo;org.eclipse:yasson;3.0.0;EXACT}!/org/eclipse/yasson/*,\
-   @${repo;org.eclipse:yasson;3.0.0;EXACT}!/META-INF/versions/*,\
-   @${repo;org.eclipse:yasson;3.0.0;EXACT}!/META-INF/services/jakarta.json.bind.spi.JsonbProvider,\
+   @${repo;org.eclipse:yasson;3.0.2;EXACT}!/org/eclipse/yasson/*,\
+   @${repo;org.eclipse:yasson;3.0.2;EXACT}!/META-INF/versions/*,\
+   @${repo;org.eclipse:yasson;3.0.2;EXACT}!/META-INF/services/jakarta.json.bind.spi.JsonbProvider,\
    yasson-messages.properties=resources/yasson-messages.properties
 
 -buildpath: \
     io.openliberty.jakarta.jsonb.3.0;version=latest,\
-	org.eclipse:yasson;version=3.0.0
+	org.eclipse:yasson;version=3.0.2
 
 -testpath: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \


### PR DESCRIPTION
Updates Liberty to Yasson 1.0.11 and 3.0.2 to stay current with any fixes that have been made.