### PR TITLE
consolidate original resource request code

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanism.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanism.java
@@ -36,12 +36,12 @@ import io.openliberty.security.jakartasec.OpenIdAuthenticationMechanismDefinitio
 import io.openliberty.security.jakartasec.credential.OidcTokensCredential;
 import io.openliberty.security.jakartasec.identitystore.OpenIdContextUtils;
 import io.openliberty.security.oidcclientcore.authentication.AuthorizationRequestUtils;
-import io.openliberty.security.oidcclientcore.authentication.OriginalResourceRequest;
 import io.openliberty.security.oidcclientcore.client.Client;
 import io.openliberty.security.oidcclientcore.client.ClientManager;
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 import io.openliberty.security.oidcclientcore.exceptions.AuthenticationResponseException;
 import io.openliberty.security.oidcclientcore.exceptions.TokenRequestException;
+import io.openliberty.security.oidcclientcore.http.OriginalResourceRequest;
 import io.openliberty.security.oidcclientcore.storage.OidcStorageUtils;
 import io.openliberty.security.oidcclientcore.storage.Storage;
 import io.openliberty.security.oidcclientcore.storage.StorageFactory;

--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/test/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanismTest.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/test/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanismTest.java
@@ -28,11 +28,11 @@ import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 
 import io.openliberty.security.jakartasec.JakartaSec30Constants;
 import io.openliberty.security.jakartasec.TestOpenIdAuthenticationMechanismDefinition;
-import io.openliberty.security.oidcclientcore.authentication.OriginalResourceRequest;
 import io.openliberty.security.oidcclientcore.client.Client;
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 import io.openliberty.security.oidcclientcore.exceptions.AuthenticationResponseException;
 import io.openliberty.security.oidcclientcore.exceptions.AuthenticationResponseException.ValidationResult;
+import io.openliberty.security.oidcclientcore.http.OriginalResourceRequest;
 import io.openliberty.security.oidcclientcore.exceptions.TokenRequestException;
 import io.openliberty.security.oidcclientcore.storage.OidcStorageUtils;
 import io.openliberty.security.oidcclientcore.token.JakartaOidcTokenRequest;

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequestTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequestTest.java
@@ -11,17 +11,10 @@
 package io.openliberty.security.oidcclientcore.authentication;
 
 import static io.openliberty.security.oidcclientcore.authentication.JakartaOidcAuthorizationRequest.IS_CONTAINER_INITIATED_FLOW;
-import static io.openliberty.security.oidcclientcore.storage.OidcClientStorageConstants.WAS_OIDC_REQ_HEADERS;
-import static io.openliberty.security.oidcclientcore.storage.OidcClientStorageConstants.WAS_OIDC_REQ_METHOD;
-import static io.openliberty.security.oidcclientcore.storage.OidcClientStorageConstants.WAS_OIDC_REQ_PARAMS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Enumeration;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -43,7 +36,6 @@ import io.openliberty.security.oidcclientcore.config.OidcMetadataService;
 import io.openliberty.security.oidcclientcore.discovery.OidcDiscoveryConstants;
 import io.openliberty.security.oidcclientcore.exceptions.OidcDiscoveryException;
 import io.openliberty.security.oidcclientcore.storage.SessionBasedStorage;
-import io.openliberty.security.oidcclientcore.utils.Utils;
 import test.common.SharedOutputManager;
 
 public class JakartaOidcAuthorizationRequestTest extends CommonTestClass {
@@ -270,45 +262,6 @@ public class JakartaOidcAuthorizationRequestTest extends CommonTestClass {
             }
         });
         authzRequest.addExtraParameters(authzParameters);
-    }
-
-    @Test
-    public void test_storeFullRequest() throws Exception {
-        String state = "12345";
-        String stateHash = Utils.getStrHashCode(state);
-
-        String requestMethod = "POST";
-
-        Enumeration<String> headerNames = Collections.enumeration(Arrays.asList("Content-Type"));
-        Enumeration<String> contentTypes = Collections.enumeration(Arrays.asList("application/x-www-form-urlencoded"));
-
-        Enumeration<String> paramNames = Collections.enumeration(Arrays.asList("id", "language"));
-        String[] ids = new String[] { "1234" };
-        String[] languages = new String[] { "Java" };
-
-        mockery.checking(new Expectations() {
-            {
-                one(request).getMethod();
-                will(returnValue(requestMethod));
-                one(sessionBasedStorage).store(with(equal(WAS_OIDC_REQ_METHOD + stateHash)), with(any(String.class)));
-
-                one(request).getHeaderNames();
-                will(returnValue(headerNames));
-                one(request).getHeaders("Content-Type");
-                will(returnValue(contentTypes));
-                one(sessionBasedStorage).store(with(equal(WAS_OIDC_REQ_HEADERS + stateHash)), with(any(String.class)));
-
-                one(request).getParameterNames();
-                will(returnValue(paramNames));
-                one(request).getParameterValues("id");
-                will(returnValue(ids));
-                one(request).getParameterValues("language");
-                will(returnValue(languages));
-                one(sessionBasedStorage).store(with(equal(WAS_OIDC_REQ_PARAMS + stateHash)), with(any(String.class)));
-            }
-        });
-
-        authzRequest.storeFullRequest(state);
     }
 
     @Test


### PR DESCRIPTION
just doing some small refactoring:
- consolidate original resource request code by moving `storeFullRequest` code into the same class as `restoreOriginalRequest` code
- move `OriginalResourceRequest` from `authentication` to `http` package