### PR TITLE
Add missing tags 3.0 bundle

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2869,7 +2869,7 @@
     <dependency>
       <groupId>org.glassfish.web</groupId>
       <artifactId>jakarta.servlet.jsp.jstl</artifactId>
-      <version>3.0.0</version>
+      <version>3.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -569,7 +569,7 @@ org.glassfish.jersey.ext.rx:jersey-rx-client-rxjava2:2.30.1
 org.glassfish.jersey.ext.rx:jersey-rx-client-rxjava:2.30.1
 org.glassfish.jersey.inject:jersey-hk2:2.26
 org.glassfish.web:jakarta.servlet.jsp.jstl:2.0.0
-org.glassfish.web:jakarta.servlet.jsp.jstl:3.0.0
+org.glassfish.web:jakarta.servlet.jsp.jstl:3.0.1
 org.glassfish:jakarta.faces:3.0.1
 org.glassfish:jakarta.json:2.0.0
 org.glassfish:javax.faces:2.3.9

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/pages-3.1/io.openliberty.pages-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/pages-3.1/io.openliberty.pages-3.1.feature
@@ -44,7 +44,7 @@ Subsystem-Name: Jakarta Server Pages 3.1
  io.openliberty.tags.3.0.facade; start-phase:=CONTAINER_EARLY, \
  io.openliberty.org.apache.taglibs.standard.3.0
 -jars=com.ibm.websphere.appserver.spi.jsp; location:=dev/spi/ibm/, \
- io.openliberty.jakarta.pages.tld.3.0; location:=dev/api/spec/
+ io.openliberty.jakarta.pages.tld.3.1; location:=dev/api/spec/
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.jsp_1.0-javadoc.zip
 kind=beta
 edition=core

--- a/dev/io.openliberty.jakarta.pages.tld.3.1/.classpath
+++ b/dev/io.openliberty.jakarta.pages.tld.3.1/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.jakarta.pages.tld.3.1/.gitignore
+++ b/dev/io.openliberty.jakarta.pages.tld.3.1/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+/build/
+/generated/

--- a/dev/io.openliberty.jakarta.pages.tld.3.1/.project
+++ b/dev/io.openliberty.jakarta.pages.tld.3.1/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.jakarta.pages.tld.3.1</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.jakarta.pages.tld.3.1/.settings/bndtools.core.prefs
+++ b/dev/io.openliberty.jakarta.pages.tld.3.1/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.jakarta.pages.tld.3.1/.settings/org.eclipse.core.resources.prefs
+++ b/dev/io.openliberty.jakarta.pages.tld.3.1/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/bnd.bnd=UTF-8

--- a/dev/io.openliberty.jakarta.pages.tld.3.1/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/io.openliberty.jakarta.pages.tld.3.1/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=11

