### PR TITLE
Add checkpoint test for Faces managed beans

### DIFF
--- a/dev/io.openliberty.checkpoint_fat/.classpath
+++ b/dev/io.openliberty.checkpoint_fat/.classpath
@@ -22,6 +22,7 @@
 	<classpathentry kind="src" path="test-applications/ServletEARapp/src"/>
 	<classpathentry kind="src" path="test-applications/webEARapp/src"/>
 	<classpathentry kind="src" path="test-applications/mphealth/src"/>
+	<classpathentry kind="src" path="test-applications/facesApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>

--- a/dev/io.openliberty.checkpoint_fat/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat/bnd.bnd
@@ -33,8 +33,8 @@ src: \
 	test-applications/EJBearApp/src,\
 	test-applications/ServletEARapp/src,\
 	test-applications/webEARapp/src,\
-	test-applications/mphealth/src
-	
+	test-applications/mphealth/src,\
+	test-applications/facesApp/src
 
 fat.project: true
 
@@ -121,6 +121,7 @@ tested.features: \
 	io.openliberty.org.eclipse.microprofile.jwt.1.2;version=latest,\
 	com.ibm.ws.security.fat.common.jwt;version=latest,\
 	com.ibm.websphere.javaee.jsonp.1.1;version=latest,\
-	io.openliberty.org.eclipse.microprofile.health.3.1;version=latest
+	io.openliberty.org.eclipse.microprofile.health.3.1;version=latest,\
+	com.ibm.websphere.javaee.concurrent.1.0;version=latest
 
 -sub: *.bnd

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FATSuite.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FATSuite.java
@@ -55,6 +55,7 @@ import componenttest.topology.impl.LibertyServer;
                 AppsecurityTest.class,
                 WebSocketTest.class,
                 FacesTest.class,
