### PR TITLE
Telemetry: enable use of the autoconfigure SPIs and add tests

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpTelemetry-1.0/io.openliberty.mpTelemetry-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpTelemetry-1.0/io.openliberty.mpTelemetry-1.0.feature
@@ -12,9 +12,11 @@ IBM-API-Package: \
   io.opentelemetry.api.trace;type="third-party",\
   io.opentelemetry.api.common;type="third-party",\
   io.opentelemetry.context;type="third-party",\
+  io.opentelemetry.context.propagation;type="third-party",\
   io.opentelemetry.sdk.trace;type="third-party",\
   io.opentelemetry.sdk.trace.export;type="third-party",\
   io.opentelemetry.sdk.trace.data;type="third-party",\
+  io.opentelemetry.sdk.trace.samplers;type="third-party",\
   io.opentelemetry.sdk.common;type="third-party",\
   io.opentelemetry.sdk.autoconfigure.spi.traces;type="third-party",\
   io.opentelemetry.sdk.autoconfigure.spi;type="third-party",\

--- a/dev/com.ibm.ws.componenttest.2.0/src/componenttest/app/AssertionErrorSerializer.java
+++ b/dev/com.ibm.ws.componenttest.2.0/src/componenttest/app/AssertionErrorSerializer.java
@@ -186,7 +186,9 @@ public class AssertionErrorSerializer {
         JsonObjectBuilder builder = BUILDER_FACTORY.createObjectBuilder();
         builder.add(CLASS_NAME_KEY, stackTraceElement.getClassName());
         builder.add(METHOD_NAME_KEY, stackTraceElement.getMethodName());
-        builder.add(FILE_NAME_KEY, stackTraceElement.getFileName());
+        if (stackTraceElement.getFileName() != null) {
+            builder.add(FILE_NAME_KEY, stackTraceElement.getFileName());
+        }
         builder.add(LINE_NUMBER_KEY, stackTraceElement.getLineNumber());
         return builder.build();
     }
