### PR TITLE
add fat tests for OpenIdAuthenticationMechanismDefinition useNonce

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/configs/TestConfigMaps.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/configs/TestConfigMaps.java
@@ -299,6 +299,18 @@ public class TestConfigMaps {
         return updatedMap;
     }
 
+    public static Map<String, Object> getUseNonceExpressionTrue() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.USE_NONCE_EXPRESSION, String.valueOf(true));
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getUseNonceExpressionFalse() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.USE_NONCE_EXPRESSION, String.valueOf(false));
+        return updatedMap;
+    }
+
     public static Map<String, Object> getOP2() throws Exception {
 
         Map<String, Object> updatedMap = new HashMap<String, Object>();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/utils/Constants.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/utils/Constants.java
@@ -28,6 +28,8 @@ public class Constants extends com.ibm.ws.security.fat.common.Constants {
     public static final String PROVIDER_SECURE_BASE = "providerSecureBase";
     public static final String CLIENT_BASE = "clientBase";
     public static final String CLIENT_SECURE_BASE = "clientSecureBase";
+    public static final String USE_NONCE = "useNonce";
+    public static final String USE_NONCE_EXPRESSION = "useNonceExpression";
     public static final String USE_SESSION = "useSession";
     public static final String USE_SESSION_EXPRESSION = "useSessionExpression";
     public static final String RESPONSE_TYPE = "responseType";

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/utils/MessageConstants.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/utils/MessageConstants.java
@@ -38,11 +38,13 @@ public class MessageConstants extends com.ibm.ws.security.fat.common.MessageCons
     public static final String CWWKS2407E_ERROR_VERIFYING_RESPONSE = "CWWKS2407E";
     public static final String CWWKS2410E_CANNOT_FIND_STATE = "CWWKS2410E";
     public static final String CWWKS2414E_CALLBACK_URL_INCLUDES_ERROR_PARAMETER = "CWWKS2414E";
+    public static final String CWWKS2415E_TOKEN_VALIDATION_EXCEPTION = "CWWKS2415E";
     public static final String CWWKS2423E_OIDC_CLIENT_INVALID_RESPONSE_TYPE = "CWWKS2423E";
 
     public static final String CWWKS2416E_FAILED_TO_REACH_ENDPOINT = "CWWKS2416E";
 
     public static final String CWWKS2500W_MISSING_CLIENTID_EL = "CWWKS2500W";
+    public static final String CWWKS2504E_CREDENTIAL_VALIDATION_ERROR = "CWWKS2504E";
 
     public static final String CWWKS9104A_NO_ACCESS_FOR_USER = "CWWKS9104A";
 

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/BaseOpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/BaseOpenIdConfig.java
@@ -118,6 +118,15 @@ public class BaseOpenIdConfig extends MinimumBaseOpenIdConfig {
         return value;
     }
 
+    public boolean getUseNonceExpression() {
+
+        boolean value = true;
+        if (config.containsKey(Constants.USE_NONCE_EXPRESSION)) {
+            value = getBooleanValue(Constants.USE_NONCE_EXPRESSION);
+        }
+        return value;
+    }
+
     public boolean getTokenAutoRefreshExpression() {
 
         boolean value = false;

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/.classpath
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/.classpath
@@ -19,6 +19,10 @@
 	<classpathentry kind="src" path="test-applications/ScopeOpenIdProfileEmailWithEL.war/src"/>
 	<classpathentry kind="src" path="test-applications/ResponseModeWithMockAuthEndpoint.war/src"/>
 	<classpathentry kind="src" path="test-applications/Authorization.war/src"/>
+	<classpathentry kind="src" path="test-applications/UseNonceTrue.war/src"/>
+	<classpathentry kind="src" path="test-applications/UseNonceFalse.war/src"/>
+	<classpathentry kind="src" path="test-applications/UseNonceTrueWithEL.war/src"/>
+	<classpathentry kind="src" path="test-applications/UseNonceFalseWithEL.war/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/bnd.bnd
@@ -30,7 +30,11 @@ src: \
     test-applications/ScopeOpenIdProfileEmail.war/src,\
     test-applications/ScopeOpenIdProfileEmailWithEL.war/src,\
     test-applications/ResponseModeWithMockAuthEndpoint.war/src,\
-    test-applications/Authorization.war/src
+    test-applications/Authorization.war/src,\
+    test-applications/UseNonceTrue.war/src,\
+    test-applications/UseNonceFalse.war/src,\
+    test-applications/UseNonceTrueWithEL.war/src,\
+    test-applications/UseNonceFalseWithEL.war/src
     
 -dependson: \
     build.changeDetector,\

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/build.gradle
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/build.gradle
@@ -51,6 +51,7 @@ autoFVT.doLast {
       from project(':io.openliberty.security.jakartasec.3.0.internal_fat.common').file('publish/shared/config')
       into new File(autoFvtDir, 'publish/shared/config')
       exclude 'oidcProvider.xml'
+      exclude 'oidcProvider_useNonce.xml'
       include '**/*.xml'
    }
  
@@ -88,6 +89,7 @@ autoFVT.doLast {
 	'jakartasec-3.0_fat.config.rp.ELOverride',
 	'jakartasec-3.0_fat.config.rp.scope',
 	'jakartasec-3.0_fat.config.rp.responseMode',
+	'jakartasec-3.0_fat.config.rp.useNonce',
 	'jakartasec-3.0_fat.config.rp.userinfo.jwt.jwt',
 	'jakartasec-3.0_fat.config.rp.userinfo.jwt.opaque',
 	'jakartasec-3.0_fat.config.rp.userinfo.json.jwt',

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/FATSuite.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/FATSuite.java
@@ -21,6 +21,7 @@ import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationELValues
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationResponseModeTests;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationScopeTests;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationTests;
+import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationUseNonceTests;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationUserInfoTests;
 
 @RunWith(Suite.class)
@@ -30,6 +31,7 @@ import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationUserInfo
                 ConfigurationClaimsDefinitionTests.class,
                 ConfigurationScopeTests.class,
                 ConfigurationResponseModeTests.class,
+                ConfigurationUseNonceTests.class,
                 // LogoutDefinition tests are handled in a separate FAT project as the test use sleeps to wait for tokens to expire and that causes the tests to take quite some time to run
                 ConfigurationELValuesOverrideTests.class,
                 ConfigurationELValuesOverrideWithoutHttpSessionTests.class,

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationUseNonceTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationUseNonceTests.java
@@ -1,0 +1,340 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.fat.config.tests;
+
+import static io.openliberty.security.jakartasec.fat.utils.OpenIdContextExpectationHelpers.buildNonceString;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.ibm.ws.security.fat.common.expectations.Expectations;
+import com.ibm.ws.security.fat.common.expectations.ResponseFullExpectation;
+import com.ibm.ws.security.fat.common.expectations.ResponseMessageExpectation;
+import com.ibm.ws.security.fat.common.expectations.ResponseStatusExpectation;
+import com.ibm.ws.security.fat.common.expectations.ResponseUrlExpectation;
+import com.ibm.ws.security.fat.common.expectations.ServerMessageExpectation;
+import com.ibm.ws.security.fat.common.utils.SecurityFatHttpUtils;
+import com.ibm.ws.security.fat.common.web.WebResponseUtils;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import io.openliberty.security.jakartasec.fat.commonTests.CommonAnnotatedSecurityTests;
+import io.openliberty.security.jakartasec.fat.configs.TestConfigMaps;
+import io.openliberty.security.jakartasec.fat.utils.Constants;
+import io.openliberty.security.jakartasec.fat.utils.MessageConstants;
+import io.openliberty.security.jakartasec.fat.utils.ServletMessageConstants;
+import io.openliberty.security.jakartasec.fat.utils.ShrinkWrapHelpers;
+
+/**
+ * Tests @OpenIdAuthenticationMechanismDefinition useNonce and useNonceExpression
+ *
+ * This class contains tests to validate that a nonce is added to the auth endpoint call
+ * and id token claims if useNonce is set to true, and not added if useNonce is set to false.
+ * Additionally, it validates that useNonceExpression overrides the value of useNonce.
+ * Lastly, it contains a test to verify that an error occurs if the nonce claim in the
+ * id token doesn't match the nonce value stored before the auth endpoint call.
+ */
+/**
+ * Tests appSecurity-5.0
+ */
+@SuppressWarnings("restriction")
+@RunWith(FATRunner.class)
+public class ConfigurationUseNonceTests extends CommonAnnotatedSecurityTests {
+
+    protected static Class<?> thisClass = ConfigurationUseNonceTests.class;
+
+    @Server("jakartasec-3.0_fat.config.op")
+    public static LibertyServer opServer;
+    @Server("jakartasec-3.0_fat.config.rp.useNonce")
+    public static LibertyServer rpServer;
+
+    protected static ShrinkWrapHelpers swh = null;
+
+    @ClassRule
+    public static RepeatTests repeat = createRandomTokenTypeRepeats();
+
+    private static Pattern NONCE_REGEX = Pattern.compile("nonce=[^&]+");
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        // write property that is used to configure the OP to generate JWT or Opaque tokens
+        setTokenTypeInBootstrap(opServer);
+
+        // Add servers to server trackers that will be used to clean servers up and prevent servers
+        // from being restored at the end of each test (so far, the tests are not reconfiguring the servers)
+        updateTrackers(opServer, rpServer, false);
+
+        List<String> waitForMsgs = null;
+        opServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
+        opHttpBase = "http://localhost:" + opServer.getBvtPort();
+        opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
+
+        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
+
+        rpHttpBase = "http://localhost:" + rpServer.getBvtPort();
+        rpHttpsBase = "https://localhost:" + rpServer.getBvtSecurePort();
+
+        deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
+
+    }
+
+    /**
+     * Deploy the apps that this test class uses
+     *
+     * @throws Exception
+     */
+    public static void deployMyApps() throws Exception {
+
+        swh = new ShrinkWrapHelpers(opHttpBase, opHttpsBase, rpHttpBase, rpHttpsBase);
+
+        swh.defaultDropinApp(rpServer, "UseNonceTrue.war", "oidc.client.useNonceTrue.servlets", "oidc.client.base.*");
+        swh.defaultDropinApp(rpServer, "UseNonceFalse.war", "oidc.client.useNonceFalse.servlets", "oidc.client.base.*");
+
+        swh.deployConfigurableTestApps(rpServer, "UseNonceTrueELTrue.war", "UseNonceTrueWithEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "UseNonceTrueELTrue", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getUseNonceExpressionTrue()),
+                                       "oidc.client.useNonceTrueWithEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "UseNonceTrueELFalse.war", "UseNonceTrueWithEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "UseNonceTrueELFalse", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getUseNonceExpressionFalse()),
+                                       "oidc.client.useNonceTrueWithEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "UseNonceFalseELTrue.war", "UseNonceFalseWithEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "UseNonceFalseELTrue", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getUseNonceExpressionTrue()),
+                                       "oidc.client.useNonceFalseWithEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "UseNonceFalseELFalse.war", "UseNonceFalseWithEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "UseNonceFalseELFalse", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getUseNonceExpressionFalse()),
+                                       "oidc.client.useNonceFalseWithEL.servlets", "oidc.client.base.*");
+
+    }
+
+    private void runGoodEndToEndTestWithNonce(String appRoot, String app) throws Exception {
+
+        runGoodEndToEndWithNonceCheck(appRoot, app, true);
+
+    }
+
+    private void runGoodEndToEndTestWithoutNonce(String appRoot, String app) throws Exception {
+
+        runGoodEndToEndWithNonceCheck(appRoot, app, false);
+
+    }
+
+    private void runGoodEndToEndWithNonceCheck(String appRoot, String app, boolean useNonce) throws Exception {
+
+        String requester = ServletMessageConstants.SERVLET + ServletMessageConstants.OPENID_CONTEXT;
+
+        WebClient webClient = getAndSaveWebClient();
+
+        String url = rpHttpsBase + "/" + appRoot + "/" + app;
+
+        Page response = invokeAppReturnLoginPage(webClient, url);
+
+        // disable redirects so we can validate the 302 responses
+        webClient.getOptions().setRedirectEnabled(false);
+
+        response = actions.doFormLogin(response, Constants.TESTUSER, Constants.TESTUSERPWD);
+
+        // follow redirect from login page to the auth endpoint
+        response = actions.invokeUrl(_testName, webClient, WebResponseUtils.getResponseHeaderField(response, Constants.RESPONSE_HEADER_LOCATION));
+
+        String authEndpointNonceRegex = "https:\\/\\/localhost:" + opServer.getBvtSecurePort() + "\\/oidc\\/endpoint\\/OP2\\/authorize\\?.*" + NONCE_REGEX;
+
+        // validates:
+        // - 302 response
+        // - if useNonce = true, then a nonce was included in the req to the auth endpoint
+        // - if useNonce = false, then a nonce was not included in the req to the auth endpoint
+        Expectations expectations = new Expectations();
+        expectations.addExpectation(new ResponseStatusExpectation(Constants.REDIRECT_STATUS));
+        expectations.addExpectation(new ResponseMessageExpectation(Constants.STRING_CONTAINS, Constants.FOUND_MSG, "Did not receive the Found message."));
+        if (useNonce) {
+            expectations.addExpectation(new ResponseUrlExpectation(Constants.STRING_MATCHES, authEndpointNonceRegex, "Did not find nonce in authorization endpoint request."));
+        } else {
+            expectations.addExpectation(new ResponseUrlExpectation(Constants.STRING_DOES_NOT_MATCH, authEndpointNonceRegex, "Found nonce in authorization endpoint request."));
+        }
+        validationUtils.validateResult(response, expectations);
+
+        // follow redirect from auth endpoint to callback
+        response = actions.invokeUrl(_testName, webClient, WebResponseUtils.getResponseHeaderField(response, Constants.RESPONSE_HEADER_LOCATION));
+
+        // follow redirect from callback to original request
+        response = actions.invokeUrl(_testName, webClient, WebResponseUtils.getResponseHeaderField(response, Constants.RESPONSE_HEADER_LOCATION));
+
+        // validates:
+        // - 200 response
+        // - if useNonce = true, then a nonce was included in the id token claims
+        // - if useNonce = false, then a nonce was not included in the id token claims
+        expectations = new Expectations();
+        expectations.addSuccessCodeForCurrentAction();
+        if (useNonce) {
+            expectations.addExpectation(new ResponseFullExpectation(null, Constants.STRING_CONTAINS, buildNonceString(requester), "Did not find an nonce claim in the id token in the OpenIdContext."));
+        } else {
+            expectations.addExpectation(new ResponseFullExpectation(null, Constants.STRING_DOES_NOT_CONTAIN, buildNonceString(requester), "Found nonce claim in the id token in the OpenIdContext."));
+        }
+        validationUtils.validateResult(response, expectations);
+
+    }
+
+    /****************************************************************************************************************/
+    /* Tests */
+    /****************************************************************************************************************/
+
+    /**
+     *
+     * Test with useNonce = true.
+     * A nonce should be included in the auth endpoint call and in the id token claims.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationUseNonceTests_useNonce_true() throws Exception {
+
+        runGoodEndToEndTestWithNonce("UseNonceTrue", "UseNonceTrueServlet");
+
+    }
+
+    /**
+     *
+     * Test with useNonce = false.
+     * A nonce should not be included in the auth endpoint call nor in the id token claims.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationUseNonceTests_useNonce_false() throws Exception {
+
+        runGoodEndToEndTestWithoutNonce("UseNonceFalse", "UseNonceFalseServlet");
+
+    }
+
+    /**
+     *
+     * Test with useNonce = true and useNonceExpression = true.
+     * The value used in useNonceExpression should take precedence.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationUseNonceTests_useNonce_true_useNonceExpression_true() throws Exception {
+
+        runGoodEndToEndTestWithNonce("UseNonceTrueELTrue", "UseNonceTrueWithELServlet");
+
+    }
+
+    /**
+     *
+     * Test with useNonce = true and useNonceExpression = false.
+     * The value used in useNonceExpression should take precedence.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationUseNonceTests_useNonce_true_useNonceExpression_false() throws Exception {
+
+        runGoodEndToEndTestWithoutNonce("UseNonceTrueELFalse", "UseNonceTrueWithELServlet");
+
+    }
+
+    /**
+     *
+     * Test with useNonce = false and useNonceExpression = true.
+     * The value used in useNonceExpression should take precedence.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationUseNonceTests_useNonce_false_useNonceExpression_true() throws Exception {
+
+        runGoodEndToEndTestWithNonce("UseNonceFalseELTrue", "UseNonceFalseWithELServlet");
+
+    }
+
+    /**
+     *
+     * Test with useNonce = false and useNonceExpression = false.
+     * The value used in useNonceExpression should take precedence.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationUseNonceTests_useNonce_false_useNonceExpression_false() throws Exception {
+
+        runGoodEndToEndTestWithoutNonce("UseNonceFalseELFalse", "UseNonceFalseWithELServlet");
+
+    }
+
+    /**
+     *
+     * Test with useNonceExpression = true.
+     * Intercepts the call to the auth endpoint and alters the nonce value to be all lowercase/uppercase.
+     * The test should fail, since the id token returned should contain the all lowercase/uppercase nonce,
+     * which will not match the nonce in the RP which was stored before the auth endpoint call as nonces
+     * are case-sensitive.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationUseNonceTests_useNonce_true_nonceDoesntMatch() throws Exception {
+
+        WebClient webClient = getAndSaveWebClient();
+
+        // disable redirects, so we can intercept the 302 redirect from the
+        // original request to the auth endpoint
+        webClient.getOptions().setRedirectEnabled(false);
+
+        String app = "UseNonceTrueServlet";
+        String url = rpHttpsBase + "/UseNonceTrue/" + app;
+
+        Page response = actions.invokeUrl(_testName, webClient, url);
+
+        String authenticationEndpoint = WebResponseUtils.getResponseHeaderField(response, Constants.RESPONSE_HEADER_LOCATION);
+
+        // modify nonce to be all lowercase
+        Matcher matcher = NONCE_REGEX.matcher(authenticationEndpoint);
+        matcher.find();
+        String authenticationEndpointWithModifiedNonce = authenticationEndpoint.replaceFirst(NONCE_REGEX.pattern(), matcher.group().toLowerCase());
+
+        // if original auth endpoint did not have any uppercase, then turn it all uppercase
+        if (authenticationEndpoint.equals(authenticationEndpointWithModifiedNonce)) {
+            authenticationEndpointWithModifiedNonce = authenticationEndpointWithModifiedNonce.toUpperCase();
+        }
+
+        // re-enable redirect to finish the flow normally
+        webClient.getOptions().setRedirectEnabled(true);
+
+        response = actions.invokeUrl(_testName, webClient, authenticationEndpointWithModifiedNonce);
+        response = actions.doFormLogin(response, Constants.TESTUSER, Constants.TESTUSERPWD);
+
+        Expectations expectations = new Expectations();
+        expectations.addExpectation(new ResponseStatusExpectation(Constants.UNAUTHORIZED_STATUS));
+        expectations.addExpectation(new ResponseMessageExpectation(Constants.STRING_CONTAINS, Constants.UNAUTHORIZED_MESSAGE, "Did not receive the Unauthorize message."));
+        expectations.addExpectation(new ServerMessageExpectation(rpServer, MessageConstants.CWWKS2504E_CREDENTIAL_VALIDATION_ERROR, "Did not receive an error stating that an error occurred while validaitng the client credentials."));
+        expectations.addExpectation(new ServerMessageExpectation(rpServer, MessageConstants.CWWKS2415E_TOKEN_VALIDATION_EXCEPTION, "Did not receive an error stating that an error occured while validating the id token."));
+
+        validationUtils.validateResult(response, expectations);
+
+    }
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/publish/servers/jakartasec-3.0_fat.config.op/configs/server_orig.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/publish/servers/jakartasec-3.0_fat.config.op/configs/server_orig.xml
@@ -17,6 +17,7 @@
 	<include location="${shared.config.dir}/OPMisc.xml" />
 	<include location="${shared.config.dir}/oauthRoles_1.xml" />
 	<include location="${shared.config.dir}/oidcProvider.xml" />
+	<include location="${shared.config.dir}/oidcProvider_useNonce.xml" />
  
 	<sslDefault sslRef="ssl_allSigAlg" />
 </server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/publish/shared/config/oidcProvider_useNonce.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/publish/shared/config/oidcProvider_useNonce.xml
@@ -1,0 +1,45 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+		 		 
+	<openidConnectProvider
+		id="OP2"
+		signatureAlgorithm="RS256"
+		keyAliasName="rs256"
+		keystoreRef="key_allSigAlg"
+		oauthProviderRef="OAuth2" />
+
+	<oauthProvider
+		id="OAuth2"
+		autoAuthorize="true"
+		tokenFormat="${opTokenFormat}"
+	>
+		<autoAuthorizeClient>client_1</autoAuthorizeClient>
+		
+		<localStore>
+			<client
+				name="client_1"
+				secret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+				redirect="https://localhost:${bvt.prop.security_2_HTTP_default.secure}/UseNonceTrue/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/UseNonceFalse/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/UseNonceTrueELTrue/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/UseNonceTrueELFalse/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/UseNonceFalseELTrue/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/UseNonceFalseELFalse/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/UseNonceELTrueMismatch/Callback"
+				scope="openid profile email"
+				enabled="true"
+			>
+			</client>
+		</localStore>
+	</oauthProvider>		
+			
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceFalse.war/src/oidc/client/useNonceFalse/servlets/CallbackServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceFalse.war/src/oidc/client/useNonceFalse/servlets/CallbackServlet.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.useNonceFalse.servlets;
+
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseCallbackServlet;
+
+@WebServlet("/Callback")
+public class CallbackServlet extends BaseCallbackServlet {
+
+    private static final long serialVersionUID = -417476984908088827L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceFalse.war/src/oidc/client/useNonceFalse/servlets/OpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceFalse.war/src/oidc/client/useNonceFalse/servlets/OpenIdConfig.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.useNonceFalse.servlets;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Named;
+import oidc.client.base.servlets.BaseOpenIdConfig;
+
+@Named
+@Dependent
+public class OpenIdConfig extends BaseOpenIdConfig {
+
+    // override and/or create new get methods
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceFalse.war/src/oidc/client/useNonceFalse/servlets/UseNonceFalseServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceFalse.war/src/oidc/client/useNonceFalse/servlets/UseNonceFalseServlet.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.useNonceFalse.servlets;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseServlet;
+
+@WebServlet("/UseNonceFalseServlet")
+@OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP2",
+                                         clientId = "client_1",
+                                         clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
+                                         claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
+                                         redirectURI = "${baseURL}/Callback",
+                                         useNonce = false,
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}")
+@DeclareRoles("all")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "all"))
+public class UseNonceFalseServlet extends BaseServlet {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceFalseWithEL.war/src/oidc/client/useNonceFalseWithEL/servlets/CallbackServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceFalseWithEL.war/src/oidc/client/useNonceFalseWithEL/servlets/CallbackServlet.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.useNonceFalseWithEL.servlets;
+
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseCallbackServlet;
+
+@WebServlet("/Callback")
+public class CallbackServlet extends BaseCallbackServlet {
+
+    private static final long serialVersionUID = -417476984908088827L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceFalseWithEL.war/src/oidc/client/useNonceFalseWithEL/servlets/OpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceFalseWithEL.war/src/oidc/client/useNonceFalseWithEL/servlets/OpenIdConfig.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.useNonceFalseWithEL.servlets;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Named;
+import oidc.client.base.servlets.BaseOpenIdConfig;
+
+@Named
+@Dependent
+public class OpenIdConfig extends BaseOpenIdConfig {
+
+    // override and/or create new get methods
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceFalseWithEL.war/src/oidc/client/useNonceFalseWithEL/servlets/UseNonceFalseWithELServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceFalseWithEL.war/src/oidc/client/useNonceFalseWithEL/servlets/UseNonceFalseWithELServlet.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.useNonceFalseWithEL.servlets;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseServlet;
+
+@WebServlet("/UseNonceFalseWithELServlet")
+@OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP2",
+                                         clientId = "client_1",
+                                         clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
+                                         claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
+                                         redirectURI = "${baseURL}/Callback",
+                                         useNonce = false,
+                                         useNonceExpression = "${openIdConfig.useNonceExpression}",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}")
+@DeclareRoles("all")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "all"))
+public class UseNonceFalseWithELServlet extends BaseServlet {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceTrue.war/src/oidc/client/useNonceTrue/servlets/CallbackServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceTrue.war/src/oidc/client/useNonceTrue/servlets/CallbackServlet.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.useNonceTrue.servlets;
+
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseCallbackServlet;
+
+@WebServlet("/Callback")
+public class CallbackServlet extends BaseCallbackServlet {
+
+    private static final long serialVersionUID = -417476984908088827L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceTrue.war/src/oidc/client/useNonceTrue/servlets/OpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceTrue.war/src/oidc/client/useNonceTrue/servlets/OpenIdConfig.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.useNonceTrue.servlets;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Named;
+import oidc.client.base.servlets.BaseOpenIdConfig;
+
+@Named
+@Dependent
+public class OpenIdConfig extends BaseOpenIdConfig {
+
+    // override and/or create new get methods
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceTrue.war/src/oidc/client/useNonceTrue/servlets/UseNonceTrueServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceTrue.war/src/oidc/client/useNonceTrue/servlets/UseNonceTrueServlet.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.useNonceTrue.servlets;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseServlet;
+
+@WebServlet("/UseNonceTrueServlet")
+@OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP2",
+                                         clientId = "client_1",
+                                         clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
+                                         claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
+                                         redirectURI = "${baseURL}/Callback",
+                                         useNonce = true,
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}")
+@DeclareRoles("all")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "all"))
+public class UseNonceTrueServlet extends BaseServlet {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceTrueWithEL.war/src/oidc/client/useNonceTrueWithEL/servlets/CallbackServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceTrueWithEL.war/src/oidc/client/useNonceTrueWithEL/servlets/CallbackServlet.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.useNonceTrueWithEL.servlets;
+
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseCallbackServlet;
+
+@WebServlet("/Callback")
+public class CallbackServlet extends BaseCallbackServlet {
+
+    private static final long serialVersionUID = -417476984908088827L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceTrueWithEL.war/src/oidc/client/useNonceTrueWithEL/servlets/OpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceTrueWithEL.war/src/oidc/client/useNonceTrueWithEL/servlets/OpenIdConfig.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.useNonceTrueWithEL.servlets;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Named;
+import oidc.client.base.servlets.BaseOpenIdConfig;
+
+@Named
+@Dependent
+public class OpenIdConfig extends BaseOpenIdConfig {
+
+    // override and/or create new get methods
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceTrueWithEL.war/src/oidc/client/useNonceTrueWithEL/servlets/UseNonceTrueWithELServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/UseNonceTrueWithEL.war/src/oidc/client/useNonceTrueWithEL/servlets/UseNonceTrueWithELServlet.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.useNonceTrueWithEL.servlets;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseServlet;
+
+@WebServlet("/UseNonceTrueWithELServlet")
+@OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP2",
+                                         clientId = "client_1",
+                                         clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
+                                         claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
+                                         redirectURI = "${baseURL}/Callback",
+                                         useNonce = true,
+                                         useNonceExpression = "${openIdConfig.useNonceExpression}",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}")
+@DeclareRoles("all")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "all"))
+public class UseNonceTrueWithELServlet extends BaseServlet {
+
+    private static final long serialVersionUID = 1L;
+
+}


### PR DESCRIPTION
add fat tests for OpenIdAuthenticationMechanismDefinition useNonce and useNonceExpression

This PR contains tests to validate that a nonce is added to the auth endpoint call and id token claims if `useNonce` is set to true, and not added if `useNonce` is set to false. Additionally, it validates that `useNonceExpression` overrides the value of `useNonce`. Lastly, it contains a test to verify that an error occurs if the nonce claim in the id token doesn't match the nonce value stored before the auth endpoint call.