+                FacesBeanTest.class,
                 OpenAPITest.class,
                 MPJWTTest.class,
                 MPMetricsTest.class,

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FacesBeanTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FacesBeanTest.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.checkpoint.fat;
+
+import static io.openliberty.checkpoint.fat.FATSuite.getTestMethod;
+import static io.openliberty.checkpoint.fat.FATSuite.getTestMethodNameOnly;
+import static org.junit.Assert.assertNotNull;
+
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfCheckpointNotSupported;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import componenttest.topology.utils.HttpUtils;
+import io.openliberty.checkpoint.spi.CheckpointPhase;
+
+@RunWith(FATRunner.class)
+@SkipIfCheckpointNotSupported
+public class FacesBeanTest extends FATServletClient {
+
+    public static final String FACES_BEAN_SERVER_NAME = "checkpointFaces-beanServer";
+    public static final String FACES_APP_NAME = "facesApp";
+
+    @Rule
+    public TestName testName = new TestName();
+
+    @ClassRule
+    public static RepeatTests repeatTests = MicroProfileActions.repeat(FACES_BEAN_SERVER_NAME, TestMode.LITE,
+                                                                       MicroProfileActions.MP41, MicroProfileActions.MP50 /* , MicroProfileActions.MP60 */);
+
+//    @ClassRule
+//    public static RepeatTests repeatTests;
+//    static {
+//        // EE10 requires Java 11. If we only specify EE10 for lite mode it will cause no tests to run which causes an error.
+//        // If we are running on Java 8 have EE9 be the lite mode test to run.
+//        if (JavaInfo.JAVA_VERSION >= 11) {
+//            repeatTests = RepeatTests.with(new EmptyAction().fullFATOnly())
+//                              .andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly())
+//                              .andWith(FeatureReplacementAction.EE10_FEATURES());
+//        } else {
+//            repeatTests = RepeatTests.with(new EmptyAction().fullFATOnly())
+//                              .andWith(FeatureReplacementAction.EE9_FEATURES());
+//        }
+//    }
+
+    @Server(FACES_BEAN_SERVER_NAME)
+    public static LibertyServer facesBeanServer;
+
+    @Before
+    public void setUp() throws Exception {
+        WebArchive facesBeanApp = ShrinkHelper.buildDefaultApp(FACES_APP_NAME, "facesapp");
+        facesBeanApp = (WebArchive) ShrinkHelper.addDirectory(facesBeanApp, "test-applications/" + FACES_APP_NAME + "/resources");
+        // Add Myfaces or Mojarra provider libraries when testing facesContainer-x.y; e.g.:
+        //facesBeanApp = FATSuite.addMyFaces(facesApp);
+        ShrinkHelper.exportDropinAppToServer(facesBeanServer, facesBeanApp, DeployOptions.SERVER_ONLY);
+
+        TestMethod testMethod = getTestMethod(TestMethod.class, testName);
+
+        facesBeanServer.setCheckpoint(CheckpointPhase.APPLICATIONS, true,
+                                      server -> {
+                                          assertNotNull("'SRVE0169I: Loading Web Module: " + FACES_APP_NAME + "' message not found in log before restore",
+                                                        server.waitForStringInLogUsingMark("SRVE0169I: .*" + FACES_APP_NAME, 0));
+                                          assertNotNull("'CWWKZ0001I: Application " + FACES_APP_NAME + " started' message not found in log.",
+                                                        server.waitForStringInLogUsingMark("CWWKZ0001I: .*" + FACES_APP_NAME, 0));
+                                      });
+        facesBeanServer.startServer(getTestMethodNameOnly(testName) + ".log");
+    }
+
+    @After
+    public void stopServer() throws Exception {
+        facesBeanServer.stopServer();
+    }
+
+    @AfterClass
+    public static void removeWebApp() throws Exception {
+        ShrinkHelper.cleanAllExportedArchives();
+    }
+
+    @Test
+    public void testFacesBeanCdi() throws Exception {
+        HttpUtils.findStringInReadyUrl(facesBeanServer, '/' + FACES_APP_NAME + "/TestBean.jsf",
+                                       "CDI Bean value:",
+                                       ":CDIBean::PostConstructCalled::EJB-injected::Resource-injected:");
+    }
+
+    @Test
+    public void testFacesBean() throws Exception {
+        HttpUtils.findStringInReadyUrl(facesBeanServer, '/' + FACES_APP_NAME + "/TestBean.jsf",
+                                       "JSF Bean value:",
+                                       ":JSFBean::PostConstructCalled::EJB-injected:");
+    }
+
+    static enum TestMethod {
+        testFacesBeanCdi,
+        testFacesBean,
+        unknown;
+    }
+}

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-beanServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-beanServer/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+io.openliberty.checkpoint.dump.threads=true
+com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
+io.openliberty.checkpoint.allowed.features=timedexit-1.0,concurrent-1.0,componenttest-1.0,concurrent-2.0,componenttest-2.0

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-beanServer/jvm.options
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-beanServer/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-beanServer/server.xml
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-beanServer/server.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+
+<server description="Faces Beans Server">
+    <featureManager>
+        <feature>jsf-2.3</feature>
+        <feature>cdi-2.0</feature>
+        <feature>concurrent-1.0</feature>
+        <feature>ejbLite-3.2</feature>
+        <feature>componenttest-1.0</feature>
+        <feature>checkpoint-1.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+
+</server>

--- a/dev/io.openliberty.checkpoint_fat/test-applications/facesApp/resources/TestBean.xhtml
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/facesApp/resources/TestBean.xhtml
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<!--
+    Copyright (c) 2018 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:f="http://xmlns.jcp.org/jsf/core"
+	xmlns:h="http://xmlns.jcp.org/jsf/html"
+	xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+<h:head>
+    <title>Bean CDI injection Test Page</title>
+</h:head>
+<h:body>
+    <p>CDI Bean value: <h:outputText id="cdiBeanValue" value="#{cdiBean.data}" /></p>
+    <p>JSF Bean value: <h:outputText id="jsfBeanValue" value="#{jsfBean.data}" /> </p>
+</h:body>
+</html>

