### PR TITLE
IgnoreCase for repository methods

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Condition.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Condition.java
@@ -10,34 +10,40 @@
  *******************************************************************************/
 package io.openliberty.data.internal.persistence;
 
+import com.ibm.websphere.ras.annotation.Trivial;
+
+import jakarta.data.exceptions.MappingException;
+
 /**
  */
 enum Condition {
-    BETWEEN(null, 7),
-    CONTAINS(null, 8),
-    EMPTY(" IS EMPTY", 5),
-    ENDS_WITH(null, 8),
-    EQUALS("=", 0),
-    FALSE("=FALSE", 5),
-    GREATER_THAN(">", 11),
-    GREATER_THAN_EQUAL(">=", 16),
-    IN(" IN ", 2),
-    LESS_THAN("<", 8),
-    LESS_THAN_EQUAL("<=", 13),
-    LIKE(null, 4),
-    NOT_EMPTY(" IS NOT EMPTY", 8),
-    NOT_EQUALS("<>", 3),
-    NOT_NULL(" IS NOT NULL", 7),
-    NULL(" IS NULL", 4),
-    STARTS_WITH(null, 10),
-    TRUE("=TRUE", 4);
+    BETWEEN(null, 7, false),
+    CONTAINS(null, 8, true),
+    EMPTY(" IS EMPTY", 5, true),
+    ENDS_WITH(null, 8, false),
+    EQUALS("=", 0, true),
+    FALSE("=FALSE", 5, false),
+    GREATER_THAN(">", 11, false),
+    GREATER_THAN_EQUAL(">=", 16, false),
+    IN(" IN ", 2, false),
+    LESS_THAN("<", 8, false),
+    LESS_THAN_EQUAL("<=", 13, false),
+    LIKE(null, 4, false),
+    NOT_EMPTY(" IS NOT EMPTY", 8, true),
+    NOT_EQUALS("<>", 3, true),
+    NOT_NULL(" IS NOT NULL", 7, false),
+    NULL(" IS NULL", 4, false),
+    STARTS_WITH(null, 10, false),
+    TRUE("=TRUE", 4, false);
 
     final int length;
     final String operator;
+    final boolean supportsCollections;
 
-    Condition(String operator, int length) {
+    Condition(String operator, int length, boolean supportsCollections) {
         this.operator = operator;
         this.length = length;
+        this.supportsCollections = supportsCollections;
     }
 
     Condition negate() {
@@ -69,5 +75,22 @@ enum Condition {
             default:
                 return null;
         }
+    }
+
+    /**
+     * Confirm that collections are supported for this condition,
+     * based on whether case insensitive comparison is requested.
+     *
+     * @param attributeName entity attribute to which the condition is to be applied.
+     * @param ignoreCase    indicates if the condition is to be performed ignoring case.
+     * @throws MappingException with chained UnsupportedOperationException if not supported.
+     */
+    @Trivial
+    void verifyCollectionsSupported(String attributeName, boolean ignoreCase) {
+        if (!supportsCollections || ignoreCase)
+            throw new MappingException(new UnsupportedOperationException("Repository keyword " +
+                                                                         (ignoreCase ? "IgnoreCase" : name()) +
+                                                                         " which is applied to entity property " + attributeName +
+                                                                         " is not supported for collection properties.")); // TODO
     }
 }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/KeysetAwarePageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/KeysetAwarePageImpl.java
@@ -61,7 +61,7 @@ public class KeysetAwarePageImpl<T> implements KeysetAwarePage<T> {
 
         int maxPageSize = this.pagination.size();
         int firstResult = this.pagination.mode() == Pageable.Mode.OFFSET //
-                        ? RepositoryImpl.computeOffset(pagination.page(), maxPageSize) //
+                        ? RepositoryImpl.computeOffset(this.pagination.page(), maxPageSize) //
                         : 0;
 
         EntityManager em = queryInfo.entityInfo.persister.createEntityManager();

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -1031,42 +1031,42 @@ public class DataTestServlet extends FATServlet {
 
         // Not
         assertIterableEquals(List.of("two", "five", "seven"),
-                             primes.findByNameNotIgnoreCaseAndNumberLessThanOrderByNumberAsc("Three", 10)
+                             primes.findByNameIgnoreCaseNotAndNumberLessThanOrderByNumberAsc("Three", 10)
                                              .stream()
                                              .map(p -> p.name)
                                              .collect(Collectors.toList()));
 
         // StartsWith
         assertIterableEquals(List.of("thirteen", "thirty-one", "thirty-seven"),
-                             primes.findByNameStartsWithIgnoreCaseAndNumberLessThanOrderByNumberAsc("Thirt%n", 1000)
+                             primes.findByNameIgnoreCaseStartsWithAndNumberLessThanOrderByNumberAsc("Thirt%n", 1000)
                                              .stream()
                                              .map(p -> p.name)
                                              .collect(Collectors.toList()));
 
         // Like
         assertIterableEquals(List.of("thirteen", "thirty-seven"),
-                             primes.findByNameLikeIgnoreCaseAndNumberLessThanOrderByNumberAsc("Thirt%n", 1000)
+                             primes.findByNameIgnoreCaseLikeAndNumberLessThanOrderByNumberAsc("Thirt%n", 1000)
                                              .stream()
                                              .map(p -> p.name)
                                              .collect(Collectors.toList()));
 
         // Contains
         assertIterableEquals(List.of("twenty-three", "seventeen"),
-                             primes.findByNameContainsIgnoreCaseAndNumberLessThanOrderByNumberDesc("ent%ee", 1000)
+                             primes.findByNameIgnoreCaseContainsAndNumberLessThanOrderByNumberDesc("ent%ee", 1000)
                                              .stream()
                                              .map(p -> p.name)
                                              .collect(Collectors.toList()));
 
         // Between
         assertIterableEquals(List.of("nineteen", "seventeen", "seven"),
-                             primes.findByNameBetweenIgnoreCaseAndNumberLessThanOrderByNumberDesc("Nine", "SEVENTEEN", 50)
+                             primes.findByNameIgnoreCaseBetweenAndNumberLessThanOrderByNumberDesc("Nine", "SEVENTEEN", 50)
                                              .stream()
                                              .map(p -> p.name)
                                              .collect(Collectors.toList()));
 
         // GreaterThan, LessThanEqual
         assertIterableEquals(List.of("XLVII", "XLIII", "XIII", "XI", "VII", "V", "III"),
-                             primes.findByHexGreaterThanIgnoreCaseAndRomanNumeralLessThanEqualIgnoreCaseAndNumberLessThan("2a", "xlvII", 50)
+                             primes.findByHexIgnoreCaseGreaterThanAndRomanNumeralIgnoreCaseLessThanEqualAndNumberLessThan("2a", "xlvII", 50)
                                              .stream()
                                              .map(p -> p.romanNumeral)
                                              .collect(Collectors.toList()));

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -938,6 +938,57 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Specify IgnoreCase on various conditions.
+     */
+    @Test
+    public void testIgnoreCase() {
+        // Equals
+        assertEquals("twenty-nine", primes.findByNameIgnoreCase("Twenty-Nine").name);
+
+        // Not
+        assertIterableEquals(List.of("two", "five", "seven"),
+                             primes.findByNameNotIgnoreCaseAndNumberLessThanOrderByNumberAsc("Three", 10)
+                                             .stream()
+                                             .map(p -> p.name)
+                                             .collect(Collectors.toList()));
+
+        // StartsWith
+        assertIterableEquals(List.of("thirteen", "thirty-one", "thirty-seven"),
+                             primes.findByNameStartsWithIgnoreCaseAndNumberLessThanOrderByNumberAsc("Thirt%n", 1000)
+                                             .stream()
+                                             .map(p -> p.name)
+                                             .collect(Collectors.toList()));
+
+        // Like
+        assertIterableEquals(List.of("thirteen", "thirty-seven"),
+                             primes.findByNameLikeIgnoreCaseAndNumberLessThanOrderByNumberAsc("Thirt%n", 1000)
+                                             .stream()
+                                             .map(p -> p.name)
+                                             .collect(Collectors.toList()));
+
+        // Contains
+        assertIterableEquals(List.of("twenty-three", "seventeen"),
+                             primes.findByNameContainsIgnoreCaseAndNumberLessThanOrderByNumberDesc("ent%ee", 1000)
+                                             .stream()
+                                             .map(p -> p.name)
+                                             .collect(Collectors.toList()));
+
+        // Between
+        assertIterableEquals(List.of("nineteen", "seventeen", "seven"),
+                             primes.findByNameBetweenIgnoreCaseAndNumberLessThanOrderByNumberDesc("Nine", "SEVENTEEN", 50)
+                                             .stream()
+                                             .map(p -> p.name)
+                                             .collect(Collectors.toList()));
+
+        // GreaterThan, LessThanEqual
+        assertIterableEquals(List.of("XLVII", "XLIII", "XIII", "XI", "VII", "V", "III"),
+                             primes.findByHexGreaterThanIgnoreCaseAndRomanNumeralLessThanEqualIgnoreCaseAndNumberLessThan("2a", "xlvII", 50)
+                                             .stream()
+                                             .map(p -> p.romanNumeral)
+                                             .collect(Collectors.toList()));
+    }
+
+    /**
      * Use an entity that inherits from another where both are kept in the same table.
      */
     @Test

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -27,6 +27,7 @@ import jakarta.data.repository.Page;
 import jakarta.data.repository.Pageable;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Sort;
 import jakarta.data.repository.Streamable;
 import jakarta.enterprise.concurrent.Asynchronous;
 
@@ -75,7 +76,15 @@ public interface Primes {
     @OrderBy("number")
     KeysetAwarePage<Prime> findByNumberBetween(long min, long max, Pageable pagination);
 
+    List<Prime> findByNumberBetween(long min, long max, Sort... orderBy);
+
+    KeysetAwarePage<Prime> findByNumberBetweenAndEvenFalse(long min, long max, Pageable pagination);
+
+    Page<Prime> findByNumberBetweenAndSumOfBitsNotNull(long min, long max, Pageable pagination);
+
     KeysetAwarePage<Prime> findByNumberBetweenOrderByEvenDescSumOfBitsDescNumberAsc(long min, long max, Pageable pagination);
+
+    List<Prime> findByNumberBetweenOrderByNameIgnoreCaseDesc(long min, long max);
 
     @OrderBy("number")
     List<Prime> findByNumberInAndRomanNumeralEmpty(List<Long> nums);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -57,19 +57,19 @@ public interface Primes {
     List<Prime> findByEvenTrueAndNumberLessThan(long max);
 
     @OrderBy(value = "romanNumeral", descending = true)
-    List<Prime> findByHexGreaterThanIgnoreCaseAndRomanNumeralLessThanEqualIgnoreCaseAndNumberLessThan(String hexAbove, String maxNumeral, long numBelow);
-
-    List<Prime> findByNameBetweenIgnoreCaseAndNumberLessThanOrderByNumberDesc(String first, String last, long max);
+    List<Prime> findByHexIgnoreCaseGreaterThanAndRomanNumeralIgnoreCaseLessThanEqualAndNumberLessThan(String hexAbove, String maxNumeral, long numBelow);
 
     Prime findByNameIgnoreCase(String name);
 
-    List<Prime> findByNameContainsIgnoreCaseAndNumberLessThanOrderByNumberDesc(String pattern, long max);
+    List<Prime> findByNameIgnoreCaseBetweenAndNumberLessThanOrderByNumberDesc(String first, String last, long max);
 
-    List<Prime> findByNameLikeIgnoreCaseAndNumberLessThanOrderByNumberAsc(String pattern, long max);
+    List<Prime> findByNameIgnoreCaseContainsAndNumberLessThanOrderByNumberDesc(String pattern, long max);
 
-    List<Prime> findByNameNotIgnoreCaseAndNumberLessThanOrderByNumberAsc(String name, long max);
+    List<Prime> findByNameIgnoreCaseLikeAndNumberLessThanOrderByNumberAsc(String pattern, long max);
 
-    List<Prime> findByNameStartsWithIgnoreCaseAndNumberLessThanOrderByNumberAsc(String pattern, long max);
+    List<Prime> findByNameIgnoreCaseNotAndNumberLessThanOrderByNumberAsc(String name, long max);
+
+    List<Prime> findByNameIgnoreCaseStartsWithAndNumberLessThanOrderByNumberAsc(String pattern, long max);
 
     Prime findByNumberBetween(long min, long max);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -55,6 +55,21 @@ public interface Primes {
 
     List<Prime> findByEvenTrueAndNumberLessThan(long max);
 
+    @OrderBy(value = "romanNumeral", descending = true)
+    List<Prime> findByHexGreaterThanIgnoreCaseAndRomanNumeralLessThanEqualIgnoreCaseAndNumberLessThan(String hexAbove, String maxNumeral, long numBelow);
+
+    List<Prime> findByNameBetweenIgnoreCaseAndNumberLessThanOrderByNumberDesc(String first, String last, long max);
+
+    Prime findByNameIgnoreCase(String name);
+
+    List<Prime> findByNameContainsIgnoreCaseAndNumberLessThanOrderByNumberDesc(String pattern, long max);
+
+    List<Prime> findByNameLikeIgnoreCaseAndNumberLessThanOrderByNumberAsc(String pattern, long max);
+
+    List<Prime> findByNameNotIgnoreCaseAndNumberLessThanOrderByNumberAsc(String name, long max);
+
+    List<Prime> findByNameStartsWithIgnoreCaseAndNumberLessThanOrderByNumberAsc(String pattern, long max);
+
     Prime findByNumberBetween(long min, long max);
 
     @OrderBy("number")

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/OrderBy.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/OrderBy.java
@@ -49,6 +49,17 @@ public @interface OrderBy {
     boolean descending() default false;
 
     /**
+     * Indicate whether or not to request case insensitive comparison when
+     * sorting by this attribute.<p>
+     *
+     * The default value of <code>false</code> means that case insensitive
+     * comparison is not requested.<p>
+     *
+     * @return whether or not to request case insensitive comparison.
+     */
+    boolean ignoreCase() default false;
+
+    /**
      * Entity attribute name to sort by.<p>
      *
      * For example, with JPQL for relational databases,<p>

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/Sort.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/Sort.java
@@ -15,23 +15,37 @@ package jakarta.data.repository;
  */
 public class Sort {
     private final boolean asc;
+    private final boolean ignoreCase;
     private final String prop;
 
-    private Sort(boolean ascending, String property) {
+    private Sort(boolean ascending, String property, boolean ignoreCase) {
         asc = ascending;
+        this.ignoreCase = ignoreCase;
         prop = property;
     }
 
     public static Sort asc(String property) {
-        return new Sort(true, property);
+        return new Sort(true, property, false);
+    }
+
+    public static Sort ascIgnoreCase(String property) {
+        return new Sort(true, property, true);
     }
 
     public static Sort desc(String property) {
-        return new Sort(false, property);
+        return new Sort(false, property, false);
     }
 
-    public static Sort of(String property, Direction direction) {
-        return new Sort(direction == Direction.ASC, property);
+    public static Sort descIgnoreCase(String property) {
+        return new Sort(false, property, true);
+    }
+
+    public static Sort of(String property, Direction direction, boolean ignoreCase) {
+        return new Sort(direction == Direction.ASC, property, ignoreCase);
+    }
+
+    public boolean ignoreCase() {
+        return ignoreCase;
     }
 
     public boolean isAscending() {
@@ -48,6 +62,6 @@ public class Sort {
 
     @Override
     public String toString() {
-        return "Sort by " + prop + (asc ? " ASC" : " DESC");
+        return "Sort by " + prop + (asc ? " ASC" : " DESC") + (ignoreCase ? " ignore case" : "");
     }
 }


### PR DESCRIPTION
Experiment with IgnoreCase on repository methods:
- as a keyword within name-pattern conditions
- as a keyword within name-pattern OrderBy
- as an attribute of the `@OrderBy` annotation
- as an attribute of dynamic `Sort`, both when sorts are use on their own as well as with both types of pagination.