### PR TITLE
Phase 2 updating non Jakarta features for EE10 repeats.

### DIFF
--- a/dev/com.ibm.ws.app.manager.wab.installer_fat/bnd.bnd
+++ b/dev/com.ibm.ws.app.manager.wab.installer_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2021 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ fat.project: true
 
 -sub: *.bnd
 
-tested.features: product1:product1, product2:product2, servlet-3.1, servlet-5.0
+tested.features: product1:product1, product2:product2, servlet-3.1, servlet-5.0, servlet-6.0
 
 -buildpath: \
 	com.ibm.websphere.appserver.spi.kernel.service,\

--- a/dev/com.ibm.ws.app.manager.wab.installer_fat/fat/src/com/ibm/ws/app/manager/wab/installer/fat/FATSuite.java
+++ b/dev/com.ibm.ws.app.manager.wab.installer_fat/fat/src/com/ibm/ws/app/manager/wab/installer/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -29,7 +30,7 @@ import componenttest.rules.repeater.RepeatTests;
 @SuiteClasses({ ConfigurableWABTests.class, WabStartDelayTests.class, WabAdditionalTests.class })
 public class FATSuite {
     @ClassRule
-    // run tests as-is and again with EE9 features+packages
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new JakartaEE9Action().fullFATOnly());
+    // run tests as-is and again with EE9 and EE10 features+packages
+    public static RepeatTests r = RepeatTests.withoutModification().andWith(new JakartaEE9Action().fullFATOnly()).andWith(new JakartaEE10Action().alwaysAddFeature("servlet-6.0").fullFATOnly());
 
 }

--- a/dev/com.ibm.ws.app.manager.wab.installer_fat/publish/productfeatures/product1_jakarta.mf
+++ b/dev/com.ibm.ws.app.manager.wab.installer_fat/publish/productfeatures/product1_jakarta.mf
@@ -7,6 +7,6 @@ Subsystem-Content: test.wab1.jakarta; version="[1,2)",
  test.wab3.jakarta; version="[1,2)",
  product1; version="[1,2)",
  com.ibm.wsspi.appserver.webBundle-1.0; type=osgi.subsystem.feature,
- com.ibm.websphere.appserver.servlet-5.0; type=osgi.subsystem.feature
+ com.ibm.websphere.appserver.servlet-5.0; type=osgi.subsystem.feature; ibm.tolerates:="6.0"
 Subsystem-Type: osgi.subsystem.feature
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.app.manager.wab.installer_fat/publish/productfeatures/product2_jakarta.mf
+++ b/dev/com.ibm.ws.app.manager.wab.installer_fat/publish/productfeatures/product2_jakarta.mf
@@ -6,6 +6,6 @@ Subsystem-Content: test.wab1.jakarta; version="[1,2)",
  test.wab2.jakarta; version="[1,2)",
  product2; version="[1,2)",
  com.ibm.wsspi.appserver.webBundle-1.0; type=osgi.subsystem.feature,
- com.ibm.websphere.appserver.servlet-5.0; type=osgi.subsystem.feature
+ com.ibm.websphere.appserver.servlet-5.0; type=osgi.subsystem.feature; ibm.tolerates:="6.0"
 Subsystem-Type: osgi.subsystem.feature
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.rest.handler.validator.cloudant_fat/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.validator.cloudant_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2021 IBM Corporation and others.
+# Copyright (c) 2019, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -27,4 +27,4 @@ fat.test.container.images: kyleaure/cloudant-developer:1.0
 	com.ibm.websphere.javaee.jsonp.1.0;version=latest,\
 	io.openliberty.org.testcontainers;version=latest
 
-tested.features: componenttest-2.0, servlet-3.1
+tested.features: componenttest-2.0, servlet-3.1, servlet-5.0, servlet-6.0

--- a/dev/com.ibm.ws.rest.handler.validator.cloudant_fat/fat/src/com/ibm/ws/rest/handler/validator/cloudant/fat/FATSuite.java
+++ b/dev/com.ibm.ws.rest.handler.validator.cloudant_fat/fat/src/com/ibm/ws/rest/handler/validator/cloudant/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.containers.TestContainerSuite;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.utils.HttpUtils;
@@ -29,7 +30,8 @@ public class FATSuite extends TestContainerSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification() // run all tests as-is (e.g. EE8 features)
-                    .andWith(new JakartaEE9Action()); // run all tests again with EE9 features+packages
+                    .andWith(new JakartaEE9Action().alwaysAddFeature("servlet-5.0")) // run all tests again with EE9 features+packages
+                    .andWith(new JakartaEE10Action().alwaysAddFeature("servlet-6.0"));
 
     static {
         // TODO: temporary debug setting so we can further investigate intermittent

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/CommonTest.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/CommonTest.java
@@ -48,13 +48,6 @@ public class CommonTest {
 
             String methodName = "failed";
             Log.info(thisClass, methodName, _testName + ": Test failed");
-            Log.info(thisClass, methodName, "");
-            Log.info(thisClass, methodName, "TTTTT EEEEE  SSSS TTTTT   FFFFF  AAA  IIIII L     EEEEE DDDD");
-            Log.info(thisClass, methodName, "  T   E     S       T     F     A   A   I   L     E     D   D");
-            Log.info(thisClass, methodName, "  T   EEE    SSS    T     FFF   AAAAA   I   L     EEE   D   D");
-            Log.info(thisClass, methodName, "  T   E         S   T     F     A   A   I   L     E     D   D");
-            Log.info(thisClass, methodName, "  T   EEEEE SSSS    T     F     A   A IIIII LLLLL EEEEE DDDD");
-            Log.info(thisClass, methodName, "");
             super.failed(e, description);
         }
 
@@ -63,13 +56,6 @@ public class CommonTest {
 
             String methodName = "succeeded";
             Log.info(thisClass, methodName, _testName + ": Test succeeded");
-            Log.info(thisClass, methodName, "");
-            Log.info(thisClass, methodName, "TTTTT EEEEE  SSSS TTTTT   PPPP   AAA   SSSS SSSSS EEEEE DDDD");
-            Log.info(thisClass, methodName, "  T   E     S       T     P   P A   A S     S     E     D   D");
-            Log.info(thisClass, methodName, "  T   EEE    SSS    T     PPPP  AAAAA  SSS   SSS  EEE   D   D");
-            Log.info(thisClass, methodName, "  T   E         S   T     F     A   A     S     S E     D   D");
-            Log.info(thisClass, methodName, "  T   EEEEE SSSS    T     F     A   A SSSS  SSSS  EEEEE DDDD");
-            Log.info(thisClass, methodName, "");
             super.succeeded(description);
         }
     };
@@ -77,13 +63,7 @@ public class CommonTest {
     protected static void testSkipped() {
 
         String methodName = "testSkipped";
-        Log.info(thisClass, methodName, "");
-        Log.info(thisClass, methodName, "TTTTT EEEEE  SSSS TTTTT   SSSS K   K IIIII PPPP  PPPP  EEEEE DDDD");
-        Log.info(thisClass, methodName, "  T   E     S       T    S     K  K    I   P   P P   P E     D   D");
-        Log.info(thisClass, methodName, "  T   EEE    SSS    T     SSS  KKK     I   PPPP  PPPP  EEE   D   D");
-        Log.info(thisClass, methodName, "  T   E         S   T        S K  K    I   P     P     E     D   D");
-        Log.info(thisClass, methodName, "  T   EEEEE SSSS    T    SSSS  K   K IIIII P     P     EEEEE DDDD");
-        Log.info(thisClass, methodName, "");
+        Log.info(thisClass, methodName, _testName + ": Test skipped");
     }
 
     /**

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/actions/SecurityTestRepeatAction.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/actions/SecurityTestRepeatAction.java
@@ -77,7 +77,6 @@ public class SecurityTestRepeatAction implements RepeatTestAction {
 
     @Override
     public void setup() throws Exception {
-        nameExtension = "default";
     }
 
     public SecurityTestRepeatAction onlyOnWindows() {

--- a/dev/com.ibm.ws.security.jwt_fat.builder/bnd.bnd
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/bnd.bnd
@@ -27,7 +27,8 @@ src: \
 
 fat.project: true
 tested.features:\
-        jwt-1.0, jsonp-2.0, restfulwsclient-3.0, restfulws-3.0, pages-3.0, appsecurity-4.0
+        jwt-1.0, jsonp-2.0, restfulwsclient-3.0, restfulws-3.0, pages-3.0, appsecurity-4.0,\
+        restfulws-3.1, pages-3.1, appsecurity-5.0
 
 
 # To define a global minimum java level for the FAT, use the following property.

--- a/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/FATSuite.java
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.security.fat.common.AlwaysRunAndPassTest;
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 
@@ -49,11 +50,12 @@ public class FATSuite {
     public static boolean runAsCollection = false;
 
     /*
-     * Run EE9 tests in LITE mode (but not on Windows) and run all tests in FULL mode.
+     * Run EE9 and EE10 tests in LITE mode (but not on Windows) and run all tests in FULL mode.
      */
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
             .andWith(new SecurityTestRepeatAction().onlyOnWindows().liteFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().forServerConfigPaths("publish/servers", "publish/shared/config").liteFATOnly());
+            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().forServerConfigPaths("publish/servers", "publish/shared/config").liteFATOnly())
+            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().forServerConfigPaths("publish/servers", "publish/shared/config").liteFATOnly());
 
 }

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/bnd.bnd
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/bnd.bnd
@@ -26,7 +26,8 @@ src: \
 
 fat.project: true
 tested.features:\
-        jwt-1.0, restfulwsclient-3.0, restfulws-3.0, jsonp-2.0, pages-3.0
+        jwt-1.0, restfulwsclient-3.0, restfulws-3.0, jsonp-2.0, pages-3.0,\
+        restfulws-3.1, pages-3.1, jsonp-2.1
 
 
 # To define a global minimum java level for the FAT, use the following property.

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/FATSuite.java
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.security.fat.common.AlwaysRunAndPassTest;
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 
@@ -39,11 +40,12 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
 
     /*
-     * Run EE9 tests in LITE mode (but not on Windows) and run all tests in FULL mode.
+     * Run EE9 and EE10 tests in LITE mode (but not on Windows) and run all tests in FULL mode.
      */
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
             .andWith(new SecurityTestRepeatAction().onlyOnWindows().liteFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().forServerConfigPaths("publish/servers", "publish/shared/config").liteFATOnly());
