### PR TITLE
Security 3.0: Add messages to ClaimsImpl

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal/resources/io/openliberty/security/jakartasec/internal/resources/JakartaSecurity30Messages.nlsprops
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/resources/io/openliberty/security/jakartasec/internal/resources/JakartaSecurity30Messages.nlsprops
@@ -42,3 +42,7 @@ CREDENTIAL_VALIDATION_ERROR.useraction=For more information, see the error in th
 JAKARTASEC_WARNING_MISSING_SUBJECT_CLAIMS=CWWKS2505W: The claims JSON object in the OpenIdContext bean cannot add the subject value for client {0} because subject value is missing from the OpenIdClaims object. 
 JAKARTASEC_WARNING_MISSING_SUBJECT_CLAIMS.explanation=The OpenIdClaims object on the OpenIdContext bean is missing the required subject value. Therefore, the subject value of the claims JSON object cannot be set.  
 JAKARTASEC_WARNING_MISSING_SUBJECT_CLAIMS.useraction=Review the logs for earlier errors related to OpenID authentication.
+
+JAKARTASEC_CLAIMS_PROCESSING_ERROR=CWWKS2506E: The OpenID Connect client {0} Claims key value is incorrect. The value is {1} and the expected type is {2}. The error is {3}.
+JAKARTASEC_CLAIMS_PROCESSING_ERROR.explanation=The OpenID Connect client encountered an error while verifying the expected type of fields on the OpenID Claims object. A frequent error is that the actual type of the returned value does not match the expected type.
+JAKARTASEC_CLAIMS_PROCESSING_ERROR.useraction=For more information, see the error in the message.

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/tokens/ClaimsImpl.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/tokens/ClaimsImpl.java
@@ -23,11 +23,17 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
 import jakarta.security.enterprise.identitystore.openid.Claims;
 
 public class ClaimsImpl implements Claims, Serializable {
 
     private static final long serialVersionUID = 1L;
+
+    private static final TraceComponent tc = Tr.register(ClaimsImpl.class);
+
     private final Map<String, Object> claims = Collections.synchronizedMap(new HashMap<>());
 
     public ClaimsImpl(Map<String, Object> claimsMap) {
@@ -57,8 +63,8 @@ public class ClaimsImpl implements Claims, Serializable {
 
             return Optional.empty();
         } catch (ClassCastException | DateTimeException e) {
-            // TODO: Determine if a translated message is needed.
-            throw new IllegalArgumentException(e.getMessage());
+            String msg = Tr.formatMessage(tc, "JAKARTASEC_CLAIMS_PROCESSING_ERROR", new Object[] { name, claims.get(name), "NumericDate", e.toString() });
+            throw new IllegalArgumentException(msg, e);
         }
     }
 
@@ -79,8 +85,8 @@ public class ClaimsImpl implements Claims, Serializable {
             result = new ArrayList<String>();
             result.addAll((List<String>) value);
         } else {
-            // TODO: Determine if a translated message is needed.
-            throw new IllegalArgumentException();
+            String msg = Tr.formatMessage(tc, "JAKARTASEC_CLAIMS_PROCESSING_ERROR", new Object[] { name, claims.get(name), "ArrayString", "Type is not String or List" });
+            throw new IllegalArgumentException(msg);
         }
 
         return result;
@@ -97,8 +103,8 @@ public class ClaimsImpl implements Claims, Serializable {
 
             return OptionalInt.empty();
         } catch (ClassCastException e) {
-            // TODO: Determine if a translated message is needed.
-            throw new IllegalArgumentException(e.getMessage());
+            String msg = Tr.formatMessage(tc, "JAKARTASEC_CLAIMS_PROCESSING_ERROR", new Object[] { name, claims.get(name), "Integer", e.toString() });
+            throw new IllegalArgumentException(msg, e);
         }
     }
 
@@ -113,8 +119,8 @@ public class ClaimsImpl implements Claims, Serializable {
 
             return OptionalLong.empty();
         } catch (ClassCastException e) {
-            // TODO: Determine if a translated message is needed.
-            throw new IllegalArgumentException(e.getMessage());
+            String msg = Tr.formatMessage(tc, "JAKARTASEC_CLAIMS_PROCESSING_ERROR", new Object[] { name, claims.get(name), "Long", e.toString() });
+            throw new IllegalArgumentException(msg, e);
         }
     }
 
@@ -129,8 +135,8 @@ public class ClaimsImpl implements Claims, Serializable {
 
             return OptionalDouble.empty();
         } catch (ClassCastException e) {
-            // TODO: Determine if a translated message is needed.
-            throw new IllegalArgumentException(e.getMessage());
+            String msg = Tr.formatMessage(tc, "JAKARTASEC_CLAIMS_PROCESSING_ERROR", new Object[] { name, claims.get(name), "Double", e.toString() });
+            throw new IllegalArgumentException(msg, e);
         }
     }
 
@@ -148,12 +154,12 @@ public class ClaimsImpl implements Claims, Serializable {
                 Claims nestedClaims = new ClaimsImpl((Map<String, Object>) value);
                 result = Optional.of(nestedClaims);
             } catch (Exception e) {
-                // TODO: Determine if a translated message is needed.
-                throw new IllegalArgumentException();
+                String msg = Tr.formatMessage(tc, "JAKARTASEC_CLAIMS_PROCESSING_ERROR", new Object[] { name, value, "Nested", e.toString() });
+                throw new IllegalArgumentException(msg, e);
             }
         } else {
-            // TODO: Determine if a translated message is needed.
-            throw new IllegalArgumentException();
+            String msg = Tr.formatMessage(tc, "JAKARTASEC_CLAIMS_PROCESSING_ERROR", new Object[] { name, value, "Nested", "Type is not Map" });
+            throw new IllegalArgumentException(msg);
         }
 
         return result;
@@ -166,8 +172,8 @@ public class ClaimsImpl implements Claims, Serializable {
                 return (T) claims.get(name);
             }
         } catch (ClassCastException e) {
-            // TODO: Determine if a translated message is needed.
-            throw new IllegalArgumentException();
+            String msg = Tr.formatMessage(tc, "JAKARTASEC_CLAIMS_PROCESSING_ERROR", new Object[] { name, claims.get(name), "Generic Type", e.toString() });
+            throw new IllegalArgumentException(msg, e);
         }
 
         return null;

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/tokens/package-info.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/tokens/package-info.java
@@ -12,4 +12,9 @@
  * @version 1.0.0
  */
 @org.osgi.annotation.versioning.Version("1.0.0")
+@TraceOptions(traceGroup = TraceConstants.TRACE_GROUP, messageBundle = TraceConstants.MESSAGE_BUNDLE)
 package io.openliberty.security.jakartasec.tokens;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;
+
+import io.openliberty.security.jakartasec.TraceConstants;


### PR DESCRIPTION
Add the translated messages for the ClaimsImpl class.

Example of the message with variables filled in: `CWWKS2506E: The OpenID Connect client importantNumber Claims key value is incorrect. The value is notANumber and the expected type is Long. The error is java.lang.ClassCastException: java.lang.String incompatible with java.lang.Long.`