### PR TITLE
Jakarta Security 3.0: Misc ID token/UserInfo validation enhancements

### DIFF
--- a/dev/io.openliberty.security.common.jwt/resources/io/openliberty/security/common/jwt/internal/resources/SecurityCommonJwtMessages.nlsprops
+++ b/dev/io.openliberty.security.common.jwt/resources/io/openliberty/security/common/jwt/internal/resources/SecurityCommonJwtMessages.nlsprops
@@ -15,5 +15,12 @@
 #NLS_MESSAGEFORMAT_VAR
 #NLS_ENCODING=UNICODE
 # -------------------------------------------------------------------------------------------------
-# Message prefix block: TODO
+# Message prefix block: CWWKS2520 - CWWKS2549
 
+EXPECTED_SIG_ALG_DOES_NOT_MATCH_HEADER=CWWKS2520E: The {0} signature algorithm in the JWT header does not match the {1} expected signature algorithm.
+EXPECTED_SIG_ALG_DOES_NOT_MATCH_HEADER.explanation=The token must be signed with the algorithm that is specified in the message.
+EXPECTED_SIG_ALG_DOES_NOT_MATCH_HEADER.useraction=Ensure the token is signed with the expected algorithm, or update the configuration for the component that receives the token to use the algorithm that is specified in the message.
+
+SIG_ALG_IN_HEADER_NOT_ALLOWED=CWWKS2521E: The {0} signature algorithm in the JWT header is not one of the allowed signature algorithms: {1}.
+SIG_ALG_IN_HEADER_NOT_ALLOWED.explanation=The token must be signed with one of the algorithms that is specified in the message.
+SIG_ALG_IN_HEADER_NOT_ALLOWED.useraction=Ensure the token is signed with one of the allowed algorithms, or update the configuration for the component that receives the token to allow the algorithm that is specified in the message.

--- a/dev/io.openliberty.security.common.jwt/src/io/openliberty/security/common/jwt/exceptions/SignatureAlgorithmNotInAllowedList.java
+++ b/dev/io.openliberty.security.common.jwt/src/io/openliberty/security/common/jwt/exceptions/SignatureAlgorithmNotInAllowedList.java
@@ -10,26 +10,29 @@
  *******************************************************************************/
 package io.openliberty.security.common.jwt.exceptions;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 
