### PR TITLE
Reverted PR: Command line --timeout option for server stop

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/LaunchArguments.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/LaunchArguments.java
@@ -19,8 +19,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import com.ibm.ws.kernel.boot.internal.BootstrapConstants;
+import com.ibm.ws.kernel.boot.internal.KernelUtils;
 import com.ibm.ws.kernel.productinfo.ProductInfo;
 
 import io.openliberty.checkpoint.spi.CheckpointPhase;
@@ -35,7 +37,8 @@ public class LaunchArguments {
     private static final List<String> KNOWN_OPTIONS = Collections.unmodifiableList(Arrays.asList(new String[] { "archive", "include",
                                                                                                                 "os", "pid", "pid-file",
                                                                                                                 "script", "template", "force",
-                                                                                                                "target", "no-password", "server-root" }));
+                                                                                                                "target", "no-password", "server-root",
+                                                                                                                "timeout" }));
 
     /**
      * Script argument: set by both batch and shell scripts to record the
@@ -198,6 +201,8 @@ public class LaunchArguments {
                         }
                     } else if (isClient && argToLower.equals("--autoacceptsigner")) {
                         initProps.put(BootstrapConstants.AUTO_ACCEPT_SIGNER, "true");
+						
+					  // options with a value.  (option=value)	
                     } else {
                         int index = arg.indexOf('=');
                         String value = "";
@@ -213,7 +218,28 @@ public class LaunchArguments {
                             key = null;
                         }
                         if (KNOWN_OPTIONS.contains(key)) {
+
+                            //  **** T I M E O U T   o p t i o n ****
+                            if (key != null && key.equals("timeout")) {
+                                // --timeout is only valid for the stop command
+                                if ( !action.equals("--stop") ) {
+                                    System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("error.optionNotApplicableToAction"), "--" + key, action));
+                                    returnValue = ReturnCode.BAD_ARGUMENT;
+                                    break;
+                                }
+                                String saveValue = value;
+                                value = KernelUtils.parseDuration(value, TimeUnit.SECONDS);
+
+                                if (!isValidTimeoutValue(value)) {
+                                    System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("error.badOptionValue"), saveValue, "--" + key));
+                                    returnValue = ReturnCode.BAD_ARGUMENT;
+                                    break;
+                                }
+                            }
+
+                            //  **** A L L   o p t i o n s  with a value ****
                             options.put(key, value);
+
                         } else {
 
                             System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("error.unknownArgument"), arg));
@@ -266,6 +292,18 @@ public class LaunchArguments {
         returnCode = setCheckpointPhase(checkpointPhase, returnValue);
         processName = processNameArg;
         actionOption = action;
+    }
+
+    /**
+     * @param timeout
+     */
+    private boolean isValidTimeoutValue(String timeoutString) {
+        try {
+            Integer.parseInt(timeoutString);
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+        return true;
     }
 
     /**
@@ -333,6 +371,31 @@ public class LaunchArguments {
 
     public String getScript() {
         return script;
+    }
+
+    // The timeout is the for whatever action is being processed.
+    // So it might be a start timeout (currently not implemented) or a stop timeout.
+    private int timeoutInSeconds = -1;
+
+    public int getStopTimeout() {
+        return getTimeout(BootstrapConstants.SERVER_STOP_WAIT_TIME_DEFAULT);
+    }
+
+    /**
+     * @param defaultValue
+     * @return Value of --timeout option in seconds if specified. If not specified return the default.
+     */
+    private int getTimeout(String defaultValue) {
+        if (timeoutInSeconds > 0)
+            return timeoutInSeconds;
+
+        timeoutInSeconds = Integer.valueOf(defaultValue);
+
+        String timeoutString = getOption("timeout");
+        if (timeoutString != null) {
+            timeoutInSeconds = Integer.valueOf(timeoutString);
+        }
+        return timeoutInSeconds;
     }
 
 }

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/BootstrapConstants.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/BootstrapConstants.java
@@ -261,8 +261,11 @@ public final class BootstrapConstants {
     /** OSGi property to request clean, boolean value **/
     public static final String OSGI_CLEAN = "osgi.clean";
 
-    /** The number of milliseconds to wait for the server process to start */
+    /** The number of seconds to wait for the server process to start */
     public static final String SERVER_START_WAIT_TIME = "server.start.wait.time";
+
+    /** The DEFAULT number of seconds to wait for the server process to stop */
+    public static final String SERVER_STOP_WAIT_TIME_DEFAULT = "30";
 
     /** The key for the SSL client command-line option "--autoAcceptSigner" **/
     public static final String AUTO_ACCEPT_SIGNER = "autoAcceptSignerCertificate";

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/KernelUtils.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/KernelUtils.java
@@ -18,9 +18,16 @@ import java.net.URL;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.text.MessageFormat;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.boot.LaunchException;
 import com.ibm.ws.kernel.boot.cmdline.Utils;
 
@@ -28,6 +35,129 @@ import com.ibm.ws.kernel.boot.cmdline.Utils;
  * File utilities required by the bootstrapping code.
  */
 public class KernelUtils {
+
+    private static final Map<String, TimeUnit> UNIT_DESCRIPTORS;
+
+    static {
+        HashMap<String, TimeUnit> units = new HashMap<String, TimeUnit>();
+
+        // We used to allow the duration abbreviations to be translated, but
+        // that causes config to be non-portable, so we now recommend that
+        // customers use English abbreviations only.  We hardcode the previously
+        // translated abbreviations for compatibility.  Additional translations
+        // should not be added.
+
+        units.put("d", TimeUnit.DAYS); // en, es, ja, ko, pl, pt_BR, zh
+        units.put("dn\u016f", TimeUnit.DAYS); // cs
+        units.put("g", TimeUnit.DAYS); // it
+        units.put("j", TimeUnit.DAYS); // fr
+        units.put("n", TimeUnit.DAYS); // hu
+        units.put("t", TimeUnit.DAYS); // de
+        units.put("z", TimeUnit.DAYS); // ro
+        units.put("\u0434", TimeUnit.DAYS); // ru
+        units.put("\u5929", TimeUnit.DAYS); // zh_TW
+
+        //units.put("g", TimeUnit.HOURS); // pl - conflicts with DAYS for "it"
+        units.put("h", TimeUnit.HOURS); // en, de, es, fr, it, ja, ko, pt_BR, ro, zh
+        units.put("hod", TimeUnit.HOURS); // cs
+        units.put("\u00f3", TimeUnit.HOURS); // hu
+        units.put("\u0447", TimeUnit.HOURS); // ru
+        units.put("\u5c0f\u6642", TimeUnit.HOURS); // zh_TW
+
+        units.put("m", TimeUnit.MINUTES); // en, de, es, fr, hu, it, ja, ko, pl, pt_BR, ro, zh
+        units.put("min", TimeUnit.MINUTES); // cs
+        units.put("\u043c", TimeUnit.MINUTES); // ru
+        units.put("\u5206", TimeUnit.MINUTES); // zh_TW
+
+        units.put("e", TimeUnit.SECONDS); // pt_BR
+        units.put("mp", TimeUnit.SECONDS); // hu
+        units.put("s", TimeUnit.SECONDS); // en, cs, de, es, fr, it, ja, ko, pl, ro, zh
+        units.put("\u0441", TimeUnit.SECONDS); // ru
+        units.put("\u79d2", TimeUnit.SECONDS); // zh_TW
+
+        units.put("ms", TimeUnit.MILLISECONDS); // en, cs, de, es, fr, hu, it, ja, ko, pl, pt_BR, ro, zh
+        units.put("\u043c\u0441", TimeUnit.MILLISECONDS); // ru
+        units.put("\u6beb\u79d2", TimeUnit.MILLISECONDS); // zh_TW
+
+        UNIT_DESCRIPTORS = Collections.unmodifiableMap(units);
+    }
+
+    private final static Pattern INTERVAL_STRING = Pattern.compile("(\\d+)(\\D+)");
+
+    /**
+     * Parse a duration from the provided 00h00m00s00ms value. Return a string in
+     * the time unit provided.
+     * <p>
+     *
+     * @param duration
+     *            The object retrieved from the configuration property map/dictionary.
+     *
+     * @param units
+     *            The unit of time for the duration value. This is only used when
+     *            converting from a String value.
+     *
+     * @return String in the specified time units if the duration is parsed successfully, otherwise null
+     */
+    @FFDCIgnore(Exception.class)
+    public static String parseDuration(String duration, TimeUnit units) {
+
+        try {
+            return Long.toString(evaluateDuration(duration, units));
+        } catch (Exception e) {
+            // null
+        }
+        return null;
+    }
+
+    /**
+     * Converts a string value representing a unit of time into a Long value.
+     *
+     * @param strVal
+     *            A String representing a unit of time.
+     * @param unit
+     *            The unit of time that the string value should be converted into
+     * @return Long The value of the string in the desired time unit
+     */
+    @FFDCIgnore(NumberFormatException.class)
+    public static Long evaluateDuration(String strVal, TimeUnit endUnit) {
+        // If the value is a number, simply return the numeric value as a long
+        try {
+            return Long.valueOf(strVal);
+        } catch (NumberFormatException ex) {
+            // ignore
+        }
+
+        // Otherwise, parse the duration with unit descriptors.
+        return evaluateDuration(strVal, endUnit, UNIT_DESCRIPTORS);
+    }
+
+    private static Long evaluateDuration(String strVal, TimeUnit endUnit, Map<String, TimeUnit> unitDescriptors) {
+        Matcher m = INTERVAL_STRING.matcher(strVal);
+        long retVal = 0;
+        boolean somethingParsed = false;
+        while (m.find()) {
+            somethingParsed = true;
+            // either of these could throw it's own Illegal argument exception
+            // if one of the component parts is bad.
+            Long numberVal = Long.valueOf(m.group(1));
+            String unitStr = m.group(2);
+            if (unitStr == null) {
+                throw new IllegalArgumentException("Could not parse configuration value as a duration: " + strVal);
+            }
+            TimeUnit sourceUnit = unitDescriptors.get(unitStr.trim().toLowerCase());
+            if (sourceUnit == null) {
+                throw new IllegalArgumentException("Could not parse configuration value as a duration: " + strVal);
+            }
+            retVal += endUnit.convert(numberVal, sourceUnit);
+        }
+
+        if (!somethingParsed) {
+            throw new IllegalArgumentException("Could not parse configuration value as a duration: " + strVal);
+        }
+
+        return retVal;
+    }
+
     /**
      * File representing the launch location.
      *
@@ -78,7 +208,7 @@ public class KernelUtils {
         URL home = source.getLocation();
         if (!home.getProtocol().equals("file"))
             throw new LaunchException("Launch location is not a local file (launch location=" + home
-                            + ")", MessageFormat.format(BootstrapConstants.messages.getString("error.unsupportedLaunch"), home));
+                                      + ")", MessageFormat.format(BootstrapConstants.messages.getString("error.unsupportedLaunch"), home));
         return home;
     }
 
@@ -116,7 +246,7 @@ public class KernelUtils {
      * returning.
      *
      * @param is
-     *               InputStream to read properties from
+     *            InputStream to read properties from
      * @return Properties object; will be empty if InputStream is null or empty.
      * @throws LaunchException
      */
@@ -145,9 +275,9 @@ public class KernelUtils {
 
     /**
      * @param reader
-     *                   Reader from which to read service class names
+     *            Reader from which to read service class names
      * @param limit
-     *                   Maximum number of service classes to find (0 is no limit)
+     *            Maximum number of service classes to find (0 is no limit)
      * @return
      * @throws IOException
      */

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/ServerLock.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/ServerLock.java
@@ -35,8 +35,8 @@ public class ServerLock {
 
     /**
      * @param bootProps
-     *                      {@link BootstrapConfig} containing all established/calculated
-     *                      values for server name and directories.
+     *            {@link BootstrapConfig} containing all established/calculated
+     *            values for server name and directories.
      * @return constructed ServerLock
      */
     public static ServerLock createTestLock(BootstrapConfig bootProps) {
@@ -71,12 +71,12 @@ public class ServerLock {
      * and are writiable.
      *
      * @param bootProps
-     *                      {@link BootstrapConfig} containing all established/calculated
-     *                      values for server name and directories.
+     *            {@link BootstrapConfig} containing all established/calculated
+     *            values for server name and directories.
      * @return constructed ServerLock
      *
      * @throws LaunchException
-     *                             exception thrown if server directories/files are not writable.
+     *             exception thrown if server directories/files are not writable.
      */
     public static ServerLock createServerLock(BootstrapConfig bootProps) {
         String serverName = bootProps.getProcessName();
@@ -221,8 +221,8 @@ public class ServerLock {
      * or multiple instances of a same server within same JVM is not supported.
      *
      * @throws LaunchException
-     *                             exception thrown if there's a problem getting the lock or
-     *                             another instance of this server is running
+     *             exception thrown if there's a problem getting the lock or
+     *             another instance of this server is running
      */
     public synchronized void obtainServerLock() {
 
@@ -245,9 +245,21 @@ public class ServerLock {
     /**
      * Try to obtain server lock
      *
+     * Uses default timeout which was originally based on polling interval and max polling attempts in milliseconds.
+     *
      * @return true if server lock was obtained (!null & valid)
      */
     private synchronized boolean getServerLock() {
+        return getServerLock((int) (BootstrapConstants.POLL_INTERVAL_MS * BootstrapConstants.MAX_POLL_ATTEMPTS) / 1000);
+    }
+
+    /**
+     * Try to obtain server lock
+     *
+     * @param timeout value in seconds
+     * @return true if server lock was obtained (!null & valid)
+     */
+    private synchronized boolean getServerLock(int timeout) {
 
         Boolean fileExists = Boolean.FALSE;
         final File sDir = lockFile;
@@ -266,20 +278,38 @@ public class ServerLock {
             fos = new FileOutputStream(lockFile);
             fc = fos.getChannel();
 
+            final long timeoutMillis = timeout * 1000;
+            final long startTime = System.currentTimeMillis();
+            final long expireTime = startTime + timeoutMillis;
+
+            // If we immediately try to get the lock, it seems to always be unavailable.  After
+            // a failed attempt at getting the lock, we sleep for 500ms.  That's pretty much
+            // the same thing as sleeping for 500ms and then trying to get the lock.  So this
+            // smaller delay is added, which will normally allow us to get the lock on the 1st try.
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                //
+            }
             // Try for a short period of time to obtain the lock
             // (if status mechanisms temporarily grab the file, we want to wait
             // to try to grab it.. )
-            for (int i = 0; i < BootstrapConstants.MAX_POLL_ATTEMPTS; i++) {
+           do {
                 serverLock = fc.tryLock();
-                if (serverLock != null) {
+               if (serverLock != null) {
                     break;
                 } else {
                     try {
+                        long timeNow = System.currentTimeMillis();
+                         if ((timeNow) > expireTime) {
+                            break;
+                        }
                         Thread.sleep(BootstrapConstants.POLL_INTERVAL_MS);
                     } catch (InterruptedException e) {
                     }
                 }
-            }
+            } while (true);
+
         } catch (OverlappingFileLockException e) {
             // If we encounter an exception obtaining the lock, we can try
             // try closing the the relevant streams (channel first)
@@ -371,14 +401,31 @@ public class ServerLock {
      * <p>
      * This is a separate process using the attach API to stop the server.
      *
-     * @return {@link ReturnCode#OK} if server lock file can be obtained within
-     *         3 seconds (see {@link #getServerLock()}, will otherwise
+     * @return {@link ReturnCode#OK} if server lock file can be obtained within the
+     *         DEFAULT timeout period (see {@link #getServerLock()}, will otherwise
      *         return {@link ReturnCode#ERROR_SERVER_STOP}
      */
     public synchronized ReturnCode waitForStop() {
+        return waitForStop(Integer.valueOf(BootstrapConstants.SERVER_STOP_WAIT_TIME_DEFAULT));
 
-        // if the lock is null or is invalid, the lock could not be obtained within the timeout
-        if (!getServerLock()) {
+    }
+
+    /**
+     * Wait until the server lock file can be obtained: Used when stopping
+     * the server to wait until the server has terminated.
+     * <p>
+     * This is a separate process using the attach API to stop the server.
+     *
+     * @param timeOut value in milliseconds.
+     * @return {@link ReturnCode#OK} if server lock file can be obtained within
+     *         timeout period (see {@link #getServerLock()}, will otherwise
+     *         return {@link ReturnCode#ERROR_SERVER_STOP}
+     * @return
+     */
+    public synchronized ReturnCode waitForStop(int timeOut) {
+
+        // if the lock is null or is invalid, the lock could not be obtained within the time out
+        if (!getServerLock(timeOut)) {
             serverLock = null;
             lockFileChannel = null;
             System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("error.stopServerError"),

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ProcessControlHelper.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ProcessControlHelper.java
@@ -110,16 +110,18 @@ public class ProcessControlHelper {
             stopRc = ReturnCode.REDUNDANT_ACTION_STATUS;
         }
 
+        int timeout = launchArgs.getStopTimeout();
+
         // If the lock file existed before we attempted to stop the server,
         // wait until we can obtain the server lock file (because the server process has stopped)
         if (stopRc == ReturnCode.OK && lockExists) {
-            stopRc = serverLock.waitForStop();
+            stopRc = serverLock.waitForStop(timeout);
         }
 
         if (stopRc == ReturnCode.OK) {
             String pid = getPID();
             if (pid != null) {
-                stopRc = waitForProcessStop(pid);
+                stopRc = waitForProcessStop(pid, timeout);
             }
         }
 
@@ -136,22 +138,30 @@ public class ProcessControlHelper {
         return stopRc;
     }
 
-    private ReturnCode waitForProcessStop(String pid) {
+    private ReturnCode waitForProcessStop(String pid, int timeout) {
         ProcessStatus ps = new PSProcessStatusImpl(pid);
 
-        for (int i = 0; i < BootstrapConstants.MAX_POLL_ATTEMPTS; i++) {
+        final long timeoutMillis = timeout * 1000;
+        final long startTime = System.currentTimeMillis();
+        final long expireTime = startTime + timeoutMillis;
+
+        do {
             try {
                 State processRunning = ps.isPossiblyRunning();
                 if ((processRunning == State.NO) || (processRunning == State.UNDETERMINED)) {
                     return ReturnCode.OK;
                 }
 
+                long timeNow = System.currentTimeMillis();
+                if ((timeNow) > expireTime) {
+                    break;
+                }
                 Thread.sleep(BootstrapConstants.POLL_INTERVAL_MS);
             } catch (Exception e) {
                 Debug.printStackTrace(e);
                 break;
             }
-        }
+        } while (true);
 
         return ReturnCode.ERROR_SERVER_STOP;
     }

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ServerHelpActions.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ServerHelpActions.java
@@ -28,7 +28,7 @@ public class ServerHelpActions implements HelpActions {
         startCmd(Category.lifecycle, "clean"),
         startWinServiceCmd(Category.win),
         statusCmd(Category.lifecycle),
-        stopCmd(Category.lifecycle, "force"),
+        stopCmd(Category.lifecycle, "force", "timeout"),
         stopWinServiceCmd(Category.win),
         unregisterWinServiceCmd(Category.win),
         versionCmd(Category.help);

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -128,7 +128,7 @@ error.kernelDefFile=CWWKE0023E: The specified kernel definition ({0}) does not e
 error.kernelDefFile.explanation=The specified kernel definition could not be found.
 error.kernelDefFile.useraction=Ensure that the kernel definition resource exists and can be read by the current user.
 
-error.badOptionValue=CWWKE0024E: The value ({0}) for the option ({1}) is not valid.
+error.badOptionValue=CWWKE0024E: The ({0}) value for the ({1}) option  is not valid.
 error.badOptionValue.explanation=The specified value is not appropriate for the specified option.
 error.badOptionValue.useraction=Try using the command (server help) for a description of the options.  If the value is a number, ensure it is in the valid range.
 

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -128,6 +128,10 @@ error.kernelDefFile=CWWKE0023E: The specified kernel definition ({0}) does not e
 error.kernelDefFile.explanation=The specified kernel definition could not be found.
 error.kernelDefFile.useraction=Ensure that the kernel definition resource exists and can be read by the current user.
 
+error.badOptionValue=CWWKE0024E: The value ({0}) for the option ({1}) is not valid.
+error.badOptionValue.explanation=The specified value is not appropriate for the specified option.
+error.badOptionValue.useraction=Try using the command (server help) for a description of the options.  If the value is a number, ensure it is in the valid range.
+
 error.specifiedLocation=CWWKE0025E: The value of {0} must refer to a directory. The specified value \
  references an existing file resource. Value: {1}
 error.specifiedLocation.explanation=The supplied location refers to an existing file instead of a directory.
@@ -141,6 +145,11 @@ warning.singleServer=CWWKE0027W: Only one server may be specified on the command
   subsequent names will be ignored (server={0}, ignored={1}).
 warning.singleServer.explanation=You may specify only one server on the command line. The first server name has been processed; the remaining names have been ignored.
 warning.singleServer.useraction=No action is required. Specify only one server to avoid this warning.
+
+error.optionNotApplicableToAction=CWWKE0028E: The option ({0}) is not applicable for action ({1}).
+error.optionNotApplicableToAction.explanation=The specified option is not allowed for the specified action.
+# Translate the word action in the command.  Enclose in < >.  User is to substitute the appropriate action, like "start", "stop", etc...
+error.optionNotApplicableToAction.useraction=Try using the command (server <action> help) for valid options.
   
 error.serverAlreadyRunning=CWWKE0029E: An instance of server {0} is already running.
 error.serverAlreadyRunning.explanation=You are trying to start a server that is already running.
@@ -710,7 +719,7 @@ warning.earlyRelease=CWWKE0953W: This version of {0} is an unsupported early rel
 warning.earlyRelease.explanation=New features that are not fully tested are made available in early releases to elicit feedback before they are included in a supported release.
 warning.earlyRelease.useraction=Do not use an early release version on production systems, since early release versions are not supported.
 
-error.invalidPhaseName=CWWKE0954E: The "{0}" checkpoint phase specified is empty or unknown.
+error.invalidPhaseName=CWWKE0954E: The ({0}) checkpoint phase specified is empty or unknown.
 error.invalidPhaseName.explanation=An unknown phase was specified as the value of the checkpoint option.
 error.invalidPhaseName.useraction=Review the documentation to determine valid phase names. Reissue the command using a valid checkpoint phase.
 

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -148,7 +148,6 @@ warning.singleServer.useraction=No action is required. Specify only one server t
 
 error.optionNotApplicableToAction=CWWKE0028E: The ({0}) option is not applicable for the ({1}) action.
 error.optionNotApplicableToAction.explanation=The specified option is not allowed for the specified action.
-# Translate the word action in the command.  Enclose in < >.  User is to substitute the appropriate action, like "start", "stop", etc...
 error.optionNotApplicableToAction.useraction=Run the `server <action> help` command  to get information about valid options for the action.
   
 error.serverAlreadyRunning=CWWKE0029E: An instance of server {0} is already running.

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -130,7 +130,7 @@ error.kernelDefFile.useraction=Ensure that the kernel definition resource exists
 
 error.badOptionValue=CWWKE0024E: The ({0}) value for the ({1}) option  is not valid.
 error.badOptionValue.explanation=The specified value is not appropriate for the specified option.
-error.badOptionValue.useraction=Try using the command (server help) for a description of the options.  If the value is a number, ensure it is in the valid range.
+error.badOptionValue.useraction=Run the `server help` command for a description of the options.  If the value is a number, ensure it is in the valid range.
 
 error.specifiedLocation=CWWKE0025E: The value of {0} must refer to a directory. The specified value \
  references an existing file resource. Value: {1}

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -146,7 +146,7 @@ warning.singleServer=CWWKE0027W: Only one server may be specified on the command
 warning.singleServer.explanation=You may specify only one server on the command line. The first server name has been processed; the remaining names have been ignored.
 warning.singleServer.useraction=No action is required. Specify only one server to avoid this warning.
 
-error.optionNotApplicableToAction=CWWKE0028E: The option ({0}) is not applicable for action ({1}).
+error.optionNotApplicableToAction=CWWKE0028E: The ({0}) option is not applicable for the ({1}) action.
 error.optionNotApplicableToAction.explanation=The specified option is not allowed for the specified action.
 # Translate the word action in the command.  Enclose in < >.  User is to substitute the appropriate action, like "start", "stop", etc...
 error.optionNotApplicableToAction.useraction=Run the `server <action> help` command  to get information about valid options for the action.

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -149,7 +149,7 @@ warning.singleServer.useraction=No action is required. Specify only one server t
 error.optionNotApplicableToAction=CWWKE0028E: The option ({0}) is not applicable for action ({1}).
 error.optionNotApplicableToAction.explanation=The specified option is not allowed for the specified action.
 # Translate the word action in the command.  Enclose in < >.  User is to substitute the appropriate action, like "start", "stop", etc...
-error.optionNotApplicableToAction.useraction=Try using the command (server <action> help) for valid options.
+error.optionNotApplicableToAction.useraction=Run the `server <action> help` command  to get information about valid options for the action.
   
 error.serverAlreadyRunning=CWWKE0029E: An instance of server {0} is already running.
 error.serverAlreadyRunning.explanation=You are trying to start a server that is already running.

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -719,7 +719,7 @@ warning.earlyRelease=CWWKE0953W: This version of {0} is an unsupported early rel
 warning.earlyRelease.explanation=New features that are not fully tested are made available in early releases to elicit feedback before they are included in a supported release.
 warning.earlyRelease.useraction=Do not use an early release version on production systems, since early release versions are not supported.
 
-error.invalidPhaseName=CWWKE0954E: The ({0}) checkpoint phase specified is empty or unknown.
+error.invalidPhaseName=CWWKE0954E: The specified ({0}) checkpoint phase is empty or unknown.
 error.invalidPhaseName.explanation=An unknown phase was specified as the value of the checkpoint option.
 error.invalidPhaseName.useraction=Review the documentation to determine valid phase names. Reissue the command using a valid checkpoint phase.
 

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherOptions.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherOptions.nlsprops
@@ -251,3 +251,11 @@ option-desc.stop.force=\
 \teffect if server stop was already invoked. If you use the --force    \n\
 \toption, you might see unexpected exceptions in the messages.log file \n\
 \tthat occur after the server stop command was received by the server.
+#------------------------------\n at 72 chars -- leading tab-----------\n\#
+option-key.timeout=\
+\ \ \ \ --timeout
+option-desc.stop.timeout=\
+\tAmount of time to allow for the server to stop before giving up.     \n\
+\tSpecify a positive integer followed by a unit of time, which can be  \n\
+\tminutes (m), or seconds (s). For example, specify 5 minutes as 5m or \n\
+\t300s.

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/FATSuite.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/FATSuite.java
@@ -49,6 +49,7 @@ import com.ibm.wsspi.kernel.embeddable.EmbeddedServerTest;
                 KernelChangeTest.class,
                 ServerEnvTest.class,
                 ServerStartTest.class,
+                ServerStopTest.class,
                 ServerStartAsServiceTest.class,
                 ShutdownTest.class,
                 ServerCommandPortTest.class,

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerStopTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerStopTest.java
@@ -1,0 +1,223 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.kernel.boot;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ProgramOutput;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
+
+/**
+ * This test bucket tests the server stop command with options.
+ */
+@RunWith(FATRunner.class)
+public class ServerStopTest {
+    private static final Class<?> c = ServerStopTest.class;
+
+    private static final String SERVER_NAME = "com.ibm.ws.kernel.boot.serverstart.fat";
+    private static final String OS = System.getProperty("os.name").toLowerCase();
+
+    private static LibertyServer server;
+
+    @Rule
+    public TestName testName = new TestName();
+
+    @Before
+    public void before() {
+        server = LibertyServerFactory.getLibertyServer(SERVER_NAME);
+    }
+
+    @After
+    public void after() throws Exception {
+        if (server.isStarted()) {
+            stopServer();
+        }
+    }
+
+    /**
+     * Test - Normal case. No options Should work.
+     */
+    @Test
+    public void testServerStop() throws Exception {
+        final String METHOD_NAME = "testServerStop";
+        Log.entering(c, METHOD_NAME);
+
+        startAndStopServer("", "CWWKE0036I", MESSAGES); // CWWKE0036I: The server <SERVER NAME> stopped after ...
+
+        Log.exiting(c, METHOD_NAME);
+    }
+
+    /**
+     * Test - Normal case, with valid --timeout option. Should work.
+     */
+    @Test
+    public void testServerStopWithTimeout_GoodArg() throws Exception {
+        final String METHOD_NAME = "testServerStopWithTimeout_GoodArg";
+        Log.entering(c, METHOD_NAME);
+
+        startAndStopServer("--timeout=60", "CWWKE0036I", MESSAGES); // CWWKE0036I: The server <SERVER NAME> stopped after ...
+
+        Log.exiting(c, METHOD_NAME);
+    }
+
+    /**
+     * Test - Provide bad argument to --timeout option. Expect failure.
+     */
+    @Test
+    public void testServerStopWithTimeout_BadArg() throws Exception {
+        final String METHOD_NAME = "testServerStopWithTimeout_BadArg";
+        Log.entering(c, METHOD_NAME);
+        if (OS.contains("win")) {
+            return;
+        }
+        startAndStopServer("--timeout=garbage", "CWWKE0024E", STDOUT);
+
+        Log.exiting(c, METHOD_NAME);
+    }
+
+    /**
+     * Test - --timeout option on the start command.
+     * That should fail, since --timeout is only supported for stop.
+     */
+    @Test
+    public void testServerStartWithTimeoutArg() throws Exception {
+        final String METHOD_NAME = "testServerStartWithTimeoutArg";
+        Log.entering(c, METHOD_NAME);
+
+        //------------------//
+        //  SERVER START    //
+        //------------------//
+        // Execute the server start command and display stdout and stderr
+        String executionDir = server.getInstallRoot() + File.separator + "bin";
+        String command = "." + File.separator + "server";
+        String[] parms = new String[3];
+        parms[0] = "start";
+        parms[1] = SERVER_NAME;
+        parms[2] = "--timeout=120s";
+        ProgramOutput po = server.getMachine().execute(command, parms, executionDir);
+        String standardOutput = po.getStdout();
+        Log.info(c, METHOD_NAME, "server start stdout = " + po.getStdout());
+        Log.info(c, METHOD_NAME, "server start stderr = " + po.getStderr());
+
+        assertTrue("sever start expected to fail, but didn't. Message [ CWWKE0028E ] not found in [" + STDOUT + "]",
+                   standardOutput.contains("CWWKE0028E"));
+        Log.info(c, METHOD_NAME, "PASSED");
+
+        Log.exiting(c, METHOD_NAME);
+    }
+
+    static final String STDOUT = "stdout";
+    static final String MESSAGES = "messages.log";
+
+    /**
+     *
+     * @param option
+     * @param expectedOutput
+     * @param where - where to search output. "stdout" or "messages.log"
+     * @throws Exception
+     */
+    public void startAndStopServer(String option, String expectedOutput, String where) throws Exception {
+        final String METHOD_NAME = "startAndStopServer[" + option + ", " + expectedOutput + "]";
+        Log.entering(c, METHOD_NAME);
+        Log.info(c, METHOD_NAME, "option [" + option + "]");
+        Log.info(c, METHOD_NAME, "expectedOutput [" + expectedOutput + "]");
+
+        //------------------//
+        //  SERVER START    //
+        //------------------//
+        // Execute the server start command and display stdout and stderr
+        String executionDir = server.getInstallRoot() + File.separator + "bin";
+        String command = "." + File.separator + "server";
+        String[] parms = new String[2];
+        parms[0] = "start";
+        parms[1] = SERVER_NAME;
+        ProgramOutput po = server.getMachine().execute(command, parms, executionDir);
+        Log.info(c, METHOD_NAME, "server start stdout = " + po.getStdout());
+        Log.info(c, METHOD_NAME, "server start stderr = " + po.getStderr());
+
+        // Check for server ready
+        String serverReady = server.waitForStringInLog("CWWKE0002I");
+        if (serverReady == null) {
+            //Log.info(c, METHOD_NAME, "Timed out waiting for server ready message, CWWKF0011I");
+            Log.info(c, METHOD_NAME, "'The kernel started after' message, CWWKF0011I");
+        }
+
+        // Because we didn't start the server using the LibertyServer APIs, we need
+        // to have it detect its started state so it will stop and save logs properly
+        server.resetStarted();
+        assertTrue("the server should have been started", server.isStarted());
+
+        //------------------//
+        //  SERVER STOP     //
+        //------------------//
+        // Execute the server stop command and display stdout and stderr
+        executionDir = server.getInstallRoot() + File.separator + "bin";
+        command = "." + File.separator + "server";
+        parms = new String[3];
+        parms[0] = "stop";
+        parms[1] = SERVER_NAME;
+        parms[2] = option; // for example "--timeout=30"
+        po = server.getMachine().execute(command, parms, executionDir);
+        String standardOutput = po.getStdout();
+        Log.info(c, METHOD_NAME, "server stop stdout = " + standardOutput);
+        Log.info(c, METHOD_NAME, "server stop stderr = " + po.getStderr());
+
+        // Check for expected output
+        if (where.equals(STDOUT)) {
+            assertTrue("sever stop expected to fail, but didn't. Message [ " + expectedOutput + " ] not found in [" + STDOUT + "]",
+                       standardOutput.contains(expectedOutput));
+            Log.info(c, METHOD_NAME, "PASSED");
+
+        } else {
+            String serverStopped = server.waitForStringInLog(expectedOutput);
+            assertNotNull("Timed out waiting for message, [ " + expectedOutput + " ]",
+                          serverStopped);
+            Log.info(c, METHOD_NAME, "PASSED");
+        }
+
+        Log.exiting(c, METHOD_NAME);
+    }
+
+    public void stopServer() throws Exception {
+        final String METHOD_NAME = "startAndStopServer";
+        Log.entering(c, METHOD_NAME);
+
+        //------------------//
+        //  SERVER STOP     //
+        //------------------//
+        // Execute the server stop command and display stdout and stderr
+        String executionDir = server.getInstallRoot() + File.separator + "bin";
+        String command = "." + File.separator + "server";
+        String[] parms = new String[2];
+        parms[0] = "stop";
+        parms[1] = SERVER_NAME;
+        ProgramOutput po = server.getMachine().execute(command, parms, executionDir);
+        String standardOutput = po.getStdout();
+        Log.info(c, METHOD_NAME, "server stop stdout = " + standardOutput);
+        Log.info(c, METHOD_NAME, "server stop stderr = " + po.getStderr());
+
+        Log.exiting(c, METHOD_NAME);
+    }
+}

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/wsspi/kernel/service/utils/MetatypeUtils.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/wsspi/kernel/service/utils/MetatypeUtils.java
@@ -12,17 +12,13 @@ package com.ibm.wsspi.kernel.service.utils;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.kernel.boot.internal.KernelUtils;
 
 /**
  * Utility class to simplify retrieving values from injected config.
@@ -40,53 +36,6 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 public class MetatypeUtils {
     static final TraceComponent tc = Tr.register(MetatypeUtils.class);
 
-    private static final Map<String, TimeUnit> UNIT_DESCRIPTORS;
-    static {
-        HashMap<String, TimeUnit> units = new HashMap<String, TimeUnit>();
-
-        // We used to allow the duration abbreviations to be translated, but
-        // that causes config to be non-portable, so we now recommend that
-        // customers use English abbreviations only.  We hardcode the previously
-        // translated abbreviations for compatibility.  Additional translations
-        // should not be added.
-
-        units.put("d", TimeUnit.DAYS); // en, es, ja, ko, pl, pt_BR, zh
-        units.put("dn\u016f", TimeUnit.DAYS); // cs
-        units.put("g", TimeUnit.DAYS); // it
-        units.put("j", TimeUnit.DAYS); // fr
-        units.put("n", TimeUnit.DAYS); // hu
-        units.put("t", TimeUnit.DAYS); // de
-        units.put("z", TimeUnit.DAYS); // ro
-        units.put("\u0434", TimeUnit.DAYS); // ru
-        units.put("\u5929", TimeUnit.DAYS); // zh_TW
-
-        //units.put("g", TimeUnit.HOURS); // pl - conflicts with DAYS for "it"
-        units.put("h", TimeUnit.HOURS); // en, de, es, fr, it, ja, ko, pt_BR, ro, zh
-        units.put("hod", TimeUnit.HOURS); // cs
-        units.put("\u00f3", TimeUnit.HOURS); // hu
-        units.put("\u0447", TimeUnit.HOURS); // ru
-        units.put("\u5c0f\u6642", TimeUnit.HOURS); // zh_TW
-
-        units.put("m", TimeUnit.MINUTES); // en, de, es, fr, hu, it, ja, ko, pl, pt_BR, ro, zh
-        units.put("min", TimeUnit.MINUTES); // cs
-        units.put("\u043c", TimeUnit.MINUTES); // ru
-        units.put("\u5206", TimeUnit.MINUTES); // zh_TW
-
-        units.put("e", TimeUnit.SECONDS); // pt_BR
-        units.put("mp", TimeUnit.SECONDS); // hu
-        units.put("s", TimeUnit.SECONDS); // en, cs, de, es, fr, it, ja, ko, pl, ro, zh
-        units.put("\u0441", TimeUnit.SECONDS); // ru
-        units.put("\u79d2", TimeUnit.SECONDS); // zh_TW
-
-        units.put("ms", TimeUnit.MILLISECONDS); // en, cs, de, es, fr, hu, it, ja, ko, pl, pt_BR, ro, zh
-        units.put("\u043c\u0441", TimeUnit.MILLISECONDS); // ru
-        units.put("\u6beb\u79d2", TimeUnit.MILLISECONDS); // zh_TW
-
-        UNIT_DESCRIPTORS = Collections.unmodifiableMap(units);
-    }
-
-    private final static Pattern INTERVAL_STRING = Pattern.compile("(\\d+)(\\D+)");
-
     /**
      * Parse a boolean from the provided config value: checks for whether or not
      * the object read from the Service/Component configuration is a String
@@ -96,7 +45,7 @@ public class MetatypeUtils {
      * A translated warning message will be issued using the provided propertyKey and object
      * as parameters. FFDC for the exception is suppressed: Callers should handle the thrown
      * IllegalArgumentException as appropriate.
-     * 
+     *
      * @param configAlias
      *            Name of config (pid or alias) associated with a registered service
      *            or DS component.
@@ -105,7 +54,7 @@ public class MetatypeUtils {
      *            Used in the warning message if the value is badly formed.
      * @param obj
      *            The object retrieved from the configuration property map/dictionary.
-     * 
+     *
      * @return boolean parsed from obj, the default value if obj is null.
      * @throws IllegalArgumentException If value is not a String/Boolean, or if the String
      *             boolean is not "true" or "false" (ignoring case)
@@ -142,7 +91,7 @@ public class MetatypeUtils {
      * A translated warning message will be issued using the provided propertyKey and object
      * as parameters. FFDC for the exception is suppressed: Callers should handle the thrown
      * IllegalArgumentException as appropriate.
-     * 
+     *
      * @param configAlias
      *            Name of config (pid or alias) associated with a registered service
      *            or DS component.
@@ -195,7 +144,7 @@ public class MetatypeUtils {
      * A translated warning message will be issued using the provided propertyKey and object
      * as parameters. FFDC for the exception is suppressed: Callers should handle the thrown
      * IllegalArgumentException as appropriate.
-     * 
+     *
      * @param configAlias
      *            Name of config (pid or alias) associated with a registered service
      *            or DS component.
@@ -206,7 +155,7 @@ public class MetatypeUtils {
      *            The object retrieved from the configuration property map/dictionary.
      * @param defaultValue
      *            The default value that should be applied if the object is null.
-     * 
+     *
      * @return Collection of strings parsed/retrieved from obj, or default value if obj is null
      * @throws IllegalArgumentException If value is not a String, String collection, or String array, or if an error
      *             occurs while converting/casting the object to the return parameter type.
@@ -247,7 +196,7 @@ public class MetatypeUtils {
      * A translated warning message will be issued using the provided propertyKey and object
      * as parameters. FFDC for the exception is suppressed: Callers should handle the thrown
      * IllegalArgumentException as appropriate.
-     * 
+     *
      * @param configAlias
      *            Name of config (pid or alias) associated with a registered service
      *            or DS component.
@@ -258,7 +207,7 @@ public class MetatypeUtils {
      *            The object retrieved from the configuration property map/dictionary.
      * @param defaultValue
      *            The default value that should be applied if the object is null.
-     * 
+     *
      * @return Long parsed/retrieved from obj, or default value if obj is null
      * @throws IllegalArgumentException If value is not a String/Short/Integer/Long, or if an error
      *             occurs while converting/casting the object to the return parameter type.
@@ -297,7 +246,7 @@ public class MetatypeUtils {
      * A translated warning message will be issued using the provided propertyKey and object
      * as parameters. FFDC for the exception is suppressed: Callers should handle the thrown
      * IllegalArgumentException as appropriate.
-     * 
+     *
      * @param configAlias
      *            Name of config (pid or alias) associated with a registered service
      *            or DS component.
@@ -308,7 +257,7 @@ public class MetatypeUtils {
      *            The object retrieved from the configuration property map/dictionary.
      * @param defaultValue
      *            The default value that should be applied if the object is null.
-     * 
+     *
      * @return Integer parsed/retrieved from obj, or default value if obj is null
      * @throws IllegalArgumentException If value is not a String/Short/Integer/Long, or if an error
      *             occurs while converting/casting the object to the return parameter type.
@@ -347,7 +296,7 @@ public class MetatypeUtils {
      * A translated warning message will be issued using the provided propertyKey and object
      * as parameters. FFDC for the exception is suppressed: Callers should handle the thrown
      * IllegalArgumentException as appropriate.
-     * 
+     *
      * @param configAlias
      *            Name of config (pid or alias) associated with a registered service
      *            or DS component.
@@ -414,7 +363,7 @@ public class MetatypeUtils {
      * A translated warning message will be issued using the provided propertyKey and object
      * as parameters. FFDC for the exception is suppressed: Callers should handle the thrown
      * IllegalArgumentException as appropriate.
-     * 
+     *
      * @param configAlias
      *            Name of config (pid or alias) associated with a registered service
      *            or DS component.
@@ -425,7 +374,7 @@ public class MetatypeUtils {
      *            The object retrieved from the configuration property map/dictionary.
      * @param defaultValue
      *            The default value that should be applied if the object is null.
-     * 
+     *
      * @return Long parsed/retrieved from obj, or default value if obj is null
      * @throws IllegalArgumentException If value is not a Long, or if an error
      *             occurs while converting/casting the object to the return parameter type.
@@ -443,7 +392,7 @@ public class MetatypeUtils {
      * A translated warning message will be issued using the provided propertyKey and object
      * as parameters. FFDC for the exception is suppressed: Callers should handle the thrown
      * IllegalArgumentException as appropriate.
-     * 
+     *
      * @param configAlias
      *            Name of config (pid or alias) associated with a registered service
      *            or DS component.
@@ -457,7 +406,7 @@ public class MetatypeUtils {
      * @param units
      *            The unit of time for the duration value. This is only used when
      *            converting from a String value.
-     * 
+     *
      * @return Long parsed/retrieved from obj, or default value if obj is null
      * @throws IllegalArgumentException If value is not a String/Short/Integer/Long, or if an error
      *             occurs while converting/casting the object to the return parameter type.
@@ -467,7 +416,7 @@ public class MetatypeUtils {
         if (obj != null) {
             try {
                 if (obj instanceof String)
-                    return evaluateDuration((String) obj, units);
+                    return KernelUtils.evaluateDuration((String) obj, units);
                 else if (obj instanceof Long)
                     return (Long) obj;
             } catch (Exception e) {
@@ -485,58 +434,22 @@ public class MetatypeUtils {
 
     /**
      * Converts a string value representing a unit of time into a Long value.
-     * 
+     *
      * @param strVal
      *            A String representing a unit of time.
-     * @param unit
-     *            The unit of time that the string value should be converted into
+     * @param endUnit
+     *            The unit of time into which the string value should be converted.
      * @return Long The value of the string in the desired time unit
      */
-    @FFDCIgnore(NumberFormatException.class)
     public static Long evaluateDuration(String strVal, TimeUnit endUnit) {
-        // If the value is a number, simply return the numeric value as a long
-        try {
-            return Long.valueOf(strVal);
-        } catch (NumberFormatException ex) {
-            // ignore
-        }
-
-        // Otherwise, parse the duration with unit descriptors.
-        return evaluateDuration(strVal, endUnit, UNIT_DESCRIPTORS);
-    }
-
-    private static Long evaluateDuration(String strVal, TimeUnit endUnit, Map<String, TimeUnit> unitDescriptors) {
-        Matcher m = INTERVAL_STRING.matcher(strVal);
-        long retVal = 0;
-        boolean somethingParsed = false;
-        while (m.find()) {
-            somethingParsed = true;
-            // either of these could throw it's own Illegal argument exception
-            // if one of the component parts is bad.
-            Long numberVal = Long.valueOf(m.group(1));
-            String unitStr = m.group(2);
-            if (unitStr == null) {
-                throw new IllegalArgumentException("Could not parse configuration value as a duration: " + strVal);
-            }
-            TimeUnit sourceUnit = unitDescriptors.get(unitStr.trim().toLowerCase());
-            if (sourceUnit == null) {
-                throw new IllegalArgumentException("Could not parse configuration value as a duration: " + strVal);
-            }
-            retVal += endUnit.convert(numberVal, sourceUnit);
-        }
-
-        if (!somethingParsed) {
-            throw new IllegalArgumentException("Could not parse configuration value as a duration: " + strVal);
-        }
-
-        return retVal;
+        return KernelUtils.evaluateDuration(strVal, endUnit);
     }
 
     /**
      * Converts a String value into a token value by collapsing whitespace. All whitespace at the beginning and
      * end of the String will be removed, and contiguous sequences of whitespace will be replaced with a single
      * space character.
-     * 
+     *
      * @param strVal
      *            A String to be trimmed
      * @return String The collapsed String

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -4855,6 +4855,9 @@ public class LibertyServer implements LogMonitorClient {
     public RemoteFile getConsoleLogFile() throws Exception {
         // Find the currently configured/in-use console log file.
         final RemoteFile remoteFile;
+        if (consoleAbsPath == null) {
+            return null;
+        }
         if (machineOS == OperatingSystem.ZOS) {
             remoteFile = new RemoteFile(machine, consoleAbsPath, Charset.forName(EBCDIC_CHARSET_NAME));
         } else {


### PR DESCRIPTION
Fixes issue #19924

**New function**
Adds --timeout= option to the ./server stop command.

**Examples:**
```
./server stop --timeout=5     // 5 seconds
./server stop --timeout=5s    // 5 seconds
./server stop --timeout=5m    // 5 minutes
./server stop --timeout=300   // 300 seconds => 5 minutes
```

**Undocumented but valid options:**
```
./server stop --timeout=1000ms  // 1 second
./server stop --timeout=1h      // 1 hour
```

**Invalid**
`./server start --timeout=30          // timeout not supported for anything action other than stop`

**Help**

./server help stop


Usage: ./server stop serverName [options] [JVM options]

	Stop the running instance of the named server.

Options:

    --force
	Skips the quiesce stage before the server is shut down. Normal server
	stop includes a quiesce stage before the server is shut down. The    
	quiesce stage, a period of 30 seconds, allows services to perform    
	pre-shutdown work; for example, inbound listeners are stopped but    
	existing requests are allowed to complete. The --force option has no 
	effect if server stop was already invoked. If you use the --force    
	option, you might see unexpected exceptions in the messages.log file 
	that occur after the server stop command was received by the server.
    --timeout
	Amount of time to allow for the server to stop before giving up.     
	Specify a positive integer followed by a unit of time, which can be  
	minutes (m), or seconds (s). For example, specify 5 minutes as 5m or 
	300s.

**Note:**
The changes to **MetaTypeUtils.java** & **KernelUtils.java** simply move existing methods to avoid a circular dependency.  These methods provide the parsing of the duration syntax 00**h**00**m**00**s**00**ms**



.