### PR TITLE
wsscxf fat cleanup: cbh file delete, errMsgVersion parameter removed

### DIFF
--- a/dev/com.ibm.ws.wssecurity.fat.utils.common/fat/src/com/ibm/ws/wssecurity/fat/utils/common/CommonTests.java
+++ b/dev/com.ibm.ws.wssecurity.fat.utils.common/fat/src/com/ibm/ws/wssecurity/fat/utils/common/CommonTests.java
@@ -819,8 +819,15 @@ public class CommonTests {
                 Log.info(thisClass, "tearDown", "Server stop threw an exception - end");
             }
 
-            Log.info(thisClass, "tearDown", "Trying to unintall the callback handler");
-            SharedTools.unInstallCallbackHandler(server);
+            //issue 23730
+            Log.info(thisClass, "tearDown", "deleting usr/extension/lib/com.ibm.ws.wssecurity.example.cbh.jar");
+            server.deleteFileFromLibertyInstallRoot("usr/extension/lib/com.ibm.ws.wssecurity.example.cbh.jar");
+            Log.info(thisClass, "tearDown", "deleting usr/extension/lib/features/wsseccbh-1.0.mf");
+            server.deleteFileFromLibertyInstallRoot("usr/extension/lib/features/wsseccbh-1.0.mf");
+            Log.info(thisClass, "tearDown", "deleting usr/extension/lib/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
+            server.deleteFileFromLibertyInstallRoot("usr/extension/lib/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
+            Log.info(thisClass, "tearDown", "deleting usr/extension/lib/features/wsseccbh-2.0.mf");
+            server.deleteFileFromLibertyInstallRoot("usr/extension/lib/features/wsseccbh-2.0.mf");
 
             /*
              * if (TCPMON_LISTENER_PORT != 0) {

--- a/dev/com.ibm.ws.wssecurity.fat.utils.common/fat/src/com/ibm/ws/wssecurity/fat/utils/common/SharedTools.java
+++ b/dev/com.ibm.ws.wssecurity.fat.utils.common/fat/src/com/ibm/ws/wssecurity/fat/utils/common/SharedTools.java
@@ -11,11 +11,8 @@
 
 package com.ibm.ws.wssecurity.fat.utils.common;
 
-import java.io.File;
 import java.security.Security;
 import java.util.HashMap;
-
-import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.topology.impl.LibertyServer;
 
@@ -107,30 +104,8 @@ public class SharedTools {
         return noUpdateMsg;
     }
 
-    public static void installCallbackHandler(LibertyServer server) throws Exception {
-
-        String cbh = "com.ibm.ws.wssecurity.example.cbh_1.0.0";
-        String cbhFullName = "." + File.separator + "publish" + File.separator + "bundles" + File.separator + cbh + ".jar";
-        Log.info(thisClass, "installCallbackHandler", "Looking for file: " + cbhFullName);
-        File f = new File(cbhFullName);
-        if (f.exists()) {
-            Log.info(thisClass, "installCallbackHandler", "Installing callback handler: " + cbh);
-            server.installUserBundle(cbh);
-            server.installUserFeature("wsseccbh-1.0");
-        }
-    }
-
-    public static void unInstallCallbackHandler(LibertyServer server) throws Exception {
-
-        String cbh = "com.ibm.ws.wssecurity.example.cbh_1.0.0";
-        String cbhFullName = "." + File.separator + "publish" + File.separator + "bundles" + File.separator + cbh + ".jar";
-        Log.info(thisClass, "uninstallCallbackHandler", "Looking for file: " + cbhFullName);
-        File f = new File(cbhFullName);
-        if (f.exists()) {
-            Log.info(thisClass, "unInstallCallbackHandler", "Un-Installing callback handler: " + cbh);
-            server.uninstallUserFeature("wsseccbh-1.0");
-            server.uninstallUserBundle(cbh);
-        }
-    }
+    //issue 23730 12/2022 removed installCallbackHandler() and unInstallCallbackHandler() from SharedTools.java
+    //since they are no longer applicable in OL wsscxf FAT where ShrinkHelper with bnd.bnd to handle CBH installation
+    //and server.deleteFileFromLibertyInstallRoot() to handle CBH uninstallation
 
 }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerX509AsymTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerX509AsymTests.java
@@ -52,9 +52,6 @@ public class CxfCallerX509AsymTests {
 
     static private final Class<?> thisClass = CxfCallerX509AsymTests.class;
 
-    private static String errMsgVersion = "";
-    private static String errMsgVersionInX509 = "";
-
     static boolean debugOnHttp = true;
 
     private static String portNumber = "";
@@ -92,8 +89,6 @@ public class CxfCallerX509AsymTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
         }
-        errMsgVersion = "wss4j";
-        errMsgVersionInX509 = "wss4j";
 
         ShrinkHelper.defaultDropinApp(server, "callerclient", "com.ibm.ws.wssecurity.fat.callerclient", "test.libertyfat.caller.contract", "test.libertyfat.caller.types");
         ShrinkHelper.defaultDropinApp(server, "callertoken", "test.libertyfat.caller");
@@ -212,8 +207,8 @@ public class CxfCallerX509AsymTests {
                         "FatBAC01Service", //String strServiceName,
                         "UrnCallerToken01", //String strServicePort
                         "test3", // Expecting User ID
-                        "test3", // Password for UserNameToken
-                        errMsgVersionInX509);
+                        "test3" // Password for UserNameToken
+            );
         } catch (Exception e) {
             throw e;
         }
@@ -243,8 +238,8 @@ public class CxfCallerX509AsymTests {
                         "FatBAC02Service", //String strServiceName,
                         "UrnCallerToken02", //String strServicePort
                         "test2", // Expecting User ID
-                        "test2", // Password
-                        errMsgVersion);
+                        "test2" // Password
+            );
         } catch (Exception e) {
             throw e;
         }
@@ -305,9 +300,8 @@ public class CxfCallerX509AsymTests {
                         "FatBAC04Service", //String strServiceName,
                         "UrnCallerToken04", //String strServicePort
                         "test4", // Expecting User ID
-                        "test4", // Password
-                        errMsgVersion,
-                        errMsgVersionInX509);
+                        "test4" // Password
+            );
         } catch (Exception e) {
             throw e;
         }
@@ -347,70 +341,7 @@ public class CxfCallerX509AsymTests {
                        callerUNTClientUrl,
                        "",
                        untID,
-                       untPassword,
-                       null, //2/2021
-                       null);//2/2021
-
-        return;
-    }
-
-    protected void testRoutine(
-                               String thisMethod,
-                               String callerPolicy,
-                               String testMode, // Positive, positive-1, negative or negative-1... etc
-                               String portNumber,
-                               String portNumberSecure,
-                               String strServiceName,
-                               String strServicePort,
-                               String untID,
-                               String untPassword,
-                               String errMsgVersion) throws Exception {
-
-        testSubRoutine(
-                       thisMethod,
-                       callerPolicy,
-                       testMode, // Positive, positive-1, negative or negative-1... etc
-                       portNumber,
-                       portNumberSecure,
-                       strServiceName,
-                       strServicePort,
-                       callerUNTClientUrl,
-                       "",
-                       untID,
-                       untPassword,
-                       errMsgVersion,
-                       null);
-
-        return;
-    }
-
-    protected void testRoutine(
-                               String thisMethod,
-                               String callerPolicy,
-                               String testMode, // Positive, positive-1, negative or negative-1... etc
-                               String portNumber,
-                               String portNumberSecure,
-                               String strServiceName,
-                               String strServicePort,
-                               String untID,
-                               String untPassword,
-                               String errMsgVersion,
-                               String errMsgVersionInX509) throws Exception {
-
-        testSubRoutine(
-                       thisMethod,
-                       callerPolicy,
-                       testMode, // Positive, positive-1, negative or negative-1... etc
-                       portNumber,
-                       portNumberSecure,
-                       strServiceName,
-                       strServicePort,
-                       callerUNTClientUrl,
-                       "",
-                       untID,
-                       untPassword,
-                       errMsgVersion, //2/2021
-                       errMsgVersionInX509); //2/2021
+                       untPassword);
 
         return;
     }
@@ -445,69 +376,7 @@ public class CxfCallerX509AsymTests {
                        callerBadUNTClientUrl,
                        "Bad",
                        untID,
-                       untPassword,
-                       null,
-                       null);
-
-        return;
-    }
-
-    protected void testBadRoutine(
-                                  String thisMethod,
-                                  String callerPolicy,
-                                  String testMode, // Positive, positive-1, negative or negative-1... etc
-                                  String portNumber,
-                                  String portNumberSecure,
-                                  String strServiceName,
-                                  String strServicePort,
-                                  String untID,
-                                  String untPassword,
-                                  String errMsgVersionInX509) throws Exception {
-        testSubRoutine(
-                       thisMethod,
-                       callerPolicy,
-                       testMode, // Positive, positive-1, negative or negative-1... etc
-                       portNumber,
-                       portNumberSecure,
-                       strServiceName,
-                       strServicePort,
-                       callerBadUNTClientUrl,
-                       "Bad",
-                       untID,
-                       untPassword,
-                       null,
-                       errMsgVersionInX509);
-
-        return;
-    }
-
-    protected void testBadRoutine(
-                                  String thisMethod,
-                                  String callerPolicy,
-                                  String testMode, // Positive, positive-1, negative or negative-1... etc
-                                  String portNumber,
-                                  String portNumberSecure,
-                                  String strServiceName,
-                                  String strServicePort,
-                                  String untID,
-                                  String untPassword,
-                                  String errMsgVersion,
-                                  String errMsgVersionInX509) throws Exception {
-
-        testSubRoutine(
-                       thisMethod,
-                       callerPolicy,
-                       testMode, // Positive, positive-1, negative or negative-1... etc
-                       portNumber,
-                       portNumberSecure,
-                       strServiceName,
-                       strServicePort,
-                       callerBadUNTClientUrl,
-                       "Bad",
-                       untID,
-                       untPassword,
-                       errMsgVersion,
-                       null); //2/2021
+                       untPassword);
 
         return;
     }
@@ -532,9 +401,7 @@ public class CxfCallerX509AsymTests {
                                   String strClientUrl,
                                   String strBadOrGood,
                                   String untID,
-                                  String untPassword,
-                                  String errMsgVersion,
-                                  String errMsgVersionInX509) throws Exception {
+                                  String untPassword) throws Exception {
 
         try {
 
@@ -559,9 +426,6 @@ public class CxfCallerX509AsymTests {
             request.setParameter("methodFull", methodFull);
             request.setParameter("untID", untID);
             request.setParameter("untPassword", untPassword);
-
-            request.setParameter("errorMsgVersion", errMsgVersion);
-            request.setParameter("errorMsgVersionInX509", errMsgVersionInX509);
 
             // Invoke the client
             response = wc.getResponse(request);

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfSampleTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfSampleTests.java
@@ -330,9 +330,6 @@ public class CxfSampleTests {
             e.printStackTrace(System.out);
         }
 
-        //orig from CL
-        //SharedTools.unInstallCallbackHandler(server);
-
         Log.info(thisClass, "tearDown", "deleting usr/extension/lib/com.ibm.ws.wssecurity.example.cbh.jar");
         server.deleteFileFromLibertyInstallRoot("usr/extension/lib/com.ibm.ws.wssecurity.example.cbh.jar");
         Log.info(thisClass, "tearDown", "deleting usr/extension/lib/features/wsseccbh-1.0.mf");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfSymSampleTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfSymSampleTests.java
@@ -387,8 +387,6 @@ public class CxfSymSampleTests {
         } catch (Exception e) {
             e.printStackTrace(System.out);
         }
-        //orig from CL
-        //SharedTools.unInstallCallbackHandler(server);
 
         Log.info(thisClass, "tearDown", "deleting usr/extension/lib/com.ibm.ws.wssecurity.example.cbh.jar");
         server.deleteFileFromLibertyInstallRoot("usr/extension/lib/com.ibm.ws.wssecurity.example.cbh.jar");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/callerclient/src/com/ibm/ws/wssecurity/fat/callerclient/CxfCallerSvcClient.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/callerclient/src/com/ibm/ws/wssecurity/fat/callerclient/CxfCallerSvcClient.java
@@ -71,8 +71,6 @@ public class CxfCallerSvcClient extends HttpServlet {
 
     String untID = "";
     String untPassword = "";
-    String errMsgVersion = "";
-    String errMsgVersionInX509 = "";
 
     private StringReader reqMsg = null;
     static boolean unlimitCryptoKeyLength = false;
@@ -115,8 +113,7 @@ public class CxfCallerSvcClient extends HttpServlet {
                            " untPassword:" + untPassword +
                            " serviceName:" + serviceName +
                            " servicePort:" + servicePort +
-                           " servername:" + serverName +
-                           "errorMsgVersion:" + errMsgVersion); 
+                           " servername:" + serverName); 
 
         // This piece of code is a work-around for a bug defect 89493
 /*
@@ -147,11 +144,7 @@ public class CxfCallerSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testCxfCallerHttpsPolicy")) {
                 service = new FatBAC02Service(wsdlURL, serviceName);
                 strExpect = "Liberty Fat Caller bac02(" + untID + ")";
-
-                //issue 23060
-                if (errMsgVersion.equals("wss4j")) {
-                    strSubErrMsg = "Unexpected number of certificates: 0";
-                } 
+                strSubErrMsg = "Unexpected number of certificates: 0";
 
             } else if (thisMethod.equals("testCxfCallerNoPolicy")) {
                 service = new FatBAC03Service(wsdlURL, serviceName);
@@ -159,21 +152,12 @@ public class CxfCallerSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testCxfCallerHttpsNoUntPolicy")) {
                 service = new FatBAC04Service(wsdlURL, serviceName);
                 strExpect = "Liberty Fat Caller bac04(" + untID + ")";
-                //strSubErrMsg = "There is no Username token in the message to process caller.";
-
-                //issue 23060
-                if (errMsgVersion.equals("wss4j")) {
-                    strSubErrMsg = "UsernameToken is missing";
-                } 
+                strSubErrMsg = "UsernameToken is missing";
 
                 // msg is There is no username token in the message to process the caller
                 //    in nlsprops
-                if (!thisMethod.equals(methodFull)) { // Test this test in x509 Caller
-                    //strSubErrMsg = "There is no Asymmetric signature token exists in the message";
-                    //issue 23060
-                    if (errMsgVersionInX509.equals("wss4j")) {
-                        strSubErrMsg = "Unexpected number of certificates: 0";
-                    } 
+                if (!thisMethod.equals(methodFull)) { // Test this test in x509 Caller   
+                    strSubErrMsg = "Unexpected number of certificates: 0";   
                 }
             } else if (thisMethod.equals("testCxfCallerX509TokenPolicy")) {
                 service = new FatBAC05Service(wsdlURL, serviceName);
@@ -187,7 +171,7 @@ public class CxfCallerSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testCxfCallerSymmetricEndorsingTLSPolicy")) {
                 service = new FatBAC08Service(wsdlURL, serviceName);
                 strExpect = "Liberty Fat Caller bac08(" + untID + ")";
-            }
+            } 
             if (service == null) {
                 throw new Exception("thisMethod '" + thisMethod + "' did not get a Service. Test cases error.");
             }
@@ -260,9 +244,9 @@ public class CxfCallerSvcClient extends HttpServlet {
                 requestContext.put("ws-security.username", untID);
                 requestContext.put("ws-security.password", untPassword);
             }
-
+            
             SOAPMessage soapResp = dispSOAPMsg.invoke(soapReq);
-
+            
             String answer = soapResp.getSOAPBody().getTextContent();
             System.out.println(thisMethod + ":answer:" + answer);
 
@@ -356,8 +340,6 @@ public class CxfCallerSvcClient extends HttpServlet {
             methodFull = request.getParameter("methodFull");
             serviceName = new QName(SERVICE_NS, rawServiceName);
             servicePort = new QName(SERVICE_NS, request.getParameter("servicePort"));
-            errMsgVersion = request.getParameter("errorMsgVersion");
-            errMsgVersionInX509 = request.getParameter("errorMsgVersionInX509");
 
             untID = request.getParameter("untID");
             if (untID == null)

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/untoken/src/com/ibm/ws/wssecurity/fat/untoken/FVTVersion_ba06.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/untoken/src/com/ibm/ws/wssecurity/fat/untoken/FVTVersion_ba06.java
@@ -65,7 +65,7 @@ public class FVTVersion_ba06 implements javax.xml.ws.Provider<SOAPMessage> {
             StringReader respMsg;
             if (muheader_exists) {
                 //default behavior, mustunderstand="1"
-                respMsg = new StringReader("<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\"><SOAP-ENV:Body><provider><message>WSSECFVT FVTVersion_ba06_mustUnderstand_in_header_expected</message></provider></SOAP-ENV:Body></SOAP-ENV:Envelope>");
+                respMsg = new StringReader("<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\"><SOAP-ENV:Body><provider><message>WSSECFVT FVTVersion_ba06</message></provider></SOAP-ENV:Body></SOAP-ENV:Envelope>");
             } else {
                 // if we set ws-security.must-understand="false" explicitly in server.xml , then this header should not exist
                 respMsg = new StringReader("<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\"><SOAP-ENV:Body><provider><message>WSSECFVT FVTVersion_ba06_NO_mustUnderstand_in_header_expected</message></provider></SOAP-ENV:Body></SOAP-ENV:Envelope>");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigSymSha2NegativeTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigSymSha2NegativeTests.java
@@ -94,7 +94,7 @@ public class CxfX509MigSymSha2NegativeTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_badsha2_wss4j.xml");
         }
-        errMsgVersion = "wss4j";
+        //errMsgVersion = "wss4j";
 
         ShrinkHelper.defaultDropinApp(server, "x509migclient", "com.ibm.ws.wssecurity.fat.x509migclient", "test.libertyfat.x509mig.contract", "test.libertyfat.x509mig.types");
         ShrinkHelper.defaultDropinApp(server, "x509migbadclient", "com.ibm.ws.wssecurity.fat.x509migbadclient", "test.libertyfat.x509mig.contract",
@@ -152,8 +152,8 @@ public class CxfX509MigSymSha2NegativeTests {
                         portNumber, //String portNumber,
                         "", //String portNumberSecure
                         "FatBAX01Service", //String strServiceName,
-                        "UrnX509Token01", //String strServicePort
-                        errMsgVersion //CxfX509MigSvcClient
+                        "UrnX509Token01" //String strServicePort
+            //errMsgVersion //CxfX509MigSvcClient
             );
         } catch (Exception e) {
             throw e;
@@ -187,8 +187,8 @@ public class CxfX509MigSymSha2NegativeTests {
                         portNumber, //String portNumber,
                         portNumberSecure, //String portNumberSecure
                         "FatBAX01Service", //String strServiceName,
-                        "UrnX509Token01", //String strServicePort
-                        errMsgVersion //CxfX509MigSvcClient
+                        "UrnX509Token01" //String strServicePort
+            //errMsgVersion //CxfX509MigSvcClient
             );
         } catch (Exception e) {
             throw e;
@@ -222,8 +222,8 @@ public class CxfX509MigSymSha2NegativeTests {
                         portNumber, //String portNumber,
                         "", //String portNumberSecure
                         "FatBAX03Service", //String strServiceName,
-                        "UrnX509Token03", //String strServicePort
-                        errMsgVersion //CxfX509MigSvcClient
+                        "UrnX509Token03" //String strServicePort
+            //errMsgVersion //CxfX509MigSvcClient
             );
         } catch (Exception e) {
             throw e;
@@ -259,36 +259,37 @@ public class CxfX509MigSymSha2NegativeTests {
                        strServiceName,
                        strServicePort,
                        x509MigSymClientUrl,
-                       "",
-                       null);
+                       "");
+        //null);
 
         return;
     }
 
-    protected void testRoutine(
-                               String thisMethod,
-                               String x509Policy,
-                               String testMode, // Positive, positive-1, negative or negative-1... etc
-                               String portNumber,
-                               String portNumberSecure,
-                               String strServiceName,
-                               String strServicePort,
-                               String errMsgVersion) throws Exception { //2/2021
-        testSubRoutine(
-                       thisMethod,
-                       x509Policy,
-                       testMode, // Positive, positive-1, negative or negative-1... etc
-                       portNumber,
-                       portNumberSecure,
-                       strServiceName,
-                       strServicePort,
-                       x509MigSymClientUrl,
-                       "",
-                       errMsgVersion);
-
-        return;
-    }
-
+/*
+ * protected void testRoutine(
+ * String thisMethod,
+ * String x509Policy,
+ * String testMode, // Positive, positive-1, negative or negative-1... etc
+ * String portNumber,
+ * String portNumberSecure,
+ * String strServiceName,
+ * String strServicePort,
+ * String errMsgVersion) throws Exception { //2/2021
+ * testSubRoutine(
+ * thisMethod,
+ * x509Policy,
+ * testMode, // Positive, positive-1, negative or negative-1... etc
+ * portNumber,
+ * portNumberSecure,
+ * strServiceName,
+ * strServicePort,
+ * x509MigSymClientUrl,
+ * "",
+ * errMsgVersion);
+ * 
+ * return;
+ * }
+ */
     /**
      * TestDescription:
      *
@@ -307,8 +308,8 @@ public class CxfX509MigSymSha2NegativeTests {
                                   String strServiceName,
                                   String strServicePort,
                                   String strClientUrl,
-                                  String strBadOrGood,
-                                  String errMsgVersion) throws Exception {
+                                  String strBadOrGood) throws Exception {
+        //String errMsgVersion) throws Exception {
         try {
 
             WebRequest request = null;
@@ -331,7 +332,7 @@ public class CxfX509MigSymSha2NegativeTests {
             request.setParameter("servicePort", strServicePort);
             request.setParameter("methodFull", methodFull);
 
-            request.setParameter("errorMsgVersion", errMsgVersion);
+            //request.setParameter("errorMsgVersion", errMsgVersion);
 
             Log.info(thisClass, methodFull, "The request is: " + request);
 
@@ -373,9 +374,13 @@ public class CxfX509MigSymSha2NegativeTests {
             e.printStackTrace(System.out);
         }
 
-        server.deleteFileFromLibertyInstallRoot("usr/extension/lib/bundles/com.ibm.ws.wssecurity.example.cbh.jar");
+        Log.info(thisClass, "tearDown", "deleting usr/extension/lib/com.ibm.ws.wssecurity.example.cbh.jar");
+        server.deleteFileFromLibertyInstallRoot("usr/extension/lib/com.ibm.ws.wssecurity.example.cbh.jar");
+        Log.info(thisClass, "tearDown", "deleting usr/extension/lib/features/wsseccbh-1.0.mf");
         server.deleteFileFromLibertyInstallRoot("usr/extension/lib/features/wsseccbh-1.0.mf");
-        server.deleteFileFromLibertyInstallRoot("usr/extension/lib/bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
+        Log.info(thisClass, "tearDown", "deleting usr/extension/lib/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
+        server.deleteFileFromLibertyInstallRoot("usr/extension/lib/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
+        Log.info(thisClass, "tearDown", "deleting usr/extension/lib/features/wsseccbh-2.0.mf");
         server.deleteFileFromLibertyInstallRoot("usr/extension/lib/features/wsseccbh-2.0.mf");
 
     }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigSymTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigSymTests.java
@@ -57,8 +57,6 @@ public class CxfX509MigSymTests {
 
     static private final Class<?> thisClass = CxfX509MigSymTests.class;
 
-    private static String errMsgVersion = "";
-
     static boolean debugOnHttp = true;
 
     private static String portNumber = "";
@@ -96,7 +94,6 @@ public class CxfX509MigSymTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_sha512_wss4j.xml");
         }
-        errMsgVersion = "wss4j";
 
         ShrinkHelper.defaultDropinApp(server, "x509migclient", "com.ibm.ws.wssecurity.fat.x509migclient", "test.libertyfat.x509mig.contract", "test.libertyfat.x509mig.types");
         ShrinkHelper.defaultDropinApp(server, "x509migbadclient", "com.ibm.ws.wssecurity.fat.x509migbadclient", "test.libertyfat.x509mig.contract",
@@ -298,8 +295,7 @@ public class CxfX509MigSymTests {
                         portNumber, //String portNumber,
                         "", //String portNumberSecure
                         "FatBAX01Service", //String strServiceName,
-                        "UrnX509Token01", //String strServicePort
-                        errMsgVersion //CxfX509MigSvcClient
+                        "UrnX509Token01" //String strServicePort
             );
         } catch (Exception e) {
             throw e;
@@ -329,8 +325,7 @@ public class CxfX509MigSymTests {
                         portNumber, //String portNumber,
                         portNumberSecure, //String portNumberSecure
                         "FatBAX01Service", //String strServiceName,
-                        "UrnX509Token01", //String strServicePort
-                        errMsgVersion //CxfX509MigSvcClient
+                        "UrnX509Token01" //String strServicePort
             );
         } catch (Exception e) {
             throw e;
@@ -509,8 +504,7 @@ public class CxfX509MigSymTests {
                         portNumber, //String portNumber,
                         "", //String portNumberSecure
                         "FatBAX03Service", //String strServiceName,
-                        "UrnX509Token03", //String strServicePort
-                        errMsgVersion //CxfX509MigSvcClient
+                        "UrnX509Token03" //String strServicePort
             );
         } catch (Exception e) {
             throw e;
@@ -1476,8 +1470,7 @@ public class CxfX509MigSymTests {
                             portNumber, //String portNumber,
                             "", //String portNumberSecure
                             "FatBAX31Service", //String strServiceName,
-                            "UrnX509Token31", //String strServicePort
-                            errMsgVersion //CxfX509MigSvcClient
+                            "UrnX509Token31" //String strServicePort
                 );
             } catch (Exception e) {
                 throw e;
@@ -1762,8 +1755,7 @@ public class CxfX509MigSymTests {
                            portNumber, //String portNumber,
                            "", //String portNumberSecure
                            "FatBAX09Service", //String strServiceName,
-                           "UrnX509Token09", //String strServicePort
-                           errMsgVersion //CxfX509MigBadSvcClient
+                           "UrnX509Token09" //String strServicePort
             );
         } catch (Exception e) {
             throw e;
@@ -2043,8 +2035,7 @@ public class CxfX509MigSymTests {
                            portNumber, //String portNumber,
                            "", //String portNumberSecure
                            "FatBAX31Service", //String strServiceName,
-                           "UrnX509Token31", //String strServicePort
-                           errMsgVersion //CxfX509MigBadSvcClient
+                           "UrnX509Token31" //String strServicePort
             );
         } catch (Exception e) {
             throw e;
@@ -2087,8 +2078,7 @@ public class CxfX509MigSymTests {
                            portNumber, //String portNumber,
                            "", //String portNumberSecure
                            "FatBAX33Service", //String strServiceName,
-                           "UrnX509Token33", //String strServicePort
-                           errMsgVersion //CxfX509MigBadSvcClient
+                           "UrnX509Token33" //String strServicePort
             );
         } catch (Exception e) {
             throw e;
@@ -2173,32 +2163,8 @@ public class CxfX509MigSymTests {
                        strServiceName,
                        strServicePort,
                        x509MigSymClientUrl,
-                       "",
-                       null);
-
-        return;
-    }
-
-    protected void testRoutine(
-                               String thisMethod,
-                               String x509Policy,
-                               String testMode, // Positive, positive-1, negative or negative-1... etc
-                               String portNumber,
-                               String portNumberSecure,
-                               String strServiceName,
-                               String strServicePort,
-                               String errMsgVersion) throws Exception {
-        testSubRoutine(
-                       thisMethod,
-                       x509Policy,
-                       testMode, // Positive, positive-1, negative or negative-1... etc
-                       portNumber,
-                       portNumberSecure,
-                       strServiceName,
-                       strServicePort,
-                       x509MigSymClientUrl,
-                       "",
-                       errMsgVersion);
+                       "");
+        //null);
 
         return;
     }
@@ -2230,32 +2196,7 @@ public class CxfX509MigSymTests {
                        strServiceName,
                        strServicePort,
                        x509MigBadSymClientUrl,
-                       "Bad",
-                       null);
-
-        return;
-    }
-
-    protected void testBadRoutine(
-                                  String thisMethod,
-                                  String x509Policy,
-                                  String testMode, // Positive, positive-1, negative or negative-1... etc
-                                  String portNumber,
-                                  String portNumberSecure,
-                                  String strServiceName,
-                                  String strServicePort,
-                                  String errMsgVersion) throws Exception {
-        testSubRoutine(
-                       thisMethod,
-                       x509Policy,
-                       testMode, // Positive, positive-1, negative or negative-1... etc
-                       portNumber,
-                       portNumberSecure,
-                       strServiceName,
-                       strServicePort,
-                       x509MigBadSymClientUrl,
-                       "Bad",
-                       errMsgVersion);
+                       "Bad");
 
         return;
     }
@@ -2278,8 +2219,7 @@ public class CxfX509MigSymTests {
                                   String strServiceName,
                                   String strServicePort,
                                   String strClientUrl,
-                                  String strBadOrGood,
-                                  String errMsgVersion) throws Exception {
+                                  String strBadOrGood) throws Exception {
         try {
 
             WebRequest request = null;
@@ -2301,7 +2241,6 @@ public class CxfX509MigSymTests {
             request.setParameter("serviceName", strServiceName);
             request.setParameter("servicePort", strServicePort);
             request.setParameter("methodFull", methodFull);
-            request.setParameter("errorMsgVersion", errMsgVersion);
 
             Log.info(thisClass, methodFull, "The request is: '" + request);
 
@@ -2342,9 +2281,13 @@ public class CxfX509MigSymTests {
             e.printStackTrace(System.out);
         }
 
-        server.deleteFileFromLibertyInstallRoot("usr/extension/lib/bundles/com.ibm.ws.wssecurity.example.cbh.jar");
+        Log.info(thisClass, "tearDown", "deleting usr/extension/lib/com.ibm.ws.wssecurity.example.cbh.jar");
+        server.deleteFileFromLibertyInstallRoot("usr/extension/lib/com.ibm.ws.wssecurity.example.cbh.jar");
+        Log.info(thisClass, "tearDown", "deleting usr/extension/lib/features/wsseccbh-1.0.mf");
         server.deleteFileFromLibertyInstallRoot("usr/extension/lib/features/wsseccbh-1.0.mf");
-        server.deleteFileFromLibertyInstallRoot("usr/extension/lib/bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
+        Log.info(thisClass, "tearDown", "deleting usr/extension/lib/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
+        server.deleteFileFromLibertyInstallRoot("usr/extension/lib/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
+        Log.info(thisClass, "tearDown", "deleting usr/extension/lib/features/wsseccbh-2.0.mf");
         server.deleteFileFromLibertyInstallRoot("usr/extension/lib/features/wsseccbh-2.0.mf");
 
     }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigTests.java
@@ -52,8 +52,6 @@ public class CxfX509MigTests {
 
     static private final Class<?> thisClass = CxfX509MigTests.class;
 
-    private static String errMsgVersion = "";
-
     static boolean debugOnHttp = true;
 
     private static String portNumber = "";
@@ -93,7 +91,6 @@ public class CxfX509MigTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
         }
-        errMsgVersion = "wss4j";
 
         ShrinkHelper.defaultDropinApp(server, "x509migclient", "com.ibm.ws.wssecurity.fat.x509migclient", "test.libertyfat.x509mig.contract", "test.libertyfat.x509mig.types");
         ShrinkHelper.defaultDropinApp(server, "x509migbadclient", "com.ibm.ws.wssecurity.fat.x509migbadclient", "test.libertyfat.x509mig.contract",
@@ -933,8 +930,7 @@ public class CxfX509MigTests {
                         portNumber, //String portNumber,
                         "", //String portNumberSecure
                         "FatBAX11Service", //String strServiceName,
-                        "UrnX509Token11", //String strServicePort
-                        errMsgVersion //CxfX509MigSvcClient
+                        "UrnX509Token11" //String strServicePort
             );
         } catch (Exception e) {
             throw e;
@@ -1087,8 +1083,7 @@ public class CxfX509MigTests {
                         portNumber, //String portNumber,
                         portNumberSecure, //String portNumberSecure
                         "FatBAX11Service", //String strServiceName,
-                        "UrnX509Token11", //String strServicePort
-                        errMsgVersion //CxfX509MigSvcClient
+                        "UrnX509Token11" //String strServicePort
             );
         } catch (Exception e) {
             throw e;
@@ -1286,8 +1281,7 @@ public class CxfX509MigTests {
                         portNumber, //String portNumber,
                         "", //String portNumberSecure
                         "FatBAX13Service", //String strServiceName,
-                        "UrnX509Token13", //String strServicePort
-                        errMsgVersion //CxfX509MigBadSvcClient
+                        "UrnX509Token13" //String strServicePort
             );
         } catch (Exception e) {
             throw e;
@@ -1848,8 +1842,7 @@ public class CxfX509MigTests {
                         portNumber, //String portNumber,
                         "", //String portNumberSecure
                         "FatBAX16Service", //String strServiceName,
-                        "UrnX509Token16", //String strServicePort
-                        errMsgVersion //CxfX509MigBadSvcClient
+                        "UrnX509Token16" //String strServicePort
             );
         } catch (Exception e) {
             throw e;
@@ -2193,8 +2186,7 @@ public class CxfX509MigTests {
                         portNumber, //String portNumber,
                         "", //String portNumberSecure
                         "FatBAX17Service", //String strServiceName,
-                        "UrnX509Token17", //String strServicePort
-                        errMsgVersion //CxfX509MigSvcClient
+                        "UrnX509Token17" //String strServicePort
             );
         } catch (Exception e) {
             throw e;
@@ -2917,8 +2909,7 @@ public class CxfX509MigTests {
                            portNumber, //String portNumber,
                            "", //String portNumberSecure
                            "FatBAX02Service", //String strServiceName,
-                           "UrnX509Token02", //String strServicePort
-                           errMsgVersion //CxfX509MigBadSvcClient
+                           "UrnX509Token02" //String strServicePort
             );
         } catch (Exception e) {
             throw e;
@@ -2981,8 +2972,7 @@ public class CxfX509MigTests {
                            portNumber, //String portNumber,
                            "", //String portNumberSecure
                            "FatBAX08Service", //String strServiceName,
-                           "UrnX509Token08", //String strServicePort
-                           errMsgVersion //CxfX509MigBadSvcClient
+                           "UrnX509Token08" //String strServicePort
             );
         } catch (Exception e) {
             throw e;
@@ -3012,8 +3002,7 @@ public class CxfX509MigTests {
                            portNumber, //String portNumber,
                            portNumberSecure, //String portNumberSecure
                            "FatBAX10Service", //String strServiceName,
-                           "UrnX509Token10", //String strServicePort
-                           errMsgVersion //CxfX509MigBadSvcClient
+                           "UrnX509Token10" //String strServicePort
             );
         } catch (Exception e) {
             throw e;
@@ -3102,8 +3091,7 @@ public class CxfX509MigTests {
                            portNumber, //String portNumber,
                            portNumberSecure, //String portNumberSecure
                            "FatBAX13Service", //String strServiceName,
-                           "UrnX509Token13", //String strServicePort
-                           errMsgVersion //CxfX509MigBadSvcClient
+                           "UrnX509Token13" //String strServicePort
             );
         } catch (Exception e) {
             throw e;
@@ -3191,8 +3179,7 @@ public class CxfX509MigTests {
                            portNumber, //String portNumber,
                            portNumberSecure, //String portNumberSecure
                            "FatBAX16Service", //String strServiceName,
-                           "UrnX509Token16", //String strServicePort
-                           errMsgVersion //CxfX509MigBadSvcClient
+                           "UrnX509Token16" //String strServicePort
             );
         } catch (Exception e) {
             throw e;
@@ -3329,8 +3316,7 @@ public class CxfX509MigTests {
                            portNumber, //String portNumber,
                            "", //String portNumberSecure
                            "FatBAX21Service", //String strServiceName,
-                           "UrnX509Token21", //String strServicePort
-                           errMsgVersion //CxfX509MigBadSvcClient
+                           "UrnX509Token21" //String strServicePort
             );
         } catch (Exception e) {
             throw e;
@@ -3398,31 +3384,7 @@ public class CxfX509MigTests {
                        portNumberSecure,
                        strServiceName,
                        strServicePort,
-                       x509MigClientUrl,
-                       null);
-
-        return;
-    }
-
-    protected void testRoutine(
-                               String thisMethod,
-                               String x509Policy,
-                               String testMode, // Positive, positive-1, negative or negative-1... etc
-                               String portNumber,
-                               String portNumberSecure,
-                               String strServiceName,
-                               String strServicePort,
-                               String errMsgVersion) throws Exception {
-        testSubRoutine(
-                       thisMethod,
-                       x509Policy,
-                       testMode, // Positive, positive-1, negative or negative-1... etc
-                       portNumber,
-                       portNumberSecure,
-                       strServiceName,
-                       strServicePort,
-                       x509MigClientUrl,
-                       errMsgVersion);
+                       x509MigClientUrl);
 
         return;
     }
@@ -3564,8 +3526,7 @@ public class CxfX509MigTests {
                            portNumber, //String portNumber,
                            "", //String portNumberSecure
                            "FatBAX32Service", //String strServiceName,
-                           "UrnX509Token32", //String strServicePort
-                           errMsgVersion //CxfX509MigBadSvcClient
+                           "UrnX509Token32" //String strServicePort
             );
         } catch (Exception e) {
             throw e;
@@ -3617,8 +3578,7 @@ public class CxfX509MigTests {
                            portNumber, //String portNumber,
                            "", //String portNumberSecure
                            "FatBAX34Service", //String strServiceName,
-                           "UrnX509Token34", //String strServicePort
-                           errMsgVersion //CxfX509MigBadSvcClient
+                           "UrnX509Token34" //String strServicePort
             );
         } catch (Exception e) {
             throw e;
@@ -3652,31 +3612,7 @@ public class CxfX509MigTests {
                        portNumberSecure,
                        strServiceName,
                        strServicePort,
-                       x509MigBadClientUrl,
-                       null);
-
-        return;
-    }
-
-    protected void testBadRoutine(
-                                  String thisMethod,
-                                  String x509Policy,
-                                  String testMode, // Positive, positive-1, negative or negative-1... etc
-                                  String portNumber,
-                                  String portNumberSecure,
-                                  String strServiceName,
-                                  String strServicePort,
-                                  String errMsgVersion) throws Exception {
-        testSubRoutine(
-                       thisMethod,
-                       x509Policy,
-                       testMode, // Positive, positive-1, negative or negative-1... etc
-                       portNumber,
-                       portNumberSecure,
-                       strServiceName,
-                       strServicePort,
-                       x509MigBadClientUrl,
-                       errMsgVersion);
+                       x509MigBadClientUrl);
 
         return;
     }
@@ -3698,8 +3634,7 @@ public class CxfX509MigTests {
                                   String portNumberSecure,
                                   String strServiceName,
                                   String strServicePort,
-                                  String strClientUrl,
-                                  String errMsgVersion) throws Exception {
+                                  String strClientUrl) throws Exception {
         try {
 
             WebRequest request = null;
@@ -3721,7 +3656,6 @@ public class CxfX509MigTests {
             request.setParameter("serviceName", strServiceName);
             request.setParameter("servicePort", strServicePort);
             request.setParameter("methodFull", methodFull);
-            request.setParameter("errorMsgVersion", errMsgVersion);
 
             // Invoke the client
             response = wc.getResponse(request);
@@ -3754,12 +3688,14 @@ public class CxfX509MigTests {
         } catch (Exception e) {
             e.printStackTrace(System.out);
         }
-        //orig from CL:
-        //SharedTools.unInstallCallbackHandler(server);
 
-        server.deleteFileFromLibertyInstallRoot("usr/extension/lib/bundles/com.ibm.ws.wssecurity.example.cbh.jar");
+        Log.info(thisClass, "tearDown", "deleting usr/extension/lib/com.ibm.ws.wssecurity.example.cbh.jar");
+        server.deleteFileFromLibertyInstallRoot("usr/extension/lib/com.ibm.ws.wssecurity.example.cbh.jar");
+        Log.info(thisClass, "tearDown", "deleting usr/extension/lib/features/wsseccbh-1.0.mf");
         server.deleteFileFromLibertyInstallRoot("usr/extension/lib/features/wsseccbh-1.0.mf");
-        server.deleteFileFromLibertyInstallRoot("usr/extension/lib/bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
+        Log.info(thisClass, "tearDown", "deleting usr/extension/lib/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
+        server.deleteFileFromLibertyInstallRoot("usr/extension/lib/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
+        Log.info(thisClass, "tearDown", "deleting usr/extension/lib/features/wsseccbh-2.0.mf");
         server.deleteFileFromLibertyInstallRoot("usr/extension/lib/features/wsseccbh-2.0.mf");
 
     }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/test-applications/x509migbadclient/src/com/ibm/ws/wssecurity/fat/x509migbadclient/CxfX509MigBadSvcClient.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/test-applications/x509migbadclient/src/com/ibm/ws/wssecurity/fat/x509migbadclient/CxfX509MigBadSvcClient.java
@@ -96,8 +96,6 @@ public class CxfX509MigBadSvcClient extends HttpServlet {
     String methodFull = null;
     SOAPMessage soapReq = null;
 
-    String errMsgVersion = "";
-
     private StringReader reqMsg = null;
 
     boolean unlimitCryptoKeyLength = false;
@@ -138,9 +136,8 @@ public class CxfX509MigBadSvcClient extends HttpServlet {
                            " methodFull:" + methodFull +
                            " serviceName:" + serviceName +
                            " servicePort:" + servicePort +
-                           " servername:" + serverName +
-                           " errorMsgVersion:" + errMsgVersion); //2/2021
-
+                           " servername:" + serverName);
+                           
         // This piece of code is a work-around for a bug defect 89493
 /*
  * if( httpProtocal.equals("https:")){
@@ -172,10 +169,7 @@ public class CxfX509MigBadSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testBadCxfX509AsymIssuerSerialMigService")) {
                 service = new FatBAX02Service();
                 strExpect = "LIBERTYFAT X509 bax02";
-                //issue 23060
-                if (errMsgVersion.equals("wss4j")) {
-                    strSubErrMsg = "An error was discovered processing the <wsse:Security> header";
-                }
+                strSubErrMsg = "An error was discovered processing the <wsse:Security> header";
             } else if (thisMethod.equals("testCxfX509IssuerSerialMigSymNoEncryptSignatureService")) {
                 service = new FatBAX03Service();
                 strExpect = "LIBERTYFAT X509 bax03";
@@ -198,24 +192,15 @@ public class CxfX509MigBadSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testCxfX509AsymProtectTokensMigService")) {
                 service = new FatBAX08Service();
                 strExpect = "LIBERTYFAT X509 bax08";
-                //issue 23060
-                if (errMsgVersion.equals("wss4j")) {
-                    strSubErrMsg = "EncryptedParts: Soap Body is not ENCRYPTED";
-                }
+                strSubErrMsg = "EncryptedParts: Soap Body is not ENCRYPTED";
             } else if (thisMethod.equals("testCxfX509ProtectTokensMigSymService")) {
                 service = new FatBAX09Service();
                 strExpect = "LIBERTYFAT X509 bax09";
-                //issue 23060
-                if (errMsgVersion.equals("wss4j")) {
-                    strSubErrMsg = "SignedParts: Soap Body is not SIGNED";
-                }
+                strSubErrMsg = "SignedParts: Soap Body is not SIGNED";
             } else if (thisMethod.equals("testCxfX509TransportEndorsingMigService")) {
                 service = new FatBAX10Service();
                 strExpect = "LIBERTYFAT X509 bax10";
-                //issue 23060
-                if (errMsgVersion.equals("wss4j")) {
-                    strSubErrMsg = "list of references must contain at least one entry";
-                }
+                strSubErrMsg = "list of references must contain at least one entry";
             } else if (thisMethod.equals("testCxfX509TransportEndorsingSP11MigService")) {
                 service = new FatBAX11Service();
                 strExpect = "LIBERTYFAT X509 bax11";
@@ -227,10 +212,7 @@ public class CxfX509MigBadSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testCxfX509TransportEndorsingEncryptedMigService")) {
                 service = new FatBAX13Service();
                 strExpect = "LIBERTYFAT X509 bax13";
-                //issue 23060
-                if (errMsgVersion.equals("wss4j")) {
-                    strSubErrMsg = "list of references must contain at least one entry";
-                }
+                strSubErrMsg = "list of references must contain at least one entry";
             } else if (thisMethod.equals("testCxfX509TransportSignedEndorsingEncryptedMigService")) {
                 service = new FatBAX14Service();
                 strExpect = "LIBERTYFAT X509 bax14";
@@ -242,10 +224,7 @@ public class CxfX509MigBadSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testCxfX509TransportKVTMigService")) {
                 service = new FatBAX16Service();
                 strExpect = "LIBERTYFAT X509 bax16";
-                //issue 23060
-                if (errMsgVersion.equals("wss4j")) {
-                    strSubErrMsg = "Received Timestamp does not match the requirements";
-                }
+                strSubErrMsg = "Received Timestamp does not match the requirements";
             } else if (thisMethod.equals("testCxfX509AsymmetricSignatureMigService")) {
                 service = new FatBAX17Service();
                 strExpect = "LIBERTYFAT X509 bax17";
@@ -266,10 +245,7 @@ public class CxfX509MigBadSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testBadWsComplexService")) {
                 service = new FatBAX21Service();
                 strExpect = "LIBERTYFAT X509 bax21";
-                //issue 23060
-                if (errMsgVersion.equals("wss4j")) {
-                    strSubErrMsg = "Not encrypted before signed";
-                }
+                strSubErrMsg = "Not encrypted before signed";
             } else if (thisMethod.equals("testBadX509KeyIdentifierUNTService")) {
                 service = new FatBAX24Service();
                 strExpect = "LIBERTYFAT X509 bax24";
@@ -301,34 +277,19 @@ public class CxfX509MigBadSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testBadBasic192Service")) {
                 service = new FatBAX31Service();
                 strExpect = "LIBERTYFAT X509 bax31";
-                //issue 23060
-                if (errMsgVersion.equals("wss4j")) {
-                    strSubErrMsg = "An error was discovered processing the <wsse:Security> header";
-                }
+                strSubErrMsg = "An error was discovered processing the <wsse:Security> header";
             } else if (thisMethod.equals("testBadTripleDesService")) {
                 service = new FatBAX32Service();
                 strExpect = "LIBERTYFAT X509 bax32";
-                //issue 23060
-                if (errMsgVersion.equals("wss4j")) {
-                    strSubErrMsg = "An error was discovered processing the <wsse:Security> header";
-                }
+                strSubErrMsg = "An error was discovered processing the <wsse:Security> header";
             } else if (thisMethod.equals("testBadInclusiveC14NService")) {
                 service = new FatBAX33Service();
                 strExpect = "LIBERTYFAT X509 bax33";
-                //issue 23060
-                if (errMsgVersion.equals("wss4j")) {
-                    strSubErrMsg = "BSP:R5404: Any CANONICALIZATION_METHOD Algorithm attribute MUST have a value of \"http://www.w3.org/2001/10/xml-exc-c14n#\" indicating that it uses Exclusive C14N without comments for canonicalization";
-                }
+                strSubErrMsg = "BSP:R5404: Any CANONICALIZATION_METHOD Algorithm attribute MUST have a value of \"http://www.w3.org/2001/10/xml-exc-c14n#\" indicating that it uses Exclusive C14N without comments for canonicalization";
             } else if (thisMethod.equals("testBadBasic128Service")) {
                 service = new FatBAX34Service();
                 strExpect = "LIBERTYFAT X509 bax34";
-                //issue 23060
-                if (errMsgVersion.equals("wss4j")) {
-                    //testMode = "negative";
-                    //the test method runs on EE8 as negative test
-                    //newErrMsg = "BSP:R5404: Any CANONICALIZATION_METHOD Algorithm attribute MUST have a value of \"http://www.w3.org/2001/10/xml-exc-c14n#\" indicating that it uses Exclusive C14N without comments for canonicalization";
-                    strSubErrMsg = "BSP:R5404: Any CANONICALIZATION_METHOD Algorithm attribute MUST have a value of \"http://www.w3.org/2001/10/xml-exc-c14n#\" indicating that it uses Exclusive C14N without comments for canonicalization";
-                }
+                strSubErrMsg = "BSP:R5404: Any CANONICALIZATION_METHOD Algorithm attribute MUST have a value of \"http://www.w3.org/2001/10/xml-exc-c14n#\" indicating that it uses Exclusive C14N without comments for canonicalization";
             } else if (thisMethod.equals("testBadSymmetricEndorsingUNTPolicy")) {
                 service = new FatBAX35Service();
                 strExpect = "LIBERTYFAT X509 bax35";
@@ -483,9 +444,7 @@ public class CxfX509MigBadSvcClient extends HttpServlet {
             methodFull = request.getParameter("methodFull");
             serviceName = new QName(SERVICE_NS, rawServiceName);
             servicePort = new QName(SERVICE_NS, request.getParameter("servicePort"));
-            //2/2021
-            errMsgVersion = request.getParameter("errorMsgVersion");
-
+           
             if (httpSecurePortNum == null || httpSecurePortNum.length() == 0) {
                 httpProtocal = "http:";
                 thePort = httpPortNum;

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/test-applications/x509migclient/src/com/ibm/ws/wssecurity/fat/x509migclient/CxfX509MigSvcClient.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/test-applications/x509migclient/src/com/ibm/ws/wssecurity/fat/x509migclient/CxfX509MigSvcClient.java
@@ -101,8 +101,6 @@ public class CxfX509MigSvcClient extends HttpServlet {
     String methodFull = null;
     SOAPMessage soapReq = null;
 
-    String errMsgVersion = "";
-
     private StringReader reqMsg = null;
     static boolean unlimitCryptoKeyLength = false;
 
@@ -142,8 +140,7 @@ public class CxfX509MigSvcClient extends HttpServlet {
                            " methodFull:" + methodFull +
                            " serviceName:" + serviceName +
                            " servicePort:" + servicePort +
-                           " servername:" + serverName +
-                           " errorMsgVersion:" + errMsgVersion); //2/2021
+                           " servername:" + serverName);
 
         // This piece of code is a work-around for a bug defect 89493
 /*
@@ -174,20 +171,14 @@ public class CxfX509MigSvcClient extends HttpServlet {
             if (thisMethod.equals("testCxfX509KeyIdMigSymService")) {
                 service = new FatBAX01Service(wsdlURL, serviceName);
                 strExpect = "LIBERTYFAT X509 bax01";
-                //issue 23060
-                if (errMsgVersion.equals("wss4j")) {
-                    strSubErrMsg = "An error was discovered processing the <wsse:Security> header";
-                }
+                strSubErrMsg = "An error was discovered processing the <wsse:Security> header";
             } else if (thisMethod.equals("testCxfX509AsymIssuerSerialMigService")) {
                 service = new FatBAX02Service(wsdlURL, serviceName);
                 strExpect = "LIBERTYFAT X509 bax02";
             } else if (thisMethod.equals("testCxfX509IssuerSerialMigSymService")) {
                 service = new FatBAX03Service(wsdlURL, serviceName);
                 strExpect = "LIBERTYFAT X509 bax03";
-                //issue 23060
-                if (errMsgVersion.equals("wss4j")) {
-                    strSubErrMsg = "An error was discovered processing the <wsse:Security> header";
-                }
+                strSubErrMsg = "An error was discovered processing the <wsse:Security> header";
             } else if (thisMethod.equals("testCxfX509ThumbprintMigSymService")) {
                 service = new FatBAX04Service(wsdlURL, serviceName);
                 strExpect = "LIBERTYFAT X509 bax04";
@@ -213,10 +204,7 @@ public class CxfX509MigSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testCxfX509TransportEndorsingSP11MigService")) {
                 service = new FatBAX11Service(wsdlURL, serviceName);
                 strExpect = "LIBERTYFAT X509 bax11";
-                //issue 23060
-                if (errMsgVersion.equals("wss4j")) {
-                    strSubErrMsg = "Assertion of type {http://schemas.xmlsoap.org/ws/2005/07/securitypolicy}HttpsToken could not be asserted: Not an HTTPs connection";
-                }
+                strSubErrMsg = "Assertion of type {http://schemas.xmlsoap.org/ws/2005/07/securitypolicy}HttpsToken could not be asserted: Not an HTTPs connection";
             } else if (thisMethod.equals("testCxfX509TransportSignedEndorsingMigService")) {
                 service = new FatBAX12Service(wsdlURL, serviceName);
                 strExpect = "LIBERTYFAT X509 bax12";
@@ -243,10 +231,7 @@ public class CxfX509MigSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testCxfX509AsymmetricSignatureReplayMigService")) {
                 service = new FatBAX17Service(wsdlURL, serviceName);
                 strExpect = "LIBERTYFAT X509 bax17";
-                //issue 23060
-                if (errMsgVersion.equals("wss4j")) {
-                    strSubErrMsg = "BSP:R3227: A SECURITY_HEADER MUST NOT contain more than one TIMESTAMP";
-                }
+                strSubErrMsg = "BSP:R3227: A SECURITY_HEADER MUST NOT contain more than one TIMESTAMP";
             } else if (thisMethod.equals("testCxfX509AsymmetricSignatureSP11MigService")) {
                 service = new FatBAX18Service(wsdlURL, serviceName);
                 strExpect = "LIBERTYFAT X509 bax18";
@@ -290,10 +275,7 @@ public class CxfX509MigSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testBasic192Service")) {
                 service = new FatBAX31Service(wsdlURL, serviceName);
                 strExpect = "LIBERTYFAT X509 bax31";
-                //issue 23060
-                if (errMsgVersion.equals("wss4j")) {
-                    strSubErrMsg = "BSP:R5620: Any ED_ENCRYPTION_METHOD Algorithm attribute MUST have a value of \"http://www.w3.org/2001/04/xmlenc#tripledes-cbc\", \"http://www.w3.org/2001/04/xmlenc#aes128-cbc\" or \"http://www.w3.org/2001/04/xmlenc#aes256-cbc\"";
-                }
+                strSubErrMsg = "BSP:R5620: Any ED_ENCRYPTION_METHOD Algorithm attribute MUST have a value of \"http://www.w3.org/2001/04/xmlenc#tripledes-cbc\", \"http://www.w3.org/2001/04/xmlenc#aes128-cbc\" or \"http://www.w3.org/2001/04/xmlenc#aes256-cbc\"";
             } else if (thisMethod.equals("testTripleDesService")) {
                 service = new FatBAX32Service(wsdlURL, serviceName);
                 strExpect = "LIBERTYFAT X509 bax32";
@@ -463,9 +445,7 @@ public class CxfX509MigSvcClient extends HttpServlet {
             methodFull = request.getParameter("methodFull");
             serviceName = new QName(SERVICE_NS, rawServiceName);
             servicePort = new QName(SERVICE_NS, request.getParameter("servicePort"));
-            //2/2021
-            errMsgVersion = request.getParameter("errorMsgVersion");
-
+            
             if (httpSecurePortNum == null || httpSecurePortNum.length() == 0) {
                 httpProtocal = "http:";
                 thePort = httpPortNum;

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509ObjectTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509ObjectTests.java
@@ -222,12 +222,16 @@ public class CxfX509ObjectTests {
         } catch (Exception e) {
             e.printStackTrace(System.out);
         }
-        //orig from CL:
-        //SharedTools.unInstallCallbackHandler(server);
-        server.deleteFileFromLibertyInstallRoot("usr/extension/lib/bundles/com.ibm.ws.wssecurity.example.cbh.jar");
+
+        Log.info(thisClass, "tearDown", "deleting usr/extension/lib/com.ibm.ws.wssecurity.example.cbh.jar");
+        server.deleteFileFromLibertyInstallRoot("usr/extension/lib/com.ibm.ws.wssecurity.example.cbh.jar");
+        Log.info(thisClass, "tearDown", "deleting usr/extension/lib/features/wsseccbh-1.0.mf");
         server.deleteFileFromLibertyInstallRoot("usr/extension/lib/features/wsseccbh-1.0.mf");
-        server.deleteFileFromLibertyInstallRoot("usr/extension/lib/bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
+        Log.info(thisClass, "tearDown", "deleting usr/extension/lib/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
+        server.deleteFileFromLibertyInstallRoot("usr/extension/lib/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
+        Log.info(thisClass, "tearDown", "deleting usr/extension/lib/features/wsseccbh-2.0.mf");
         server.deleteFileFromLibertyInstallRoot("usr/extension/lib/features/wsseccbh-2.0.mf");
+
     }
 
     private static void printMethodName(String strMethod) {

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509OverRideTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509OverRideTests.java
@@ -238,9 +238,13 @@ public class CxfX509OverRideTests {
             e.printStackTrace(System.out);
         }
 
-        server.deleteFileFromLibertyInstallRoot("usr/extension/lib/bundles/com.ibm.ws.wssecurity.example.cbh.jar");
+        Log.info(thisClass, "tearDown", "deleting usr/extension/lib/com.ibm.ws.wssecurity.example.cbh.jar");
+        server.deleteFileFromLibertyInstallRoot("usr/extension/lib/com.ibm.ws.wssecurity.example.cbh.jar");
+        Log.info(thisClass, "tearDown", "deleting usr/extension/lib/features/wsseccbh-1.0.mf");
         server.deleteFileFromLibertyInstallRoot("usr/extension/lib/features/wsseccbh-1.0.mf");
-        server.deleteFileFromLibertyInstallRoot("usr/extension/lib/bundles/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
+        Log.info(thisClass, "tearDown", "deleting usr/extension/lib/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
+        server.deleteFileFromLibertyInstallRoot("usr/extension/lib/com.ibm.ws.wssecurity.example.cbhwss4j.jar");
+        Log.info(thisClass, "tearDown", "deleting usr/extension/lib/features/wsseccbh-2.0.mf");
         server.deleteFileFromLibertyInstallRoot("usr/extension/lib/features/wsseccbh-2.0.mf");
 
     }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/FATSuite.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/FATSuite.java
@@ -16,6 +16,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+//comment out temporarily
+//import com.ibm.ws.wssecurity.fat.cxf.caller.CxfCallerUNTCBHPackageTests;
 import com.ibm.ws.wssecurity.fat.cxf.caller.CxfCallerUNTTests;
 import com.ibm.ws.wssecurity.fat.cxf.usernametoken.CxfSSLUNTBasicTests;
 import com.ibm.ws.wssecurity.fat.cxf.usernametoken.CxfSSLUNTNonceTests;

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerUNTCBHPackageTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerUNTCBHPackageTests.java
@@ -94,8 +94,6 @@ public class CxfCallerUNTCBHPackageTests {
             Log.info(thisClass, "setUp", "the test is: EE7 to run with existing Import Package version (e.g., \"[1.6,2)\") bundled in the jar ");
         }
 
-        errMsgVersion = "wss4j";
-
         ShrinkHelper.defaultDropinApp(server, "callerclient", "com.ibm.ws.wssecurity.fat.callerclient",
                                       "test.libertyfat.caller.contract", "test.libertyfat.caller.types");
         ShrinkHelper.defaultDropinApp(server, "callertoken", "test.libertyfat.caller");
@@ -156,8 +154,8 @@ public class CxfCallerUNTCBHPackageTests {
                         "FatBAC02Service", //String strServiceName,
                         "UrnCallerToken02", //String strServicePort
                         "test2", // Expecting User ID
-                        "", // Password; original "test2"; null password as intended
-                        errMsgVersion);
+                        "" // Password; original "test2"; null password as intended
+            );
         } catch (Exception e) {
             Log.info(thisClass, thisMethod, "In test method testCxfCallerHttpsPolicy, exception occurred as expected: " + e);
             String result = server.waitForStringInLog("java.lang.IncompatibleClassChangeError: org/apache/ws/security/WSPasswordCallback");
@@ -208,101 +206,7 @@ public class CxfCallerUNTCBHPackageTests {
                        callerUNTClientUrl,
                        "",
                        untID,
-                       untPassword,
-                       null);
-
-        return;
-    }
-
-    protected void testRoutine(
-                               String thisMethod,
-                               String callerPolicy,
-                               String testMode, // Positive, positive-1, negative or negative-1... etc
-                               String portNumber,
-                               String portNumberSecure,
-                               String strServiceName,
-                               String strServicePort,
-                               String untID,
-                               String untPassword,
-                               String errMsgVersion) throws Exception {
-        testSubRoutine(
-                       thisMethod,
-                       callerPolicy,
-                       testMode, // Positive, positive-1, negative or negative-1... etc
-                       portNumber,
-                       portNumberSecure,
-                       strServiceName,
-                       strServicePort,
-                       callerUNTClientUrl,
-                       "",
-                       untID,
-                       untPassword,
-                       errMsgVersion);
-
-        return;
-    }
-
-    /**
-     * TestDescription:
-     *
-     * This test invokes a jax-ws cxf web service.
-     * It needs to have caller key set to sign and encrypt the SOAPBody
-     * The request is request in https.
-     * Though this test is not enforced it yet.
-     *
-     */
-
-    protected void testBadRoutine(
-                                  String thisMethod,
-                                  String callerPolicy,
-                                  String testMode, // Positive, positive-1, negative or negative-1... etc
-                                  String portNumber,
-                                  String portNumberSecure,
-                                  String strServiceName,
-                                  String strServicePort,
-                                  String untID,
-                                  String untPassword) throws Exception {
-        testSubRoutine(
-                       thisMethod,
-                       callerPolicy,
-                       testMode, // Positive, positive-1, negative or negative-1... etc
-                       portNumber,
-                       portNumberSecure,
-                       strServiceName,
-                       strServicePort,
-                       callerBadUNTClientUrl,
-                       "Bad",
-                       untID,
-                       untPassword,
-                       null);
-
-        return;
-    }
-
-    protected void testBadRoutine(
-                                  String thisMethod,
-                                  String callerPolicy,
-                                  String testMode, // Positive, positive-1, negative or negative-1... etc
-                                  String portNumber,
-                                  String portNumberSecure,
-                                  String strServiceName,
-                                  String strServicePort,
-                                  String untID,
-                                  String untPassword,
-                                  String errMsgVersion) throws Exception {
-        testSubRoutine(
-                       thisMethod,
-                       callerPolicy,
-                       testMode, // Positive, positive-1, negative or negative-1... etc
-                       portNumber,
-                       portNumberSecure,
-                       strServiceName,
-                       strServicePort,
-                       callerBadUNTClientUrl,
-                       "Bad",
-                       untID,
-                       untPassword,
-                       errMsgVersion);
+                       untPassword);
 
         return;
     }
@@ -327,8 +231,7 @@ public class CxfCallerUNTCBHPackageTests {
                                   String strClientUrl,
                                   String strBadOrGood,
                                   String untID,
-                                  String untPassword,
-                                  String errMsgVersion) throws Exception {
+                                  String untPassword) throws Exception {
         try {
 
             WebRequest request = null;
@@ -352,8 +255,6 @@ public class CxfCallerUNTCBHPackageTests {
             request.setParameter("methodFull", methodFull);
             request.setParameter("untID", untID);
             request.setParameter("untPassword", untPassword);
-
-            request.setParameter("errorMsgVersion", errMsgVersion);
 
             // Invoke the client
             Log.info(thisClass, thisMethod, "In testSubRoutine, before wc.getResponse(request)");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerUNTTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerUNTTests.java
@@ -84,7 +84,7 @@ public class CxfCallerUNTTests {
             server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/wsseccbh-2.0.mf");
             copyServerXml(System.getProperty("user.dir") + File.separator + server.getPathToAutoFVTNamedServer() + "server_wss4j.xml");
         }
-        errMsgVersion = "wss4j";
+
         //issue 23599
         ShrinkHelper.defaultDropinApp(server, "callerclient", "com.ibm.ws.wssecurity.fat.callerclient",
                                       "test.libertyfat.caller.contract", "test.libertyfat.caller.types");
@@ -173,8 +173,8 @@ public class CxfCallerUNTTests {
                         "FatBAC02Service", //String strServiceName,
                         "UrnCallerToken02", //String strServicePort
                         "test2", // Expecting User ID
-                        "test2", // Password
-                        errMsgVersion);
+                        "test2" // Password
+            );
         } catch (Exception e) {
             throw e;
         }
@@ -235,8 +235,8 @@ public class CxfCallerUNTTests {
                         "FatBAC04Service", //String strServiceName,
                         "UrnCallerToken04", //String strServicePort
                         "test4", // Expecting User ID
-                        "test4", // Password
-                        errMsgVersion);
+                        "test4" // Password
+            );
         } catch (Exception e) {
             throw e;
         }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfSSLUNTNonceTimeOutTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/CxfSSLUNTNonceTimeOutTests.java
