### PR TITLE
Instanton server fixes

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -862,9 +862,9 @@ readServerEnv()
 criuEnvDefaults() {
   if [ -z "$GLIBC_TUNABLES" ]
   then
-    GLIBC_TUNABLES=glibc.cpu.hwcaps=-XSAVEC,-XSAVE,-AVX2,-ERMS,-AVX,-AVX_Fast_Unaligned_Load
+    GLIBC_TUNABLES=glibc.cpu.hwcaps=-XSAVEC,-XSAVE,-AVX2,-ERMS,-AVX,-AVX_Fast_Unaligned_Load:glibc.pthread.rseq=0
   else
-    GLIBC_TUNABLES=${GLIBC_TUNABLES}:glibc.cpu.hwcaps=-XSAVEC,-XSAVE,-AVX2,-ERMS,-AVX,-AVX_Fast_Unaligned_Load
+    GLIBC_TUNABLES=${GLIBC_TUNABLES}:glibc.cpu.hwcaps=-XSAVEC,-XSAVE,-AVX2,-ERMS,-AVX,-AVX_Fast_Unaligned_Load:glibc.pthread.rseq=0
   fi
   export GLIBC_TUNABLES
   export LD_BIND_NOT=on
@@ -1421,7 +1421,7 @@ criuRestore()
   fi
 
   return $rc
-}         
+}
 
 ## restoreServer: restore a server from a checkpoint image if it exists
 ##

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -34,10 +34,6 @@
 #                     value the switch will not be passed in. 
 #                     If unset, the unprivileged switch is passed in unless the current user is root
 #
-# CRIU_EXTRA_ARGS   - Pass extra arguments to `criu restore`. Extra arguments are
-#                     appended to the end of the list of arguments and can therefore
-#                     override existing arguments, if desired.
-#
 # CRIU_RESTORE_DISABLE_RECOVERY - 
 #              When restoring a server from a checkpoint it is possible
 #              that CRIU will fail to restore the process.  By default

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -923,13 +923,11 @@ serverUmask()
   fi
 }
 
-##  kill process associated with pid passed in as argument.
+##  Silently kill the process associated with pid passed in as argument.
+##  No output if the pid does not exist.
 ##
-##
-killIfRunning() {
-    if ps --pid ${1} > /dev/null 2>&1 ; then
-        kill ${1}
-    fi        
+killSilent() {
+  kill ${1} > /dev/null 2>&1
 }
 ##
 ## javaCmd: Execute a java-based command.  Arguments are:
@@ -1048,7 +1046,7 @@ javaCmd()
     TAIL_PID=$!
     # trap on the signals here to ensure the background tail process ends.
     trap "exit" INT TERM
-    trap "killIfRunning $TAIL_PID" EXIT
+    trap "killSilent $TAIL_PID" EXIT
     "${JAVA_CMD}" "$@" >> "${CHECKPOINT_CONSOLE_LOG}" 2>&1 < /dev/null
     rc=$?
     if [ $rc -eq 20 ]; then
@@ -1387,8 +1385,9 @@ criuRestore()
     mkdirs "${X_PID_DIR}"
     rmIfExist "${X_PID_FILE}"
     criu restore --skip-file-rwx-check --cpu-cap=none --file-locks --tcp-established --images-dir=${SERVER_OUTPUT_DIR}/workarea/checkpoint/image \
-      --shell-job --verbosity=${CRIU_LOG_LEVEL} --log-file ${X_LOG_DIR}/checkpoint/restore.log --pidfile ${X_PID_FILE} \
-      --restore-detached ${CRIU_EXTRA_ARGS}
+      --shell-job --verbosity=${CRIU_LOG_LEVEL} --log-file ${X_LOG_DIR}/checkpoint/restore.log ${CRIU_EXTRA_ARGS} \
+      --pidfile ${X_PID_FILE} \
+      --restore-detached
     rc=$?
     PID=`cat ${X_PID_FILE}`
     if [ $rc = 0 ]; then
@@ -1412,7 +1411,7 @@ criuRestore()
     TAIL_PID=$!
     # trap on the signals here to ensure the background tail process ends
     trap "exit" INT TERM
-    trap "killIfRunning $TAIL_PID" EXIT
+    trap "killSilent $TAIL_PID" EXIT
 
     criu restore --skip-file-rwx-check --cpu-cap=none --file-locks --tcp-established --images-dir=${SERVER_OUTPUT_DIR}/workarea/checkpoint/image \
       --shell-job --verbosity=${CRIU_LOG_LEVEL} --log-file ${X_LOG_DIR}/checkpoint/restore.log ${CRIU_EXTRA_ARGS}


### PR DESCRIPTION
Remove need for using the 'ps' command.

Add glibc.pthread.rseq=0 to the glibc tunables to make process images more portable.