+            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().forServerConfigPaths("publish/servers", "publish/shared/config").liteFATOnly())
+            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().forServerConfigPaths("publish/servers", "publish/shared/config").liteFATOnly());
 
 }

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/publish/servers/com.ibm.ws.security.jwt_fat.consumer/configs/server_configTests.xml
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/publish/servers/com.ibm.ws.security.jwt_fat.consumer/configs/server_configTests.xml
@@ -6,6 +6,7 @@
 		<feature>jwt-1.0</feature>
 		<feature>jaxrs-2.0</feature>
 		<feature>jsonp-1.0</feature>
+		<feature>servlet-3.1</feature>
 	</featureManager>
 
 	<include location="${shared.config.dir}/fatTestPorts.xml" />

--- a/dev/com.ibm.ws.security.jwtsso_fat.noMpJwt/fat/src/com/ibm/ws/security/jwtsso/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat.noMpJwt/fat/src/com/ibm/ws/security/jwtsso/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 import com.ibm.ws.security.jwtsso.fat.utils.JwtFatConstants;
@@ -36,6 +37,7 @@ public class FATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.with(new SecurityTestRepeatAction(JwtFatConstants.NO_MPJWT))
-            .andWith(new SecurityTestFeatureEE9RepeatAction(JwtFatConstants.NO_MPJWT).notOnWindows().liteFATOnly());
+            .andWith(new SecurityTestFeatureEE9RepeatAction(JwtFatConstants.NO_MPJWT).notOnWindows().liteFATOnly())
+            .andWith(new SecurityTestFeatureEE10RepeatAction(JwtFatConstants.NO_MPJWT).notOnWindows().liteFATOnly());
 
 }

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonValidationTools.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonValidationTools.java
@@ -290,8 +290,8 @@ public class CommonValidationTools {
                 }
             }
 
-            Log.info(thisClass, thisMethod, "checkType is: " + expected.getCheckType());
-            Log.info(thisClass, thisMethod, "Checking for: " + expected.getValidationValue());
+            Log.info(thisClass, thisMethod, "checkType is: " + expected.getCheckType() + " " +
+                "Checking for: " + expected.getValidationValue());
 
             String fullResponseContent = AutomationTools.getFullResponseContentForFailureMessage(response, expected.getWhere());
 
@@ -330,7 +330,6 @@ public class CommonValidationTools {
                     }
                 }
             }
