### PR TITLE
Disable /metrics if Prometheus Registry is not available

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.common/resources/com/ibm/ws/microprofile/metrics/resources/Metrics.nlsprops
+++ b/dev/com.ibm.ws.microprofile.metrics.common/resources/com/ibm/ws/microprofile/metrics/resources/Metrics.nlsprops
@@ -59,6 +59,11 @@ internal.error.CWMMC0006E=CWMMC0006E: An internal error occurred.
 internal.error.CWMMC0006E.explanation=The application server experienced an internal error.
 internal.error.CWMMC0006E.useraction=Gather a set of traces and open a new issue against your application server.
 
+#User configured mpMetrics to use user-defined library for Micrometer binaries without Prometheus Registry JAR
+noPrometheusRegistry.info.CWMMC0008I=CWMMC0008I: The /metrics endpoint is not available as there is no Prometheus Registry available.
+noPrometheusRegistry.info.CWMMC0008I.explanation=Either the MP Config "mp.metrics.prometheus.enabled" was set to "false" or the MicroProfile Metrics feature is loading Micrometer libraries defined through the libraryRef attribute and this referenced Library does not contain a Micrometer Prometheus Registry.
+noPrometheusRegistry.info.CWMMC0008I.useraction=If the disabling or unavailability  of the Prometheus Registry was not intentional then take one or both of the following steps. Configure the MP Config value for "mp.metrics.prometheus.enabled" to be "true". Modify the contents of the library referenced by the libraryRef attribute to contain a Micrometer Prometheus Registry JAR.
+
 #Memory usedHeap message
 memory.usedHeap.description=Displays the amount of used heap memory in bytes.
 

--- a/dev/com.ibm.ws.microprofile.metrics.common/resources/com/ibm/ws/microprofile/metrics/resources/Metrics.nlsprops
+++ b/dev/com.ibm.ws.microprofile.metrics.common/resources/com/ibm/ws/microprofile/metrics/resources/Metrics.nlsprops
@@ -62,7 +62,7 @@ internal.error.CWMMC0006E.useraction=Gather a set of traces and open a new issue
 #User configured mpMetrics to use user-defined library for Micrometer binaries without Prometheus Registry JAR
 noPrometheusRegistry.info.CWMMC0008I=CWMMC0008I: The /metrics endpoint is not available because no Prometheus Registry is available.
 noPrometheusRegistry.info.CWMMC0008I.explanation=The MicroProfile Metrics feature is loading Micrometer libraries that are defined through the libraryRef attribute, but the referenced Library does not contain a Micrometer Prometheus Registry.
-noPrometheusRegistry.info.CWMMC0008I.useraction=If the unavailability of the Prometheus Registry is not intentional, modify the contents of the library referenced by the libraryRef attribute to contain a Micrometer Prometheus Registry JAR.
+noPrometheusRegistry.info.CWMMC0008I.useraction=If the unavailability of the Prometheus Registry is not intentional, modify the contents of the library that is referenced by the libraryRef attribute to contain a Micrometer Prometheus Registry JAR.
 
 #Prometheus Registry was disabled through the mp.metrics.prometheus.enabled MicroProfile Config property
 disabled.info.CWMMC0009I=CWMMC0009I: The /metrics endpoint is not available because the Prometheus Registry is disabled.

--- a/dev/com.ibm.ws.microprofile.metrics.common/resources/com/ibm/ws/microprofile/metrics/resources/Metrics.nlsprops
+++ b/dev/com.ibm.ws.microprofile.metrics.common/resources/com/ibm/ws/microprofile/metrics/resources/Metrics.nlsprops
@@ -60,9 +60,9 @@ internal.error.CWMMC0006E.explanation=The application server experienced an inte
 internal.error.CWMMC0006E.useraction=Gather a set of traces and open a new issue against your application server.
 
 #User configured mpMetrics to use user-defined library for Micrometer binaries without Prometheus Registry JAR
-noPrometheusRegistry.info.CWMMC0008I=CWMMC0008I: The /metrics endpoint is not available as there is no Prometheus Registry available.
-noPrometheusRegistry.info.CWMMC0008I.explanation=Either the MP Config "mp.metrics.prometheus.enabled" was set to "false" or the MicroProfile Metrics feature is loading Micrometer libraries defined through the libraryRef attribute and this referenced Library does not contain a Micrometer Prometheus Registry.
-noPrometheusRegistry.info.CWMMC0008I.useraction=If the disabling or unavailability  of the Prometheus Registry was not intentional then take one or both of the following steps. Configure the MP Config value for "mp.metrics.prometheus.enabled" to be "true". Modify the contents of the library referenced by the libraryRef attribute to contain a Micrometer Prometheus Registry JAR.
+noPrometheusRegistry.info.CWMMC0008I=CWMMC0008I: The /metrics endpoint is not available because no Prometheus Registry is available.
+noPrometheusRegistry.info.CWMMC0008I.explanation=The mp.metrics.prometheus.enabled MP Config might be set to false. Alternatively, the MicroProfile Metrics feature might be loading Micrometer libraries that are defined through the libraryRef attribute, but a referenced Library does not contain a Micrometer Prometheus Registry.
+noPrometheusRegistry.info.CWMMC0008I.useraction=If the unavailability of the Prometheus Registry is not intentional, complete one or both of the following steps. Set the value for the mp.metrics.prometheus.enabled MP Config property to true. Modify the contents of the library referenced by the libraryRef attribute to contain a Micrometer Prometheus Registry JAR.
 
 #Memory usedHeap message
 memory.usedHeap.description=Displays the amount of used heap memory in bytes.

