### PR TITLE
return types when using Query annotation

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Condition.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Condition.java
@@ -17,6 +17,7 @@ enum Condition {
     CONTAINS(null, 8),
     ENDS_WITH(null, 8),
     EQUALS("=", 0),
+    FALSE("=FALSE", 5),
     GREATER_THAN(">", 11),
     GREATER_THAN_EQUAL(">=", 16),
     IN(" IN ", 2),
@@ -24,9 +25,10 @@ enum Condition {
     LESS_THAN_EQUAL("<=", 13),
     LIKE(null, 4),
     NOT_EQUALS("<>", 3),
-    NOT_NULL("IS NOT NULL", 7),
-    NULL("IS NULL", 4),
-    STARTS_WITH(null, 10);
+    NOT_NULL(" IS NOT NULL", 7),
+    NULL(" IS NULL", 4),
+    STARTS_WITH(null, 10),
+    TRUE("=TRUE", 4);
 
     final int length;
     final String operator;
@@ -48,12 +50,16 @@ enum Condition {
                 return GREATER_THAN_EQUAL;
             case LESS_THAN_EQUAL:
                 return GREATER_THAN;
+            case NULL:
+                return NOT_NULL;
+            case TRUE:
+                return FALSE;
+            case FALSE:
+                return TRUE;
             case NOT_EQUALS:
                 return EQUALS;
             case NOT_NULL:
                 return NULL;
-            case NULL:
-                return NOT_NULL;
             default:
                 return null;
         }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Condition.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Condition.java
@@ -24,6 +24,8 @@ enum Condition {
     LESS_THAN_EQUAL("<=", 13),
     LIKE(null, 4),
     NOT_EQUALS("<>", 3),
+    NOT_NULL("IS NOT NULL", 7),
+    NULL("IS NULL", 4),
     STARTS_WITH(null, 10);
 
     final int length;
@@ -48,6 +50,10 @@ enum Condition {
                 return GREATER_THAN;
             case NOT_EQUALS:
                 return EQUALS;
+            case NOT_NULL:
+                return NULL;
+            case NULL:
+                return NOT_NULL;
             default:
                 return null;
         }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -542,12 +542,15 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
                     }
                 }
                 break;
-            case 'l': // GreaterThanEqual | LessThanEqual
-                if (length > Condition.LESS_THAN_EQUAL.length && expression.charAt(length - 4) == 'q')
+            case 'l': // GreaterThanEqual | LessThanEqual | Null
+                if (length > Condition.LESS_THAN_EQUAL.length && expression.charAt(length - 4) == 'q') {
                     if (expression.endsWith("GreaterThanEqual"))
                         condition = Condition.GREATER_THAN_EQUAL;
                     else if (expression.endsWith("LessThanEqual"))
                         condition = Condition.LESS_THAN_EQUAL;
+                } else if (expression.endsWith("Null")) {
+                    condition = Condition.NULL;
+                }
                 break;
             case 'e': // Like
                 if (expression.endsWith("Like"))
@@ -622,6 +625,10 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
                     q.append(" ?").append(++queryInfo.paramCount).append(negated ? " NOT " : " ").append("MEMBER OF ").append(attributeExpr);
                 else
                     q.append(attributeExpr).append(negated ? " NOT " : " ").append("LIKE CONCAT('%', ?").append(++queryInfo.paramCount).append(", '%')");
+                break;
+            case NULL:
+            case NOT_NULL:
+                q.append(attributeExpr).append(' ').append(condition.operator);
                 break;
             default:
                 q.append(attributeExpr).append(negated ? " NOT " : "").append(condition.operator).append('?').append(++queryInfo.paramCount);

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -552,9 +552,13 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
                     condition = Condition.NULL;
                 }
                 break;
-            case 'e': // Like
+            case 'e': // Like, True, False
                 if (expression.endsWith("Like"))
                     condition = Condition.LIKE;
+                else if (expression.endsWith("True"))
+                    condition = Condition.TRUE;
+                else if (expression.endsWith("False"))
+                    condition = Condition.FALSE;
                 break;
             case 'h': // StartsWith | EndsWith
                 if (expression.endsWith("StartsWith"))
