### PR TITLE
stop command will wait for sCommand file when server starting

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ProcessControlHelper.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ProcessControlHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 IBM Corporation and others.
+ * Copyright (c) 2011, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
Fixes #23392.

If the stop command detects that the server is running, but yet there is no .sCommand file then assume that the server must still be starting and simply hasn't created the .sCommand file yet.

If we don't do this, then the stop command will fail, since it needs the .sCommand file to know how to communicate with the server.  In the case of running the server as a Windows service, this causes a hang in prunsrv.  I believe this is a bug in prunsrv.