### PR TITLE
Remove EE9 toleration from concurrency 3.0 API

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.concurrency-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.concurrency-3.0.feature
@@ -2,8 +2,7 @@
 symbolicName=io.openliberty.jakarta.concurrency-3.0
 visibility=private
 singleton=true
-#TODO remove toleration of eeCompatible-9.0 once other EE 10 features are usable in beta form
--features=com.ibm.websphere.appserver.eeCompatible-10.0; ibm.tolerates:="9.0"
+-features=com.ibm.websphere.appserver.eeCompatible-10.0
 -bundles=io.openliberty.jakarta.concurrency.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:3.0.2"
 kind=beta
 edition=core


### PR DESCRIPTION
EE9 toleration is no longer required now that everything is in beta

