### PR TITLE
PR for Issue 23213: Update refresh token logic to perform same validation and updates as login

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/bnd.bnd
@@ -46,8 +46,9 @@ instrument.classesExcludes: io/openliberty/security/jakartasec/internal/resource
     io.openliberty.jakarta.security.3.0,\
     io.openliberty.security.oidcclientcore.internal.jakarta,\
     io.openliberty.jakarta.jsonp.2.1,\
-	io.openliberty.jakarta.servlet.6.0,\
-	com.ibm.ws.org.jose4j;version=latest
+    io.openliberty.jakarta.servlet.6.0,\
+    com.ibm.ws.org.jose4j;version=latest,\
+    com.ibm.ws.security;version=latest
 
 -testpath: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file,\

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
@@ -122,7 +122,26 @@ public class OidcIdentityStore implements IdentityStore {
             openIdContext.setRefreshToken(new RefreshTokenImpl(refreshTokenString));
         }
 
+        OpenIdContextImpl existingOpenIdContext = (OpenIdContextImpl) OpenIdContextUtils.getOpenIdContextFromSubject();
+        if (existingOpenIdContext != null) {
+            return updateExistingOpenIdContext(existingOpenIdContext, openIdContext);
+        }
         return openIdContext;
+    }
+
+    private OpenIdContext updateExistingOpenIdContext(OpenIdContextImpl existingOpenIdContext, OpenIdContextImpl newOpenIdContext) {
+        existingOpenIdContext.setSubject(newOpenIdContext.getSubject());
+        existingOpenIdContext.setTokenType(newOpenIdContext.getTokenType());
+        existingOpenIdContext.setAccessToken(newOpenIdContext.getAccessToken());
+        existingOpenIdContext.setRefreshToken(newOpenIdContext.getRefreshToken().orElse(null));
+        existingOpenIdContext.setIdentityToken(newOpenIdContext.getIdentityToken());
+        existingOpenIdContext.setExpiresIn(newOpenIdContext.getExpiresIn().orElse(0L));
+        existingOpenIdContext.setClaims(newOpenIdContext.getClaims());
+        existingOpenIdContext.setProviderMetadata(newOpenIdContext.getProviderMetadata());
+        existingOpenIdContext.setState(newOpenIdContext.getState());
+        existingOpenIdContext.setUseSession(newOpenIdContext.isUseSession());
+        existingOpenIdContext.setClientId(newOpenIdContext.getClientId());
+        return existingOpenIdContext;
     }
 
     @FFDCIgnore({ Exception.class })

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OpenIdContextImpl.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OpenIdContextImpl.java
@@ -41,16 +41,16 @@ public class OpenIdContextImpl implements OpenIdContext {
 
     private static final TraceComponent tc = Tr.register(OpenIdContextImpl.class);
 
-    private final String subjectIdentifier;
-    private final String tokenType;
-    private final AccessToken accessToken;
-    private final IdentityToken identityToken;
-    private final OpenIdClaims userinfoClaims;
+    private String subjectIdentifier;
+    private String tokenType;
+    private AccessToken accessToken;
+    private IdentityToken identityToken;
+    private OpenIdClaims userinfoClaims;
     private JsonObject userinfoClaimsAsJson = null;
-    private final JsonObject providerMetadata; // TODO: Store JSON String instead for serialization
-    private final String state; // TODO: Determine if storage values can be obtained without relying on state.
-    private final boolean useSession;
-    private final String clientId;
+    private JsonObject providerMetadata; // TODO: Store JSON String instead for serialization
+    private String state; // TODO: Determine if storage values can be obtained without relying on state.
+    private boolean useSession;
+    private String clientId;
 
     private RefreshToken refreshToken;
     private Long expiresIn;
@@ -72,17 +72,13 @@ public class OpenIdContextImpl implements OpenIdContext {
         this.clientId = clientId;
     }
 
-    public void setRefreshToken(RefreshToken refreshToken) {
-        this.refreshToken = refreshToken;
-    }
-
-    public void setExpiresIn(Long expiresIn) {
-        this.expiresIn = expiresIn;
-    }
-
     @Override
     public String getSubject() {
         return subjectIdentifier;
+    }
+
+    public void setSubject(String subjectIdentifier) {
+        this.subjectIdentifier = subjectIdentifier;
     }
 
     @Override
@@ -90,14 +86,26 @@ public class OpenIdContextImpl implements OpenIdContext {
         return tokenType;
     }
 
+    public void setTokenType(String tokenType) {
+        this.tokenType = tokenType;
+    }
+
     @Override
     public AccessToken getAccessToken() {
         return accessToken;
     }
 
+    public void setAccessToken(AccessToken accessToken) {
+        this.accessToken = accessToken;
+    }
+
     @Override
     public IdentityToken getIdentityToken() {
         return identityToken;
+    }
+
+    public void setIdentityToken(IdentityToken identityToken) {
+        this.identityToken = identityToken;
     }
 
     @Override
@@ -108,12 +116,20 @@ public class OpenIdContextImpl implements OpenIdContext {
         return Optional.empty();
     }
 
+    public void setRefreshToken(RefreshToken refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
     @Override
     public Optional<Long> getExpiresIn() {
         if (expiresIn != null) {
             return Optional.of(expiresIn);
         }
         return Optional.empty();
+    }
+
+    public void setExpiresIn(Long expiresIn) {
+        this.expiresIn = expiresIn;
     }
 
     @Override
@@ -216,10 +232,45 @@ public class OpenIdContextImpl implements OpenIdContext {
         return userinfoClaims;
     }
 
+    public void setClaims(OpenIdClaims userinfoClaims) {
+        this.userinfoClaims = userinfoClaims;
+    }
+
     @Override
     public JsonObject getProviderMetadata() {
+        if (providerMetadata == null) {
+            return null;
+        }
         // Clone providerMetadata before returning it to avoid modifications.
         return Json.createReader(new StringReader(providerMetadata.toString())).readObject();
+    }
+
+    public void setProviderMetadata(JsonObject providerMetadata) {
+        this.providerMetadata = providerMetadata;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public boolean isUseSession() {
+        return useSession;
+    }
+
+    public void setUseSession(boolean useSession) {
+        this.useSession = useSession;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
     }
 
     @SuppressWarnings("unchecked")

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OpenIdContextUtils.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OpenIdContextUtils.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.identitystore;
+
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.Set;
+
+import javax.security.auth.Subject;
+
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.security.context.SubjectManager;
+
+import jakarta.security.enterprise.identitystore.openid.OpenIdContext;
+
+public class OpenIdContextUtils {
+
+    public static OpenIdContext getOpenIdContextFromSubject() {
+        Subject sessionSubject = getSessionSubject();
+        if (sessionSubject == null) {
+            return null;
+        }
+        Set<OpenIdContext> creds = sessionSubject.getPrivateCredentials(OpenIdContext.class);
+        for (OpenIdContext openIdContext : creds) {
+            // there should only be one OpenIdContext in the clientSubject.getPrivateCredentials(OpenIdContext.class) set.
+            return openIdContext;
+        }
+        return null;
+    }
+
+    @FFDCIgnore(PrivilegedActionException.class)
+    private static Subject getSessionSubject() {
+        Subject sessionSubject = null;
+        try {
+            sessionSubject = (Subject) java.security.AccessController.doPrivileged(new PrivilegedExceptionAction<Object>() {
+                @Override
+                public Object run() throws Exception {
+                    return new SubjectManager().getCallerSubject();
+                }
+            });
+        } catch (PrivilegedActionException pae) {
+
+        }
+        return sessionSubject;
+    }
+
+}


### PR DESCRIPTION
The refresh token flow for expired tokens previously did not perform any validation of the returned tokens or update the OpenIdContext as specified in https://jakarta.ee/specifications/security/3.0/jakarta-security-spec-3.0.html#token-expiration. This should update the code to do the same required checks.
    
Resolves #23213