-            Log.info(thisClass, thisMethod, "Checked Value: " + expected.getValidationValue());
             return;
         } catch (Exception e) {
             e.printStackTrace();
@@ -1013,6 +1012,12 @@ public class CommonValidationTools {
                 } else {
                     for (String line : responseLines) {
                         if (line != null && line.contains(searchKey)) {
+                            if (!searchKey.endsWith(":")) {
+                                char nextChar = line.charAt(line.indexOf(searchKey) + searchKey.length());
+                                if (nextChar != ':' && nextChar != '=' && nextChar != ' ') {
+                                    continue;
+                                }
+                            }
                             String part1 = line.substring(line.indexOf(searchKey) + searchKey.length() + 1, line.length());
                             String[] splitLine = part1.split(",");
                             if (splitLine != null) {
@@ -2215,8 +2220,8 @@ public class CommonValidationTools {
 
     public String removeQuote(String str) {
 
-        if (str == null || str == "") {
-            return null;
+        if (str == null || str.equals("")) {
+            return str;
         }
 
         char char1 = str.charAt(0);

--- a/dev/com.ibm.ws.security.oauth_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.oauth_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -15,7 +15,8 @@ src: \
     fat/src
 
 tested.features:\
-    appsecurity-4.0, expressionlanguage-4.0, cdi-3.0, pages-3.0
+    appsecurity-4.0, expressionlanguage-4.0, cdi-3.0, pages-3.0, \
+    appsecurity-5.0, pages-3.1
 
 fat.project: true
 

--- a/dev/com.ibm.ws.security.oauth_fat/fat/src/com/ibm/ws/security/oauth20/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.oauth_fat/fat/src/com/ibm/ws/security/oauth20/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,8 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
@@ -68,11 +70,12 @@ import componenttest.topology.impl.LibertyServer;
 public class FATSuite extends CommonLocalLDAPServerSuite {
 
     /*
-     * Run EE9 tests in LITE mode and run all tests in FULL mode.
+     * Run EE10 tests in LITE mode and run all tests in FULL mode.
      */
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
-                    .andWith(new JakartaEE9Action());
+                    .andWith(new JakartaEE9Action().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                    .andWith(new JakartaEE10Action());
 
     /**
      * JakartaEE9 transform a list of applications.
@@ -81,7 +84,12 @@ public class FATSuite extends CommonLocalLDAPServerSuite {
      * @param apps     The names of the applications to transform. Should include the path from the server root directory.
      */
     public static void transformApps(LibertyServer myServer, String... apps) {
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE10Action.isActive()) {
+            for (String app : apps) {
+                Path someArchive = Paths.get(myServer.getServerRoot() + File.separatorChar + app);
+                JakartaEE10Action.transformApp(someArchive);
+            }
+        } else if (JakartaEE9Action.isActive()) {
             for (String app : apps) {
                 Path someArchive = Paths.get(myServer.getServerRoot() + File.separatorChar + app);
                 JakartaEE9Action.transformApp(someArchive);

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/bnd.bnd
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/bnd.bnd
@@ -18,7 +18,8 @@ fat.project: true
 publish.wlp.jar.disabled: true
 
 tested.features: jsp-2.3, el-3.0, restfulwsclient-3.0, restfulws-3.0,\
-    appsecurity-4.0, expressionlanguage-4.0, pages-3.0
+    appsecurity-4.0, expressionlanguage-4.0, pages-3.0,\
+    restfulws-3.1, appsecurity-5.0, pages-3.1
 
 -buildpath: \
     com.ibm.websphere.javaee.jsonp.1.0;version=latest,\

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/FATSuite.java
@@ -31,7 +31,7 @@ import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientDiscoveryJWTBa
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.rules.repeater.EmptyAction;
-import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
@@ -57,11 +57,11 @@ import componenttest.rules.repeater.RepeatTests;
  */
 public class FATSuite extends CommonLocalLDAPServerSuite {
     /*
-     * Run EE9 tests in only FULL mode and run EE7/EE8 tests only in LITE mode.
+     * Run EE10 tests in only FULL mode and run EE7/EE8 tests only in LITE mode.
      *
-     * This was done to increase coverage of EE9 while not adding a large amount of of test runtime.
+     * This was done to increase coverage of EE10 while not adding a large amount of test runtime.
      */
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
-            .andWith(new JakartaEE9Action().fullFATOnly());
+            .andWith(new JakartaEE10Action().fullFATOnly());
 }

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientCookieVerificationTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientCookieVerificationTests.java
@@ -35,6 +35,7 @@ import com.ibm.ws.security.oauth_oidc.fat.commonTest.ValidationData.validationDa
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
@@ -97,8 +98,9 @@ public class OidcClientCookieVerificationTests extends CommonTest {
         expectations = vData.addExpectation(expectations, Constants.GET_LOGIN_PAGE, Constants.RESPONSE_COOKIE, Constants.STRING_MATCHES, "Should have found a WASOidcState cookie but didn't.", null, "WASOidcState[pn][0-9]+=[^" + CommonValidationTools.COOKIE_DELIMITER + "]+");
         expectations = vData.addExpectation(expectations, Constants.GET_LOGIN_PAGE, Constants.RESPONSE_COOKIE, Constants.STRING_MATCHES, "Should have found a WASOidcNonce cookie but didn't.", null, "WASOidcNonce[pn][0-9]+=[^" + CommonValidationTools.COOKIE_DELIMITER + "]+");
         expectations = getSuccessfulAccessExpectations(updatedTestSettings, expectations);
-        expectations = vData.addExpectation(expectations, Constants.LOGIN_USER, Constants.RESPONSE_HEADER, Constants.STRING_MATCHES, "Should have found a Set-Cookie header to clear the WASOidcState cookie but didn't.", null, "WASOidcState[pn][0-9]+=\"\"; Expires=Thu, 01 Dec 1994");
-        expectations = vData.addExpectation(expectations, Constants.LOGIN_USER, Constants.RESPONSE_HEADER, Constants.STRING_MATCHES, "Should have found a Set-Cookie header to clear the WASOidcNonce cookie but didn't.", null, "WASOidcNonce[pn][0-9]+=\"\"; Expires=Thu, 01 Dec 1994");
+        String expirationCookieFormat = JakartaEE10Action.isActive() ? "; max-age=0" : "; Expires=Thu, 01 Dec 1994";
+        expectations = vData.addExpectation(expectations, Constants.LOGIN_USER, Constants.RESPONSE_HEADER, Constants.STRING_MATCHES, "Should have found a Set-Cookie header to clear the WASOidcState cookie but didn't.", null, "WASOidcState[pn][0-9]+=\"\"" + expirationCookieFormat);
+        expectations = vData.addExpectation(expectations, Constants.LOGIN_USER, Constants.RESPONSE_HEADER, Constants.STRING_MATCHES, "Should have found a Set-Cookie header to clear the WASOidcNonce cookie but didn't.", null, "WASOidcNonce[pn][0-9]+=\"\"" + expirationCookieFormat);
 
         genericRP(_testName, webClient, updatedTestSettings, Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT, expectations);
 

--- a/dev/com.ibm.ws.security.oidc.client_fat.2/bnd.bnd
+++ b/dev/com.ibm.ws.security.oidc.client_fat.2/bnd.bnd
@@ -18,7 +18,8 @@ fat.project: true
 publish.wlp.jar.disabled: true
 
 tested.features: jsp-2.3, el-3.0, restfulwsclient-3.0, restfulws-3.0,\
-    appsecurity-4.0, expressionlanguage-4.0, pages-3.0
+    appsecurity-4.0, expressionlanguage-4.0, pages-3.0,\
+    restfulws-3.1, appsecurity-5.0, pages-3.1
 
 Import-Package: \
     !*.internal.*, \

--- a/dev/com.ibm.ws.security.oidc.client_fat.2/fat/src/com/ibm/ws/security/openidconnect/client/fat/CommonTests/CookieNameOidcClientTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.2/fat/src/com/ibm/ws/security/openidconnect/client/fat/CommonTests/CookieNameOidcClientTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,6 +30,7 @@ import com.meterware.httpunit.WebConversation;
 
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
 
 /**
  * This is the test class that contains common code for all of the
@@ -127,8 +128,9 @@ public class CookieNameOidcClientTests extends CommonTest {
             i++;
         }
         boolean foundExpiredCookie = false;
-        if (cookieLine != null && (cookieLine.contains("Expires=") && cookieLine.contains("16:00"))) {
-            foundExpiredCookie = true;
+        if (cookieLine != null) {
+            foundExpiredCookie = JakartaEE10Action.isActive() ? cookieLine.contains("max-age=0") : 
+            	(cookieLine.contains("Expires=") && cookieLine.contains("16:00"));
         }
         Assert.assertTrue("did not find expected expired cookie", foundExpiredCookie);
     }

--- a/dev/com.ibm.ws.security.oidc.client_fat.2/fat/src/com/ibm/ws/security/openidconnect/client/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.2/fat/src/com/ibm/ws/security/openidconnect/client/fat/FATSuite.java
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 import com.ibm.ws.security.fat.common.utils.ldaputils.CommonLocalLDAPServerSuite;
@@ -51,13 +52,14 @@ import componenttest.rules.repeater.RepeatTests;
  */
 public class FATSuite extends CommonLocalLDAPServerSuite {
     /*
-     * Run EE9 tests in only FULL mode and run EE7/EE8 tests only in LITE mode.
+     * Run EE9 and EE10 tests in only FULL mode and run EE7/EE8 tests only in LITE mode.
      *
-     * This was done to increase coverage of EE9 while not adding a large amount of of test runtime.
+     * This was done to increase coverage of EE9 and EE10 while not adding a large amount of of test runtime.
      */
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
             .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly());
+            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly())
+            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().fullFATOnly());
 
 }

--- a/dev/com.ibm.ws.security.oidc.client_fat.claimPropagation/bnd.bnd
+++ b/dev/com.ibm.ws.security.oidc.client_fat.claimPropagation/bnd.bnd
@@ -11,7 +11,8 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-tested.features: jsp-2.2, servlet-3.1, transportsecurity-1.0, appsecurity-4.0, expressionlanguage-4.0, servlet-5.0, cdi-3.0, pages-3.0, jsonp-2.0
+tested.features: jsp-2.2, servlet-3.1, transportsecurity-1.0, appsecurity-4.0, expressionlanguage-4.0, servlet-5.0, cdi-3.0, pages-3.0, jsonp-2.0,\
+                 appsecurity-5.0, pages-3.1
 
 src: \
   fat/src

--- a/dev/com.ibm.ws.security.oidc.client_fat.claimPropagation/fat/src/com/ibm/ws/security/oidc/client/claimPropagation/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.claimPropagation/fat/src/com/ibm/ws/security/oidc/client/claimPropagation/fat/FATSuite.java
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 import com.ibm.ws.security.fat.common.utils.ldaputils.CommonLocalLDAPServerSuite;
@@ -50,6 +51,7 @@ public class FATSuite extends CommonLocalLDAPServerSuite {
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
             .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().alwaysAddFeature("servlet-5.0").notOnWindows().fullFATOnly());
+            .andWith(new SecurityTestFeatureEE9RepeatAction().alwaysAddFeature("servlet-5.0").notOnWindows().fullFATOnly())
+            .andWith(new SecurityTestFeatureEE10RepeatAction().alwaysAddFeature("servlet-6.0").notOnWindows().fullFATOnly());
 
 }

--- a/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/bnd.bnd
+++ b/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/bnd.bnd
@@ -11,7 +11,8 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-tested.features: restfulwsclient-3.0, restfulws-3.0, appsecurity-4.0, expressionlanguage-4.0, pages-3.0
+tested.features: restfulwsclient-3.0, restfulws-3.0, appsecurity-4.0, expressionlanguage-4.0, pages-3.0,\
+                 restfulws-3.1, appsecurity-5.0, pages-3.1
 
 src: \
   fat/src, \

--- a/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/fat/src/com/ibm/ws/security/openidconnect/client/fat/jaxrs/FATSuite.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/fat/src/com/ibm/ws/security/openidconnect/client/fat/jaxrs/FATSuite.java
@@ -18,6 +18,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 import com.ibm.ws.security.openidconnect.client.fat.jaxrs.IBM.OIDCTokenMappingResolverGenericTest;
@@ -62,15 +63,16 @@ public class FATSuite {
     }
 
     /*
-     * Run EE9 tests in only FULL mode and run EE7/EE8 tests only in LITE mode.
+     * Run EE9 and EE10 tests in only FULL mode and run EE7/EE8 tests only in LITE mode.
      *
-     * This was done to increase coverage of EE9 while not adding a large amount of test runtime.
+     * This was done to increase coverage of EE9 and EE10 while not adding a large amount of test runtime.
      *
      */
     /* always add servlet-5.0 to enable EE9 in the op which had no feature versions to swap out to enable EE9 */
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
             .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().removeFeatures(REMOVE).addFeatures(INSERT).alwaysAddFeature("servlet-5.0").fullFATOnly());
+            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().removeFeatures(REMOVE).addFeatures(INSERT).alwaysAddFeature("servlet-5.0").fullFATOnly())
+            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().removeFeatures(REMOVE).addFeatures(INSERT).alwaysAddFeature("servlet-6.0").fullFATOnly());
 
 }

--- a/dev/com.ibm.ws.security.oidc.server_fat.jaxrs.config/bnd.bnd
+++ b/dev/com.ibm.ws.security.oidc.server_fat.jaxrs.config/bnd.bnd
@@ -11,7 +11,8 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-tested.features: appsecurity-4.0, expressionlanguage-4.0, cdi-3.0, pages-3.0, restfulwsclient-3.0, restfulws-3.0, jsonp-2.0
+tested.features: appsecurity-4.0, expressionlanguage-4.0, cdi-3.0, pages-3.0, restfulwsclient-3.0, restfulws-3.0, jsonp-2.0,\
+                 appsecurity-5.0, pages-3.1, restfulws-3.1
 
 src: \
   fat/src

--- a/dev/com.ibm.ws.security.oidc.server_fat.jaxrs.config/fat/src/com/ibm/ws/security/openidconnect/server/fat/jaxrs/config/FATSuite.java
+++ b/dev/com.ibm.ws.security.oidc.server_fat.jaxrs.config/fat/src/com/ibm/ws/security/openidconnect/server/fat/jaxrs/config/FATSuite.java
@@ -16,7 +16,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 import com.ibm.ws.security.fat.common.utils.ldaputils.CommonAltRemoteLDAPServerSuite;
 import com.ibm.ws.security.openidconnect.server.fat.jaxrs.config.OAuth.OAuthCookieAttributesInboundPropNoneNoOPToken2ServerTests;
@@ -105,15 +105,15 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite extends CommonAltRemoteLDAPServerSuite {
 
     /*
-     * Run EE9 tests in only FULL mode and run EE7/EE8 tests only in LITE mode.
+     * Run EE10 tests in only FULL mode and run EE7/EE8 tests only in LITE mode.
      *
-     * This was done to increase coverage of EE9 while not adding a large amount of test runtime.
+     * This was done to increase coverage of EE10 while not adding a large amount of test runtime.
      *
      */
-    /* always add servlet-5.0 to enable EE9 in the op which had no feature versions to swap out to enable EE9 */
+    /* always add servlet-6.0 to enable EE10 in the op which had no feature versions to swap out to enable EE10 */
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
             .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().alwaysAddFeature("servlet-5.0").fullFATOnly());
+            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().alwaysAddFeature("servlet-6.0").fullFATOnly());
 
 }

--- a/dev/com.ibm.ws.security.oidc.server_fat.oidc/bnd.bnd
+++ b/dev/com.ibm.ws.security.oidc.server_fat.oidc/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -16,7 +16,8 @@ src: \
 
 fat.project: true
 
-tested.features: oidctai-2.0, appsecurity-4.0, expressionlanguage-4.0, cdi-3.0, pages-3.0
+tested.features: oidctai-2.0, appsecurity-4.0, expressionlanguage-4.0, cdi-3.0, pages-3.0, \
+                 appsecurity-5.0, pages-3.1
 
 -buildpath: \
     com.ibm.json4j;version=latest,\

--- a/dev/com.ibm.ws.security.oidc.server_fat.oidc/fat/src/com/ibm/ws/security/openidconnect/server/fat/oidc/FATSuite.java
+++ b/dev/com.ibm.ws.security.oidc.server_fat.oidc/fat/src/com/ibm/ws/security/openidconnect/server/fat/oidc/FATSuite.java
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 import com.ibm.ws.security.fat.common.utils.ldaputils.CommonRemoteLDAPServerSuite;
@@ -103,15 +104,16 @@ public class FATSuite extends CommonRemoteLDAPServerSuite {
     }
 
     /*
-     * Run EE9 tests in only LITE mode on all but Windows - the transforms just run too slowly on the Windows OS.
-     * So, we'll run without EE9 in LIte mode on Windows.
+     * Run EE9 and EE10 tests in only LITE mode on all but Windows - the transforms just run too slowly on the Windows OS.
+     * So, we'll run without EE9 and EE10 in LIte mode on Windows.
      * We'll run EE7/EE8 tests everywhere in FULL mode.
      *
-     * This was done to increase coverage of EE9 while not adding a large amount of of test runtime.
+     * This was done to increase coverage of EE9 and EE10 while not adding a large amount of of test runtime.
      */
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
                     .andWith(new SecurityTestRepeatAction().onlyOnWindows().liteFATOnly())
-                    .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().removeFeatures(REMOVE).addFeatures(INSERT).liteFATOnly());
+                    .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().removeFeatures(REMOVE).addFeatures(INSERT).liteFATOnly())
+                    .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().removeFeatures(REMOVE).addFeatures(INSERT).liteFATOnly());
 
 }

