### PR TITLE
Telemetry exporter attribute and exception tests

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/apps/spanTest/TestResource.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/apps/spanTest/TestResource.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package io.openliberty.microprofile.telemetry.internal.apps.spanTest;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
@@ -33,6 +34,9 @@ public class TestResource extends Application {
 
     public static final String TEST_OPERATION_NAME = "TestOp";
     public static final String TEST_EVENT_NAME = "TestEvent";
+
+    public static final AttributeKey<String> TEST_ATTRIBUTE_KEY = AttributeKey.stringKey("test_key_foo");
+    public static final String TEST_ATTRIBUTE_VALUE = "test_value_bar";
 
     @Inject
     private Tracer tracer;
@@ -67,6 +71,14 @@ public class TestResource extends Application {
         Span span = Span.current();
         span.recordException(new RuntimeException());
         span.setStatus(StatusCode.ERROR);
+        return span.getSpanContext().getTraceId();
+    }
+
+    @GET
+    @Path("/attributeAdded")
+    public String attributeAdded() {
+        Span span = Span.current();
+        span.setAttribute(TEST_ATTRIBUTE_KEY, TEST_ATTRIBUTE_VALUE);
         return span.getSpanContext().getTraceId();
     }
 }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/ZipkinTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/ZipkinTest.java
@@ -135,6 +135,31 @@ public class ZipkinTest {
         assertThat(child, hasProperty("name", equalToIgnoringCase(TestResource.TEST_OPERATION_NAME)));
     }
 
+    @Test
+    public void testExceptionRecorded() throws Exception {
+        HttpRequest request = new HttpRequest(server, "/spanTest/exception");
+        String traceId = request.run(String.class);
+
+        List<ZipkinSpan> spans = client.waitForSpansForTraceId(traceId, hasSize(1));
+
+        ZipkinSpan span = spans.get(0);
+
+        // Note Zipkin doesn't record any details about the exception, just that it occurred
+        assertThat(span, ZipkinSpanMatcher.hasAnnotation("exception"));
+    }
+
+    @Test
+    public void testAttributeAdded() throws Exception {
+        HttpRequest request = new HttpRequest(server, "/spanTest/attributeAdded");
+        String traceId = request.run(String.class);
+
+        List<ZipkinSpan> spans = client.waitForSpansForTraceId(traceId, hasSize(1));
+
+        ZipkinSpan span = spans.get(0);
+
+        assertThat(span, ZipkinSpanMatcher.hasTag(TestResource.TEST_ATTRIBUTE_KEY.getKey(), TestResource.TEST_ATTRIBUTE_VALUE));
+    }
+
     private boolean hasParent(ZipkinSpan span) {
         return span.getParentId() != null;
     }


### PR DESCRIPTION
Add tests for Zipkin and Jaeger for exceptions and attributes added to spans.

Fixes #23177 