### PR TITLE
Clean up MpConfigProxyService impls to have shared implementations

### DIFF
--- a/dev/com.ibm.ws.security.mp.jwt.1.1.config/test/com/ibm/ws/security/mp/jwt/v11/config/impl/MpConfigProxyServiceImplTest.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1.config/test/com/ibm/ws/security/mp/jwt/v11/config/impl/MpConfigProxyServiceImplTest.java
@@ -11,12 +11,10 @@
 package com.ibm.ws.security.mp.jwt.v11.config.impl;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Optional;
 
-import org.eclipse.microprofile.config.Config;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JUnit4Mockery;
@@ -30,6 +28,7 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 
 import com.ibm.ws.security.jwt.config.MpConfigProperties;
+import com.ibm.ws.security.mp.jwt.MpConfigProxyService.MpConfigProxy;
 
 import test.common.SharedOutputManager;
 
@@ -47,8 +46,8 @@ public class MpConfigProxyServiceImplTest {
 
     @SuppressWarnings("unchecked")
     private final ClassLoader cl = mockery.mock(ClassLoader.class);
-    private final Config configNoCL = mockery.mock(Config.class, "configNoCL");
-    private final Config configCL = mockery.mock(Config.class, "configCL");
+    private final MpConfigProxy configNoCL = mockery.mock(MpConfigProxy.class, "configNoCL");
+    private final MpConfigProxy configCL = mockery.mock(MpConfigProxy.class, "configCL");
 
     @Rule
     public final TestName testName = new TestName();
@@ -137,70 +136,6 @@ public class MpConfigProxyServiceImplTest {
         assertTrue("true should be returned", output);
     }
 
-    /**
-     * Tests getConfigValue method
-     */
-    @Test
-    public void testGetConfigValueNoCL() {
-        MpConfigProxyServiceImpl mpConfigProxyServiceImpl = new MpConfigProxyServiceImplDouble();
-        String NAME = "name";
-        Class CLAZZ = Object.class;
-
-        String output = (String) mpConfigProxyServiceImpl.getConfigValue(null, NAME, CLAZZ);
-        assertNull("Expected the result to be null but was [" + output + "].", output);
-    }
-
-    @Test
-    public void testGetConfigValueNoCL_supportedMpJwtConfigProperty() {
-        MpConfigProxyServiceImpl mpConfigProxyServiceImpl = new MpConfigProxyServiceImplDouble();
-        String NAME = MpConfigProperties.PUBLIC_KEY;
-        Class CLAZZ = Object.class;
-        String VALUE = "value";
-
-        mockery.checking(new Expectations() {
-            {
-                never(configCL).getValue(NAME, CLAZZ);
-                one(configNoCL).getOptionalValue(NAME, CLAZZ);
-                will(returnValue(Optional.of(VALUE)));
-            }
-        });
-
-        String output = (String) mpConfigProxyServiceImpl.getConfigValue(null, NAME, CLAZZ);
-        assertEquals("the expected value should be returned", VALUE, output);
-    }
-
-    /**
-     * Tests getConfigValue method
-     */
-    @Test
-    public void testGetConfigValueCL_unknownMpJwtConfigProperty() {
-        MpConfigProxyServiceImpl mpConfigProxyServiceImpl = new MpConfigProxyServiceImplDouble();
-        String NAME = "name";
-        Class CLAZZ = Object.class;
-
-        String output = (String) mpConfigProxyServiceImpl.getConfigValue(cl, NAME, CLAZZ);
-        assertNull("Expected the result to be null but was [" + output + "].", output);
-    }
-
-    @Test
-    public void testGetConfigValueCL_supportedMpJwtConfigProperty() {
-        MpConfigProxyServiceImpl mpConfigProxyServiceImpl = new MpConfigProxyServiceImplDouble();
-        String NAME = MpConfigProperties.ISSUER;
-        Class CLAZZ = Object.class;
-        String VALUE = "value";
-
-        mockery.checking(new Expectations() {
-            {
-                never(configNoCL).getValue(NAME, CLAZZ);
-                one(configCL).getOptionalValue(NAME, CLAZZ);
-                will(returnValue(Optional.of(VALUE)));
-            }
-        });
-
-        String output = (String) mpConfigProxyServiceImpl.getConfigValue(cl, NAME, CLAZZ);
-        assertEquals("the expected value should be returned", VALUE, output);
-    }
-
     @Test
     public void testGetConfigValuesNoClassLoader() {
         MpConfigProxyServiceImpl mpConfigProxyServiceImpl = new MpConfigProxyServiceImplDouble();
@@ -286,7 +221,7 @@ public class MpConfigProxyServiceImplTest {
 
     class MpConfigProxyServiceImplDouble extends MpConfigProxyServiceImpl {
         @Override
-        protected Config getConfig(ClassLoader cl) {
+        public MpConfigProxy getConfigProxy(ClassLoader cl) {
             if (cl != null) {
                 return configCL;
             } else {

--- a/dev/io.openliberty.security.mp.jwt.1.2.config/src/io/openliberty/security/mp/jwt/v12/config/impl/MpConfigProxyServiceImpl.java
+++ b/dev/io.openliberty.security.mp.jwt.1.2.config/src/io/openliberty/security/mp/jwt/v12/config/impl/MpConfigProxyServiceImpl.java
@@ -11,7 +11,6 @@
 package io.openliberty.security.mp.jwt.v12.config.impl;
 
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 
@@ -26,7 +25,6 @@ import org.osgi.service.component.annotations.Modified;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.ws.security.jwt.config.MpConfigProperties;
 import com.ibm.ws.security.mp.jwt.MpConfigProxyService;
 
@@ -59,62 +57,20 @@ public class MpConfigProxyServiceImpl implements MpConfigProxyService {
         return MP_VERSION;
     }
 
-    /**
-     * @return
-     */
-    @Sensitive
-    @Override
-    public <T> T getConfigValue(ClassLoader cl, String propertyName, Class<T> propertyType) throws IllegalArgumentException, NoSuchElementException {
-        if (isAcceptableMpConfigProperty(propertyName)) {
-            Optional<T> value = getConfig(cl).getOptionalValue(propertyName, propertyType);
-            if (value != null && value.isPresent()) {
-                return value.get();
-            }
-            return null;
-        }
-        return null;
-    }
-
-    /** return */
-    @Sensitive
-    @Override
-    public MpConfigProperties getConfigProperties(ClassLoader cl) {
-        Config config = getConfig(cl);
-        Set<String> propertyNames = getSupportedConfigPropertyNames();
-        MpConfigProperties mpConfigProps = new MpConfigProperties();
-
-        for (String propertyName : propertyNames) {
-            Optional<String> value = config.getOptionalValue(propertyName, String.class);
-            if (value != null && value.isPresent()) {
-                String valueString = value.get().trim();
-                if (!valueString.isEmpty()) {
-                    mpConfigProps.put(propertyName, valueString);
-                } else {
-                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                        Tr.debug(tc, propertyName + " is empty. Ignore it.");
-                    }
-
-                }
-            } else {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, propertyName + " is not in mpConfig.");
-                }
-            }
-        }
-
-        return mpConfigProps;
-    }
-
     @Override
     public Set<String> getSupportedConfigPropertyNames() {
         return MpConfigProperties.acceptableMpConfigPropNames12;
     }
 
-    protected Config getConfig(ClassLoader cl) {
-        if (cl != null) {
-            return ConfigProvider.getConfig(cl);
-        } else {
-            return ConfigProvider.getConfig();
-        }
+    @Override
+    public MpConfigProxy getConfigProxy(ClassLoader cl) {
+        Config config = cl != null ? ConfigProvider.getConfig(cl) : ConfigProvider.getConfig();
+
+        return new MpConfigProxy() {
+            @Override
+            public <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType) {
+                return config.getOptionalValue(propertyName, propertyType);
+            }
+        };
     }
 }

--- a/dev/io.openliberty.security.mp.jwt.1.2.config/test/io/openliberty/security/mp/jwt/v12/config/impl/MpConfigProxyServiceImplTest.java
+++ b/dev/io.openliberty.security.mp.jwt.1.2.config/test/io/openliberty/security/mp/jwt/v12/config/impl/MpConfigProxyServiceImplTest.java
@@ -11,12 +11,10 @@
 package io.openliberty.security.mp.jwt.v12.config.impl;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Optional;
 
-import org.eclipse.microprofile.config.Config;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JUnit4Mockery;
@@ -30,6 +28,7 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 
 import com.ibm.ws.security.jwt.config.MpConfigProperties;
+import com.ibm.ws.security.mp.jwt.MpConfigProxyService.MpConfigProxy;
 
 import test.common.SharedOutputManager;
 
@@ -44,8 +43,8 @@ public class MpConfigProxyServiceImplTest {
     private static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("io.openliberty.security.mp.jwt*=all:com.ibm.ws.security.mp.jwt.*=all");
 
     private final ClassLoader cl = mockery.mock(ClassLoader.class);
-    private final Config configNoClassLoader = mockery.mock(Config.class, "configNoClassLoader");
-    private final Config configClassLoader = mockery.mock(Config.class, "configClassLoader");
+    private final MpConfigProxy configNoClassLoader = mockery.mock(MpConfigProxy.class, "configNoClassLoader");
+    private final MpConfigProxy configClassLoader = mockery.mock(MpConfigProxy.class, "configClassLoader");
 
     @Rule
     public final TestName testName = new TestName();
@@ -104,67 +103,6 @@ public class MpConfigProxyServiceImplTest {
         MpConfigProxyServiceImpl mpConfigProxyServiceImpl = new MpConfigProxyServiceImpl();
         boolean output = mpConfigProxyServiceImpl.isMpConfigAvailable();
         assertTrue("MP config should have been considered available.", output);
-    }
-
-    @Test
-    public void testGetConfigValueNoClassLoader() {
-        MpConfigProxyServiceImpl mpConfigProxyServiceImpl = new MpConfigProxyServiceImplDouble();
-        String NAME = "name";
-        Class CLAZZ = Object.class;
-
-        String output = (String) mpConfigProxyServiceImpl.getConfigValue(null, NAME, CLAZZ);
-        assertNull("Expected the result to be null but was [" + output + "].", output);
-    }
-
-    @Test
-    public void testGetConfigValueNoClassLoader_supportedMpJwtConfigProperty() {
-        MpConfigProxyServiceImpl mpConfigProxyServiceImpl = new MpConfigProxyServiceImplDouble();
-        String NAME = MpConfigProperties.PUBLIC_KEY;
-        Class CLAZZ = Object.class;
-        String VALUE = "value";
-
-        mockery.checking(new Expectations() {
-            {
-                never(configClassLoader).getValue(NAME, CLAZZ);
-                one(configNoClassLoader).getOptionalValue(NAME, CLAZZ);
-                will(returnValue(Optional.of(VALUE)));
-            }
-        });
-
-        String output = (String) mpConfigProxyServiceImpl.getConfigValue(null, NAME, CLAZZ);
-        assertEquals("the expected value should be returned", VALUE, output);
-    }
-
-    /**
-     * Tests getConfigValue method
-     */
-    @Test
-    public void testGetConfigValueClassLoader_unknownMpJwtConfigProperty() {
-        MpConfigProxyServiceImpl mpConfigProxyServiceImpl = new MpConfigProxyServiceImplDouble();
-        String NAME = "name";
-        Class CLAZZ = Object.class;
-
-        String output = (String) mpConfigProxyServiceImpl.getConfigValue(cl, NAME, CLAZZ);
-        assertNull("Expected the result to be null but was [" + output + "].", output);
-    }
-
-    @Test
-    public void testGetConfigValueClassLoader_supportedMpJwtConfigProperty() {
-        MpConfigProxyServiceImpl mpConfigProxyServiceImpl = new MpConfigProxyServiceImplDouble();
-        String NAME = MpConfigProperties.ISSUER;
-        Class CLAZZ = Object.class;
-        String VALUE = "value";
-
-        mockery.checking(new Expectations() {
-            {
-                never(configNoClassLoader).getValue(NAME, CLAZZ);
-                one(configClassLoader).getOptionalValue(NAME, CLAZZ);
-                will(returnValue(Optional.of(VALUE)));
-            }
-        });
-
-        String output = (String) mpConfigProxyServiceImpl.getConfigValue(cl, NAME, CLAZZ);
-        assertEquals("the expected value should be returned", VALUE, output);
     }
 
     @Test
@@ -291,7 +229,7 @@ public class MpConfigProxyServiceImplTest {
 
     class MpConfigProxyServiceImplDouble extends MpConfigProxyServiceImpl {
         @Override
-        protected Config getConfig(ClassLoader cl) {
+        public MpConfigProxy getConfigProxy(ClassLoader cl) {
             if (cl != null) {
                 return configClassLoader;
             } else {

--- a/dev/io.openliberty.security.mp.jwt.2.1.config/src/io/openliberty/security/mp/jwt/v21/config/impl/MpConfigProxyServiceImpl.java
+++ b/dev/io.openliberty.security.mp.jwt.2.1.config/src/io/openliberty/security/mp/jwt/v21/config/impl/MpConfigProxyServiceImpl.java
@@ -11,7 +11,6 @@
 package io.openliberty.security.mp.jwt.v21.config.impl;
 
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 
@@ -26,7 +25,6 @@ import org.osgi.service.component.annotations.Modified;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.ws.security.jwt.config.MpConfigProperties;
 import com.ibm.ws.security.mp.jwt.MpConfigProxyService;
 
@@ -58,62 +56,20 @@ public class MpConfigProxyServiceImpl implements MpConfigProxyService {
         return MP_VERSION;
     }
 
-    /**
-     * @return
-     */
-    @Sensitive
-    @Override
-    public <T> T getConfigValue(ClassLoader cl, String propertyName, Class<T> propertyType) throws IllegalArgumentException, NoSuchElementException {
-        if (isAcceptableMpConfigProperty(propertyName)) {
-            Optional<T> value = getConfig(cl).getOptionalValue(propertyName, propertyType);
-            if (value != null && value.isPresent()) {
-                return value.get();
-            }
-            return null;
-        }
-        return null;
-    }
-
-    /** return */
-    @Sensitive
-    @Override
-    public MpConfigProperties getConfigProperties(ClassLoader cl) {
-        Config config = getConfig(cl);
-        Set<String> propertyNames = getSupportedConfigPropertyNames();
-        MpConfigProperties mpConfigProps = new MpConfigProperties();
-
-        for (String propertyName : propertyNames) {
-            Optional<String> value = config.getOptionalValue(propertyName, String.class);
-            if (value != null && value.isPresent()) {
-                String valueString = value.get().trim();
-                if (!valueString.isEmpty()) {
-                    mpConfigProps.put(propertyName, valueString);
-                } else {
-                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                        Tr.debug(tc, propertyName + " is empty. Ignore it.");
-                    }
-
-                }
-            } else {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, propertyName + " is not in mpConfig.");
-                }
-            }
-        }
-
-        return mpConfigProps;
-    }
-
     @Override
     public Set<String> getSupportedConfigPropertyNames() {
         return MpConfigProperties.acceptableMpConfigPropNames21;
     }
 
-    protected Config getConfig(ClassLoader cl) {
-        if (cl != null) {
-            return ConfigProvider.getConfig(cl);
-        } else {
-            return ConfigProvider.getConfig();
-        }
+    @Override
+    public MpConfigProxy getConfigProxy(ClassLoader cl) {
+        Config config = cl != null ? ConfigProvider.getConfig(cl) : ConfigProvider.getConfig();
+
+        return new MpConfigProxy() {
+            @Override
+            public <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType) {
+                return config.getOptionalValue(propertyName, propertyType);
+            }
+        };
     }
 }


### PR DESCRIPTION
- Create getConfigProxy method that each impl needs to implement for their MP Config implementation.
- Move getConfigProperties to a default impl in the interface that all impls then share.
- Remove code and test for getConfigValue since it isn't called any more except in test.

This resolves the review comments from @ayoho about duplicate code from Joe's and my PRs (#23231 and #22886 respectively).

#build