--- a/dev/com.ibm.ws.security.oidc.server_fat/fat/src/com/ibm/ws/security/openidconnect/server/fat/BasicTests/CommonTests/genericWebClientAuthTaiTest.java
+++ b/dev/com.ibm.ws.security.oidc.server_fat/fat/src/com/ibm/ws/security/openidconnect/server/fat/BasicTests/CommonTests/genericWebClientAuthTaiTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ import com.meterware.httpunit.WebConversation;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
@@ -48,7 +49,7 @@ public class genericWebClientAuthTaiTest extends CommonTest {
     // Copy OidcTAI files into their proper locations in the build.image
     static protected void copyTaiFiles(String serverDir) throws Exception {
     	LibertyServer aTestServer = LibertyServerFactory.getLibertyServer(serverDir);
-    	if (JakartaEE9Action.isActive()) {
+    	if (JakartaEE9Action.isActive() || JakartaEE10Action.isActive()) {
     		aTestServer.copyFileToLibertyInstallRoot("lib", "lib/com.ibm.ws.security.tai_2.0.jar");
     		aTestServer.copyFileToLibertyInstallRoot("lib", "lib/com.ibm.ws.security.tai.sample_2.0.jar");
     		aTestServer.copyFileToLibertyInstallRoot("lib/features", "lib/features/oidcTai-2.0.mf");

--- a/dev/com.ibm.ws.security.saml.sso_fat.2/bnd.bnd
+++ b/dev/com.ibm.ws.security.saml.sso_fat.2/bnd.bnd
@@ -17,7 +17,8 @@ src: \
 fat.project: true
 
 tested.features: servlet-4.0, jsp-2.3, jdbc-4.1, el-3.0,\
-    servlet-5.0, expressionlanguage-4.0, pages-3.0, appsecurity-4.0, cdi-3.0
+    servlet-5.0, expressionlanguage-4.0, pages-3.0, appsecurity-4.0, cdi-3.0,\
+    pages-3.1, appsecurity-5.0
 
 -buildpath: \
     fattest.simplicity;version=latest, \

--- a/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/FATSuite.java
@@ -17,6 +17,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 import com.ibm.ws.security.saml.fat.IDPInitiated.EncryptionIDPInitiatedTests;
@@ -67,7 +68,8 @@ public class FATSuite {
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
             .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly());
+            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly())
+            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().fullFATOnly());
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/BasicEncryptionTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/BasicEncryptionTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2021 IBM Corporation and others.
+ * Copyright (c) 2015, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,7 +21,6 @@ import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
-import com.ibm.ws.security.saml20.fat.commonTest.actions.JakartaEE9SAMLRepeatAction;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.ExpectedFFDC;
@@ -29,6 +28,7 @@ import componenttest.annotation.MaximumJavaLevel;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServerWrapper;
 
@@ -262,7 +262,7 @@ public class BasicEncryptionTests extends SAMLCommonTest {
      * @throws Exception
      */
     @Mode(TestMode.LITE)
-    @AllowedFFDC(value = { "com.ibm.ws.security.saml.error.SamlException", "org.opensaml.xmlsec.encryption.support.DecryptionException" },repeatAction = {EmptyAction.ID,JakartaEE9SAMLRepeatAction.ID})
+    @AllowedFFDC(value = { "com.ibm.ws.security.saml.error.SamlException", "org.opensaml.xmlsec.encryption.support.DecryptionException" },repeatAction = {EmptyAction.ID,JakartaEE9Action.ID,JakartaEE10Action.ID})
     @Test
     public void testKeyAlias_MultipleCertsInKeystore_KeyAliasIsWrongCert() throws Exception {
 

--- a/dev/com.ibm.ws.security.saml.sso_fat.3/bnd.bnd
+++ b/dev/com.ibm.ws.security.saml.sso_fat.3/bnd.bnd
@@ -17,7 +17,8 @@ src: \
 fat.project: true
 
 tested.features: servlet-4.0, jsp-2.3, jdbc-4.1, el-3.0, samlweb-2.0, jdbc-4.0,\
-    servlet-5.0, expressionlanguage-4.0, pages-3.0, appsecurity-4.0, cdi-3.0
+    servlet-5.0, expressionlanguage-4.0, pages-3.0, appsecurity-4.0, cdi-3.0,\
+    pages-3.1, appsecurity-5.0
 
 -buildpath: \
     fattest.simplicity;version=latest, \

--- a/dev/com.ibm.ws.security.saml.sso_fat.3/fat/src/com/ibm/ws/security/saml/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.3/fat/src/com/ibm/ws/security/saml/fat/FATSuite.java
@@ -17,6 +17,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 import com.ibm.ws.security.saml.fat.IDPInitiated.PkixIDPInitiatedTests;
@@ -54,7 +55,8 @@ public class FATSuite {
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
             .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly());
+            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly())
+            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().fullFATOnly());
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.security.saml.sso_fat.config.mapToUserRegistry/bnd.bnd
+++ b/dev/com.ibm.ws.security.saml.sso_fat.config.mapToUserRegistry/bnd.bnd
@@ -17,7 +17,8 @@ src: \
 fat.project: true
 
 tested.features: jsp-2.3, jdbc-4.1, el-3.0, servlet-4.0, samlweb-2.0, jdbc-4.0, \
-    servlet-5.0, expressionlanguage-4.0, pages-3.0, appsecurity-4.0, cdi-3.0
+    servlet-5.0, expressionlanguage-4.0, pages-3.0, appsecurity-4.0, cdi-3.0, \
+    pages-3.1, appsecurity-5.0
 
 -buildpath: \
     fattest.simplicity;version=latest, \

--- a/dev/com.ibm.ws.security.saml.sso_fat.config.mapToUserRegistry/fat/src/com/ibm/ws/security/saml/sso/fat/config/mapToUserRegistry/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.config.mapToUserRegistry/fat/src/com/ibm/ws/security/saml/sso/fat/config/mapToUserRegistry/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -32,6 +34,7 @@ public class FATSuite {
 
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
-            .andWith(new JakartaEE9Action());
+            .andWith(new JakartaEE9Action().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+            .andWith(new JakartaEE10Action());
 
 }

--- a/dev/com.ibm.ws.security.saml.sso_fat.config/bnd.bnd
+++ b/dev/com.ibm.ws.security.saml.sso_fat.config/bnd.bnd
@@ -17,7 +17,8 @@ src: \
 fat.project: true
 
 tested.features: jsp-2.3, jdbc-4.1, el-3.0, servlet-4.0, samlweb-2.0, jdbc-4.0, \
-    servlet-5.0, expressionlanguage-4.0, pages-3.0, appsecurity-4.0, cdi-3.0
+    servlet-5.0, expressionlanguage-4.0, pages-3.0, appsecurity-4.0, cdi-3.0, \
+    pages-3.1, appsecurity-5.0
 
 -buildpath: \
     fattest.simplicity;version=latest, \

--- a/dev/com.ibm.ws.security.saml.sso_fat.config/fat/src/com/ibm/ws/security/saml/sso/fat/config/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.config/fat/src/com/ibm/ws/security/saml/sso/fat/config/FATSuite.java
@@ -17,6 +17,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 
@@ -39,7 +40,8 @@ public class FATSuite {
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
             .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly());
+            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly())
+            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().fullFATOnly());
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.security.saml.sso_fat.config/fat/src/com/ibm/ws/security/saml/sso/fat/config/SAMLMisc1ConfigTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.config/fat/src/com/ibm/ws/security/saml/sso/fat/config/SAMLMisc1ConfigTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,6 +29,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServerWrapper;
 
@@ -902,7 +903,7 @@ public class SAMLMisc1ConfigTests extends SAMLConfigCommonTests {
      * time (not having to reconfig multiple times) we'll do all of this in one
      * test)
      */
-    @AllowedFFDC(value = { "com.ibm.ws.security.saml.error.SamlException", "org.opensaml.messaging.handler.MessageHandlerException", "org.opensaml.xmlsec.signature.support.SignatureException"  }, repeatAction = {EmptyAction.ID,JakartaEE9Action.ID})
+    @AllowedFFDC(value = { "com.ibm.ws.security.saml.error.SamlException", "org.opensaml.messaging.handler.MessageHandlerException", "org.opensaml.xmlsec.signature.support.SignatureException"  }, repeatAction = {EmptyAction.ID,JakartaEE9Action.ID,JakartaEE10Action.ID})
     // @Mode(TestMode.LITE)
     @Test
     public void test_config_errorPageURL() throws Exception {
@@ -972,7 +973,7 @@ public class SAMLMisc1ConfigTests extends SAMLConfigCommonTests {
      * value (non existant url) Test shows that we get a decent
      */
     @ExpectedFFDC(value = {"com.ibm.ws.security.saml.error.SamlException"})
-    @ExpectedFFDC(value = {"org.opensaml.messaging.handler.MessageHandlerException"}, repeatAction = {EmptyAction.ID,JakartaEE9Action.ID})
+    @ExpectedFFDC(value = {"org.opensaml.messaging.handler.MessageHandlerException"}, repeatAction = {EmptyAction.ID,JakartaEE9Action.ID,JakartaEE10Action.ID})
     @AllowedFFDC(value = {"com.ibm.ws.jsp.webcontainerext.JSPErrorReport"})
     // @Mode(TestMode.LITE)
     @Test

--- a/dev/com.ibm.ws.security.saml.sso_fat.endpoint.samlmetadata/bnd.bnd
+++ b/dev/com.ibm.ws.security.saml.sso_fat.endpoint.samlmetadata/bnd.bnd
@@ -17,7 +17,8 @@ src: \
 fat.project: true
 
 tested.features: samlweb-2.0, jdbc-4.0, jsp-2.3, servlet-4.0, el-3.0, \
-    servlet-5.0, appsecurity-4.0, expressionlanguage-4.0, cdi-3.0, pages-3.0
+    servlet-5.0, appsecurity-4.0, expressionlanguage-4.0, cdi-3.0, pages-3.0, \
+    appsecurity-5.0, pages-3.1
 
 -buildpath: \
     fattest.simplicity;version=latest, \

--- a/dev/com.ibm.ws.security.saml.sso_fat.endpoint.samlmetadata/fat/src/com/ibm/ws/security/saml/sso/fat/endpoint/samlmetadata/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.endpoint.samlmetadata/fat/src/com/ibm/ws/security/saml/sso/fat/endpoint/samlmetadata/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,8 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -33,6 +35,7 @@ public class FATSuite {
 
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
-            .andWith(new JakartaEE9Action());
+            .andWith(new JakartaEE9Action().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+            .andWith(new JakartaEE10Action());
 
 }

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/bnd.bnd
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/bnd.bnd
@@ -17,7 +17,8 @@ src: \
 fat.project: true
 
 tested.features: jdbc-4.1, restfulwsclient-3.0, restfulws-3.0, jsonp-2.0, \
-    expressionlanguage-4.0, pages-3.0, appsecurity-4.0
+    expressionlanguage-4.0, pages-3.0, appsecurity-4.0, \
+    restfulws-3.1, pages-3.1, appsecurity-5.0
 
 -buildpath: \
 	fattest.simplicity;version=latest,\

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/fat/src/com/ibm/ws/security/saml/fat/jaxrs/config/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/fat/src/com/ibm/ws/security/saml/fat/jaxrs/config/FATSuite.java
@@ -16,7 +16,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 import com.ibm.ws.security.saml.fat.jaxrs.config.IDPInitiated.RSSamlIDPInitiatedMapToUserRegistryConfigTests;
 import com.ibm.ws.security.saml.fat.jaxrs.config.IDPInitiated.RSSamlIDPInitiatedMiscConfigTests;
@@ -43,7 +43,7 @@ public class FATSuite {
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
             .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly());
+            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().fullFATOnly());
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/bnd.bnd
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/bnd.bnd
@@ -19,7 +19,8 @@ src: \
 fat.project: true
 
 tested.features: jdbc-4.1, restfulwsclient-3.0, restfulws-3.0, jsonp-2.0, \
-    expressionlanguage-4.0, pages-3.0, appsecurity-4.0
+    expressionlanguage-4.0, pages-3.0, appsecurity-4.0, \
+    restfulws-3.1, pages-3.1, appsecurity-5.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/FATSuite.java
@@ -17,6 +17,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 import com.ibm.ws.security.saml.fat.jaxrs.IDPInitiated.RSSamlIDPInitiatedAPITests;
@@ -52,7 +53,8 @@ public class FATSuite {
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
             .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly());
+            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly())
+            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().fullFATOnly());
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/common/RSSamlBasicTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/common/RSSamlBasicTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -418,7 +418,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
      * @throws Exception
      */
     //	@Mode(TestMode.LITE)
-    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
+    @SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES})
     @Test
     public void RSSamlBasicTests_unprotectedApp() throws Exception {
 

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout.IDP_initiated/bnd.bnd
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout.IDP_initiated/bnd.bnd
@@ -17,7 +17,8 @@ src: \
 fat.project: true
 
 tested.features: jsp-2.3, jdbc-4.1, el-3.0, servlet-4.0, samlweb-2.0, jdbc-4.0, \
-    servlet-5.0, expressionlanguage-4.0, pages-3.0, appsecurity-4.0, cdi-3.0
+    servlet-5.0, expressionlanguage-4.0, pages-3.0, appsecurity-4.0, cdi-3.0, \
+    pages-3.1, appsecurity-5.0
 
 -buildpath: \
 	fattest.simplicity;version=latest,\

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout.IDP_initiated/fat/src/com/ibm/ws/security/saml/fat/logout/IDPInitiated/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout.IDP_initiated/fat/src/com/ibm/ws/security/saml/fat/logout/IDPInitiated/FATSuite.java
@@ -17,6 +17,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.security.fat.common.AlwaysRunAndPassTest;
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 import com.ibm.ws.security.saml.fat.logout.IDPInitiated_Login.IDPInitiatedLogin_IDPInitiated_LogoutUrl_LTPA_Tests;
@@ -52,7 +53,8 @@ public class FATSuite {
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
             .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly());
+            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly())
+            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().fullFATOnly());
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout.httpServletRequest/bnd.bnd
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout.httpServletRequest/bnd.bnd
@@ -17,7 +17,8 @@ src: \
 fat.project: true
 
 tested.features: jsp-2.3, jdbc-4.1, el-3.0, servlet-4.0, samlweb-2.0, jdbc-4.0, \
