### PR TITLE
JAX-WS: SOAP Prefix Null QName in ReadHeadersInterceptor

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/.classpath
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/.classpath
@@ -22,6 +22,7 @@
 	<classpathentry kind="src" path="test-applications/helloClientDDMerge/src"/>
 	<classpathentry kind="src" path="test-applications/helloClientServiceResource/src"/>
 	<classpathentry kind="src" path="test-applications/helloServer/src"/>
+	<classpathentry kind="src" path="test-applications/soapEnvelopePrefix/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/bnd.bnd
@@ -24,6 +24,7 @@ src: \
   test-applications/httpConduitProperties/src,\
   test-applications/pureCXF/src,\
   test-applications/pureCXFWSDLFirst/src,\
+  test-applications/soapEnvelopePrefix/src,\
   test-applications/stubClient/src,\
   test-applications/testBindingTypeWsdlWeb/src,\
   test-applications/testCXFJMXSupport/src,\
@@ -34,6 +35,7 @@ src: \
   test-applications/testWebServiceMonitor/src,\
   test-applications/virtualhost/src,\
   test-applications/webServiceRefFeatures/src
+  
   
 
 fat.project: true

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/FATSuite.java
@@ -39,12 +39,11 @@ import componenttest.rules.repeater.RepeatTests;
                 WebServiceContextTest.class,
                 WebServiceMonitorTest.class,
                 WebServiceRefFeaturesTest.class,
