### PR TITLE
Update personalbuild.yml and add rtcbuild.yml

### DIFF
--- a/.ci-orchestrator/compilePersonal.properties
+++ b/.ci-orchestrator/compilePersonal.properties
@@ -6,7 +6,7 @@ allow.load.profiles=true
 async.target.name=Liberty Personal Async Tests - EBC
 async.thread.count.for.full=13
 # Prefix the build label with your username to find it easier
-buildLabelPrefix=${git.laos.clone.repository.username}
+buildLabelPrefix=${git.laos.clone.repository.username}-${github_pr_number}
 cognitive_auto_resolve_hung_builds=abandon
 # Setting create.im.repo to true will implicitly turn spawn.zos to true
 create.im.repo=false

--- a/.ci-orchestrator/personalbuild.yml
+++ b/.ci-orchestrator/personalbuild.yml
@@ -1,18 +1,18 @@
 type: pipeline_definition
-product: Liberty
-name: Liberty Personal Build
-description: A build run against Open Liberty Pull Requests
+product: OpenLiberty
+name: OpenLiberty Personal Build
+description: A build run against OpenLiberty Pull Requests
 triggers:
 - type: github
   triggerName: "ol-pbbeta"
-  triggerRank: 20
+  triggerRank: 50
   triggerMonitored: false
-  keyword: "#ol-pbbeta"
+  keyword: "#pbbeta"
 - type: github
   triggerName: "ol-fullpbbeta"
-  triggerRank: 20
+  triggerRank: 50
   triggerMonitored: false
-  keyword: "#ol-fullpbbeta"
+  keyword: "#fullpbbeta"
   propertyDefinitions:
   - name: fat.test.mode
     defaultValue: full
@@ -28,10 +28,50 @@ triggers:
     - stepName: compile
 
 steps:
+- stepName: pr-changes
+  workType: PRChangesDetection
+  timeoutInMinutes: 30
+  properties:
+    githubPRApi: ${github_pr_api}
+    githubPRNumber: ${github_pr_number}
+
 - stepName: compile
   workType: RTC
   projectName: "Liberty Personal Build CI Orchestrator - EBC"
+  dependsOn:
+  - stepName: pr-changes
+    awaitOutputProperties: true
   timeoutInMinutes: 1440
+  properties:
+    build.stub.target: build.CachedWSCD.CompileImage
+    run.packaging.verification: ${pr-changes:run.packaging.verification}
+    fat.buckets.to.run: ${pr-changes:fat.buckets.to.run}
+    disable.run.runBvtTests: ${pr-changes:disable.run.runBvtTests}
+    disable.run.runUnitTests: ${pr-changes:disable.run.runUnitTests}
+    run.chkpii: ${pr-changes:run.chkpii}
+    run.findbugs: ${pr-changes:run.findbugs}
+    spawn.zos: ${pr-changes:spawn.zos}
+    create.im.repo: ${pr-changes:create.im.repo}
+    personal.im.build: ${pr-changes:personal.im.build}
+    disable.run.createDoc: ${pr-changes:disable.run.createDoc}
+    skip.open.liberty.build.if.possible: ${pr-changes:skip.open.liberty.build.if.possible}
+    skip.open.liberty.fats.if.possible: ${pr-changes:skip.open.liberty.fats.if.possible}
+  includeProperties:
+  - file: compilePersonal.properties
+  - file: compile.properties
+
+- stepName: unittest
+  workType: RTC
+  projectName: "Liberty Personal Build CI Orchestrator - EBC"
+  dependsOn:
+  - stepName: pr-changes
+    awaitOutputProperties: true
+  timeoutInMinutes: 1440
+  properties:
+    build.stub.target: build.CachedWSCD.OLTest
+    disable.run.runUnitTests: ${pr-changes:disable.run.runUnitTests}
+    skip.open.liberty.build.if.possible: ${pr-changes:skip.open.liberty.build.if.possible}
+    skip.open.liberty.fats.if.possible: ${pr-changes:skip.open.liberty.fats.if.possible}
   includeProperties:
   - file: compilePersonal.properties
   - file: compile.properties
@@ -66,6 +106,7 @@ steps:
     runner_projectName: ebcTestRunner
     runner_workType: Jenkins
     runner_threshold: 40
