### PR TITLE
Move common logic to JCache code

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -13,7 +13,6 @@ package com.ibm.ws.session.store.cache;
 import java.io.PrintWriter;
 import java.lang.management.ManagementFactory;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
@@ -74,7 +73,6 @@ public class CacheStoreService implements Introspector, SessionStoreService {
     private static final String CONFIG_KEY_URI = "uri";
     private static final String CONFIG_KEY_LIBRARY_REF = "libraryRef";
     private static final String CONFIG_KEY_PROPERTIES = "properties";
-    private static final String HAZELCAST_PROVIDER = "com.hazelcast.cache.HazelcastCachingProvider";
 
     Map<String, Object> configurationProperties;
     private static final int BASE_PREFIX_LENGTH = CONFIG_KEY_PROPERTIES.length();
@@ -183,24 +181,7 @@ public class CacheStoreService implements Introspector, SessionStoreService {
                     if (trace && tc.isDebugEnabled()) {
                         Tr.debug(this, tc, "uri attribute value = ", uriValue);
                     }
-                    final URI configuredURI;
-                    if (uriValue != null)
-                    {
-                        if (HAZELCAST_PROVIDER.equals(cachingProviderClassName)) {
-                            vendorProperties.setProperty("hazelcast.config.location", uriValue);
-                            configuredURI = null;
-                        }
-                        else {
-                            try {
-                                configuredURI = new URI(uriValue);
-                            } catch (URISyntaxException e) {
-                                throw new IllegalArgumentException(Tr.formatMessage(tc, "INCORRECT_URI_SYNTAX", e), e);
-                            }
-                        }
-                    }
-                    else {
-                        configuredURI = null;
-                    }
+
 
                     for (Map.Entry<String, Object> entry : configurationProperties.entrySet()) {
                         String key = entry.getKey();
@@ -218,7 +199,7 @@ public class CacheStoreService implements Introspector, SessionStoreService {
                     tcCachingProvider = "CachingProvider" + Integer.toHexString(System.identityHashCode(cachingProvider));
 
                     cacheConfigUtil = new CacheConfigUtil();
-                    URI uri = cacheConfigUtil.preConfigureCacheManager(configuredURI, cachingProvider, vendorProperties);
+                    URI uri = cacheConfigUtil.preConfigureCacheManager(uriValue, cachingProvider, vendorProperties);
 
                     if (trace && tc.isDebugEnabled()) {
                         CacheHashMap.tcReturn("Caching", "getCachingProvider", tcCachingProvider, cachingProvider);

--- a/dev/io.openliberty.jcache.internal/src/io/openliberty/jcache/internal/CacheManagerServiceImpl.java
+++ b/dev/io.openliberty.jcache.internal/src/io/openliberty/jcache/internal/CacheManagerServiceImpl.java
@@ -14,7 +14,6 @@ import static org.osgi.service.component.annotations.ConfigurationPolicy.REQUIRE
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ScheduledExecutorService;
@@ -54,7 +53,7 @@ public class CacheManagerServiceImpl implements CacheManagerService {
     private static final int TOTAL_PREFIX_LENGTH = BASE_PREFIX_LENGTH + 3; // 3 is the length of .0.
 
     private Properties properties = null;
-    private URI configuredUri = null;
+    private String uriValue = null;
     private CacheManager cacheManager = null;
 
     private CachingProviderService cachingProviderService = null;
@@ -81,19 +80,7 @@ public class CacheManagerServiceImpl implements CacheManagerService {
         /*
          * Get the URI.
          */
-        String uriValue = (String) config.get(KEY_URI);
-        if (uriValue != null)
-            try {
-                this.configuredUri = new URI(uriValue);
-            } catch (URISyntaxException e) {
-                /*
-                 * Catch incorrectly formatted httpSessionCache uri values from server.xml file
-                 */
-                throw new IllegalArgumentException(Tr.formatMessage(tc, "CWLJC0007_URI_INVALID_SYNTAX", e), e);
-            }
-        else {
-            this.configuredUri = null;
-        }
+        this.uriValue = (String) config.get(KEY_URI);
 
         /*
          * Get the configured vendor properties.
@@ -181,7 +168,7 @@ public class CacheManagerServiceImpl implements CacheManagerService {
                          * Perform some custom configuration updates for the CacheManager.
                          */
                         cacheConfigUtil = new CacheConfigUtil();
-                        URI uri = cacheConfigUtil.preConfigureCacheManager(configuredUri, cachingProvider, properties);
+                        URI uri = cacheConfigUtil.preConfigureCacheManager(uriValue, cachingProvider, properties);
 
                         /*
                          * Get the CacheManager instance. We don't provide the ClassLoader to the
@@ -285,7 +272,7 @@ public class CacheManagerServiceImpl implements CacheManagerService {
 
     @Override
     public String toString() {
-        return super.toString() + "{id=" + id + ", configuredUri=" + configuredUri + ", cacheManager=" + cacheManager + "}";
+        return super.toString() + "{id=" + id + ", uriValue=" + uriValue + ", cacheManager=" + cacheManager + "}";
     }
 
     /**

--- a/dev/io.openliberty.jcache.internal/src/io/openliberty/jcache/utils/CacheConfigUtil.java
+++ b/dev/io.openliberty.jcache.internal/src/io/openliberty/jcache/utils/CacheConfigUtil.java
@@ -56,6 +56,11 @@ public class CacheConfigUtil {
 
     private static final TraceComponent tc = Tr.register(CacheConfigUtil.class);
     private static final String HAZELCAST_PROVIDER = "com.hazelcast.cache.HazelcastCachingProvider";
+    private static final String HAZELCAST_MEMBER_PROVIDER = "com.hazelcast.cache.HazelcastMemberCachingProvider";
+    private static final String HAZELCAST_SERVER_IMPL_PROVIDER = "com.hazelcast.cache.impl.HazelcastServerCachingProvider";
+    private static final String HAZELCAST_CLIENT_PROVIDER = "com.hazelcast.client.cache.HazelcastClientCachingProvider";
+    private static final String HAZELCAST_CLIENT_IMPL_PROVIDER = "com.hazelcast.client.cache.impl.HazelcastClientCachingProvider";
+
     private static final String INFINISPAN_EMBEDDED_PROVIDER = "org.infinispan.jcache.embedded.JCachingProvider";
     private static final String INFINISPAN_REMOTE_PROVIDER = "org.infinispan.jcache.remote.JCachingProvider";
 
@@ -79,7 +84,7 @@ public class CacheConfigUtil {
      * configuration for use when getting the {@link CacheManager} from the
      * {@link CachingProvider}.
      *
-     * @param configuredUri   The configured URI.
+     * @param uriValue        The configured URI.
      * @param cachingProvider The {@link CachingProvider} that will be used to get
      *                            the {@link CacheManager} from.
      * @param properties      The configured properties. These may be updated.
@@ -105,6 +110,10 @@ public class CacheConfigUtil {
         switch (cachingProvider.getClass().getName()) {
 
             case HAZELCAST_PROVIDER:
+            case HAZELCAST_MEMBER_PROVIDER:
+            case HAZELCAST_SERVER_IMPL_PROVIDER:
+            case HAZELCAST_CLIENT_PROVIDER:
+            case HAZELCAST_CLIENT_IMPL_PROVIDER:
                 if (uriValue != null)
                     properties.setProperty("hazelcast.config.location", uriValue);
                 break;


### PR DESCRIPTION
That common logic is moved to the common JCache code (CacheConfigUtil) so that both the old style configuration and the new style would use the same code for SessionCache.