-                WebServiceRefTest.class
+                WebServiceRefTest.class,
+                SoapEnvelopePrefixTest.class
 })
 public class FATSuite {
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly())
-    .andWith(FeatureReplacementAction.EE9_FEATURES().removeFeature("jaxwstest-2.2").addFeature("xmlwstest-3.0").conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
-    .andWith(FeatureReplacementAction.EE10_FEATURES().removeFeature("jaxwstest-2.2").removeFeature("xmlwstest-3.0").addFeature("xmlwstest-4.0"));
+    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(FeatureReplacementAction.EE9_FEATURES().removeFeature("jaxwstest-2.2").addFeature("xmlwstest-3.0").conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11)).andWith(FeatureReplacementAction.EE10_FEATURES().removeFeature("jaxwstest-2.2").removeFeature("xmlwstest-3.0").addFeature("xmlwstest-4.0"));
 }

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/SoapEnvelopePrefixTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/SoapEnvelopePrefixTest.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxws.fat;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.jaxws.test.soapenv.prefix.SoapEnvelopePrefixTestServlet;
+
+import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+/**
+ * Tests the SOAP Envelope default namespace via a FATServlet.
+ * See SoapEnvelopePrefixTestServlet.java for test description
+ * Test reuses LoggingServer and the WSR stub classes, Hello Server endpoint.
+ */
+@RunWith(FATRunner.class)
+@MinimumJavaLevel(javaLevel = 11)
+public class SoapEnvelopePrefixTest extends FATServletClient {
+
+    private static final String APP_NAME = "soapEnvelopePrefix";
+
+    // Reuse LoggingServer
+    @Server("LoggingServer")
+    @TestServlet(servlet = SoapEnvelopePrefixTestServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        WebArchive app = ShrinkHelper.buildDefaultApp(APP_NAME, "com.ibm.ws.jaxws.test.wsr.server",
+                                                      "com.ibm.ws.jaxws.test.wsr.server.impl",
+                                                      "com.ibm.ws.jaxws.test.wsr.server.stub", "com.ibm.ws.jaxws.test.soapenv.prefix");
+
+        ShrinkHelper.exportDropinAppToServer(server, app);
+
+        server.startServer("LoggingServer.log");
+        System.out.println("Starting Server");
+
+        assertNotNull("Application hello does not appear to have started.", server.waitForStringInLog("CWWKZ0001I:.*" + APP_NAME));
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server != null && server.isStarted()) {
+            server.stopServer("CWWKW0056W");
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/test/wsr/server/stub/Hello.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/test/wsr/server/stub/Hello.java
@@ -12,6 +12,8 @@ package com.ibm.ws.jaxws.test.wsr.server.stub;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 /**
@@ -33,12 +35,14 @@ import javax.xml.bind.annotation.XmlType;
  *
  *
  */
+@XmlRootElement(name = "wsmain", namespace = "http://server.wsr.test.jaxws.ws.ibm.com")
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "hello", propOrder = {
                                        "arg0"
 })
 public class Hello {
 
+    @XmlElement(name = "arg0", namespace = "")
     protected String arg0;
 
     /**
@@ -47,7 +51,7 @@ public class Hello {
      * @return
      *         possible object is
      *         {@link String }
-     * 
+     *
      */
     public String getArg0() {
         return arg0;
@@ -59,7 +63,7 @@ public class Hello {
      * @param value
      *                  allowed object is
      *                  {@link String }
-     * 
+     *
      */
     public void setArg0(String value) {
         this.arg0 = value;

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/publish/servers/LoggingServer/server.xml
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/publish/servers/LoggingServer/server.xml
@@ -2,6 +2,8 @@
     <featureManager>
         <feature>jsp-2.2</feature>        
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
+        <feature>componenttest-1.0</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>
@@ -21,6 +23,7 @@
 	<javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
   	<javaPermission className="org.osgi.framework.ServicePermission" name="*" actions="get" />
 	<javaPermission className="org.osgi.framework.AdminPermission" name="*" actions="*" />
+  	<javaPermission className="javax.security.auth.AuthPermission" name="*" actions="getSubject" />
 	
 	<!-- Trace logging and debug are turned on to enable feature logging -->
 	<logging traceSpecification="com.ibm.ws.jaxws.*=debug:org.apache.cxf.ext.logging.*=debug"/>

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/test-applications/soapEnvelopePrefix/src/com/ibm/ws/jaxws/test/soapenv/prefix/SoapEnvelopePrefixTestServlet.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/test-applications/soapEnvelopePrefix/src/com/ibm/ws/jaxws/test/soapenv/prefix/SoapEnvelopePrefixTestServlet.java
@@ -1,0 +1,175 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxws.test.soapenv.prefix;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import javax.servlet.annotation.WebServlet;
+import javax.xml.namespace.QName;
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.ws.Dispatch;
+import javax.xml.ws.Service;
+import javax.xml.ws.soap.SOAPBinding;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+/**
+ * Tests setting the default namespace of a soap envelope to the SOAP 1.1
+ * Envelope namespace on a request. This helps us verify that CXF properly handles valid
+ * and invalid XML for unmarshalling.
+ *
+ * Each test uses the response to verify if the XML contains the expected response or the
+ * expected exception.
+ *
+ */
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/SoapEnvelopePrefixTestServlet")
+public class SoapEnvelopePrefixTestServlet extends FATServlet {
+
+    // Construct a single instance of the dispatch client
+    private static URL WSDL_URL;
+    private static QName qs;
+    private static QName qp;
+    private static Service service;
+    private static Dispatch<StreamSource> dispatch;
+
+    static {
+        try {
+            WSDL_URL = new URL(new StringBuilder().append("http://localhost:").append(Integer.getInteger("bvt.prop.HTTP_default")).append("/soapEnvelopePrefix/PeopleService?wsdl").toString());
+
+            //dispatch client --no need stubs
+            qs = new QName("http://server.wsr.test.jaxws.ws.ibm.com", "PeopleService");
+            qp = new QName("http://server.wsr.test.jaxws.ws.ibm.com", "BillPort");
+
+            service = Service.create(qs);
+            service.addPort(qp, SOAPBinding.SOAP11HTTP_BINDING, WSDL_URL.toString());
+
+            // Uses Service.Mode.MESSAGE to prevent CXF from altering the outbound request Payload
+            // now create a dispatch object from it
+            dispatch = service.createDispatch(qp, StreamSource.class, Service.Mode.MESSAGE);
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // String constants to verify the response messages match what's expected
+    private static final String SOAP11_UNMARSHAL_EXPECTED_EXCEPTION = "unexpected element (uri:\"http://schemas.xmlsoap.org/soap/envelope/\", local:\"arg0";
+    private static final String EXPECTED_PASSING_RESPONSE = "from dispatch World";
+
+    /*
+     * A positive test where the default namespace is set to the SOAP 1.1 Envelope NS, but then redeclares the default namespace
+     * to the " (empty) namespace in a child element making the xml valid.
+     *
+     * Default Envelope Namespace: SOAP 1.1 NS - http://schemas.xmlsoap.org/soap/envelope/
+     *
+     * Valid Element QNames:
+     *
+     * Envelope QName: {http://schemas.xmlsoap.org/soap/envelope/}Envelope
+     * Body QName: {http://schemas.xmlsoap.org/soap/envelope/}Body
+     * hello QName: {http://server.wsr.test.jaxws.ws.ibm.com}hello
+     * arg0 QName: {}arg0
+     */
+    @Test
+    public void testSoap11DefaultPrefixInEnvelopeValidXML() throws Exception {
+
+        String msgString = "<Envelope xmlns=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+                           + "  <Body>\n"
+                           + "    <ser:hello xmlns=\"\" xmlns:ser=\"http://server.wsr.test.jaxws.ws.ibm.com\">\n"
+                           + "       <arg0>from dispatch World</arg0>\n"
+                           + "    </ser:hello>\n"
+                           + "  </Body>\n"
+                           + "</Envelope>";
+
+        if (dispatch == null) {
+            throw new RuntimeException("dispatch  is null!");
+        }
+
+        StreamSource response = dispatch.invoke(new StreamSource(new StringReader(msgString)));
+        String parsedResponse = parseSourceResponse(response);
+        assertTrue("Expected parsed string to contain: " + EXPECTED_PASSING_RESPONSE + " but was actually: " + parsedResponse,
+                   parsedResponse.contains(EXPECTED_PASSING_RESPONSE));
+        //assertNull(notFoundString + " is expected to be in generated schema: " + schemaString, notFoundString);
+    }
+
+    /*
+     * A negative test where the default namespace is set to the SOAP 1.1 Envelope NS.
+     *
+     * Default Envelope Namespace: SOAP 1.1 NS - http://schemas.xmlsoap.org/soap/envelope/
+     *
+     * Valid Element QNames:
+     *
+     * Envelope QName: {http://schemas.xmlsoap.org/soap/envelope/}Envelope
+     * Body QName: {http://schemas.xmlsoap.org/soap/envelope/}Body
+     * hello QName: {http://server.wsr.test.jaxws.ws.ibm.com}hello
+     *
+     * Invalid Element QNames:
+     *
+     * arg0 QName: {http://schemas.xmlsoap.org/soap/envelope/}arg0
+     */
+    @Test
+    public void testSoap11DefaultPrefixInEnvelopeInvalidXML() throws Exception {
+
+        String msgString = "<Envelope xmlns=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+                           + "  <Body>\n"
+                           + "    <ser:hello xmlns:ser=\"http://server.wsr.test.jaxws.ws.ibm.com\">\n"
+                           + "       <arg0>from dispatch World</arg0>\n"
+                           + "    </ser:hello>\n"
+                           + "  </Body>\n"
+                           + "</Envelope>";
+
+        if (dispatch == null) {
+            throw new RuntimeException("dispatch  is null!");
+        }
+
+        try {
+
+            StreamSource response = dispatch.invoke(new StreamSource(new StringReader(msgString)));
+
+        } catch (Exception e) {
+
+            //tring parsedResponse = parseSourceResponse(response);
+            assertTrue("Expected parsed string to contain: " + SOAP11_UNMARSHAL_EXPECTED_EXCEPTION + " but was actually: " + e.toString(),
+                       e.toString().contains(SOAP11_UNMARSHAL_EXPECTED_EXCEPTION));
+        }
+
+        //assertNull(notFoundString + " is expected to be in generated schema: " + schemaString, notFoundString);
+    }
+
+    /*
+     * Method for parsing response from StreamSource to a String
+     */
+    private String parseSourceResponse(Source response) {
+        try {
+            StringWriter writer = new StringWriter();
+            StreamResult result = new StreamResult(writer);
+            TransformerFactory tFactory = TransformerFactory.newInstance();
+            Transformer transformer = tFactory.newTransformer();
+            transformer.transform(response, result);
+            String strResult = writer.toString();
+            return strResult;
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
This pull request handles a failure when the SOAP envelope is using a default namespace, and is not decorated with a prefix. Such a message will generate the following failure:

```
javax.xml.ws.soap.SOAPFaultException: local part cannot be "null" when creating a QName
at org.apache.cxf.jaxws.JaxWsClientProxy.mapException(JaxWsClientProxy.java:195)
at org.apache.cxf.jaxws.JaxWsClientProxy.invoke(JaxWsClientProxy.java:145)
at com.sun.proxy.$Proxy56.wsmain(Unknown Source)
at web.test.TestServlet.doGet(TestServlet.java:96)
at javax.servlet.http.HttpServlet.service(HttpServlet.java:687)
at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)

```
Also included in this PR is a new fat test: SoapEnvelopePrefixTest.  

Fixes #23419 