### PR TITLE
Ensure first app is stopped, before restarting

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_config/fat/src/com/ibm/ws/concurrent/fat/EEConcurrencyConfigTest.java
+++ b/dev/com.ibm.ws.concurrent_fat_config/fat/src/com/ibm/ws/concurrent/fat/EEConcurrencyConfigTest.java
@@ -440,7 +440,7 @@ public class EEConcurrencyConfigTest extends FATServletClient {
         // save
         server.setMarkToEndOfLog();
         server.updateServerConfiguration(config);
-        server.waitForConfigUpdateInLogUsingMark(Collections.emptySet());
+        server.waitForConfigUpdateInLogUsingMark(Collections.emptySet(), "CWWKZ0009I"); //CWWKZ0009I: The application concurrent has stopped successfully.
 
         // Start the application by putting it back
         config.getApplications().add(concurrentApp);


### PR DESCRIPTION
In this test, we ensure that a ManagedThreadFactory is persisted when an application is restarted.
To do that we remove the app from the apps location, and then put it back.
We currently wait for the config update message: 
`CWWKG0017I: The server configuration was successfully updated`

Before attempting to reinstall the application. 
However, the application could still be running. 
Resulting in the following error: 
`CWWKZ0013E: It is not possible to start two applications called concurrent.`

We should additionally, wait until we see the message: 
`CWWKZ0009I: The application concurrent has stopped successfully.`