### PR TITLE
Enable EE10 repeat for tests previously failing on Java17

### DIFF
--- a/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/JSF23FacesDataModelTests.java
+++ b/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/JSF23FacesDataModelTests.java
@@ -28,7 +28,6 @@ import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.jsf23.fat.JSFUtils;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
@@ -72,7 +71,6 @@ public class JSF23FacesDataModelTests {
      * @throws Exception
      */
     @Test
-    @SkipForRepeat(SkipForRepeat.EE10_FEATURES) // Test fails on Java17+, needs more investigation.
     public void testFacesDataModelUIRepeat() throws Exception {
         String contextRoot = "FacesDataModel";
         try (WebClient webClient = new WebClient()) {
@@ -193,7 +191,6 @@ public class JSF23FacesDataModelTests {
      * @throws Exception
      */
     @Test
-    @SkipForRepeat(SkipForRepeat.EE10_FEATURES) // Test fails on Java17+, needs more investigation.
     public void testFacesDataModelChildUIRepeat() throws Exception {
         String contextRoot = "FacesDataModel";
         try (WebClient webClient = new WebClient()) {

--- a/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/JSF23SelectOneRadioGroupTests.java
+++ b/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/JSF23SelectOneRadioGroupTests.java
@@ -32,7 +32,6 @@ import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.jsf23.fat.JSFUtils;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -79,7 +78,6 @@ public class JSF23SelectOneRadioGroupTests {
      * @throws Exception
      */
     @Test
-    @SkipForRepeat(SkipForRepeat.EE10_FEATURES)
     public void testSelectOneRadioGroup_AjaxRequest() throws Exception {
         try (WebClient webClient = new WebClient(BrowserVersion.CHROME)) {
             // Use a synchronizing ajax controller to allow proper ajax updating
@@ -702,7 +700,6 @@ public class JSF23SelectOneRadioGroupTests {
      * @throws Exception
      */
     @Test
-    @SkipForRepeat(SkipForRepeat.EE10_FEATURES)
     public void testSelectOneRadioGroup_uiRepeat() throws Exception {
         try (WebClient webClient = new WebClient()) {
 

--- a/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/JSF23UIRepeatConditionTests.java
+++ b/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/JSF23UIRepeatConditionTests.java
@@ -77,6 +77,7 @@ public class JSF23UIRepeatConditionTests {
      * @throws Exception
      */
     @Test
+    // Need to investigate test failure, fails on Java11 and Java17
     @SkipForRepeat(SkipForRepeat.EE10_FEATURES)
     public void testUIRepeatCondition() throws Exception {
         String contextRoot = "UIRepeatConditionCheck";
@@ -148,7 +149,6 @@ public class JSF23UIRepeatConditionTests {
     @Mode(TestMode.FULL)
     @Test
     @ExpectedFFDC({ "javax.servlet.ServletException" })
-    @SkipForRepeat(SkipForRepeat.EE10_FEATURES)
     public void testUIRepeatConditionErrorEndTooLarge() throws Exception {
         String contextRoot = "UIRepeatConditionCheck";
         String errorText = "end cannot be greater than collection size";


### PR DESCRIPTION
fixes #22630