### PR TITLE
Allow encoded / when running with servlet 6

### DIFF
--- a/dev/com.ibm.ws.rest.handler/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.rest.handler/resources/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2013 IBM Corporation and others.
+    Copyright (c) 2013,2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -29,6 +29,13 @@
     <servlet-name>RESTProxyServlet</servlet-name>
     <url-pattern>/*</url-pattern>
   </servlet-mapping>
+
+  <!-- This stops the container rejecting encoded '/' when running 
+       with servlet 6. Necessary for for the 'config' handler -->
+  <context-param>
+    <param-name>SKIP_ENCODED_CHAR_VERIFICATION</param-name>
+    <param-value>True</param-value>
+  </context-param>
   
   <security-constraint id="SecurityConstraint_1">
     <display-name>ibm/api REST Security Constraint - DefaultAuthorizationHelper</display-name>


### PR DESCRIPTION
The config rest handler needs to be able to access config elements using URIs such as
/ibm/api/config/adminObject/adminObject[java:global/env/eis/conSpec1] and so needs to allow encoded / in the URI