--- a/dev/io.openliberty.jakarta.pages.tld.3.1/bnd.bnd
+++ b/dev/io.openliberty.jakarta.pages.tld.3.1/bnd.bnd
@@ -1,0 +1,40 @@
+#*******************************************************************************
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+-nouses=true
+
+Bundle-SymbolicName: io.openliberty.jakarta.pages.tld.3.1
+Bundle-Description: Jakarta Standard Tag Library, version 3.0
+
+Import-Package: \
+   !org.eclipse.tags.shaded.org.apache.xml.serialize,\
+   !org.eclipse.tags.shaded.org.apache.xml.serializer,\
+   !org.apache.xerces*, \
+   *
+
+Export-Package: \
+    org.apache.taglibs.standard.tag.common.core;version="3.0.1", \
+    org.apache.taglibs.standard.tag.common.xml;version="3.0.1", \
+    org.apache.taglibs.standard.tag.el.core;version="3.0.1", \
+    org.apache.taglibs.standard.tag.el.fmt;version="3.0.1", \
+    org.apache.taglibs.standard.tag.el.sql;version="3.0.1", \
+    org.apache.taglibs.standard.tag.el.xml;version="3.0.1", \
+    org.apache.taglibs.standard.tag.rt.core;version="3.0.1", \
+    org.apache.taglibs.standard.tag.rt.fmt;version="3.0.1", \
+    org.apache.taglibs.standard.tag.rt.sql;version="3.0.1", \
+    org.apache.taglibs.standard.tag.rt.xml;version="3.0.1"
+
+-includeresource: @${repo;org.glassfish.web:jakarta.servlet.jsp.jstl;3.0.1;EXACT}!/!org/eclipse/tags/shaded/*
+
+instrument.disabled: true
+
+publish.wlp.jar.suffix: dev/api/spec

--- a/dev/io.openliberty.jakarta.servlet.jsp.tags.3.0.internal/bnd.bnd
+++ b/dev/io.openliberty.jakarta.servlet.jsp.tags.3.0.internal/bnd.bnd
@@ -17,7 +17,7 @@ javac.target: 11
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
 
 Bundle-SymbolicName: io.openliberty.jakarta.servlet.jsp.tags.3.0.internal
-Bundle-Description: TLDs for the Jakarta Standard Tag Library; Version 3.0
+Bundle-Description: TLDs for the Jakarta Standard Tag Library; Version 3.0.1
 
 publish.wlp.jar.disabled: true
 

--- a/dev/io.openliberty.jakarta.servlet.jsp.tags.3.0.internal/bnd.bnd
+++ b/dev/io.openliberty.jakarta.servlet.jsp.tags.3.0.internal/bnd.bnd
@@ -17,12 +17,12 @@ javac.target: 11
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
 
 Bundle-SymbolicName: io.openliberty.jakarta.servlet.jsp.tags.3.0.internal
-Bundle-Description: TLDs for the Jakarta Standard Tag Library; Version 3.0.0
+Bundle-Description: TLDs for the Jakarta Standard Tag Library; Version 3.0
 
 publish.wlp.jar.disabled: true
 
 -includeresource: \
-	@${repo;org.glassfish.web:jakarta.servlet.jsp.jstl;3.0.0}!/META-INF/*.tld
+	@${repo;org.glassfish.web:jakarta.servlet.jsp.jstl;3.0.1}!/META-INF/*.tld
 
 -buildpath: \
-  org.glassfish.web:jakarta.servlet.jsp.jstl;version=3.0
+  org.glassfish.web:jakarta.servlet.jsp.jstl;version=3.0.1

--- a/dev/io.openliberty.org.apache.taglibs.standard.3.0/bnd.bnd
+++ b/dev/io.openliberty.org.apache.taglibs.standard.3.0/bnd.bnd
@@ -42,6 +42,6 @@ Export-Package: \
   org.eclipse.tags.shaded.org.apache.xpath.*
 
 -buildpath: \
-  org.glassfish.web:jakarta.servlet.jsp.jstl;version=3.0, \
+  org.glassfish.web:jakarta.servlet.jsp.jstl;version=3.0.1, \
   io.openliberty.jakarta.servlet.6.0;version=latest,\
-  io.openliberty.jakarta.pages.3.0;version=latest
+  io.openliberty.jakarta.pages.3.1;version=latest

--- a/dev/io.openliberty.org.apache.taglibs.standard.3.0/build.gradle
+++ b/dev/io.openliberty.org.apache.taglibs.standard.3.0/build.gradle
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+// Local vars
+File downloadSrcDir = project.file('build/source')
+
+configurations {
+    sourceJar
+}
+
+dependencies {
+     sourceJar 'org.glassfish.web:jakarta.servlet.jsp.jstl:3.0.1:sources'
+}
+
+task copySource(type: Copy) {
+    from configurations.sourceJar
+    into downloadSrcDir
+}
+
+assemble {
+    dependsOn copySource
+}
+
+task deleteJars(type:Delete) {
+    doLast {
+        println "deleteJars task, deleting " + downloadSrcDir
+        file(downloadSrcDir).deleteDir()
+    }
+}
+
+clean {
+    dependsOn deleteJars
+}


### PR DESCRIPTION
After working on adding the bundles, realized there was a newer tags version which I decided to pull in as well.
- Add tld bundle for tags 3.0 fixes #23556 
- Update outdated versions
- Update tag 3.0 version jars to 3.0.1 fixes #23633 
- Readded sources for tag 3.0 version 3.0.1
