### PR TITLE
add fat tests for OpenIdAuthenticationMechanismDefinition responseMode

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/Constants.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/Constants.java
@@ -204,6 +204,7 @@ public class Constants {
     public static final String HTTP_ERROR_UNAUTHORIZED = "HTTP Error 401";
     public static final String HTTP_ERROR_MESSAGE = "HTTP Error Message";
     public static final String FORBIDDEN = "Forbidden";
+    public static final String FOUND_MSG = "Found";
     public static final String NOT_FOUND_MSG = "Not Found";
     public static final String NOT_FOUND_ERROR = "Error 404:";
     public static final String OK_MESSAGE = "OK";
@@ -226,6 +227,7 @@ public class Constants {
     public static final String RESPONSE_HEADER_CONTENT_TYPE = "Content-Type";
     public static final String RESPONSE_HEADER_CACHE_CONTROL = "Cache-Control";
     public static final String RESPONSE_HEADER_PRAGMA = "Pragma";
+    public static final String RESPONSE_HEADER_LOCATION = "Location";
 
     /* ********************** Cookies *********************** */
     public static final String JSESSION_ID_COOKIE = "JSESSIONID";

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/configs/TestConfigMaps.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/configs/TestConfigMaps.java
@@ -275,6 +275,30 @@ public class TestConfigMaps {
         return updatedMap;
     }
 
+    public static Map<String, Object> getResponseModeQuery() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.RESPONSE_MODE, Constants.QUERY_RESPONSE_MODE);
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getResponseModeFragment() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.RESPONSE_MODE, Constants.FRAGMENT_RESPONSE_MODE);
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getResponseModeFormPost() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.RESPONSE_MODE, Constants.FORM_POST_RESPONSE_MODE);
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getResponseModeError() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.RESPONSE_MODE, "error");
+        return updatedMap;
+    }
+
     public static Map<String, Object> getOP2() throws Exception {
 
         Map<String, Object> updatedMap = new HashMap<String, Object>();
@@ -440,6 +464,14 @@ public class TestConfigMaps {
 
         Map<String, Object> updatedMap = new HashMap<String, Object>();
         updatedMap.put(Constants.IDENTITY_TOKEN_EXPIRY_EXPRESSION, String.valueOf(false));
+        return updatedMap;
+
+    }
+
+    public static Map<String, Object> getAuthorizationEndpoint(String rpBase, String authApp) throws Exception {
+
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.AUTHORIZATION_ENDPOINT, rpBase + "/Authorization/" + authApp);
         return updatedMap;
 
     }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/utils/Constants.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/utils/Constants.java
