### PR TITLE
Update dependency part 2

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1902,11 +1902,6 @@
       <version>2.2.3</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.bcel</artifactId>
-      <version>5.2_3</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-common</artifactId>
       <version>2.5.1</version>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -376,7 +376,6 @@ org.apache.myfaces.core:myfaces-impl:4.0.0-RC2
 org.apache.neethi:neethi:3.1.1
 org.apache.openjpa:openjpa:3.1.2
 org.apache.santuario:xmlsec:2.2.3
-org.apache.servicemix.bundles:org.apache.servicemix.bundles.bcel:5.2_3
 org.apache.sshd:sshd-common:2.5.1
 org.apache.sshd:sshd-core:2.5.1
 org.apache.sshd:sshd-scp:2.5.1

--- a/dev/com.ibm.ws.org.apache.servicemix.bundles.bcel/.project
+++ b/dev/com.ibm.ws.org.apache.servicemix.bundles.bcel/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>com.ibm.ws.org.apache.servicemix.bundles.bcel</name>
+	<name>io.openliberty.org.apache.bcel</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/dev/com.ibm.ws.org.apache.servicemix.bundles.bcel/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.servicemix.bundles.bcel/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -8,9 +8,9 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
--include= jar:${fileuri;${repo;org.apache.servicemix.bundles:org.apache.servicemix.bundles.bcel;5.2}}!/META-INF/MANIFEST.MF,bnd.overrides
+-include= jar:${fileuri;${repo;org.apache.bcel:bcel;6.6.1}}!/META-INF/MANIFEST.MF,bnd.overrides
 
 -includeresource: \
-   @${repo;org.apache.servicemix.bundles:org.apache.servicemix.bundles.bcel;5.2}!/!META-INF/maven/*
+   @${repo;org.apache.bcel:bcel;6.6.1}!/!META-INF/maven/*
 
--buildpath: org.apache.servicemix.bundles:org.apache.servicemix.bundles.bcel;version=5.2
+-buildpath: org.apache.bcel:bcel;version=6.6.1

--- a/dev/com.ibm.ws.org.apache.servicemix.bundles.bcel/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.servicemix.bundles.bcel/bnd.overrides
@@ -1,4 +1,17 @@
+#*******************************************************************************
+# Copyright (c) 2017,2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
 -include= ~../cnf/resources/bnd/rejar.props
 bVersion=1.0
 
-Bundle-SymbolicName: com.ibm.ws.org.apache.servicemix.bundles.bcel.5.2
+Bundle-SymbolicName: io.openliberty.org.apache.bcel
+
+Include-Resource: \
+    @${repo;org.apache.bcel:bcel;6.6.1}!/!META-INF/MANIFEST.MF|META-INF/maven/*|META-INF/NOTICE.txt|META-INF/LICENSE.txt


### PR DESCRIPTION
This removes the older version of bcel, which can be integrated once nothing uses it anymore.