### PR TITLE
Remove trace enablement, which was still enabled for one of the serve…

### DIFF
--- a/dev/com.ibm.ws.anno_fat/publish/servers/annoFat_server/config/jandexDefaultsAutoExpandTrue_server.xml
+++ b/dev/com.ibm.ws.anno_fat/publish/servers/annoFat_server/config/jandexDefaultsAutoExpandTrue_server.xml
@@ -6,11 +6,11 @@
     <feature>servlet-3.1</feature>
   </featureManager>
 
-  <logging
+<!--  logging
     traceSpecification="*=info=enabled:com.ibm.ws.anno*=finer"
     maxFileSize="20"
     maxFiles="10"
-    traceFormat="BASIC"/>
+    traceFormat="BASIC" -->
 
   <javaPermission
     className="java.util.PropertyPermission"


### PR DESCRIPTION
Test defect.  One of the annotations FAT server configurations had trace enabled.