### PR TITLE
Increase the jwks read timeout to deal with slower machines

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/utils/Constants.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/utils/Constants.java
@@ -48,6 +48,8 @@ public class Constants extends com.ibm.ws.security.fat.common.Constants {
 
     public static final String USERINFOENDPOINT = "userinfoEndpoint";
     public static final String IDTOKENSIGNINGALGORITHMSSUPPORTED = "idTokenSigningAlgorithmsSupported";
+    public static final String JWKSCONNECTTIMEOUTEXPRESSION = "jwksConnectTimeoutExpression";
+    public static final String JWKSREADTIMEOUTEXPRESSION = "jwksReadTimeoutExpression";
 
     public static final String EMPTY_VALUE = "EmptyValue";
     public static final String NULL_VALUE = "NullValue";
@@ -73,6 +75,7 @@ public class Constants extends com.ibm.ws.security.fat.common.Constants {
     public static final String PAGE_DISPLAY = "page";
 
     public static final int DEFAULT_JWKS_CONN_TIMEOUT = 500;
+    public static final int OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT = 60000;
     public static final int TOKEN_MIN_VALIDITY = 10 * 1000;
 
     public static final String OPEN_LIBERTY = "Open Liberty";

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/utils/Constants.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/utils/Constants.java
@@ -75,7 +75,7 @@ public class Constants extends com.ibm.ws.security.fat.common.Constants {
     public static final String PAGE_DISPLAY = "page";
 
     public static final int DEFAULT_JWKS_CONN_TIMEOUT = 500;
-    public static final int OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT = 60000;
+    public static final int OVERRIDE_DEFAULT_JWKS_READ_TIMEOUT = 60000;
     public static final int TOKEN_MIN_VALIDITY = 10 * 1000;
 
     public static final String OPEN_LIBERTY = "Open Liberty";

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/BaseOpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/BaseOpenIdConfig.java
@@ -200,9 +200,9 @@ public class BaseOpenIdConfig extends MinimumBaseOpenIdConfig {
 
     public int getJwksConnectTimeoutExpression() {
 
-        int value = 500;
+        int value = Constants.DEFAULT_JWKS_CONN_TIMEOUT;
         if (config.containsKey(Constants.JWKSCONNECTTIMEOUTEXPRESSION)) {
-            value = getIntValue(Constants.JWKSCONNECTTIMEOUTEXPRESSION, 500);
+            value = getIntValue(Constants.JWKSCONNECTTIMEOUTEXPRESSION, Constants.DEFAULT_JWKS_CONN_TIMEOUT);
         }
 
         return value;
@@ -212,9 +212,9 @@ public class BaseOpenIdConfig extends MinimumBaseOpenIdConfig {
     public int getJwksReadTimeoutExpression() {
 
 //        int value = 500;
-        int value = Constants.OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT;
+        int value = Constants.OVERRIDE_DEFAULT_JWKS_READ_TIMEOUT;
         if (config.containsKey(Constants.JWKSREADTIMEOUTEXPRESSION)) {
-            value = getIntValue(Constants.JWKSREADTIMEOUTEXPRESSION, 500);
+            value = getIntValue(Constants.JWKSREADTIMEOUTEXPRESSION, Constants.OVERRIDE_DEFAULT_JWKS_READ_TIMEOUT);
         }
 
         return value;

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/BaseOpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/BaseOpenIdConfig.java
@@ -198,6 +198,29 @@ public class BaseOpenIdConfig extends MinimumBaseOpenIdConfig {
 
     }
 
+    public int getJwksConnectTimeoutExpression() {
+
+        int value = 500;
+        if (config.containsKey(Constants.JWKSCONNECTTIMEOUTEXPRESSION)) {
+            value = getIntValue(Constants.JWKSCONNECTTIMEOUTEXPRESSION, 500);
+        }
+
+        return value;
+
+    }
+
+    public int getJwksReadTimeoutExpression() {
+
+//        int value = 500;
+        int value = Constants.OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT;
+        if (config.containsKey(Constants.JWKSREADTIMEOUTEXPRESSION)) {
+            value = getIntValue(Constants.JWKSREADTIMEOUTEXPRESSION, 500);
+        }
+
+        return value;
+
+    }
+
     public String getLogoutRedirectURI() {
         System.out.println("in BaseOpenIdConfig - getLogoutRedirectURI");
         String value = "";

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/MinimumBaseOpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/MinimumBaseOpenIdConfig.java
@@ -118,6 +118,22 @@ public class MinimumBaseOpenIdConfig {
 
     }
 
+    public int getIntValue(String key, int defaultValue) {
+        String value = config.getProperty(key);
+        if (value.equals(Constants.EMPTY_VALUE)) {
+            System.out.println("Can't return an empty value for config attribute: " + key + ", but will return the default value.");
+            return defaultValue;
+        } else {
+            if (value.equals(Constants.NULL_VALUE)) {
+                System.out.println("Can't unset the value for config attribute: " + key + ", but will return the default value.");
+                return defaultValue;
+            } else {
+                System.out.println("Setting the value for config attribute: " + key + " to: " + value);
+                return Integer.valueOf(value);
+            }
+        }
+    }
+
     public String getProviderBase() {
 
         String value = "Must be set in openIdConfig.properties before it can be used";;

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/GenericAnnotatedWithConfigInFile.war/src/oidc/client/generic/servlets/GenericOIDCAuthMechanism.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/GenericAnnotatedWithConfigInFile.war/src/oidc/client/generic/servlets/GenericOIDCAuthMechanism.java
@@ -31,6 +31,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          //                                         redirectToOriginalResource = false,
                                          //                                         redirectToOriginalResourceExpression = "${openIdConfig.redirectToOriginalResource}", // overrides specified value
                                          responseType = "${openIdConfig.responseType}",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          providerMetadata = @OpenIdProviderMetadata(authorizationEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/authorize",
                                                                                     tokenEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/token",
                                                                                     userinfoEndpoint = "${openIdConfig.userinfoEndpoint}",

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ClaimsDefinition.war/src/oidc/client/claimsDefinition/servlets/ClaimsDefinitionServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ClaimsDefinition.war/src/oidc/client/claimsDefinition/servlets/ClaimsDefinitionServlet.java
@@ -23,6 +23,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "${openIdConfig.callerNameClaim}",
                                                                               callerGroupsClaim = "${openIdConfig.callerGroupsClaim}"),
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          redirectURI = "${baseURL}/Callback")
 @DeclareRoles("group2")
 @ServletSecurity(@HttpConstraint(rolesAllowed = "group2"))

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ClaimsDefinitionNoRole.war/src/oidc/client/claimsDefinitionNoRole/servlets/ClaimsDefinitionNoRoleServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ClaimsDefinitionNoRole.war/src/oidc/client/claimsDefinitionNoRole/servlets/ClaimsDefinitionNoRoleServlet.java
@@ -20,6 +20,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "${openIdConfig.callerNameClaim}",
                                                                               callerGroupsClaim = "${openIdConfig.callerGroupsClaim}"),
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          redirectURI = "${baseURL}/Callback")
 
 public class ClaimsDefinitionNoRoleServlet extends BaseServlet {

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/MaximumAnnotation.war/src/oidc/client/maximumAnnotation/servlets/MaximumAnnotationServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/MaximumAnnotation.war/src/oidc/client/maximumAnnotation/servlets/MaximumAnnotationServlet.java
@@ -46,7 +46,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          extraParameters = {},
                                          extraParametersExpression = "",
                                          jwksConnectTimeout = Constants.DEFAULT_JWKS_CONN_TIMEOUT,
-                                         jwksReadTimeoutExpression = "",
+                                         jwksReadTimeout = Constants.OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT,
                                          tokenAutoRefresh = false,
                                          tokenAutoRefreshExpression = "",
                                          tokenMinValidity = Constants.TOKEN_MIN_VALIDITY,

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/MaximumAnnotation.war/src/oidc/client/maximumAnnotation/servlets/MaximumAnnotationServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/MaximumAnnotation.war/src/oidc/client/maximumAnnotation/servlets/MaximumAnnotationServlet.java
@@ -46,7 +46,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          extraParameters = {},
                                          extraParametersExpression = "",
                                          jwksConnectTimeout = Constants.DEFAULT_JWKS_CONN_TIMEOUT,
-                                         jwksReadTimeout = Constants.OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT,
+                                         jwksReadTimeout = Constants.OVERRIDE_DEFAULT_JWKS_READ_TIMEOUT,
                                          tokenAutoRefresh = false,
                                          tokenAutoRefreshExpression = "",
                                          tokenMinValidity = Constants.TOKEN_MIN_VALIDITY,

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/MaximumAnnotationUsingEL.war/src/oidc/client/maximumAnnotationUsingEL/servlets/MaximumAnnotationUsingELServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/MaximumAnnotationUsingEL.war/src/oidc/client/maximumAnnotationUsingEL/servlets/MaximumAnnotationUsingELServlet.java
@@ -49,7 +49,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          extraParameters = {},
                                          extraParametersExpression = "",
                                          jwksConnectTimeout = Constants.DEFAULT_JWKS_CONN_TIMEOUT,
-                                         jwksReadTimeoutExpression = "",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          tokenAutoRefresh = false,
                                          tokenAutoRefreshExpression = "",
                                          tokenMinValidity = Constants.TOKEN_MIN_VALIDITY,

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/MinimumAnnotation.war/src/oidc/client/minimumAnnotation/servlets/MinimumAnnotationServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/MinimumAnnotation.war/src/oidc/client/minimumAnnotation/servlets/MinimumAnnotationServlet.java
@@ -25,7 +25,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          clientId = "client_1",
                                          clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
-                                         jwksReadTimeout = Constants.OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT,
+                                         jwksReadTimeout = Constants.OVERRIDE_DEFAULT_JWKS_READ_TIMEOUT,
                                          redirectURI = "${providerBean.clientSecureRoot}/MinimumAnnotation/Callback")
 @DeclareRoles("all")
 @ServletSecurity(@HttpConstraint(rolesAllowed = "all"))

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/MinimumAnnotation.war/src/oidc/client/minimumAnnotation/servlets/MinimumAnnotationServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/MinimumAnnotation.war/src/oidc/client/minimumAnnotation/servlets/MinimumAnnotationServlet.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package oidc.client.minimumAnnotation.servlets;
 
+import io.openliberty.security.jakartasec.fat.utils.Constants;
 import jakarta.annotation.security.DeclareRoles;
 import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
 import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
@@ -24,6 +25,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          clientId = "client_1",
                                          clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
+                                         jwksReadTimeout = Constants.OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT,
                                          redirectURI = "${providerBean.clientSecureRoot}/MinimumAnnotation/Callback")
 @DeclareRoles("all")
 @ServletSecurity(@HttpConstraint(rolesAllowed = "all"))

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/NoProviderURIInAnnotationWithProviderMetadata.war/src/oidc/client/noProviderURIInAnnotationWithProviderMetadata/servlets/NoProviderURIInAnnotationWithProviderMetadataServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/NoProviderURIInAnnotationWithProviderMetadata.war/src/oidc/client/noProviderURIInAnnotationWithProviderMetadata/servlets/NoProviderURIInAnnotationWithProviderMetadataServlet.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package oidc.client.noProviderURIInAnnotationWithProviderMetadata.servlets;
 
+import io.openliberty.security.jakartasec.fat.utils.Constants;
 import jakarta.annotation.security.DeclareRoles;
 import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
 import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
@@ -25,6 +26,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
                                          redirectURI = "${providerBean.clientSecureRoot}/NoProviderURIInAnnotationWithProviderMetadata/Callback",
+                                         jwksReadTimeout = Constants.OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT,
                                          providerMetadata = @OpenIdProviderMetadata(authorizationEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/authorize",
                                                                                     tokenEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/token",
                                                                                     issuer = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1",

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/NoProviderURIInAnnotationWithProviderMetadata.war/src/oidc/client/noProviderURIInAnnotationWithProviderMetadata/servlets/NoProviderURIInAnnotationWithProviderMetadataServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/NoProviderURIInAnnotationWithProviderMetadata.war/src/oidc/client/noProviderURIInAnnotationWithProviderMetadata/servlets/NoProviderURIInAnnotationWithProviderMetadataServlet.java
@@ -26,7 +26,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
                                          redirectURI = "${providerBean.clientSecureRoot}/NoProviderURIInAnnotationWithProviderMetadata/Callback",
-                                         jwksReadTimeout = Constants.OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT,
+                                         jwksReadTimeout = Constants.OVERRIDE_DEFAULT_JWKS_READ_TIMEOUT,
                                          providerMetadata = @OpenIdProviderMetadata(authorizationEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/authorize",
                                                                                     tokenEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/token",
                                                                                     issuer = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1",

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/NoProviderURIInAnnotationWithoutProviderMetadata.war/src/oidc/client/noProviderURIInAnnotationWithoutProviderMetadata/servlets/NoProviderURIInAnnotationWithoutProviderMetadataServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/NoProviderURIInAnnotationWithoutProviderMetadata.war/src/oidc/client/noProviderURIInAnnotationWithoutProviderMetadata/servlets/NoProviderURIInAnnotationWithoutProviderMetadataServlet.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package oidc.client.noProviderURIInAnnotationWithoutProviderMetadata.servlets;
 
+import io.openliberty.security.jakartasec.fat.utils.Constants;
 import jakarta.annotation.security.DeclareRoles;
 import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
 import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
@@ -23,6 +24,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          clientId = "client_1",
                                          clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
                                          redirectURI = "${providerBean.clientSecureRoot}/NoProviderURIInAnnotationWithoutProviderMetadata/Callback",
+                                         jwksReadTimeout = Constants.OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT,
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"))
 @DeclareRoles("all")
 @ServletSecurity(@HttpConstraint(rolesAllowed = "all"))

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/NoProviderURIInAnnotationWithoutProviderMetadata.war/src/oidc/client/noProviderURIInAnnotationWithoutProviderMetadata/servlets/NoProviderURIInAnnotationWithoutProviderMetadataServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/NoProviderURIInAnnotationWithoutProviderMetadata.war/src/oidc/client/noProviderURIInAnnotationWithoutProviderMetadata/servlets/NoProviderURIInAnnotationWithoutProviderMetadataServlet.java
@@ -24,7 +24,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          clientId = "client_1",
                                          clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
                                          redirectURI = "${providerBean.clientSecureRoot}/NoProviderURIInAnnotationWithoutProviderMetadata/Callback",
-                                         jwksReadTimeout = Constants.OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT,
+                                         jwksReadTimeout = Constants.OVERRIDE_DEFAULT_JWKS_READ_TIMEOUT,
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"))
 @DeclareRoles("all")
 @ServletSecurity(@HttpConstraint(rolesAllowed = "all"))

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/OnlyProviderInAnnotation.war/src/oidc/client/onlyProvider/servlets/OnlyProviderInAnnotationServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/OnlyProviderInAnnotation.war/src/oidc/client/onlyProvider/servlets/OnlyProviderInAnnotationServlet.java
@@ -20,7 +20,7 @@ import oidc.client.base.servlets.BaseServlet;
 
 @WebServlet("/OnlyProviderInAnnotationServlet")
 @OpenIdAuthenticationMechanismDefinition(
-                                         providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1", jwksReadTimeout = Constants.OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT)
+                                         providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1", jwksReadTimeout = Constants.OVERRIDE_DEFAULT_JWKS_READ_TIMEOUT)
 // have to include the jwksReadTimeout value to avoid random timeouts - it should not affect what the test is trying to verify
 @DeclareRoles("all")
 @ServletSecurity(@HttpConstraint(rolesAllowed = "all"))

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/OnlyProviderInAnnotation.war/src/oidc/client/onlyProvider/servlets/OnlyProviderInAnnotationServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/OnlyProviderInAnnotation.war/src/oidc/client/onlyProvider/servlets/OnlyProviderInAnnotationServlet.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package oidc.client.onlyProvider.servlets;
 
+import io.openliberty.security.jakartasec.fat.utils.Constants;
 import jakarta.annotation.security.DeclareRoles;
 import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
 import jakarta.servlet.annotation.HttpConstraint;
@@ -19,7 +20,8 @@ import oidc.client.base.servlets.BaseServlet;
 
 @WebServlet("/OnlyProviderInAnnotationServlet")
 @OpenIdAuthenticationMechanismDefinition(
-                                         providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1")
+                                         providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1", jwksReadTimeout = Constants.OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT)
+// have to include the jwksReadTimeout value to avoid random timeouts - it should not affect what the test is trying to verify
 @DeclareRoles("all")
 @ServletSecurity(@HttpConstraint(rolesAllowed = "all"))
 public class OnlyProviderInAnnotationServlet extends BaseServlet {

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseSessionFalse.war/src/oidc/client/useSessionFalse/servlets/UseSessionFalseServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseSessionFalse.war/src/oidc/client/useSessionFalse/servlets/UseSessionFalseServlet.java
@@ -24,6 +24,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
                                          redirectURI = "${baseURL}/Callback",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          useSession = false,
                                          useSessionExpression = "${openIdConfig.useSessionExpression}")
 @DeclareRoles("all")

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseSessionTrue.war/src/oidc/client/useSessionTrue/servlets/UseSessionTrueServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseSessionTrue.war/src/oidc/client/useSessionTrue/servlets/UseSessionTrueServlet.java
@@ -24,6 +24,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
                                          redirectURI = "${baseURL}/Callback",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          useSession = true,
                                          useSessionExpression = "#{openIdConfig.useSessionExpression}")
 @DeclareRoles("all")

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/test-applications/BasicLogout.war/src/oidc/client/basicLogout/servlets/BasicLogoutServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/test-applications/BasicLogout.war/src/oidc/client/basicLogout/servlets/BasicLogoutServlet.java
@@ -26,6 +26,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "${openIdConfig.callerNameClaim}",
                                                                               callerGroupsClaim = "${openIdConfig.callerGroupsClaim}"),
                                          redirectURI = "${baseURL}/Callback",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          tokenMinValidity = 0, // tokens used with these tests have very short lifetimes so the test cases don't have to sleep too long - keep this small to allow such short lifetimes
                                          promptExpression = "${openIdConfig.promptExpression}",
                                          logout = @LogoutDefinition(notifyProviderExpression = "${openIdConfig.notifyProviderExpression}",

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.refresh/test-applications/BasicRefresh.war/src/oidc/client/basicRefresh/servlets/BasicRefreshServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.refresh/test-applications/BasicRefresh.war/src/oidc/client/basicRefresh/servlets/BasicRefreshServlet.java
@@ -28,6 +28,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "${openIdConfig.callerNameClaim}",
                                                                               callerGroupsClaim = "${openIdConfig.callerGroupsClaim}"),
                                          redirectURI = "${baseURL}/Callback",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          tokenMinValidity = 0, // tokens used with these tests have very short lifetimes so the test cases don't have to sleep too long - keep this small to allow such short lifetimes
                                          promptExpression = "${openIdConfig.promptExpression}",
                                          tokenAutoRefreshExpression = "${openIdConfig.tokenAutoRefreshExpression}",

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/ApplicationScoped.war/src/oidc/client/applicationScoped/servlets/ApplicationScopedServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/ApplicationScoped.war/src/oidc/client/applicationScoped/servlets/ApplicationScopedServlet.java
@@ -25,6 +25,7 @@ import oidc.client.base.servlets.BaseServlet;
 @OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1", clientId = "${openIdConfig.clientId}",
                                          clientSecret = "${openIdConfig.clientSecret}",
                                          redirectURI = "${baseURL}/Callback",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "${openIdConfig.callerNameClaim}",
                                                                               callerGroupsClaim = "${openIdConfig.callerGroupsClaim}"),
                                          providerMetadata = @OpenIdProviderMetadata(authorizationEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/authorize",

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/MultipleServletsDifferentProviders.war/src/oidc/client/differentProviders/servlets/Provider1Servlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/MultipleServletsDifferentProviders.war/src/oidc/client/differentProviders/servlets/Provider1Servlet.java
@@ -24,6 +24,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
                                          redirectURI = "${baseURL}/Callback",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          providerMetadata = @OpenIdProviderMetadata(authorizationEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/authorize",
                                                                                     tokenEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/token"))
 @DeclareRoles("all")

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/MultipleServletsDifferentProviders.war/src/oidc/client/differentProviders/servlets/Provider2Servlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/MultipleServletsDifferentProviders.war/src/oidc/client/differentProviders/servlets/Provider2Servlet.java
@@ -24,6 +24,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
                                          redirectURI = "${baseURL}/Callback",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          providerMetadata = @OpenIdProviderMetadata(authorizationEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP2/authorize",
                                                                                     tokenEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP2/token"))
 @DeclareRoles("all")

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/MultipleServletsDifferentRoles.war/src/oidc/client/differentRoles/servlets/Group1Servlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/MultipleServletsDifferentRoles.war/src/oidc/client/differentRoles/servlets/Group1Servlet.java
@@ -24,6 +24,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
                                          redirectURI = "${baseURL}/Callback",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          providerMetadata = @OpenIdProviderMetadata(authorizationEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/authorize",
                                                                                     tokenEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/token"))
 @DeclareRoles("group1")

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/MultipleServletsDifferentRoles.war/src/oidc/client/differentRoles/servlets/Group2Servlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/MultipleServletsDifferentRoles.war/src/oidc/client/differentRoles/servlets/Group2Servlet.java
@@ -24,6 +24,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
                                          redirectURI = "${baseURL}/Callback",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          providerMetadata = @OpenIdProviderMetadata(authorizationEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/authorize",
                                                                                     tokenEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/token"))
 @DeclareRoles("group2")

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/MultipleServletsSimilarAnnotations.war/src/oidc/client/similarAnnotations/servlets/OidcAnnotatedServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/MultipleServletsSimilarAnnotations.war/src/oidc/client/similarAnnotations/servlets/OidcAnnotatedServlet.java
@@ -25,7 +25,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
                                          redirectURI = "${baseURL}/Callback",
-                                         jwksReadTimeout = Constants.OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT,
+                                         jwksReadTimeout = Constants.OVERRIDE_DEFAULT_JWKS_READ_TIMEOUT,
                                          providerMetadata = @OpenIdProviderMetadata(authorizationEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/authorize",
                                                                                     tokenEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/token"))
 @DeclareRoles("all")

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/MultipleServletsSimilarAnnotations.war/src/oidc/client/similarAnnotations/servlets/OidcAnnotatedServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/MultipleServletsSimilarAnnotations.war/src/oidc/client/similarAnnotations/servlets/OidcAnnotatedServlet.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package oidc.client.similarAnnotations.servlets;
 
+import io.openliberty.security.jakartasec.fat.utils.Constants;
 import jakarta.annotation.security.DeclareRoles;
 import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
 import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
@@ -24,6 +25,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
                                          redirectURI = "${baseURL}/Callback",
+                                         jwksReadTimeout = Constants.OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT,
                                          providerMetadata = @OpenIdProviderMetadata(authorizationEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/authorize",
                                                                                     tokenEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/token"))
 @DeclareRoles("all")

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/MultipleServletsSimilarAnnotations.war/src/oidc/client/similarAnnotations/servlets/OidcAnnotatedServletWithEL.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/MultipleServletsSimilarAnnotations.war/src/oidc/client/similarAnnotations/servlets/OidcAnnotatedServletWithEL.java
@@ -25,6 +25,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "${openIdConfig.callerNameClaim}",
                                                                               callerGroupsClaim = "${openIdConfig.callerGroupsClaim}"),
                                          redirectURI = "${baseURL}/Callback",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          providerMetadata = @OpenIdProviderMetadata(authorizationEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/authorize",
                                                                                     tokenEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/token"))
 @DeclareRoles("all")

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/RequestScoped.war/src/oidc/client/requestScoped/servlets/RequestScopedServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/RequestScoped.war/src/oidc/client/requestScoped/servlets/RequestScopedServlet.java
@@ -25,6 +25,7 @@ import oidc.client.base.servlets.BaseServlet;
 @OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1", clientId = "${openIdConfig.clientId}",
                                          clientSecret = "${openIdConfig.clientSecret}",
                                          redirectURI = "${baseURL}/Callback",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "${openIdConfig.callerNameClaim}",
                                                                               callerGroupsClaim = "${openIdConfig.callerGroupsClaim}"),
                                          providerMetadata = @OpenIdProviderMetadata(authorizationEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/authorize",

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/SessionScoped.war/src/oidc/client/sessionScoped/servlets/SessionScopedServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/SessionScoped.war/src/oidc/client/sessionScoped/servlets/SessionScopedServlet.java
@@ -25,6 +25,7 @@ import oidc.client.base.servlets.BaseServlet;
 @OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1", clientId = "${openIdConfig.clientId}",
                                          clientSecret = "${openIdConfig.clientSecret}",
                                          redirectURI = "${baseURL}/Callback",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "${openIdConfig.callerNameClaim}",
                                                                               callerGroupsClaim = "${openIdConfig.callerGroupsClaim}"),
                                          providerMetadata = @OpenIdProviderMetadata(authorizationEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/authorize",

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/SimplestAnnotated.war/src/oidc/client/servlets/OidcAnnotatedServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/SimplestAnnotated.war/src/oidc/client/servlets/OidcAnnotatedServlet.java
@@ -27,7 +27,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
                                          useSession = false,
                                          redirectURI = "https://localhost:8940/SimplestAnnotated/Callback",
-                                         jwksReadTimeout = Constants.OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT,
+                                         jwksReadTimeout = Constants.OVERRIDE_DEFAULT_JWKS_READ_TIMEOUT,
                                          providerMetadata = @OpenIdProviderMetadata(authorizationEndpoint = "https://localhost:8920/oidc/endpoint/OP1/authorize",
                                                                                     tokenEndpoint = "https://localhost:8920/oidc/endpoint/OP1/token"))
 @DeclareRoles("all")

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/SimplestAnnotated.war/src/oidc/client/servlets/OidcAnnotatedServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/SimplestAnnotated.war/src/oidc/client/servlets/OidcAnnotatedServlet.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package oidc.client.servlets;
 
+import io.openliberty.security.jakartasec.fat.utils.Constants;
 import jakarta.annotation.security.DeclareRoles;
 import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
 import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
@@ -26,6 +27,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
                                          useSession = false,
                                          redirectURI = "https://localhost:8940/SimplestAnnotated/Callback",
+                                         jwksReadTimeout = Constants.OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT,
                                          providerMetadata = @OpenIdProviderMetadata(authorizationEndpoint = "https://localhost:8920/oidc/endpoint/OP1/authorize",
                                                                                     tokenEndpoint = "https://localhost:8920/oidc/endpoint/OP1/token"))
 @DeclareRoles("all")

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/SimplestAnnotatedWithEL.war/src/oidc/client/withEL/servlets/OidcAnnotatedServletWithEL.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/SimplestAnnotatedWithEL.war/src/oidc/client/withEL/servlets/OidcAnnotatedServletWithEL.java
@@ -24,6 +24,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          clientSecret = "${openIdConfig.clientSecret}",
                                          redirectToOriginalResourceExpression = "${openIdConfig.redirectToOriginalResourceExpression}",
                                          redirectURI = "${openIdConfig.redirectURI}",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "${openIdConfig.callerNameClaim}",
                                                                               callerGroupsClaim = "${openIdConfig.callerGroupsClaim}"),
                                          providerMetadata = @OpenIdProviderMetadata(authorizationEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/authorize",

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/SimplestAnnotatedWithELAltOP.war/src/oidc/client/withELAltOP/servlets/OidcAnnotatedServletWithEL.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/SimplestAnnotatedWithELAltOP.war/src/oidc/client/withELAltOP/servlets/OidcAnnotatedServletWithEL.java
@@ -23,6 +23,7 @@ import oidc.client.base.servlets.BaseServlet;
 @OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP2", clientId = "${openIdConfig.clientId}",
                                          clientSecret = "${openIdConfig.clientSecret}",
                                          redirectURI = "${baseURL}/Callback",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          redirectToOriginalResourceExpression = "${openIdConfig.redirectToOriginalResourceExpression}",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "${openIdConfig.callerNameClaim}",
                                                                               callerGroupsClaim = "${openIdConfig.callerGroupsClaim}"),

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/SimplestAnnotatedWithELAltOPAndRole.war/src/oidc/client/withELAltOPAndRole/servlets/OidcAnnotatedServletWithEL.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/SimplestAnnotatedWithELAltOPAndRole.war/src/oidc/client/withELAltOPAndRole/servlets/OidcAnnotatedServletWithEL.java
@@ -23,6 +23,7 @@ import oidc.client.base.servlets.BaseServlet;
 @OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP2", clientId = "${openIdConfig.clientId}",
                                          clientSecret = "${openIdConfig.clientSecret}",
                                          redirectURI = "${baseURL}/Callback",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          redirectToOriginalResourceExpression = "${openIdConfig.redirectToOriginalResourceExpression}",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "${openIdConfig.callerNameClaim}",
                                                                               callerGroupsClaim = "${openIdConfig.callerGroupsClaim}"),

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/SimplestAnnotatedWithELAltRole.war/src/oidc/client/withELAltRole/servlets/OidcAnnotatedServletWithEL.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/SimplestAnnotatedWithELAltRole.war/src/oidc/client/withELAltRole/servlets/OidcAnnotatedServletWithEL.java
@@ -23,6 +23,7 @@ import oidc.client.base.servlets.BaseServlet;
 @OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1", clientId = "${openIdConfig.clientId}",
                                          clientSecret = "${openIdConfig.clientSecret}",
                                          redirectURI = "${baseURL}/Callback",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          redirectToOriginalResourceExpression = "${openIdConfig.redirectToOriginalResourceExpression}",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "${openIdConfig.callerNameClaim}",
                                                                               callerGroupsClaim = "${openIdConfig.callerGroupsClaim}"),


### PR DESCRIPTION
The default jwksReadTimeout value is 500 milliseconds.  We're getting a read timeout with some jdk's and slower machines.

`[12/3/22, 8:42:02:316 PST] 0000002d nliberty.security.jakartasec.identitystore.OidcIdentityStore E CWWKS2504E: The client_1 OpenID Connect client encountered the following error while validating the credential for the authenticated user: io.openliberty.security.oidcclientcore.token.TokenValidationException: CWWKS2415E: The client_1 OpenID Connect client encountered the following error during validation of the token that was received from the OpenID Connect provider: io.openliberty.security.oidcclientcore.exceptions.VerificationKeyException: CWWKS2420E: The client_1 OpenID Connect client encountered the following error while getting the key to verify the identity token from the OpenID Connect provider: CWWKS2422E: The OpenID Connect client failed to read data from the [https://localhost:8920/oidc/endpoint/OP1/jwk] JWK URI of the OpenID Connect provider within 500 milliseconds. Consider updating the jwksReadTimeout property in the OpenID Connect client configuration.`

We'll update the tests to use 1 minute as the default timeout.
We will be adding tests to use 500, 0, 1 and a negative value, but that will be done as part of another work item.

If we need to adjust the jwks read timeout again in the future, we can simply update the value of:
OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT in
io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/utils/Constants.java