### PR TITLE
Duplicate items issue is resolved

### DIFF
--- a/dev/io.openliberty.xmlBinding.4.0.internal_fat/test-applications/jaxbApp/src/jaxb/web/utils/JAXBContextUtils.java
+++ b/dev/io.openliberty.xmlBinding.4.0.internal_fat/test-applications/jaxbApp/src/jaxb/web/utils/JAXBContextUtils.java
@@ -93,18 +93,13 @@ public class JAXBContextUtils {
      * @return
      */
     public static Items getItems() {
-        if (ITEMS == null) {
-            Items tempItems = new Items();
-            List<Item> itemList = createItemsList();
-            List<String> itemNames = createItemNames(itemList);
-            tempItems.setItem(itemList);
-            tempItems.setItemNames(itemNames);
-            ITEMS = tempItems;
-            return ITEMS;
-        } else {
-            return ITEMS;
-        }
-
+        Items tempItems = new Items();
+        List<Item> itemList = createItemsList();
+        List<String> itemNames = createItemNames(itemList);
+        tempItems.setItem(itemList);
+        tempItems.setItemNames(itemNames);
+        ITEMS = tempItems;
+        return ITEMS;
     }
 
     /**


### PR DESCRIPTION
Fixes #23467

Checking and returning existing items was the root cause of the duplicated items causing the test to fail. Mentioned if block is removed. 