@@ -198,9 +200,9 @@ public class AssertionErrorSerializer {
      * @return A StackTraceElement instance
      */
     private static StackTraceElement deserializeStackTraceElement(JsonObject jsonObject) {
-        String declaringClass = jsonObject.getString(CLASS_NAME_KEY);
-        String methodName = jsonObject.getString(METHOD_NAME_KEY);
-        String fileName = jsonObject.getString(FILE_NAME_KEY);
+        String declaringClass = jsonObject.getString(CLASS_NAME_KEY, null);
+        String methodName = jsonObject.getString(METHOD_NAME_KEY, null);
+        String fileName = jsonObject.getString(FILE_NAME_KEY, null);
         int lineNumber = jsonObject.getInt(LINE_NUMBER_KEY);
         StackTraceElement element = new StackTraceElement(declaringClass, methodName, fileName, lineNumber);
         return element;

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
@@ -21,7 +21,8 @@ import componenttest.annotation.MinimumJavaLevel;
 @SuiteClasses({
                 Telemetry10.class,
                 JaxRsIntegration.class,
-                TelemetryBeanTest.class
+                TelemetryBeanTest.class,
+                TelemetrySpiTest.class,
 })
 public class FATSuite {
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetrySpiTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetrySpiTest.java
@@ -1,0 +1,149 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.PropertiesAsset;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.annotation.TestServlets;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporter;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporterProvider;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.customizer.CustomizerTestServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.customizer.TestCustomizer;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.exporter.ExporterTestServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.propagator.PropagatorTestServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.propagator.TestPropagator;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.propagator.TestPropagatorProvider;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.resource.ResourceTestServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.resource.TestResourceProvider;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.sampler.SamplerTestServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.sampler.TestSampler;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.sampler.TestSamplerProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+
+/**
+ * Test use of the Open Telemetry Autoconfigure Trace SPIs: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi/latest/index.html
+ */
+@RunWith(FATRunner.class)
+public class TelemetrySpiTest extends FATServletClient {
+
+    public static final String EXPORTER_APP_NAME = "exporterTest";
+    public static final String SAMPLER_APP_NAME = "samplerTest";
+    public static final String RESOURCE_APP_NAME = "resourceTest";
+    public static final String PROPAGATOR_APP_NAME = "propagatorTest";
+    public static final String CUSTOMIZER_APP_NAME = "customizerTest";
+
+    @TestServlets({
+                    @TestServlet(contextRoot = EXPORTER_APP_NAME, servlet = ExporterTestServlet.class),
+                    @TestServlet(contextRoot = SAMPLER_APP_NAME, servlet = SamplerTestServlet.class),
+                    @TestServlet(contextRoot = RESOURCE_APP_NAME, servlet = ResourceTestServlet.class),
+                    @TestServlet(contextRoot = PROPAGATOR_APP_NAME, servlet = PropagatorTestServlet.class),
+                    @TestServlet(contextRoot = CUSTOMIZER_APP_NAME, servlet = CustomizerTestServlet.class),
+    })
+    @Server("Telemetry10Spi")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        // Exporter test
+        PropertiesAsset exporterConfig = new PropertiesAsset()
+                        .addProperty("otel.traces.exporter", "in-memory");
+        WebArchive exporterTestWar = ShrinkWrap.create(WebArchive.class, EXPORTER_APP_NAME + ".war")
+                        .addClass(ExporterTestServlet.class)
+                        .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
+                        .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                        .addAsResource(exporterConfig, "META-INF/microprofile-config.properties");
+
+        ShrinkHelper.exportAppToServer(server, exporterTestWar, SERVER_ONLY);
+
+        // Sampler test
+        PropertiesAsset samplerConfig = new PropertiesAsset()
+                        .addProperty("otel.traces.sampler", TestSamplerProvider.NAME);
+        WebArchive samplerTestWar = ShrinkWrap.create(WebArchive.class, SAMPLER_APP_NAME + ".war")
+                        .addClass(SamplerTestServlet.class)
+                        .addClasses(TestSampler.class, TestSamplerProvider.class)
+                        .addAsServiceProvider(ConfigurableSamplerProvider.class, TestSamplerProvider.class)
+                        .addAsResource(samplerConfig, "META-INF/microprofile-config.properties");
+
+        ShrinkHelper.exportAppToServer(server, samplerTestWar, SERVER_ONLY);
+
+        // Resource test
+        // TEST_KEY1 and TEST_KEY2 are expected by TestResourceProvider
+        PropertiesAsset resourceConfig = new PropertiesAsset()
+                        .addProperty("otel.traces.exporter", "in-memory")
+                        .addProperty(TestResourceProvider.TEST_KEY1.getKey(), ResourceTestServlet.TEST_VALUE1);
+        server.addEnvVar("OTEL_TEST_KEY2", ResourceTestServlet.TEST_VALUE2);
+
+        WebArchive resourceTestWar = ShrinkWrap.create(WebArchive.class, RESOURCE_APP_NAME + ".war")
+                        .addClass(ResourceTestServlet.class)
+                        .addClass(TestResourceProvider.class)
+                        .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
+                        .addAsServiceProvider(ResourceProvider.class, TestResourceProvider.class)
+                        .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                        .addAsResource(resourceConfig, "META-INF/microprofile-config.properties");
+
+        ShrinkHelper.exportAppToServer(server, resourceTestWar, SERVER_ONLY);
+
+        // Propagator test
+        PropertiesAsset propagatorConfig = new PropertiesAsset()
+                        .addProperty("otel.traces.exporter", "in-memory")
+                        .addProperty("otel.propagators", TestPropagatorProvider.NAME);
+
+        WebArchive propagatorTestWar = ShrinkWrap.create(WebArchive.class, PROPAGATOR_APP_NAME + ".war")
+                        .addClass(PropagatorTestServlet.class)
+                        .addClasses(TestPropagator.class, TestPropagatorProvider.class)
+                        .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
+                        .addAsServiceProvider(ConfigurablePropagatorProvider.class, TestPropagatorProvider.class)
+                        .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                        .addAsResource(propagatorConfig, "META-INF/microprofile-config.properties");
+
+        ShrinkHelper.exportAppToServer(server, propagatorTestWar, SERVER_ONLY);
+
+        // CustomizerTest
+        PropertiesAsset customizerConfig = new PropertiesAsset()
+                        .addProperty("otel.traces.exporter", "in-memory");
+        WebArchive customizerTestWar = ShrinkWrap.create(WebArchive.class, CUSTOMIZER_APP_NAME + ".war")
+                        .addClass(CustomizerTestServlet.class)
+                        .addClass(TestCustomizer.class)
+                        .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
+                        .addAsServiceProvider(AutoConfigurationCustomizerProvider.class, TestCustomizer.class)
+                        .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                        .addAsResource(customizerConfig, "META-INF/microprofile-config.properties");
+
+        ShrinkHelper.exportAppToServer(server, customizerTestWar, SERVER_ONLY);
+
+        server.addEnvVar("OTEL_SDK_DISABLED", "false");
+        server.addEnvVar("OTEL_BSP_SCHEDULE_DELAY", "100");
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/customizer/CustomizerTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/customizer/CustomizerTestServlet.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.spi.customizer;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporter;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+
+/**
+ * Test that an AutoConfigurationCustomizerProvider can be provided by the SPI
+ * <p>
+ * The test customizer adds an attribute to a resource and also logs when each of the other customizations are called.
+ */
+@SuppressWarnings("serial")
+@WebServlet("/customizer")
+public class CustomizerTestServlet extends FATServlet {
+    @Inject
+    private Tracer tracer;
+
+    @Inject
+    private InMemorySpanExporter exporter;
+
+    @Test
+    public void testCustomizer() {
+        Span span = tracer.spanBuilder("span").startSpan();
+        span.end();
+
+        SpanData spanData = exporter.getFinishedSpanItems(1).get(0);
+
+        // Attributes added by TestCustomizer should have been merged into the default resource
+        Resource resource = spanData.getResource();
+        assertThat(resource.getAttribute(TestCustomizer.TEST_KEY), equalTo(TestCustomizer.TEST_VALUE));
+
+        // Check that the other customizers added were called
+        // Note: propagator listed twice since by default there are two propagators (W3C trace and W3C baggage)
+        assertThat(TestCustomizer.loggedEvents, containsInAnyOrder("propagator", "propagator", "properties", "sampler", "exporter", "tracer"));
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/customizer/TestCustomizer.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/customizer/TestCustomizer.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.spi.customizer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+
+public class TestCustomizer implements AutoConfigurationCustomizerProvider {
+
+    public static final AttributeKey<String> TEST_KEY = AttributeKey.stringKey("test-key");
+    public static final String TEST_VALUE = "test-value";
+
+    public static final List<String> loggedEvents = new ArrayList<>();
+
+    /** {@inheritDoc} */
+    @Override
+    public void customize(AutoConfigurationCustomizer autoConfiguration) {
+        // Do an actual customization of the resource
+        autoConfiguration.addResourceCustomizer((r, c) -> r.toBuilder().put(TEST_KEY, TEST_VALUE).build());
+
+        // Just check that we can add the other customizers that relate to tracing and that they get called
+        // Use actual methods so that we know we're really loading every class and not missing some due to generic erasure
+        autoConfiguration.addPropagatorCustomizer(this::customizePropagator);
+        autoConfiguration.addPropertiesCustomizer(this::customizeProperties);
+        autoConfiguration.addSamplerCustomizer(this::customizeSampler);
+        autoConfiguration.addSpanExporterCustomizer(this::customizeExporter);
+        autoConfiguration.addTracerProviderCustomizer(this::customizeTracer);
+    }
+
+    private TextMapPropagator customizePropagator(TextMapPropagator propagator, ConfigProperties config) {
+        loggedEvents.add("propagator");
+        return propagator;
+    }
+
+    private Map<String, String> customizeProperties(ConfigProperties config) {
+        loggedEvents.add("properties");
+        return Collections.emptyMap();
+    }
+
+    private Sampler customizeSampler(Sampler sampler, ConfigProperties config) {
+        loggedEvents.add("sampler");
+        return sampler;
+    }
+
+    private SpanExporter customizeExporter(SpanExporter exporter, ConfigProperties config) {
+        loggedEvents.add("exporter");
+        return exporter;
+    }
+
+    private SdkTracerProviderBuilder customizeTracer(SdkTracerProviderBuilder tracerBuilder, ConfigProperties config) {
+        loggedEvents.add("tracer");
+        return tracerBuilder;
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/exporter/ExporterTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/exporter/ExporterTestServlet.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.spi.exporter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporter;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+
+/**
+ * Basic test of a span exporter
+ */
+@SuppressWarnings("serial")
+@WebServlet("/exporterTest")
+public class ExporterTestServlet extends FATServlet {
+
+    @Inject
+    private InMemorySpanExporter exporter;
+
+    @Inject
+    private Tracer tracer;
+
+    @Test
+    public void testExporter() {
+        AttributeKey<String> FOO_KEY = AttributeKey.stringKey("foo");
+        Span span = tracer.spanBuilder("test span").setAttribute(FOO_KEY, "bar").startSpan();
+        span.end();
+
+        SpanData spanData = exporter.getFinishedSpanItems(1).get(0);
+        assertThat(spanData.getName(), equalTo("test span"));
+        assertThat(spanData.getAttributes().asMap(), hasEntry(FOO_KEY, "bar"));
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/propagator/PropagatorTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/propagator/PropagatorTestServlet.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.spi.propagator;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporter;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+
+/**
+ * Test that a custom Propagator can be provided.
+ */
+@SuppressWarnings("serial")
+@WebServlet("/propagator")
+public class PropagatorTestServlet extends FATServlet {
+
+    public static final AttributeKey<String> TEST_KEY = AttributeKey.stringKey("test-key");
+    public static final String TEST_VALUE = "test-value";
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Inject
+    private InMemorySpanExporter exporter;
+
+    @Inject
+    private Baggage baggage;
+
+    @Test
+    public void testPropagator() {
+        // Add a key to the baggage that we will look for later
+        baggage.toBuilder().put(TEST_KEY.getKey(), TEST_VALUE).build().makeCurrent();
+
+        // Call PropagatorTarget (below)
+        String result = ClientBuilder.newClient().target(getTargetURI()).request().get(String.class);
+        assertEquals("OK", result);
+
+        // Expect two spans (client and server)
+        List<SpanData> spans = exporter.getFinishedSpanItems(2);
+
+        SpanData client = spans.get(0);
+        SpanData server = spans.get(1);
+
+        // Check that baggage propagation worked by checking that the baggage entry was copied into a span attribute
+        assertThat(server.getAttributes().asMap(), hasEntry(TEST_KEY, TEST_VALUE));
+
+        // Check that trace context propagation worked by checking that the parent was set correctly
+        assertThat(server.getParentSpanId(), equalTo(client.getSpanId()));
+    }
+
+    @ApplicationPath("/")
+    @Path("/target")
+    public static class PropagatorTarget extends Application {
+
+        @Inject
+        private Baggage baggage;
+
+        @Inject
+        private Span span;
+
+        @GET
+        public String get(@Context HttpHeaders headers) {
+            // Check the TestPropagator headers were used
+            assertThat(headers.getHeaderString(TestPropagator.TRACE_KEY), notNullValue());
+            assertThat(headers.getHeaderString(TestPropagator.BAGGAGE_KEY), notNullValue());
+
+            // Test that the default W3C headers were not used
+            assertThat(headers.getHeaderString("traceparent"), nullValue());
+            assertThat(headers.getHeaderString("tracestate"), nullValue());
+            assertThat(headers.getHeaderString("baggage"), nullValue());
+
+            // Copy TEST_KEY from baggage into a span attribute
+            span.setAttribute(TEST_KEY, baggage.getEntryValue(TEST_KEY.getKey()));
+            return "OK";
+        }
+    }
+
+    private URI getTargetURI() {
+        try {
+            URI originalUri = URI.create(request.getRequestURL().toString());
+            URI targetUri = new URI(originalUri.getScheme(), originalUri.getAuthority(), request.getContextPath() + "/target", null, null);
+            return targetUri;
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/propagator/TestPropagator.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/propagator/TestPropagator.java
@@ -1,0 +1,176 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.spi.propagator;
+
+import static java.util.Collections.unmodifiableList;
+
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map.Entry;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageBuilder;
+import io.opentelemetry.api.baggage.BaggageEntry;
+import io.opentelemetry.api.baggage.BaggageEntryMetadata;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.api.trace.TraceStateBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.context.propagation.TextMapSetter;
+
+/**
+ * A basic propagator for span context and baggage
+ * <p>
+ * Span information is passed in the TEST-SPAN key with format {@code traceId;spanId;flags;statekey1=value,statekey2=value}
+ * <p>
+ * Baggage information is passed in the TEST-BAGGAGE key with format {@code key,value,metadata;key2,value,metadata;key3,value,metadata;...}
+ * <p>
+ * All individual values are urlencoded to make parsing easy (don't have to worry about values containing separator characters)
+ */
+public class TestPropagator implements TextMapPropagator {
+
+    public static final String BAGGAGE_KEY = "TEST-BAGGAGE";
+    public static final String TRACE_KEY = "TEST-SPAN";
+
+    private static final List<String> FIELDS = unmodifiableList(Arrays.asList(BAGGAGE_KEY, TRACE_KEY));
+
+    /** {@inheritDoc} */
+    @Override
+    public Collection<String> fields() {
+        return FIELDS;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public <C> Context extract(Context context, C carrier, TextMapGetter<C> getter) {
+        // extract data from carrier using getter and put it into context
+
+        String baggageString = getter.get(carrier, BAGGAGE_KEY);
+        if (baggageString != null && !baggageString.isEmpty()) {
+            Baggage baggage = deserializeBaggage(baggageString);
+            context = context.with(baggage);
+        }
+
+        String traceString = getter.get(carrier, TRACE_KEY);
+        if (traceString != null && !traceString.isEmpty()) {
+            Span span = deserializeSpan(traceString);
+            context = context.with(span);
+        }
+
+        return context;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public <C> void inject(Context context, C carrier, TextMapSetter<C> setter) {
+        // take data from context and inject it into carrier using setter
+        Baggage baggage = Baggage.fromContextOrNull(context);
+        if (baggage != null && !baggage.isEmpty()) {
+            setter.set(carrier, BAGGAGE_KEY, serializeBaggage(baggage));
+        }
+
+        Span span = Span.fromContextOrNull(context);
+        if (span != null && span.getSpanContext().isValid()) {
+            setter.set(carrier, TRACE_KEY, serializeSpan(span.getSpanContext()));
+        }
+    }
+
+    private String serializeBaggage(Baggage baggage) {
+        StringBuffer baggageString = new StringBuffer();
+        boolean first = true;
+        for (Entry<String, BaggageEntry> entry : baggage.asMap().entrySet()) {
+            if (!first) {
+                baggageString.append(';');
+                first = false;
+            }
+            baggageString.append(encode(entry.getKey()))
+                            .append(',')
+                            .append(encode(entry.getValue().getValue()))
+                            .append(',')
+                            .append(encode(entry.getValue().getMetadata().getValue()));
+        }
+        return baggageString.toString();
+    }
+
+    private Baggage deserializeBaggage(String string) {
+        BaggageBuilder builder = Baggage.empty().toBuilder();
+        for (String entry : string.split(";")) {
+            if (entry.isEmpty()) {
+                continue;
+            }
+            String[] parts = entry.split(",", -1); // -1 -> keep trailing empty strings
+            builder.put(decode(parts[0]),
+                        decode(parts[1]),
+                        BaggageEntryMetadata.create(decode(parts[2])));
+        }
+        return builder.build();
+    }
+
+    private String serializeSpan(SpanContext span) {
+        StringBuffer spanString = new StringBuffer();
+        spanString.append(span.getTraceId())
+                        .append(';')
+                        .append(span.getSpanId())
+                        .append(';')
+                        .append(span.getTraceFlags().asHex())
+                        .append(';');
+        boolean first = true;
+        for (Entry<String, String> entry : span.getTraceState().asMap().entrySet()) {
+            if (first) {
+                spanString.append(',');
+                first = false;
+            }
+
+            spanString.append(encode(entry.getKey()))
+                            .append('=')
+                            .append(encode(entry.getValue()));
+        }
+
+        return spanString.toString();
+    }
+
+    private Span deserializeSpan(String string) {
+        String[] parts = string.split(";", -1);
+        String traceId = decode(parts[0]);
+        String spanId = decode(parts[1]);
+        TraceFlags flags = TraceFlags.fromHex(decode(parts[2]), 0);
+
+        TraceStateBuilder stateBuilder = TraceState.builder();
+        for (String entry : parts[3].split(",")) {
+            if (entry.isEmpty()) {
+                continue;
+            }
+            String[] entryParts = entry.split("=");
+            stateBuilder.put(decode(entryParts[0]),
+                             decode(entryParts[1]));
+        }
+
+        SpanContext spanContext = SpanContext.create(traceId, spanId, flags, stateBuilder.build());
+        return Span.wrap(spanContext);
+    }
+
+    private String encode(String s) {
+        return URLEncoder.encode(s, StandardCharsets.UTF_8);
+    }
+
+    private String decode(String s) {
+        return URLDecoder.decode(s, StandardCharsets.UTF_8);
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/propagator/TestPropagatorProvider.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/propagator/TestPropagatorProvider.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.spi.propagator;
+
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
+
+public class TestPropagatorProvider implements ConfigurablePropagatorProvider {
+
+    public static final String NAME = "test-propagator";
+
+    /** {@inheritDoc} */
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public TextMapPropagator getPropagator(ConfigProperties arg0) {
+        return new TestPropagator();
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/resource/ResourceTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/resource/ResourceTestServlet.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.spi.resource;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporter;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+
+/**
+ * Test that the Resource can be customized via SPI
+ */
+@SuppressWarnings("serial")
+@WebServlet("/resource")
+public class ResourceTestServlet extends FATServlet {
+
+    public static final String TEST_VALUE1 = "test1";
+    public static final String TEST_VALUE2 = "test2";
+
+    @Inject
+    private Tracer tracer;
+
+    @Inject
+    private InMemorySpanExporter exporter;
+
+    @Test
+    public void testResource() {
+        Span span = tracer.spanBuilder("span").startSpan();
+        span.end();
+
+        SpanData spanData = exporter.getFinishedSpanItems(1).get(0);
+
+        // Attributes added by TestResourceProvider should have been merged into the default resource
+        Resource resource = spanData.getResource();
+        assertThat(resource.getAttribute(TestResourceProvider.TEST_KEY1), equalTo(TEST_VALUE1));
+        assertThat(resource.getAttribute(TestResourceProvider.TEST_KEY2), equalTo(TEST_VALUE2));
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/resource/TestResourceProvider.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/resource/TestResourceProvider.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.spi.resource;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import io.opentelemetry.sdk.resources.Resource;
+
+public class TestResourceProvider implements ResourceProvider {
+
+    public static final AttributeKey<String> TEST_KEY1 = AttributeKey.stringKey("otel.test.key1");
+    public static final AttributeKey<String> TEST_KEY2 = AttributeKey.stringKey("otel.test.key2");
+
+    /** {@inheritDoc} */
+    @Override
+    public Resource createResource(ConfigProperties config) {
+        System.out.println("createResource called with config: " + config);
+        // Read two test values from config and add them
+        return Resource.builder()
+                        .put(TEST_KEY1, config.getString(TEST_KEY1.getKey()))
+                        .put(TEST_KEY2, config.getString(TEST_KEY2.getKey()))
+                        .build();
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/sampler/SamplerTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/sampler/SamplerTestServlet.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.spi.sampler;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+
+/**
+ * Test that a sampler can be provided via SPI
+ */
+@SuppressWarnings("serial")
+@WebServlet("/sampler")
+@ApplicationScoped // Make this a bean so that there's one bean in the archive, otherwise CDI gets disabled and @Inject doesn't work
+public class SamplerTestServlet extends FATServlet {
+
+    @Inject
+    private Tracer tracer;
+
+    @Test
+    public void testSampler() {
+        // Span 1 does not set SAMPLE_ME, so it should not be sampled
+        Span span1 = tracer.spanBuilder("span1").startSpan();
+        try {
+            assertFalse(span1.isRecording());
+            assertFalse(span1.getSpanContext().isSampled());
+        } finally {
+            span1.end();
+        }
+
+        Span span2 = tracer.spanBuilder("span2").setAttribute(TestSampler.SAMPLE_ME, true).startSpan();
+        try {
+            assertTrue(span2.isRecording());
+            assertTrue(span2.getSpanContext().isSampled());
+        } finally {
+            span2.end();
+        }
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/sampler/TestSampler.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/sampler/TestSampler.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.spi.sampler;
+
+import java.util.List;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+
+/**
+ * A test sampler which looks for the "test.sample.me" attribute to decide whether a span should be sampled
+ */
+public class TestSampler implements Sampler {
+
+    public static final AttributeKey<Boolean> SAMPLE_ME = AttributeKey.booleanKey("test.sample.me");
+
+    /** {@inheritDoc} */
+    @Override
+    public String getDescription() {
+        return "Test sampler, samples if test.sample.me is true";
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public SamplingResult shouldSample(Context context, String traceId, String name, SpanKind spanKind, Attributes attributes, List<LinkData> parentLinks) {
+
+        if (attributes.get(SAMPLE_ME) == Boolean.TRUE) {
+            return SamplingResult.recordAndSample();
+        } else {
+            return SamplingResult.drop();
+        }
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/sampler/TestSamplerProvider.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/sampler/TestSamplerProvider.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.spi.sampler;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+
+public class TestSamplerProvider implements ConfigurableSamplerProvider {
+
+    public static final String NAME = "test-sampler";
+
+    /** {@inheritDoc} */
+    @Override
+    public Sampler createSampler(ConfigProperties config) {
+        return new TestSampler();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Spi/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Spi/bootstrap.properties
@@ -1,0 +1,1 @@
+bootstrap.include=../testports.properties

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Spi/server.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Spi/server.xml
@@ -1,0 +1,31 @@
+<server description="Server for testing Telemetry10">
+
+	<include location="../fatTestPorts.xml" />
+
+	<featureManager>
+		<feature>servlet-6.0</feature>
+		<feature>mpTelemetry-1.0</feature>
+		<feature>componentTest-2.0</feature>
+	</featureManager>
+
+	<application type="war" location="exporterTest.war">
+		<classloader apiTypeVisibility="+third-party" />
+	</application>
+
+	<application type="war" location="samplerTest.war">
+		<classloader apiTypeVisibility="+third-party" />
+	</application>
+
+	<application type="war" location="resourceTest.war">
+		<classloader apiTypeVisibility="+third-party" />
+	</application>
+
+	<application type="war" location="propagatorTest.war">
+		<classloader apiTypeVisibility="+third-party" />
+	</application>
+
+	<application type="war" location="customizerTest.war">
+		<classloader apiTypeVisibility="+third-party" />
+	</application>
+
+</server>

--- a/dev/io.openliberty.mpTelemetry.1.0.thirdparty/bnd.bnd
+++ b/dev/io.openliberty.mpTelemetry.1.0.thirdparty/bnd.bnd
@@ -26,9 +26,11 @@ Private-Package: \
   io.opentelemetry.api.common; version=${openTelemetryVersion},\
   io.opentelemetry.api.trace; version=${openTelemetryVersion},\
   io.opentelemetry.context; version=${openTelemetryVersion},\
+  io.opentelemetry.context.propagation; version=${openTelemetryVersion},\
   io.opentelemetry.sdk.trace;version=${openTelemetryVersion},\
   io.opentelemetry.sdk.trace.export;version=${openTelemetryVersion},\
   io.opentelemetry.sdk.trace.data;version=${openTelemetryVersion},\
+  io.opentelemetry.sdk.trace.samplers;version=${openTelemetryVersion},\
   io.opentelemetry.sdk.common;version=${openTelemetryVersion},\
   io.opentelemetry.sdk.autoconfigure.spi.traces;version=${openTelemetryVersion},\
   io.opentelemetry.sdk.autoconfigure.spi;version=${openTelemetryVersion},\


### PR DESCRIPTION
Test that users can use the OTel autoconfigure SPI. This tests all of the SPIs which are relevant to tracing, but doesn't test those which are specific to metrics or logging as we do not support them.

Some of the classes referenced by the SPI were in packages we weren't exposing, so I had to update the feature to add these.

Fixes  #23453