### PR TITLE
Update com.ibm.ws.ui to have a separate jar to be transformed

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.adminCenter1.0.internal.ee-10.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.adminCenter1.0.internal.ee-10.0.feature
@@ -8,6 +8,6 @@ singleton=true
   io.openliberty.jta-2.0, \
   io.openliberty.pages-3.1
 -bundles=\
-  com.ibm.ws.ui.jakarta
+  com.ibm.ws.ui.servlet.filter.jakarta
 kind=beta
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.adminCenter1.0.internal.ee-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.adminCenter1.0.internal.ee-6.0.feature
@@ -7,6 +7,6 @@ singleton=true
   com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0", \
   com.ibm.websphere.appserver.javax.jsp-2.2; ibm.tolerates:="2.3"
 -bundles=\
-  com.ibm.ws.ui
+  com.ibm.ws.ui.servlet.filter
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.adminCenter1.0.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.adminCenter1.0.internal.ee-9.0.feature
@@ -8,6 +8,6 @@ singleton=true
   io.openliberty.jta-2.0, \
   io.openliberty.pages-3.0
 -bundles=\
-  com.ibm.ws.ui.jakarta
+  com.ibm.ws.ui.servlet.filter.jakarta
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/adminCenter-1.0/com.ibm.websphere.appserver.adminCenter-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/adminCenter-1.0/com.ibm.websphere.appserver.adminCenter-1.0.feature
@@ -12,6 +12,7 @@ Subsystem-Icon: OSGI-INF/admincenter_200x200.png,OSGI-INF/admincenter_200x200.pn
   com.ibm.websphere.appserver.adminCenter.tool.serverConfig-1.0, \
   io.openliberty.adminCenter1.0.internal.ee-6.0; ibm.tolerates:="9.0,10.0"
 -bundles=\
+    com.ibm.ws.ui,\
     com.ibm.websphere.jsonsupport,\
     com.ibm.ws.org.joda.time.1.6.2, \
     io.openliberty.com.google.gson

--- a/dev/com.ibm.ws.ui/bnd.bnd
+++ b/dev/com.ibm.ws.ui/bnd.bnd
@@ -14,52 +14,9 @@
 
 bVersion=1.0
 
-
 WS-TraceGroup: UI
 
-Web-ContextPath: /adminCenter
-OL-VirtualHost: ${admin.virtual.host}
-
-IBM-Authorization-Roles: com.ibm.ws.management
-
 instrument.disabled: true
-
-
-Export-Package: \
-  com.ibm.ws.ui.persistence,\
-  com.ibm.ws.ui.servlet.filter
-
-Private-Package: \
-  com.ibm.ws.ui.internal.*
-
-# Need a special import to properly construct import for commons.io
-Import-Package: \
-  com.ibm.websphere.jsonsupport.*, \
-  !*.internal.*, \
-  *
-
-DynamicImport-Package: \
- com.ibm.ws.security.openidconnect.server.plugins
-
-Include-Resource: \
-  ${if;${driver;gradle};=lib/dojo-release}, \
-  ${if;${driver;gradle};fonts=lib/fonts}, \
-  ${if;${driver;gradle};imagesShared=build/dojo/imagesShared}, \
-  WEB-INF=resources/WEB-INF, \
-  images=resources/WEB-CONTENT/images, \
-  login.jsp=resources/WEB-CONTENT/login.jsp, \
-  feature=resources/WEB-CONTENT/feature, \
-  404=resources/WEB-CONTENT/404, \
-  login/images=resources/WEB-CONTENT/login/images, \
-  toolbox.jsp=resources/WEB-CONTENT/toolbox.jsp, \
-  html=resources/WEB-CONTENT/html
-
--dsannotations: \
-  com.ibm.ws.ui.internal.persistence.FilePersistenceProvider, \
-  com.ibm.ws.ui.internal.rest.AdminCenterRouter, \
-  com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService, \
-  com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService, \
-  com.ibm.ws.ui.internal.v1.utils.FeatureToolService
 
 -buildpath: \
   com.ibm.websphere.appserver.api.kernel.service;version=latest,\

--- a/dev/com.ibm.ws.ui/main.bnd
+++ b/dev/com.ibm.ws.ui/main.bnd
@@ -1,0 +1,56 @@
+#*******************************************************************************
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+
+Bundle-Name: ui
+Bundle-SymbolicName: com.ibm.ws.ui
+Bundle-Description: Provides the Admin Center toolbox and catalog
+
+Web-ContextPath: /adminCenter
+OL-VirtualHost: ${admin.virtual.host}
+
+IBM-Authorization-Roles: com.ibm.ws.management
+
+Export-Package: \
+  com.ibm.ws.ui.persistence
+
+Private-Package: \
+  com.ibm.ws.ui.internal.*
+
+# Need a special import to properly construct import for commons.io
+Import-Package: \
+  com.ibm.websphere.jsonsupport.*, \
+  com.ibm.ws.ui.servlet.filter, \
+  !*.internal.*, \
+  *
+
+DynamicImport-Package: \
+ com.ibm.ws.security.openidconnect.server.plugins
+
+Include-Resource: \
+  ${if;${driver;gradle};=lib/dojo-release}, \
+  ${if;${driver;gradle};fonts=lib/fonts}, \
+  ${if;${driver;gradle};imagesShared=build/dojo/imagesShared}, \
+  WEB-INF=resources/WEB-INF, \
+  images=resources/WEB-CONTENT/images, \
+  login.jsp=resources/WEB-CONTENT/login.jsp, \
+  feature=resources/WEB-CONTENT/feature, \
+  404=resources/WEB-CONTENT/404, \
+  login/images=resources/WEB-CONTENT/login/images, \
+  toolbox.jsp=resources/WEB-CONTENT/toolbox.jsp, \
+  html=resources/WEB-CONTENT/html
+
+-dsannotations: \
+  com.ibm.ws.ui.internal.persistence.FilePersistenceProvider, \
+  com.ibm.ws.ui.internal.rest.AdminCenterRouter, \
+  com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService, \
+  com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService, \
+  com.ibm.ws.ui.internal.v1.utils.FeatureToolService
+

--- a/dev/com.ibm.ws.ui/original.bnd
+++ b/dev/com.ibm.ws.ui/original.bnd
@@ -9,7 +9,9 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 
-Bundle-Name: ui
-Bundle-SymbolicName: com.ibm.ws.ui
-Bundle-Description: Provides the Admin Center toolbox and catalog
+Bundle-Name: ui servlet filter
+Bundle-SymbolicName: com.ibm.ws.ui.servlet.filter
+Bundle-Description: Provides the Admin Center servlet filter
 
+Export-Package: \
+  com.ibm.ws.ui.servlet.filter

--- a/dev/com.ibm.ws.ui/transformed.bnd
+++ b/dev/com.ibm.ws.ui/transformed.bnd
@@ -10,6 +10,9 @@
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/transform.props
 
-Bundle-Name: ui Jakarta
-Bundle-SymbolicName: com.ibm.ws.ui.jakarta
-Bundle-Description: Provides the Admin Center toolbox and catalog; Jakarta Enabled
+Bundle-Name: ui servlet filter Jakarta
+Bundle-SymbolicName: com.ibm.ws.ui.servlet.filter.jakarta
+Bundle-Description: Provides the Admin Center servlet filter; Jakarta Enabled
+
+Export-Package: \
+  com.ibm.ws.ui.servlet.filter


### PR DESCRIPTION
- Do a jar with just one class in it since it is the only one that needs to be transformed.  This should reduce the footprint for the jars since com.ibm.ws.ui.jar is such a large jar.

#build
Fixes #23701 