### PR TITLE
Tolerate null ID token in token response for refresh flows

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanism.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanism.java
@@ -416,8 +416,12 @@ public class OidcHttpAuthenticationMechanism implements HttpAuthenticationMechan
         }
         IdentityToken idToken = openIdContext.getIdentityToken();
         boolean isAccessTokenExpired = openIdContext.getAccessToken().isExpired();
-        boolean isIdTokenExpired = idToken.isExpired();
-        String idTokenString = idToken.getToken();
+        boolean isIdTokenExpired = false;
+        String idTokenString = null;
+        if (idToken != null) {
+            isIdTokenExpired = idToken.isExpired();
+            idTokenString = idToken.getToken();
+        }
         String refreshTokenString = getRefreshToken(openIdContext);
         return client.processExpiredToken(request, response, isAccessTokenExpired, isIdTokenExpired, idTokenString, refreshTokenString);
     }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
@@ -200,7 +200,11 @@ public class OidcIdentityStore implements IdentityStore {
     }
 
     private IdentityToken createIdentityTokenFromTokenResponse(long tokenMinValidityInMillis, TokenResponse tokenResponse, JwtClaims idTokenClaims) {
-        return new IdentityTokenImpl(tokenResponse.getIdTokenString(), idTokenClaims.getClaimsMap(), tokenMinValidityInMillis);
+        String idTokenString = tokenResponse.getIdTokenString();
+        if (idTokenString == null) {
+            return null;
+        }
+        return new IdentityTokenImpl(idTokenString, idTokenClaims.getClaimsMap(), tokenMinValidityInMillis);
     }
 
     @FFDCIgnore(Exception.class)

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/logout/RPInitiatedLogoutStrategy.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/logout/RPInitiatedLogoutStrategy.java
@@ -45,15 +45,20 @@ public class RPInitiatedLogoutStrategy {
     public ProviderAuthenticationResult logout() {
         String clientId = null;
         String redirectURI = null;
-        if (oidcClientConfig != null)
+        if (oidcClientConfig != null) {
             clientId = oidcClientConfig.getClientId();
-        if (logoutConfig != null)
+        }
+        if (logoutConfig != null) {
             redirectURI = logoutConfig.getRedirectURI();
+        }
 
-        req.setAttribute(ID_TOKEN_HINT, idTokenString);
+        if (idTokenString != null) {
+            req.setAttribute(ID_TOKEN_HINT, idTokenString);
+        }
         req.setAttribute(CLIENT_ID, clientId);
-        if (redirectURI != null && !redirectURI.isEmpty())
+        if (redirectURI != null && !redirectURI.isEmpty()) {
             req.setAttribute(POST_LOGOUT_REDIRECT_URI, redirectURI);
+        }
 
         return new ProviderAuthenticationResult(AuthResult.REDIRECT_TO_PROVIDER, HttpServletResponse.SC_OK, null, null, null, endSessionEndPoint);
 


### PR DESCRIPTION
Adds fix to avoid checks on an ID token that might have null claims.