### PR TITLE
Add scheduled personal builds to regression test auto FAT selection

### DIFF
--- a/.ci-orchestrator/scheduledPersonalBuilds.yml
+++ b/.ci-orchestrator/scheduledPersonalBuilds.yml
@@ -1,0 +1,240 @@
+type: pipeline_definition
+product: OpenLiberty
+name: OpenLiberty Personal Build
+description: A build run against OpenLiberty Pull Requests
+triggers:
+- type: schedule
+  triggerName: "Personal product only change"
+  triggerRank: 50
+  triggerMonitored: false
+  triggerThreshold: 100
+  every:
+    hours: 24
+  propertyDefinitions:
+  - name: git.laos.clone.repository.username
+    defaultValue: "fritze2"
+    steps:
+    - stepName: compile
+    - stepName: unittest
+  - name: git.laos.clone.checkout.branch
+    defaultValue: "test-change-com.ibm.ws.jca"
+    steps:
+    - stepName: compile
+    - stepName: unittest
+  - name: githubPRApi
+    defaultValue: "https://api.github.com/repos/OpenLiberty/open-liberty/pulls/23250"
+    steps:
+    - stepName: pr-changes
+    - stepName: dependencymapping
+  - name: githubPRNumber
+    defaultValue: "23250"
+    steps:
+    - stepName: pr-changes
+    
+- type: schedule
+  triggerName: "Personal unittest only change"
+  triggerRank: 50
+  triggerMonitored: false
+  triggerThreshold: 100
+  every:
+    hours: 24
+  propertyDefinitions:
+  - name: git.laos.clone.repository.username
+    defaultValue: "fritze2"
+    steps:
+    - stepName: compile
+    - stepName: unittest
+  - name: git.laos.clone.checkout.branch
+    defaultValue: "test-change-com.ibm.ws.jmx-unittest"
+    steps:
+    - stepName: compile
+    - stepName: unittest
+  - name: githubPRApi
+    defaultValue: "https://api.github.com/repos/OpenLiberty/open-liberty/pulls/23738"
+    steps:
+    - stepName: pr-changes
+    - stepName: dependencymapping
+  - name: githubPRNumber
+    defaultValue: "23738"
+    steps:
+    - stepName: pr-changes
+    
+- type: schedule
+  triggerName: "Personal FAT only change"
+  triggerRank: 50
+  triggerMonitored: false
+  triggerThreshold: 100
+  every:
+    hours: 24
+  propertyDefinitions:
+  - name: git.laos.clone.repository.username
+    defaultValue: "fritze2"
+    steps:
+    - stepName: compile
+    - stepName: unittest
+  - name: git.laos.clone.checkout.branch
+    defaultValue: "test-change-com.ibm.ws.jca_fat"
+    steps:
+    - stepName: compile
+    - stepName: unittest
+  - name: githubPRApi
+    defaultValue: "https://api.github.com/repos/OpenLiberty/open-liberty/pulls/23249"
+    steps:
+    - stepName: pr-changes
+    - stepName: dependencymapping
+  - name: githubPRNumber
+    defaultValue: "23249"
+    steps:
+    - stepName: pr-changes
+    
+- type: schedule
+  triggerName: "Personal BVT only change"
+  triggerRank: 50
+  triggerMonitored: false
+  triggerThreshold: 100
+  every:
+    hours: 24
+  propertyDefinitions:
+  - name: git.laos.clone.repository.username
+    defaultValue: "fritze2"
+    steps:
+    - stepName: compile
+    - stepName: unittest
+  - name: git.laos.clone.checkout.branch
+    defaultValue: "test-change-com.ibm.ws.jca_fat_bvt"
+    steps:
+    - stepName: compile
+    - stepName: unittest
+  - name: githubPRApi
+    defaultValue: "https://api.github.com/repos/OpenLiberty/open-liberty/pulls/23248"
+    steps:
+    - stepName: pr-changes
+    - stepName: dependencymapping
+  - name: githubPRNumber
+    defaultValue: "23248"
+    steps:
+    - stepName: pr-changes
+    
+- type: schedule
+  triggerName: "Personal infrastructure only change"
+  triggerRank: 50
+  triggerMonitored: false
+  triggerThreshold: 100
+  every:
+    hours: 24
+  propertyDefinitions:
+  - name: git.laos.clone.repository.username
+    defaultValue: "fritze2"
+    steps:
+    - stepName: compile
+    - stepName: unittest
+  - name: git.laos.clone.checkout.branch
+    defaultValue: "test-change-infra"
+    steps:
+    - stepName: compile
+    - stepName: unittest
+  - name: githubPRApi
+    defaultValue: "https://api.github.com/repos/OpenLiberty/open-liberty/pulls/23739"
+    steps:
+    - stepName: pr-changes
+    - stepName: dependencymapping
+  - name: githubPRNumber
+    defaultValue: "23739"
+    steps:
+    - stepName: pr-changes
+    
+steps:
+- stepName: pr-changes
+  workType: PRChangesDetection
+  timeoutInMinutes: 30
+  properties:
+    githubPRApi: ${github_pr_api}
+    githubPRNumber: ${github_pr_number}
+
+- stepName: compile
+  workType: RTC
+  projectName: "Liberty Personal Build CI Orchestrator - EBC"
+  dependsOn:
+  - stepName: pr-changes
+    awaitOutputProperties: true
+  timeoutInMinutes: 1440
+  properties:
+    build.stub.target: build.CachedWSCD.CompileImage
+    run.packaging.verification: ${pr-changes:run.packaging.verification}
+    fat.buckets.to.run: ${pr-changes:fat.buckets.to.run}
+    disable.run.runBvtTests: ${pr-changes:disable.run.runBvtTests}
+    disable.run.runUnitTests: ${pr-changes:disable.run.runUnitTests}
+    run.chkpii: ${pr-changes:run.chkpii}
+    run.findbugs: ${pr-changes:run.findbugs}
+    spawn.zos: ${pr-changes:spawn.zos}
+    create.im.repo: ${pr-changes:create.im.repo}
+    personal.im.build: ${pr-changes:personal.im.build}
+    disable.run.createDoc: ${pr-changes:disable.run.createDoc}
+    skip.open.liberty.build.if.possible: ${pr-changes:skip.open.liberty.build.if.possible}
+    skip.open.liberty.fats.if.possible: ${pr-changes:skip.open.liberty.fats.if.possible}
+  includeProperties:
+  - file: compilePersonal.properties
+  - file: compile.properties
+
+- stepName: unittest
+  workType: RTC
+  projectName: "Liberty Personal Build CI Orchestrator - EBC"
+  dependsOn:
+  - stepName: pr-changes
+    awaitOutputProperties: true
+  timeoutInMinutes: 1440
+  properties:
+    build.stub.target: build.CachedWSCD.OLTest
+    disable.run.runUnitTests: ${pr-changes:disable.run.runUnitTests}
+    skip.open.liberty.build.if.possible: ${pr-changes:skip.open.liberty.build.if.possible}
+    skip.open.liberty.fats.if.possible: ${pr-changes:skip.open.liberty.fats.if.possible}
+  includeProperties:
+  - file: compilePersonal.properties
+  - file: compile.properties
+
+- stepName: dependencymapping
+  workType: Jenkins
+  projectName: dependencyMapper
+  dependsOn:
+    - stepName: compile
+      awaitOutputProperties: true
+  timeoutInMinutes: 30
+  properties:
+    artifact_execution_id: ${compile:execution_id}
+    aggregationId: ${compile:execution_id}
+    buildType: personal
+    bndFilesZipUrl: ${compile:bndFilesZipUrl}
+    imageUrl: ${compile:imageUrl}
+    changeDetectorImageUrl: ${compile:changeDetectorImageUrl}
+    fatFeatureJsonUrl: ${compile:fatFeatureJsonUrl}
+    githubPRApi: ${github_pr_api}
+
+- stepName: fats
+  workType: FAT
+  dependsOn:
+    - stepName: compile
+      awaitOutputProperties: true
+    - stepName: dependencymapping
+      allowFailures: true
+  timeoutInMinutes: 1920
+  properties:
+    artifact_execution_id: ${compile:execution_id}
+    runner_projectName: ebcTestRunner
+    runner_workType: Jenkins
+    runner_threshold: 40
+    runner_minimum_total: 10
+    fat.buckets.to.run: auto
+    fat.test.mode: lite
+    fats_to_omit: "com.ibm.ws.collective.controller.deploy_fat, com.ibm.ws.health.manager.odrlib_fat, com.ibm.ws.dynamic.routing_ihs_fat, com.ibm.ws.node.scaling_fat, com.ibm.ws.scaling.member_fat_multinode, com.ibm.ws.node.health_fat"
+    fat_uploads_to_expect: ${compile:fat_uploads_to_expect}
+    outputServer: libertyfs.hursley.ibm.com
+    outputPath: /liberty/personal/2/ciorchestrator
+    command: ant -f build-test.xml localrun -propertyfile ../../../buildandbucket.properties -DhaltOnFailure=false -lib ../ant_build/lib.antClasspath
+    aggregationId: ${compile:execution_id}
+    buildType: personal
+    reportingOS: ubuntu18_x86
+    retry_failing_fats: true
+    repeat_if_few_fats: true  #If there are fewer than x fat buckets then we will run each fat multiple times
+  includeProperties:
+  - file: fatMaxDurationOverrides.properties
+  - file: jvms/dev/linux_x86_64.properties


### PR DESCRIPTION
- Add a few schedule triggered pipelines into .ci-orchestrator/scheduledPersonalBuilds.yml to routinely check that pipelines testing product code, unittest, FAT, BVT and infrastructure changes do not break.