--- a/dev/com.ibm.ws.microprofile.metrics.common/resources/com/ibm/ws/microprofile/metrics/resources/Metrics.nlsprops
+++ b/dev/com.ibm.ws.microprofile.metrics.common/resources/com/ibm/ws/microprofile/metrics/resources/Metrics.nlsprops
@@ -61,8 +61,13 @@ internal.error.CWMMC0006E.useraction=Gather a set of traces and open a new issue
 
 #User configured mpMetrics to use user-defined library for Micrometer binaries without Prometheus Registry JAR
 noPrometheusRegistry.info.CWMMC0008I=CWMMC0008I: The /metrics endpoint is not available because no Prometheus Registry is available.
-noPrometheusRegistry.info.CWMMC0008I.explanation=The mp.metrics.prometheus.enabled MP Config might be set to false. Alternatively, the MicroProfile Metrics feature might be loading Micrometer libraries that are defined through the libraryRef attribute, but a referenced Library does not contain a Micrometer Prometheus Registry.
-noPrometheusRegistry.info.CWMMC0008I.useraction=If the unavailability of the Prometheus Registry is not intentional, complete one or both of the following steps. Set the value for the mp.metrics.prometheus.enabled MP Config property to true. Modify the contents of the library referenced by the libraryRef attribute to contain a Micrometer Prometheus Registry JAR.
+noPrometheusRegistry.info.CWMMC0008I.explanation=The MicroProfile Metrics feature is loading Micrometer libraries that are defined through the libraryRef attribute, but the referenced Library does not contain a Micrometer Prometheus Registry.
+noPrometheusRegistry.info.CWMMC0008I.useraction=If the unavailability of the Prometheus Registry is not intentional, modify the contents of the library referenced by the libraryRef attribute to contain a Micrometer Prometheus Registry JAR.
+
+#Prometheus Registry was disabled through the mp.metrics.prometheus.enabled MicroProfile Config property
+disabled.info.CWMMC0009I=CWMMC0009I: The /metrics endpoint is not available because the Prometheus Registry is disabled.
+disabled.info.CWMMC0009I.explanation=The mp.metrics.prometheus.enabled MicroProfile Config property is set to false.
+disabled.info.CWMMC0009I.useraction=If the disabling of the Prometheus Registry is not intentional, remove the configuration of mp.metrics.prometheus.enabled MicroProfile Config property or explicitly set the property to true.
 
 #Memory usedHeap message
 memory.usedHeap.description=Displays the amount of used heap memory in bytes.

--- a/dev/io.openliberty.microprofile.metrics.5.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.metrics.5.0.internal/bnd.bnd
@@ -75,6 +75,7 @@ WS-TraceGroup: METRICS
 	io.openliberty.jakarta.cdi.4.0;version=latest, \
 	com.ibm.ws.cdi.interfaces.jakarta;version=latest,\
 	com.ibm.websphere.rest.handler;version=latest,\
+	com.ibm.websphere.org.eclipse.microprofile.config.1.4;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.ws.microprofile.metrics.common;version=latest,\
 	com.ibm.ws.microprofile.metrics;version=latest

--- a/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/internal/MetricsConfig.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/internal/MetricsConfig.java
@@ -113,7 +113,6 @@ public class MetricsConfig {
     }
 
     public synchronized void disableMetricsEndpoint() {
-        Tr.info(tc, "noPrometheusRegistry.info.CWMMC0008I");
         publicWabConfigMgr.processEnableAuthentication(componentCtx, false);
         privateWabConfigMgr.processEnableAuthentication(componentCtx, false);
     }

--- a/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/internal/MetricsConfig.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/internal/MetricsConfig.java
@@ -55,6 +55,8 @@ public class MetricsConfig {
     // Cached WAB service configurations for Private MicroProfile Metrics
     private final WABConfigManager privateWabConfigMgr;
 
+    private ComponentContext componentCtx;
+
     public MetricsConfig() {
         // Initialize WAB configuration managers for public URLs
         publicWabConfigMgr = new WABConfigManager(PUBLIC_MP_METRICS_VAR_NAME, MP_METRICS_ENDPOINT_URL);
@@ -64,6 +66,9 @@ public class MetricsConfig {
 
     @Activate
     protected void activate(ComponentContext context, Map<String, Object> properties) {
+
+        componentCtx = context;
+
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
             Tr.event(tc, "Activate MetricsConfig", properties);
         }
@@ -105,6 +110,12 @@ public class MetricsConfig {
                 publicWabConfigMgr.processEnableAuthentication(context, true);
             }
         }
+    }
+
+    public synchronized void disableMetricsEndpoint() {
+        Tr.info(tc, "noPrometheusRegistry.info.CWMMC0008I");
+        publicWabConfigMgr.processEnableAuthentication(componentCtx, false);
+        privateWabConfigMgr.processEnableAuthentication(componentCtx, false);
     }
 
     private boolean valueChanged(Object oldValue, Object newValue) {


### PR DESCRIPTION
Disable the /metrics endpoint if the SmallRye Metrics implementation is unable to resolve the Prometheus Registry. Issue an INFO message if that is the case

#build