### PR TITLE
Fix UnrecoverableKeyException when using WS-Security Callback handler on Liberty 22.0.0.8

### DIFF
--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.common.2.3.0/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.common.2.3.0/bnd.overrides
@@ -16,7 +16,7 @@ bVersion=1.0
 WS-TraceGroup: WSS4J
 
 Export-Package: \
- org.apache.ws.security.*;version=2.0.0, \
+ org.apache.ws.security.*;version=1.6.2, \
  org.apache.wss4j.common.*;version=2.3.0
   
 # these should be optional only when resolving jars from wlp/dev


### PR DESCRIPTION
fixes #23410 