### PR TITLE
Disable metrics and logs for MPTelemetry

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/cdi/OpenTelemetryProducer.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/cdi/OpenTelemetryProducer.java
@@ -42,6 +42,10 @@ public class OpenTelemetryProducer {
     private static final String INSTRUMENTATION_NAME = "io.openliberty.microprofile.telemetry";
     private static final String ENV_DISABLE_PROPERTY = "OTEL_SDK_DISABLED";
     private static final String CONFIG_DISABLE_PROPERTY = "otel.sdk.disabled";
+    private static final String ENV_METRICS_EXPORTER_PROPERTY = "OTEL_METRICS_EXPORTER";
+    private static final String CONFIG_METRICS_EXPORTER_PROPERTY = "otel.metrics.exporter";
+    private static final String ENV_LOGS_EXPORTER_PROPERTY = "OTEL_LOGS_EXPORTER";
+    private static final String CONFIG_LOGS_EXPORTER_PROPERTY = "otel.logs.exporter";
 
     @Inject
     Config config;
@@ -127,8 +131,16 @@ public class OpenTelemetryProducer {
         HashMap<String, String> telemetryProperties = new HashMap<>();
         for (String propertyName : config.getPropertyNames()) {
             if (propertyName.startsWith("otel.") || propertyName.startsWith("OTEL_")) {
-                config.getOptionalValue(propertyName, String.class).ifPresent(
-                                                                              value -> telemetryProperties.put(propertyName, value));
+                //Do not set metrics or logs exporter
+                if ((!propertyName.equals(ENV_METRICS_EXPORTER_PROPERTY)) && (!propertyName.equals(CONFIG_METRICS_EXPORTER_PROPERTY))
+                    && (!propertyName.equals(ENV_LOGS_EXPORTER_PROPERTY)) && (!propertyName.equals(CONFIG_LOGS_EXPORTER_PROPERTY))) {
+                    config.getOptionalValue(propertyName, String.class).ifPresent(
+                                                                                  value -> telemetryProperties.put(propertyName, value));
+
+                }
+                //Metrics and logs are disabled by default
+                telemetryProperties.put(CONFIG_METRICS_EXPORTER_PROPERTY, "none");
+                telemetryProperties.put(CONFIG_LOGS_EXPORTER_PROPERTY, "none");
             }
         }
         return telemetryProperties;

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/cdi/OpenTelemetryProducer.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/cdi/OpenTelemetryProducer.java
@@ -64,7 +64,6 @@ public class OpenTelemetryProducer {
         HashMap<String, String> telemetryProperties = getTelemetryProperties();
         //Builds tracer provider if user has enabled tracing aspects with config properties
         if (!checkDisabled(telemetryProperties)) {
-
             OpenTelemetry openTelemetry = AccessController.doPrivileged((PrivilegedAction<OpenTelemetry>) () -> {
                 return AutoConfiguredOpenTelemetrySdk.builder()
                                 .addPropertiesSupplier(() -> telemetryProperties)
@@ -131,19 +130,19 @@ public class OpenTelemetryProducer {
         HashMap<String, String> telemetryProperties = new HashMap<>();
         for (String propertyName : config.getPropertyNames()) {
             if (propertyName.startsWith("otel.") || propertyName.startsWith("OTEL_")) {
-                //Do not set metrics or logs exporter
-                if ((!propertyName.equals(ENV_METRICS_EXPORTER_PROPERTY)) && (!propertyName.equals(CONFIG_METRICS_EXPORTER_PROPERTY))
-                    && (!propertyName.equals(ENV_LOGS_EXPORTER_PROPERTY)) && (!propertyName.equals(CONFIG_LOGS_EXPORTER_PROPERTY))) {
-                    config.getOptionalValue(propertyName, String.class).ifPresent(
-                                                                                  value -> telemetryProperties.put(propertyName, value));
+                config.getOptionalValue(propertyName, String.class).ifPresent(
+                                                                              value -> telemetryProperties.put(propertyName, value));
 
-                }
-                //Metrics and logs are disabled by default
-                telemetryProperties.put(CONFIG_METRICS_EXPORTER_PROPERTY, "none");
-                telemetryProperties.put(CONFIG_LOGS_EXPORTER_PROPERTY, "none");
             }
         }
+        //Metrics and logs are disabled by default
+        telemetryProperties.put(CONFIG_METRICS_EXPORTER_PROPERTY, "none");
+        telemetryProperties.put(CONFIG_LOGS_EXPORTER_PROPERTY, "none");
+        telemetryProperties.put(ENV_METRICS_EXPORTER_PROPERTY, "none");
+        telemetryProperties.put(ENV_LOGS_EXPORTER_PROPERTY, "none");
+
         return telemetryProperties;
+
     }
 
     @Produces

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/Telemetry10.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/Telemetry10.java
@@ -45,7 +45,8 @@ public class Telemetry10 extends FATServletClient {
                     @TestServlet(servlet = OpenTelemetryBeanServlet.class, contextRoot = APP_NAME),
                     @TestServlet(servlet = BaggageServlet.class, contextRoot = APP_NAME),
                     @TestServlet(servlet = SpanCurrentServlet.class, contextRoot = APP_NAME),
-                    @TestServlet(servlet = WithSpanServlet.class, contextRoot = APP_NAME),
+                    @TestServlet(servlet = MetricsDisabledServlet.class, contextRoot = APP_NAME),
+                    @TestServlet(servlet = WithSpanServlet.class, contextRoot = APP_NAME)
     })
     public static LibertyServer server;
 
@@ -56,9 +57,11 @@ public class Telemetry10 extends FATServletClient {
                         .addClasses(Telemetry10Servlet.class,
                                     OpenTelemetryBeanServlet.class,
                                     PatchTestApp.class,
+                                    OpenTelemetryBeanServlet.class,
                                     BaggageServlet.class,
-                                    WithSpanServlet.class,
-                                    SpanCurrentServlet.class);
+                                    MetricsDisabledServlet.class,
+                                    SpanCurrentServlet.class,
+                                    WithSpanServlet.class)
 
         ShrinkHelper.exportAppToServer(server, app, SERVER_ONLY);
         server.startServer();

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/Telemetry10.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/Telemetry10.java
@@ -61,7 +61,7 @@ public class Telemetry10 extends FATServletClient {
                                     BaggageServlet.class,
                                     MetricsDisabledServlet.class,
                                     SpanCurrentServlet.class,
-                                    WithSpanServlet.class)
+                                    WithSpanServlet.class);
 
         ShrinkHelper.exportAppToServer(server, app, SERVER_ONLY);
         server.startServer();

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/Telemetry10.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/Telemetry10.java
@@ -57,7 +57,6 @@ public class Telemetry10 extends FATServletClient {
                         .addClasses(Telemetry10Servlet.class,
                                     OpenTelemetryBeanServlet.class,
                                     PatchTestApp.class,
-                                    OpenTelemetryBeanServlet.class,
                                     BaggageServlet.class,
                                     MetricsDisabledServlet.class,
                                     SpanCurrentServlet.class,

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/Telemetry10.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/Telemetry10.java
@@ -32,6 +32,7 @@ import io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry.PatchTe
 import io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry.SpanCurrentServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry.Telemetry10Servlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry.WithSpanServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry.MetricsDisabledServlet;
 
 @RunWith(FATRunner.class)
 public class Telemetry10 extends FATServletClient {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/telemetry/MetricsDisabledServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/telemetry/MetricsDisabledServlet.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import io.opentelemetry.api.OpenTelemetry;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+
+@WebServlet("/MetricsDisabledServlet")
+@ApplicationScoped
+public class MetricsDisabledServlet extends FATServlet {
+
+    @Inject
+    OpenTelemetry openTelemetry;
+
+    @Test
+    public void testMetricsDisabledServlet() {
+        //metricReaders should not contain an
+        //The exporter should be set to `none` despite having `otel.metrics.exporter=otlp` in microprofile-config.properties
+        assertThat(openTelemetry.toString(), containsString("metricReaders=[]"));
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/telemetry/microprofile-config.properties
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/telemetry/microprofile-config.properties
@@ -3,3 +3,4 @@ otel.traces.exporter=jaeger
 otel.exporter.jaeger.timeout=10000
 otel.sdk.disabled=false
 otel.service.name=fat_test
+otel.metrics.exporter=otlp


### PR DESCRIPTION
For issue #23175 

Ignores config properties that the user has set for the logs and metrics exporters from OpenTelemetry. The  properties are then set to "none" 