### PR TITLE
Add EE10 repeats for non Jakarta features phase 1

### DIFF
--- a/dev/com.ibm.websphere.security_fat.1/bnd.bnd
+++ b/dev/com.ibm.websphere.security_fat.1/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -19,7 +19,8 @@ src: \
 
 fat.project: true
 
-tested.features: expressionLanguage-4.0, appsecurity-4.0, servlet-5.0, cdi-3.0, passwordutilities-1.1
+tested.features: expressionLanguage-4.0, appsecurity-4.0, servlet-5.0, cdi-3.0, passwordutilities-1.1,\
+  expressionLanguage-5.0, appsecurity-5.0, servlet-6.0, cdi-4.0, jsonp-2.1
 
 -buildpath: \
   com.ibm.websphere.javaee.servlet.3.1;version=latest,\

--- a/dev/com.ibm.websphere.security_fat.1/fat/src/com/ibm/websphere/security/fat/FATSuite.java
+++ b/dev/com.ibm.websphere.security_fat.1/fat/src/com/ibm/websphere/security/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 IBM Corporation and others.
+ * Copyright (c) 2011, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,8 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -30,8 +32,10 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite extends CommonLocalLDAPServerSuite {
 
     /*
-     * Run EE9 tests in LITE mode and run all tests in FULL mode.
+     * Run EE9 tests in LITE mode if Java 8, EE10 tests in LITE mode if >= Java 11 and run all tests in FULL mode.
      */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(new JakartaEE9Action());
+    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
+                    .andWith(new JakartaEE9Action().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                    .andWith(new JakartaEE10Action());
 }

--- a/dev/com.ibm.websphere.security_fat.1/fat/src/com/ibm/websphere/security/fat/PasswordUtilAPITest.java
+++ b/dev/com.ibm.websphere.security_fat.1/fat/src/com/ibm/websphere/security/fat/PasswordUtilAPITest.java
@@ -32,6 +32,7 @@ import com.ibm.websphere.simplicity.log.Log;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
@@ -101,7 +102,7 @@ public class PasswordUtilAPITest {
              * The feature passwordUtilties-1.0 starts federatedRegistry-1.0, except when using EE9 since then
              * appSecurity-1.0 (which brings in federatedRegistry-1.0) is no longer compatible.
              */
-            if (!JakartaEE9Action.isActive()) {
+            if (!JakartaEE9Action.isActive() && !JakartaEE10Action.isActive()) {
                 assertFalse("Federated registry feature (federatedRegistry-1.0) should have started.", myServer.findStringsInLogs("federatedRegistry-1.0").isEmpty());
             } else {
                 assertTrue("Federated registry feature (federatedRegistry-1.0) should not have started.", myServer.findStringsInLogs("federatedRegistry-1.0").isEmpty());

--- a/dev/com.ibm.websphere.security_fat.1/fat/src/com/ibm/websphere/security/fat/SecurityFatUtils.java
+++ b/dev/com.ibm.websphere.security_fat.1/fat/src/com/ibm/websphere/security/fat/SecurityFatUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
@@ -27,13 +28,18 @@ public class SecurityFatUtils {
      * JakartaEE9 transform a list of applications. The applications are the simple app names and they must exist at '<server>/dropins/<appname>'.
      *
      * @param myServer The server to transform the applications on.
-     * @param apps The simple names of the applications to transform.
+     * @param apps     The simple names of the applications to transform.
      */
     public static void transformApps(LibertyServer myServer, String... apps) {
         if (JakartaEE9Action.isActive()) {
             for (String app : apps) {
                 Path someArchive = Paths.get(myServer.getServerRoot() + File.separatorChar + "dropins" + File.separatorChar + app);
                 JakartaEE9Action.transformApp(someArchive);
+            }
+        } else if (JakartaEE10Action.isActive()) {
+            for (String app : apps) {
+                Path someArchive = Paths.get(myServer.getServerRoot() + File.separatorChar + "dropins" + File.separatorChar + app);
+                JakartaEE10Action.transformApp(someArchive);
             }
         }
     }

--- a/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -17,7 +17,8 @@ src: \
 fat.project: true
 
 tested.features: \
-	jacc-1.5, expressionLanguage-4.0, appsecurity-4.0, servlet-5.0, cdi-3.0, enterpriseBeansLite-4.0, appAuthorization-2.0
+	jacc-1.5, expressionLanguage-4.0, appsecurity-4.0, servlet-5.0, cdi-3.0, enterpriseBeansLite-4.0, appAuthorization-2.0, \
+	expressionLanguage-5.0, appsecurity-5.0, servlet-6.0, cdi-4.0, appAuthorization-2.1, jsonp-2.1
 
 -buildpath: \
     com.ibm.json4j;version=latest,\

--- a/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/fat/src/com/ibm/ws/ejbcontainer/security/jacc_fat/FATSuite.java
+++ b/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/fat/src/com/ibm/ws/ejbcontainer/security/jacc_fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,8 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -55,14 +57,20 @@ public class FATSuite {
                                                          "usr:jaccTestProvider-2.0"
     };
 
+    private static final Set<String> EE10_FEATURES;
+    private static final String[] EE10_FEATURES_ARRAY = {
+                                                          "usr:jaccTestProvider-2.1"
+    };
+
     static {
         EE78_FEATURES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE78_FEATURES_ARRAY)));
         EE9_FEATURES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE9_FEATURES_ARRAY)));
+        EE10_FEATURES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE10_FEATURES_ARRAY)));
     }
 
     /*
-     * Run EE9 tests in LITE mode and run all tests in FULL mode.
+     * Run EE9 tests in LITE mode if Java 8, EE10 tests in LITE mode if >= Java 11 and run all tests in FULL mode.
      */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(new JakartaEE9Action().removeFeatures(EE78_FEATURES).addFeatures(EE9_FEATURES));
+    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(new JakartaEE9Action().removeFeatures(EE78_FEATURES).addFeatures(EE9_FEATURES).conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11)).andWith(new JakartaEE10Action().removeFeatures(EE78_FEATURES).removeFeatures(EE9_FEATURES).addFeatures(EE10_FEATURES));
 }

--- a/dev/com.ibm.ws.ejbcontainer.security.jacc_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.security.jacc_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -17,7 +17,8 @@ src: \
 fat.project: true
 
 tested.features: \
-	jacc-1.5, expressionLanguage-4.0, appsecurity-4.0, servlet-5.0, cdi-3.0, enterpriseBeansLite-4.0, appAuthorization-2.0
+	jacc-1.5, expressionLanguage-4.0, appsecurity-4.0, servlet-5.0, cdi-3.0, enterpriseBeansLite-4.0, appAuthorization-2.0, \
+	expressionLanguage-5.0, appsecurity-5.0, servlet-6.0, cdi-4.0, appAuthorization-2.1, jsonp-2.1
 
 -buildpath: \
     com.ibm.json4j;version=latest,\

--- a/dev/com.ibm.ws.ejbcontainer.security.jacc_fat/fat/src/com/ibm/ws/ejbcontainer/security/jacc_fat/EJBAnnTestBase.java
+++ b/dev/com.ibm.ws.ejbcontainer.security.jacc_fat/fat/src/com/ibm/ws/ejbcontainer/security/jacc_fat/EJBAnnTestBase.java
@@ -21,6 +21,7 @@ import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.webcontainer.security.test.servlets.BasicAuthClient;
 import com.ibm.ws.webcontainer.security.test.servlets.ServletClient;
 
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
@@ -148,7 +149,7 @@ public class EJBAnnTestBase {
         /*
          * EE9 removed getCallerIdentity() from SessionContext.
          */
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE9Action.isActive() || JakartaEE10Action.isActive()) {
             verifyResponseWithoutDeprecated(response, getCallerPrincipal, isCallerInRoleManager, isCallerInRoleEmployee);
         } else {
             mustContain(response, getCallerPrincipal);

--- a/dev/com.ibm.ws.ejbcontainer.security.jacc_fat/fat/src/com/ibm/ws/ejbcontainer/security/jacc_fat/FATSuite.java
+++ b/dev/com.ibm.ws.ejbcontainer.security.jacc_fat/fat/src/com/ibm/ws/ejbcontainer/security/jacc_fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,8 @@ import com.ibm.ws.ejbcontainer.security.jacc_fat.audit.EJBJarX03JACCAuditTest;
 import com.ibm.ws.ejbcontainer.security.jacc_fat.audit.PureAnnA08JAASLoginFromEJBJACCAuditTest;
 
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -77,14 +79,20 @@ public class FATSuite {
                                                          "usr:jaccTestProvider-2.0"
     };
 
+    private static final Set<String> EE10_FEATURES;
+    private static final String[] EE10_FEATURES_ARRAY = {
+                                                          "usr:jaccTestProvider-2.1"
+    };
+
     static {
         EE78_FEATURES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE78_FEATURES_ARRAY)));
         EE9_FEATURES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE9_FEATURES_ARRAY)));