-    servlet-5.0, expressionlanguage-4.0, pages-3.0, appsecurity-4.0, cdi-3.0
+    servlet-5.0, expressionlanguage-4.0, pages-3.0, appsecurity-4.0, cdi-3.0, \
+    pages-3.1, appsecurity-5.0
 
 -buildpath: \
 	fattest.simplicity;version=latest,\

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout.httpServletRequest/fat/src/com/ibm/ws/security/saml/fat/logout/httpServletRequest/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout.httpServletRequest/fat/src/com/ibm/ws/security/saml/fat/logout/httpServletRequest/FATSuite.java
@@ -17,7 +17,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.security.fat.common.AlwaysRunAndPassTest;
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 import com.ibm.ws.security.saml.fat.logout.IDPInitiated_Login.IDPInitiatedLogin_servletRequestLogout_spLogoutFalse_LTPA_Tests;
 import com.ibm.ws.security.saml.fat.logout.IDPInitiated_Login.IDPInitiatedLogin_servletRequestLogout_spLogoutFalse_Tests;
@@ -71,7 +71,7 @@ public class FATSuite {
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
             .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly());
+            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().fullFATOnly());
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout.ibm_security_logout/bnd.bnd
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout.ibm_security_logout/bnd.bnd
@@ -17,7 +17,8 @@ src: \
 fat.project: true
 
 tested.features: jsp-2.3, jdbc-4.1, el-3.0, servlet-4.0, samlweb-2.0, jdbc-4.0, \
-    servlet-5.0, expressionlanguage-4.0, pages-3.0, appsecurity-4.0, cdi-3.0
+    servlet-5.0, expressionlanguage-4.0, pages-3.0, appsecurity-4.0, cdi-3.0, \
+    pages-3.1, appsecurity-5.0
 
 -buildpath: \
 	fattest.simplicity;version=latest,\

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout.ibm_security_logout/fat/src/com/ibm/ws/security/saml/fat/logout/ibmSecurityLogout/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout.ibm_security_logout/fat/src/com/ibm/ws/security/saml/fat/logout/ibmSecurityLogout/FATSuite.java
@@ -17,7 +17,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.security.fat.common.AlwaysRunAndPassTest;
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 import com.ibm.ws.security.saml.fat.logout.IDPInitiated_Login.IDPInitiatedLogin_ibmSecurityLogout_spLogoutFalse_LTPA_Tests;
 import com.ibm.ws.security.saml.fat.logout.IDPInitiated_Login.IDPInitiatedLogin_ibmSecurityLogout_spLogoutFalse_Tests;
@@ -71,7 +71,7 @@ public class FATSuite {
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
             .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly());
+            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().fullFATOnly());
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout/bnd.bnd
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout/bnd.bnd
@@ -17,7 +17,8 @@ src: \
 fat.project: true
 
 tested.features: jsp-2.3, jdbc-4.1, el-3.0, samlweb-2.0, jdbc-4.0, servlet-4.0, \
-    servlet-5.0, expressionlanguage-4.0, pages-3.0, appsecurity-4.0, cdi-3.0
+    servlet-5.0, expressionlanguage-4.0, pages-3.0, appsecurity-4.0, cdi-3.0, \
+    pages-3.1, appsecurity-5.0
 
 -buildpath: \
 	fattest.simplicity;version=latest,\

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout/fat/src/com/ibm/ws/security/saml/fat/logout/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout/fat/src/com/ibm/ws/security/saml/fat/logout/FATSuite.java
@@ -18,7 +18,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.security.fat.common.AlwaysRunAndPassTest;
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 import com.ibm.ws.security.saml.fat.logout.IDPInitiated_Login.IDPInitiatedLogin_2ServerLogout_usingApps_Tests;
 import com.ibm.ws.security.saml.fat.logout.IDPInitiated_Login.IDPInitiatedLogin_2ServerLogout_usingServlets_Tests;
@@ -74,7 +74,7 @@ public class FATSuite {
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
             .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly());
+            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().fullFATOnly());
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.security.saml.sso_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.saml.sso_fat/bnd.bnd
@@ -17,7 +17,8 @@ src: \
 fat.project: true
 
 tested.features: servlet-4.0, jsp-2.3, jdbc-4.1, el-3.0,\
-    servlet-5.0, expressionlanguage-4.0, pages-3.0, appsecurity-4.0, cdi-3.0
+    servlet-5.0, expressionlanguage-4.0, pages-3.0, appsecurity-4.0, cdi-3.0, \
+    pages-3.1, appsecurity-5.0
 
 -buildpath: \
     fattest.simplicity;version=latest, \

--- a/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/FATSuite.java
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 import com.ibm.ws.security.saml.fat.IDPInitiated.BasicIDPInitiatedTests;
@@ -40,7 +41,8 @@ public class FATSuite {
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
                     .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-                    .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly());
+                    .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly())
+                    .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().fullFATOnly());
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/common/BasicSAMLTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/common/BasicSAMLTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,6 +31,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServerWrapper;
 
@@ -243,7 +244,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
      */
 
     @ExpectedFFDC(value = { "com.ibm.ws.security.saml.error.SamlException" })
