### PR TITLE
Add test of spec change for Response.created() when using relative url

### DIFF
--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/FATSuite.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/FATSuite.java
@@ -28,6 +28,8 @@ import componenttest.rules.repeater.RepeatTests;
                 JakartaPackageTest.class,
                 JsonbTest.class,
                 ManagedBeansTest.class,
+                ResponseRelativePathTest.class,
+                RestfulWsPrototypeTest.class,
                 ValidatorTest.class,
                 WebXmlAppTest.class,
                 WebXmlNoAppTest.class,

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/ResponseRelativePathTest.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/ResponseRelativePathTest.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.fat;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.restfulWS30.fat.responserelativepath.ResponseRelativePathClientTestServlet;
+
+/*
+ * The purpose of this test is to ensure that the following change to the RestfulWS specification was implemented correctly:
+ * "Response.created(URI) now resolves relative URIs into an absolute URI against the base URI, not against the
+ * request URI anymore."
+ */
+@RunWith(FATRunner.class)
+public class ResponseRelativePathTest extends FATServletClient {
+
+    public static final String APP_NAME = "responserelativepath";
+    public static final String SERVER_NAME = APP_NAME;
+    
+    @Server(SERVER_NAME)
+    @TestServlet(servlet = ResponseRelativePathClientTestServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        // Build the application
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addPackages(true, ResponseRelativePathClientTestServlet.class.getPackage());
+
+        ShrinkHelper.exportDropinAppToServer(server, war, DeployOptions.SERVER_ONLY);
+        
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server != null) {
+            server.stopServer("CWWKE1102W");  //ignore server quiesce timeouts due to slow test machines
+        }
+    }
+    
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/RestfulWsPrototypeTest.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/RestfulWsPrototypeTest.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.fat;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.restfulWS30.fat.restfulwsprototype.RestfulWsPrototypeClientTestServlet;
+
+/*
+ * The purpose of this test is to provide an empty canvas for rapid/easy test experimentation,
+ * as well as providing and example of FAT best practices.
+ *
+ * This Test should never have any real tests, if you use this Test to create a test that should
+ * be added permanently, create a new FAT Test using this test as a template.
+ */
+@RunWith(FATRunner.class)
+public class RestfulWsPrototypeTest extends FATServletClient {
+
+    public static final String APP_NAME = "restfulwsprototype";
+    public static final String SERVER_NAME = APP_NAME;
+    
+    // If needed, third party libs are copied to ${buildDir}/autoFVT/appLibs/prototype in build.gradle
+//    private static final String libs = "appLibs/prototype";
+
+
+    @Server(SERVER_NAME)
+    @TestServlet(servlet = RestfulWsPrototypeClientTestServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        // Build an application
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addPackages(true, RestfulWsPrototypeClientTestServlet.class.getPackage());
+
+        ShrinkHelper.exportDropinAppToServer(server, war, DeployOptions.SERVER_ONLY);
+        
+        // Build an application, add third party libs, and manually export to the dropins directory
+//      WebArchive app = ShrinkHelper.buildDefaultApp(APP_NAME, "restfulwsprototype");
+//      app.addAsLibraries(new File(libs).listFiles());
+//      ShrinkHelper.exportDropinAppToServer(server, app);
+//      server.addInstalledAppForValidation(APP_NAME);
+
+
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server != null) {
+            server.stopServer("CWWKE1102W");  //ignore server quiesce timeouts due to slow test machines
+        }
+    }
+    
+    @Before
+    public void beforeTest() {}
+
+    @After
+    public void afterTest() {}
+
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/responserelativepath/App.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/responserelativepath/App.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.fat.responserelativepath;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class App extends Application {
+
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/responserelativepath/Resource.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/responserelativepath/Resource.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.fat.responserelativepath;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+@Path("/")
+@Produces(MediaType.TEXT_PLAIN)
+public class Resource {
+
+    @GET
+    @Path("testRelativePath")
+    public String testRelativePath(@Context UriInfo uriInfo) {
+        try {
+            System.out.println("BaseURI = " + uriInfo.getBaseUri().getPath());
+            System.out.println("RequestURI = " + uriInfo.getRequestUri().getPath());
+            //create URI using relative path
+            Response returnResponse = Response.created(new URI("/test"))
+                            .build();
+            return returnResponse.getHeaderString("Location");
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/responserelativepath/ResponseRelativePathClientTestServlet.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/responserelativepath/ResponseRelativePathClientTestServlet.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.fat.responserelativepath;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import jakarta.servlet.annotation.WebServlet;
+
+@SuppressWarnings("serial")
+@WebServlet("/ResponseRelativePathClientTestServlet")
+public class ResponseRelativePathClientTestServlet extends FATServlet {
+
+    @Test
+    public void testResourceIsRequestScoped() throws Exception {
+        URI uri = URI.create("http://localhost:" + System.getProperty("bvt.prop.HTTP_default") + "/responserelativepath/testRelativePath");
+        HttpURLConnection conn = (HttpURLConnection) uri.toURL().openConnection();
+        assertEquals(200, conn.getResponseCode());
+        String uriValue = readEntity(conn.getInputStream());
+        // The URI in the response should be built on the baseuri and not the requesturi.  
+        // "testRelativePath" is only in the requesturi
+        assertTrue(uriValue.contains("/responserelativepath/"));       
+        assertFalse(uriValue.contains("/responserelativepath/testRelativePath/"));       
+    }
+
+    private String readEntity(InputStream is) throws Exception {
+        StringBuilder sb = new StringBuilder();
+        byte[] b = new byte[256];
+        int i = is.read(b);
+        while (i > 0) {
+            sb.append(new String(b, 0, i));
+            i = is.read(b);
+        }
+        return sb.toString().trim();
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/restfulwsprototype/RestfulWsPrototypeApp.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/restfulwsprototype/RestfulWsPrototypeApp.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.fat.restfulwsprototype;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class RestfulWsPrototypeApp extends Application {
+
+
+//  @Override
+//  public Set<Class<?>> getClasses() {
+//      Set<Class<?>> classes = new HashSet<Class<?>>();
+//      classes.add(Resource.class);
+//      return classes;
+//      return Collections.singleton(Resource.class);
+//  }
+//
+//  @Override
+//  public Map<String, Object> getProperties() {
+//      Map<String, Object> properties = new HashMap<String, Object>();
+//      return properties;
+//      return Collections.singleton(props);
+//  }
+//
+//  @Override
+//  public Set<Object> getSingletons() {
+//      Set<Object> singletons = new HashSet<Object>();
+//      singletons.add(new Resource());
+//      return singletons;
+//      return Collections.singleton(new Resource());
+//  }
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/restfulwsprototype/RestfulWsPrototypeClientTestServlet.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/restfulwsprototype/RestfulWsPrototypeClientTestServlet.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.fat.restfulwsprototype;
+
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import jakarta.servlet.annotation.WebServlet;
+
+@SuppressWarnings("serial")
+@WebServlet("/RestfulWsPrototypeClientTestServlet")
+public class RestfulWsPrototypeClientTestServlet extends FATServlet {
+
+    @Test
+    public void testResourceIsRequestScoped() throws Exception {
+        URI uri = URI.create("http://localhost:" + System.getProperty("bvt.prop.HTTP_default") + "/restfulwsprototype/echo");
+        HttpURLConnection conn = (HttpURLConnection) uri.toURL().openConnection();
+        assertEquals(200, conn.getResponseCode());
+        String returnValue = readEntity(conn.getInputStream());
+        assertEquals("Hello World!",returnValue);       
+    }
+
+    private String readEntity(InputStream is) throws Exception {
+        StringBuilder sb = new StringBuilder();
+        byte[] b = new byte[256];
+        int i = is.read(b);
+        while (i > 0) {
+            sb.append(new String(b, 0, i));
+            i = is.read(b);
+        }
+        return sb.toString().trim();
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/restfulwsprototype/RestfulWsPrototypeResource.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/restfulwsprototype/RestfulWsPrototypeResource.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.fat.restfulwsprototype;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/")
+@Produces(MediaType.TEXT_PLAIN)
+public class RestfulWsPrototypeResource {
+
+    @GET
+    @Path("echo")
+    public String hello() {
+        return "Hello World!";
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/responserelativepath/.gitignore
+++ b/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/responserelativepath/.gitignore
@@ -1,0 +1,2 @@
+/apps
+/dropins

--- a/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/responserelativepath/bootstrap.properties
+++ b/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/responserelativepath/bootstrap.properties
@@ -1,0 +1,4 @@
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all:org.jboss.resteasy*=all
+com.ibm.ws.logging.max.file.size=0
+
+bootstrap.include=../testports.properties

--- a/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/responserelativepath/server.xml
+++ b/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/responserelativepath/server.xml
@@ -1,0 +1,11 @@
+<server>
+    <featureManager>
+        <feature>componenttest-2.0</feature>
+         <feature>restfulWS-3.0</feature>
+    </featureManager>
+  	<include location="../fatTestPorts.xml"/>
+  	
+    <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
+    <javaPermission className="java.net.URLPermission" name="http://localhost:8010/responserelativepath/-" actions="GET:"/>
+    <javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
+</server>

--- a/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/restfulwsprototype/.gitignore
+++ b/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/restfulwsprototype/.gitignore
@@ -1,0 +1,2 @@
+/apps
+/dropins

--- a/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/restfulwsprototype/bootstrap.properties
+++ b/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/restfulwsprototype/bootstrap.properties
@@ -1,0 +1,4 @@
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all:org.jboss.resteasy*=all
+com.ibm.ws.logging.max.file.size=0
+
+bootstrap.include=../testports.properties

--- a/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/restfulwsprototype/server.xml
+++ b/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/restfulwsprototype/server.xml
@@ -1,0 +1,11 @@
+<server>
+    <featureManager>
+        <feature>componenttest-2.0</feature>
+         <feature>restfulWS-3.0</feature>
+    </featureManager>
+  	<include location="../fatTestPorts.xml"/>
+  	
+    <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
+    <javaPermission className="java.net.URLPermission" name="http://localhost:8010/restfulwsprototype/-" actions="GET:"/>
+    <javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
+</server>


### PR DESCRIPTION
Fixes #23657 

The Jakarta Rest 3.0 spec changed for when a relative URL is used in Response.created().  The resulting URI should be based on the Base URI and not the Request URI as  before EE9.   This change tests that.

In addition this PR contains a prototype testcase for the io.openliberty.restfulWS.3.0_fat.
