### PR TITLE
reset the mark in the trace.log between tests

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/CommonSecurityFat.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/CommonSecurityFat.java
@@ -100,7 +100,8 @@ public class CommonSecurityFat {
             }
             loggingUtils.logTestCaseInServerLog(server, _testName, actionToLog);
             try {
-                server.setMarkToEndOfLog(server.getDefaultLogFile());
+                server.setMarkToEndOfLog(); // mesages.log
+                server.setTraceMarkToEndOfDefaultTrace();
             } catch (Exception e) {
                 Log.error(thisClass, "Failed to set mark to end of default log file for server " + server.getServerName(), e);
             }
@@ -138,7 +139,8 @@ public class CommonSecurityFat {
             }
             loggingUtils.logTestCaseInServerLog(server, _testName + ": " + infoToLog, actionToLog);
             try {
-                server.setMarkToEndOfLog(server.getDefaultLogFile());
+                server.setMarkToEndOfLog(); // mesages.log
+                server.setTraceMarkToEndOfDefaultTrace();
             } catch (Exception e) {
                 Log.error(thisClass, "Failed to set mark to end of default log file for server " + server.getServerName(), e);
             }


### PR DESCRIPTION
The security test framework automatically resets the "mark" in messages.log between tests - this allows the tests to only search for messages issued during a particular tests execution.  The refresh tests need to search for a message only recorded in trace.log.  The trace log mark is not reset between tests and we're finding the message from a previous test.
I can't reproduce locally, but this is happening quite frequently in our automated builds.
I will add a setMark request for the trace log to the between tests tooling.