### PR TITLE
Phase 3 updates to FATs for Jakarta EE 10 for unchanged EE features

### DIFF
--- a/dev/com.ibm.ws.clientcontainer.8.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.clientcontainer.8.0_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2018 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -24,7 +24,8 @@ src: \
 fat.project: true
 
 tested.features: \
-  jakartaeeClient-9.1
+  jakartaeeClient-9.1, \
+  jakartaeeClient-10.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.1;version=latest

--- a/dev/com.ibm.ws.clientcontainer.8.0_fat/fat/src/com/ibm/ws/clientcontainer/fat/FATSuite.java
+++ b/dev/com.ibm.ws.clientcontainer.8.0_fat/fat/src/com/ibm/ws/clientcontainer/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -26,4 +26,6 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(new JakartaEE9Action());}
+                    .andWith(new JakartaEE9Action())
+                    .andWith(new JakartaEE10Action());
+}

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/bnd.bnd
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -22,7 +22,8 @@ src: \
 fat.project: true
 
 tested.features: \
-  jakartaeeClient-9.1
+  jakartaeeClient-9.1, \
+  jakartaeeClient-10.0
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/fat/src/com/ibm/ws/clientcontainer/fat/BvalAppClientTest_11.java
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/fat/src/com/ibm/ws/clientcontainer/fat/BvalAppClientTest_11.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ import componenttest.annotation.SkipForRepeat;
 public class BvalAppClientTest_11 extends AbstractAppClientTest {
     
 	@Test
-	@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
+	@SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES})
 	public void testApacheBvalConfig_11_AppClient() throws Exception {
 		String testClientName = "com.ibm.ws.clientcontainer.beanvalidation.fat.ApacheBvalConfig_11";
 		client = LibertyClientFactory.getLibertyClient(testClientName);
@@ -36,7 +36,7 @@ public class BvalAppClientTest_11 extends AbstractAppClientTest {
 	}
 	
 	@Test
-	@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
+    @SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES})
 	public void testBeanvalidation_11_AppClient() throws Exception {
 		String testClientName = "com.ibm.ws.clientcontainer.beanvalidation.fat.beanvalidation_11";
 		client = LibertyClientFactory.getLibertyClient(testClientName);
@@ -50,7 +50,7 @@ public class BvalAppClientTest_11 extends AbstractAppClientTest {
 	}
 	
 	@Test
-	@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
+    @SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES})
 	public void testBeanValidationCDI_11_AppClient() throws Exception {
 		String testClientName = "com.ibm.ws.clientcontainer.beanvalidation.fat.BeanValidationCDI_11";
 		client = LibertyClientFactory.getLibertyClient(testClientName);
@@ -64,7 +64,7 @@ public class BvalAppClientTest_11 extends AbstractAppClientTest {
 	}
 	
 	@Test
-	@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
+    @SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES})
 	public void testDefaultbeanvalidation_11_AppClient() throws Exception {
 		String testClientName = "com.ibm.ws.clientcontainer.beanvalidation.fat.defaultbeanvalidation_11";
 		client = LibertyClientFactory.getLibertyClient(testClientName);
@@ -78,7 +78,7 @@ public class BvalAppClientTest_11 extends AbstractAppClientTest {
 	}
 	
 	@Test
-	@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
+    @SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES})
 	public void testDefaultBeanValidationCDI_11_AppClient() throws Exception {
 		String testClientName = "com.ibm.ws.clientcontainer.beanvalidation.fat.DefaultBeanValidationCDI_11";
 		client = LibertyClientFactory.getLibertyClient(testClientName);

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/fat/src/com/ibm/ws/clientcontainer/fat/BvalAppClientTest_20.java
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/fat/src/com/ibm/ws/clientcontainer/fat/BvalAppClientTest_20.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ import componenttest.annotation.SkipForRepeat;
 public class BvalAppClientTest_20 extends AbstractAppClientTest {
 	
 	@Test
-	@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
+    @SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES})
 	public void testBeanvalidation_20_AppClient() throws Exception {
 		String testClientName = "com.ibm.ws.clientcontainer.beanvalidation.fat.beanvalidation_20";
 		client = LibertyClientFactory.getLibertyClient(testClientName);

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/fat/src/com/ibm/ws/clientcontainer/fat/FATSuite.java
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/fat/src/com/ibm/ws/clientcontainer/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -40,7 +41,8 @@ public class FATSuite {
 
 	@ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(new JakartaEE9Action());
+                    .andWith(new JakartaEE9Action())
+                    .andWith(new JakartaEE10Action());
 
 	public static EnterpriseArchive apacheBvalConfigApp;
 	public static EnterpriseArchive beanValidationApp;

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/test-applications/DefaultBeanValidationCDI.jar/resources/META-INF/beans.xml
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/test-applications/DefaultBeanValidationCDI.jar/resources/META-INF/beans.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://java.sun.com/xml/ns/javaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+   	   version="1.1"
+   	   bean-discovery-mode="all">
        
    <!-- TODO this file shouldn't need to be here when CDI 1.1 removes the restriction to need
              beans.xml to enable an app for CDI -->

--- a/dev/com.ibm.ws.clientcontainer.cdi_fat/bnd.bnd
+++ b/dev/com.ibm.ws.clientcontainer.cdi_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -21,7 +21,8 @@ src: \
 	
 
 tested.features: \
-  jakartaeeClient-9.1
+  jakartaeeClient-9.1, \
+  jakartaeeClient-10.0
 	
 	
 test.project: true

--- a/dev/com.ibm.ws.clientcontainer.cdi_fat/fat/src/com/ibm/ws/cdi12/suite/FATSuite.java
+++ b/dev/com.ibm.ws.clientcontainer.cdi_fat/fat/src/com/ibm/ws/cdi12/suite/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@ import com.ibm.ws.cdi12.fat.tests.AppClientTest;
 import com.ibm.ws.fat.util.FatLogHandler;
 
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -34,7 +35,8 @@ public class FATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
                     .andWith(FeatureReplacementAction.EE8_FEATURES())
-                    .andWith(new JakartaEE9Action());
+                    .andWith(new JakartaEE9Action())
+                    .andWith(new JakartaEE10Action());
 
     /**
      * @see {@link FatLogHandler#generateHelpFile()}

--- a/dev/com.ibm.ws.context_fat_customproviders/bnd.bnd
+++ b/dev/com.ibm.ws.context_fat_customproviders/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@ src: \
 
 fat.project: true
 
-tested.features=concurrent-2.0, servlet-5.0
+tested.features=concurrent-2.0, servlet-5.0, concurrent-3.0, servlet-6.0
 
 -sub: *.bnd
 

--- a/dev/com.ibm.ws.context_fat_customproviders/fat/src/test/context/ContextServiceTest.java
+++ b/dev/com.ibm.ws.context_fat_customproviders/fat/src/test/context/ContextServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011,2020 IBM Corporation and others.
+ * Copyright (c) 2011,2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
@@ -35,7 +36,8 @@ public class ContextServiceTest extends FATServletClient {
     @ClassRule
     public static RepeatTests r = RepeatTests
                     .withoutModification()
-                    .andWith(new JakartaEE9Action());
+                    .andWith(new JakartaEE9Action())
+                    .andWith(new JakartaEE10Action());
 
     @Server("com.ibm.ws.context.fat.customproviders")
     @TestServlet(servlet = ContextServiceTestServlet.class, path = "contextbvt/ContextServiceTestServlet")

--- a/dev/com.ibm.ws.context_fat_serialization/bnd.bnd
+++ b/dev/com.ibm.ws.context_fat_serialization/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -18,7 +18,8 @@ src: \
 
 fat.project: true
 
-tested.features: appsecurity-4.0, cdi-3.0, concurrent-2.0, enterpriseBeansLite-4.0, expressionLanguage-4.0, pages-3.0, servlet-5.0
+tested.features: appsecurity-4.0, cdi-3.0, concurrent-2.0, enterpriseBeansLite-4.0, expressionLanguage-4.0, pages-3.0, servlet-5.0, \
+                 appsecurity-5.0, concurrent-3.0, pages-3.1
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.context_fat_serialization/fat/src/test/context/serialization/ContextServiceSerializationTest.java
+++ b/dev/com.ibm.ws.context_fat_serialization/fat/src/test/context/serialization/ContextServiceSerializationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 IBM Corporation and others.
+ * Copyright (c) 2011, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -37,6 +37,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
@@ -47,7 +48,8 @@ public class ContextServiceSerializationTest extends FATServletClient {
     @ClassRule
     public static RepeatTests r = RepeatTests
                     .withoutModification()
-                    .andWith(new JakartaEE9Action());
+                    .andWith(new JakartaEE9Action())
+                    .andWith(new JakartaEE10Action());
 
     @Server("com.ibm.ws.context.fat.serialization")
     //@TestServlet(servlet = ContextServiceSerializationTestServlet.class, path = "contextserbvt/ContextServiceSerializationTestServlet")

--- a/dev/com.ibm.ws.ejbcontainer.remote.client_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -26,12 +26,16 @@ tested.features: \
 	appClientSupport-2.0, \
 	appSecurity-3.0, \
 	appSecurity-4.0, \
+	appSecurity-5.0, \
 	cdi-2.0, \
 	cdi-3.0, \
+	cdi-4.0, \
+	connectors-2.1, \
 	enterpriseBeans-4.0, \
 	enterpriseBeansRemote-4.0, \
 	servlet-4.0, \
-	servlet-5.0 
+	servlet-5.0, \
+	servlet-6.0 
 
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\

--- a/dev/com.ibm.ws.ejbcontainer.remote.client_fat/fat/src/com/ibm/ws/ejbcontainer/remote/client/fat/tests/EjbLinkTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client_fat/fat/src/com/ibm/ws/ejbcontainer/remote/client/fat/tests/EjbLinkTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,6 +35,7 @@ import com.ibm.websphere.simplicity.log.Log;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyClient;
@@ -68,7 +69,7 @@ public class EjbLinkTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.remote.client.fat.serverInjection")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.remote.client.fat.serverInjection")).andWith(new JakartaEE9Action().forServers("com.ibm.ws.ejbcontainer.remote.client.fat.serverInjection"));
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.remote.client.fat.serverInjection")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.remote.client.fat.serverInjection")).andWith(new JakartaEE9Action().forServers("com.ibm.ws.ejbcontainer.remote.client.fat.serverInjection").fullFATOnly()).andWith(new JakartaEE10Action().forServers("com.ibm.ws.ejbcontainer.remote.client.fat.serverInjection"));
 
     @BeforeClass
     public static void beforeClass() throws Exception {

--- a/dev/com.ibm.ws.javamail.1.6/src/com/ibm/ws/javamail/internal/injection/MailSessionResourceFactoryBuilder.java
+++ b/dev/com.ibm.ws.javamail.1.6/src/com/ibm/ws/javamail/internal/injection/MailSessionResourceFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015,2017
+ * Copyright (c) 2015,2022
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -101,9 +101,6 @@ public class MailSessionResourceFactoryBuilder implements ResourceFactoryBuilder
 
         MailSessionResourceFactory mss = new MailSessionResourceFactory();
         mss.processProperties(mailSessionSvcProps);
-
-        // MailSessionService does not use the Resource, pass null
-        mss.createResource(null);
 
         return mss;
     }

--- a/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionResourceFactoryBuilder.java
+++ b/dev/com.ibm.ws.javamail/src/com/ibm/ws/javamail/internal/injection/MailSessionResourceFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015,2021
+ * Copyright (c) 2015,2022
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -101,9 +101,6 @@ public class MailSessionResourceFactoryBuilder implements ResourceFactoryBuilder
 
         MailSessionResourceFactory mss = new MailSessionResourceFactory();
         mss.processProperties(mailSessionSvcProps);
-
-        // MailSessionService does not use the Resource, pass null
-        mss.createResource(null);
 
         return mss;
     }

--- a/dev/com.ibm.ws.jpa.tests.container.client_fat/fat/src/com/ibm/ws/jpa/clientcontainer/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.container.client_fat/fat/src/com/ibm/ws/jpa/clientcontainer/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,11 +11,14 @@
 
 package com.ibm.ws.jpa.clientcontainer.fat;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -30,6 +33,10 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
 public class FATSuite {
     private static final Class<?> c = FATSuite.class;
 
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.NO_REPLACEMENT().fullFATOnly())
+                    .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                    .andWith(FeatureReplacementAction.EE10_FEATURES());
 //    @ClassRule
 //    public static ExternalResource testRule = new ExternalResource() {
 //        /**

--- a/dev/com.ibm.ws.managedbeans_fat/bnd.bnd
+++ b/dev/com.ibm.ws.managedbeans_fat/bnd.bnd
@@ -30,6 +30,7 @@ fat.project: true
 tested.features:\
 	cdi-2.0,\
 	cdi-3.0,\
+	cdi-4.0,\
 	enterpriseBeansLite-4.0,\
 	jdbc-4.2,\
 	jpa-2.2,\
@@ -38,8 +39,10 @@ tested.features:\
 	messagingClient-3.0,\
 	messagingServer-3.0,\
 	persistence-3.0,\
+	persistence-3.1,\
 	servlet-4.0,\
-	servlet-5.0
+	servlet-5.0,\
+	servlet-6.0
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/com.ibm.ws.managedbeans_fat/fat/src/com/ibm/ws/managedbeans/fat/tests/ManagedBeanBindingsEJBTest.java
+++ b/dev/com.ibm.ws.managedbeans_fat/fat/src/com/ibm/ws/managedbeans/fat/tests/ManagedBeanBindingsEJBTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
@@ -47,7 +48,8 @@ public class ManagedBeanBindingsEJBTest extends FATServletClient {
     @ClassRule
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("ManagedBeansBindingsEjbServer"))
                     .andWith(FeatureReplacementAction.EE8_FEATURES().forServers("ManagedBeansBindingsEjbServer"))
-                    .andWith(new JakartaEE9Action().fullFATOnly().forServers("ManagedBeansBindingsEjbServer"));
+                    .andWith(new JakartaEE9Action().fullFATOnly().forServers("ManagedBeansBindingsEjbServer"))
+                    .andWith(new JakartaEE10Action().forServers("ManagedBeansBindingsEjbServer"));
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.managedbeans_fat/fat/src/com/ibm/ws/managedbeans/fat/tests/ManagedBeansCdiTest.java
+++ b/dev/com.ibm.ws.managedbeans_fat/fat/src/com/ibm/ws/managedbeans/fat/tests/ManagedBeansCdiTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 IBM Corporation and others.
+ * Copyright (c) 2015, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,6 +27,7 @@ import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
@@ -46,7 +47,8 @@ public class ManagedBeansCdiTest extends FATServletClient {
     @ClassRule
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("ManagedBeansCdiServer"))
                     .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly().forServers("ManagedBeansCdiServer"))
-                    .andWith(new JakartaEE9Action().fullFATOnly().forServers("ManagedBeansCdiServer"));
+                    .andWith(new JakartaEE9Action().fullFATOnly().forServers("ManagedBeansCdiServer"))
+                    .andWith(new JakartaEE10Action().forServers("ManagedBeansCdiServer"));
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.managedbeans_fat/fat/src/com/ibm/ws/managedbeans/fat/tests/ManagedBeansEjbTest.java
+++ b/dev/com.ibm.ws.managedbeans_fat/fat/src/com/ibm/ws/managedbeans/fat/tests/ManagedBeansEjbTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,6 +28,7 @@ import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
@@ -47,7 +48,8 @@ public class ManagedBeansEjbTest extends FATServletClient {
     @ClassRule
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("ManagedBeansEjbServer"))
                     .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly().forServers("ManagedBeansEjbServer"))
-                    .andWith(new JakartaEE9Action().fullFATOnly().forServers("ManagedBeansEjbServer"));
+                    .andWith(new JakartaEE9Action().fullFATOnly().forServers("ManagedBeansEjbServer"))
+                    .andWith(new JakartaEE10Action().forServers("ManagedBeansEjbServer"));
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.managedbeans_fat/fat/src/com/ibm/ws/managedbeans/fat/tests/ManagedBeansWebTest.java
+++ b/dev/com.ibm.ws.managedbeans_fat/fat/src/com/ibm/ws/managedbeans/fat/tests/ManagedBeansWebTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,7 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
@@ -39,7 +40,8 @@ public class ManagedBeansWebTest extends FATServletClient {
     @ClassRule
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("ManagedBeansServer"))
                     .andWith(FeatureReplacementAction.EE8_FEATURES().forServers("ManagedBeansServer"))
-                    .andWith(new JakartaEE9Action().forServers("ManagedBeansServer"));
+                    .andWith(new JakartaEE9Action().fullFATOnly().forServers("ManagedBeansServer"))
+                    .andWith(new JakartaEE10Action().forServers("ManagedBeansServer"));
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.managedbeans_fat/test-applications/ManagedBeanInterceptorWeb.war/resources/WEB-INF/beans.xml
+++ b/dev/com.ibm.ws.managedbeans_fat/test-applications/ManagedBeanInterceptorWeb.war/resources/WEB-INF/beans.xml
@@ -1,3 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans>
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+   	   version="1.1"
+   	   bean-discovery-mode="all">
 </beans>

--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/bnd.bnd
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2020 IBM Corporation and others.
+# Copyright (c) 2018, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -28,7 +28,10 @@ tested.features: \
         messagingServer-3.0,\
         messaging-3.0,\
         jakartaeeClient-9.1,\
-        xmlWS-3.0
+        xmlWS-3.0,\
+        messaging-3.1,\
+        jakartaeeClient-10.0,\
+        xmlWS-4.0
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 # or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/fat/src/com/ibm/ws/messaging/open_clientcontainer/fat/FATSuite.java
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/fat/src/com/ibm/ws/messaging/open_clientcontainer/fat/FATSuite.java
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -29,5 +30,5 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite { 
 	
 	@ClassRule
-	public static RepeatTests repeater = RepeatTests.withoutModification().andWith(new JakartaEE9Action().removeFeature("jaxws-2.2"));
+	public static RepeatTests repeater = RepeatTests.withoutModification().andWith(new JakartaEE9Action().removeFeature("jaxws-2.2")).andWith(new JakartaEE10Action());
 }

--- a/dev/com.ibm.ws.messaging.open_comms_fat/bnd.bnd
+++ b/dev/com.ibm.ws.messaging.open_comms_fat/bnd.bnd
@@ -18,6 +18,10 @@ src: \
 
 fat.project: true
 
+tested.features: \
+  transportsecurity-1.0, messagingserver-3.0, expressionlanguage-4.0, servlet-5.0, messagingsecurity-3.0, pages-3.0, \
+  messagingclient-3.0, xmlbinding-3.0, expressionlanguage-5.0, pages-3.1, servlet-6.0
+
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
 # fat.minimum.java.level: 11

--- a/dev/com.ibm.ws.messaging.open_comms_fat/build.gradle
+++ b/dev/com.ibm.ws.messaging.open_comms_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,5 @@
  *******************************************************************************/
 
 addRequiredLibraries {
-  dependsOn addDerby
   dependsOn addJakartaTransformer
 }

--- a/dev/com.ibm.ws.messaging.open_comms_fat/fat/src/com/ibm/ws/messaging/open_comms/fat/FATBase.java
+++ b/dev/com.ibm.ws.messaging.open_comms_fat/fat/src/com/ibm/ws/messaging/open_comms/fat/FATBase.java
@@ -1,5 +1,5 @@
 /* ============================================================================
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@
 package com.ibm.ws.messaging.open_comms.fat;
 
 import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.FATServletClient;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import static org.junit.Assert.assertNotNull;
@@ -55,8 +56,11 @@ public class FATBase extends FATServletClient {
     return successFlag;
   }
 
-  protected static void setup() throws Exception {
+  protected static void setup(String serverName, String clientName) throws Exception {
     Util.TRACE_ENTRY("server_="+server_+",client_="+client_);
+
+    server_ = LibertyServerFactory.getLibertyServer(serverName);
+    client_ = LibertyServerFactory.getLibertyServer(clientName);
 
     setServerProps(server_,new String[]{"fat.test.debug",System.getProperty("fat.test.debug")});
     setServerProps(client_,new String[]{"fat.test.debug",System.getProperty("fat.test.debug")});

--- a/dev/com.ibm.ws.messaging.open_comms_fat/fat/src/com/ibm/ws/messaging/open_comms/fat/FATSuite.java
+++ b/dev/com.ibm.ws.messaging.open_comms_fat/fat/src/com/ibm/ws/messaging/open_comms/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /* ============================================================================
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,10 +11,18 @@
  */
 package com.ibm.ws.messaging.open_comms.fat;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import componenttest.rules.repeater.JakartaEE10Action;
+import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.RepeatTests;
+
 @RunWith(Suite.class)
 @SuiteClasses({FeatureUpdate.class, WasJmsOutBoundTest.class})
-public class FATSuite {}
+public class FATSuite {
+    @ClassRule
+    public static RepeatTests repeater = RepeatTests.withoutModification().andWith(new JakartaEE9Action()).andWith(new JakartaEE10Action());
+}

--- a/dev/com.ibm.ws.messaging.open_comms_fat/fat/src/com/ibm/ws/messaging/open_comms/fat/FeatureUpdate.java
+++ b/dev/com.ibm.ws.messaging.open_comms_fat/fat/src/com/ibm/ws/messaging/open_comms/fat/FeatureUpdate.java
@@ -1,5 +1,5 @@
 /* ============================================================================
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,15 +29,11 @@ import org.junit.BeforeClass;
 @Mode(TestMode.LITE)
 @RunWith(FATRunner.class)
 public class FeatureUpdate extends FATBase {
-  static {
-    server_ = LibertyServerFactory.getLibertyServer("com.ibm.ws.messaging.open_comms.server");
-    client_ = LibertyServerFactory.getLibertyServer("com.ibm.ws.messaging.open_comms.client");
-  }
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
     Util.TRACE_ENTRY();
-    setup();
+    setup("com.ibm.ws.messaging.open_comms.server", "com.ibm.ws.messaging.open_comms.client");
     Util.TRACE_EXIT();
   }
 

--- a/dev/com.ibm.ws.messaging.open_comms_fat/fat/src/com/ibm/ws/messaging/open_comms/fat/WasJmsOutBoundTest.java
+++ b/dev/com.ibm.ws.messaging.open_comms_fat/fat/src/com/ibm/ws/messaging/open_comms/fat/WasJmsOutBoundTest.java
@@ -1,5 +1,5 @@
 /* ============================================================================
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,15 +27,11 @@ import org.junit.BeforeClass;
 @Mode(TestMode.LITE)
 @RunWith(FATRunner.class)
 public class WasJmsOutBoundTest extends FATBase {
-  static {
-    server_ = LibertyServerFactory.getLibertyServer("com.ibm.ws.messaging.open_comms.WJOServer");
-    client_ = LibertyServerFactory.getLibertyServer("com.ibm.ws.messaging.open_comms.WJOClient");
-  }
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
     Util.TRACE_ENTRY();
-    setup();
+    setup("com.ibm.ws.messaging.open_comms.WJOServer", "com.ibm.ws.messaging.open_comms.WJOClient");
     Util.TRACE_EXIT();
   }
 

--- a/dev/com.ibm.ws.messaging.open_jms20contextSecurity_fat/bnd.bnd
+++ b/dev/com.ibm.ws.messaging.open_jms20contextSecurity_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -26,7 +26,11 @@ tested.features: \
   messagingClient-3.0,\
   messagingSecurity-3.0,\
   mdb-4.0,\
-  cdi-3.0
+  cdi-3.0,\
+  servlet-6.0,\
+  pages-3.1,\
+  cdi-4.0,\
+  connectors-2.1
 
 -buildpath: \
   com.ibm.websphere.javaee.annotation.1.1;version=latest,\

--- a/dev/com.ibm.ws.messaging.open_jms20contextSecurity_fat/fat/src/com/ibm/ws/messaging/JMS20contextSecurity/fat/FATSuite.java
+++ b/dev/com.ibm.ws.messaging.open_jms20contextSecurity_fat/fat/src/com/ibm/ws/messaging/JMS20contextSecurity/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,7 @@ import com.ibm.ws.messaging.JMS20.fat.Transaction.JMSContextTest_118065;
 import com.ibm.ws.messaging.JMS20contextSecurity.fat.JMSContextTest.JMSContextTest;
 
 import componenttest.rules.repeater.EE7FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -37,5 +38,6 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests.with( new EE7FeatureReplacementAction() )
-                                             .andWith( new JakartaEE9Action().fullFATOnly() );
+                                             .andWith( new JakartaEE9Action().fullFATOnly() )
+                                             .andWith( new JakartaEE10Action().fullFATOnly() );
 }

--- a/dev/com.ibm.ws.messaging.open_jms20contextSecurity_fat/test-applications/JMSContextInject/resources/WEB-INF/beans.xml
+++ b/dev/com.ibm.ws.messaging.open_jms20contextSecurity_fat/test-applications/JMSContextInject/resources/WEB-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+   	   version="1.1"
+   	   bean-discovery-mode="all">
+</beans>

--- a/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/bnd.bnd
+++ b/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/bnd.bnd
@@ -31,7 +31,9 @@ tested.features:\
   messagingServer-3.0,\
   messagingClient-3.0,\
   messagingSecurity-3.0,\
-  mdb-4.0
+  mdb-4.0,\
+  connectors-2.1,\
+  pages-3.1
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/fat/src/com/ibm/ws/messaging/jms20/deliverydelay/fat/DelayFullTest.java
+++ b/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/fat/src/com/ibm/ws/messaging/jms20/deliverydelay/fat/DelayFullTest.java
@@ -43,6 +43,7 @@ import com.ibm.websphere.simplicity.RemoteFile;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
@@ -80,13 +81,17 @@ public class DelayFullTest {
     };
 
     private static void transformConfigurations() throws Exception {
-        if ( !JakartaEE9Action.isActive() ) {
+        if ( !JakartaEE9Action.isActive() && !JakartaEE10Action.isActive()) {
             return;
         }
 
         for ( String config : EE9_TRANSFORMED_CONFIGS ) {
             Path configPath = Paths.get("lib/LibertyFATTestFiles", config);
-            JakartaEE9Action.transformApp(configPath);
+            if (JakartaEE9Action.isActive()) {
+                JakartaEE9Action.transformApp(configPath);
+            } else if (JakartaEE10Action.isActive()) {
+                JakartaEE10Action.transformApp(configPath);
+            }
         }
     }
 
@@ -461,11 +466,11 @@ public class DelayFullTest {
     }
     
     private String getServerFeature() {
-        return ( JakartaEE9Action.isActive() ? "messagingServer-3.0" : "wasJmsServer-1.0" );
+        return ( JakartaEE10Action.isActive() || JakartaEE9Action.isActive() ? "messagingServer-3.0" : "wasJmsServer-1.0" );
     }
 
     private String getServerMessageFragment() {
-        return ( JakartaEE9Action.isActive() ? "messagingServer" : "wasJmsServer" );
+        return ( JakartaEE10Action.isActive() || JakartaEE9Action.isActive() ? "messagingServer" : "wasJmsServer" );
     }
 
     private void verifyRemovedFeature(LibertyServer server, String fragment) throws Exception {

--- a/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/fat/src/com/ibm/ws/messaging/jms20/deliverydelay/fat/FATSuite.java
+++ b/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/fat/src/com/ibm/ws/messaging/jms20/deliverydelay/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 IBM Corporation and others.
+ * Copyright (c) 2016, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import org.junit.ClassRule;
 
-import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -35,5 +35,6 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
      @ClassRule
      public static RepeatTests repeater = RepeatTests.withoutModification()
-                                                     .andWith( new JakartaEE9Action() );
+                                                     .andWith( new JakartaEE9Action() )
+                                                     .andWith( new JakartaEE10Action() );
 }

--- a/dev/com.ibm.ws.messaging.open_jms20security_fat/bnd.bnd
+++ b/dev/com.ibm.ws.messaging.open_jms20security_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -29,7 +29,11 @@ tested.features: \
   messagingClient-3.0,\
   messagingSecurity-3.0,\
   mdb-4.0,\
-  cdi-3.0
+  cdi-3.0,\
+  servlet-6.0,\
+  pages-3.1,\
+  cdi-4.0,\
+  connectors-2.1
 
 -buildpath: \
   com.ibm.websphere.javaee.annotation.1.1;version=latest,\

--- a/dev/com.ibm.ws.messaging.open_jms20security_fat/fat/src/com/ibm/ws/messaging/JMS20/fat/DurableUnshared/DurableUnshared.java
+++ b/dev/com.ibm.ws.messaging.open_jms20security_fat/fat/src/com/ibm/ws/messaging/JMS20/fat/DurableUnshared/DurableUnshared.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,6 +31,7 @@ import com.ibm.ws.messaging.JMS20security.fat.TestUtils;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
@@ -132,7 +133,7 @@ public class DurableUnshared {
     
     private static void stopAppServers() throws Exception {
         
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE9Action.isActive() || JakartaEE10Action.isActive()) {
             // Remove the Jakarta special case once fixed.
             // Also remove @AllowedFFDC( { "jakarta.resource.spi.InvalidPropertyException"} )
             // [24/03/21 16:57:09:781 GMT] 0000004b com.ibm.ws.config.xml.internal.ConfigEvaluator               W CWWKG0032W: Unexpected value specified for property [destinationType], value = [javax.jms.Topic]. Expected value(s) are: [jakarta.jms.Queue][jakarta.jms.Topic]. Default value in use: [jakarta.jms.Queue].

--- a/dev/com.ibm.ws.messaging.open_jms20security_fat/fat/src/com/ibm/ws/messaging/JMS20security/fat/FATSuite.java
+++ b/dev/com.ibm.ws.messaging.open_jms20security_fat/fat/src/com/ibm/ws/messaging/JMS20security/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ import com.ibm.ws.messaging.JMS20security.fat.DCFTest.JMSDefaultConnectionFactor
 import com.ibm.ws.messaging.JMS20security.fat.JMSConsumerTest.JMSConsumerTest;
 
 import componenttest.rules.repeater.EE7FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -35,5 +36,6 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests.with( new EE7FeatureReplacementAction() )
-                                             .andWith( new JakartaEE9Action().fullFATOnly() );
+                                             .andWith( new JakartaEE9Action().fullFATOnly() )
+                                             .andWith( new JakartaEE10Action().fullFATOnly() );
 }

--- a/dev/com.ibm.ws.messaging.open_jms20security_fat/fat/src/com/ibm/ws/messaging/JMS20security/fat/JMSConsumerTest/JMSConsumerTest.java
+++ b/dev/com.ibm.ws.messaging.open_jms20security_fat/fat/src/com/ibm/ws/messaging/JMS20security/fat/JMSConsumerTest/JMSConsumerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -45,6 +45,7 @@ import componenttest.annotation.ExpectedFFDC;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
@@ -135,7 +136,7 @@ public class JMSConsumerTest {
         ServerConfiguration config = ServerConfigurationFactory.fromFile(file);
 
         Map<String, String> transformation = new HashMap<>();
-        if (JakartaEE9Action.isActive()) {
+        if (JakartaEE9Action.isActive() || JakartaEE10Action.isActive()) {
             transformation.put("javax.jms.Queue", "jakarta.jms.Queue");
             transformation.put("javax.jms.Topic", "jakarta.jms.Topic");
         } else {

--- a/dev/com.ibm.ws.security.client_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.client_fat/bnd.bnd
@@ -17,7 +17,8 @@ fat.project: true
 tested.features: \
   expressionLanguage-4.0, appsecurity-4.0, servlet-5.0, cdi-3.0, enterprisebeansremote-4.0, ejblite-4.0, \
   appclientsupport-2.0, connectors-2.0, enterprisebeans-4.0, jaxb-3.0, mdb-4.0, jdbc-4.2, \
-  enterprisebeanshome-4.0, beanvalidation-3.0, mail-2.0
+  enterprisebeanshome-4.0, beanvalidation-3.0, mail-2.0, \
+  appsecurity-5.0, connectors-2.1, mail-2.1
 
 src:\
   fat/src,\

--- a/dev/com.ibm.ws.security.client_fat/fat/src/com/ibm/ws/security/client/fat/CommonTest.java
+++ b/dev/com.ibm.ws.security.client_fat/fat/src/com/ibm/ws/security/client/fat/CommonTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -42,6 +42,7 @@ import com.meterware.httpunit.WebConversation;
 import com.meterware.httpunit.WebRequest;
 
 import componenttest.common.apiservices.Bootstrap;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyClient;
 import componenttest.topology.impl.LibertyClientFactory;
@@ -840,8 +841,8 @@ public class CommonTest {
      *            The client to transform the applications on.
      */
     public static void transformApps(LibertyClient client) {
-        if (JakartaEE9Action.isActive()) {
-            String[] apps = null;
+        String[] apps = null;
+        if (JakartaEE9Action.isActive() || JakartaEE10Action.isActive()) {
 
             switch (client.getClientName()) {
 
@@ -891,10 +892,16 @@ public class CommonTest {
                     apps = new String[] {};
                     break;
             }
+        }
 
+        if (apps != null) {
             for (String app : apps) {
                 Path someArchive = Paths.get(client.getClientRoot() + File.separatorChar + app);
-                JakartaEE9Action.transformApp(someArchive);
+                if (JakartaEE9Action.isActive()) {
+                    JakartaEE9Action.transformApp(someArchive);
+                } else if (JakartaEE10Action.isActive()) {
+                    JakartaEE10Action.transformApp(someArchive);
+                }
             }
         }
     }
@@ -905,8 +912,8 @@ public class CommonTest {
      * @param server The server to transform the applications on.
      */
     public static void transformApps(LibertyServer server) {
-        if (JakartaEE9Action.isActive()) {
-            String[] apps = null;
+        String[] apps = null;
+        if (JakartaEE9Action.isActive() || JakartaEE10Action.isActive()) {
 
             switch (server.getServerName()) {
 
@@ -926,10 +933,16 @@ public class CommonTest {
                     apps = new String[] {};
                     break;
             }
+        }
 
+        if (apps != null) {
             for (String app : apps) {
                 Path someArchive = Paths.get(server.getServerRoot() + File.separatorChar + app);
-                JakartaEE9Action.transformApp(someArchive);
+                if (JakartaEE9Action.isActive()) {
+                    JakartaEE9Action.transformApp(someArchive);
+                } else if (JakartaEE10Action.isActive()) {
+                    JakartaEE10Action.transformApp(someArchive);
+                }
             }
         }
     }

--- a/dev/com.ibm.ws.security.client_fat/fat/src/com/ibm/ws/security/client/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.client_fat/fat/src/com/ibm/ws/security/client/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 IBM Corporation and others.
+ * Copyright (c) 2015, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,8 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -36,8 +38,10 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
 
     /*
-     * Run EE9 tests in LITE mode and run all tests in FULL mode.
+     * Run EE10 tests in LITE mode and run all tests in FULL mode.
      */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(new JakartaEE9Action());
+    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
+                    .andWith(new JakartaEE9Action().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                    .andWith(new JakartaEE10Action());
 }

--- a/dev/com.ibm.ws.security.client_fat/fat/src/com/ibm/ws/security/client/fat/JavaColonInjectionsTest.java
+++ b/dev/com.ibm.ws.security.client_fat/fat/src/com/ibm/ws/security/client/fat/JavaColonInjectionsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 IBM Corporation and others.
+ * Copyright (c) 2015, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,7 +26,6 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.log.Log;
 
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -38,58 +37,60 @@ import componenttest.topology.impl.LibertyServerFactory;
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class JavaColonInjectionsTest {
-	private static Class<?> c = JavaColonInjectionsTest.class;
+    private static Class<?> c = JavaColonInjectionsTest.class;
 
-	@Rule
-	public TestName testName = new TestName();
+    @Rule
+    public TestName testName = new TestName();
 
-	private static LibertyClient client = LibertyClientFactory.getLibertyClient("javacolonClientInjection");
-	private static LibertyServer server = LibertyServerFactory.getLibertyServer("javacolonServerInjection");
+    private static LibertyClient client = LibertyClientFactory.getLibertyClient("javacolonClientInjection");
+    private static LibertyServer server = LibertyServerFactory.getLibertyServer("javacolonServerInjection");
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		CommonTest.transformApps(server);
-		ProgramOutput po = server.startServer();
-		assertEquals("server did not start correctly", 0, po.getReturnCode());
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        CommonTest.transformApps(server);
+        ProgramOutput po = server.startServer();
+        assertEquals("server did not start correctly", 0, po.getReturnCode());
 
-		CommonTest.transformApps(client);
-		client.startClient();
-	}
+        CommonTest.transformApps(client);
+        client.startClient();
+    }
 
-	@AfterClass
-	public static void afterClass() throws Exception {
-		server.stopServer("CWWKG0033W", "CWWKZ0124E: Application testmarker does not contain any modules.");
-	}
+    @AfterClass
+    public static void afterClass() throws Exception {
+        server.stopServer("CWWKG0033W", "CWWKZ0124E: Application testmarker does not contain any modules.");
+    }
 
-	private void check() throws Exception {
-		String methodName = testName.getMethodName();
-		int idx = -1;
-		if ((idx = methodName.indexOf("_EE9_FEATURES")) != -1) {
-		    methodName = methodName.substring(0, idx);
-		}
-		List<String> strings = client.findStringsInCopiedLogs(methodName+"-PASSED");
-		Log.info(c, methodName, "Found in logs: " + strings);
-		assertTrue("Did not find expected method message " + methodName, strings != null && strings.size() >= 1);
+    private void check() throws Exception {
+        String methodName = testName.getMethodName();
+        int idx = -1;
+        if ((idx = methodName.indexOf("_EE9_FEATURES")) != -1) {
+            methodName = methodName.substring(0, idx);
+        } else if ((idx = methodName.indexOf("_EE10_FEATURES")) != -1) {
+            methodName = methodName.substring(0, idx);
+        }
+        List<String> strings = client.findStringsInCopiedLogs(methodName + "-PASSED");
+        Log.info(c, methodName, "Found in logs: " + strings);
+        assertTrue("Did not find expected method message " + methodName, strings != null && strings.size() >= 1);
 
-		// now explicitly check that we do not see messages like this in the log output:
-		// W CWNEN0057W: The com.ibm.ws.clientcontainer.security.fat.InjectionClientMain.mailSessionComp injection target must not be declared static.
-		// The spec says that injection into client modules MUST be static - this message indicates a bug in how injection is
-		// processed - usually by the client container injection runtime or CDI.
-		strings = client.findStringsInCopiedLogs("CWNEN0057W");
-		assertTrue("Invalid warning message about injecting into static field", 0 == strings.size());
-	}
+        // now explicitly check that we do not see messages like this in the log output:
+        // W CWNEN0057W: The com.ibm.ws.clientcontainer.security.fat.InjectionClientMain.mailSessionComp injection target must not be declared static.
+        // The spec says that injection into client modules MUST be static - this message indicates a bug in how injection is
+        // processed - usually by the client container injection runtime or CDI.
+        strings = client.findStringsInCopiedLogs("CWNEN0057W");
+        assertTrue("Invalid warning message about injecting into static field", 0 == strings.size());
+    }
 
-	//////////////////////////////////////////////////////
-	// java:global
+    //////////////////////////////////////////////////////
+    // java:global
 
-	/**
-	 * Tests that a remote EJB is injected when using a
-	 * java:global lookup.
-	 */
-	@Mode(TestMode.LITE)
-	@Test
-	public void injectGlobal_EJB() throws Exception {
-		check();
-	}
+    /**
+     * Tests that a remote EJB is injected when using a
+     * java:global lookup.
+     */
+    @Mode(TestMode.LITE)
+    @Test
+    public void injectGlobal_EJB() throws Exception {
+        check();
+    }
 
 }

--- a/dev/io.openliberty.mail.2.0.internal/src/io/openliberty/mail/internal/injection/MailSessionResourceFactoryBuilder.java
+++ b/dev/io.openliberty.mail.2.0.internal/src/io/openliberty/mail/internal/injection/MailSessionResourceFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 IBM Corporation and others.
+ * Copyright (c) 2015, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -102,9 +102,6 @@ public class MailSessionResourceFactoryBuilder implements ResourceFactoryBuilder
 
         MailSessionResourceFactory mss = new MailSessionResourceFactory();
         mss.processProperties(mailSessionSvcProps);
-
-        // MailSessionService does not use the Resource, pass null
-        mss.createResource(null);
 
         return mss;
     }


### PR DESCRIPTION
Update tests to have EE10 repeats for features that are the same between EE9 and EE10.
- beanValidation-3.0
- managedBeans-2.0
- mdb-4.0
- messagingSecurity-3.0
- appClientSupport-2.0
- jakartaeeClient-10.0

Updates to mail logic to not create a Session when creating the builder, but to only create it when the factory is called.