### PR TITLE
skip running test on older jdk level where certpath apis fail when using certificate chain 

### DIFF
--- a/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/common/BasicSAMLTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/common/BasicSAMLTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1022,11 +1022,18 @@ public class BasicSAMLTests extends SAMLCommonTest {
     @Mode(TestMode.LITE)
     @Test
     public void basicSAMLTests_chainedCert_noMetaData_intermediateInKeyStore() throws Exception {
-        if (System.getProperty("os.name").contains("Mac")) {
-            Log.info(thisClass, _testName, "Aborting the test due to issues with the IBM JDK on Mac. See Defect 249821.");
-            // Defect 249821: IBM JDKs on Mac have trouble with this test because some underlying open source code is making a call
-            // to CertPathBuilder.getInstance("PKIX") instead of using the CertPathBuilder.getInstance(String, String) or
-            // CertPathBuilder.getInstance(String, Provider) method to specify a particular provider.
+        
+        String javaVersion = System.getProperty("java.version");
+        String vendorName = System.getProperty("java.vendor");
+        
+        Log.info(thisClass, _testName, "java version = " + javaVersion);
+        Log.info(thisClass, _testName, "java vendor = " + vendorName);
+        boolean jdk_issue_with_certpath_api = false;
+        if(javaVersion.contains("1.8.0") && vendorName.contains("Oracle")) {
+            jdk_issue_with_certpath_api = true; 
+        }
+        if (jdk_issue_with_certpath_api) {
+            Log.info(thisClass, _testName, "Aborting the test due to issues with the " + vendorName + ", version :  " + javaVersion + ". See Defect 291667.");
             return;
         }
 
@@ -1057,14 +1064,20 @@ public class BasicSAMLTests extends SAMLCommonTest {
      * @throws Exception
      */
     @AllowedFFDC(value = { "com.ibm.ws.security.saml.error.SamlException" })
-    // re-enable when 195531 is fixed
     @Test
     public void basicSAMLTests_chainedCert_noMetaData_rootInKeyStore() throws Exception {
-        if (System.getProperty("os.name").contains("Mac")) {
-            Log.info(thisClass, _testName, "Aborting the test due to issues with the IBM JDK on Mac. See Defect 249821.");
-            // Defect 249821: IBM JDKs on Mac have trouble with this test because some underlying open source code is making a call
-            // to CertPathBuilder.getInstance("PKIX") instead of using the CertPathBuilder.getInstance(String, String) or
-            // CertPathBuilder.getInstance(String, Provider) method to specify a particular provider.
+        
+        String javaVersion = System.getProperty("java.version");
+        String vendorName = System.getProperty("java.vendor");
+        
+        Log.info(thisClass, _testName, "java version = " + javaVersion);
+        Log.info(thisClass, _testName, "java vendor = " + vendorName);
+        boolean jdk_issue_with_certpath_api = false;
+        if(javaVersion.contains("1.8.0") && vendorName.contains("Oracle")) {
+            jdk_issue_with_certpath_api = true; 
+        }
+        if (jdk_issue_with_certpath_api) {
+            Log.info(thisClass, _testName, "Aborting the test due to issues with the " + vendorName + ", version :  " + javaVersion + ". See Defect 291667.");
             return;
         }
 

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/acs/SAMLMessageXMLSignatureSecurityPolicyRule.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/acs/SAMLMessageXMLSignatureSecurityPolicyRule.java
@@ -54,7 +54,7 @@ import net.shibboleth.utilities.java.support.resolver.ResolverException;
  * If an optional {@link Validator} for {@link Signature} objects is supplied, this validator will be used to validate
  * the XML Signature element prior to the actual cryptographic validation of the signature. This might for example be
  * used to enforce certain signature profile requirements or to detect signatures upon which it would be unsafe to
- * attempt cryptographic processing. When using the single argument constructuor form, the validator will default to {@link SAMLSignatureProfileValidator}.
+ * attempt cryptographic processing. When using the single argument constructor form, the validator will default to {@link SAMLSignatureProfileValidator}.
  * </p>
  */
 


### PR DESCRIPTION

fix 291667