+        EE10_FEATURES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE10_FEATURES_ARRAY)));
     }
 
     /*
-     * Run EE9 tests in LITE mode and run all tests in FULL mode.
+     * Run EE9 tests in LITE mode if Java 8, EE10 tests in LITE mode if >= Java 11 and run all tests in FULL mode.
      */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(new JakartaEE9Action().removeFeatures(EE78_FEATURES).addFeatures(EE9_FEATURES));
+    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(new JakartaEE9Action().removeFeatures(EE78_FEATURES).addFeatures(EE9_FEATURES).conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11)).andWith(new JakartaEE10Action().removeFeatures(EE78_FEATURES).removeFeatures(EE9_FEATURES).addFeatures(EE10_FEATURES));
 }

--- a/dev/com.ibm.ws.grpc_fat/bnd.bnd
+++ b/dev/com.ibm.ws.grpc_fat/bnd.bnd
@@ -42,7 +42,16 @@ tested.features:\
 	mpJwt-2.0,\
 	mpConfig-3.0,\
 	pages-3.0,\
-	jsonb-2.0
+	jsonb-2.0,\
+	servlet-6.0,\
+	appsecurity-5.0,\
+	expressionlanguage-5.0,\
+	cdi-4.0,\
+	mpOpenAPI-3.1,\
+	mpMetrics-5.0,\
+	mpJwt-2.1,\
+	pages-3.1,\
+	jsonb-3.0
 
 -buildpath: \
     com.ibm.websphere.javaee.servlet.4.0;version=latest,\

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/FATSuite.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 
 import org.junit.ClassRule;
-
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -49,16 +48,24 @@ public class FATSuite {
 
     private static final Class<?> c = FATSuite.class;
 
-    static String[] removedFeatures = {"mpOpenAPI-1.1", "mpMetrics-2.3", "mpJwt-1.1", "mpConfig-1.3", "mpRestClient-1.3", "appSecurity-2.0"};
+    static String[] removedFeatures = { "mpOpenAPI-1.1", "mpMetrics-2.3", "mpJwt-1.1", "mpConfig-1.3", "mpRestClient-1.3", "appSecurity-2.0" };
 
-    static String[] addedFeatures = {"mpOpenAPI-3.0", "mpMetrics-4.0", "mpJwt-2.0", "mpConfig-3.0", "mpRestClient-3.0", "appSecurity-4.0"};
+    static String[] addedFeatures = { "mpOpenAPI-3.0", "mpMetrics-4.0", "mpJwt-2.0", "mpConfig-3.0", "mpRestClient-3.0", "appSecurity-4.0" };
+
+    static String[] ee10AddedFeatures = { "mpOpenAPI-3.1", "mpMetrics-5.0", "mpJwt-2.1", "mpConfig-3.0", "mpRestClient-3.0", "appSecurity-5.0" };
 
     @ClassRule
     public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly())
-                             .andWith(FeatureReplacementAction.EE9_FEATURES()
-                             .removeFeatures(new HashSet<>(Arrays.asList(removedFeatures)))
-                             .addFeatures(new HashSet<>(Arrays.asList(addedFeatures)))
-                             .alwaysAddFeature("servlet-5.0")
-                             .alwaysAddFeature("jsonb-2.0"));
-
+                    .andWith(FeatureReplacementAction.EE9_FEATURES()
+                                    .removeFeatures(new HashSet<>(Arrays.asList(removedFeatures)))
+                                    .addFeatures(new HashSet<>(Arrays.asList(addedFeatures)))
+                                    .alwaysAddFeature("servlet-5.0")
+                                    .alwaysAddFeature("jsonb-2.0")
+                                    .conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                    .andWith(FeatureReplacementAction.EE10_FEATURES()
+                                    .removeFeatures(new HashSet<>(Arrays.asList(removedFeatures)))
+                                    .removeFeatures(new HashSet<>(Arrays.asList(addedFeatures)))
+                                    .addFeatures(new HashSet<>(Arrays.asList(ee10AddedFeatures)))
+                                    .alwaysAddFeature("servlet-6.0")
+                                    .alwaysAddFeature("jsonb-3.0"));
 }

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/GrpcMetricsTest.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/GrpcMetricsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@
 package com.ibm.ws.fat.grpc;
 
 import static com.ibm.ws.fat.grpc.monitoring.GrpcMetricsTestUtils.checkMetric;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.net.URL;
@@ -74,8 +73,8 @@ public class GrpcMetricsTest extends FATServletClient {
 
         // add the "service" app to the client server, to be used by testGrpcMetricsSingleServer()
         ShrinkHelper.defaultDropinApp(GrpcClientOnly, "HelloWorldService.war",
-                                    "com.ibm.ws.grpc.fat.helloworld.service",
-                                    "io.grpc.examples.helloworld");
+                                      "com.ibm.ws.grpc.fat.helloworld.service",
+                                      "io.grpc.examples.helloworld");
 
         LOG.info("GrpcMetricsTest : setUp() : add HelloWorldService app to GrpcServerOnly");
         ShrinkHelper.defaultDropinApp(GrpcServerOnly, "HelloWorldService.war",
@@ -145,16 +144,16 @@ public class GrpcMetricsTest extends FATServletClient {
             assertTrue("the gRPC request did not complete correctly", page.asText().contains("us3r1"));
 
             // check the gRPC server-side metrics
-            checkMetric(GrpcServerOnly, "/metrics/vendor/grpc.server.rpcStarted.total", "1");
-            checkMetric(GrpcServerOnly, "/metrics/vendor/grpc.server.rpcCompleted.total", "1");
-            checkMetric(GrpcServerOnly, "/metrics/vendor/grpc.server.sentMessages.total", "1");
-            checkMetric(GrpcServerOnly, "/metrics/vendor/grpc.server.receivedMessages.total", "1");
+            checkMetric(GrpcServerOnly, "/metrics/vendor/grpc.server.rpcStarted.total", null, "1");
+            checkMetric(GrpcServerOnly, "/metrics/vendor/grpc.server.rpcCompleted.total", null, "1");
+            checkMetric(GrpcServerOnly, "/metrics/vendor/grpc.server.sentMessages.total", null, "1");
+            checkMetric(GrpcServerOnly, "/metrics/vendor/grpc.server.receivedMessages.total", null, "1");
 
             // check the gRPC client-side metrics
-            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.client.rpcStarted.total", String.valueOf(clientCallCount));
-            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.client.rpcCompleted.total", String.valueOf(clientCallCount));
-            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.client.sentMessages.total", String.valueOf(clientCallCount));
-            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.client.receivedMessages.total", String.valueOf(clientCallCount));
+            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.client.rpcStarted.total", null, String.valueOf(clientCallCount));
+            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.client.rpcCompleted.total", null, String.valueOf(clientCallCount));
+            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.client.sentMessages.total", null, String.valueOf(clientCallCount));
+            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.client.receivedMessages.total", null, String.valueOf(clientCallCount));
         }
     }
 