@@ -628,7 +632,9 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
                 break;
             case NULL:
             case NOT_NULL:
-                q.append(attributeExpr).append(' ').append(condition.operator);
+            case TRUE:
+            case FALSE:
+                q.append(attributeExpr).append(condition.operator);
                 break;
             default:
                 q.append(attributeExpr).append(negated ? " NOT " : "").append(condition.operator).append('?').append(++queryInfo.paramCount);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -33,6 +34,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
+import java.util.Stack;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -1664,6 +1666,77 @@ public class DataTestServlet extends FATServlet {
         assertEquals(t8.leviedAgainst, list.get(7).leviedAgainst);
 
         assertEquals(8, tariffs.deleteByLeviedBy("USA"));
+    }
+
+    /**
+     * Various return types for a repository query that performs multiple aggregate functions.
+     */
+    @Test
+    public void testMultipleAggregates() {
+        Object[] objects = primes.minMaxSumCountAverageObject(50);
+        assertEquals(Long.valueOf(2L), objects[0]); // minimum
+        assertEquals(Long.valueOf(47L), objects[1]); // maximum
+        assertEquals(Long.valueOf(328L), objects[2]); // sum
+        assertEquals(Long.valueOf(15L), objects[3]); // count
+        assertEquals(true, objects[4] instanceof Number); // average
+        assertEquals(21.0, Math.floor(((Number) objects[4]).doubleValue()), 0.01);
+
+        Number[] numbers = primes.minMaxSumCountAverageNumber(45);
+        assertEquals(Long.valueOf(2L), numbers[0]); // minimum
+        assertEquals(Long.valueOf(43L), numbers[1]); // maximum
+        assertEquals(Long.valueOf(281L), numbers[2]); // sum
+        assertEquals(Long.valueOf(14L), numbers[3]); // count
+        assertEquals(20.0, Math.floor(numbers[4].doubleValue()), 0.01);
+
+        Long[] longs = primes.minMaxSumCountAverageLong(42);
+        assertEquals(Long.valueOf(2L), longs[0]); // minimum
+        assertEquals(Long.valueOf(41L), longs[1]); // maximum
+        assertEquals(Long.valueOf(238L), longs[2]); // sum
+        assertEquals(Long.valueOf(13L), longs[3]); // count
+        assertEquals(Long.valueOf(18L), longs[4]); // average
+
+        int[] ints = primes.minMaxSumCountAverageInt(40);
+        assertEquals(2, ints[0]); // minimum
+        assertEquals(37, ints[1]); // maximum
+        assertEquals(197, ints[2]); // sum
+        assertEquals(12, ints[3]); // count
+        assertEquals(16, ints[4]); // average
+
+        float[] floats = primes.minMaxSumCountAverageFloat(35);
+        assertEquals(2.0f, floats[0], 0.01f); // minimum
+        assertEquals(31.0f, floats[1], 0.01f); // maximum
+        assertEquals(160.0f, floats[2], 0.01f); // sum
+        assertEquals(11.0f, floats[3], 0.01f); // count
+        assertEquals(14.0f, Math.floor(floats[4]), 0.01f); // average
+
+        List<Long> list = primes.minMaxSumCountAverageList(30);
+        assertEquals(Long.valueOf(2L), list.get(0)); // minimum
+        assertEquals(Long.valueOf(29L), list.get(1)); // maximum
+        assertEquals(Long.valueOf(129L), list.get(2)); // sum
+        assertEquals(Long.valueOf(10L), list.get(3)); // count
+        assertEquals(Long.valueOf(12L), list.get(4)); // average
+
+        Stack<String> stack = primes.minMaxSumCountAverageStack(25);
+        assertEquals("2", stack.get(0)); // minimum
+        assertEquals("23", stack.get(1)); // maximum
+        assertEquals("100", stack.get(2)); // sum
+        assertEquals("9", stack.get(3)); // count
+        assertEquals(stack.get(4), true, stack.get(4).startsWith("11.")); // average
+
+        Iterable<Integer> iterable = primes.minMaxSumCountAverageIterable(20);
+        Iterator<Integer> it = iterable.iterator();
+        assertEquals(Integer.valueOf(2), it.next()); // minimum
+        assertEquals(Integer.valueOf(19), it.next()); // maximum
+        assertEquals(Integer.valueOf(77), it.next()); // sum
+        assertEquals(Integer.valueOf(8), it.next()); // count
+        assertEquals(Integer.valueOf(9), it.next()); // average
+
+        Deque<Double> deque = primes.minMaxSumCountAverageDeque(18);
+        assertEquals(2.0, deque.removeFirst(), 0.01); // minimum
+        assertEquals(17.0, deque.removeFirst(), 0.01); // maximum
+        assertEquals(58.0, deque.removeFirst(), 0.01); // sum
+        assertEquals(7.0, deque.removeFirst(), 0.01); // count
+        assertEquals(8.0, Math.floor(deque.removeFirst()), 0.01); // average
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -463,6 +463,36 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Test True, False, NotTrue, and NotFalse on repository methods.
+     */
+    @Test
+    public void testBooleanConditions() {
+        assertIterableEquals(List.of(3L, 5L, 7L),
+                             primes.findByEvenFalseAndNumberLessThan(10L)
+                                             .stream()
+                                             .map(p -> p.number)
+                                             .collect(Collectors.toList()));
+
+        assertIterableEquals(List.of(7L, 5L, 3L),
+                             primes.findByEvenNotTrueAndNumberLessThan(10L)
+                                             .stream()
+                                             .map(p -> p.number)
+                                             .collect(Collectors.toList()));
+
+        assertIterableEquals(List.of(2L),
+                             primes.findByEvenTrueAndNumberLessThan(10L)
+                                             .stream()
+                                             .map(p -> p.number)
+                                             .collect(Collectors.toList()));
+
+        assertIterableEquals(List.of(2L),
+                             primes.findByEvenNotFalseAndNumberLessThan(10L)
+                                             .stream()
+                                             .map(p -> p.number)
+                                             .collect(Collectors.toList()));
+    }
+
+    /**
      * Asynchronous repository method that returns a CompletionStage of KeysetAwarePage.
      */
     @Test

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -140,7 +140,10 @@ public class DataTestServlet extends FATServlet {
                     new Prime(37, "25", "100101", 3, "XXXVII", "thirty-seven"),
                     new Prime(41, "29", "101001", 3, "XLI", "forty-one"),
                     new Prime(43, "2B", "101011", 4, "XLIII", "forty-three"),
-                    new Prime(47, "2F", "101111", 5, "XLVII", "forty-seven"));
+                    new Prime(47, "2F", "101111", 5, "XLVII", "forty-seven"),
+                    new Prime(4001, "FA1", "111110100001", 7, null, "four thousand one"),
+                    new Prime(4003, "FA3", "111110100011", 8, null, "four thousand three"),
+                    new Prime(4007, "FA7", "111110100111", 9, null, "four thousand seven"));
     }
 
     /**
@@ -1737,6 +1740,24 @@ public class DataTestServlet extends FATServlet {
         assertEquals(58.0, deque.removeFirst(), 0.01); // sum
         assertEquals(7.0, deque.removeFirst(), 0.01); // count
         assertEquals(8.0, Math.floor(deque.removeFirst()), 0.01); // average
+    }
+
+    /**
+     * Test Null and NotNull on repository methods.
+     */
+    @Test
+    public void testNulls() {
+        assertIterableEquals(List.of(4001L, 4003L, 4007L),
+                             primes.findByNumberInAndRomanNumeralNull(Set.of(41L, 4001L, 43L, 4003L, 47L, 4007L))
+                                             .stream()
+                                             .map(p -> p.number)
+                                             .collect(Collectors.toList()));
+
+        assertIterableEquals(List.of(41L, 43L, 47L),
+                             primes.findByNumberInAndRomanNumeralNotNull(Set.of(41L, 4001L, 43L, 4003L, 47L, 4007L))
+                                             .stream()
+                                             .map(p -> p.number)
+                                             .collect(Collectors.toList()));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -13,6 +13,7 @@ package test.jakarta.data.web;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.Stack;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -49,6 +50,12 @@ public interface Primes {
     KeysetAwarePage<Prime> findByNumberBetween(long min, long max, Pageable pagination);
 
     KeysetAwarePage<Prime> findByNumberBetweenOrderByEvenDescSumOfBitsDescNumberAsc(long min, long max, Pageable pagination);
+
+    @OrderBy("number")
+    List<Prime> findByNumberInAndRomanNumeralNull(Iterable<Long> nums);
+
+    @OrderBy("number")
+    List<Prime> findByNumberInAndRomanNumeralNotNull(Set<Long> nums);
 
     Stream<Prime> findByNumberLessThan(long max);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -10,7 +10,10 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
+import java.util.Deque;
+import java.util.List;
 import java.util.Map;
+import java.util.Stack;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
@@ -68,6 +71,33 @@ public interface Primes {
     boolean existsByNumber(long number);
 
     Boolean existsNumberBetween(Long first, Long last);
+
+    @Query("SELECT MIN(o.number), MAX(o.number), SUM(o.number), COUNT(o.number), AVG(o.number) FROM Prime o WHERE o.number < ?1")
+    Deque<Double> minMaxSumCountAverageDeque(long numBelow);
+
+    @Query("SELECT MIN(o.number), MAX(o.number), SUM(o.number), COUNT(o.number), AVG(o.number) FROM Prime o WHERE o.number < ?1")
+    float[] minMaxSumCountAverageFloat(long numBelow);
+
+    @Query("SELECT MIN(o.number), MAX(o.number), SUM(o.number), COUNT(o.number), AVG(o.number) FROM Prime o WHERE o.number < ?1")
+    int[] minMaxSumCountAverageInt(long numBelow);
+
+    @Query("SELECT MIN(o.number), MAX(o.number), SUM(o.number), COUNT(o.number), AVG(o.number) FROM Prime o WHERE o.number < ?1")
+    Iterable<Integer> minMaxSumCountAverageIterable(long numBelow);
+
+    @Query("SELECT MIN(o.number), MAX(o.number), SUM(o.number), COUNT(o.number), AVG(o.number) FROM Prime o WHERE o.number < ?1")
+    List<Long> minMaxSumCountAverageList(long numBelow);
+
+    @Query("SELECT MIN(o.number), MAX(o.number), SUM(o.number), COUNT(o.number), AVG(o.number) FROM Prime o WHERE o.number < ?1")
+    Long[] minMaxSumCountAverageLong(long numBelow);
+
+    @Query("SELECT MIN(o.number), MAX(o.number), SUM(o.number), COUNT(o.number), AVG(o.number) FROM Prime o WHERE o.number < ?1")
+    Number[] minMaxSumCountAverageNumber(long numBelow);
+
+    @Query("SELECT MIN(o.number), MAX(o.number), SUM(o.number), COUNT(o.number), AVG(o.number) FROM Prime o WHERE o.number < ?1")
+    Object[] minMaxSumCountAverageObject(long numBelow); // TODO List<Number>?, List<Object>?
+
+    @Query("SELECT MIN(o.number), MAX(o.number), SUM(o.number), COUNT(o.number), AVG(o.number) FROM Prime o WHERE o.number < ?1")
+    Stack<String> minMaxSumCountAverageStack(long numBelow);
 
     @Query(value = "SELECT NEW java.util.AbstractMap.SimpleImmutableEntry(p.number, p.name) FROM Prime p WHERE p.number <= ?1 ORDER BY p.name",
            count = "SELECT COUNT(p) FROM Prime p WHERE p.number <= ?1")

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -44,6 +44,16 @@ public interface Primes {
     @Query("SELECT p.number FROM Prime p WHERE p.number >= ?1 AND p.number <= ?2")
     long findAsLongBetween(long min, long max);
 
+    @OrderBy("number")
+    List<Prime> findByEvenFalseAndNumberLessThan(long max);
+
+    List<Prime> findByEvenNotFalseAndNumberLessThan(long max);
+
+    @OrderBy(value = "number", descending = true)
+    List<Prime> findByEvenNotTrueAndNumberLessThan(long max);
+
+    List<Prime> findByEvenTrueAndNumberLessThan(long max);
+
     Prime findByNumberBetween(long min, long max);
 
     @OrderBy("number")


### PR DESCRIPTION
Experiment with some additional return types that are possible when using the Query annotation.
Also includes experimentation with Null, True, and False repository keywords.