### PR TITLE
Rename EndpointRequest to OidcMetadataService and refactor into OSGi service

### DIFF
--- a/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
+++ b/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
@@ -37,9 +37,8 @@ Export-Package: \
 	io.openliberty.security.oidcclientcore.utils
 
 -dsannotations: \
-	io.openliberty.security.oidcclientcore.http.EndpointRequest,\
-	io.openliberty.security.oidcclientcore.token.TokenResponseValidator,\
-	io.openliberty.security.oidcclientcore.config.MetadataUtils
+	io.openliberty.security.oidcclientcore.config.MetadataUtils,\
+	io.openliberty.security.oidcclientcore.config.OidcMetadataService
 
 -buildpath: \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationRequest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/AuthorizationRequest.java
@@ -17,19 +17,17 @@ import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 
 import io.openliberty.security.oidcclientcore.exceptions.OidcClientConfigurationException;
 import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
-import io.openliberty.security.oidcclientcore.http.EndpointRequest;
 import io.openliberty.security.oidcclientcore.storage.OidcClientStorageConstants;
 import io.openliberty.security.oidcclientcore.storage.OidcStorageUtils;
 import io.openliberty.security.oidcclientcore.storage.Storage;
 import io.openliberty.security.oidcclientcore.storage.StorageProperties;
 