@@ -21,6 +21,7 @@ public class Constants extends com.ibm.ws.security.fat.common.Constants {
     public static final String RECIRECT_TO_ORIGINAL_RESOURCE_EXPRESSION = "redirectToOriginalResourceExpression";
     public static final String SCOPE = "scope";
     public static final String SCOPE_EXPRESSION = "scopeExpression";
+    public static final String RESPONSE_MODE = "responseMode";
     public static final String CLIENT_ID = "clientId";
     public static final String CLIENT_SECRET = "clientSecret";
     public static final String PROVIDER_BASE = "providerBase";
@@ -48,6 +49,7 @@ public class Constants extends com.ibm.ws.security.fat.common.Constants {
     public static final String TOKEN_AUTO_REFRESH = "tokenAutoRefresh";
     public static final String TOKEN_AUTO_REFRESH_EXPRESSION = "tokenAutoRefreshExpression";
 
+    public static final String AUTHORIZATION_ENDPOINT = "authorizationEndpoint";
     public static final String USERINFOENDPOINT = "userinfoEndpoint";
     public static final String IDTOKENSIGNINGALGORITHMSSUPPORTED = "idTokenSigningAlgorithmsSupported";
     public static final String JWKSCONNECTTIMEOUTEXPRESSION = "jwksConnectTimeoutExpression";
@@ -72,6 +74,11 @@ public class Constants extends com.ibm.ws.security.fat.common.Constants {
     public static final String CODE_IDTOKEN_FLOW = "code id_token";
     public static final String CODE_TOKEN_FLOW = "code token";
     public static final String CODE_IDTOKEN_TOKEN_FLOW = "code id_token token";
+
+    // response modes
+    public static final String QUERY_RESPONSE_MODE = "query";
+    public static final String FRAGMENT_RESPONSE_MODE = "fragment";
+    public static final String FORM_POST_RESPONSE_MODE = "form_post";
 
     // Display
     public static final String PAGE_DISPLAY = "page";

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/utils/MessageConstants.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/utils/MessageConstants.java
@@ -37,6 +37,7 @@ public class MessageConstants extends com.ibm.ws.security.fat.common.MessageCons
     public static final String CWWKS2405E_PROVIDERMETADATA_MISSING_AUTHENDPOINT = "CWWKS2405E";
     public static final String CWWKS2407E_ERROR_VERIFYING_RESPONSE = "CWWKS2407E";
     public static final String CWWKS2410E_CANNOT_FIND_STATE = "CWWKS2410E";
+    public static final String CWWKS2414E_CALLBACK_URL_INCLUDES_ERROR_PARAMETER = "CWWKS2414E";
     public static final String CWWKS2423E_OIDC_CLIENT_INVALID_RESPONSE_TYPE = "CWWKS2423E";
 
     public static final String CWWKS2416E_FAILED_TO_REACH_ENDPOINT = "CWWKS2416E";

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/BaseCallbackServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/BaseCallbackServlet.java
@@ -55,9 +55,40 @@ public class BaseCallbackServlet extends HttpServlet {
 
         if (context != null) {
             Optional<String> originalRequest = context.getStoredValue(request, response, OpenIdConstant.ORIGINAL_REQUEST);
-            String originalRequestString = originalRequest.get();
-            response.sendRedirect(originalRequestString);
+            if (originalRequest.isPresent()) {
+                String originalRequestString = originalRequest.get();
+                response.sendRedirect(originalRequestString);
+            }
         }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+        ServletOutputStream ps = response.getOutputStream();
+
+        ServletLogger.printLine(ps, "Class: " + this.getClass().getName());
+        ServletLogger.printLine(ps, "Super Class: " + this.getClass().getSuperclass().getName());
+
+        ServletLogger.printLine(ps, "got here post callback");
+
+        RequestLogger requestLogger = new RequestLogger(request, ServletMessageConstants.CALLBACK + ServletMessageConstants.REQUEST);
+        requestLogger.printRequest(ps);
+
+        OpenIdContextLogger contextLogger = new OpenIdContextLogger(request, response, ServletMessageConstants.CALLBACK + ServletMessageConstants.OPENID_CONTEXT, context);
+        contextLogger.logContext(ps);
+
+        WSSubjectLogger subjectLogger = new WSSubjectLogger(request, ServletMessageConstants.CALLBACK + ServletMessageConstants.WSSUBJECT);
+        subjectLogger.printProgrammaticApiValues(ps);
+
+        if (context != null) {
+            Optional<String> originalRequest = context.getStoredValue(request, response, OpenIdConstant.ORIGINAL_REQUEST);
+            if (originalRequest.isPresent()) {
+                String originalRequestString = originalRequest.get();
+                response.sendRedirect(originalRequestString);
+            }
+        }
+
     }
 
 }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/BaseOpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/BaseOpenIdConfig.java
@@ -63,7 +63,7 @@ public class BaseOpenIdConfig extends MinimumBaseOpenIdConfig {
 
         String[] value = { Constants.OPENID_SCOPE, Constants.PROFILE_SCOPE, Constants.EMAIL_SCOPE };
         if (config.containsKey(Constants.SCOPE_EXPRESSION)) {
-            value = getScopeValue(Constants.SCOPE_EXPRESSION);
+            value = getStringArrayValue(Constants.SCOPE_EXPRESSION, " ");
         }
 
         return value;

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/BaseOpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/BaseOpenIdConfig.java
@@ -69,6 +69,16 @@ public class BaseOpenIdConfig extends MinimumBaseOpenIdConfig {
         return value;
     }
 
+    public String getResponseMode() {
+
+        String value = Constants.QUERY_RESPONSE_MODE;
+        if (config.containsKey(Constants.RESPONSE_MODE)) {
+            value = getStringValue(Constants.RESPONSE_MODE);
+        }
+
+        return value;
+    }
+
     public String getClientId() {
 
         String value = "client_1";
@@ -182,6 +192,16 @@ public class BaseOpenIdConfig extends MinimumBaseOpenIdConfig {
         boolean value = false;
         if (config.containsKey(Constants.IDENTITY_TOKEN_EXPIRY_EXPRESSION)) {
             value = getBooleanValue(Constants.IDENTITY_TOKEN_EXPIRY_EXPRESSION);
+        }
+
+        return value;
+    }
+
+    public String getAuthorizationEndpoint() {
+
+        String value = "";
+        if (config.containsKey(Constants.AUTHORIZATION_ENDPOINT)) {
+            value = getStringValue(Constants.AUTHORIZATION_ENDPOINT);
         }
 
         return value;

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/MinimumBaseOpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/MinimumBaseOpenIdConfig.java
@@ -69,11 +69,11 @@ public class MinimumBaseOpenIdConfig {
         }
     }
 
-    public String[] getScopeValue(String key) {
+    public String[] getStringArrayValue(String key, String delimiter) {
         String value = config.getProperty(key);
         String[] returnValue = {};
         if (value != null && !value.isEmpty() && !value.contains(Constants.EMPTY_VALUE)) {
-            returnValue = value.split(" ");
+            returnValue = value.split(delimiter);
         }
         return returnValue;
     }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/GenericAnnotatedWithConfigInFile.war/src/oidc/client/generic/servlets/GenericOIDCAuthMechanism.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/GenericAnnotatedWithConfigInFile.war/src/oidc/client/generic/servlets/GenericOIDCAuthMechanism.java
@@ -32,6 +32,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          //                                         redirectToOriginalResourceExpression = "${openIdConfig.redirectToOriginalResource}", // overrides specified value
                                          responseType = "${openIdConfig.responseType}",
                                          scopeExpression = "${openIdConfig.scopeExpression}",
+                                         responseMode = "${openIdConfig.responseMode}",
                                          jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          providerMetadata = @OpenIdProviderMetadata(authorizationEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/authorize",
                                                                                     tokenEndpoint = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1/token",

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/.classpath
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/.classpath
@@ -17,6 +17,8 @@
 	<classpathentry kind="src" path="test-applications/ScopeOpenIdEmail.war/src"/>
 	<classpathentry kind="src" path="test-applications/ScopeOpenIdProfileEmail.war/src"/>
 	<classpathentry kind="src" path="test-applications/ScopeOpenIdProfileEmailWithEL.war/src"/>
+	<classpathentry kind="src" path="test-applications/ResponseModeWithMockAuthEndpoint.war/src"/>
+	<classpathentry kind="src" path="test-applications/Authorization.war/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/bnd.bnd
@@ -28,7 +28,9 @@ src: \
     test-applications/ScopeOpenIdProfile.war/src,\
     test-applications/ScopeOpenIdEmail.war/src,\
     test-applications/ScopeOpenIdProfileEmail.war/src,\
-    test-applications/ScopeOpenIdProfileEmailWithEL.war/src
+    test-applications/ScopeOpenIdProfileEmailWithEL.war/src,\
+    test-applications/ResponseModeWithMockAuthEndpoint.war/src,\
+    test-applications/Authorization.war/src
     
 -dependson: \
     build.changeDetector,\

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/build.gradle
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/build.gradle
@@ -87,6 +87,7 @@ autoFVT.doLast {
 	'jakartasec-3.0_fat.config.rp.claimsDef',
 	'jakartasec-3.0_fat.config.rp.ELOverride',
 	'jakartasec-3.0_fat.config.rp.scope',
+	'jakartasec-3.0_fat.config.rp.responseMode',
 	'jakartasec-3.0_fat.config.rp.userinfo.jwt.jwt',
 	'jakartasec-3.0_fat.config.rp.userinfo.jwt.opaque',
 	'jakartasec-3.0_fat.config.rp.userinfo.json.jwt',

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/FATSuite.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/FATSuite.java
@@ -18,6 +18,7 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationClaimsDefinitionTests;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationELValuesOverrideTests;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationELValuesOverrideWithoutHttpSessionTests;
+import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationResponseModeTests;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationScopeTests;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationTests;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationUserInfoTests;
@@ -28,6 +29,7 @@ import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationUserInfo
                 ConfigurationTests.class,
                 ConfigurationClaimsDefinitionTests.class,
                 ConfigurationScopeTests.class,
+                ConfigurationResponseModeTests.class,
                 // LogoutDefinition tests are handled in a separate FAT project as the test use sleeps to wait for tokens to expire and that causes the tests to take quite some time to run
                 ConfigurationELValuesOverrideTests.class,
                 ConfigurationELValuesOverrideWithoutHttpSessionTests.class,

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationResponseModeTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationResponseModeTests.java
@@ -1,0 +1,342 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.fat.config.tests;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlButton;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.ibm.ws.security.fat.common.expectations.Expectations;
+import com.ibm.ws.security.fat.common.expectations.ResponseFullExpectation;
+import com.ibm.ws.security.fat.common.expectations.ResponseHeaderExpectation;
+import com.ibm.ws.security.fat.common.expectations.ResponseMessageExpectation;
+import com.ibm.ws.security.fat.common.expectations.ResponseStatusExpectation;
+import com.ibm.ws.security.fat.common.expectations.ServerMessageExpectation;
+import com.ibm.ws.security.fat.common.utils.SecurityFatHttpUtils;
+import com.ibm.ws.security.fat.common.web.WebResponseUtils;
+
+import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import io.openliberty.security.jakartasec.fat.commonTests.CommonAnnotatedSecurityTests;
+import io.openliberty.security.jakartasec.fat.configs.TestConfigMaps;
+import io.openliberty.security.jakartasec.fat.utils.Constants;
+import io.openliberty.security.jakartasec.fat.utils.MessageConstants;
+import io.openliberty.security.jakartasec.fat.utils.ServletMessageConstants;
+import io.openliberty.security.jakartasec.fat.utils.ShrinkWrapHelpers;
+
+/**
+ * Tests @OpenIdAuthenticationMechanismDefinition responseMode.
+ *
+ * This class contains tests using different response_mode values in the call to the auth endpoint.
+ * Since Jakarta Security 3.0 currently only supports the auth code flow, the only valid
+ * response_mode values are query and form_post. In these cases, the tests will verify that the correct response
+ * is retrieved from the OP's authorization endpoint and that a successful flow can be completed.
+ * Since the OpenLiberty OP does not allow values other than query and form_post for the auth code flow,
+ * mock authorization endpoints were created to test the fragment and error cases. In these cases, the tests will
+ * verify that the correct response is retrieved from the mock authorization endpoint and the callback is handled
+ * the correct way.
+ */
+/**
+ * Tests appSecurity-5.0
+ */
+@SuppressWarnings("restriction")
+@RunWith(FATRunner.class)
+public class ConfigurationResponseModeTests extends CommonAnnotatedSecurityTests {
+
+    protected static Class<?> thisClass = ConfigurationResponseModeTests.class;
+
+    @Server("jakartasec-3.0_fat.config.op")
+    public static LibertyServer opServer;
+    @Server("jakartasec-3.0_fat.config.rp.responseMode")
+    public static LibertyServer rpServer;
+
+    protected static ShrinkWrapHelpers swh = null;
+
+    @ClassRule
+    public static RepeatTests repeat = createRandomTokenTypeRepeats();
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        // write property that is used to configure the OP to generate JWT or Opaque tokens
+        setTokenTypeInBootstrap(opServer);
+
+        // Add servers to server trackers that will be used to clean servers up and prevent servers
+        // from being restored at the end of each test (so far, the tests are not reconfiguring the servers)
+        updateTrackers(opServer, rpServer, false);
+
+        List<String> waitForMsgs = null;
+        opServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
+        opHttpBase = "http://localhost:" + opServer.getBvtPort();
+        opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
+
+        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
+
+        rpHttpBase = "http://localhost:" + rpServer.getBvtPort();
+        rpHttpsBase = "https://localhost:" + rpServer.getBvtSecurePort();
+
+        deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
+
+    }
+
+    /**
+     * Deploy the apps that this test class uses
+     *
+     * @throws Exception
+     */
+    public static void deployMyApps() throws Exception {
+
+        swh = new ShrinkWrapHelpers(opHttpBase, opHttpsBase, rpHttpBase, rpHttpsBase);
+
+        swh.defaultDropinApp(opServer, "Authorization.war", "authorization.servlets");
+
+        swh.deployConfigurableTestApps(rpServer, "responseModeQuery.war", "GenericOIDCAuthMechanism.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "responseModeQuery", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getResponseModeQuery()),
+                                       "oidc.client.generic.servlets", "oidc.client.base.*");
+
+        swh.deployConfigurableTestApps(rpServer, "responseModeFragment.war", "ResponseModeWithMockAuthEndpoint.war",
+                                       buildUpdatedConfigMapWithMockAuthorization(opServer, rpServer, "responseModeFragment", "AuthorizationResponseModeFragmentServlet",
+                                                                                  "allValues.openIdConfig.properties",
+                                                                                  TestConfigMaps.getResponseModeFragment()),
+                                       "oidc.client.responseModeWithMockAuthEndpoint.servlets", "oidc.client.base.*");
+
+        swh.deployConfigurableTestApps(rpServer, "responseModeFormPost.war", "GenericOIDCAuthMechanism.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "responseModeFormPost", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getResponseModeFormPost()),
+                                       "oidc.client.generic.servlets", "oidc.client.base.*");
+
+        swh.deployConfigurableTestApps(rpServer, "responseModeError.war", "ResponseModeWithMockAuthEndpoint.war",
+                                       buildUpdatedConfigMapWithMockAuthorization(opServer, rpServer, "responseModeError", "AuthorizationResponseModeErrorServlet",
+                                                                                  "allValues.openIdConfig.properties",
+                                                                                  TestConfigMaps.getResponseModeError()),
+                                       "oidc.client.responseModeWithMockAuthEndpoint.servlets", "oidc.client.base.*");
+
+    }
+
+    public static Map<String, Object> buildUpdatedConfigMapWithMockAuthorization(LibertyServer opServer, LibertyServer rpServer, String appName, String authServletName,
+                                                                                 String configFileName,
+                                                                                 Map<String, Object> overrideConfigSettings) throws Exception {
+
+        Map<String, Object> authorizationConfigMap = TestConfigMaps.getAuthorizationEndpoint(opHttpsBase, authServletName);
+        overrideConfigSettings.putAll(authorizationConfigMap);
+        return buildUpdatedConfigMap(opServer, rpServer, appName, configFileName, overrideConfigSettings);
+    }
+
+    /****************************************************************************************************************/
+    /* Tests */
+    /****************************************************************************************************************/
+
+    /**
+     *
+     * Tests with responseMode = "query"
+     * The auth endpoint should return a 302 response, redirecting to redirect uri with the code and state params as query params.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationResponseModeTests_responseMode_query() throws Exception {
+
+        WebClient webClient = getAndSaveWebClient();
+
+        String app = "GenericOIDCAuthMechanism";
+        String url = rpHttpsBase + "/responseModeQuery/" + app;
+
+        Page response = invokeAppReturnLoginPage(webClient, url);
+
+        // disable redirect, so we are able to see the 302 responses
+        // (otherwise, can't see redirect response from auth endpoint)
+        webClient.getOptions().setRedirectEnabled(false);
+
+        response = actions.doFormLogin(response, Constants.TESTUSER, Constants.TESTUSERPWD);
+
+        // follow redirect from login form to auth endpoint
+        response = actions.invokeUrl(_testName, webClient, WebResponseUtils.getResponseHeaderField(response, Constants.RESPONSE_HEADER_LOCATION));
+
+        // validate 302 response, redirect uri, and that the code and state params were included as query params
+        Expectations expectations = new Expectations();
+        expectations.addExpectation(new ResponseStatusExpectation(Constants.REDIRECT_STATUS));
+        expectations.addExpectation(new ResponseMessageExpectation(Constants.STRING_CONTAINS, Constants.FOUND_MSG, "Did not receive the Found message."));
+        expectations.addExpectation(new ResponseHeaderExpectation(null, Constants.STRING_MATCHES, Constants.RESPONSE_HEADER_LOCATION, "https:\\/\\/localhost:"
+                                                                                                                                      + rpServer.getBvtSecurePort()
+                                                                                                                                      + "\\/responseModeQuery\\/Callback\\?code=.+&state=.+", "Did not get the code and state params as query params."));
+        validationUtils.validateResult(response, expectations);
+
+        // follow redirect from auth endpoint to redirect uri
+        response = actions.invokeUrl(_testName, webClient, WebResponseUtils.getResponseHeaderField(response, Constants.RESPONSE_HEADER_LOCATION));
+
+        // follow redirect from callback servlet to original request
+        response = actions.invokeUrl(_testName, webClient, WebResponseUtils.getResponseHeaderField(response, Constants.RESPONSE_HEADER_LOCATION));
+
+        // validate that we were able to get to the original request and that we have an openid context
+        validationUtils.validateResult(response, getGeneralAppExpecations(app));
+
+    }
+
+    /**
+     *
+     * Tests with responseMode = "fragment"
+     * Since the OpenLiberty OP won't allow this value for code flow, a mock auth endpoint was used in this test case.
+     * The mock auth endpoint should return a 302 response, redirecting to redirect uri with the code and state params as fragment params.
+     * However, the callback should be treated a regular call to an unprotected resource, since the fragment params aren't passed from
+     * the browser to server (rp) and thus, the rp can't tell if it's a callback request (determined by existence of state param).
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationResponseModeTests_responseMode_fragment() throws Exception {
+
+        WebClient webClient = getAndSaveWebClient();
+
+        // disable redirect, so we are able to see the 302 responses
+        // (otherwise, can't see redirect response from auth endpoint)
+        webClient.getOptions().setRedirectEnabled(false);
+
+        String app = "ResponseModeWithMockAuthEndpointServlet";
+        String url = rpHttpsBase + "/responseModeFragment/" + app;
+
+        // invoke the mock auth endpoint, this endpoint will return a 302 to the redirect uri with the code and state params as fragment params
+        Page response = actions.invokeUrl(_testName, webClient, url);
+
+        // follow redirect from original request to auth endpoint (mocked in this test case)
+        response = actions.invokeUrl(_testName, webClient, WebResponseUtils.getResponseHeaderField(response, Constants.RESPONSE_HEADER_LOCATION));
+
+        // validate 302 response, redirect uri, and that the code and state params were included as fragment params
+        Expectations expectations = new Expectations();
+        expectations.addExpectation(new ResponseStatusExpectation(Constants.REDIRECT_STATUS));
+        expectations.addExpectation(new ResponseMessageExpectation(Constants.STRING_CONTAINS, Constants.FOUND_MSG, "Did not receive the Found message."));
+        expectations.addExpectation(new ResponseHeaderExpectation(null, Constants.STRING_MATCHES, Constants.RESPONSE_HEADER_LOCATION, "https:\\/\\/localhost:"
+                                                                                                                                      + rpServer.getBvtSecurePort()
+                                                                                                                                      + "\\/responseModeFragment\\/Callback#code=.+&state=.+", "Did not get the code and state params as fragment params."));
+        validationUtils.validateResult(response, expectations);
+
+        // follow redirect from auth endpoint to redirect uri
+        response = actions.invokeUrl(_testName, webClient, WebResponseUtils.getResponseHeaderField(response, Constants.RESPONSE_HEADER_LOCATION));
+
+        // validate 200 response, since fragment params are not passed to the rp (they are only read by the browser),
+        // so it should be treated as a call to an unprotected resource (since it can't detect the state param to determine if it's a callback req)
+        expectations = new Expectations();
+        expectations.addSuccessCodeForCurrentAction();
+        expectations.addExpectation(new ResponseFullExpectation(null, Constants.STRING_CONTAINS, "got here callback", "Did not land on the callback."));
+        expectations.addExpectation(new ResponseFullExpectation(null, Constants.STRING_CONTAINS, ServletMessageConstants.CALLBACK + ServletMessageConstants.OPENID_CONTEXT
+                                                                                                 + "OpenIdContext subject: null", "The subject was not null and should have been."));
+        validationUtils.validateResult(response, expectations);
+
+    }
+
+    /**
+     *
+     * Tests with respondeMode = "form_post"
+     * The auth endpoint should return a 200 response with an html form which contains the code and state params as input elements.
+     * The html form should send a POST request to the redirect uri when submitted.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationResponseModeTests_responseMode_formPost() throws Exception {
+
+        WebClient webClient = getAndSaveWebClient();
+
+        String app = "GenericOIDCAuthMechanism";
+        String url = rpHttpsBase + "/responseModeFormPost/" + app;
+
+        Page response = invokeAppReturnLoginPage(webClient, url);
+
+        // disable javascript, so the form_post form doesn't automatically redirect us
+        // (otherwise, can't see form_post response from auth endpoint)
+        webClient.getOptions().setJavaScriptEnabled(false);
+
+        response = actions.doFormLogin(response, Constants.TESTUSER, Constants.TESTUSERPWD);
+
+        // validate 200 response and html form response containing the redirect uri, code param, and state param
+        Expectations expectations = new Expectations();
+        expectations.addSuccessCodeForCurrentAction();
+        expectations.addExpectation(new ResponseFullExpectation(Constants.STRING_MATCHES, ".*<FORM .* action=\"https:\\/\\/localhost:"
+                                                                                          + rpServer.getBvtSecurePort()
+                                                                                          + "\\/responseModeFormPost\\/Callback\" method=\"POST\">.*<input type=\"hidden\" name=\"code\" value=\".+\" \\/><input type=\"hidden\" name=\"state\" value=\".+\" \\/>.*", "Did not get the redirect uri, code param, and state param in the html form."));
+        validationUtils.validateResult(response, expectations);
+
+        // manually submit form, since we disabled javascript from automatically submitting it
+        HtmlPage formPostPage = (HtmlPage) response;
+        HtmlForm formPostForm = formPostPage.getForms().get(0);
+        HtmlButton submitButton = formPostForm.getButtonByName("redirectform");
+        response = submitButton.click();
+
+        // validate that we were able to get to the original request and that we have an openid context
+        validationUtils.validateResult(response, getGeneralAppExpecations(app));
+
+    }
+
+    /**
+     *
+     * Tests with responseMode = "error"
+     * Since the OpenLiberty OP won't allow this value for code flow, a mock auth endpoint was used in this test case.
+     * The mock auth endpoint should return a 302 response, redirecting to redirect uri with the error, error_description, and state params as query params.
+     * The callback should detect the error param and fail.
+     *
+     * @throws Exception
+     */
+    @ExpectedFFDC({ "io.openliberty.security.oidcclientcore.exceptions.AuthenticationResponseException" })
+    @Test
+    public void ConfigurationResponseModeTests_responseMode_error() throws Exception {
+
+        WebClient webClient = getAndSaveWebClient();
+
+        // disable redirect, so we are able to see the 302 responses
+        // (otherwise, can't see redirect response from auth endpoint)
+        webClient.getOptions().setRedirectEnabled(false);
+
+        String app = "ResponseModeWithMockAuthEndpointServlet";
+        String url = rpHttpsBase + "/responseModeError/" + app;
+
+        // invoke the mock auth endpoint, this endpoint will return a 302 to the redirect uri with the error and state params as query params
+        Page response = actions.invokeUrl(_testName, webClient, url);
+
+        // follow redirect from original request to auth endpoint (mocked in this test case)
+        response = actions.invokeUrl(_testName, webClient, WebResponseUtils.getResponseHeaderField(response, Constants.RESPONSE_HEADER_LOCATION));
+
+        // validate 302 response, redirect uri, and that the error and state params were included as query params
+        Expectations expectations = new Expectations();
+        expectations.addExpectation(new ResponseStatusExpectation(Constants.REDIRECT_STATUS));
+        expectations.addExpectation(new ResponseMessageExpectation(Constants.STRING_CONTAINS, Constants.FOUND_MSG, "Did not receive the Found message."));
+        expectations.addExpectation(new ResponseHeaderExpectation(null, Constants.STRING_MATCHES, Constants.RESPONSE_HEADER_LOCATION, "https:\\/\\/localhost:"
+                                                                                                                                      + rpServer.getBvtSecurePort()
+                                                                                                                                      + "\\/responseModeError\\/Callback\\?error=.+&error_description=.+&state=.+", "Did not get the error, error_description, and state params as query params."));
+        validationUtils.validateResult(response, expectations);
+
+        // follow redirect from auth endpoint to redirect uri
+        response = actions.invokeUrl(_testName, webClient, WebResponseUtils.getResponseHeaderField(response, Constants.RESPONSE_HEADER_LOCATION));
+
+        // validate 401 response and error param detected messages
+        expectations = new Expectations();
+        expectations.addExpectation(new ResponseStatusExpectation(Constants.UNAUTHORIZED_STATUS));
+        expectations.addExpectation(new ResponseMessageExpectation(Constants.STRING_CONTAINS, Constants.UNAUTHORIZED_MESSAGE, "Did not receive the Unauthorize message."));
+        expectations.addExpectation(new ServerMessageExpectation(rpServer, MessageConstants.CWWKS2407E_ERROR_VERIFYING_RESPONSE, "Did not receive an error message stating that the client encountered an error verifying the authentication response."));
+        expectations.addExpectation(new ServerMessageExpectation(rpServer, MessageConstants.CWWKS2414E_CALLBACK_URL_INCLUDES_ERROR_PARAMETER, "Did not receive an error message stating that the callback url includes an error param."));
+        validationUtils.validateResult(response, expectations);
+
+    }
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/publish/shared/config/oidcProvider.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/publish/shared/config/oidcProvider.xml
@@ -60,6 +60,8 @@
 							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/scopeELUppercaseScopes/Callback,
 							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/scopeELUnknownScope/Callback,
 							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/scopeELDuplicateScope/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/responseModeQuery/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/responseModeFormPost/Callback,
 							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/useSessionTrueELTrue/Callback,
 							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/useSessionTrueELFalse/Callback,
 							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/useSessionFalseELTrue/Callback,

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/Authorization.war/src/authorization/servlets/AuthorizationResponseModeErrorServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/Authorization.war/src/authorization/servlets/AuthorizationResponseModeErrorServlet.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package authorization.servlets;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import io.openliberty.security.jakartasec.fat.utils.Constants;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdConstant;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@WebServlet("/AuthorizationResponseModeErrorServlet")
+public class AuthorizationResponseModeErrorServlet extends AuthorizationServlet {
+
+    private static final long serialVersionUID = 230335973928990220L;
+
+    private static final List<String> VALID_RESPONSE_MODES = Arrays.asList(Constants.QUERY_RESPONSE_MODE,
+                                                                           Constants.FRAGMENT_RESPONSE_MODE,
+                                                                           Constants.FORM_POST_RESPONSE_MODE);
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String responseMode = request.getParameter(OpenIdConstant.RESPONSE_MODE);
+        if (VALID_RESPONSE_MODES.contains(responseMode)) {
+            throw new Error("response_mode is valid");
+        }
+
+        String redirectUri = request.getParameter(OpenIdConstant.REDIRECT_URI);
+        String state = request.getParameter(OpenIdConstant.STATE);
+
+        String redirect = redirectUri + "?error=invalid_request&error_description=Invalid%20response_mode%20requested&state=" + state;
+        response.sendRedirect(redirect);
+    }
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/Authorization.war/src/authorization/servlets/AuthorizationResponseModeFragmentServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/Authorization.war/src/authorization/servlets/AuthorizationResponseModeFragmentServlet.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package authorization.servlets;
+
+import java.io.IOException;
+
+import io.openliberty.security.jakartasec.fat.utils.Constants;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdConstant;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@WebServlet("/AuthorizationResponseModeFragmentServlet")
+public class AuthorizationResponseModeFragmentServlet extends AuthorizationServlet {
+
+    private static final long serialVersionUID = 230335973928990220L;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String responseMode = request.getParameter(OpenIdConstant.RESPONSE_MODE);
+        if (!Constants.FRAGMENT_RESPONSE_MODE.equals(responseMode)) {
+            throw new Error("response_mode does not equal fragment");
+        }
+
+        String redirectUri = request.getParameter(OpenIdConstant.REDIRECT_URI);
+        String state = request.getParameter(OpenIdConstant.STATE);
+
+        String redirect = redirectUri + "#code=abc123&state=" + state;
+        response.sendRedirect(redirect);
+    }
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/Authorization.war/src/authorization/servlets/AuthorizationServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/Authorization.war/src/authorization/servlets/AuthorizationServlet.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package authorization.servlets;
+
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+
+@WebServlet("/Authorization")
+public class AuthorizationServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 230335973928990220L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ResponseModeWithMockAuthEndpoint.war/src/oidc/client/responseModeWithMockAuthEndpoint/servlets/CallbackServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ResponseModeWithMockAuthEndpoint.war/src/oidc/client/responseModeWithMockAuthEndpoint/servlets/CallbackServlet.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.responseModeWithMockAuthEndpoint.servlets;
+
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseCallbackServlet;
+
+@WebServlet("/Callback")
+public class CallbackServlet extends BaseCallbackServlet {
+
+    private static final long serialVersionUID = -417476984908088827L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ResponseModeWithMockAuthEndpoint.war/src/oidc/client/responseModeWithMockAuthEndpoint/servlets/OpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ResponseModeWithMockAuthEndpoint.war/src/oidc/client/responseModeWithMockAuthEndpoint/servlets/OpenIdConfig.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.responseModeWithMockAuthEndpoint.servlets;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Named;
+import oidc.client.base.servlets.BaseOpenIdConfig;
+
+@Named
+@Dependent
+public class OpenIdConfig extends BaseOpenIdConfig {
+
+    // override and/or create new get methods
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ResponseModeWithMockAuthEndpoint.war/src/oidc/client/responseModeWithMockAuthEndpoint/servlets/ResponseModeWithMockAuthEndpointServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ResponseModeWithMockAuthEndpoint.war/src/oidc/client/responseModeWithMockAuthEndpoint/servlets/ResponseModeWithMockAuthEndpointServlet.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.responseModeWithMockAuthEndpoint.servlets;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdProviderMetadata;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseServlet;
+
+@WebServlet("/ResponseModeWithMockAuthEndpointServlet")
+@OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1",
+                                         clientId = "client_1",
+                                         clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
+                                         claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
+                                         redirectURI = "${baseURL}/Callback",
+                                         responseMode = "${openIdConfig.responseMode}",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
+                                         providerMetadata = @OpenIdProviderMetadata(authorizationEndpoint = "${openIdConfig.authorizationEndpoint}"))
+@DeclareRoles("all")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "all"))
+public class ResponseModeWithMockAuthEndpointServlet extends BaseServlet {
+
+    private static final long serialVersionUID = 1L;
+
+}


### PR DESCRIPTION
add fat tests for OpenIdAuthenticationMechanismDefinition responseMode

This class contains tests using different `response_mode` values in the call to the auth endpoint.

Since Jakarta Security 3.0 currently only supports the auth code flow, the only valid `response_mode` values are `query` and `form_post`. In these cases, the tests will verify that the correct response is retrieved from the OpenLiberty OP's authorization endpoint and that a successful flow can be completed. 

Since the OpenLiberty OP does not allow values other than `query` and `form_post` for the auth code flow, mock authorization endpoints were created to test the `fragment` and error cases. In these cases, the tests will verify that the correct response is retrieved from the mock authorization endpoint and the callback is handled the correct way.