### PR TITLE
Increase token lifetime to handle slow test systems

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/commonTests/CommonLogoutAndRefreshTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/commonTests/CommonLogoutAndRefreshTests.java
@@ -62,7 +62,7 @@ public class CommonLogoutAndRefreshTests extends CommonAnnotatedSecurityTests {
         Page response1 = runGoodEndToEndTest(webClient, appName, baseAppName);
 
         // now logged in - wait for token to expire
-        actions.testLogAndSleep(20);
+        actions.testLogAndSleep(25);
         String url = rpHttpsBase + "/" + appName + "/" + baseAppName;
         Page response2 = invokeAppGetToApp(webClient, url); // get to app not because either id or access token is good, but because the token was refreshed.
 
@@ -97,7 +97,7 @@ public class CommonLogoutAndRefreshTests extends CommonAnnotatedSecurityTests {
         runGoodEndToEndTest(webClient, appName, baseAppName);
 
         // now logged in - wait for token to expire
-        actions.testLogAndSleep(20);
+        actions.testLogAndSleep(25);
         String url = rpHttpsBase + "/" + appName + "/" + baseAppName;
         invokeAppReturnLogoutPage(webClient, url);
 
@@ -130,7 +130,7 @@ public class CommonLogoutAndRefreshTests extends CommonAnnotatedSecurityTests {
         Page response1 = runGoodEndToEndTest(webClient, appName, baseAppName);
 
         // now logged in - wait for token to expire
-        actions.testLogAndSleep(20);
+        actions.testLogAndSleep(25);
         String url = rpHttpsBase + "/" + appName + "/" + baseAppName;
         Page response2 = invokeAppGetToApp(webClient, url);
 
@@ -162,7 +162,7 @@ public class CommonLogoutAndRefreshTests extends CommonAnnotatedSecurityTests {
         runGoodEndToEndTest(webClient, appName, baseAppName);
 
         // now logged in - wait for token to expire
-        actions.testLogAndSleep(20);
+        actions.testLogAndSleep(25);
         String url = rpHttpsBase + "/" + appName + "/" + baseAppName;
         invokeAppGetToSplashPage(webClient, url);
 

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/publish/shared/config/oidcProvider.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/publish/shared/config/oidcProvider.xml
@@ -72,7 +72,7 @@ https://localhost:${bvt.prop.security_2_HTTP_default.secure}/App_31/Callback"
 		signatureAlgorithm="RS256"
 		keyAliasName="rs256"
 		keystoreRef="key_allSigAlg"
-		idTokenLifetime="15s"
+		idTokenLifetime="20s"
 		oauthProviderRef="OAuth1" />
 
 	<oauthProvider
@@ -136,7 +136,7 @@ https://localhost:${bvt.prop.security_2_HTTP_default.secure}/App_31/Callback"
 		id="OAuth2"
 		autoAuthorize="true"
 		tokenFormat="${opTokenFormat}"
-		accessTokenLifetime="15s"
+		accessTokenLifetime="20s"
 	>
 		<autoAuthorizeClient>client_1</autoAuthorizeClient>
 		
@@ -189,14 +189,14 @@ https://localhost:${bvt.prop.security_2_HTTP_default.secure}/App_31/Callback"
 		signatureAlgorithm="RS256"
 		keyAliasName="rs256"
 		keystoreRef="key_allSigAlg"
-		idTokenLifetime="15s"
+		idTokenLifetime="20s"
 		oauthProviderRef="OAuth3" />
 
 	<oauthProvider
 		id="OAuth3"
 		autoAuthorize="true"
 		tokenFormat="${opTokenFormat}"
-		accessTokenLifetime="15s"
+		accessTokenLifetime="20s"
 	>
 		<autoAuthorizeClient>client_1</autoAuthorizeClient>
 		
@@ -259,14 +259,14 @@ https://localhost:${bvt.prop.security_2_HTTP_default.secure}/GoodRedirectNotifyP
 		signatureAlgorithm="RS256"
 		keyAliasName="rs256"
 		keystoreRef="key_allSigAlg"
-		idTokenLifetime="15s"
+		idTokenLifetime="20s"
 		oauthProviderRef="OAuth4" />
 
 	<oauthProvider
 		id="OAuth4"
 		autoAuthorize="true"
 		tokenFormat="${opTokenFormat}"
-		accessTokenLifetime="15s"
+		accessTokenLifetime="20s"
 	>
 		<autoAuthorizeClient>client_1</autoAuthorizeClient>
 		


### PR DESCRIPTION
Increase token lifetimes to account for slow test machines.
The logout tests need tokens that do not live long since they'll be invoking logout with/without expired tokens and we don't want to have to wait too long for them to expire.  But, we've hit some slow machines where the tokens have expired before they're returned to the clients during a normal login process.

