### PR TITLE
Remove stagging repo from TCK

### DIFF
--- a/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -15,7 +15,8 @@
 	<version>1.0-SNAPSHOT</version>
 	<name>Jakarta JSON Binding TCK Runner TCK Module</name>
 
-	<repositories> <!-- For artifacts not yet in Maven Central -->
+	<!-- For artifacts not yet in Maven Central -->
+	<!-- <repositories> 
 		<repository>
 			<id>sonatype-nexus-staging</id>
 			<name>Sonatype Nexus Staging</name>
@@ -27,7 +28,7 @@
 				<enabled>true</enabled>
 			</snapshots>
 		</repository>
-	</repositories>
+	</repositories> -->
 
 	<properties>
 		<!-- Global Maven settings -->

--- a/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -15,7 +15,8 @@
 	<version>1.0-SNAPSHOT</version>
 	<name>Jakarta JSON Processing TCK Runner TCK Module</name>
 
-	<repositories> <!-- For artifacts not yet in Maven Central -->
+	<!-- For artifacts not yet in Maven Central -->
+	<!-- <repositories> 
 		<repository>
 			<id>sonatype-nexus-staging</id>
 			<name>Sonatype Nexus Staging</name>
@@ -27,7 +28,7 @@
 				<enabled>true</enabled>
 			</snapshots>
 		</repository>
-	</repositories>
+	</repositories> -->
 
 	<properties>
 		<!-- Global Maven settings -->


### PR DESCRIPTION
These artifacts are now in maven central and we no longer need to get them from the Jakarta stagging repo.
