### PR TITLE
add jaxrs trace for JAXRS20ClientAsyncInvokerTest

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/jaxrs20.client.JAXRS20ClientAsyncInvokerTest/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/jaxrs20.client.JAXRS20ClientAsyncInvokerTest/bootstrap.properties
@@ -1,12 +1,12 @@
 bootstrap.include=../testports.properties
 
-#com.ibm.ws.logging.trace.specification=*=info:\
-#com.ibm.ws.jaxrs*=all:\
-#com.ibm.websphere.jaxrs*=all:\
-#org.apache.cxf.*=all:\
-#RESTfulWS=all:\
-#org.jboss.resteasy.*=all:\
-#io.openliberty.org.jboss.*=all:\
-#io.openliberty.restfulWS.*=all
+com.ibm.ws.logging.trace.specification=*=info:\
+  com.ibm.ws.jaxrs*=all:\
+  com.ibm.websphere.jaxrs*=all:\
+  org.apache.cxf.*=all:\
+  RESTfulWS=all:\
+  org.jboss.resteasy.*=all:\
+  io.openliberty.org.jboss.*=all:\
+  io.openliberty.restfulWS.*=all
 
 com.ibm.ws.logging.max.file.size=0


### PR DESCRIPTION
I believe [this line](https://github.com/OpenLiberty/open-liberty/blob/integration/dev/com.ibm.ws.jaxrs.2.0.client_fat/test-applications/bookstore/src/com/ibm/ws/jaxrs20/fat/bookstore/AsyncInvokerTestServlet.java#L454)  isn't timing out like it should. I have no idea why this only occurs on some platforms and not others.

Adding trace to the test server so that we can get trace from failing builds.