@@ -47,9 +47,8 @@ public class CxfSSLUNTNonceTimeOutTests extends SSLTestCommon {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        String thisMethod = "setup";
+
         String copyFromFile = "";
-        String repeatAction = null;
 
         //issue 23060, 23418
         copyFromFile = System.getProperty("user.dir") +

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/test-applications/callerclient/src/com/ibm/ws/wssecurity/fat/callerclient/CxfCallerSvcClient.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/test-applications/callerclient/src/com/ibm/ws/wssecurity/fat/callerclient/CxfCallerSvcClient.java
@@ -71,8 +71,6 @@ public class CxfCallerSvcClient extends HttpServlet {
 
     String untID = "";
     String untPassword = "";
-    String errMsgVersion = "";
-    String errMsgVersionInX509 = "";
 
     private StringReader reqMsg = null;
     static boolean unlimitCryptoKeyLength = false;
@@ -115,8 +113,7 @@ public class CxfCallerSvcClient extends HttpServlet {
                            " untPassword:" + untPassword +
                            " serviceName:" + serviceName +
                            " servicePort:" + servicePort +
-                           " servername:" + serverName +
-                           "errorMsgVersion:" + errMsgVersion); 
+                           " servername:" + serverName); 
 
         // This piece of code is a work-around for a bug defect 89493
 /*
@@ -147,11 +144,7 @@ public class CxfCallerSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testCxfCallerHttpsPolicy")) {
                 service = new FatBAC02Service(wsdlURL, serviceName);
                 strExpect = "Liberty Fat Caller bac02(" + untID + ")";
-
-                //issue 23060
-                if (errMsgVersion.equals("wss4j")) {
-                    strSubErrMsg = "Unexpected number of certificates: 0";
-                } 
+                strSubErrMsg = "Unexpected number of certificates: 0";
 
             } else if (thisMethod.equals("testCxfCallerNoPolicy")) {
                 service = new FatBAC03Service(wsdlURL, serviceName);
@@ -159,21 +152,12 @@ public class CxfCallerSvcClient extends HttpServlet {
             } else if (thisMethod.equals("testCxfCallerHttpsNoUntPolicy")) {
                 service = new FatBAC04Service(wsdlURL, serviceName);
                 strExpect = "Liberty Fat Caller bac04(" + untID + ")";
-                //strSubErrMsg = "There is no Username token in the message to process caller.";
-
-                //issue 23060
-                if (errMsgVersion.equals("wss4j")) {
-                    strSubErrMsg = "UsernameToken is missing";
-                } 
+                strSubErrMsg = "UsernameToken is missing";
 
                 // msg is There is no username token in the message to process the caller
                 //    in nlsprops
-                if (!thisMethod.equals(methodFull)) { // Test this test in x509 Caller
-                    //strSubErrMsg = "There is no Asymmetric signature token exists in the message";
-                    //issue 23060
-                    if (errMsgVersionInX509.equals("wss4j")) {
-                        strSubErrMsg = "Unexpected number of certificates: 0";
-                    } 
+                if (!thisMethod.equals(methodFull)) { // Test this test in x509 Caller   
+                    strSubErrMsg = "Unexpected number of certificates: 0";   
                 }
             } else if (thisMethod.equals("testCxfCallerX509TokenPolicy")) {
                 service = new FatBAC05Service(wsdlURL, serviceName);
@@ -356,8 +340,6 @@ public class CxfCallerSvcClient extends HttpServlet {
             methodFull = request.getParameter("methodFull");
             serviceName = new QName(SERVICE_NS, rawServiceName);
             servicePort = new QName(SERVICE_NS, request.getParameter("servicePort"));
-            errMsgVersion = request.getParameter("errorMsgVersion");
-            errMsgVersionInX509 = request.getParameter("errorMsgVersionInX509");
 
             untID = request.getParameter("untID");
             if (untID == null)


### PR DESCRIPTION
1. To handle cbh file delete: https://github.com/OpenLiberty/open-liberty/issues/23730
2. `errMsgVersion` parameter is not needed now and as a result, several svc client and test class testroutine logic are updated.
