### PR TITLE
Update EE compatibility test to use the EE10 EEVersion for MP features

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE8FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE8FeatureReplacementAction.java
@@ -55,7 +55,6 @@ public class EE8FeatureReplacementAction extends FeatureReplacementAction {
                                                  "jaxb-2.2",
                                                  "managedBeans-1.0",
                                                  "mdb-3.2",
-                                                 "nosqlUnused-1.0", // TODO temporarily exists to work around transformer limitation. Remove once no longer needed.
                                                  "componenttest-1.0",
                                                  "txtest-1.0",
                                                  "websocket-1.1",

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
@@ -216,7 +216,6 @@ public class MicroProfileActions {
                                                           "mpRestClient-3.0" };
 
     private static final String[] MP60_FEATURES_ARRAY = { "microProfile-6.0",
-                                                          "servlet-6.0",
                                                           "cdi-4.0",
                                                           "restfulWS-3.1",
                                                           "restfulWSClient-3.1",

--- a/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10FeatureCompatibilityTest.java
+++ b/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10FeatureCompatibilityTest.java
@@ -54,7 +54,7 @@ import componenttest.rules.repeater.EE8FeatureReplacementAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
-import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatActions.EEVersion;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
@@ -113,12 +113,7 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
 
         // MP features are only compatible if they're in MP versions which work with EE10
         compatibleFeatures.removeAll(FeatureUtilities.allMpFeatures());
-        // Add only the MP 6.0 features which we've made compatible
-
-        compatibleFeatures.addAll(MicroProfileActions.MP60.getFeatures());
-        compatibleFeatures.add("mpContextPropagation-1.3");
-        // TODO: switch to adding all of them when ready
-        //compatibleFeatures.addAll(FeatureUtilities.compatibleMpFeatures(EEVersion.EE10));
+        compatibleFeatures.addAll(FeatureUtilities.compatibleMpFeatures(EEVersion.EE10));
 
         // Value-add features which aren't compatible
         compatibleFeatures.remove("openid-2.0"); // stabilized
@@ -144,9 +139,6 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
         // Logically, incompatible features are all those that aren't compatible...
         incompatibleFeatures.addAll(allFeatures);
         incompatibleFeatures.removeAll(compatibleFeatures);
-
-        // TODO: We're working on getting mpGraphQL-2.0 to be EE10 compatible, so don't assert that it isn't
-        incompatibleFeatures.remove("mpGraphQL-2.0");
 
         // Test features may or may not be compatible, we don't want to assert either way
         incompatibleFeatures.removeAll(FeatureUtilities.allTestFeatures());
@@ -187,9 +179,6 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
 
         // jcaInboundSecurity-1.0 was removed in Jakarta EE 10 in favor of using an auto feature.
         ee8Features.remove("jcaInboundSecurity-1.0");
-
-        // TODO nosqlUnused-1.0 is a temporary workaround and can eventually be removed
-        ee8Features.remove("nosqlUnused-1.0");
 
         // servlet long name is the same for EE10 so it will fail because the prefixes
         // match and it is marked as a singleton.
@@ -328,7 +317,8 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
             if (!JakartaEE10Action.EE10_FEATURE_SET.contains(feature)) {
                 // The features below are not included in the convenience feature
                 // so they will not conflict on the long name.
-                if (!feature.startsWith("jsonpContainer-") &&
+                if (!feature.startsWith("connectorsInboundSecurity-") &&
+                    !feature.startsWith("jsonpContainer-") &&
                     !feature.startsWith("jsonbContainer-") &&
                     !feature.startsWith("facesContainer-") &&
                     !feature.startsWith("jakartaeeClient-")) {

--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9FeatureCompatibilityTest.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9FeatureCompatibilityTest.java
@@ -54,7 +54,6 @@ import componenttest.rules.repeater.EE8FeatureReplacementAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
-import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatActions.EEVersion;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -141,9 +140,6 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
         incompatibleFeatures.addAll(allFeatures);
         incompatibleFeatures.removeAll(compatibleFeatures);
 
-        // ...but there are a few in-development features which are maybe compatible
-        incompatibleFeatures.removeAll(MicroProfileActions.MP60.getFeatures());
-
         // Test features may or may not be compatible, we don't want to assert either way
         incompatibleFeatures.removeAll(FeatureUtilities.allTestFeatures());
 
@@ -180,9 +176,6 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
 
         // j2eeManagement-1.1 was removed in Jakarta EE 9 so there is no replacement
         ee8Features.remove("j2eeManagement-1.1");
-
-        // TODO nosqlUnused-1.0 is a temporary workaround and can eventually be removed
-        ee8Features.remove("nosqlUnused-1.0");
 
         // servlet long name is the same for EE9 so it will fail because the prefixes
         // match and it is marked as a singleton.
@@ -317,7 +310,9 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
             if (!JakartaEE9Action.EE9_FEATURE_SET.contains(feature)) {
                 // The features below are not included in the convenience feature
                 // so they will not conflict on the long name.
-                if (!feature.startsWith("jsonpContainer-") &&
+                if (!feature.startsWith("nosql-") &&
+                    !feature.startsWith("data-") &&
+                    !feature.startsWith("jsonpContainer-") &&
                     !feature.startsWith("jsonbContainer-") &&
                     !feature.startsWith("facesContainer-") &&
                     !feature.startsWith("jakartaeeClient-")) {


### PR DESCRIPTION
- Resolves the todo to update to use the tooling that is availableonce all MP 6 features are updated to work with EE 10.

fixes #22276 