@@ -216,16 +215,16 @@ public class GrpcMetricsTest extends FATServletClient {
             assertTrue("the gRPC request did not complete correctly", page.asText().contains("us3r1"));
 
             // check the gRPC server-side metrics
-            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.server.rpcStarted.total", String.valueOf(serverCallCount));
-            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.server.rpcCompleted.total", String.valueOf(serverCallCount));
-            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.server.sentMessages.total", String.valueOf(serverCallCount));
-            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.server.receivedMessages.total", String.valueOf(serverCallCount));
+            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.server.rpcStarted.total", null, String.valueOf(serverCallCount));
+            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.server.rpcCompleted.total", null, String.valueOf(serverCallCount));
+            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.server.sentMessages.total", null, String.valueOf(serverCallCount));
+            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.server.receivedMessages.total", null, String.valueOf(serverCallCount));
 
             // check the gRPC client-side metrics
-            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.client.rpcStarted.total", String.valueOf(clientCallCount));
-            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.client.rpcCompleted.total", String.valueOf(clientCallCount));
-            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.client.sentMessages.total", String.valueOf(clientCallCount));
-            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.client.receivedMessages.total", String.valueOf(clientCallCount));
+            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.client.rpcStarted.total", null, String.valueOf(clientCallCount));
+            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.client.rpcCompleted.total", null, String.valueOf(clientCallCount));
+            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.client.sentMessages.total", null, String.valueOf(clientCallCount));
+            checkMetric(GrpcClientOnly, "/metrics/vendor/grpc.client.receivedMessages.total", null, String.valueOf(clientCallCount));
         }
     }
 }

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreProducerServletClientTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreProducerServletClientTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -426,7 +426,7 @@ public class StoreProducerServletClientTests extends FATServletClient {
                 // Log the page for debugging if necessary in the future.
                 Log.info(c, name.getMethodName(), ": client stream entity/result: " + metricValue);
 
-                if (metricValue == null || Integer.parseInt(metricValue) < 200) {
+                if (metricValue == null || new Float(metricValue).intValue() < 200) {
                     fail(String.format("Incorrect metric value [%s]. Expected [%s], got [%s]", "grpc.client.receivedMessages.total", ">=200", metricValue));
                 }
             } else {

--- a/dev/com.ibm.ws.grpc_fat/test-applications/StoreProducerApp.war/src/com/ibm/testapp/g3store/servletProducer/ProducerServlet.java
+++ b/dev/com.ibm.ws.grpc_fat/test-applications/StoreProducerApp.war/src/com/ibm/testapp/g3store/servletProducer/ProducerServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -51,6 +51,17 @@ import com.ibm.testapp.g3store.utilsProducer.ProducerUtils;
 public class ProducerServlet extends HttpServlet {
     private static final long serialVersionUID = 1L;
     private static Logger log = Logger.getLogger(ProducerServlet.class.getName());
+
+    private static final boolean isMetrics50OrLater;
+    static {
+        boolean isMeterFound = true;
+        try {
+            Class.forName("org.eclipse.microprofile.metrics.Meter");
+        } catch (Throwable t) {
+            isMeterFound = false;
+        }
+        isMetrics50OrLater = !isMeterFound;
+    }
 
     /**
      * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
@@ -274,7 +285,12 @@ public class ProducerServlet extends HttpServlet {
 
         // retrieve the metrics
         int httpPort = Integer.parseInt(ProducerUtils.getSysProp("bvt.prop.HTTP_secondary"));
-        String metricValue = getMetric("localhost", httpPort, "/metrics/vendor/grpc.client.receivedMessages.total");
+        String metricName = "/metrics/vendor/grpc.client.receivedMessages.total";
+        if (isMetrics50OrLater) {
+            metricName = "/metrics?scope=vendor&name=grpc.client.receivedMessages.total";
+        }
+
+        String metricValue = getMetric("localhost", httpPort, metricName, "test_g3store_grpc_AppProducerService_serverStreamA");
 
         // create HTML response
         response.setContentType("text/html");
@@ -302,7 +318,12 @@ public class ProducerServlet extends HttpServlet {
 
         // retrieve the metrics
         int httpPort = Integer.parseInt(ProducerUtils.getSysProp("bvt.prop.HTTP_default"));
-        String metricValue = getMetric("localhost", httpPort, "/metrics/vendor/grpc.server.receivedMessages.total");
+        String metricName = "/metrics/vendor/grpc.server.receivedMessages.total";
+        if (isMetrics50OrLater) {
+            metricName = "/metrics?scope=vendor&name=grpc.server.receivedMessages.total";
+        }
+
+        String metricValue = getMetric("localhost", httpPort, metricName, null);
 
         // create HTML response
         response.setContentType("text/html");

--- a/dev/com.ibm.ws.jbatch.fat.common/src/com/ibm/ws/jbatch/test/BatchAppUtils.java
+++ b/dev/com.ibm.ws.jbatch.fat.common/src/com/ibm/ws/jbatch/test/BatchAppUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,6 +30,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
@@ -207,6 +208,8 @@ public class BatchAppUtils {
         targetServer.copyFileToLibertyServerRoot(PrebuiltAppArtifactPath, "dropins", appName);
         if (JakartaEE9Action.isActive()) {
             JakartaEE9Action.transformApp(Paths.get(targetServer.getServerRoot(), "dropins", appName));
+        } else if (JakartaEE10Action.isActive()) {
+            JakartaEE10Action.transformApp(Paths.get(targetServer.getServerRoot(), "dropins", appName));
         }
     }
 

--- a/dev/com.ibm.ws.jbatch.open_fat/fat/src/batch/fat/junit/FATSuite.java
+++ b/dev/com.ibm.ws.jbatch.open_fat/fat/src/batch/fat/junit/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -70,5 +72,7 @@ import componenttest.rules.repeater.RepeatTests;
 })
 public class FATSuite {
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(new JakartaEE9Action()); 
+    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly())
+        .andWith(new JakartaEE9Action().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+        .andWith(new JakartaEE10Action()); 
 }

--- a/dev/com.ibm.ws.logging_fat/publish/features/logServiceTest-1.0.mf
+++ b/dev/com.ibm.ws.logging_fat/publish/features/logServiceTest-1.0.mf
@@ -3,7 +3,9 @@ Subsystem-ManifestVersion: 1
 IBM-ShortName: logServiceTest-1.0
 Subsystem-SymbolicName: com.ibm.websphere.appserver.logServiceTest-1.0; visibility:=public
 Subsystem-Version: 1.0.0
-Subsystem-Content:  logservice.tester;  version="[1,1.0.100)", com.ibm.wsspi.appserver.webBundle-1.0; type="osgi.subsystem.feature", com.ibm.websphere.appserver.servlet-3.1; type="osgi.subsystem.feature"
+Subsystem-Content:  logservice.tester;  version="[1,1.0.100)",
+ com.ibm.wsspi.appserver.webBundle-1.0; type="osgi.subsystem.feature",
+ com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0,5.0,6.0"; type="osgi.subsystem.feature"
 Subsystem-Type: osgi.subsystem.feature
 IBM-Feature-Version: 2
 Subsystem-Localization: OSGI-INF/l10n/subsystem 

--- a/dev/com.ibm.ws.logging_fat/publish/features/sampleTraceSourceHandler-1.0.mf
+++ b/dev/com.ibm.ws.logging_fat/publish/features/sampleTraceSourceHandler-1.0.mf
@@ -4,6 +4,7 @@ IBM-ShortName: sampleTraceSourceHandler-1.0
 Subsystem-SymbolicName: com.ibm.websphere.appserver.sampleTraceSourceHandler-1.0; visibility:=public
 Subsystem-Version: 1.0.0
 Subsystem-Content:  com.ibm.websphere.appserver.restHandler-1.0; type="osgi.subsystem.feature",
+  com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature",
   trace.source.handler;  version="[1,1.0.100)",
   accesslog.source.handler;  version="[1,1.0.100)"
 Subsystem-Type: osgi.subsystem.feature

--- a/dev/com.ibm.ws.request.timing.monitor_fat/bnd.bnd
+++ b/dev/com.ibm.ws.request.timing.monitor_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -28,7 +28,13 @@ tested.features: \
 	mpMetrics-2.0,\
 	cdi-1.2,\
 	appsecurity-4.0,\
-	cdi-3.0
+	cdi-3.0,\
+	mpMetrics-4.0,\
+	mpMetrics-5.0,\
+	appsecurity-5.0,\
+	cdi-4.0,\
+	pages-3.1,\
+	expressionLanguage-5.0
 
 -buildpath: \
 	com.ibm.ws.request.timing;version=latest,\

--- a/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/FATSuite.java
+++ b/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,6 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction("mpMetrics-3.0", "mpMetrics-2.3").withID("MPM23")).andWith(new FeatureReplacementAction("mpMetrics-2.3", "mpMetrics-2.2").withID("MPM22")).andWith(new FeatureReplacementAction("mpMetrics-2.2", "mpMetrics-2.0").withID("MPM20")).andWith(FeatureReplacementAction.EE9_FEATURES().removeFeature("mpMetrics-2.0"));
+    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction("mpMetrics-3.0", "mpMetrics-2.3").withID("MPM23")).andWith(new FeatureReplacementAction("mpMetrics-2.3", "mpMetrics-2.2").withID("MPM22")).andWith(new FeatureReplacementAction("mpMetrics-2.2", "mpMetrics-2.0").withID("MPM20")).andWith(FeatureReplacementAction.EE9_FEATURES().removeFeature("mpMetrics-2.0")).andWith(FeatureReplacementAction.EE10_FEATURES().removeFeature("mpMetrics-2.0"));
 
 }

--- a/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/RequestTimingMetricsTest.java
+++ b/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/RequestTimingMetricsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,6 +33,7 @@ import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
@@ -49,7 +50,7 @@ import componenttest.topology.impl.LibertyServer;
  * request during the mbean call which happens inside the initial servlet call.
  */
 @RunWith(FATRunner.class)
-@SkipForRepeat(JakartaEE9Action.ID)
+@SkipForRepeat({ JakartaEE9Action.ID, JakartaEE10Action.ID })
 public class RequestTimingMetricsTest {
 
     private static final Class<RequestTimingMetricsTest> c = RequestTimingMetricsTest.class;

--- a/dev/com.ibm.ws.security.acme_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.acme_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2021 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -18,7 +18,8 @@ src: \
 	test-applications/slowapp.war/src
 
 fat.project: true
-tested.features: servlet-3.1, appsecurity-4.0, expressionlanguage-4.0, cdi-3.0
+tested.features: servlet-3.1, appsecurity-4.0, expressionlanguage-4.0, cdi-3.0, \
+  appsecurity-5.0, expressionlanguage-5.0, cdi-4.0
 
 # Uncomment to use remote docker host to simulate continuous build behavior.
 #fat.test.use.remote.docker: true

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeCaRestHandlerTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeCaRestHandlerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -71,7 +71,7 @@ import componenttest.topology.impl.LibertyServer;
  * Test the {@link AcmeCaRestHandler} REST endpoint.
  */
 @RunWith(FATRunner.class)
-@SkipForRepeat(SkipForRepeat.EE9_FEATURES) // No value added
+@SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES}) // No value added
 public class AcmeCaRestHandlerTest extends TestContainerSuite {
 	@Server("com.ibm.ws.security.acme.fat.rest")
 	public static LibertyServer server;

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeClientTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeClientTest.java
@@ -50,7 +50,7 @@ import componenttest.custom.junit.runner.FATRunner;
  * that do not interact with an ACME CA service.
  */
 @RunWith(FATRunner.class)
-@SkipForRepeat(SkipForRepeat.EE9_FEATURES) // No value added
+@SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES}) // No value added
 public class AcmeClientTest {
 
 	private static final String TEST_DOMAIN_1 = "domain1.com";

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeConfigVariationsTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeConfigVariationsTest.java
@@ -71,7 +71,7 @@ import componenttest.topology.impl.LibertyServer;
  */
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-@SkipForRepeat(SkipForRepeat.EE9_FEATURES) // No value added
+@SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES}) // No value added
 public class AcmeConfigVariationsTest {
 
 	@Server("com.ibm.ws.security.acme.fat.config_var")

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeDisableTriggerSimpleTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeDisableTriggerSimpleTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -59,7 +59,7 @@ import componenttest.topology.impl.LibertyServer;
  */
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-@SkipForRepeat(SkipForRepeat.EE9_FEATURES) // No value added
+@SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES}) // No value added
 public class AcmeDisableTriggerSimpleTest {
 	
 	@Server("com.ibm.ws.security.acme.fat.trigger")

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeRevocationTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeRevocationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020,2021 IBM Corporation and others.
+ * Copyright (c) 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -67,7 +67,7 @@ import componenttest.topology.impl.LibertyServer;
  */
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-@SkipForRepeat(SkipForRepeat.EE9_FEATURES) // No value added
+@SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES}) // No value added
 public class AcmeRevocationTest {
 	
 	@Server("com.ibm.ws.security.acme.fat.revocation")

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSwapDirectoriesTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSwapDirectoriesTest.java
@@ -55,7 +55,7 @@ import componenttest.topology.impl.LibertyServer;
  */
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-@SkipForRepeat(SkipForRepeat.EE9_FEATURES) // No value added
+@SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES}) // No value added
 public class AcmeSwapDirectoriesTest {
 
 	@Server("com.ibm.ws.security.acme.fat.simple")

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeURIConfigVariationsTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeURIConfigVariationsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,7 +30,7 @@ import componenttest.topology.impl.JavaInfo;
  */
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-@SkipForRepeat(SkipForRepeat.EE9_FEATURES) // No value added
+@SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES}) // No value added
 public class AcmeURIConfigVariationsTest extends AcmeConfigVariationsTest {
 
 	@Override

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeURISimpleTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeURISimpleTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,7 +30,7 @@ import componenttest.topology.impl.JavaInfo;
  */
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-@SkipForRepeat(SkipForRepeat.EE9_FEATURES) // No value added
+@SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES}) // No value added
 public class AcmeURISimpleTest extends AcmeSimpleTest {
 
 	@Override

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeValidityAndRenewTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeValidityAndRenewTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020,2021 IBM Corporation and others.
+ * Copyright (c) 2020,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -58,7 +58,7 @@ import componenttest.topology.impl.LibertyServer;
  */
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-@SkipForRepeat(SkipForRepeat.EE9_FEATURES) // No value added
+@SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES}) // No value added
 public class AcmeValidityAndRenewTest {
 
 	@Server("com.ibm.ws.security.acme.fat.renew")

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,9 +15,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import componenttest.containers.ExternalTestServiceDockerClientStrategy;
 import componenttest.containers.TestContainerSuite;
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -42,6 +43,7 @@ public class FATSuite extends TestContainerSuite {
      */
     @ClassRule
 	public static RepeatTests repeat = RepeatTests.with(new EmptyAction())
-			.andWith(new JakartaEE9Action().alwaysAddFeature("servlet-5.0"));
+			.andWith(new JakartaEE9Action().alwaysAddFeature("servlet-5.0").conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+			.andWith(new JakartaEE10Action().alwaysAddFeature("servlet-6.0"));
     
 }

--- a/dev/com.ibm.ws.security.auth.data_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.auth.data_fat/bnd.bnd
@@ -19,7 +19,8 @@ src: \
 fat.project: true
 
 tested.features: connectors-2.0, xmlBinding-3.0,\
-  appsecurity-4.0, expressionlanguage-4.0, cdi-3.0, passwordUtilities-1.1
+  appsecurity-4.0, expressionlanguage-4.0, cdi-3.0, passwordUtilities-1.1,\
+  connectors-2.1, appsecurity-5.0, expressionlanguage-5.0, cdi-4.0
 
 -buildpath: \
   com.ibm.websphere.javaee.connector.1.7;version=latest,\

--- a/dev/com.ibm.ws.security.auth.data_fat/fat/src/com/ibm/ws/security/auth/data/fat/AuthDataFatUtils.java
+++ b/dev/com.ibm.ws.security.auth.data_fat/fat/src/com/ibm/ws/security/auth/data/fat/AuthDataFatUtils.java
@@ -19,6 +19,7 @@ import org.junit.rules.TestName;
 
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
@@ -38,6 +39,11 @@ public class AuthDataFatUtils {
             for (String app : apps) {
                 Path someArchive = Paths.get(myServer.getServerRoot() + File.separatorChar + "apps" + File.separatorChar + app);
                 JakartaEE9Action.transformApp(someArchive);
+            }
+        } else if (JakartaEE10Action.isActive()) {
+            for (String app : apps) {
+                Path someArchive = Paths.get(myServer.getServerRoot() + File.separatorChar + "apps" + File.separatorChar + app);
+                JakartaEE10Action.transformApp(someArchive);
             }
         }
     }

--- a/dev/com.ibm.ws.security.auth.data_fat/fat/src/com/ibm/ws/security/auth/data/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.auth.data_fat/fat/src/com/ibm/ws/security/auth/data/fat/FATSuite.java
@@ -18,6 +18,8 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -34,9 +36,12 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
 
     /*
-     * Run EE9 tests in LITE mode and run all tests in FULL mode.
+     * Run EE9 tests in LITE mode if Java 8, EE10 tests in LITE mode if >= Java 11 and run all tests in FULL mode.
      */
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
-                    .andWith(new JakartaEE9Action().removeFeature("appSecurity-1.0").addFeature("appSecurity-4.0"));
+                    .andWith(new JakartaEE9Action().removeFeature("appSecurity-1.0")
+                                    .addFeature("appSecurity-4.0")
+                                    .conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                    .andWith(new JakartaEE10Action().removeFeature("appSecurity-1.0").removeFeature("appSecurity-4.0").addFeature("appSecurity-5.0"));
 }

--- a/dev/com.ibm.ws.security.jaspic_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.jaspic_fat/bnd.bnd
@@ -24,7 +24,8 @@ src: \
 
 fat.project: true
 
-tested.features: expressionLanguage-4.0, appsecurity-4.0, servlet-5.0, cdi-3.0, pages-3.0, xmlBinding-3.0, appAuthentication-2.0, appAuthorization-2.0
+tested.features: expressionLanguage-4.0, appsecurity-4.0, servlet-5.0, cdi-3.0, pages-3.0, xmlBinding-3.0, appAuthentication-2.0, appAuthorization-2.0, \
+  expressionLanguage-5.0, appsecurity-5.0, servlet-6.0, cdi-4.0, pages-3.1, appAuthentication-3.0, appAuthorization-2.1
 
 -buildpath: \
     com.ibm.json4j;version=latest,\

--- a/dev/com.ibm.ws.security.jaspic_fat/build.gradle
+++ b/dev/com.ibm.ws.security.jaspic_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -264,8 +264,14 @@ autoFVT.doLast {
      rename 'com.ibm.ws.security.jaspic.test.jakarta.jar', 'com.ibm.ws.security.jaspic.test_2.0.jar'
   }
   copy {
+     from new File(project(':com.ibm.ws.security.jaspic.test').projectDir, '/build/libs/com.ibm.ws.security.jaspic.test.jakarta.jar')
+     into new File(autoFvtDir, 'publish/bundles')
+     rename 'com.ibm.ws.security.jaspic.test.jakarta.jar', 'com.ibm.ws.security.jaspic.test_3.0.jar'
+  }
+  copy {
      from new File(project(':com.ibm.ws.security.jaspic.test').projectDir , "/publish/features/jaspicUserTestFeature-1.0.mf")  
      from new File(project(':com.ibm.ws.security.jaspic.test').projectDir , "/publish/features/jaspicUserTestFeature-2.0.mf")  
+     from new File(project(':com.ibm.ws.security.jaspic.test').projectDir , "/publish/features/jaspicUserTestFeature-3.0.mf")  
      into new File(autoFvtDir, 'publish/features')
   }
     
@@ -283,8 +289,14 @@ autoFVT.doLast {
      rename 'com.ibm.ws.security.authorization.jacc.testprovider.jakarta.jar', 'com.ibm.ws.security.authorization.jacc.testprovider_2.0.jar'
   }
   copy {
+     from new File(project(':com.ibm.ws.security.authorization.jacc.testprovider').projectDir, "/build/libs/com.ibm.ws.security.authorization.jacc.testprovider.jakarta.jar") 
+     into new File(autoFvtDir, 'publish/bundles')
+     rename 'com.ibm.ws.security.authorization.jacc.testprovider.jakarta.jar', 'com.ibm.ws.security.authorization.jacc.testprovider_2.1.jar'
+  }
+  copy {
      from new File(project(':com.ibm.ws.security.authorization.jacc.testprovider').projectDir ,"/publish/usr/extension/lib/features/jaccTestProvider-1.0.mf")  
      from new File(project(':com.ibm.ws.security.authorization.jacc.testprovider').projectDir ,"/publish/usr/extension/lib/features/jaccTestProvider-2.0.mf")  
+     from new File(project(':com.ibm.ws.security.authorization.jacc.testprovider').projectDir ,"/publish/usr/extension/lib/features/jaccTestProvider-2.1.mf")  
      into new File(autoFvtDir, 'publish/features')
   }
   

--- a/dev/com.ibm.ws.security.jaspic_fat/fat/src/com/ibm/ws/security/jaspic11/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.jaspic_fat/fat/src/com/ibm/ws/security/jaspic11/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,6 +28,8 @@ import com.ibm.ws.security.jaspic11.fat.audit.JASPIFormLoginJACCAuthorizationAud
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -66,14 +68,21 @@ public class FATSuite {
                                                          "usr:jaccTestProvider-2.0"
     };
 
+    private static final Set<String> EE10_FEATURES;
+    private static final String[] EE10_FEATURES_ARRAY = {
+                                                          "usr:jaspicUserTestFeature-3.0",
+                                                          "usr:jaccTestProvider-2.1"
+    };
+
     static {
         EE78_FEATURES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE78_FEATURES_ARRAY)));
         EE9_FEATURES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE9_FEATURES_ARRAY)));
