### PR TITLE
Update tests for backchannel logout when token endpoint uses providers

### DIFF
--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/MessageConstants.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/MessageConstants.java
@@ -95,6 +95,10 @@ public class MessageConstants extends com.ibm.ws.security.fat.common.MessageCons
     public static final String CWWKS1631I_OIDC_ENDPOINT_SERVICE_ACTIVATED = "CWWKS1631I";
     public static final String CWWKS1633E_USERINFO_UNSUPPORTED_PARAM = "CWWKS1633E";
     public static final String CWWKS1636E_POST_LOGOUT_REDIRECT_MISMATCH = "CWWKS1636E";
+
+    public static final String CWWKS1642E_BACK_CHANNEL_LOGOUT_FAILURE_BUILDING_LOGOUT_TOKEN = "CWWKS1642E";
+    public static final String CWWKS1643E_BACK_CHANNEL_LOGOUT_CANNOT_EXTRACT_CLAIMS = "CWWKS1643E";
+    public static final String CWWKS1646E_BACK_CHANNEL_LOGOUT_ISSUER_MISMATCH = "CWWKS1646E";
     public static final String CWWKS1648E_BACK_CHANNEL_LOGOUT_INVALID_URI = "CWWKS1648E";
     public static final String CWWKS1649E_BACK_CHANNEL_LOGOUT_TIMEOUT = "CWWKS1649E";
 

--- a/dev/com.ibm.ws.security.oidc.server_fat/publish/servers/com.ibm.ws.security.openidconnect.server-1.0_fat/bootstrap.properties
+++ b/dev/com.ibm.ws.security.oidc.server_fat/publish/servers/com.ibm.ws.security.openidconnect.server-1.0_fat/bootstrap.properties
@@ -20,7 +20,8 @@ com.ibm.ws.webcontainer.security.*=all=enabled:\
 com.ibm.oauth.*=all=enabled:\
 com.ibm.wsspi.security.oauth20.*=all=enabled:\
 com.ibm.ws.transport.http=all:\
-org.apache.http.client.*=all
+org.apache.http.client.*=all:\
+io.openliberty.security.*=all
 
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug


### PR DESCRIPTION

The authorization and token endpoints can be invoked using either "providers" or "endpoint" in the url.
ie: https://localhost:8920/oidc/providers/OidcConfigSample/authorize or https://localhost:8920/oidc/endpoint/OidcConfigSample/authorize
The id_token created will use the request uri to generate the issuer: https://localhost:8920/oidc/providers/OidcConfigSample or https://localhost:8920/oidc/endpoint/OidcConfigSample
The end_session endpoint is invoked using endpoint: https://localhost:8920/oidc/endpoint/OidcConfigSample
When back channel logout is enabled, we'll try to build the logout token. As part of that, we'll verify the issuer. The issuer in the id_token can be https://localhost:8920/oidc/providers/OidcConfigSample and
the issuer that we'll try to compare against now will be https://localhost:8920/oidc/endpoint/OidcConfigSample - since the back channel logout will construct the issuer to validate against using the url that was used to invoke end_session.
The logout process will record an ffdc for the issuer mismatch, but the logout will proceed.

Updating the fat to allow the ffdc/error messages