-    @AllowedFFDC(value = { "org.opensaml.messaging.handler.MessageHandlerException" }, repeatAction = { EmptyAction.ID,JakartaEE9Action.ID })
+    @AllowedFFDC(value = { "org.opensaml.messaging.handler.MessageHandlerException" }, repeatAction = { EmptyAction.ID, JakartaEE9Action.ID, JakartaEE10Action.ID })
     @Test
     public void basicSAMLTests_noIdAssertNoUser_IDPSignMisMatch_IDPEncrypt() throws Exception {
 

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.1/bnd.bnd
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.1/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -17,7 +17,8 @@ src: \
 fat.project: true
 
 tested.features: oauth-2.0, securitylibertyinternals-1.0, openidconnectserver-1.0, jsp-2.3, jwt-1.0, sociallogin-1.0, jaxrs-2.0, el-3.0, \
-                 restfulwsclient-3.0, restfulws-3.0, appsecurity-4.0, expressionlanguage-4.0, pages-3.0
+                 restfulwsclient-3.0, restfulws-3.0, appsecurity-4.0, expressionlanguage-4.0, pages-3.0, \
+                 restfulws-3.1, appsecurity-5.0, pages-3.1
 
 -buildpath: \
     com.ibm.json4j;version=latest,\

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.1/fat/src/com/ibm/ws/security/social/fat/LibertyOP/FATSuite.java
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.1/fat/src/com/ibm/ws/security/social/fat/LibertyOP/FATSuite.java
@@ -20,6 +20,8 @@ import com.ibm.ws.security.oauth_oidc.fat.commonTest.Constants;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -44,8 +46,10 @@ public class FATSuite {
     public static String UserApiEndpoint = Constants.USERINFO_ENDPOINT;
 
     /*
-     * Run EE9 tests in LITE mode and run all tests in FULL mode.
+     * Run EE10 tests in LITE mode and run all tests in FULL mode.
      */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(new JakartaEE9Action().liteFATOnly());
+    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
+            .andWith(new JakartaEE9Action().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+            .andWith(new JakartaEE10Action().liteFATOnly());
 }

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.1/fat/src/com/ibm/ws/security/social/fat/LibertyOP/LibertyOP_CookieVerificationTests.java
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.1/fat/src/com/ibm/ws/security/social/fat/LibertyOP/LibertyOP_CookieVerificationTests.java
@@ -33,6 +33,7 @@ import com.ibm.ws.security.social.fat.utils.SocialTestSettings;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServerWrapper;
 
@@ -98,8 +99,9 @@ public class LibertyOP_CookieVerificationTests extends SocialCommonTest {
         expectations = vData.addExpectation(expectations, SocialConstants.INVOKE_SOCIAL_RESOURCE, Constants.RESPONSE_HEADER, Constants.STRING_DOES_NOT_CONTAIN, "Should not have seen any Set-Cookie headers in the response but did.", null, "Set-Cookie");
         expectations = vData.addExpectation(expectations, SocialConstants.INVOKE_SOCIAL_RESOURCE, Constants.RESPONSE_COOKIE, Constants.STRING_MATCHES, "Should have found a WASOidcState cookie but didn't.", null, "WASOidcState[pn][0-9]+=[^" + CommonValidationTools.COOKIE_DELIMITER + "]+");
         expectations = vData.addExpectation(expectations, SocialConstants.INVOKE_SOCIAL_RESOURCE, Constants.RESPONSE_COOKIE, Constants.STRING_MATCHES, "Should have found a WASOidcNonce cookie but didn't.", null, "WASOidcNonce[pn][0-9]+=[^" + CommonValidationTools.COOKIE_DELIMITER + "]+");
-        expectations = vData.addExpectation(expectations, SocialConstants.LIBERTYOP_PERFORM_SOCIAL_LOGIN, Constants.RESPONSE_HEADER, Constants.STRING_MATCHES, "Should have found a Set-Cookie header to clear the WASOidcState cookie but didn't.", null, "WASOidcState[pn][0-9]+=\"\"; Expires=Thu, 01 Dec 1994");
-        expectations = vData.addExpectation(expectations, SocialConstants.LIBERTYOP_PERFORM_SOCIAL_LOGIN, Constants.RESPONSE_HEADER, Constants.STRING_MATCHES, "Should have found a Set-Cookie header to clear the WASOidcNonce cookie but didn't.", null, "WASOidcNonce[pn][0-9]+=\"\"; Expires=Thu, 01 Dec 1994");
+        String expirationCookieFormat = JakartaEE10Action.isActive() ? "; max-age=0" : "; Expires=Thu, 01 Dec 1994";
+        expectations = vData.addExpectation(expectations, SocialConstants.LIBERTYOP_PERFORM_SOCIAL_LOGIN, Constants.RESPONSE_HEADER, Constants.STRING_MATCHES, "Should have found a Set-Cookie header to clear the WASOidcState cookie but didn't.", null, "WASOidcState[pn][0-9]+=\"\"" + expirationCookieFormat);
+        expectations = vData.addExpectation(expectations, SocialConstants.LIBERTYOP_PERFORM_SOCIAL_LOGIN, Constants.RESPONSE_HEADER, Constants.STRING_MATCHES, "Should have found a Set-Cookie header to clear the WASOidcNonce cookie but didn't.", null, "WASOidcNonce[pn][0-9]+=\"\"" + expirationCookieFormat);
 
         genericSocial(_testName, webClient, inovke_social_login_actions, socialSettings, expectations);
 

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.2/bnd.bnd
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.2/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -17,7 +17,8 @@ src: \
 fat.project: true
 
 tested.features: oauth-2.0, securitylibertyinternals-1.0, openidconnectserver-1.0, jsp-2.3, jwt-1.0, sociallogin-1.0, jaxrs-2.0, el-3.0, \
-                 restfulwsclient-3.0, restfulws-3.0, appsecurity-4.0, expressionlanguage-4.0, pages-3.0
+                 restfulwsclient-3.0, restfulws-3.0, appsecurity-4.0, expressionlanguage-4.0, pages-3.0, \
+                 restfulws-3.1, appsecurity-5.0, pages-3.1
 
 -buildpath: \
     com.ibm.json4j;version=latest,\

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.2/fat/src/com/ibm/ws/security/social/fat/LibertyOP/FATSuite.java
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.2/fat/src/com/ibm/ws/security/social/fat/LibertyOP/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,8 @@ import com.ibm.ws.security.oauth_oidc.fat.commonTest.Constants;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -45,8 +47,10 @@ public class FATSuite {
     public static String UserApiEndpoint = Constants.USERINFO_ENDPOINT;
 
     /*
-     * Run EE9 tests in LITE mode and run all tests in FULL mode.
+     * Run EE10 tests in LITE mode and run all tests in FULL mode.
      */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(new JakartaEE9Action().liteFATOnly());
+    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
+            .andWith(new JakartaEE9Action().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+            .andWith(new JakartaEE10Action().liteFATOnly());
 }

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/bnd.bnd
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/bnd.bnd
@@ -23,7 +23,8 @@ fat.project: true
 
 publish.wlp.jar.disabled: true
 
-tested.features:  restfulwsclient-3.0, transportsecurity-1.0, appsecurity-4.0, expressionlanguage-4.0, servlet-5.0, concurrent-2.0, restfulws-3.0, jsonp-2.0, cdi-3.0, pages-3.0
+tested.features:  transportsecurity-1.0, appsecurity-4.0, restfulws-3.0, pages-3.0, \
+                  appsecurity-5.0, restfulws-3.1, pages-3.1
 
 -buildpath: \
 	com.ibm.websphere.javaee.jsonp.1.0;version=latest,\

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/FATSuite.java
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 
@@ -37,13 +38,14 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
 
     /*
-     * Run EE9 tests in only FULL mode and run EE7/EE8 tests only in LITE mode.
+     * Run EE9 and EE10 tests in only FULL mode and run EE7/EE8 tests only in LITE mode.
      *
-     * This was done to increase coverage of EE9 while not adding a large amount of of test runtime.
+     * This was done to increase coverage of EE9 and EE10 while not adding a large amount of test runtime.
      */
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
             .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().alwaysAddFeature("servlet-5.0").fullFATOnly());
+            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().alwaysAddFeature("servlet-5.0").fullFATOnly())
+            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().alwaysAddFeature("servlet-6.0").fullFATOnly());
 
 }

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.claimPropagation/bnd.bnd
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.claimPropagation/bnd.bnd
@@ -11,7 +11,8 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-tested.features: jsp-2.2, servlet-3.1, transportsecurity-1.0, appsecurity-4.0, expressionlanguage-4.0, servlet-5.0, cdi-3.0, pages-3.0, jsonp-2.0
+tested.features: jsp-2.2, servlet-3.1, transportsecurity-1.0, appsecurity-4.0, pages-3.0, jsonp-2.0, \
+                 appsecurity-5.0, pages-3.1
 
 src: \
   fat/src

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.claimPropagation/fat/src/com/ibm/ws/security/social/claimPropagation/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.claimPropagation/fat/src/com/ibm/ws/security/social/claimPropagation/fat/FATSuite.java
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
 import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 import com.ibm.ws.security.fat.common.utils.ldaputils.CommonLocalLDAPServerSuite;
@@ -39,15 +40,16 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite extends CommonLocalLDAPServerSuite {
 
     /*
-     * Run EE9 tests in only FULL mode and run EE7/EE8 tests only in LITE mode.
+     * Run EE9 and EE10 tests in only FULL mode and run EE7/EE8 tests only in LITE mode.
      *
-     * This was done to increase coverage of EE9 while not adding a large amount of test runtime.
+     * This was done to increase coverage of EE9 and EE10 while not adding a large amount of test runtime.
      *
      */
 
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
             .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().alwaysAddFeature("servlet-5.0").notOnWindows().fullFATOnly());
+            .andWith(new SecurityTestFeatureEE9RepeatAction().alwaysAddFeature("servlet-5.0").notOnWindows().fullFATOnly())
+            .andWith(new SecurityTestFeatureEE10RepeatAction().alwaysAddFeature("servlet-6.0").notOnWindows().fullFATOnly());
 
 }

--- a/dev/com.ibm.ws.security.wim.core_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.wim.core_fat/bnd.bnd
@@ -16,7 +16,8 @@ src: \
 	fat/src
 
 fat.project: true
-tested.features: appsecurity-4.0, expressionlanguage-4.0, cdi-3.0, servlet-3.1
+tested.features: appsecurity-4.0, expressionlanguage-4.0, cdi-3.0, servlet-3.1,\
+	appsecurity-5.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\

