### PR TITLE
Help Debug why servlet Mbean is not registered for TestEDF2 in com.ibm.ws.microprofile.metrics.2.x.monitor_fat

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF2/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF2/bootstrap.properties
@@ -1,2 +1,2 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.microprofile.metrics.monitor.*=all
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.microprofile.metrics.monitor.*=all:com.ibm.ws.webcontainer.monitor.WebContainerMonitor=all:com.ibm.websphere.monitor.meters=all


### PR DESCRIPTION
#build
related to #23445