### PR TITLE
Stop servers after test failure

### DIFF
--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/fat/src/com/ibm/ws/transaction/test/tests/FailoverTest.java
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/fat/src/com/ibm/ws/transaction/test/tests/FailoverTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.fail;
 
 import java.util.List;
 
+import org.junit.After;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import com.ibm.tx.jta.ut.util.LastingXAResourceImpl;
@@ -38,6 +39,27 @@ public class FailoverTest extends TxFATServletClient {
     public static final String SERVLET_NAME = "transaction/FailoverServlet";
 
     protected static final int START_TIMEOUT = 30000;
+
+    // This is the server that will be stopped after each test
+    protected LibertyServer server;
+    protected String[] serverMsgs;
+
+    @After
+    public void cleanup() throws Exception {
+
+        if (server != null) {
+            if (serverMsgs != null) {
+                FATUtils.stopServers(serverMsgs, server);
+                serverMsgs = null;
+            } else {
+                FATUtils.stopServers(server);
+            }
+
+            server = null;
+        }
+
+        FailoverTest.commonCleanup(this.getClass().getName());
+    }
 
     public void runInServletAndCheck(LibertyServer server, String path, String method) throws Exception {
         StringBuilder sb = runInServlet(server, path, method);


### PR DESCRIPTION
#build
#spawn.fullfat.buckets=com.ibm.ws.transaction.hadb_fat.db2.1,com.ibm.ws.transaction.hadb_fat.db2.2,com.ibm.ws.transaction.hadb_fat.db2.lease,com.ibm.ws.transaction.hadb_fat.db2.retriablecodes,com.ibm.ws.transaction.hadb_fat.derby.1,com.ibm.ws.transaction.hadb_fat.derby.2,com.ibm.ws.transaction.hadb_fat.derby.lease,com.ibm.ws.transaction.hadb_fat.derby.retriablecodes,com.ibm.ws.transaction.hadb_fat.oracle.1,com.ibm.ws.transaction.hadb_fat.oracle.2,com.ibm.ws.transaction.hadb_fat.oracle.lease,com.ibm.ws.transaction.hadb_fat.oracle.retriablecodes,com.ibm.ws.transaction.hadb_fat.postgresql.1,com.ibm.ws.transaction.hadb_fat.postgresql.2,com.ibm.ws.transaction.hadb_fat.postgresql.lease,com.ibm.ws.transaction.hadb_fat.postgresql.retriablecodes,com.ibm.ws.transaction.hadb_fat.sqlserver.1,com.ibm.ws.transaction.hadb_fat.sqlserver.2,com.ibm.ws.transaction.hadb_fat.sqlserver.lease,com.ibm.ws.transaction.hadb_fat.sqlserver.retriablecodes