--- a/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/FATSuite.java
@@ -27,6 +27,7 @@ import com.ibm.ws.com.unboundid.InMemoryLDAPServer;
 import com.ibm.ws.com.unboundid.InMemoryTDSLDAPServer;
 
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
@@ -49,14 +50,16 @@ public class FATSuite {
     private static InMemoryLDAPServer tdsLdapServer, adLdapServer;
 
     /**
-     * Repeat tests for Jakarta EE 9.
+     * Repeat tests for Jakarta EE 9 and 10.
      *
-     * Wee need to replace appSecurity-1.0 with appSecurity-4.0. The appSecurity-3.0 and 4.0 features
+     * We need to replace appSecurity-1.0 with appSecurity-4.0. The appSecurity-3.0 4.0 and 5.0 features
      * no longer include ldapRegistry-3.0, so we need to add that as well.
      */
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction())
-                    .andWith(new JakartaEE9Action().addFeature("appSecurity-4.0").removeFeature("appSecurity-1.0").alwaysAddFeature("ldapRegistry-3.0"));
+                    .andWith(new JakartaEE9Action().addFeature("appSecurity-4.0").removeFeature("appSecurity-1.0").alwaysAddFeature("ldapRegistry-3.0")
+                             .conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                    .andWith(new JakartaEE10Action().addFeature("appSecurity-5.0").removeFeature("appSecurity-1.0").alwaysAddFeature("ldapRegistry-3.0"));
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.tx.jta_fat/fat/src/com/ibm/ws/tx/jta/test/SimpleTest.java
+++ b/dev/com.ibm.ws.tx.jta_fat/fat/src/com/ibm/ws/tx/jta/test/SimpleTest.java
@@ -25,6 +25,7 @@ import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.rules.repeater.EE8FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -66,7 +67,7 @@ public class SimpleTest extends FATServletClient {
         // Use test-specific public features (e.g. txjtafat-x.y) to enable protected features
         // jta-x.y on the server. And since these public features are not in the repeatable EE
         // feature set, the following sets the appropriate features for each repeatable test.
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE9Action.isActive() || JakartaEE10Action.isActive()) {
             server.changeFeatures(Arrays.asList("txjtafat-2.0", "servlet-5.0", "componenttest-2.0", "osgiconsole-1.0"));
         } else if (RepeatTestFilter.isRepeatActionActive(EE8FeatureReplacementAction.ID)) { // e.g. isActive()
             server.changeFeatures(Arrays.asList("txjtafat-1.2", "servlet-4.0", "componenttest-1.0", "osgiconsole-1.0"));

--- a/dev/fattest.simplicity/src/componenttest/topology/ldap/LocalLdapServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/ldap/LocalLdapServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,6 +32,7 @@ public class LocalLdapServer {
     private static final Class<?> c = LocalLdapServer.class;
     private static final String APACHE_DS_HOME = PrivHelper.getProperty("apache.ds.home");
     private static final String OS_NAME = PrivHelper.getProperty("os.name");
+    private static final int STOP_RETRY_COUNT = 35;
 
     /**
      * Sets the name of the instance
@@ -145,6 +146,16 @@ public class LocalLdapServer {
         // Stop the ldap instance started.
         Log.info(c, method, "Stopping the " + instanceName + " instance of Apache DS");
         localLdapInstance.destroy();
+        int retry = 0;
+        while (localLdapInstance.isAlive() && retry < STOP_RETRY_COUNT) {
+            Log.info(c, method, instanceName + " instance of Apache DS is stopping via the proc.destroy() method.  Retry = " + retry);
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            retry++;
+        }
         Log.exiting(c, method);
     }
 }

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/LDAPUtils.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/LDAPUtils.java
@@ -523,40 +523,38 @@ public class LDAPUtils {
      */
     private static void logLdapServerInfo() {
         final String METHOD_NAME = "logLDAPServerInfo";
-        Log.info(c, METHOD_NAME, "USE_LOCAL_LDAP_SERVER=" + USE_LOCAL_LDAP_SERVER);
+        Log.info(c, METHOD_NAME, "USE_LOCAL_LDAP_SERVER=" + USE_LOCAL_LDAP_SERVER + '\n' +
 
-        Log.info(c, METHOD_NAME, "Active Directory WAS SVT LDAP Servers");
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_2_NAME=" + LDAP_SERVER_2_NAME);
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_2_PORT=" + LDAP_SERVER_2_PORT + '\n');
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_2_SSL_PORT=" + LDAP_SERVER_2_SSL_PORT + '\n');
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_6_NAME=" + LDAP_SERVER_6_NAME);
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_6_PORT=" + LDAP_SERVER_6_PORT + '\n');
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_6_SSL_PORT=" + LDAP_SERVER_6_SSL_PORT + '\n');
+        "Active Directory WAS SVT LDAP Servers\n" +
+        "\tLDAP_SERVER_2_NAME=" + LDAP_SERVER_2_NAME + '\n' +
+        "\tLDAP_SERVER_2_PORT=" + LDAP_SERVER_2_PORT + '\n' +
+        "\tLDAP_SERVER_2_SSL_PORT=" + LDAP_SERVER_2_SSL_PORT + '\n' +
+        "\tLDAP_SERVER_6_NAME=" + LDAP_SERVER_6_NAME + '\n' +
+        "\tLDAP_SERVER_6_PORT=" + LDAP_SERVER_6_PORT + '\n' +
+        "\tLDAP_SERVER_6_SSL_PORT=" + LDAP_SERVER_6_SSL_PORT + "\n\n" +
 
-        Log.info(c, METHOD_NAME, "IBM Continuous Delivery LDAP Servers");
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_1_NAME=" + LDAP_SERVER_1_NAME);
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_1_PORT=" + LDAP_SERVER_1_PORT + '\n');
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_5_NAME=" + LDAP_SERVER_5_NAME);
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_5_PORT=" + LDAP_SERVER_5_PORT + '\n');
+        "IBM Continuous Delivery LDAP Servers\n" +
+        "\tLDAP_SERVER_1_NAME=" + LDAP_SERVER_1_NAME + '\n' +
+        "\tLDAP_SERVER_1_PORT=" + LDAP_SERVER_1_PORT + '\n' +
+        "\tLDAP_SERVER_5_NAME=" + LDAP_SERVER_5_NAME + '\n' +
+        "\tLDAP_SERVER_5_PORT=" + LDAP_SERVER_5_PORT + "\n\n" +
 
-        Log.info(c, METHOD_NAME, "IBM WAS Security FVT LDAP Servers");
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_4_NAME=" + LDAP_SERVER_4_NAME);
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_4_PORT=" + LDAP_SERVER_4_PORT);
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_4_SSL_PORT=" + LDAP_SERVER_4_SSL_PORT + '\n');
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_7_NAME=" + LDAP_SERVER_7_NAME);
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_7_PORT=" + LDAP_SERVER_7_PORT);
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_7_SSL_PORT=" + LDAP_SERVER_7_SSL_PORT + '\n');
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_8_NAME=" + LDAP_SERVER_8_NAME);
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_8_PORT=" + LDAP_SERVER_8_PORT);
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_8_SSL_PORT=" + LDAP_SERVER_8_SSL_PORT + '\n');
+        "IBM WAS Security FVT LDAP Servers\n" +
+        "\tLDAP_SERVER_4_NAME=" + LDAP_SERVER_4_NAME + '\n' +
+        "\tLDAP_SERVER_4_PORT=" + LDAP_SERVER_4_PORT + '\n' +
+        "\tLDAP_SERVER_4_SSL_PORT=" + LDAP_SERVER_4_SSL_PORT + '\n' +
+        "\tLDAP_SERVER_7_NAME=" + LDAP_SERVER_7_NAME + '\n' +
+        "\tLDAP_SERVER_7_PORT=" + LDAP_SERVER_7_PORT + '\n' +
+        "\tLDAP_SERVER_7_SSL_PORT=" + LDAP_SERVER_7_SSL_PORT + '\n' +
+        "\tLDAP_SERVER_8_NAME=" + LDAP_SERVER_8_NAME + '\n' +
+        "\tLDAP_SERVER_8_PORT=" + LDAP_SERVER_8_PORT + '\n' +
+        "\tLDAP_SERVER_8_SSL_PORT=" + LDAP_SERVER_8_SSL_PORT + "\n\n" +
 
-        Log.info(c, METHOD_NAME, "IBM WAS Security LDAP Servers");
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_10_NAME=" + LDAP_SERVER_10_NAME);
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_10_PORT=" + LDAP_SERVER_10_PORT + '\n');
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_12_NAME=" + LDAP_SERVER_12_NAME);
-        Log.info(c, METHOD_NAME, "           LDAP_SERVER_12_PORT=" + LDAP_SERVER_12_PORT + '\n');
-
-        Log.info(c, METHOD_NAME, "Oracle WAS SVT LDAP Servers -- removed");
+        "IBM WAS Security LDAP Servers\n" +
+        "\tLDAP_SERVER_10_NAME=" + LDAP_SERVER_10_NAME + '\n' +
+        "\tLDAP_SERVER_10_PORT=" + LDAP_SERVER_10_PORT + '\n' +
+        "\tLDAP_SERVER_12_NAME=" + LDAP_SERVER_12_NAME + '\n' +
+        "\tLDAP_SERVER_12_PORT=" + LDAP_SERVER_12_PORT);
 
     }
 

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/bnd.bnd
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/bnd.bnd
@@ -18,7 +18,8 @@ src: \
 
 fat.project: true
 tested.features: appsecurity-4.0, expressionlanguage-4.0, servlet-5.0, cdi-3.0, pages-3.0, jsonp-2.0, \
-                 restfulwsclient-3.0, concurrent-2.0, restfulws-3.0, sessioncache-1.0
+                 restfulwsclient-3.0, concurrent-2.0, restfulws-3.0, sessioncache-1.0, \
+                 appsecurity-5.0, pages-3.1, restfulws-3.1
 
 # Uncomment to use remote docker host to simulate continuous build behavior.
 #fat.test.use.remote.docker: true

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/FATSuite.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/FATSuite.java
@@ -20,6 +20,8 @@ import com.ibm.websphere.simplicity.Machine;
 
 import componenttest.containers.TestContainerSuite;
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyFileManager;
@@ -50,11 +52,12 @@ import io.openliberty.jcache.internal.fat.plugins.TestPluginHelper;
 public class FATSuite extends TestContainerSuite {
 
     /*
-     * Run EE9 tests in LITE mode and run all tests in FULL mode.
+     * Run EE10 tests in LITE mode and run all tests in FULL mode.
      */
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
-                    .andWith(new JakartaEE9Action());
+                    .andWith(new JakartaEE9Action().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                    .andWith(new JakartaEE10Action());
 
     @BeforeClass
     public static void beforeSuite() throws Exception {

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheAuthCacheFailureTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheAuthCacheFailureTest.java
@@ -33,6 +33,7 @@ import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
@@ -63,6 +64,9 @@ public class JCacheAuthCacheFailureTest extends BaseTestCase {
         if (JakartaEE9Action.isActive()) {
             JakartaEE9Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/basicauth.war"));
             JakartaEE9Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/basicauth.war"));
+        } else if (JakartaEE10Action.isActive()) {
+            JakartaEE10Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/basicauth.war"));
+            JakartaEE10Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/basicauth.war"));
         }
     }
 

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheAuthenticationCacheServerRestartTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheAuthenticationCacheServerRestartTest.java
@@ -35,7 +35,7 @@ import componenttest.topology.impl.LibertyServer;
 /**
  * Contains distributed JCache authentication cache tests for server restart.
  */
-@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
+@SkipForRepeat({ SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES })
 @SkipIfSysProp("skip.tests=true")
 @SuppressWarnings("restriction")
 @RunWith(FATRunner.class)

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheAuthenticationCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheAuthenticationCacheTest.java
@@ -30,6 +30,7 @@ import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import io.openliberty.jcache.internal.fat.plugins.TestPluginHelper;
@@ -62,6 +63,9 @@ public class JCacheAuthenticationCacheTest extends BaseTestCase {
         if (JakartaEE9Action.isActive()) {
             JakartaEE9Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/basicauth.war"));
             JakartaEE9Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/basicauth.war"));
+        } else if (JakartaEE10Action.isActive()) {
+            JakartaEE10Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/basicauth.war"));
+            JakartaEE10Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/basicauth.war"));
         }
     }
 

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheCustomPrincipalCastingTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheCustomPrincipalCastingTest.java
@@ -32,6 +32,7 @@ import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
@@ -86,6 +87,9 @@ public class JCacheCustomPrincipalCastingTest extends BaseTestCase {
         if (JakartaEE9Action.isActive()) {
             JakartaEE9Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/subjectcast.war"));
             JakartaEE9Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/subjectcast.war"));
+        } else if (JakartaEE10Action.isActive()) {
+            JakartaEE10Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/subjectcast.war"));
+            JakartaEE10Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/subjectcast.war"));
         }
     }
 

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheDeleteAuthCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheDeleteAuthCacheTest.java
@@ -32,6 +32,7 @@ import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
@@ -63,6 +64,9 @@ public class JCacheDeleteAuthCacheTest extends BaseTestCase {
         if (JakartaEE9Action.isActive()) {
             JakartaEE9Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/basicauth.war"));
             JakartaEE9Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/basicauth.war"));
+        } else if (JakartaEE10Action.isActive()) {
+            JakartaEE10Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/basicauth.war"));
+            JakartaEE10Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/basicauth.war"));
         }
     }
 

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheDynamicUpdateTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheDynamicUpdateTest.java
@@ -43,7 +43,7 @@ import io.openliberty.jcache.internal.fat.plugins.TestPluginHelper;
  */
 @SuppressWarnings("restriction")
 @SkipIfSysProp("skip.tests=true")
-@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
+@SkipForRepeat({ SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES })
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class JCacheDynamicUpdateTest extends BaseTestCase {

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheJwtAuthenticationCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheJwtAuthenticationCacheTest.java
@@ -30,6 +30,7 @@ import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import io.openliberty.jcache.internal.fat.plugins.TestPluginHelper;
@@ -63,6 +64,9 @@ public class JCacheJwtAuthenticationCacheTest extends BaseTestCase {
         if (JakartaEE9Action.isActive()) {
             JakartaEE9Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/basicauth.war"));
             JakartaEE9Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/basicauth.war"));
+        } else if (JakartaEE10Action.isActive()) {
+            JakartaEE10Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/basicauth.war"));
+            JakartaEE10Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/basicauth.war"));
         }
     }
 

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheJwtLoggedOutCookieCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheJwtLoggedOutCookieCacheTest.java
@@ -32,6 +32,7 @@ import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
@@ -63,6 +64,9 @@ public class JCacheJwtLoggedOutCookieCacheTest extends BaseTestCase {
         if (JakartaEE9Action.isActive()) {
             JakartaEE9Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/formlogin.war"));
             JakartaEE9Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/formlogin.war"));
+        } else if (JakartaEE10Action.isActive()) {
+            JakartaEE10Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/formlogin.war"));
+            JakartaEE10Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/formlogin.war"));
         }
     }
 

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheLtpaLoggedOutCookieCacheServerRestartTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheLtpaLoggedOutCookieCacheServerRestartTest.java
@@ -38,7 +38,7 @@ import componenttest.topology.impl.LibertyServer;
  * This won't work in hazelcast because hazelcast runs the cache on the Liberty server.
  */
 @SkipIfSysProp("skip.tests=true")
-@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
+@SkipForRepeat({ SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES })
 @SuppressWarnings("restriction")
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheLtpaLoggedOutCookieCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheLtpaLoggedOutCookieCacheTest.java
@@ -31,6 +31,7 @@ import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
@@ -60,6 +61,9 @@ public class JCacheLtpaLoggedOutCookieCacheTest extends BaseTestCase {
         if (JakartaEE9Action.isActive()) {
             JakartaEE9Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/formlogin.war"));
             JakartaEE9Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/formlogin.war"));
+        } else if (JakartaEE10Action.isActive()) {
+            JakartaEE10Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/formlogin.war"));
+            JakartaEE10Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/formlogin.war"));
         }
     }
 

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheOauth20AuthenticationCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheOauth20AuthenticationCacheTest.java
@@ -44,6 +44,7 @@ import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import io.openliberty.jcache.internal.fat.docker.KeycloakContainer;
@@ -93,6 +94,9 @@ public class JCacheOauth20AuthenticationCacheTest extends BaseTestCase {
         if (JakartaEE9Action.isActive()) {
             JakartaEE9Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/helloworld.war"));
             JakartaEE9Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/helloworld.war"));
+        } else if (JakartaEE10Action.isActive()) {
+            JakartaEE10Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/helloworld.war"));
+            JakartaEE10Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/helloworld.war"));
         }
     }
 

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheOidcClientAuthenticationCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheOidcClientAuthenticationCacheTest.java
@@ -45,6 +45,7 @@ import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import io.openliberty.jcache.internal.fat.docker.KeycloakContainer;
@@ -98,6 +99,9 @@ public class JCacheOidcClientAuthenticationCacheTest extends BaseTestCase {
         if (JakartaEE9Action.isActive()) {
             JakartaEE9Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/helloworld.war"));
             JakartaEE9Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/helloworld.war"));
+        } else if (JakartaEE10Action.isActive()) {
+            JakartaEE10Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/helloworld.war"));
+            JakartaEE10Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/helloworld.war"));
         }
     }
 

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheOidcLoginAuthenticationCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheOidcLoginAuthenticationCacheTest.java
@@ -44,6 +44,7 @@ import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import io.openliberty.jcache.internal.fat.docker.KeycloakContainer;
@@ -97,6 +98,9 @@ public class JCacheOidcLoginAuthenticationCacheTest extends BaseTestCase {
         if (JakartaEE9Action.isActive()) {
             JakartaEE9Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/helloworld.war"));
             JakartaEE9Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/helloworld.war"));
+        } else if (JakartaEE10Action.isActive()) {
+            JakartaEE10Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/helloworld.war"));
+            JakartaEE10Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/helloworld.war"));
         }
     }
 

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheProviderInAppTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheProviderInAppTest.java
@@ -36,6 +36,7 @@ import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
@@ -45,7 +46,7 @@ import componenttest.topology.impl.LibertyServer;
  * can load and is not regressed by our JCache feature.
  */
 @SkipIfSysProp("skip.tests=true")
-@SkipForRepeat(JakartaEE9Action.ID) // No value gained
+@SkipForRepeat({ JakartaEE9Action.ID, JakartaEE10Action.ID }) // No value gained
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class JCacheProviderInAppTest extends BaseTestCase {

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheSamlAuthenticationCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheSamlAuthenticationCacheTest.java
@@ -51,6 +51,7 @@ import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import io.openliberty.jcache.internal.fat.docker.KeycloakContainer;
@@ -93,6 +94,9 @@ public class JCacheSamlAuthenticationCacheTest extends BaseTestCase {
         if (JakartaEE9Action.isActive()) {
             JakartaEE9Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/samlclient.war"));
             JakartaEE9Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/samlclient.war"));
+        } else if (JakartaEE10Action.isActive()) {
+            JakartaEE10Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/samlclient.war"));
+            JakartaEE10Action.transformApp(Paths.get(server2.getServerRoot() + "/apps/samlclient.war"));
         }
     }
 

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheSpnegoAuthenticationCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheSpnegoAuthenticationCacheTest.java
@@ -42,6 +42,7 @@ import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import io.openliberty.jcache.internal.fat.testresource.KdcResource;
@@ -114,6 +115,8 @@ public class JCacheSpnegoAuthenticationCacheTest extends BaseTestCase {
          */
         if (JakartaEE9Action.isActive()) {
             JakartaEE9Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/basicauth.war"));
+        } else if (JakartaEE10Action.isActive()) {
+            JakartaEE10Action.transformApp(Paths.get(server1.getServerRoot() + "/apps/basicauth.war"));
         }
     }
 

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/bnd.bnd
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/bnd.bnd
@@ -17,7 +17,8 @@ src: \
 
 fat.project: true
 tested.features: appsecurity-4.0, expressionlanguage-4.0, servlet-5.0, cdi-3.0, pages-3.0, jsonp-2.0, \
-                 restfulwsclient-3.0, concurrent-2.0, restfulws-3.0, sessioncache-1.0
+                 restfulwsclient-3.0, concurrent-2.0, restfulws-3.0, sessioncache-1.0, \
+                 appsecurity-5.0, pages-3.1, restfulws-3.1
 
 # Uncomment to use remote docker host to simulate continuous build behavior.
 #fat.test.use.remote.docker: true

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/fat/src/io/openliberty/jcache/internal/fat/FATSuite.java
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/fat/src/io/openliberty/jcache/internal/fat/FATSuite.java
@@ -25,6 +25,8 @@ import componenttest.containers.TestContainerSuite;
 import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyFileManager;
@@ -62,7 +64,8 @@ public class FATSuite extends TestContainerSuite {
      */
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
-                    .andWith(new JakartaEE9Action());
+                    .andWith(new JakartaEE9Action().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                    .andWith(new JakartaEE10Action());
 
     @ClassRule
     public static InfinispanContainer infinispan = new InfinispanContainer();


### PR DESCRIPTION
Add repeats for fats that test the following features:
- federatedRegistry-1.0
- jwt-1.0
- oauth-2.0
- openidConnectClient-1.0
- openidConnectServer-1.0
- restConnector-2.0
- samlWeb-2.0
- sessionCache-1.0
- socialLogin-1.0
- spnego-1.0
- webBundle-1.0

For: #18722 