### PR TITLE
Revert "Update to Felix SCR 2.2.2"

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -3543,11 +3543,6 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.service.component</artifactId>
-      <version>1.5.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.coordinator</artifactId>
       <version>1.0.2</version>
     </dependency>
@@ -4334,7 +4329,7 @@
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.scr</artifactId>
-      <version>2.2.2</version>
+      <version>2.1.26</version>
     </dependency>
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -704,7 +704,6 @@ org.osgi:org.osgi.service.blueprint:1.0.2
 org.osgi:org.osgi.service.cm:1.6.0
 org.osgi:org.osgi.service.component.annotations:1.4.0
 org.osgi:org.osgi.service.component:1.4.0
-org.osgi:org.osgi.service.component:1.5.0
 org.osgi:org.osgi.service.coordinator:1.0.2
 org.osgi:org.osgi.service.event:1.3.1
 org.osgi:org.osgi.service.http.whiteboard:1.0.0

--- a/dev/cnf/oss_source_dependencies.maven
+++ b/dev/cnf/oss_source_dependencies.maven
@@ -78,7 +78,7 @@ org.apache.cxf:cxf-tools-wadlto-jaxrs:3.3.0
 org.apache.felix:org.apache.felix.gogo.command:1.1.2
 org.apache.felix:org.apache.felix.gogo.runtime:1.1.4
 org.apache.felix:org.apache.felix.gogo.shell:1.1.4
-org.apache.felix:org.apache.felix.scr:2.2.2
+org.apache.felix:org.apache.felix.scr:2.1.26
 org.apache.geronimo.specs:geronimo-jta_1.1_spec:1.1.1
 org.apache.geronimo.specs:geronimo-osgi-registry:1.1
 org.apache.geronimo.specs:geronimo-validation_1.0_spec:1.1

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/tcpchannel/internal/TCPChannelConfiguration.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/tcpchannel/internal/TCPChannelConfiguration.java
@@ -128,8 +128,7 @@ public class TCPChannelConfiguration implements TCPConfigConstants, FFDCSelfIntr
                key.startsWith("service.") ||
                key.startsWith("component.") ||
                key.startsWith("config.") ||
