### PR TITLE
Adjust java11 FAT test to work with JDK20+

### DIFF
--- a/dev/com.ibm.ws.java11_fat/fat/src/com/ibm/ws/java11_fat/JavaInfoTest.java
+++ b/dev/com.ibm.ws.java11_fat/fat/src/com/ibm/ws/java11_fat/JavaInfoTest.java
@@ -86,8 +86,8 @@ public class JavaInfoTest extends FATServletClient {
     @Test
     public void testMajorVersion() {
         int major = JavaInfo.majorVersion();
-        assertTrue("Java major version was not within a known range (7-19): " + major,
-                   major >= 7 && major < 20);
+        assertTrue("Java major version was not within a known range (7+): " + major,
+                   major >= 7);
 
         assertEquals(major, fatJavaInfo.majorVersion());
     }


### PR DESCRIPTION
Fix a java 11 test case which had a check limit of up to Java 19. 