### PR TITLE
Add sleep to test setup

### DIFF
--- a/dev/io.openliberty.wsoc.2.1.internal_fat/fat/src/io/openliberty/wsoc/tests/Basic21Test.java
+++ b/dev/io.openliberty.wsoc.2.1.internal_fat/fat/src/io/openliberty/wsoc/tests/Basic21Test.java
@@ -101,6 +101,9 @@ public class Basic21Test {
         wt_secure = new WsocTest(LS, true);
         ssl = new SSLTest(wt_secure);
         bwst.setUp();
+
+        // Allow Jetty to finish starting up - https://github.com/OpenLiberty/open-liberty/issues/23172
+        Thread.sleep(3000);
     }
 
     @AfterClass


### PR DESCRIPTION
I'm thinking Jetty isn't finished initializing? Adding a Thread.sleep to see if it helps. 

fixes #23172 