### PR TITLE
Removing beta fence for maxFfdcAge feature

### DIFF
--- a/dev/com.ibm.ws.logging.osgi/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.logging.osgi/resources/OSGI-INF/metatype/metatype.xml
@@ -141,11 +141,11 @@
 
         <AD name="%max.ffdc.age" description="%max.ffdc.age.desc" 
             ibm:variable="com.ibm.ws.logging.max.ffdc.age"
-            id="maxFfdcAge" required="false" type="String" ibm:type="duration(m)" default="-1" ibm:beta="true">
+            id="maxFfdcAge" required="false" type="String" ibm:type="duration(m)" default="-1">
         </AD>
 
         <AD name="internal" description="internal use only" 
-            id="ffdcCleanupStartDelay" required="false" type="Integer" default="-1" ibm:beta="true">
+            id="ffdcCleanupStartDelay" required="false" type="Integer" default="-1">
         </AD>
     </OCD>
   

--- a/dev/com.ibm.ws.logging/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.logging/resources/OSGI-INF/metatype/metatype.xml
@@ -142,11 +142,11 @@
 
         <AD name="%max.ffdc.age" description="%max.ffdc.age.desc" 
             ibm:variable="com.ibm.ws.logging.max.ffdc.age"
-            id="maxFfdcAge" required="false" type="String" ibm:type="duration(m)" default="-1" ibm:beta="true">
+            id="maxFfdcAge" required="false" type="String" ibm:type="duration(m)" default="-1">
         </AD>
 
         <AD name="internal" description="internal use only" 
-            id="ffdcCleanupStartDelay" required="false" type="Integer" default="-1" ibm:beta="true">
+            id="ffdcCleanupStartDelay" required="false" type="Integer" default="-1">
         </AD>
     </OCD>
   

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
@@ -259,20 +259,7 @@ public class BaseTraceService implements TrService {
     private boolean isLogRolloverScheduled = false;
     private boolean isFfdcCleanupScheduled = false;
 
-    private static Boolean isBetaEdition;
     private static TraceComponent tc = Tr.register(BaseTraceService.class, NLSConstants.GROUP, NLSConstants.LOGGING_NLS);
-
-    public Boolean betaFenceCheck() {
-        if (isBetaEdition == null) {
-            if (Boolean.getBoolean("com.ibm.ws.beta.edition")) {
-                isBetaEdition = true;
-            } else {
-                Tr.warning(tc, "The 'maxFfdcAge' logging configuration option is in beta and is not available in this version of OpenLiberty.");
-                isBetaEdition = false;
-            }
-        }
-        return isBetaEdition;
-    }
 
     /** Flags for suppressing traceback output to the console */
     private static class StackTraceFlags {
@@ -402,8 +389,7 @@ public class BaseTraceService implements TrService {
 
         scheduleTimeBasedLogRollover(trConfig);
 
-        if (betaFenceCheck())
-            scheduleFfdcFileDeletion(trConfig);
+        scheduleFfdcFileDeletion(trConfig);
         /*
          * Need to know the values of wlpServerName and wlpUserDir
          * They are passed into the handlers for use as part of the jsonified output

--- a/dev/com.ibm.ws.logging_fat/publish/servers/com.ibm.ws.logging.ffdcCleanup/jvm.options
+++ b/dev/com.ibm.ws.logging_fat/publish/servers/com.ibm.ws.logging.ffdcCleanup/jvm.options
@@ -1,1 +1,0 @@
--Dcom.ibm.ws.beta.edition=true


### PR DESCRIPTION
Removing beta fence for the maxFfdcAge feature. This will be merged after the Epic has all the approvals.

https://github.com/OpenLiberty/open-liberty/issues/19418