### PR TITLE
Repeat jaxrs.2.0.cdi.1.2 test for EE10

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018,2020 IBM Corporation and others.
+# Copyright (c) 2018,2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -34,15 +34,13 @@ tested.features: \
   jaxrs-2.1,\
   cdi-2.0,\
   beanvalidation-2.0, \
-  restfulwsclient-3.0, \
   restfulws-3.0, \
-  restfulwsclient-3.1, \
   restfulws-3.1, \
   beanvalidation-3.0, \
-  jsonp-2.0, \
-  concurrent-2.0, \
   enterprisebeanslite-4.0, \
-  servlet-5.0
+  servlet-6.0, \
+  concurrent-3.0, \
+  expressionlanguage-5.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,6 +31,7 @@ import com.ibm.ws.jaxrs20.cdi12.fat.test.ResourceInfoAtStartupTest;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -55,5 +56,6 @@ public class FATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
                     .andWith(FeatureReplacementAction.EE8_FEATURES().withID("JAXRS-2.1"))
-                    .andWith(new JakartaEE9Action());
+                    .andWith(new JakartaEE9Action())
+                    .andWith(new JakartaEE10Action());
 }

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/Basic12Test.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/Basic12Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,7 +30,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // skip because cdi injection of singletons has changed
+@SkipForRepeat({"EE9_FEATURES", "EE10_FEATURES"}) // skip because cdi injection of singletons has changed
 public class Basic12Test extends AbstractTest {
 
     private static final String classesType = "PerRequest";

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/CDIInjectIntoAppTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/CDIInjectIntoAppTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,7 +26,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // skip because cdi injection in Application subclasses require the @ApplicationPath annotation in our EE9 implementation
+@SkipForRepeat({"EE9_FEATURES", "EE10_FEATURES"}) // skip because cdi injection in Application subclasses require the @ApplicationPath annotation in our EE9 implementation
 public class CDIInjectIntoAppTest extends FATServletClient {
 
     public static final String APP_NAME = "cdiinjectintoapp";

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/Complex12Test.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/Complex12Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,7 +30,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // skip because cdi injection of singletons has changed
+@SkipForRepeat({"EE9_FEATURES", "EE10_FEATURES"}) // skip because cdi injection of singletons has changed
 public class Complex12Test extends AbstractTest {
 
     private final Class<?> c = Complex12Test.class;

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/ContextandCDI12Test.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/ContextandCDI12Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,7 +30,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // skip because cdi injection of singletons has changed
+@SkipForRepeat({"EE9_FEATURES", "EE10_FEATURES"}) // skip because cdi injection of singletons has changed
 public class ContextandCDI12Test extends AbstractTest {
 
     public static final String[] ignore_messages =  new String[] { "CWWKW1001W" , "CWWKW1002W" , "CWWKE1102W", "CWWKE1106W" , "CWWKE1107W" };    

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/DependentIntoJaxTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/DependentIntoJaxTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") //The fact this doesn't work on EE9 is probably a bug and needs investigating
+@SkipForRepeat({"EE9_FEATURES", "EE10_FEATURES"}) //The fact this doesn't work on EE9 is probably a bug and needs investigating
 public class DependentIntoJaxTest extends AbstractTest {
 
     @Server("com.ibm.ws.jaxrs20.cdi12.fat.basic")

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/DisableTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/DisableTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,7 +28,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // skip because cdi injection of singletons has changed
+@SkipForRepeat({"EE9_FEATURES", "EE10_FEATURES"}) // skip because cdi injection of singletons has changed
 public class DisableTest extends AbstractTest {
 
     private static final String classesType = "PerRequest";

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/LifeCycle12Test.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/LifeCycle12Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,7 +30,7 @@ import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // skip because cdi injection of singletons has changed
+@SkipForRepeat({"EE9_FEATURES", "EE10_FEATURES"}) // skip because cdi injection of singletons has changed
 public class LifeCycle12Test extends AbstractTest {
 
     private static final String LIFECYCLEWAR = "lifecyclemethod.war";

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/LifeCycleMismatch12Test.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/LifeCycleMismatch12Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,7 +29,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // skip because cdi injection of singletons has changed
+@SkipForRepeat({"EE9_FEATURES", "EE10_FEATURES"}) // skip because cdi injection of singletons has changed
 public class LifeCycleMismatch12Test extends AbstractTest {
 
     private final static String target = "lifecyclemismatch/ClientTestServlet";

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/beanvalidation/resources/WEB-INF/beans.xml
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/beanvalidation/resources/WEB-INF/beans.xml
@@ -1,6 +1,6 @@
 <!-- This xml file was empty for these testcase until EE10. 
-Prior to EE10 an empty Beans.xml file meant "annotated" mode.  
-In EE10 and beyond and empty beans.xml means "all" mode. Another option would have been to leave 
+Prior to EE10 an empty Beans.xml file meant "all" mode.  
+In EE10 and beyond and empty beans.xml means "annotated" mode. Another option would have been to leave 
 this file empty and add @Dependent to each of the bean classes.-->
 
 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/beanvalidation/resources/WEB-INF/beans.xml
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/beanvalidation/resources/WEB-INF/beans.xml
@@ -1,0 +1,11 @@
+<!-- This xml file was empty for these testcase until EE10. 
+Prior to EE10 an empty Beans.xml file meant "annotated" mode.  
+In EE10 and beyond and empty beans.xml means "all" mode. Another option would have been to leave 
+this file empty and add @Dependent to each of the bean classes.-->
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+   version="1.1" 
+   bean-discovery-mode="all">
+</beans>


### PR DESCRIPTION
The purpose of this PR is to repeat the 2.0 cdi tests for EE10 as part of #18739
Note one change due to CDI behavior change in EE10:  See comment in beans.xml in beanvalidation application:
```
<!-- This xml file was empty for these testcase until EE10. 
Prior to EE10 an empty Beans.xml file meant "annotated" mode.  
In EE10 and beyond and empty beans.xml means "all" mode. Another option would have been to leave 
this file empty and add @Dependent to each of the bean classes.-->
```
