### PR TITLE
Check for dir exists before deleting

### DIFF
--- a/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/monitor/DropinMonitor.java
+++ b/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/monitor/DropinMonitor.java
@@ -300,7 +300,7 @@ public class DropinMonitor {
     private void tidyUpMonitoredDirectory(boolean createdDir, File dirToCleanup) {
         if (createdDir && dirToCleanup != null) {
             File[] fileListing = dirToCleanup.listFiles();
-            if (fileListing == null || fileListing.length == 0) {
+            if (fileListing != null && fileListing.length == 0) {
                 if (!!!dirToCleanup.delete()) {
                     Tr.error(_tc, "MONITOR_DIR_CLEANUP_FAIL", dirToCleanup);
                 } else if (_tc.isDebugEnabled()) {

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPJWT/dropins/.keep
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPJWT/dropins/.keep
@@ -1,1 +1,0 @@
-Keep dropins folder


### PR DESCRIPTION
DropinMonitor was attempting an rm on a non-existent dir. This was breaking a new checkpoint FAT