-public class SignatureAlgorithmDoesNotMatchHeaderException extends Exception {
+public class SignatureAlgorithmNotInAllowedList extends Exception {
 
-    private static final TraceComponent tc = Tr.register(SignatureAlgorithmDoesNotMatchHeaderException.class);
+    private static final TraceComponent tc = Tr.register(SignatureAlgorithmNotInAllowedList.class);
 
-    private static final long serialVersionUID = -4376636239462726717L;
+    private static final long serialVersionUID = 5850783893619480595L;
 
-    private final String signatureAlgorithm;
     private final String sigAlgInHeader;
+    private final List<String> signatureAlgorithmsAllowed;
 
-    public SignatureAlgorithmDoesNotMatchHeaderException(String signatureAlgorithm, String sigAlgInHeader) {
-        this.signatureAlgorithm = signatureAlgorithm;
+    public SignatureAlgorithmNotInAllowedList(String sigAlgInHeader, List<String> signatureAlgorithmsAllowed) {
         this.sigAlgInHeader = sigAlgInHeader;
+        this.signatureAlgorithmsAllowed = new ArrayList<>(signatureAlgorithmsAllowed);
     }
 
     @Override
     public String getMessage() {
-        return Tr.formatMessage(tc, "EXPECTED_SIG_ALG_DOES_NOT_MATCH_HEADER", sigAlgInHeader, signatureAlgorithm);
+        return Tr.formatMessage(tc, "SIG_ALG_IN_HEADER_NOT_ALLOWED", sigAlgInHeader, signatureAlgorithmsAllowed);
     }
 
 }

--- a/dev/io.openliberty.security.common.jwt/src/io/openliberty/security/common/jwt/exceptions/package-info.java
+++ b/dev/io.openliberty.security.common.jwt/src/io/openliberty/security/common/jwt/exceptions/package-info.java
@@ -6,10 +6,15 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 /**
  * @version 1.0.0
  */
 @org.osgi.annotation.versioning.Version("1.0.0")
+@TraceOptions(traceGroup = TraceConstants.TRACE_GROUP, messageBundle = TraceConstants.MESSAGE_BUNDLE)
 package io.openliberty.security.common.jwt.exceptions;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;
+
+import io.openliberty.security.common.jwt.TraceConstants;

--- a/dev/io.openliberty.security.common.jwt/src/io/openliberty/security/common/jwt/package-info.java
+++ b/dev/io.openliberty.security.common.jwt/src/io/openliberty/security/common/jwt/package-info.java
@@ -6,10 +6,13 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 /**
  * @version 1.0.0
  */
 @org.osgi.annotation.versioning.Version("1.0.0")
+@TraceOptions(traceGroup = TraceConstants.TRACE_GROUP, messageBundle = TraceConstants.MESSAGE_BUNDLE)
 package io.openliberty.security.common.jwt;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationUserInfoTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationUserInfoTests.java
@@ -123,6 +123,22 @@ public class ConfigurationUserInfoTests extends CommonAnnotatedSecurityTests {
         }
     }
 
+    public static class skipIfJwtUserInfo extends MySkipRule {
+        @Override
+        public Boolean callSpecificCheck() {
+            String instance = RepeatTestFilter.getRepeatActionsAsString();
+            Log.info(thisClass, "skipIfJwtUserInfo", instance);
+
+            if (instance.contains(Constants.USERINFO_JWT)) {
+                Log.info(thisClass, "skipIfJwtUserInfo", "Test case is using a userinfo endpoint that returns data in JWT format - skip test");
+                testSkipped();
+                return true;
+            }
+            Log.info(thisClass, "skipIfJwtUserInfo", "Test case is using a userinfo endpoint that returns data in JSON format - run test");
+            return false;
+        }
+    }
+
     @BeforeClass
     public static void setUp() throws Exception {
 
@@ -399,6 +415,7 @@ public class ConfigurationUserInfoTests extends CommonAnnotatedSecurityTests {
      *
      * @throws Exception
      */
+    @ConditionalIgnoreRule.ConditionalIgnore(condition = skipIfJwtUserInfo.class)
     @Test
     public void ConfigurationUserInfoTests_defaultNameClaimOtherGroupClaims_UserinfoGoodSubGoodGroups() throws Exception {
 
@@ -450,6 +467,7 @@ public class ConfigurationUserInfoTests extends CommonAnnotatedSecurityTests {
      *
      * @throws Exception
      */
+    @ConditionalIgnoreRule.ConditionalIgnore(condition = skipIfJwtUserInfo.class)
     @Test
     public void ConfigurationUserInfoTests_defaultNameClaimOtherGroupClaims_UserinfoBadSubGoodGroups() throws Exception {
 
@@ -467,6 +485,7 @@ public class ConfigurationUserInfoTests extends CommonAnnotatedSecurityTests {
      *
      * @throws Exception
      */
+    @ConditionalIgnoreRule.ConditionalIgnore(condition = skipIfJwtUserInfo.class)
     @Test
     public void ConfigurationUserInfoTests_otherNameClaimDefaultGroupClaims_UserinfoGoodSubGoodGroups() throws Exception {
 
@@ -486,6 +505,7 @@ public class ConfigurationUserInfoTests extends CommonAnnotatedSecurityTests {
      *
      * @throws Exception
      */
+    @ConditionalIgnoreRule.ConditionalIgnore(condition = skipIfJwtUserInfo.class)
     @Test
     public void ConfigurationUserInfoTests_otherNameClaimDefaultGroupClaims_UserinfoGoodSubBadGroups() throws Exception {
 
@@ -506,6 +526,7 @@ public class ConfigurationUserInfoTests extends CommonAnnotatedSecurityTests {
      *
      * @throws Exception
      */
+    @ConditionalIgnoreRule.ConditionalIgnore(condition = skipIfJwtUserInfo.class)
     @Test
     public void ConfigurationUserInfoTests_otherNameClaimDefaultGroupClaims_UserinfoBadSubGoodGroups() throws Exception {
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
+++ b/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
@@ -115,3 +115,7 @@ JWK_READ_TIMED_OUT.useraction=Update the jwksReadTimeout property in the OpenID 
 OIDC_CLIENT_INVALID_RESPONSE_TYPE=CWWKS2423E: The following invalid response type is specified: ''{0}''. Valid response types are [{1}].
 OIDC_CLIENT_INVALID_RESPONSE_TYPE.explanation=The specified response type is not valid. 
 OIDC_CLIENT_INVALID_RESPONSE_TYPE.useraction=Specify one of the valid response types.
+
+TOKEN_CLAIM_VALUE_MISMATCH=CWWKS2424E: The [{0}] value for the [{1}] claim in the token does not match the [{2}] expected value.
+TOKEN_CLAIM_VALUE_MISMATCH.explanation=The claim value is incorrect or malformed. The configuration for the OpenID Connect client might be incorrect, or the token was created with incorrect values.
+TOKEN_CLAIM_VALUE_MISMATCH.useraction=Ensure the attribute in the OpenID Connect client configuration that is related to the claim that is specified in the message is configured correctly.

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/client/Client.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/client/Client.java
@@ -56,9 +56,7 @@ public class Client {
     }
 
     public JwtClaims validate(TokenResponse tokenResponse, HttpServletRequest request, HttpServletResponse response) throws TokenValidationException {
-        TokenResponseValidator tokenResponseValidator = new TokenResponseValidator(this.oidcClientConfig);
-        tokenResponseValidator.setRequest(request);
-        tokenResponseValidator.setResponse(response);
+        TokenResponseValidator tokenResponseValidator = new TokenResponseValidator(this.oidcClientConfig, request, response);
         return tokenResponseValidator.validate(tokenResponse);
     }
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/jwt/JwtUtils.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/jwt/JwtUtils.java
@@ -43,7 +43,7 @@ public class JwtUtils {
         Key jwtVerificationKey = getJwsVerificationKey(jws, clientConfig);
 
         io.openliberty.security.common.jwt.jws.JwsSignatureVerifier.Builder verifierBuilder = new JwsSignatureVerifier.Builder();
-        JwsSignatureVerifier signatureVerifier = verifierBuilder.key(jwtVerificationKey).signatureAlgorithm(jws.getAlgorithmHeaderValue()).build();
+        JwsSignatureVerifier signatureVerifier = verifierBuilder.key(jwtVerificationKey).signatureAlgorithmsSupported(MetadataUtils.getIdTokenSigningAlgorithmsSupported(clientConfig)).build();
         return signatureVerifier;
     }
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenClaimMismatchException.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenClaimMismatchException.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oidcclientcore.token;
+
+import com.ibm.websphere.ras.Tr;
+
+public class TokenClaimMismatchException extends TokenValidationException {
+
+    private static final long serialVersionUID = 3348448258753761187L;
+
+    public TokenClaimMismatchException(String clientId, String claimValue, String claimName, String expectedClaimValue) {
+        super(clientId, Tr.formatMessage(tc, "TOKEN_CLAIM_VALUE_MISMATCH", claimValue, claimName, expectedClaimValue));
+    }
+
+}

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenResponseValidator.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenResponseValidator.java
@@ -46,12 +46,14 @@ public class TokenResponseValidator {
     public static final TraceComponent tc = Tr.register(TokenResponseValidator.class);
 
     OidcClientConfig clientConfig;
-    private HttpServletRequest request;
-    private HttpServletResponse response;
+    private final HttpServletRequest request;
+    private final HttpServletResponse response;
     private Storage storage;
 
-    public TokenResponseValidator(OidcClientConfig oidcClientConfig) {
+    public TokenResponseValidator(OidcClientConfig oidcClientConfig, HttpServletRequest request, HttpServletResponse response) {
         this.clientConfig = oidcClientConfig;
+        this.request = request;
+        this.response = response;
     }
 
     @FFDCIgnore({ TokenValidationException.class, Exception.class })
@@ -148,20 +150,6 @@ public class TokenResponseValidator {
     public String getStateParameter() {
         return request.getParameter(AuthorizationRequestParameters.STATE);
         //TODO: maybe throw an exception right here if this state is not valid
-    }
-
-    /**
-     * @param request
-     */
-    public void setRequest(HttpServletRequest request) {
-        this.request = request;
-    }
-
-    /**
-     * @param response
-     */
-    public void setResponse(HttpServletResponse response) {
-        this.response = response;
     }
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenValidator.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenValidator.java
@@ -17,9 +17,6 @@ import org.jose4j.jwt.NumericDate;
 
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 
-/**
- *
- */
 public class TokenValidator {
 
     private String issuer;
@@ -34,75 +31,45 @@ public class TokenValidator {
 
     private final long clockSkewInSeconds = 120; // default value in seconds
 
-    /**
-     * @param clientConfig
-     */
     public TokenValidator(OidcClientConfig clientConfig) {
         this.oidcConfig = clientConfig;
     }
 
-    /**
-     * @param issuer
-     * @return
-     */
     public TokenValidator issuer(String issuer) {
         this.issuer = issuer;
         return this;
     }
 
-    /**
-     * @param subject
-     */
     public TokenValidator subject(String subject) {
         this.subject = subject;
         return this;
     }
 
-    /**
-     * @param audience
-     */
     public TokenValidator audiences(List<String> audience) {
         this.audiences = new ArrayList<String>(audience);
         return this;
     }
 
-    /**
-     * @param claimValue
-     */
     public TokenValidator azp(String azp) {
         this.azp = azp;
         return this;
     }
 
-    /**
-     * @param issuedAt
-     */
     public TokenValidator iat(NumericDate iat) {
         this.iat = iat;
         return this;
     }
 
-    /**
-     * @param expirationTime
-     * @return
-     */
     public TokenValidator exp(NumericDate exp) {
         this.exp = exp;
         return this;
     }
 
-    /**
-     * @param notBefore
-     * @return
-     */
     public TokenValidator nbf(NumericDate notBefore) {
         this.notBefore = notBefore;
         return this;
     }
 
-    /**
-     *
-     */
     public void validate() throws TokenValidationException {
         validateIssuer();
         validateSubject();
@@ -114,9 +81,6 @@ public class TokenValidator {
 
     }
 
-    /**
-     *
-     */
     protected void validateNotBefore() throws TokenValidationException {
         if (this.notBefore != null) {
             long now = System.currentTimeMillis();
@@ -126,9 +90,6 @@ public class TokenValidator {
         }
     }
 
-    /**
-     *
-     */
     protected void validateIssuedAt() throws TokenValidationException {
         long now = System.currentTimeMillis();
         if (now + (this.clockSkewInSeconds * 1000) < this.iat.getValueInMillis()) {
@@ -136,10 +97,6 @@ public class TokenValidator {
         }
     }
 
-    /**
-     * @throws TokenValidationException
-     *
-     */
     protected void validateExpiration() throws TokenValidationException {
         long now = System.currentTimeMillis();
         if (now - (this.clockSkewInSeconds * 1000) > this.exp.getValueInMillis()) {
@@ -147,27 +104,20 @@ public class TokenValidator {
         }
     }
 
-    /**
-     *
-     */
     protected void validateAZP() throws TokenValidationException {
         if (this.azp != null) {
             if (!(oidcConfig.getClientId().equals(this.azp))) {
-                throw new TokenValidationException(oidcConfig.getClientId(), "azp is [ " + this.azp + " ], expecting  [ " + oidcConfig.getClientId() + " ]");
+                throw new TokenClaimMismatchException(oidcConfig.getClientId(), azp, "azp", oidcConfig.getClientId());
             }
         }
     }
 
-    /**
-     * @throws TokenValidationException
-     *
-     */
     protected void validateAudiences() throws TokenValidationException {
         if (this.audiences != null && !(this.audiences.isEmpty())) {
             if (this.audiences.size() == 1) {
                 // validate aud claim against client id
                 if (!(oidcConfig.getClientId().equals(this.audiences.get(0)))) {
-                    throw new TokenValidationException(oidcConfig.getClientId(), "audience is [ " + this.audiences.get(0) + " ], expecting [ " + oidcConfig.getClientId() + " ]");
+                    throw new TokenClaimMismatchException(oidcConfig.getClientId(), audiences.get(0), "aud", oidcConfig.getClientId());
                 }
             } else if (this.azp == null) {
                 // if more than one audience, then azp claim is a must
@@ -177,10 +127,6 @@ public class TokenValidator {
         }
     }
 
-    /**
-     * @throws TokenValidationException
-     *
-     */
     protected void validateSubject() throws TokenValidationException {
         if (this.subject != null) {
             if (this.subject.isEmpty()) {
@@ -189,20 +135,12 @@ public class TokenValidator {
         }
     }
 
-    /**
-     * @throws TokenValidationException
-     *
-     */
     protected void validateIssuer() throws TokenValidationException {
         if (!issuerconfigured.equals(this.issuer)) {
-            throw new TokenValidationException(oidcConfig.getClientId(), "issuer is [ " + this.issuer + " ], expecting  [ " + oidcConfig.getProviderMetadata().getIssuer() + " ]");
+            throw new TokenClaimMismatchException(oidcConfig.getClientId(), issuer, "iss", issuerconfigured);
         }
     }
 
-    /**
-     * @param issuerFromDiscovery
-     * @return
-     */
     public TokenValidator issuerconfigured(String issuerFromProviderMetadata) {
         this.issuerconfigured = issuerFromProviderMetadata;
         return this;

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/userinfo/UserInfoRequestor.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/userinfo/UserInfoRequestor.java
@@ -27,6 +27,7 @@ import org.jose4j.jwt.consumer.JwtContext;
 import com.ibm.json.java.JSONObject;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 import io.openliberty.security.common.jwt.JwtParsingUtils;
 import io.openliberty.security.common.jwt.jws.JwsSignatureVerifier;
@@ -64,6 +65,7 @@ public class UserInfoRequestor {
         this.params = new ArrayList<NameValuePair>();
     }
 
+    @FFDCIgnore(Exception.class)
     public UserInfoResponse requestUserInfo() throws UserInfoResponseException {
         if (!userInfoEndpoint.toLowerCase().startsWith(HttpConstants.HTTPS_SCHEME)) {
             throw new UserInfoEndpointNotHttpsException(userInfoEndpoint, oidcClientConfig.getClientId());


### PR DESCRIPTION
- Updates `JwsSignatureVerifier` to set `AlgorithmConstraints` on the `JwtConsumerBuilder` based on either a specified signature algorithm or a list of supported algorithms
- Adds NLS messages for JWT signature validation:
    - `"alg"` header does not match the expected signature algorithm
    - `"alg"` header does not match one of the allowed signature algorithms
- Updates `TokenValidator` to use a new NLS message for when claim values do not match expected values