### PR TITLE
Use httpMessageContext.redirect() instead of response.sendRedirect for LoginToContinue intercepter

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/beans/LoginToContinueInterceptor.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/beans/LoginToContinueInterceptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -129,7 +129,7 @@ public class LoginToContinueInterceptor {
                             // redirect to the original url.
                             postLoginProcess(req, res);
                         } else if (AuthenticationStatus.SEND_FAILURE.equals(result)) {
-                            redirectErrorPage(mpp.getAuthMechProperties(getClass(ic)), req, res);
+                            redirectErrorPage(mpp.getAuthMechProperties(getClass(ic)), req, hmc);
                         }
                         return result;
                     } else if (hmc.getRequest().getUserPrincipal() != null) {
@@ -240,8 +240,7 @@ public class LoginToContinueInterceptor {
                 status = AuthenticationStatus.SEND_FAILURE;
             }
         } else {
-            res.setStatus(HttpServletResponse.SC_FOUND);
-            res.sendRedirect(res.encodeURL(getUrl(req, loginPage, false)));
+            httpMessageContext.redirect(getUrl(req, loginPage, false));
         }
         return status;
     }
@@ -352,10 +351,10 @@ public class LoginToContinueInterceptor {
         req.setAttribute(ATTR_DONE_LOGIN_PROCESS, Boolean.TRUE);
     }
 
-    protected void redirectErrorPage(Properties props, HttpServletRequest req, HttpServletResponse res) throws IOException {
+    protected void redirectErrorPage(Properties props, HttpServletRequest req, HttpMessageContext hmc) throws IOException {
         String errorPage = resolveString((String) props.get(JavaEESecConstants.LOGIN_TO_CONTINUE_ERRORPAGE), _errorPage);
         if (errorPage != null && !errorPage.isEmpty()) {
-            res.sendRedirect(res.encodeURL(getUrl(req, errorPage, _useGlobalLogin)));
+            hmc.redirect(getUrl(req, errorPage, _useGlobalLogin));
         }
         req.setAttribute(ATTR_DONE_LOGIN_PROCESS, Boolean.TRUE);
     }

--- a/dev/com.ibm.ws.security.javaeesec.cdi/test/com/ibm/ws/security/javaeesec/cdi/beans/LoginToContinueInterceptorTest.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/test/com/ibm/ws/security/javaeesec/cdi/beans/LoginToContinueInterceptorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,10 +27,11 @@ import javax.security.enterprise.AuthenticationStatus;
 import javax.security.enterprise.authentication.mechanism.http.AuthenticationParameters;
 import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
 import javax.security.enterprise.credential.Credential;
-import javax.servlet.http.Cookie;
 import javax.servlet.RequestDispatcher;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JUnit4Mockery;
@@ -482,7 +483,7 @@ public class LoginToContinueInterceptorTest {
         Properties props = new Properties();
         props.put(JavaEESecConstants.LOGIN_TO_CONTINUE_LOGINPAGE, LOGIN_PAGE);
         props.put(JavaEESecConstants.LOGIN_TO_CONTINUE_ERRORPAGE, ERROR_PAGE);
-        final Cookie[] cookies = {sessionCookie};
+        final Cookie[] cookies = { sessionCookie };
         Object expect = AuthenticationStatus.SUCCESS;
         withProps(props).withParams().withNoELP().withAuthParams(null).withReferrer();
         withJSecurityCheck("contextRoot/original.html").withSessionCookie(principal).withWasReqUrlCookie(true).withRemoveWasReqUrlCookie();
@@ -737,14 +738,11 @@ public class LoginToContinueInterceptorTest {
         final StringBuffer sb = new StringBuffer(ORIGINAL_URL);
         mockery.checking(new Expectations() {
             {
-                one(res).setStatus(HttpServletResponse.SC_FOUND);
                 one(req).getRequestURL();
                 will(returnValue(sb));
                 one(req).getContextPath();
                 will(returnValue(CONTEXT_ROOT));
-                one(res).sendRedirect(LOGIN_URL);
-                one(res).encodeURL(LOGIN_URL);
-                will(returnValue(LOGIN_URL));
+                one(hmc).redirect(LOGIN_URL);
             }
         });
         return this;
@@ -777,7 +775,7 @@ public class LoginToContinueInterceptorTest {
     @SuppressWarnings("unchecked")
     private LoginToContinueInterceptorTest withWasReqUrlCookie(boolean isExist) throws Exception {
         if (isExist) {
-            final Cookie [] cookies = {wasReqUrlCookie};
+            final Cookie[] cookies = { wasReqUrlCookie };
             mockery.checking(new Expectations() {
                 {
                     one(req).getCookies();


### PR DESCRIPTION
For https://github.com/OpenLiberty/open-liberty/issues/23310