### PR TITLE
Iterator with keyset pagination

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PaginatedIterator.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PaginatedIterator.java
@@ -10,10 +10,14 @@
  *******************************************************************************/
 package io.openliberty.data.internal.persistence;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 import jakarta.data.repository.Pageable;
@@ -23,6 +27,8 @@ import jakarta.persistence.TypedQuery;
 /**
  */
 public class PaginatedIterator<T> implements Iterator<T> {
+    private final TraceComponent tc = Tr.register(PaginatedIterator.class);
+
     private final Object[] args;
     private int index;
     private Boolean hasNext;
@@ -39,27 +45,61 @@ public class PaginatedIterator<T> implements Iterator<T> {
     }
 
     @FFDCIgnore(Exception.class)
+    @Trivial
     private void getPage() {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
+            Tr.entry(this, tc, "getPage " + pagination.page());
+
+        Pageable.Cursor keysetCursor = pagination.cursor();
+        int maxPageSize = pagination.size();
+        int startAt = keysetCursor == null ? RepositoryImpl.computeOffset(pagination.page(), maxPageSize) : 0;
+        String jpql = keysetCursor == null ? queryInfo.jpql : //
+                        pagination.mode() == Pageable.Mode.CURSOR_NEXT ? queryInfo.jpqlAfterKeyset : //
+                                        queryInfo.jpqlBeforeKeyset;
+
         EntityManager em = queryInfo.entityInfo.persister.createEntityManager();
         try {
             @SuppressWarnings("unchecked")
-            TypedQuery<T> query = (TypedQuery<T>) em.createQuery(queryInfo.jpql, queryInfo.entityInfo.type);
+            TypedQuery<T> query = (TypedQuery<T>) em.createQuery(jpql, queryInfo.entityInfo.type);
             queryInfo.setParameters(query, args);
 
-            // TODO Keyset pagination
-            int maxPageSize = pagination.size();
-            query.setFirstResult(RepositoryImpl.computeOffset(pagination.page(), maxPageSize));
+            if (keysetCursor != null)
+                queryInfo.setKeysetParameters(query, keysetCursor);
+
+            if (startAt > 0)
+                query.setFirstResult(startAt);
+
             query.setMaxResults(maxPageSize);
-            pagination = pagination.next();
 
             page = query.getResultList();
             index = -1;
             hasNext = !page.isEmpty();
+            if (hasNext && pagination.mode() == Pageable.Mode.CURSOR_PREVIOUS)
+                Collections.reverse(page);
+            if (page.size() == maxPageSize) {
+                if (keysetCursor == null) {
+                    pagination = pagination.next();
+                } else if (pagination.mode() == Pageable.Mode.CURSOR_NEXT) {
+                    Pageable next = pagination.page() == Long.MAX_VALUE ? pagination : pagination.page(pagination.page() + 1);
+                    pagination = next.afterKeyset(queryInfo.getKeysetValues(page.get(page.size() - 1)));
+                } else { // CURSOR_PREVIOUS
+                    // Decrement page number by 1 unless it would go below 1.
+                    Pageable prev = pagination.page() == 1 ? pagination : pagination.page(pagination.page() - 1);
+                    pagination = prev.beforeKeyset(queryInfo.getKeysetValues(page.get(0)));
+                }
+            } else {
+                pagination = null;
+            }
         } catch (Exception x) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
+                Tr.entry(this, tc, "getPage", x);
             throw RepositoryImpl.failure(x);
         } finally {
             em.close();
         }
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
+            Tr.exit(this, tc, "getPage size " + page.size());
     }
 
     @Override

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -146,7 +146,9 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
                                     || KeysetAwarePage.class.equals(queryInfo.returnTypeParam);
         boolean needsKeysetQueries = isKeysetAwarePage
                                      || KeysetAwareSlice.class.equals(queryInfo.method.getReturnType())
-                                     || KeysetAwareSlice.class.equals(queryInfo.returnTypeParam);
+                                     || KeysetAwareSlice.class.equals(queryInfo.returnTypeParam)
+                                     || Iterator.class.equals(queryInfo.method.getReturnType())
+                                     || Iterator.class.equals(queryInfo.returnTypeParam);
         boolean countPages = isKeysetAwarePage
                              || Page.class.equals(queryInfo.method.getReturnType())
                              || Page.class.equals(queryInfo.returnTypeParam);
