### PR TITLE
Add a doPrivileged call to WithSpanInterceptor

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/cdi/WithSpanInterceptor.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/cdi/WithSpanInterceptor.java
@@ -102,12 +102,14 @@ public class WithSpanInterceptor {
     private static final class MethodRequestSpanNameExtractor implements SpanNameExtractor<MethodRequest> {
         @Override
         public String extract(final MethodRequest methodRequest) {
-            WithSpan annotation = methodRequest.getMethod().getDeclaredAnnotation(WithSpan.class);
-            String spanName = annotation.value();
-            if (spanName.isEmpty()) {
-                spanName = SpanNames.fromMethod(methodRequest.getMethod());
-            }
-            return spanName;
+            return AccessController.doPrivileged((PrivilegedAction<String>) () -> {
+                WithSpan annotation = methodRequest.getMethod().getDeclaredAnnotation(WithSpan.class);
+                String spanName = annotation.value();
+                if (spanName.isEmpty()) {
+                    spanName = SpanNames.fromMethod(methodRequest.getMethod());
+                }
+                return spanName;
+            });
         }
     }
 


### PR DESCRIPTION
Fixes a Java 2 Security error from the mpTelemetry `@WithSpan`  annotation