### PR TITLE
Change to use proper intantiation of EntityPart objects.

### DIFF
--- a/dev/io.openliberty.org.jboss.resteasy.common.ee10/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.common.ee10/bnd.bnd
@@ -28,6 +28,7 @@ src: src, resources
 
 app-resources= \
   META-INF/services/jakarta.ws.rs.client.ClientBuilder | \
+  META-INF/services/jakarta.ws.rs.core.EntityPart$Builder | \
   META-INF/services/jakarta.ws.rs.sse.SseEventSource\$Builder | \
   META-INF/services/jakarta.ws.rs.sse.SseEventSource.Builder | \
   META-INF/services/jakarta.ws.rs.ext.MessageBodyReader | \

--- a/dev/io.openliberty.restfulWS.3.1_fat/fat/src/io/openliberty/restfulWS31/fat/multipart/MultipartTestServlet.java
+++ b/dev/io.openliberty.restfulWS.3.1_fat/fat/src/io/openliberty/restfulWS31/fat/multipart/MultipartTestServlet.java
@@ -126,44 +126,40 @@ public class MultipartTestServlet extends FATServlet {
     }
     
     private void testEntityPartMultipartRequest(String path, boolean useDefault) {
-        List<EntityPart> parts = new ArrayList<>();
 
+        List<EntityPart> parts = null;
         try {
+             File file = new File("./person.xml");
             if (useDefault) {
-                ResteasyEntityPartBuilder builder = new ResteasyEntityPartBuilder("fileid");
-                parts.add(builder.content(new ByteArrayInputStream("person1234".getBytes()))
-                                .build());
-
-                builder = new ResteasyEntityPartBuilder("description");
-                parts.add(builder.content(new ByteArrayInputStream("XML file about person1234".getBytes()))
-                                .build());
-
-                File file = new File("./person.xml");
-                builder = new ResteasyEntityPartBuilder("thefile");
-                parts.add(builder.fileName("person.xml")
+                parts = List.of(
+                        EntityPart.withName("fileid")
+                                .content(new ByteArrayInputStream("person1234".getBytes()))
+                                .build(),
+                        EntityPart.withName("description")
+                                .content(new ByteArrayInputStream("XML file about person1234".getBytes()))
+                                .build(),
+                        EntityPart.withName("thefile")
                                 .content("person.xml",new FileInputStream(file))
-                                .build());
-                
+                                .build()
+                 );               
                 
             } else {
-                ResteasyEntityPartBuilder builder = new ResteasyEntityPartBuilder("fileid");
-                parts.add(builder.content(new ByteArrayInputStream("person1234".getBytes()))
+                parts = List.of(
+                        EntityPart.withName("fileid")
+                                .content(new ByteArrayInputStream("person1234".getBytes()))
                                 .mediaType(MediaType.TEXT_PLAIN)
-                                .build());
-
-                builder = new ResteasyEntityPartBuilder("description");
-                parts.add(builder.content(new ByteArrayInputStream("XML file about person1234".getBytes()))
+                                .build(),
+                        EntityPart.withName("description")
+                                .content(new ByteArrayInputStream("XML file about person1234".getBytes()))
                                 .mediaType(MediaType.WILDCARD)
-                                .build());
-
-                File file = new File("./person.xml");
-                builder = new ResteasyEntityPartBuilder("thefile");
-                parts.add(builder.fileName("person.xml")
+                                .build(),
+                        EntityPart.withName("thefile")
                                 .content("person.xml",new FileInputStream(file))
                                 .mediaType(MediaType.APPLICATION_XML_TYPE)
-                                .build());
-                
+                                .build()
+                 );
             }
+
         } catch (IOException e) {
             e.printStackTrace();
             fail("Exception caught: " + e);


### PR DESCRIPTION
Fixes #22884 
Changed the new EE10 multipart tests to instantiate the EntityPart objects correctly rather than using the internal use builder.