--- a/dev/io.openliberty.checkpoint_fat/test-applications/facesApp/src/facesapp/CDIBean.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/facesApp/src/facesapp/CDIBean.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package facesapp;
+
+import java.io.Serializable;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.annotation.Resource;
+import javax.ejb.EJB;
+import javax.enterprise.concurrent.ManagedExecutorService;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Named;
+
+@Named("cdiBean")
+@SessionScoped
+public class CDIBean implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private String data = ":" + getClass().getSimpleName() + ":";
+
+    @EJB
+    TestEJB ejb;
+
+    @Resource
+    ManagedExecutorService defaultExec;
+
+    @PostConstruct
+    public void start() {
+        System.out.println("CDIBean postConstruct called");
+        this.data += ":PostConstructCalled:";
+        if (ejb != null && ejb.verifyPostConstruct())
+            this.data += ":EJB-injected:";
+        if (defaultExec != null)
+            this.data += ":Resource-injected:";
+        System.out.println("CDIBean data is: " + data);
+    }
+
+    @PreDestroy
+    public void stop() {
+        System.out.println("CDIBean preDestroy called.");
+    }
+
+    public void setData(String newData) {
+        this.data += newData;
+    }
+
+    public String getData() {
+        return this.data;
+    }
+
+    public String nextPage() {
+        return "TestBean";
+    }
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/facesApp/src/facesapp/JSFBean.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/facesApp/src/facesapp/JSFBean.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package facesapp;
+
+import java.io.Serializable;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.ejb.EJB;
+import javax.enterprise.context.ApplicationScoped;
+import javax.faces.bean.ManagedBean;
+
+@ManagedBean(name="jsfBean", eager=true)
+@ApplicationScoped
+public class JSFBean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private String data = ":" + getClass().getSimpleName() + ":";
+
+    // Mojarra does not support @EJB, but MyFaces does
+    @EJB
+    TestEJB ejb;
+
+    @PostConstruct
+    public void start() {
+        System.out.println("JSFBean postConstruct called");
+        this.data += ":PostConstructCalled:";
+        if (ejb != null && ejb.verifyPostConstruct())
+            this.data += ":EJB-injected:";
+        System.out.println("JSFBean data is: " + data);
+    }
+
+    @PreDestroy
+    public void stop() {
+        System.out.println("JSFBean preDestroy called.");
+    }
+
+    public void setData(String newData) {
+        this.data += newData;
+    }
+
+    public String getData() {
+        return this.data;
+    }
+
+    public String nextPage() {
+        return "TestBean";
+    }
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/facesApp/src/facesapp/TestEJB.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/facesApp/src/facesapp/TestEJB.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package facesapp;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.Stateless;
+
+@Stateless
+public class TestEJB {
+
+    protected boolean postConstructCalled;
+
+    @PostConstruct
+    public void postConstruct() {
+        postConstructCalled = true;
+    }
+
+    public boolean verifyPostConstruct() {
+        return postConstructCalled;
+    }
+
+}


### PR DESCRIPTION
For issue https://github.com/OpenLiberty/open-liberty/issues/21327

Add a Faces test that verifies managed beans function correctly upon restore of checkpoint-at-application.  Of particular importance are managed beans that are eager or scoped to the application. The Faces provider runtime may create these beans during application startup.  

Some considerations:
1. We don't care about custom scoping.
2. The test does not repeat for MP60/EE10.  The test application uses a JSP view, which much change in order to support Faces-4.0 (EE10)
3. The test uses CDI scope annotations, only.  However, the test verifies both Faces (`@ManagedBean`) and CDI (`@Named`) managed beans.  Faces annotations for managed beans are deprecated in EE8 and EE9, and ultimately removed in EE10. So, we can skip `testJsfBean()` for EE10/MP60.
