### PR TITLE
New message for unhandled exceptions using RestfulWS applications (for MP Metrics)

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/RestMetricsTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/RestMetricsTest.java
@@ -122,7 +122,7 @@ public class RestMetricsTest {
     public static void tearDown() throws Exception {
         if (server != null) {
             server.stopServer("MetricsUnmappedUncheckedException", "MetricsUnmappedCheckedException",
-                              "Fault: Unmapped Checked","SRVE0777E", "SRVE0315E", "CWPMI2005W");
+                              "Fault: Unmapped Checked","SRVE0777E", "SRVE0315E", "CWPMI2005W", "CWPMI2006W");
         }
     }
 

--- a/dev/com.ibm.ws.microprofile.metrics.common/resources/com/ibm/ws/microprofile/metrics/monitor/resources/MonitorMetrics.nlsprops
+++ b/dev/com.ibm.ws.microprofile.metrics.common/resources/com/ibm/ws/microprofile/metrics/monitor/resources/MonitorMetrics.nlsprops
@@ -30,6 +30,6 @@ METRICS_UNHANDLED_JAXRS_EXCEPTION=CWPMI2005W: The MicroProfile Metrics exception
 METRICS_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application experienced an exception that is not handled within the application. The MicroProfile code handles it by logging the exception stack trace and returning a 500 Internal Server Error response.
 METRICS_UNHANDLED_JAXRS_EXCEPTION.useraction=This behavior might be acceptable. To handle the exception differently, add an ExceptionMapper interface that handles the exception and maps it to a different response.
 
-METRICS_UNHANDLED_RESTFULWS_EXCEPTION=CWPMI2006W: The MicroProfile Metrics exception mapper detected and is handling an unhandled exception from the Restful web service application.
+METRICS_UNHANDLED_RESTFULWS_EXCEPTION=CWPMI2006W: The MicroProfile Metrics exception mapper detected and is handling an unhandled exception from the RESTful web service application.
 METRICS_UNHANDLED_RESTFULWS_EXCEPTION.explanation=The RESTful web service based application experienced an exception that is not handled within the application. The MicroProfile code handles it by logging the exception stack trace and returning a 500 Internal Server Error response.
 METRICS_UNHANDLED_RESTFULWS_EXCEPTION.useraction=This behavior might be acceptable. To handle the exception differently, add an ExceptionMapper interface that handles the exception and maps it to a different response.

--- a/dev/com.ibm.ws.microprofile.metrics.common/resources/com/ibm/ws/microprofile/metrics/monitor/resources/MonitorMetrics.nlsprops
+++ b/dev/com.ibm.ws.microprofile.metrics.common/resources/com/ibm/ws/microprofile/metrics/monitor/resources/MonitorMetrics.nlsprops
@@ -29,3 +29,7 @@ FEATURE_UNREGISTERED.useraction=No user action is required.
 METRICS_UNHANDLED_JAXRS_EXCEPTION=CWPMI2005W: The MicroProfile Metrics exception mapper detected and is handling an unhandled exception from the JAX-RS application.
 METRICS_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application experienced an exception that is not handled within the application. The MicroProfile code handles it by logging the exception stack trace and returning a 500 Internal Server Error response.
 METRICS_UNHANDLED_JAXRS_EXCEPTION.useraction=This behavior might be acceptable. To handle the exception differently, add an ExceptionMapper interface that handles the exception and maps it to a different response.
+
+METRICS_UNHANDLED_RESTFULWS_EXCEPTION=CWPMI2006W: The MicroProfile Metrics exception mapper detected and is handling an unhandled exception from the Restful web service application.
+METRICS_UNHANDLED_RESTFULWS_EXCEPTION.explanation=The RESTful web service based application experienced an exception that is not handled within the application. The MicroProfile code handles it by logging the exception stack trace and returning a 500 Internal Server Error response.
+METRICS_UNHANDLED_RESTFULWS_EXCEPTION.useraction=This behavior might be acceptable. To handle the exception differently, add an ExceptionMapper interface that handles the exception and maps it to a different response.

--- a/dev/io.openliberty.microprofile.metrics.internal.5.0_fat_tck/fat/src/io/openliberty/microprofile/metrics50/internal/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.0_fat_tck/fat/src/io/openliberty/microprofile/metrics50/internal/tck/launcher/MetricsTCKLauncher.java
@@ -46,7 +46,7 @@ public class MetricsTCKLauncher {
     @AfterClass
     public static void tearDown() throws Exception {
         // Ignore CWWKZ0131W - In windows, some jars are being locked during the test. Issue #2768
-        server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWWKZ0002E", "CWWKZ0131W", "CWWKW1001W", "CWWKW1002W", "CWPMI2005W");
+        server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWWKZ0002E", "CWWKZ0131W", "CWWKW1001W", "CWWKW1002W", "CWPMI2005W", "CWPMI2006W");
     }
 
     @Test

--- a/dev/io.openliberty.restfulWS.mpMetrics.filter/src/io/openliberty/restfulws/mpmetrics/MetricsRestfulWsEMCallbackImpl.java
+++ b/dev/io.openliberty.restfulWS.mpMetrics.filter/src/io/openliberty/restfulws/mpmetrics/MetricsRestfulWsEMCallbackImpl.java
@@ -96,7 +96,7 @@ public class MetricsRestfulWsEMCallbackImpl implements DefaultExceptionMapperCal
         }
 
         // Todo: update reference to message
-        Tr.warning(tc, "METRICS_UNHANDLED_JAXRS_EXCEPTION", throwable);
+        Tr.warning(tc, "METRICS_UNHANDLED_RESTFULWS_EXCEPTION", throwable);
 
         return Collections.singletonMap(EXCEPTION_KEY, throwable);
     }


### PR DESCRIPTION
Add new unhandled exception for RestfulWS applications and update the MetricsRestfulWsEMCallbackImpl to use this new message.

Fixes #23545

#build