+        EE10_FEATURES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE10_FEATURES_ARRAY)));
     }
 
     /*
-     * Run EE9 tests in LITE mode and run all tests in FULL mode.
+     * Run EE9 tests in LITE mode if Java 8, EE10 tests in LITE mode if >= Java 11 and run all tests in FULL mode.
      */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(new JakartaEE9Action().removeFeatures(EE78_FEATURES).addFeatures(EE9_FEATURES));
+    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(new JakartaEE9Action().removeFeatures(EE78_FEATURES).addFeatures(EE9_FEATURES).conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11)).andWith(new JakartaEE10Action().removeFeatures(EE78_FEATURES).removeFeatures(EE9_FEATURES).addFeatures(EE10_FEATURES));
 }

--- a/dev/com.ibm.ws.security.jaspic_fat/fat/src/com/ibm/ws/security/jaspic11/fat/JASPIFatUtils.java
+++ b/dev/com.ibm.ws.security.jaspic_fat/fat/src/com/ibm/ws/security/jaspic11/fat/JASPIFatUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
@@ -30,7 +31,10 @@ public class JASPIFatUtils {
      * @throws Exception If the install failed.
      */
     public static void installJaspiUserFeature(LibertyServer myServer) throws Exception {
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE10Action.isActive()) {
+            myServer.installUserBundle("com.ibm.ws.security.jaspic.test_3.0");
+            myServer.installUserFeature("jaspicUserTestFeature-3.0");
+        } else if (JakartaEE9Action.isActive()) {
             myServer.installUserBundle("com.ibm.ws.security.jaspic.test_2.0");
             myServer.installUserFeature("jaspicUserTestFeature-2.0");
         } else {
@@ -46,7 +50,10 @@ public class JASPIFatUtils {
      * @throws Exception If the uninstall failed.
      */
     public static void uninstallJaspiUserFeature(LibertyServer myServer) throws Exception {
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE10Action.isActive()) {
+            myServer.uninstallUserBundle("com.ibm.ws.security.jaspic.test_3.0");
+            myServer.uninstallUserFeature("jaspicUserTestFeature-3.0");
+        } else if (JakartaEE9Action.isActive()) {
             myServer.uninstallUserBundle("com.ibm.ws.security.jaspic.test_2.0");
             myServer.uninstallUserFeature("jaspicUserTestFeature-2.0");
         } else {
@@ -62,7 +69,10 @@ public class JASPIFatUtils {
      * @throws Exception If the install failed.
      */
     public static void installJaccUserFeature(LibertyServer myServer) throws Exception {
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE10Action.isActive()) {
+            myServer.installUserBundle("com.ibm.ws.security.authorization.jacc.testprovider_2.1");
+            myServer.installUserFeature("jaccTestProvider-2.1");
+        } else if (JakartaEE9Action.isActive()) {
             myServer.installUserBundle("com.ibm.ws.security.authorization.jacc.testprovider_2.0");
             myServer.installUserFeature("jaccTestProvider-2.0");
         } else {
@@ -78,7 +88,10 @@ public class JASPIFatUtils {
      * @throws Exception If the uninstall failed.
      */
     public static void uninstallJaccUserFeature(LibertyServer myServer) throws Exception {
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE10Action.isActive()) {
+            myServer.uninstallUserBundle("com.ibm.ws.security.authorization.jacc.testprovider_2.1");
+            myServer.uninstallUserFeature("jaccTestProvider-2.1");
+        } else if (JakartaEE9Action.isActive()) {
             myServer.uninstallUserBundle("com.ibm.ws.security.authorization.jacc.testprovider_2.0");
             myServer.uninstallUserFeature("jaccTestProvider-2.0");
         } else {
@@ -91,13 +104,18 @@ public class JASPIFatUtils {
      * JakartaEE9 transform a list of applications. The applications are the simple app names and they must exist at '<server>/apps/<appname>'.
      *
      * @param myServer The server to transform the applications on.
-     * @param apps The simple names of the applications to transform.
+     * @param apps     The simple names of the applications to transform.
      */
     public static void transformApps(LibertyServer myServer, String... apps) {
         if (JakartaEE9Action.isActive()) {
             for (String app : apps) {
                 Path someArchive = Paths.get(myServer.getServerRoot() + File.separatorChar + "apps" + File.separatorChar + app);
                 JakartaEE9Action.transformApp(someArchive);
+            }
+        } else if (JakartaEE10Action.isActive()) {
+            for (String app : apps) {
+                Path someArchive = Paths.get(myServer.getServerRoot() + File.separatorChar + "apps" + File.separatorChar + app);
+                JakartaEE10Action.transformApp(someArchive);
             }
         }
     }

--- a/dev/com.ibm.ws.security.jaspic_fat/fat/src/com/ibm/ws/security/jaspic11/fat/JASPITestBase.java
+++ b/dev/com.ibm.ws.security.jaspic_fat/fat/src/com/ibm/ws/security/jaspic11/fat/JASPITestBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,6 +40,7 @@ import org.apache.http.util.EntityUtils;
 
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
@@ -217,7 +218,10 @@ public class JASPITestBase {
         verifyServerUpdated(server);
         assertNotNull("The JASPI user feature did not report it was ready",
                       server.waitForStringInLogUsingMark(MSG_JASPI_PROVIDER_ACTIVATED));
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE10Action.isActive()) {
+            assertNotNull("The feature manager did not report the JASPI provider is included in features.",
+                          server.waitForStringInLogUsingMark("CWWKF0012I.*" + "usr:jaspicUserTestFeature-3.0"));
+        } else if (JakartaEE9Action.isActive()) {
             assertNotNull("The feature manager did not report the JASPI provider is included in features.",
                           server.waitForStringInLogUsingMark("CWWKF0012I.*" + "usr:jaspicUserTestFeature-2.0"));
         } else {
@@ -247,7 +251,10 @@ public class JASPITestBase {
         verifyServerStarted(server);
         assertNotNull("The JASPI user feature did not report it was ready",
                       server.waitForStringInLogUsingMark(MSG_JASPI_PROVIDER_ACTIVATED));
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE10Action.isActive()) {
+            assertNotNull("The feature manager did not report the JASPI provider is included in features.",
+                          server.waitForStringInLogUsingMark("CWWKF0012I.*" + "usr:jaspicUserTestFeature-3.0"));
+        } else if (JakartaEE9Action.isActive()) {
             assertNotNull("The feature manager did not report the JASPI provider is included in features.",
                           server.waitForStringInLogUsingMark("CWWKF0012I.*" + "usr:jaspicUserTestFeature-2.0"));
         } else {
@@ -294,7 +301,7 @@ public class JASPITestBase {
      * Process the response from an http invocation, such as validating
      * the status code, extracting the response entity...
      *
-     * @param response the HttpResponse
+     * @param response           the HttpResponse
      * @param expectedStatusCode
      * @return The response entity text, or null if request failed
      * @throws IOException
@@ -319,10 +326,10 @@ public class JASPITestBase {
      * Send HttpClient get request to the given URL, ensure that the user is redirected to the form login page
      * and that the JASPI provider was or was not called, as expected.
      *
-     * @param httpclient HttpClient object to execute request
-     * @param url URL for request, should be protected and redirect to form login page
+     * @param httpclient   HttpClient object to execute request
+     * @param url          URL for request, should be protected and redirect to form login page
      * @param providerName Name of JASPI provider that should authenticate the request, null if JASPI not enabled for request
-     * @param formTitle Name of Login form (defaults to Form Login Page if not specified)
+     * @param formTitle    Name of Login form (defaults to Form Login Page if not specified)
      * @throws Exception
      */
 
@@ -364,9 +371,9 @@ public class JASPITestBase {
      * Post HttpClient request to execute a form login on the given page, using the given username and password
      *
      * @param httpclient HttpClient object to execute login
-     * @param url URL for login page
-     * @param username User name
-     * @param password User password
+     * @param url        URL for login page
+     * @param username   User name
+     * @param password   User password
      * @return URL of page redirected to after the login
      * @throws Exception
      */

--- a/dev/com.ibm.ws.security.spnego_fat.1/bnd.bnd
+++ b/dev/com.ibm.ws.security.spnego_fat.1/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2021 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -16,7 +16,8 @@ src: \
 
 fat.project: true
 
-tested.features: pages-3.0, appsecurity-4.0, cdi-3.0, constraineddelegation-1.0
+tested.features: pages-3.0, appsecurity-4.0, cdi-3.0, constraineddelegation-1.0,\
+    pages-3.1, appsecurity-5.0, cdi-4.0
 
 -buildpath: \
     fattest.simplicity;version=latest,\

--- a/dev/com.ibm.ws.security.spnego_fat.1/fat/src/com/ibm/ws/security/spnego/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.spnego_fat.1/fat/src/com/ibm/ws/security/spnego/fat/FATSuite.java
@@ -28,6 +28,8 @@ import com.ibm.ws.security.spnego.fat.config.InitClass;
 import com.ibm.ws.security.spnego.fat.config.SPNEGOConstants;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.JavaInfo;
@@ -46,7 +48,9 @@ public class FATSuite extends InitClass {
     private static final Class<?> c = FATSuite.class;
 
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.withoutModification().andWith(new JakartaEE9Action());
+    public static RepeatTests repeat = RepeatTests.withoutModification()
+                    .andWith(new JakartaEE9Action().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                    .andWith(new JakartaEE10Action());
 
     /**
      * Rule to setup users, SPNs etc on the KDC.
@@ -168,7 +172,7 @@ public class FATSuite extends InitClass {
      * JakartaEE9 transform a list of applications. The applications are the simple app names and they must exist at '<server>/apps/<appname>'.
      *
      * @param myServer The server to transform the applications on.
-     * @param apps The simple names of the applications to transform.
+     * @param apps     The simple names of the applications to transform.
      */
     public static void transformApps(LibertyServer myServer, String... apps) {
         if (JakartaEE9Action.isActive()) {
@@ -176,6 +180,12 @@ public class FATSuite extends InitClass {
                 Path someArchive = Paths.get(myServer.getServerRoot() + File.separatorChar + "apps" + File.separatorChar + app);
                 JakartaEE9Action.transformApp(someArchive);
             }
+        } else if (JakartaEE10Action.isActive()) {
+            for (String app : apps) {
+                Path someArchive = Paths.get(myServer.getServerRoot() + File.separatorChar + "apps" + File.separatorChar + app);
+                JakartaEE10Action.transformApp(someArchive);
+            }
         }
+
     }
 }

--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.spnego.fat.config.InitClass;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.JavaInfo;
@@ -138,13 +139,18 @@ public class FATSuite extends ApacheKDCforSPNEGO {
      * JakartaEE9 transform a list of applications. The applications are the simple app names and they must exist at '<server>/apps/<appname>'.
      *
      * @param myServer The server to transform the applications on.
-     * @param apps The simple names of the applications to transform.
+     * @param apps     The simple names of the applications to transform.
      */
     public static void transformApps(LibertyServer myServer, String... apps) {
         if (JakartaEE9Action.isActive()) {
             for (String app : apps) {
                 Path someArchive = Paths.get(myServer.getServerRoot() + File.separatorChar + "apps" + File.separatorChar + app);
                 JakartaEE9Action.transformApp(someArchive);
+            }
+        } else if (JakartaEE10Action.isActive()) {
+            for (String app : apps) {
+                Path someArchive = Paths.get(myServer.getServerRoot() + File.separatorChar + "apps" + File.separatorChar + app);
+                JakartaEE10Action.transformApp(someArchive);
             }
         }
     }

--- a/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 IBM Corporation and others.
+ * Copyright (c) 2011, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,6 +27,7 @@ import com.ibm.ws.com.unboundid.InMemoryLDAPServer;
 import com.ibm.ws.com.unboundid.InMemoryTDSLDAPServer;
 
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
@@ -88,6 +89,11 @@ public class FATSuite {
             for (String appPath : appPaths) {
                 Path someArchive = Paths.get(myServer.getServerRoot() + File.separatorChar + appPath);
                 JakartaEE9Action.transformApp(someArchive);
+            }
+        } else if (JakartaEE10Action.isActive()) {
+            for (String appPath : appPaths) {
+                Path someArchive = Paths.get(myServer.getServerRoot() + File.separatorChar + appPath);
+                JakartaEE10Action.transformApp(someArchive);
             }
         }
     }

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/FATSuite.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/FATSuite.java
@@ -27,7 +27,6 @@ import com.ibm.websphere.simplicity.log.Log;
 import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
@@ -46,20 +45,10 @@ import componenttest.topology.utils.HttpUtils;
 public class FATSuite {
 
     @ClassRule
-    public static RepeatTests r;
-
-    static {
-        // EE10 requires Java 11.  If we only specify EE10 for lite mode it will cause no tests to run which causes an error.
-        // If we are running on Java 8 have EE9 be the lite mode test to run.
-        if (JavaInfo.JAVA_VERSION >= 11) {
-            r = RepeatTests.with(new EmptyAction().fullFATOnly()) // run all tests as-is (e.g. EE8 features)
-                            .andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly()) // run all tests again with EE9 features+packages
-                            .andWith(FeatureReplacementAction.EE10_FEATURES());
-        } else {
-            r = RepeatTests.with(new EmptyAction().fullFATOnly()) // run all tests as-is (e.g. EE8 features)
-                            .andWith(FeatureReplacementAction.EE9_FEATURES()); // run all tests again with EE9 features+packages
-        }
-    }
+    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly()) // run all tests as-is (e.g. EE8 features)
+                    .andWith(FeatureReplacementAction.EE9_FEATURES() // run all tests again with EE9 features+packages
+                                    .conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                    .andWith(FeatureReplacementAction.EE10_FEATURES());
 
     @BeforeClass
     public static void beforeSuite() throws Exception {

--- a/dev/com.ibm.ws.ui_rest_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ui_rest_fat/bnd.bnd
@@ -24,10 +24,12 @@ tested.features:\
     pages-3.0, \
     com.ibm.websphere.appserver.autorestconnector-2.0, \
     basicpublicautofeaturetool-1.0, \
-    scopedprodextn:publicprodextntool-1.0 \
-    jsp-2.2 \
-    servlet-3.1 \
-    scopedprodextn:publicprodextntool-1.0
+    scopedprodextn:publicprodextntool-1.0, \
+    jsp-2.2, \
+    servlet-3.1, \
+    scopedprodextn:publicprodextntool-1.0, \
+    expressionlanguage-5.0, \
+    pages-3.1
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/FATSuite.java
+++ b/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/FATSuite.java
@@ -72,11 +72,15 @@ public class FATSuite {
     static {
         boolean isWindows = System.getProperty("os.name").toLowerCase().startsWith("win");
         if (!isWindows) {
-            r = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(new FeatureReplacementAction("restConnector-1.0", "restConnector-2.0").fullFATOnly()).andWith(FeatureReplacementAction.EE9_FEATURES().alwaysAddFeature("servlet-5.0"));
+            r = RepeatTests.with(new EmptyAction().fullFATOnly())
+            		.andWith(new FeatureReplacementAction("restConnector-1.0", "restConnector-2.0").fullFATOnly())
+            		.andWith(FeatureReplacementAction.EE9_FEATURES().alwaysAddFeature("servlet-5.0")
+            				.conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+            		.andWith(FeatureReplacementAction.EE10_FEATURES().alwaysAddFeature("servlet-6.0"));
         } else {
             // On Windows only run each repeat scenario on lite or full mode so
             // that both do not run on Windows.
-            r = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(new FeatureReplacementAction("restConnector-1.0", "restConnector-2.0").fullFATOnly()).andWith(FeatureReplacementAction.EE9_FEATURES().alwaysAddFeature("servlet-5.0").liteFATOnly());
+            r = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(new FeatureReplacementAction("restConnector-1.0", "restConnector-2.0").fullFATOnly()).andWith(FeatureReplacementAction.EE10_FEATURES().alwaysAddFeature("servlet-6.0").liteFATOnly());
         }
     }
     private static final Class<?> c = FATSuite.class;

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/basicAutoFeatureTool.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/basicAutoFeatureTool.mf
@@ -10,7 +10,7 @@ Subsystem-Category: adminCenter
 Subsystem-Icon: icons/toolicon48.png;size=48,icons/toolicon64.png;size=64,icons/toolicon128.png;size=128
 Subsystem-Content: com.ibm.ws.appserver.basicAutoFeatureTool; version="[1,1.0.100)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0"; type="osgi.subsystem.feature"  
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"  
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 IBM-Install-Policy: manual
 Subsystem-Vendor: IBM

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/emptyIconHeaderManifest.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/emptyIconHeaderManifest.mf
@@ -8,7 +8,7 @@ Subsystem-Description: This is the description for No Sized IconHeader.
 Subsystem-Icon:
 Subsystem-Content: com.ibm.ws.appserver.toolbundle1; version="[1,1.0.100)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0"; type="osgi.subsystem.feature"  
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"  
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 Subsystem-Vendor: IBM
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/gifIconHeaderManifest.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/gifIconHeaderManifest.mf
@@ -8,7 +8,7 @@ Subsystem-Description: This is the description for gif IconHeader.
 Subsystem-Icon: icons/toolicon9.gif
 Subsystem-Content: com.ibm.ws.appserver.toolbundle1; version="[1,1.0.100)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0"; type="osgi.subsystem.feature" 
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature" 
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 Subsystem-Vendor: IBM
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/invalidRelativeIconURIHeaderManifest.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/invalidRelativeIconURIHeaderManifest.mf
@@ -8,7 +8,7 @@ Subsystem-Description: This is the description for Invalid Relative Icon URI Hea
 Subsystem-Icon: /../../icons/toolicon1.jpg
 Subsystem-Content: com.ibm.ws.appserver.toolbundle1; version="[1,1.0.100)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 Subsystem-Vendor: IBM
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/jpegIconHeaderManifest.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/jpegIconHeaderManifest.mf
@@ -8,7 +8,7 @@ Subsystem-Description: This is the description for Jpg IconHeader.
 Subsystem-Icon: icons/toolicon9.jpg
 Subsystem-Content: com.ibm.ws.appserver.toolbundle1; version="[1,1.0.100)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 Subsystem-Vendor: IBM
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/mixedSizedIconHeaderManifest.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/mixedSizedIconHeaderManifest.mf
@@ -8,7 +8,7 @@ Subsystem-Description: This is the description for mixedsized IconHeader.
 Subsystem-Icon: icons/toolicon1.png;size=142, icons/toolicon2.png;size=77
 Subsystem-Content: com.ibm.ws.appserver.toolbundle1; version="[1,1.0.100)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 Subsystem-Vendor: IBM
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/mixedSizedWithUnsizedIconHeaderManifest.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/mixedSizedWithUnsizedIconHeaderManifest.mf
@@ -8,7 +8,7 @@ Subsystem-Description: This is the description for mixedsizedwithunsized IconHea
 Subsystem-Icon: icons/toolicon1.png, icons/toolicon2.png;size=142
 Subsystem-Content: com.ibm.ws.appserver.toolbundle1; version="[1,1.0.100)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 Subsystem-Vendor: IBM
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/multiUnsizedIconHeaderManifest.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/multiUnsizedIconHeaderManifest.mf
@@ -8,7 +8,7 @@ Subsystem-Description: This is the description for multiunsized IconHeader.
 Subsystem-Icon: icons/toolicon1.png, icons/toolicon2.png
 Subsystem-Content: com.ibm.ws.appserver.toolbundle1; version="[1,1.0.100)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 Subsystem-Vendor: IBM
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/noIconHeaderManifest.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/noIconHeaderManifest.mf
@@ -7,7 +7,7 @@ Subsystem-Category: adminCenter
 Subsystem-Description: This is the description for No IconHeader.
 Subsystem-Content: com.ibm.ws.appserver.toolbundle1; version="[1,1.0.100)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 Subsystem-Vendor: IBM
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/noSizedIconHeaderManifest.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/noSizedIconHeaderManifest.mf
@@ -8,7 +8,7 @@ Subsystem-Description: This is the description for No Sized IconHeader.
 Subsystem-Icon: icons/toolicon1.png
 Subsystem-Content: com.ibm.ws.appserver.toolbundle1; version="[1,1.0.100)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 Subsystem-Vendor: IBM
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/usr.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/usr.mf
@@ -11,7 +11,7 @@ Subsystem-Icon: icons/toolicon7.png,icons/toolicon8.png;size=58
 IBM-AdminCenter-Endpoint: usrtool/welcome
 Subsystem-Content: com.ibm.ws.appserver.usrtoolbundle; version="[1,1.0.100)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 IBM-Install-Policy: manual
 Subsystem-Vendor: IBM

--- a/dev/com.ibm.ws.ui_rest_fat/publish/productfeatures/prodextn1.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/productfeatures/prodextn1.mf
@@ -11,7 +11,7 @@ Subsystem-Icon: icons/toolicon3.png,icons/toolicon4.png;size=58
 IBM-AdminCenter-Endpoint: prodextn1/welcome
 Subsystem-Content: com.ibm.ws.appserver.prodextn1toolbundle; version="[1,1.0.100)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 IBM-Install-Policy: manual
 Subsystem-Vendor: IBM

--- a/dev/com.ibm.ws.ui_rest_fat/publish/productfeatures/prodextn2.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/productfeatures/prodextn2.mf
@@ -10,7 +10,7 @@ Subsystem-Description: This is the description for prodextn2. It is used to test
 IBM-AdminCenter-Endpoint: prodextn2/welcome
 Subsystem-Content: com.ibm.ws.appserver.prodextn2toolbundle; version="[1,1.0.100)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 IBM-Install-Policy: manual
 Subsystem-Vendor: IBM

--- a/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -16,7 +16,8 @@ src: fat/src
 
 fat.project: true
 
-tested.features: jacc-1.5, expressionLanguage-4.0, appsecurity-4.0, servlet-5.0, cdi-3.0, pages-3.0, appAuthorization-2.0
+tested.features: jacc-1.5, expressionLanguage-4.0, appsecurity-4.0, servlet-5.0, cdi-3.0, pages-3.0, appAuthorization-2.0, \
+    expressionLanguage-5.0, appsecurity-5.0, servlet-6.0, cdi-4.0, pages-3.1, appAuthorization-2.1
 
 -buildpath: \
     com.ibm.json4j;version=latest,\

--- a/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/build.gradle
+++ b/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -414,8 +414,14 @@ autoFVT.doLast {
      rename 'com.ibm.ws.security.authorization.jacc.testprovider.jakarta.jar', 'com.ibm.ws.security.authorization.jacc.testprovider_2.0.jar'
   }
   copy {
+     from new File(project(':com.ibm.ws.security.authorization.jacc.testprovider').projectDir, "/build/libs/com.ibm.ws.security.authorization.jacc.testprovider.jakarta.jar") 
+     into new File(autoFvtDir, 'publish/bundles')
+     rename 'com.ibm.ws.security.authorization.jacc.testprovider.jakarta.jar', 'com.ibm.ws.security.authorization.jacc.testprovider_2.1.jar'
+  }
+  copy {
      from new File(project(':com.ibm.ws.security.authorization.jacc.testprovider').projectDir ,"/publish/usr/extension/lib/features/jaccTestProvider-1.0.mf")  
      from new File(project(':com.ibm.ws.security.authorization.jacc.testprovider').projectDir ,"/publish/usr/extension/lib/features/jaccTestProvider-2.0.mf")  
+     from new File(project(':com.ibm.ws.security.authorization.jacc.testprovider').projectDir ,"/publish/usr/extension/lib/features/jaccTestProvider-2.1.mf")  
      into new File(autoFvtDir, 'publish/features')
   }
 

--- a/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/fat/src/com/ibm/ws/webcontainer/security/jacc15/fat/FATSuite.java
+++ b/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/fat/src/com/ibm/ws/webcontainer/security/jacc15/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,8 @@ import com.ibm.ws.webcontainer.security.jacc15.fat.audit.BasicAuthAuditAUTHZTest
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -76,14 +78,20 @@ public class FATSuite extends CommonLocalLDAPServerSuite {
                                                          "usr:jaccTestProvider-2.0"
     };
 
+    private static final Set<String> EE10_FEATURES;
+    private static final String[] EE10_FEATURES_ARRAY = {
+                                                          "usr:jaccTestProvider-2.1"
+    };
+
     static {
         EE78_FEATURES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE78_FEATURES_ARRAY)));
         EE9_FEATURES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE9_FEATURES_ARRAY)));
+        EE10_FEATURES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE10_FEATURES_ARRAY)));
     }
 
     /*
-     * Run EE9 tests in LITE mode and run all tests in FULL mode.
+     * Run EE9 tests in LITE mode if Java 8, EE10 tests in LITE mode if >= Java 11 and run all tests in FULL mode.
      */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(new JakartaEE9Action().removeFeatures(EE78_FEATURES).addFeatures(EE9_FEATURES));
+    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(new JakartaEE9Action().removeFeatures(EE78_FEATURES).addFeatures(EE9_FEATURES).conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11)).andWith(new JakartaEE10Action().removeFeatures(EE78_FEATURES).removeFeatures(EE9_FEATURES).addFeatures(EE10_FEATURES));
 }

--- a/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/fat/src/com/ibm/ws/webcontainer/security/jacc15/fat/JACCFatUtils.java
+++ b/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/fat/src/com/ibm/ws/webcontainer/security/jacc15/fat/JACCFatUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
@@ -44,6 +45,9 @@ public class JACCFatUtils {
         if (JakartaEE9Action.isActive()) {
             myServer.installUserBundle("com.ibm.ws.security.authorization.jacc.testprovider_2.0");
             myServer.installUserFeature("jaccTestProvider-2.0");
+        } else if (JakartaEE10Action.isActive()) {
+            myServer.installUserBundle("com.ibm.ws.security.authorization.jacc.testprovider_2.1");
+            myServer.installUserFeature("jaccTestProvider-2.1");
         } else {
             myServer.installUserBundle("com.ibm.ws.security.authorization.jacc.testprovider_1.0");
             myServer.installUserFeature("jaccTestProvider-1.0");
@@ -71,6 +75,9 @@ public class JACCFatUtils {
         if (JakartaEE9Action.isActive()) {
             myServer.uninstallUserBundle("com.ibm.ws.security.authorization.jacc.testprovider_2.0");
             myServer.uninstallUserFeature("jaccTestProvider-2.0");
+        } else if (JakartaEE10Action.isActive()) {
+            myServer.uninstallUserBundle("com.ibm.ws.security.authorization.jacc.testprovider_2.1");
+            myServer.uninstallUserFeature("jaccTestProvider-2.1");
         } else {
             myServer.uninstallUserBundle("com.ibm.ws.security.authorization.jacc.testprovider_1.0");
             myServer.uninstallUserFeature("jaccTestProvider-1.0");
@@ -81,13 +88,18 @@ public class JACCFatUtils {
      * JakartaEE9 transform a list of applications. The applications are the simple app names and they must exist at '<server>/apps/<appname>'.
      *
      * @param myServer The server to transform the applications on.
-     * @param apps The simple names of the applications to transform.
+     * @param apps     The simple names of the applications to transform.
      */
     public static void transformApps(LibertyServer myServer, String... apps) {
         if (JakartaEE9Action.isActive()) {
             for (String app : apps) {
                 Path someArchive = Paths.get(myServer.getServerRoot() + File.separatorChar + "apps" + File.separatorChar + app);
                 JakartaEE9Action.transformApp(someArchive);
+            }
+        } else if (JakartaEE10Action.isActive()) {
+            for (String app : apps) {
+                Path someArchive = Paths.get(myServer.getServerRoot() + File.separatorChar + "apps" + File.separatorChar + app);
+                JakartaEE10Action.transformApp(someArchive);
             }
         }
     }

--- a/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/publish/servers/com.ibm.ws.webcontainer.security.fat.basicauth/bootstrap.properties
+++ b/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/publish/servers/com.ibm.ws.webcontainer.security.fat.basicauth/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -9,19 +9,20 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 
-com.ibm.ws.logging.trace.specification=*=event=enabled:\
-logservice=all=enabled:\
-com.ibm.websphere.ssl.*=all=enabled:\
-com.ibm.wsspi.ssl.*=all=enabled:\
-com.ibm.ws.ssl.*=all=enabled:\
-com.ibm.ws.channel.ssl.*=all=enabled:\
-com.ibm.ws.webcontainer.*=all=enabled:\
-com.ibm.wsspi.webcontainer.*=all=enabled:\
-com.ibm.ws.app.manager.*=all=enabled:\
-com.ibm.ws.javaee.*=all=enabled:\
-ChannelFramework=all=enabled:\
-TCPChannel=all=enabled:\
-com.ibm.ws.security.*=all=enabled
+#com.ibm.ws.logging.trace.specification=*=event=enabled:\
+#logservice=all=enabled:\
+#com.ibm.websphere.ssl.*=all=enabled:\
+#com.ibm.wsspi.ssl.*=all=enabled:\
+#com.ibm.ws.ssl.*=all=enabled:\
+#com.ibm.ws.channel.ssl.*=all=enabled:\
+#com.ibm.ws.webcontainer.*=all=enabled:\
+#com.ibm.wsspi.webcontainer.*=all=enabled:\
+#com.ibm.ws.app.manager.*=all=enabled:\
+#com.ibm.ws.javaee.*=all=enabled:\
+#ChannelFramework=all=enabled:\
+#TCPChannel=all=enabled:\
+#com.ibm.ws.security.*=all=enabled
+
 #config=all=enabled
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug

--- a/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/publish/servers/com.ibm.ws.webcontainer.security.fat.loginmethod/bootstrap.properties
+++ b/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/publish/servers/com.ibm.ws.webcontainer.security.fat.loginmethod/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -9,12 +9,13 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 
-com.ibm.ws.logging.trace.specification=*=info=enabled:\
-com.ibm.ws.security.*=all=enabled:\
-com.ibm.ws.webcontainer.security.*=all=enabled:\
-SSL=all=enabled:SSLChannel=all=enabled:\
-ChannelFramework=all=enabled:TCPChannel=all=enabled:\
-com.ibm.ws.webcontainer.*=all=enabled:logservice=all=enabled
+#com.ibm.ws.logging.trace.specification=*=info=enabled:\
+#com.ibm.ws.security.*=all=enabled:\
+#com.ibm.ws.webcontainer.security.*=all=enabled:\
+#SSL=all=enabled:SSLChannel=all=enabled:\
+#ChannelFramework=all=enabled:TCPChannel=all=enabled:\
+#com.ibm.ws.webcontainer.*=all=enabled:logservice=all=enabled
+
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
 

--- a/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/internal/SmallryeMetricsCDIMetadata.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/internal/SmallryeMetricsCDIMetadata.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.osgi.framework.VersionRange;
 import org.osgi.service.component.ComponentContext;
@@ -70,6 +71,7 @@ public class SmallryeMetricsCDIMetadata implements CDIExtensionMetadata {
     private ClassLoadingService classLoadingService;
     private volatile Library sharedLib = null;
     private static boolean isSuccesfulActivation = true;
+    private static AtomicBoolean isActivated = new AtomicBoolean();
 
     /**
      * Used by SharedMetricRegistries to figure out if it should provide any
@@ -84,6 +86,9 @@ public class SmallryeMetricsCDIMetadata implements CDIExtensionMetadata {
 
     @Activate
     protected void activate(ComponentContext context, Map<String, Object> properties) throws Exception {
+
+        if (isActivated.get())
+            return;
 
         File smallRyeMetricsJarFile;
         try {
@@ -163,6 +168,7 @@ public class SmallryeMetricsCDIMetadata implements CDIExtensionMetadata {
              * throw new Exception("Unable to initialize MicroProfile Metrics 5.0 feature");
              */
         }
+        isActivated.set(true);
     }
 
     @Override


### PR DESCRIPTION
Add repeats for fats that test the following features:
- acmeCA-2.0
- adminCenter-1.0
- audit-1.0
- batchManagement-1.0
- constrainedDelegation-1.0
- grpc-1.0 / grpcClient-1.0
- passwordUtilities-1.0 and 1.1
- restHandler-1.0
- sessionDatabase-1.0

For: #18722 