-public abstract class AuthorizationRequest extends EndpointRequest {
+public abstract class AuthorizationRequest {
 
     protected HttpServletRequest request;
     protected HttpServletResponse response;
     protected String clientId;
     protected Storage storage;
-
 
     protected AuthorizationRequestUtils requestUtils = new AuthorizationRequestUtils();
     protected OidcStorageUtils storageUtils = new OidcStorageUtils();

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/config/MetadataUtils.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/config/MetadataUtils.java
@@ -26,23 +26,21 @@ import io.openliberty.security.oidcclientcore.client.OidcProviderMetadata;
 import io.openliberty.security.oidcclientcore.discovery.OidcDiscoveryConstants;
 import io.openliberty.security.oidcclientcore.exceptions.OidcClientConfigurationException;
 import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
-import io.openliberty.security.oidcclientcore.http.EndpointRequest;
 
 @Component(service = MetadataUtils.class, immediate = true, configurationPolicy = ConfigurationPolicy.IGNORE)
 public class MetadataUtils {
 
     public static final TraceComponent tc = Tr.register(MetadataUtils.class);
 
-    private static final String KEY_EP_REQUEST = "endpointRequest";
-    private static volatile EndpointRequest endpointRequest;
+    private static volatile OidcMetadataService oidcMetadataService;
 
-    @Reference(name = KEY_EP_REQUEST, policy = ReferencePolicy.DYNAMIC)
-    public void setEndpointRequest(EndpointRequest endpointRequestService) {
-        endpointRequest = endpointRequestService;
+    @Reference(name = OidcMetadataService.KEY_METADATA_SERVICE, policy = ReferencePolicy.DYNAMIC)
+    public void setOidcMetadataService(OidcMetadataService oidcMetadataServiceRef) {
+        oidcMetadataService = oidcMetadataServiceRef;
     }
 
-    public void unsetEndpointRequest(EndpointRequest endpointRequestService) {
-        endpointRequest = null;
+    public void unsetOidcMetadataService(OidcMetadataService oidcMetadataServiceRef) {
+        oidcMetadataService = null;
     }
 
     /**
@@ -76,7 +74,7 @@ public class MetadataUtils {
     @SuppressWarnings("unchecked")
     public static <T> T getValueFromDiscoveryMetadata(OidcClientConfig oidcClientConfig, String key) throws OidcDiscoveryException, OidcClientConfigurationException {
         T value = null;
-        JSONObject providerDiscoveryMetadata = endpointRequest.getProviderDiscoveryMetadata(oidcClientConfig);
+        JSONObject providerDiscoveryMetadata = oidcMetadataService.getProviderDiscoveryMetadata(oidcClientConfig);
         if (providerDiscoveryMetadata != null) {
             value = (T) providerDiscoveryMetadata.get(key);
         }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/config/OidcMetadataService.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/config/OidcMetadataService.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package io.openliberty.security.oidcclientcore.http;
+package io.openliberty.security.oidcclientcore.config;
 
 import javax.net.ssl.SSLSocketFactory;
 
@@ -28,10 +28,12 @@ import io.openliberty.security.oidcclientcore.discovery.OidcDiscoveryConstants;
 import io.openliberty.security.oidcclientcore.exceptions.OidcClientConfigurationException;
 import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
 
-@Component(service = EndpointRequest.class, immediate = true, configurationPolicy = ConfigurationPolicy.IGNORE)
-public class EndpointRequest {
+@Component(service = OidcMetadataService.class, immediate = true, configurationPolicy = ConfigurationPolicy.IGNORE)
+public class OidcMetadataService {
 
-    public static final TraceComponent tc = Tr.register(EndpointRequest.class);
+    public static final TraceComponent tc = Tr.register(OidcMetadataService.class);
+
+    public static final String KEY_METADATA_SERVICE = "oidcMetadataService";
 
     private static final String KEY_SSL_SUPPORT = "sslSupport";
     protected static volatile SSLSupport sslSupport;
@@ -45,11 +47,11 @@ public class EndpointRequest {
         sslSupport = null;
     }
 
-    public SSLSupport getSSLSupport() {
+    public static SSLSupport getSSLSupport() {
         return sslSupport;
     }
 
-    public SSLSocketFactory getSSLSocketFactory() {
+    public static SSLSocketFactory getSSLSocketFactory() {
         if (sslSupport != null) {
             return sslSupport.getSSLSocketFactory();
         }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/logout/LogoutHandler.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/logout/LogoutHandler.java
@@ -15,6 +15,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.webcontainer.security.AuthResult;
 import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
@@ -25,9 +26,11 @@ import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 import io.openliberty.security.oidcclientcore.config.MetadataUtils;
 import io.openliberty.security.oidcclientcore.exceptions.OidcClientConfigurationException;
 import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
-import io.openliberty.security.oidcclientcore.http.EndpointRequest;
 
-public class LogoutHandler extends EndpointRequest {
+public class LogoutHandler {
+
+    public static final TraceComponent tc = Tr.register(LogoutHandler.class);
+
     HttpServletRequest req;
     HttpServletResponse resp;
     OidcClientConfig oidcClientConfig;

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/JakartaOidcTokenRequest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/JakartaOidcTokenRequest.java
@@ -26,13 +26,13 @@ import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 import io.openliberty.security.oidcclientcore.config.MetadataUtils;
+import io.openliberty.security.oidcclientcore.config.OidcMetadataService;
 import io.openliberty.security.oidcclientcore.exceptions.OidcClientConfigurationException;
 import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
 import io.openliberty.security.oidcclientcore.exceptions.TokenRequestException;
-import io.openliberty.security.oidcclientcore.http.EndpointRequest;
 import io.openliberty.security.oidcclientcore.token.TokenRequestor.Builder;
 
-public class JakartaOidcTokenRequest extends EndpointRequest {
+public class JakartaOidcTokenRequest {
 
     public static final TraceComponent tc = Tr.register(JakartaOidcTokenRequest.class);
 
@@ -72,7 +72,7 @@ public class JakartaOidcTokenRequest extends EndpointRequest {
         }
 
         Builder tokenRequestBuilder = createTokenRequestorBuilder(tokenEndpoint, clientId, clientSecret, null);
-        tokenRequestBuilder.sslSocketFactory(getSSLSocketFactory());
+        tokenRequestBuilder.sslSocketFactory(OidcMetadataService.getSSLSocketFactory());
         tokenRequestBuilder.grantType(TokenConstants.REFRESH_TOKEN);
         tokenRequestBuilder.refreshToken(refreshToken);
         //TODO: check do we need to include scope parameter?
@@ -104,7 +104,7 @@ public class JakartaOidcTokenRequest extends EndpointRequest {
         }
 
         Builder tokenRequestBuilder = createTokenRequestorBuilder(tokenEndpoint, clientId, clientSecret, authzCode);
-        tokenRequestBuilder.sslSocketFactory(getSSLSocketFactory());
+        tokenRequestBuilder.sslSocketFactory(OidcMetadataService.getSSLSocketFactory());
         tokenRequestBuilder.grantType(TokenConstants.AUTHORIZATION_CODE);
         TokenRequestor tokenRequestor = tokenRequestBuilder.build();
         try {

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenRefresher.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenRefresher.java
@@ -13,8 +13,6 @@ package io.openliberty.security.oidcclientcore.token;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.ibm.websphere.ras.Tr;
-import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.webcontainer.security.AuthResult;
 import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 
@@ -22,8 +20,6 @@ import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 import io.openliberty.security.oidcclientcore.exceptions.TokenRequestException;
 
 public class TokenRefresher {
-
-    private static final TraceComponent tc = Tr.register(TokenRefresher.class);
 
     private HttpServletRequest request = null;
     private OidcClientConfig oidcClientConfig = null;

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/userinfo/UserInfoHandler.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/userinfo/UserInfoHandler.java
@@ -20,10 +20,9 @@ import io.openliberty.security.oidcclientcore.config.MetadataUtils;
 import io.openliberty.security.oidcclientcore.exceptions.OidcClientConfigurationException;
 import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
 import io.openliberty.security.oidcclientcore.exceptions.UserInfoResponseException;
-import io.openliberty.security.oidcclientcore.http.EndpointRequest;
 import io.openliberty.security.oidcclientcore.userinfo.UserInfoRequestor.Builder;
 
-public class UserInfoHandler extends EndpointRequest {
+public class UserInfoHandler {
 
     public static final TraceComponent tc = Tr.register(UserInfoHandler.class);
 
@@ -39,7 +38,7 @@ public class UserInfoHandler extends EndpointRequest {
     }
 
     UserInfoRequestor createUserInfoRequestor(String userInfoEndpoint, OidcClientConfig oidcClientConfig, String accessToken) throws OidcDiscoveryException {
-        Builder builder = new UserInfoRequestor.Builder(this, oidcClientConfig, userInfoEndpoint, accessToken);
+        Builder builder = new UserInfoRequestor.Builder(oidcClientConfig, userInfoEndpoint, accessToken);
         return builder.build();
     }
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/userinfo/UserInfoRequestor.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/userinfo/UserInfoRequestor.java
@@ -36,12 +36,12 @@ import io.openliberty.security.common.jwt.jws.JwsSignatureVerifier;
 import io.openliberty.security.common.jwt.jws.JwsVerificationKeyHelper;
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 import io.openliberty.security.oidcclientcore.config.MetadataUtils;
+import io.openliberty.security.oidcclientcore.config.OidcMetadataService;
 import io.openliberty.security.oidcclientcore.exceptions.OidcClientConfigurationException;
 import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
 import io.openliberty.security.oidcclientcore.exceptions.UserInfoEndpointNotHttpsException;
 import io.openliberty.security.oidcclientcore.exceptions.UserInfoResponseException;
 import io.openliberty.security.oidcclientcore.exceptions.UserInfoResponseNot200Exception;
-import io.openliberty.security.oidcclientcore.http.EndpointRequest;
 import io.openliberty.security.oidcclientcore.http.HttpConstants;
 import io.openliberty.security.oidcclientcore.http.OidcClientHttpUtil;
 
@@ -49,7 +49,6 @@ public class UserInfoRequestor {
 
     public static final TraceComponent tc = Tr.register(UserInfoRequestor.class);
 
-    private final EndpointRequest endpointRequestClass;
     private final OidcClientConfig oidcClientConfig;
     private final String userInfoEndpoint;
     private final String accessToken;
@@ -61,7 +60,6 @@ public class UserInfoRequestor {
     OidcClientHttpUtil oidcClientHttpUtil = OidcClientHttpUtil.getInstance();
 
     private UserInfoRequestor(Builder builder) {
-        this.endpointRequestClass = builder.endpointRequestClass;
         this.oidcClientConfig = builder.oidcClientConfig;
         this.userInfoEndpoint = builder.userInfoEndpoint;
         this.accessToken = builder.accessToken;
@@ -168,7 +166,7 @@ public class UserInfoRequestor {
         RemoteJwkData jwkData = new RemoteJwkData();
         String jwksUri = MetadataUtils.getJwksUri(oidcClientConfig);
         jwkData.setJwksUri(jwksUri);
-        jwkData.setSslSupport(endpointRequestClass.getSSLSupport());
+        jwkData.setSslSupport(OidcMetadataService.getSSLSupport());
         return jwkData;
     }
 
@@ -178,14 +176,13 @@ public class UserInfoRequestor {
                                                   null,
                                                   null,
                                                   accessToken,
-                                                  endpointRequestClass.getSSLSocketFactory(),
+                                                  OidcMetadataService.getSSLSocketFactory(),
                                                   hostnameVerification,
                                                   useSystemPropertiesForHttpClientConnections);
     }
 
     public static class Builder {
 
-        private final EndpointRequest endpointRequestClass;
         private final OidcClientConfig oidcClientConfig;
         private final String userInfoEndpoint;
         private final String accessToken;
@@ -193,8 +190,7 @@ public class UserInfoRequestor {
         private boolean hostnameVerification = false;
         private boolean useSystemPropertiesForHttpClientConnections = false;
 
-        public Builder(EndpointRequest endpointRequestClass, OidcClientConfig oidcClientConfig, String userInfoEndpoint, String accessToken) {
-            this.endpointRequestClass = endpointRequestClass;
+        public Builder(OidcClientConfig oidcClientConfig, String userInfoEndpoint, String accessToken) {
             this.oidcClientConfig = oidcClientConfig;
             this.userInfoEndpoint = userInfoEndpoint;
             this.accessToken = accessToken;

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequestTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequestTest.java
@@ -39,9 +39,9 @@ import com.ibm.ws.security.test.common.CommonTestClass;
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 import io.openliberty.security.oidcclientcore.client.OidcProviderMetadata;
 import io.openliberty.security.oidcclientcore.config.MetadataUtils;
+import io.openliberty.security.oidcclientcore.config.OidcMetadataService;
 import io.openliberty.security.oidcclientcore.discovery.OidcDiscoveryConstants;
 import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
-import io.openliberty.security.oidcclientcore.http.EndpointRequest;
 import io.openliberty.security.oidcclientcore.storage.SessionBasedStorage;
 import io.openliberty.security.oidcclientcore.utils.Utils;
 import test.common.SharedOutputManager;
@@ -56,7 +56,7 @@ public class JakartaOidcAuthorizationRequestTest extends CommonTestClass {
     private final OidcProviderMetadata providerMetadata = mockery.mock(OidcProviderMetadata.class);
     private final AuthorizationRequestParameters authzParameters = mockery.mock(AuthorizationRequestParameters.class);
     private final SessionBasedStorage sessionBasedStorage = mockery.mock(SessionBasedStorage.class);
-    private final EndpointRequest endpointRequest = mockery.mock(EndpointRequest.class);
+    private final OidcMetadataService oidcMetadataService = mockery.mock(OidcMetadataService.class);
 
     private final String CWWKS2403E_DISCOVERY_EXCEPTION = "CWWKS2403E";
     private final String CWWKS2405E_DISCOVERY_METADATA_MISSING_VALUE = "CWWKS2405E";
@@ -81,13 +81,13 @@ public class JakartaOidcAuthorizationRequestTest extends CommonTestClass {
         providerUrl = providerUrlBase + testName.getMethodName();
 
         MetadataUtils utils = new MetadataUtils();
-        utils.setEndpointRequest(endpointRequest);
+        utils.setOidcMetadataService(oidcMetadataService);
     }
 
     @After
     public void tearDown() {
         MetadataUtils utils = new MetadataUtils();
-        utils.unsetEndpointRequest(endpointRequest);
+        utils.unsetOidcMetadataService(oidcMetadataService);
 
         outputMgr.resetStreams();
         mockery.assertIsSatisfied();
@@ -144,7 +144,7 @@ public class JakartaOidcAuthorizationRequestTest extends CommonTestClass {
                 {
                     one(config).getProviderMetadata();
                     will(returnValue(null));
-                    one(endpointRequest).getProviderDiscoveryMetadata(config);
+                    one(oidcMetadataService).getProviderDiscoveryMetadata(config);
                     will(returnValue(discoveryData));
                     one(config).getClientId();
                     will(returnValue(clientId));
@@ -173,7 +173,7 @@ public class JakartaOidcAuthorizationRequestTest extends CommonTestClass {
                 {
                     one(config).getProviderMetadata();
                     will(returnValue(null));
-                    one(endpointRequest).getProviderDiscoveryMetadata(config);
+                    one(oidcMetadataService).getProviderDiscoveryMetadata(config);
                     will(returnValue(discoveryData));
                 }
             });

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/config/MetadataUtilsTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/config/MetadataUtilsTest.java
@@ -27,7 +27,6 @@ import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 import io.openliberty.security.oidcclientcore.client.OidcProviderMetadata;
 import io.openliberty.security.oidcclientcore.discovery.OidcDiscoveryConstants;
 import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
-import io.openliberty.security.oidcclientcore.http.EndpointRequest;
 import test.common.SharedOutputManager;
 
 public class MetadataUtilsTest extends CommonTestClass {
@@ -38,7 +37,7 @@ public class MetadataUtilsTest extends CommonTestClass {
     public static final String CWWKS2405E_DISCOVERY_METADATA_MISSING_VALUE = "CWWKS2405E";
 
     private final OidcClientConfig oidcClientConfig = mockery.mock(OidcClientConfig.class);
-    private final EndpointRequest endpointRequestClass = mockery.mock(EndpointRequest.class);
+    private final OidcMetadataService oidcMetadataService = mockery.mock(OidcMetadataService.class);
     private final OidcProviderMetadata providerMetadata = mockery.mock(OidcProviderMetadata.class);
 
     private final String clientId = "myClientId";
@@ -62,13 +61,13 @@ public class MetadataUtilsTest extends CommonTestClass {
             }
         });
         MetadataUtils utils = new MetadataUtils();
-        utils.setEndpointRequest(endpointRequestClass);
+        utils.setOidcMetadataService(oidcMetadataService);
     }
 
     @After
     public void tearDown() {
         MetadataUtils utils = new MetadataUtils();
-        utils.unsetEndpointRequest(endpointRequestClass);
+        utils.unsetOidcMetadataService(oidcMetadataService);
         outputMgr.resetStreams();
         mockery.assertIsSatisfied();
     }
@@ -105,7 +104,7 @@ public class MetadataUtilsTest extends CommonTestClass {
                 will(returnValue(providerMetadata));
                 one(providerMetadata).getIssuer();
                 will(returnValue(""));
-                one(endpointRequestClass).getProviderDiscoveryMetadata(oidcClientConfig);
+                one(oidcMetadataService).getProviderDiscoveryMetadata(oidcClientConfig);
                 will(returnValue(discoveryData));
             }
         });
@@ -122,7 +121,7 @@ public class MetadataUtilsTest extends CommonTestClass {
             {
                 one(oidcClientConfig).getProviderMetadata();
                 will(returnValue(null));
-                one(endpointRequestClass).getProviderDiscoveryMetadata(oidcClientConfig);
+                one(oidcMetadataService).getProviderDiscoveryMetadata(oidcClientConfig);
                 will(returnValue(discoveryData));
             }
         });

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/config/OidcMetadataServiceTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/config/OidcMetadataServiceTest.java
@@ -8,7 +8,7 @@
  * Contributors:
  * IBM Corporation - initial API and implementation
  *******************************************************************************/
-package io.openliberty.security.oidcclientcore.http;
+package io.openliberty.security.oidcclientcore.config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -33,7 +33,7 @@ import io.openliberty.security.oidcclientcore.exceptions.OidcClientConfiguration
 import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
 import test.common.SharedOutputManager;
 
-public class EndpointRequestTest extends CommonTestClass {
+public class OidcMetadataServiceTest extends CommonTestClass {
 
     protected static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
 
@@ -53,7 +53,7 @@ public class EndpointRequestTest extends CommonTestClass {
 
     private DiscoveryHandler discoveryHandler = null;
 
-    private EndpointRequest endpointRequest;
+    private OidcMetadataService oidcMetadataService;
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
@@ -74,7 +74,7 @@ public class EndpointRequestTest extends CommonTestClass {
                 return mockedHttpUtils;
             }
         };
-        endpointRequest = createEndpointRequest();
+        oidcMetadataService = createOidcMetadataService();
         // Ensure provider URLs are unique for each test to avoid cache contamination between tests
         providerUrl = providerUrlBase + testName.getMethodName();
     }
@@ -90,8 +90,8 @@ public class EndpointRequestTest extends CommonTestClass {
         outputMgr.restoreStreams();
     }
 
-    private EndpointRequest createEndpointRequest() {
-        return new EndpointRequest() {
+    private OidcMetadataService createOidcMetadataService() {
+        return new OidcMetadataService() {
             @Override
             public DiscoveryHandler getDiscoveryHandler() {
                 return discoveryHandler;
@@ -108,7 +108,7 @@ public class EndpointRequestTest extends CommonTestClass {
             }
         });
         try {
-            JSONObject result = endpointRequest.getProviderDiscoveryMetadata(config);
+            JSONObject result = oidcMetadataService.getProviderDiscoveryMetadata(config);
             fail("Should have thrown an exception but got " + result);
         } catch (OidcClientConfigurationException e) {
             verifyException(e, CWWKS2401E_OIDC_CLIENT_CONFIGURATION_ERROR + ".+" + CWWKS2404W_OIDC_CLIENT_MISSING_PROVIDER_URI);
@@ -128,7 +128,7 @@ public class EndpointRequestTest extends CommonTestClass {
                     will(returnValue(discoveryData.toString()));
                 }
             });
-            JSONObject result = endpointRequest.getProviderDiscoveryMetadata(config);
+            JSONObject result = oidcMetadataService.getProviderDiscoveryMetadata(config);
             assertEquals(discoveryData, result);
         } catch (Exception e) {
             outputMgr.failWithThrowable(testName.getMethodName(), e);
@@ -147,7 +147,7 @@ public class EndpointRequestTest extends CommonTestClass {
             }
         });
         try {
-            JSONObject result = endpointRequest.getProviderDiscoveryMetadata(config);
+            JSONObject result = oidcMetadataService.getProviderDiscoveryMetadata(config);
             fail("Should have thrown an exception but got " + result);
         } catch (OidcDiscoveryException e) {
             verifyException(e, CWWKS2403E_DISCOVERY_EXCEPTION + ".+" + "Unexpected character");
@@ -168,11 +168,11 @@ public class EndpointRequestTest extends CommonTestClass {
                     will(returnValue(discoveryData.toString()));
                 }
             });
-            JSONObject result = endpointRequest.getProviderDiscoveryMetadata(config);
+            JSONObject result = oidcMetadataService.getProviderDiscoveryMetadata(config);
             assertEquals(discoveryData, result);
 
             // Should get metadata from the cache, so shouldn't need another discoveryHandler call
-            JSONObject result2 = endpointRequest.getProviderDiscoveryMetadata(config);
+            JSONObject result2 = oidcMetadataService.getProviderDiscoveryMetadata(config);
             assertEquals(discoveryData, result2);
         } catch (Exception e) {
             outputMgr.failWithThrowable(testName.getMethodName(), e);
@@ -182,7 +182,7 @@ public class EndpointRequestTest extends CommonTestClass {
     @Test
     public void test_addWellKnownSuffixIfNeeded_noSuffix_noTrailingSlash() throws OidcDiscoveryException {
         String input = providerUrl;
-        String result = endpointRequest.addWellKnownSuffixIfNeeded(input);
+        String result = oidcMetadataService.addWellKnownSuffixIfNeeded(input);
         String expectedValue = providerUrl + "/" + OidcDiscoveryConstants.WELL_KNOWN_SUFFIX;
         assertEquals(expectedValue, result);
     }
@@ -190,7 +190,7 @@ public class EndpointRequestTest extends CommonTestClass {
     @Test
     public void test_addWellKnownSuffixIfNeeded_noSuffix_withTrailingSlash() throws OidcDiscoveryException {
         String input = providerUrl + "/";
-        String result = endpointRequest.addWellKnownSuffixIfNeeded(input);
+        String result = oidcMetadataService.addWellKnownSuffixIfNeeded(input);
         String expectedValue = providerUrl + "/" + OidcDiscoveryConstants.WELL_KNOWN_SUFFIX;
         assertEquals(expectedValue, result);
     }
@@ -198,14 +198,14 @@ public class EndpointRequestTest extends CommonTestClass {
     @Test
     public void test_addWellKnownSuffixIfNeeded_includesSuffix_notAsSeparatePath() throws OidcDiscoveryException {
         String input = providerUrl + OidcDiscoveryConstants.WELL_KNOWN_SUFFIX;
-        String result = endpointRequest.addWellKnownSuffixIfNeeded(input);
+        String result = oidcMetadataService.addWellKnownSuffixIfNeeded(input);
         assertEquals(input, result);
     }
 
     @Test
     public void test_addWellKnownSuffixIfNeeded_includesSuffix() throws OidcDiscoveryException {
         String input = providerUrl + "/" + OidcDiscoveryConstants.WELL_KNOWN_SUFFIX;
-        String result = endpointRequest.addWellKnownSuffixIfNeeded(input);
+        String result = oidcMetadataService.addWellKnownSuffixIfNeeded(input);
         assertEquals(input, result);
     }
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/userinfo/UserInfoHandlerTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/userinfo/UserInfoHandlerTest.java
@@ -28,11 +28,10 @@ import com.ibm.ws.security.test.common.CommonTestClass;
 
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 import io.openliberty.security.oidcclientcore.config.MetadataUtils;
-import io.openliberty.security.oidcclientcore.discovery.DiscoveryHandler;
+import io.openliberty.security.oidcclientcore.config.OidcMetadataService;
 import io.openliberty.security.oidcclientcore.discovery.OidcDiscoveryConstants;
 import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
 import io.openliberty.security.oidcclientcore.exceptions.UserInfoResponseException;
-import io.openliberty.security.oidcclientcore.http.EndpointRequest;
 import test.common.SharedOutputManager;
 
 public class UserInfoHandlerTest extends CommonTestClass {
@@ -44,10 +43,9 @@ public class UserInfoHandlerTest extends CommonTestClass {
     public static final String CWWKS2418W_USERINFO_RESPONSE_ERROR = "CWWKS2418W";
 
     private final OidcClientConfig oidcClientConfig = mockery.mock(OidcClientConfig.class);
-    private final DiscoveryHandler discoveryHandler = mockery.mock(DiscoveryHandler.class);
     private final UserInfoRequestor userInfoRequestor = mockery.mock(UserInfoRequestor.class);
     private final UserInfoResponse userInfoResponse = mockery.mock(UserInfoResponse.class);
-    private final EndpointRequest endpointRequest = mockery.mock(EndpointRequest.class);
+    private final OidcMetadataService oidcMetadataService = mockery.mock(OidcMetadataService.class);
 
     private final String clientId = "myClientId";
     private final String discoveryUrl = "https://localhost/OP/" + OidcDiscoveryConstants.WELL_KNOWN_SUFFIX;
@@ -73,23 +71,18 @@ public class UserInfoHandlerTest extends CommonTestClass {
         });
         handler = new UserInfoHandler() {
             @Override
-            public DiscoveryHandler getDiscoveryHandler() {
-                return discoveryHandler;
-            }
-
-            @Override
             UserInfoRequestor createUserInfoRequestor(String userInfoEndpoint, OidcClientConfig oidcClientConfig, String accessToken) {
                 return userInfoRequestor;
             }
         };
         MetadataUtils utils = new MetadataUtils();
-        utils.setEndpointRequest(endpointRequest);
+        utils.setOidcMetadataService(oidcMetadataService);
     }
 
     @After
     public void tearDown() {
         MetadataUtils utils = new MetadataUtils();
-        utils.unsetEndpointRequest(endpointRequest);
+        utils.unsetOidcMetadataService(oidcMetadataService);
         outputMgr.resetStreams();
         mockery.assertIsSatisfied();
     }
@@ -106,7 +99,7 @@ public class UserInfoHandlerTest extends CommonTestClass {
             {
                 one(oidcClientConfig).getProviderMetadata();
                 will(returnValue(null));
-                one(endpointRequest).getProviderDiscoveryMetadata(oidcClientConfig);
+                one(oidcMetadataService).getProviderDiscoveryMetadata(oidcClientConfig);
                 will(returnValue(new JSONObject()));
             }
         });
@@ -126,7 +119,7 @@ public class UserInfoHandlerTest extends CommonTestClass {
             {
                 one(oidcClientConfig).getProviderMetadata();
                 will(returnValue(null));
-                one(endpointRequest).getProviderDiscoveryMetadata(oidcClientConfig);
+                one(oidcMetadataService).getProviderDiscoveryMetadata(oidcClientConfig);
                 will(returnValue(discoveryData));
                 one(userInfoRequestor).requestUserInfo();
                 will(throwException(new UserInfoResponseException(userInfoEndpoint, new Exception(defaultExceptionMsg))));
@@ -148,7 +141,7 @@ public class UserInfoHandlerTest extends CommonTestClass {
             {
                 one(oidcClientConfig).getProviderMetadata();
                 will(returnValue(null));
-                one(endpointRequest).getProviderDiscoveryMetadata(oidcClientConfig);
+                one(oidcMetadataService).getProviderDiscoveryMetadata(oidcClientConfig);
                 will(returnValue(discoveryData));
                 one(userInfoRequestor).requestUserInfo();
                 will(returnValue(userInfoResponse));

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/userinfo/UserInfoRequestorTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/userinfo/UserInfoRequestorTest.java
@@ -23,8 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.net.ssl.SSLSocketFactory;
-
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.StatusLine;
@@ -43,14 +41,12 @@ import com.ibm.json.java.JSONObject;
 import com.ibm.websphere.ras.ProtectedString;
 import com.ibm.ws.security.test.common.CommonTestClass;
 import com.ibm.ws.security.test.common.jwt.utils.JwtUnitTestUtils;
-import com.ibm.wsspi.ssl.SSLSupport;
 
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 import io.openliberty.security.oidcclientcore.client.OidcProviderMetadata;
 import io.openliberty.security.oidcclientcore.exceptions.UserInfoEndpointNotHttpsException;
 import io.openliberty.security.oidcclientcore.exceptions.UserInfoResponseException;
 import io.openliberty.security.oidcclientcore.exceptions.UserInfoResponseNot200Exception;
-import io.openliberty.security.oidcclientcore.http.EndpointRequest;
 import io.openliberty.security.oidcclientcore.http.HttpConstants;
 import io.openliberty.security.oidcclientcore.http.OidcClientHttpUtil;
 import test.common.SharedOutputManager;
@@ -73,10 +69,7 @@ public class UserInfoRequestorTest extends CommonTestClass {
     private static final String userInfoJSONResponseEntity = "{\"sub\":\"" + sub + "\",\"iss\":\"" + iss + "\",\"name\":\"" + name + "\"}";
 
     private final OidcClientConfig oidcClientConfig = mockery.mock(OidcClientConfig.class);
-    private final EndpointRequest endpointRequestClass = mockery.mock(EndpointRequest.class);
     private final OidcClientHttpUtil oidcClientHttpUtil = mockery.mock(OidcClientHttpUtil.class);
-    private final SSLSupport sslSupport = mockery.mock(SSLSupport.class);
-    private final SSLSocketFactory sslSocketFactory = mockery.mock(SSLSocketFactory.class);
     private final HttpResponse httpResponse = mockery.mock(HttpResponse.class);
     private final HttpGet httpGet = mockery.mock(HttpGet.class);
     private final StatusLine statusLine = mockery.mock(StatusLine.class);
@@ -97,13 +90,6 @@ public class UserInfoRequestorTest extends CommonTestClass {
         userInfoResponseMap = new HashMap<String, Object>();
         userInfoResponseMap.put(HttpConstants.RESPONSEMAP_CODE, httpResponse);
         userInfoResponseMap.put(HttpConstants.RESPONSEMAP_METHOD, httpGet);
-
-        mockery.checking(new Expectations() {
-            {
-                allowing(endpointRequestClass).getSSLSocketFactory();
-                will(returnValue(sslSocketFactory));
-            }
-        });
     }
 
     @After
@@ -120,13 +106,13 @@ public class UserInfoRequestorTest extends CommonTestClass {
 
     @Test
     public void test_requestUserInfo() throws Exception {
-        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(endpointRequestClass, oidcClientConfig, userInfoEndpoint, accessToken).build();
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(oidcClientConfig, userInfoEndpoint, accessToken).build();
         userInfoRequestor.oidcClientHttpUtil = oidcClientHttpUtil;
 
         BasicHttpEntity httpEntity = createBasicHttpEntity(userInfoJSONResponseEntity, HttpConstants.APPLICATION_JSON);
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, sslSocketFactory, false, false);
+                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, null, false, false);
                 will(returnValue(userInfoResponseMap));
                 one(httpResponse).getEntity();
                 will(returnValue(httpEntity));
@@ -143,13 +129,13 @@ public class UserInfoRequestorTest extends CommonTestClass {
     }
 
     public void test_requestUserInfo_withHostnameVerification() throws Exception {
-        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(endpointRequestClass, oidcClientConfig, userInfoEndpoint, accessToken).hostnameVerification(true).build();
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(oidcClientConfig, userInfoEndpoint, accessToken).hostnameVerification(true).build();
         userInfoRequestor.oidcClientHttpUtil = oidcClientHttpUtil;
 
         BasicHttpEntity httpEntity = createBasicHttpEntity(userInfoJSONResponseEntity, HttpConstants.APPLICATION_JSON);
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, sslSocketFactory, true, false);
+                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, null, true, false);
                 will(returnValue(userInfoResponseMap));
                 one(httpResponse).getEntity();
                 will(returnValue(httpEntity));
@@ -166,13 +152,13 @@ public class UserInfoRequestorTest extends CommonTestClass {
     }
 
     public void test_requestUserInfo_useSystemPropertiesForHttpClientConnections() throws Exception {
-        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(endpointRequestClass, oidcClientConfig, userInfoEndpoint, accessToken).useSystemPropertiesForHttpClientConnections(true).build();
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(oidcClientConfig, userInfoEndpoint, accessToken).useSystemPropertiesForHttpClientConnections(true).build();
         userInfoRequestor.oidcClientHttpUtil = oidcClientHttpUtil;
 
         BasicHttpEntity httpEntity = createBasicHttpEntity(userInfoJSONResponseEntity, HttpConstants.APPLICATION_JSON);
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, sslSocketFactory, false, true);
+                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, null, false, true);
                 will(returnValue(userInfoResponseMap));
                 one(httpResponse).getEntity();
                 will(returnValue(httpEntity));
@@ -189,13 +175,13 @@ public class UserInfoRequestorTest extends CommonTestClass {
     }
 
     public void test_requestUserInfo_withHostnameVerificationAndUseSystemPropertiesForHttpClientConnections() throws Exception {
-        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(endpointRequestClass, oidcClientConfig, userInfoEndpoint, accessToken).hostnameVerification(true).useSystemPropertiesForHttpClientConnections(true).build();
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(oidcClientConfig, userInfoEndpoint, accessToken).hostnameVerification(true).useSystemPropertiesForHttpClientConnections(true).build();
         userInfoRequestor.oidcClientHttpUtil = oidcClientHttpUtil;
 
         BasicHttpEntity httpEntity = createBasicHttpEntity(userInfoJSONResponseEntity, HttpConstants.APPLICATION_JSON);
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, sslSocketFactory, true, true);
+                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, null, true, true);
                 will(returnValue(userInfoResponseMap));
                 one(httpResponse).getEntity();
                 will(returnValue(httpEntity));
@@ -213,7 +199,7 @@ public class UserInfoRequestorTest extends CommonTestClass {
 
     @Test(expected = UserInfoEndpointNotHttpsException.class)
     public void test_requestUserInfo_urlNotHTTPS() throws Exception {
-        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(endpointRequestClass, oidcClientConfig, "http://superfoo", accessToken).build();
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(oidcClientConfig, "http://superfoo", accessToken).build();
         mockery.checking(new Expectations() {
             {
                 one(oidcClientConfig).getClientId();
@@ -226,13 +212,13 @@ public class UserInfoRequestorTest extends CommonTestClass {
 
     @Test(expected = UserInfoResponseException.class)
     public void test_requestUserInfo_httpResponseIsNull() throws Exception {
-        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(endpointRequestClass, oidcClientConfig, userInfoEndpoint, accessToken).build();
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(oidcClientConfig, userInfoEndpoint, accessToken).build();
         userInfoRequestor.oidcClientHttpUtil = oidcClientHttpUtil;
 
         userInfoResponseMap.put(HttpConstants.RESPONSEMAP_CODE, null);
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, sslSocketFactory, false, false);
+                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, null, false, false);
                 will(returnValue(userInfoResponseMap));
             }
         });
@@ -242,13 +228,13 @@ public class UserInfoRequestorTest extends CommonTestClass {
 
     @Test(expected = UserInfoResponseException.class)
     public void test_requestUserInfo_responseHasMalformedJSON() throws Exception {
-        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(endpointRequestClass, oidcClientConfig, userInfoEndpoint, accessToken).build();
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(oidcClientConfig, userInfoEndpoint, accessToken).build();
         userInfoRequestor.oidcClientHttpUtil = oidcClientHttpUtil;
 
         BasicHttpEntity httpEntity = createBasicHttpEntity("notJSON", HttpConstants.APPLICATION_JSON);
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, sslSocketFactory, false, false);
+                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, null, false, false);
                 will(returnValue(userInfoResponseMap));
                 one(httpResponse).getEntity();
                 will(returnValue(httpEntity));
@@ -260,13 +246,13 @@ public class UserInfoRequestorTest extends CommonTestClass {
 
     @Test(expected = UserInfoResponseNot200Exception.class)
     public void test_requestUserInfo_responseStatusCodeNot200() throws Exception {
-        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(endpointRequestClass, oidcClientConfig, userInfoEndpoint, accessToken).build();
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(oidcClientConfig, userInfoEndpoint, accessToken).build();
         userInfoRequestor.oidcClientHttpUtil = oidcClientHttpUtil;
 
         BasicHttpEntity httpEntity = createBasicHttpEntity(userInfoJSONResponseEntity, HttpConstants.APPLICATION_JSON);
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, sslSocketFactory, false, false);
+                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, null, false, false);
                 will(returnValue(userInfoResponseMap));
                 one(httpResponse).getEntity();
                 will(returnValue(httpEntity));
@@ -282,13 +268,13 @@ public class UserInfoRequestorTest extends CommonTestClass {
 
     @Test
     public void test_requestUserInfo_contentTypeUnknown() throws Exception {
-        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(endpointRequestClass, oidcClientConfig, userInfoEndpoint, accessToken).build();
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(oidcClientConfig, userInfoEndpoint, accessToken).build();
         userInfoRequestor.oidcClientHttpUtil = oidcClientHttpUtil;
 
         BasicHttpEntity httpEntity = createBasicHttpEntity(userInfoJSONResponseEntity, "unknownContentType");
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, sslSocketFactory, false, false);
+                one(oidcClientHttpUtil).getFromEndpoint(userInfoEndpoint, params, null, null, accessToken, null, false, false);
                 will(returnValue(userInfoResponseMap));
                 one(httpResponse).getEntity();
                 will(returnValue(httpEntity));
@@ -306,7 +292,7 @@ public class UserInfoRequestorTest extends CommonTestClass {
 
     @Test(expected = InvalidJwtException.class)
     public void test_extractClaimsFromJwtResponse_responseIsEmptyString() throws Exception {
-        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(endpointRequestClass, oidcClientConfig, userInfoEndpoint, accessToken).build();
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(oidcClientConfig, userInfoEndpoint, accessToken).build();
 
         String jwtResponse = "";
 
@@ -316,7 +302,7 @@ public class UserInfoRequestorTest extends CommonTestClass {
 
     @Test(expected = InvalidJwtException.class)
     public void test_extractClaimsFromJwtResponse_responseIsJson() throws Exception {
-        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(endpointRequestClass, oidcClientConfig, userInfoEndpoint, accessToken).build();
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(oidcClientConfig, userInfoEndpoint, accessToken).build();
 
         String jwtResponse = "{\"key\":\"value\"}";
 
@@ -326,15 +312,13 @@ public class UserInfoRequestorTest extends CommonTestClass {
 
     @Test
     public void test_extractClaimsFromJwtResponse_emptyClaims() throws Exception {
-        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(endpointRequestClass, oidcClientConfig, userInfoEndpoint, accessToken).build();
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(oidcClientConfig, userInfoEndpoint, accessToken).build();
         mockery.checking(new Expectations() {
             {
                 one(oidcClientConfig).getProviderMetadata();
                 will(returnValue(providerMetadata));
                 one(providerMetadata).getJwksURI();
                 will(returnValue(jwksUri));
-                one(endpointRequestClass).getSSLSupport();
-                will(returnValue(sslSupport));
                 one(oidcClientConfig).getClientId();
                 will(returnValue(clientId));
                 one(oidcClientConfig).getClientSecret();
@@ -352,15 +336,13 @@ public class UserInfoRequestorTest extends CommonTestClass {
 
     @Test
     public void test_extractClaimsFromJwtResponse_withClaims() throws Exception {
-        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(endpointRequestClass, oidcClientConfig, userInfoEndpoint, accessToken).build();
+        UserInfoRequestor userInfoRequestor = new UserInfoRequestor.Builder(oidcClientConfig, userInfoEndpoint, accessToken).build();
         mockery.checking(new Expectations() {
             {
                 one(oidcClientConfig).getProviderMetadata();
                 will(returnValue(providerMetadata));
                 one(providerMetadata).getJwksURI();
                 will(returnValue(jwksUri));
-                one(endpointRequestClass).getSSLSupport();
-                will(returnValue(sslSupport));
                 one(oidcClientConfig).getClientId();
                 will(returnValue(clientId));
                 one(oidcClientConfig).getClientSecret();


### PR DESCRIPTION
Also changes some classes so they're not unnecessary OSGi components.