@@ -768,8 +770,10 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
         String methodName = queryInfo.method.getName();
         boolean needsKeysetQueries = KeysetAwarePage.class.equals(queryInfo.method.getReturnType())
                                      || KeysetAwareSlice.class.equals(queryInfo.method.getReturnType())
+                                     || Iterator.class.equals(queryInfo.method.getReturnType())
                                      || KeysetAwarePage.class.equals(queryInfo.returnTypeParam)
-                                     || KeysetAwareSlice.class.equals(queryInfo.returnTypeParam);
+                                     || KeysetAwareSlice.class.equals(queryInfo.returnTypeParam)
+                                     || Iterator.class.equals(queryInfo.returnTypeParam);
         StringBuilder o = needsKeysetQueries ? new StringBuilder(100) : q; // forward order
         StringBuilder r = needsKeysetQueries ? new StringBuilder(100).append(" ORDER BY ") : null; // reverse order
         List<Sort> keyset = needsKeysetQueries ? new ArrayList<>() : null;

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -37,7 +37,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.BaseStream;
 import java.util.stream.Collector;
@@ -1039,8 +1038,6 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
                         break;
                     }
                     case SELECT: {
-                        Collector<Object, Object, Object> collector = null;
-                        Consumer<Object> consumer = null;
                         Limit limit = null;
                         Pageable pagination = null;
                         List<Sort> sortList = null;
@@ -1050,11 +1047,7 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
                         // Collector is added here for experimentation.
                         for (int i = queryInfo.paramCount; i < (args == null ? 0 : args.length); i++) {
                             Object param = args[i];
-                            if (param instanceof Collector)
-                                collector = (Collector<Object, Object, Object>) param;
-                            else if (param instanceof Consumer)
-                                consumer = (Consumer<Object>) param;
-                            else if (param instanceof Limit)
+                            if (param instanceof Limit)
                                 limit = (Limit) param;
                             else if (param instanceof Pageable)
                                 pagination = (Pageable) param;
@@ -1096,11 +1089,6 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
                                                                      (void.class.equals(returnType) || CompletableFuture.class.equals(returnType)
                                                                       || CompletionStage.class.equals(returnType));
 
-                        if (asyncCompatibleResultForPagination && collector != null)
-                            return runAndCollect(queryInfo, pagination, collector, args);
-                        else if (asyncCompatibleResultForPagination && consumer != null)
-                            return runWithConsumer(queryInfo, pagination, consumer, args);
-
                         Class<?> type = queryInfo.returnTypeParam != null && (Optional.class.equals(returnType)
                                                                               || CompletableFuture.class.equals(returnType)
                                                                               || CompletionStage.class.equals(returnType)) //
@@ -1136,16 +1124,7 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
                             if (startAt > 0)
                                 query.setFirstResult(startAt);
 
-                            if (collector != null) { // Does not provide much value over directly returning Stream
-                                try (Stream<?> stream = query.getResultStream()) {
-                                    returnValue = stream.collect(collector);
-                                }
-                            } else if (consumer != null) { // Does not provide much value over directly returning Stream
-                                try (Stream<?> stream = query.getResultStream()) {
-                                    stream.forEach(consumer::accept);
-                                    returnValue = null;
-                                }
-                            } else if (BaseStream.class.isAssignableFrom(type)) {
+                            if (BaseStream.class.isAssignableFrom(type)) {
                                 Stream<?> stream = query.getResultStream();
                                 if (Stream.class.equals(type))
                                     returnValue = stream;
@@ -1396,107 +1375,6 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
             else
                 queryInfo.maxResults = num;
         }
-    }
-
-    /**
-     * This is an experiment with allowing a collector to perform reduction
-     * on the contents of each page as the page is read in. This avoids having
-     * all pages loaded at once and gives the application a completion stage
-     * with a final result that can be awaited, or to which dependent stages
-     * can be added to run once the final result is ready.
-     *
-     * @param queryInfo
-     * @param pagination
-     * @param collector
-     * @param args
-     * @return completion stage that is already completed if only being used to
-     *         supply the result to an Asynchronous method. If the database supports
-     *         asynchronous patterns, it could be a not-yet-completed completion stage
-     *         that is controlled by the database's async support.
-     */
-    private CompletableFuture<Object> runAndCollect(QueryInfo queryInfo, Pageable pagination,
-                                                    Collector<Object, Object, Object> collector,
-                                                    Object[] args) throws Exception {
-        final boolean trace = TraceComponent.isAnyTracingEnabled();
-
-        Object r = collector.supplier().get();
-        BiConsumer<Object, Object> accumulator = collector.accumulator();
-
-        // TODO it would be possible to process multiple pages in parallel if we wanted to and if the collector supports it
-        EntityManager em = queryInfo.entityInfo.persister.createEntityManager();
-        try {
-            @SuppressWarnings("unchecked")
-            TypedQuery<E> query = (TypedQuery<E>) em.createQuery(queryInfo.jpql, queryInfo.entityInfo.type);
-            queryInfo.setParameters(query, args);
-
-            List<E> page;
-            int maxPageSize;
-            do {
-                // TODO Keyset pagination
-                maxPageSize = pagination.size();
-                query.setFirstResult(computeOffset(pagination.page(), maxPageSize));
-                query.setMaxResults(maxPageSize);
-                pagination = pagination.next();
-
-                page = query.getResultList();
-
-                for (Object item : page)
-                    accumulator.accept(r, item);
-
-                if (trace && tc.isDebugEnabled())
-                    Tr.debug(this, tc, "Processed page with " + page.size() + " results");
-            } while (pagination != null && page.size() == maxPageSize);
-        } finally {
-            em.close();
-        }
-
-        return void.class.equals(queryInfo.method.getReturnType()) ? null : CompletableFuture.completedFuture(collector.finisher().apply(r));
-    }
-
-    /**
-     * Copies the Jakarta NoSQL pattern of invoking a Consumer with the value of each result.
-     *
-     * @param queryInfo
-     * @param pagination
-     * @param consumer
-     * @param args
-     * @return completion stage that is already completed if only being used to
-     *         run as an Asynchronous method. If the database supports
-     *         asynchronous patterns, it could be a not-yet-completed completion stage
-     *         that is controlled by the database's async support.
-     */
-    private CompletableFuture<Void> runWithConsumer(QueryInfo queryInfo, Pageable pagination, Consumer<Object> consumer, Object[] args) throws Exception {
-        final boolean trace = TraceComponent.isAnyTracingEnabled();
-
-        // TODO it would be possible to process multiple pages in parallel if we wanted to and if the consumer supports it
-        EntityManager em = queryInfo.entityInfo.persister.createEntityManager();
-        try {
-            @SuppressWarnings("unchecked")
-            TypedQuery<E> query = (TypedQuery<E>) em.createQuery(queryInfo.jpql, queryInfo.entityInfo.type);
-            queryInfo.setParameters(query, args);
-
-            List<E> page;
-            int maxPageSize;
-            do {
-                // TODO Keyset pagination
-                maxPageSize = pagination.size();
-                query.setFirstResult(computeOffset(pagination.page(), maxPageSize));
-                query.setMaxResults(maxPageSize);
-                pagination = pagination.next();
-
-                page = query.getResultList();
-
-                for (Object item : page)
-                    consumer.accept(item);
-
-                if (trace && tc.isDebugEnabled())
-                    Tr.debug(this, tc, "Processed page with " + page.size() + " results");
-            } while (pagination != null && page.size() == maxPageSize);
-        } finally {
-            em.close();
-        }
-
-        return void.class.equals(queryInfo.method.getReturnType()) ? null : CompletableFuture.completedFuture(null);
     }
 
     /**

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -142,9 +142,12 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
     private QueryInfo completeQueryInfo(EntityInfo entityInfo, QueryInfo queryInfo) {
 
         queryInfo.entityInfo = entityInfo;
-        boolean needsKeysetQueries = KeysetAwarePage.class.equals(queryInfo.method.getReturnType())
-                                     || KeysetAwarePage.class.equals(queryInfo.returnTypeParam);
-        boolean countPages = needsKeysetQueries
+        boolean isKeysetAwarePage = KeysetAwarePage.class.equals(queryInfo.method.getReturnType())
+                                    || KeysetAwarePage.class.equals(queryInfo.returnTypeParam);
+        boolean needsKeysetQueries = isKeysetAwarePage
+                                     || KeysetAwareSlice.class.equals(queryInfo.method.getReturnType())
+                                     || KeysetAwareSlice.class.equals(queryInfo.returnTypeParam);
+        boolean countPages = isKeysetAwarePage
                              || Page.class.equals(queryInfo.method.getReturnType())
                              || Page.class.equals(queryInfo.returnTypeParam);
         StringBuilder q = null;
@@ -764,7 +767,9 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
     private void generateRepositoryQueryOrderBy(QueryInfo queryInfo, int orderBy, StringBuilder q) {
         String methodName = queryInfo.method.getName();
         boolean needsKeysetQueries = KeysetAwarePage.class.equals(queryInfo.method.getReturnType())
-                                     || KeysetAwarePage.class.equals(queryInfo.returnTypeParam);
+                                     || KeysetAwareSlice.class.equals(queryInfo.method.getReturnType())
+                                     || KeysetAwarePage.class.equals(queryInfo.returnTypeParam)
+                                     || KeysetAwareSlice.class.equals(queryInfo.returnTypeParam);
         StringBuilder o = needsKeysetQueries ? new StringBuilder(100) : q; // forward order
         StringBuilder r = needsKeysetQueries ? new StringBuilder(100).append(" ORDER BY ") : null; // reverse order
         List<Sort> keyset = needsKeysetQueries ? new ArrayList<>() : null;

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -1831,13 +1831,14 @@ public class DataTestServlet extends FATServlet {
         assertIterableEquals(List.of("Copper", "Lumber"),
                              tariffs.findByLeviedAgainst("Canada").map(o -> o.leviedOn).sorted().collect(Collectors.toList()));
 
-        // Iterator with paging:
+        // Iterator with offset pagination:
         Iterator<Tariff> it = tariffs.findByLeviedAgainstLessThanOrderByKeyDesc("M", Pageable.ofSize(3));
 
         Tariff t;
         assertEquals(true, it.hasNext());
         assertNotNull(t = it.next());
         assertEquals(t8.leviedAgainst, t.leviedAgainst);
+        Long t8key = t.key;
 
         assertEquals(true, it.hasNext());
         assertNotNull(t = it.next());
@@ -1857,11 +1858,59 @@ public class DataTestServlet extends FATServlet {
 
         assertNotNull(t = it.next());
         assertEquals(t2.leviedAgainst, t.leviedAgainst);
+        Long t2key = t.key;
 
         assertNotNull(t = it.next());
         assertEquals(t1.leviedAgainst, t.leviedAgainst);
 
         assertEquals(false, it.hasNext());
+        assertEquals(false, it.hasNext());
+
+        // Iterator with keyset pagination:
+        it = tariffs.findByLeviedAgainstLessThanOrderByKeyDesc("M", Pageable.ofSize(2).afterKeyset(t8key));
+
+        assertNotNull(t = it.next());
+        assertEquals(t6.leviedAgainst, t.leviedAgainst);
+
+        assertNotNull(t = it.next());
+        assertEquals(t5.leviedAgainst, t.leviedAgainst);
+
+        assertNotNull(t = it.next());
+        assertEquals(t4.leviedAgainst, t.leviedAgainst);
+
+        assertEquals(true, it.hasNext());
+        assertNotNull(t = it.next());
+        assertEquals(t3.leviedAgainst, t.leviedAgainst);
+
+        assertNotNull(t = it.next());
+        assertEquals(t2.leviedAgainst, t.leviedAgainst);
+
+        assertEquals(true, it.hasNext());
+        assertNotNull(t = it.next());
+        assertEquals(t1.leviedAgainst, t.leviedAgainst);
+
+        assertEquals(false, it.hasNext());
+
+        // Iterator with keyset pagination obtaining pages in reverse direction
+        it = tariffs.findByLeviedAgainstLessThanOrderByKeyDesc("M", Pageable.ofSize(2).beforeKeyset(t2key));
+
+        assertEquals(true, it.hasNext());
+        assertNotNull(t = it.next());
+        assertEquals(t4.leviedAgainst, t.leviedAgainst);
+
+        assertNotNull(t = it.next());
+        assertEquals(t3.leviedAgainst, t.leviedAgainst);
+
+        assertNotNull(t = it.next());
+        assertEquals(t6.leviedAgainst, t.leviedAgainst);
+
+        assertEquals(true, it.hasNext());
+        assertNotNull(t = it.next());
+        assertEquals(t5.leviedAgainst, t.leviedAgainst);
+
+        assertNotNull(t = it.next());
+        assertEquals(t8.leviedAgainst, t.leviedAgainst);
+
         assertEquals(false, it.hasNext());
 
         // Paginated iterator with no results:

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -56,6 +56,7 @@ import jakarta.data.exceptions.EmptyResultException;
 import jakarta.data.exceptions.MappingException;
 import jakarta.data.exceptions.NonUniqueResultException;
 import jakarta.data.repository.KeysetAwarePage;
+import jakarta.data.repository.KeysetAwareSlice;
 import jakarta.data.repository.Limit;
 import jakarta.data.repository.Page;
 import jakarta.data.repository.Pageable;
@@ -930,14 +931,14 @@ public class DataTestServlet extends FATServlet {
     @Test
     public void testIgnoreCaseInKeysetPagination() {
         Pageable pagination = Pageable.ofSize(3).sortBy(Sort.asc("sumOfBits"), Sort.descIgnoreCase("name"));
-        KeysetAwarePage<Prime> page1 = primes.findByNumberBetweenAndEvenFalse(4000L, 4020L, pagination);
+        KeysetAwareSlice<Prime> page1 = primes.findByNumberBetweenAndEvenFalse(4000L, 4020L, pagination);
         assertIterableEquals(List.of("four thousand one", "four thousand three", "Four Thousand Thirteen"),
                              page1
                                              .stream()
                                              .map(p -> p.name)
                                              .collect(Collectors.toList()));
 
-        KeysetAwarePage<Prime> page2 = primes.findByNumberBetweenAndEvenFalse(4000L, 4020L, page1.nextPageable());
+        KeysetAwareSlice<Prime> page2 = primes.findByNumberBetweenAndEvenFalse(4000L, 4020L, page1.nextPageable());
         assertIterableEquals(List.of("four thousand seven", "four thousand nineteen"),
                              page2
                                              .stream()
@@ -1210,7 +1211,7 @@ public class DataTestServlet extends FATServlet {
                                  new Package(150, 48.0f, 45.0f, 50.0f, "package#150"), // page 5
                                  new Package(151, 48.0f, 45.0f, 41.0f, "package#151")));
 
-        KeysetAwarePage<Package> page;
+        KeysetAwareSlice<Package> page;
 
         // Page 1
         page = packages.findByHeightGreaterThanOrderByLengthAscWidthDescHeightDescIdAsc(10.0f, Pageable.ofSize(3));
@@ -1364,7 +1365,7 @@ public class DataTestServlet extends FATServlet {
         packages.saveAll(List.of(new Package(440, 40.0f, 44.0f, 40.0f, "package#440"), // page1
                                  new Package(441, 41.0f, 41.0f, 41.0f, "package#441"))); // will be deleted
 
-        KeysetAwarePage<Package> page;
+        KeysetAwareSlice<Package> page;
 
         // Page 1
         page = packages.findByHeightGreaterThan(4.0f, Pageable.ofSize(1));
@@ -1473,7 +1474,7 @@ public class DataTestServlet extends FATServlet {
                                  new Package(236, 36.0f, 50.0f, 93.0f, "package#236"), // page 3
                                  new Package(240, 40.0f, 21.0f, 42.0f, "package#240")));
 
-        KeysetAwarePage<Package> page;
+        KeysetAwareSlice<Package> page;
 
         // Page 3
         page = packages.findByHeightGreaterThanOrderByLengthAscWidthDescHeightDescIdAsc(20.0f, Pageable.ofSize(3).page(3).beforeKeyset(40.0f, 94.0f, 42.0f, 240));
@@ -1659,7 +1660,7 @@ public class DataTestServlet extends FATServlet {
                                  // will add 315, 66.0f, 31.0f, 37.0f, "package#315"
                                  new Package(310, 55.0f, 10.0f, 31.0f, "package#310")));
 
-        KeysetAwarePage<Package> page;
+        KeysetAwareSlice<Package> page;
 
         // Page 3
         page = packages.findByHeightGreaterThan(20.0f, Pageable.ofPage(3).size(3).beforeKeyset(10.0f, 31.0f, 310));

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
@@ -15,6 +15,7 @@ import java.util.List;
 import jakarta.data.Where;
 import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.KeysetAwarePage;
+import jakarta.data.repository.KeysetAwareSlice;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Pageable;
 import jakarta.data.repository.Param;
@@ -31,9 +32,9 @@ public interface Packages extends CrudRepository<Package, Integer> {
     @OrderBy(value = "width", descending = true)
     @OrderBy(value = "height")
     @OrderBy(value = "id", descending = true)
-    KeysetAwarePage<Package> findByHeightGreaterThan(float minHeight, Pageable pagination);
+    KeysetAwareSlice<Package> findByHeightGreaterThan(float minHeight, Pageable pagination);
 
-    KeysetAwarePage<Package> findByHeightGreaterThanOrderByLengthAscWidthDescHeightDescIdAsc(float minHeight, Pageable pagination);
+    KeysetAwareSlice<Package> findByHeightGreaterThanOrderByLengthAscWidthDescHeightDescIdAsc(float minHeight, Pageable pagination);
 
     boolean updateByIdAddHeightMultiplyLengthDivideWidth(int id, float heightToAdd, float lengthMultiplier, float widthDivisor);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Personnel.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Personnel.java
@@ -13,17 +13,15 @@ package test.jakarta.data.web;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.function.Consumer;
-import java.util.stream.Collector;
 import java.util.stream.Stream;
 
 import jakarta.data.Delete;
 import jakarta.data.Select;
 import jakarta.data.Update;
 import jakarta.data.Where;
-import jakarta.data.repository.Pageable;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Streamable;
 import jakarta.enterprise.concurrent.Asynchronous;
 
 /**
@@ -40,18 +38,16 @@ public interface Personnel {
     CompletionStage<Integer> changeSurnames(String oldSurname, String newSurname, List<Long> ssnList);
 
     @Asynchronous
-    CompletableFuture<Long> findByFirstNameStartsWith(String beginningOfFirstName,
-                                                      Collector<Person, ?, Long> collector);
+    CompletableFuture<Long> countByFirstNameStartsWith(String beginningOfFirstName);
+
+    @Asynchronous
+    void deleteByFirstName(String firstName);
+
+    @Asynchronous
+    CompletableFuture<Void> deleteBySsn(long ssn);
 
     @Asynchronous
     CompletionStage<List<Person>> findByLastNameOrderByFirstName(String lastName);
-
-    @Asynchronous
-    @Select("firstName")
-    void findByLastNameOrderByFirstNameDesc(String lastName, Consumer<String> callback);
-
-    @Asynchronous
-    CompletableFuture<Void> findByOrderBySsnDesc(Consumer<Person> callback, Pageable pagination);
 
     @Asynchronous
     CompletableFuture<Person> findBySsn(long ssn);
@@ -64,12 +60,9 @@ public interface Personnel {
     @Query("SELECT DISTINCT o.lastName FROM Person o ORDER BY o.lastName")
     CompletionStage<String[]> lastNames();
 
-    @Asynchronous
     @Select("firstName")
     @Where("o.firstName LIKE CONCAT(?1, '%')")
-    CompletableFuture<Long> namesThatStartWith(String beginningOfFirstName,
-                                               Pageable pagination,
-                                               Collector<String, ?, Long> collector);
+    Streamable<String> namesThatStartWith(String beginningOfFirstName);
 
     // An alternative to the above would be to make the Collector class a parameter
     // of the Paginated annotation, although this would rule out easily accessing the

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 
 import jakarta.data.repository.KeysetAwarePage;
+import jakarta.data.repository.KeysetAwareSlice;
 import jakarta.data.repository.Limit;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Page;
@@ -78,7 +79,7 @@ public interface Primes {
 
     List<Prime> findByNumberBetween(long min, long max, Sort... orderBy);
 
-    KeysetAwarePage<Prime> findByNumberBetweenAndEvenFalse(long min, long max, Pageable pagination);
+    KeysetAwareSlice<Prime> findByNumberBetweenAndEvenFalse(long min, long max, Pageable pagination);
 
     Page<Prime> findByNumberBetweenAndSumOfBitsNotNull(long min, long max, Pageable pagination);
 


### PR DESCRIPTION
Experiment with keyset pagination on an Iterator, trying it out for next/previous direction and with sort criteria that comes from Pageable, the OrderBy keyword, and the OrderBy annotation.
Also in this pull:
Tests with KeysetAwareSlice
Remove examples for consumer/collector which isn't in the spec