-               key.startsWith("objectClass") ||
-               key.startsWith("osgi.ds.");
+               key.startsWith("objectClass");
     }
 
     private void setValues() throws ChannelException {

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/udpchannel/internal/UDPChannelConfiguration.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/udpchannel/internal/UDPChannelConfiguration.java
@@ -64,8 +64,7 @@ public class UDPChannelConfiguration {
                     key.startsWith("component.") ||
                     key.startsWith("config.") ||
                     key.startsWith("objectClass") ||
-                    key.startsWith("parentPid") ||
-                    key.startsWith("osgi.ds.")) {
+                    key.startsWith("parentPid")) {
                     // skip osgi standard properties
                     continue;
                 }

--- a/dev/com.ibm.ws.javaee.ddmodel.wsbnd/src/com/ibm/ws/javaee/ddmodel/wsbnd/impl/WebserviceEndpointPropertiesComponentImpl.java
+++ b/dev/com.ibm.ws.javaee.ddmodel.wsbnd/src/com/ibm/ws/javaee/ddmodel/wsbnd/impl/WebserviceEndpointPropertiesComponentImpl.java
@@ -29,7 +29,7 @@ public class WebserviceEndpointPropertiesComponentImpl implements WebserviceEndp
     private final Map<String, String> attributes = new HashMap<String, String>();
 
     // These are properties added by the config runtime -- ignore them.
-    private final String[] ignoredPrefixes = { "service.", "config.", "component.", "osgi.ds." };
+    private final String[] ignoredPrefixes = { "service.", "config.", "component." };
 
     @Activate
     protected void activate(Map<String, Object> config) {

--- a/dev/com.ibm.ws.org.apache.felix.scr/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.felix.scr/bnd.bnd
@@ -9,18 +9,16 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= \
- jar:${fileuri;${repo;org.apache.felix:org.apache.felix.scr;2.2.2;EXACT}}!/META-INF/MANIFEST.MF,\
+ jar:${fileuri;${repo;org.apache.felix:org.apache.felix.scr;2.1.26;EXACT}}!/META-INF/MANIFEST.MF,\
  bnd.overrides
 
 -includeresource: \
    OSGI-INF=resources/OSGI-INF, \
-   @${repo;org.apache.felix:org.apache.felix.scr;2.2.2;EXACT}!/!META-INF/maven/*,\
+   @${repo;org.apache.felix:org.apache.felix.scr;2.1.26;EXACT}!/!META-INF/maven/*,\
    @${repo;org.osgi:org.osgi.util.function;1.1.0;EXACT}!/!(OSGI-OPT|META-INF)/*,\
-   @${repo;org.osgi:org.osgi.util.promise;1.1.1;EXACT}!/!(OSGI-OPT|META-INF)/*,\
-   @${repo;org.osgi:org.osgi.service.component;1.5.0;EXACT}!/!(OSGI-OPT|META-INF)/*
+   @${repo;org.osgi:org.osgi.util.promise;1.1.1;EXACT}!/!(OSGI-OPT|META-INF)/*
 
 -buildpath: \
-	org.apache.felix:org.apache.felix.scr;strategy=exact;version=2.2.2,\
+	org.apache.felix:org.apache.felix.scr;strategy=exact;version=2.1.26,\
 	org.osgi:org.osgi.util.function;strategy=exact;version=1.1.0,\
-	org.osgi:org.osgi.util.promise;strategy=exact;version=1.1.1,\
-        org.osgi:org.osgi.service.component;strategy=exact;version=1.5.0
+	org.osgi:org.osgi.util.promise;strategy=exact;version=1.1.1

--- a/dev/com.ibm.ws.rest.handler.config/src/com/ibm/ws/rest/handler/config/internal/ConfigRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.config/src/com/ibm/ws/rest/handler/config/internal/ConfigRESTHandler.java
@@ -176,8 +176,7 @@ public class ConfigRESTHandler extends ConfigBasedRESTHandler {
             // Don't display items starting with config. or service. or ibm.extends (added by config service)
             // Also don't display items added by app-defined resources
             if (key.startsWith("config.") || key.startsWith("service.") || key.startsWith("ibm.extends") ||
-                key.equals("creates.objectClass") || key.equals("jndiName.unique") ||
-                key.startsWith("osgi.ds.")) {
+                key.equals("creates.objectClass") || key.equals("jndiName.unique")) {
                 continue;
             }
 

--- a/dev/com.ibm.ws.security.authentication.tai/src/com/ibm/ws/security/authentication/tai/internal/InterceptorConfigImpl.java
+++ b/dev/com.ibm.ws.security.authentication.tai/src/com/ibm/ws/security/authentication/tai/internal/InterceptorConfigImpl.java
@@ -173,8 +173,7 @@ public class InterceptorConfigImpl implements TrustAssociationInterceptor, Confi
                 if (key.startsWith(".")
                     || key.startsWith("config.")
                     || key.startsWith("service.")
-                    || key.equals("id")
-                    || key.startsWith("osgi.ds.")) {
+                    || key.equals("id")) {
                     continue;
                 }
                 properties.put(key, cProps.get(key));

--- a/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/internal/JAASLoginModuleConfigImpl.java
+++ b/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/internal/JAASLoginModuleConfigImpl.java
@@ -384,8 +384,7 @@ public class JAASLoginModuleConfigImpl implements JAASLoginModuleConfig, Synchro
                 if (key.startsWith(".")
                     || key.startsWith("config.")
                     || key.startsWith("service.")
-                    || key.equals("id")
-                    || key.startsWith("osgi.ds.")) {
+                    || key.equals("id")) {
                     continue;
                 }
                 options.put(key, option.getValue());

--- a/dev/com.ibm.ws.security.oidc.server_fat/test-bundles/com.ibm.ws.security.tai.sample/src/com/ibm/ws/security/tai/sample/SampleTAI.java
+++ b/dev/com.ibm.ws.security.oidc.server_fat/test-bundles/com.ibm.ws.security.tai.sample/src/com/ibm/ws/security/tai/sample/SampleTAI.java
@@ -229,8 +229,7 @@ public class SampleTAI implements TrustAssociationInterceptor {
                 if (key.startsWith(".")
                     || key.startsWith("config.")
                     || key.startsWith("service.")
-                    || key.equals("id")
-                    || key.startsWith("osgi.ds.")) {
+                    || key.equals("id")) {
                     continue;
                 }
                 Object value = cProps.get(key);

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/common/ConfigUtils.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/common/ConfigUtils.java
@@ -219,8 +219,7 @@ public class ConfigUtils {
                     if (key.startsWith(".")
                             || key.startsWith("config.")
                             || key.startsWith("service.")
-                            || key.equals("id")
-                            || key.startsWith("osgi.ds.")) {
+                            || key.equals("id")) {
                         continue;
                     }
                     Object value = cProps.get(key);
@@ -321,8 +320,7 @@ public class ConfigUtils {
                     || key.startsWith("config.")
                     || key.startsWith("service.")
                     || key.startsWith("property.")
-                    || key.equals("id")
-                    || key.startsWith("osgi.ds.")) {
+                    || key.equals("id")) {
                 continue;
             }
             Object value = entry.getValue();

--- a/dev/com.ibm.ws.wsbytebuffer/src/com/ibm/ws/bytebuffer/internal/WsByteBufferPoolManagerImpl.java
+++ b/dev/com.ibm.ws.wsbytebuffer/src/com/ibm/ws/bytebuffer/internal/WsByteBufferPoolManagerImpl.java
@@ -127,8 +127,7 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
                     key.startsWith("component.") ||
                     key.startsWith("config.") ||
                     key.startsWith("parentPid") ||
-                    key.startsWith("id") ||
-                    key.startsWith("osgi.ds.")) {
+                    key.startsWith("id")) {
                     // skip osgi standard properties
                     continue;
                 }

--- a/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityClientConfiguration.java
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityClientConfiguration.java
@@ -255,8 +255,7 @@ public class WSSecurityClientConfiguration implements ConfigurationListener {
                 if (entry_key.startsWith(".")
                     || entry_key.startsWith("config.")
                     || entry_key.startsWith("service.")
-                    || entry_key.equals("id")
-                    || entry_key.startsWith("osgi.ds.")) {
+                    || entry_key.equals("id")) {
                     continue;
                 }
                 Object entry_value = entry.getValue();//(String) properties.get(entry_key);

--- a/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityConfiguration.java
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityConfiguration.java
@@ -463,8 +463,7 @@ public class WSSecurityConfiguration implements ConfigurationListener {
                 if (entry_key.startsWith(".")
                     || entry_key.startsWith("config.")
                     || entry_key.startsWith("service.")
-                    || entry_key.equals("id")
-                    || entry_key.startsWith("osgi.ds.")) {
+                    || entry_key.equals("id")) {
                     continue;
                 }
                 Object entry_value = entry.getValue();//(String) properties.get(entry_key);

--- a/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/tcp/TCPConfigurationImpl.java
+++ b/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/tcp/TCPConfigurationImpl.java
@@ -152,8 +152,7 @@ public class TCPConfigurationImpl implements BootstrapConfiguration, TCPConfigCo
                key.startsWith("service.") ||
                key.startsWith("component.") ||
                key.startsWith("config.") ||
-               key.startsWith("objectClass") ||
-               key.startsWith("osgi.ds.");
+               key.startsWith("objectClass");
     }
     //@formatter:on
 

--- a/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/udp/UDPConfigurationImpl.java
+++ b/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/udp/UDPConfigurationImpl.java
@@ -110,8 +110,7 @@ public class UDPConfigurationImpl implements BootstrapConfiguration {
                     key.startsWith("component.") ||
                     key.startsWith("config.") ||
                     key.startsWith("objectClass") ||
-                    key.startsWith("parentPid") ||
-                    key.startsWith("osgi.ds.")) {
+                    key.startsWith("parentPid")) {
                     // skip osgi standard properties
                     continue;
                 }


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#22004

The contents of `dev/api/spec/com.ibm.websphere.org.osgi.service.component_1.1.72.jar` and `dev/api/third-party/com.ibm.websphere.appserver.thirdparty.blueprint_1.3.72.jar` changed in a way that should have failed the API checker but did not until the new baselines were delivered.