+    runner_minimum_total: 10
     fat.buckets.to.run: auto
     fat.test.mode: lite
     fats_to_omit: "com.ibm.ws.collective.controller.deploy_fat, com.ibm.ws.health.manager.odrlib_fat, com.ibm.ws.dynamic.routing_ihs_fat, com.ibm.ws.node.scaling_fat, com.ibm.ws.scaling.member_fat_multinode, com.ibm.ws.node.health_fat"
@@ -75,7 +116,6 @@ steps:
     command: ant -f build-test.xml localrun -propertyfile ../../../buildandbucket.properties -DhaltOnFailure=false -lib ../ant_build/lib.antClasspath
     aggregationId: ${compile:execution_id}
     buildType: personal
-    reportingJVM: system_java
     reportingOS: ubuntu18_x86
     retry_failing_fats: true
     repeat_if_few_fats: true  #If there are fewer than x fat buckets then we will run each fat multiple times

--- a/.ci-orchestrator/rtcbuild.yml
+++ b/.ci-orchestrator/rtcbuild.yml
@@ -1,0 +1,68 @@
+type: pipeline_definition
+product: OpenLiberty
+name: OpenLiberty Personal Build RTC
+description: A build run against OpenLiberty Pull Requests
+triggers:
+- type: github
+  triggerName: "ol-pb"
+  triggerRank: 20
+  triggerMonitored: false
+  keyword: "#pb"
+#- type: github
+#  triggerName: "ol-pb-build"
+#  triggerRank: 20
+#  triggerMonitored: false
+#  keyword: "#build"
+- type: github
+  triggerName: "ol-fullpb"
+  triggerRank: 20
+  triggerMonitored: false
+  keyword: "#fullpb"
+  propertyDefinitions:
+  - name: fat.test.mode
+    defaultValue: full
+    steps:
+    - stepName: fats
+  - name: create.im.repo
+    defaultValue: true
+    steps:
+    - stepName: compile
+  - name: spawn.zos
+    defaultValue: true
+    steps:
+    - stepName: compile
+  - name: fat.buckets.to.run
+    defaultValue: all
+    steps:
+    - stepName: compile
+
+steps:
+- stepName: pr-changes
+  workType: PRChangesDetection
+  timeoutInMinutes: 30
+  properties:
+    githubPRApi: ${github_pr_api}
+    githubPRNumber: ${github_pr_number}
+
+- stepName: compile
+  workType: RTC
+  projectName: "Liberty Personal Build - EBC"
+  timeoutInMinutes: 1440
+  dependsOn:
+  - stepName: pr-changes
+    awaitOutputProperties: true
+  properties:
+    run.packaging.verification: ${pr-changes:run.packaging.verification}
+    fat.buckets.to.run: ${pr-changes:fat.buckets.to.run}
+    disable.run.runBvtTests: ${pr-changes:disable.run.runBvtTests}
+    disable.run.runUnitTests: ${pr-changes:disable.run.runUnitTests}
+    run.chkpii: ${pr-changes:run.chkpii}
+    run.findbugs: ${pr-changes:run.findbugs}
+    spawn.zos: ${pr-changes:spawn.zos}
+    create.im.repo: ${pr-changes:create.im.repo}
+    personal.im.build: ${pr-changes:personal.im.build}
+    disable.run.createDoc: ${pr-changes:disable.run.createDoc}
+    skip.open.liberty.build.if.possible: ${pr-changes:skip.open.liberty.build.if.possible}
+    skip.open.liberty.fats.if.possible: ${pr-changes:skip.open.liberty.fats.if.possible}
+  includeProperties:
+  - file: compilePersonalRTC.properties


### PR DESCRIPTION
- Update personalbuild.yml to contain changes that were made to the matching personalbuild.yml that we use in WebSphere Liberty.
- Add rtcbuild.yml for launching pipelines that have the same functionality as a hashtag build triggered RTC build.
- Test that the pipelines launched by `#pb`, `#pbbeta`, `#fullpb`, and `#fullpbbeta` are running equivalent functionality as what we have in WebSphere Liberty pipelines: same number of tests, all passing tests, and for pipelines launched by beta keywords, utilize test runners that improve robustness and improve performance of time to results.