### PR TITLE
CDI: Consider shared libs as "application" BDAs

### DIFF
--- a/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/current/CDICurrentTestServlet.java
+++ b/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/current/CDICurrentTestServlet.java
@@ -10,22 +10,25 @@
  *******************************************************************************/
 package com.ibm.ws.cdi.api.fat.apps.current;
 
+import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import static java.time.temporal.ChronoUnit.SECONDS;
+import java.time.Duration;
+import java.util.logging.Logger;
 
 import javax.annotation.Resource;
 import javax.enterprise.concurrent.ManagedExecutorService;
 import javax.enterprise.inject.spi.CDI;
+import javax.inject.Inject;
 import javax.servlet.annotation.WebServlet;
 
-import java.time.Duration;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.junit.Test;
 
 import com.ibm.ws.cdi.api.fat.apps.current.extension.MyDeploymentVerifier;
+import com.ibm.ws.cdi.api.fat.apps.current.sharedLib.ISimpleBean;
+import com.ibm.ws.cdi.api.fat.apps.current.sharedLib.SharedLibBean;
 
 import componenttest.app.FATServlet;
 
@@ -39,15 +42,21 @@ public class CDICurrentTestServlet extends FATServlet {
     private static Boolean wasCDICurrentFound = null;
     private static volatile Boolean wasCDICurrentFoundViaMES = null;
 
+    @Inject
+    private SharedLibBean sharedLibBean;
+
     @Resource
     ManagedExecutorService managedExecutorService;
 
+    /*
+     * Not annotated @Test because it's called manually from CDIAPITests
+     */
     public void testCDICurrent() {
 
         String message = MyDeploymentVerifier.getMessage();
         assertEquals(message, MyDeploymentVerifier.SUCCESS, message);
 
-        SimpleBean sb = CDI.current().select(SimpleBean.class).get();
+        ISimpleBean sb = CDI.current().select(ISimpleBean.class).get();
         assertNotNull("SimpleBean was null", sb);
         String msg = sb.test();
         assertEquals("SimpleBean message was: " + msg, SimpleBean.MSG, msg);
@@ -60,7 +69,8 @@ public class CDICurrentTestServlet extends FATServlet {
      * when called from a new thread.
      *
      * Note that threads created via new Thread() will not have the required context and CDI.current() will return null
-     */    
+     */
+    @Test
     public void testCDICurrentViaMES() throws Exception {
         long startTime = System.nanoTime();
 
@@ -77,19 +87,24 @@ public class CDICurrentTestServlet extends FATServlet {
             Thread.sleep(15);
         }
 
-        LOGGER.info("About to throw exception");  
+        LOGGER.info("About to throw exception");
         assertTrue("The thread with CDI.current never completed", false);
+    }
+
+    @Test
+    public void testCDICurrentViaSharedLib() {
+        sharedLibBean.testCdiCurrentSharedLib();
     }
 
     public static void setWasCDICurrentFound(boolean b) {
 
-        wasCDICurrentFoundViaMES = b;        
-        LOGGER.info("Set test variable");  
+        wasCDICurrentFoundViaMES = b;
+        LOGGER.info("Set test variable");
 
     }
 
     public class CallCDICurrent implements Runnable {
- 
+
         @Override
         public void run() {
             CDI cdi = CDI.current();

--- a/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/current/sharedLib/ISimpleBean.java
+++ b/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/current/sharedLib/ISimpleBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,24 +8,13 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.cdi.api.fat.apps.current;
-
-import javax.enterprise.context.Dependent;
-
-import com.ibm.ws.cdi.api.fat.apps.current.sharedLib.ISimpleBean;
+package com.ibm.ws.cdi.api.fat.apps.current.sharedLib;
 
 /**
  *
  */
-@Dependent
-public class SimpleBean implements ISimpleBean {
+public interface ISimpleBean {
 
-    public static final String MSG = "bean exists";
-
-    /** {@inheritDoc} */
-    @Override
-    public String test() {
-        return MSG;
-    }
+    String test();
 
 }

--- a/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/current/sharedLib/SharedLibBean.java
+++ b/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/current/sharedLib/SharedLibBean.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.api.fat.apps.current.sharedLib;
+
+import static org.junit.Assert.assertTrue;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.CDI;
+import javax.inject.Inject;
+
+@Dependent
+public class SharedLibBean {
+
+    @Inject
+    private Instance<ISimpleBean> injectedInstance;
+
+    public void testCdiCurrentSharedLib() {
+        CDI<Object> cdi = CDI.current();
+
+        // OK, we can get CDI.current, but does it return the right beans?
+        // We should not be able to see a bean from the .war
+
+        // Test with injected instance
+        assertTrue("injectedInstance was satisfied", injectedInstance.isUnsatisfied());
+        // Test with CDI.current()
+        assertTrue("current instance was satisfied", cdi.select(ISimpleBean.class).isUnsatisfied());
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/tests/CDIAPITests.java
+++ b/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/tests/CDIAPITests.java
@@ -39,6 +39,7 @@ import com.ibm.ws.cdi.api.fat.apps.current.CDICurrentTestServlet;
 import com.ibm.ws.cdi.api.fat.apps.current.SimpleBean;
 import com.ibm.ws.cdi.api.fat.apps.current.extension.CDICurrentTestBean;
 import com.ibm.ws.cdi.api.fat.apps.current.extension.MyDeploymentVerifier;
+import com.ibm.ws.cdi.api.fat.apps.current.sharedLib.SharedLibBean;
 import com.ibm.ws.cdi.api.fat.apps.injectInjectionPoint.InjectInjectionPointServlet;
 import com.ibm.ws.cdi.api.fat.apps.injectInjectionPointBeansXML.InjectInjectionPointBeansXMLServlet;
 import com.ibm.ws.cdi.api.fat.apps.injectInjectionPointParam.InjectInjectionPointAsParamServlet;
@@ -88,7 +89,9 @@ public class CDIAPITests extends FATServletClient {
     @Server(SERVER_NAME)
     @TestServlets({
                     @TestServlet(servlet = AlterableContextTestServlet.class, contextRoot = ALTERABLE_CONTEXT_APP_NAME), //FULL
-                    @TestServlet(servlet = InjectInjectionPointAsParamServlet.class, contextRoot = INJECT_IP_AS_PARAM_APP_NAME) }) //FULL
+                    @TestServlet(servlet = InjectInjectionPointAsParamServlet.class, contextRoot = INJECT_IP_AS_PARAM_APP_NAME), //FULL
+                    @TestServlet(servlet = CDICurrentTestServlet.class, contextRoot = CDI_CURRENT_APP_NAME),
+    })
     public static LibertyServer server;
 
     @BeforeClass
@@ -103,7 +106,11 @@ public class CDIAPITests extends FATServletClient {
                                              .addClass(SimpleBean.class.getName())
                                              .addAsLibrary(cdiCurrentTest);
 
-        ShrinkHelper.exportDropinAppToServer(server, cdiCurrentWar, DeployOptions.SERVER_ONLY);
+        ShrinkHelper.exportAppToServer(server, cdiCurrentWar, DeployOptions.SERVER_ONLY);
+
+        JavaArchive cdiCurrentSharedLib = ShrinkWrap.create(JavaArchive.class, "cdiCurrentSharedLib.jar")
+                                                    .addPackage(SharedLibBean.class.getPackage());
+        ShrinkHelper.exportToServer(server, "", cdiCurrentSharedLib, DeployOptions.SERVER_ONLY);
 
         if (TestModeFilter.shouldRun(TestMode.FULL)) {
             JavaArchive alterableContextExtension = ShrinkWrap.create(JavaArchive.class, "alterableContextExtension.jar");
@@ -149,12 +156,6 @@ public class CDIAPITests extends FATServletClient {
         server.restartApplication(CDI_CURRENT_APP_NAME);
 
         runTest(server, CDI_CURRENT_APP_NAME, "testCDICurrent");
-    }
-
-    @Test
-    @Mode(TestMode.LITE)
-    public void testCDICurrentViaMES() throws Exception {
-        runTest(server, CDI_CURRENT_APP_NAME, "testCDICurrentViaMES");
     }
 
     @Test

--- a/dev/com.ibm.ws.cdi.api_fat/publish/servers/cdi12APIServer/server.xml
+++ b/dev/com.ibm.ws.cdi.api_fat/publish/servers/cdi12APIServer/server.xml
@@ -9,6 +9,14 @@
         <feature>componentTest-1.0</feature>
         <feature>concurrent-1.0</feature>
     </featureManager>
+    
+    <library id="cdiCurrentSharedLib">
+        <file name="${server.config.dir}/cdiCurrentSharedLib.jar"/>
+    </library>
+    
+    <webApplication location="cdiCurrentTest.war">
+        <classloader commonLibraryRef="cdiCurrentSharedLib"/>
+    </webApplication>
 
    <!-- Usually, we recommend customers not to change this, however we have a test that checks behaviour on a new thread with a history of timing out -->
    <executor coreThreads="20"/>

--- a/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/apps/enablementSharedLib/DummyBean.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/apps/enablementSharedLib/DummyBean.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.extension.apps.enablementSharedLib;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ * This is just a bean to enabled CDI. It's never referenced but it should cause CDI to be enabled just by existing.
+ */
+@ApplicationScoped
+public class DummyBean {
+
+}

--- a/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/apps/enablementWar/EnablementSharedLibServlet.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/apps/enablementWar/EnablementSharedLibServlet.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.extension.apps.enablementWar;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import com.ibm.ws.cdi.extension.impl.RTExtensionReqScopedBean;
+
+import componenttest.app.FATServlet;
+
+/**
+ * Test that CDI is enabled if there's a shared lib containing a bean
+ * <p>
+ * The app must be deployed with a shared library for this test to pass
+ */
+@SuppressWarnings("serial")
+@WebServlet("/testWithSharedLib")
+public class EnablementSharedLibServlet extends FATServlet {
+
+    @Inject
+    private Instance<RTExtensionReqScopedBean> rtExtensionReqScopedBean;
+
+    @Test
+    public void testCdiEnabledViaSharedLib() {
+        // If there's a bean visible via a shared library, CDI gets enabled and injection works
+        assertThat(rtExtensionReqScopedBean, not(nullValue()));
+        assertThat(rtExtensionReqScopedBean.get().getName(), equalTo("RTExtensionReqScopedBean"));
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/apps/enablementWar/EnablementTestServlet.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/apps/enablementWar/EnablementTestServlet.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.extension.apps.enablementWar;
+
+import static org.junit.Assert.fail;
+
+import javax.enterprise.inject.spi.CDI;
+import javax.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+/**
+ * Test that CDI is not enabled when there are no beans visible except from extensions
+ * <p>
+ * The app must be deployed without the shared library for this test to pass
+ */
+@SuppressWarnings("serial")
+@WebServlet("/test")
+public class EnablementTestServlet extends FATServlet {
+
+    @Test
+    public void testCdiNotEnabledForApp() {
+        // If there are no beans visible, CDI gets disabled for the whole app
+        try {
+            CDI.current();
+            fail("CDI.current() did not throw exception");
+        } catch (IllegalStateException e) {
+            // expected
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.extension_fat/publish/servers/cdi12RuntimeExtensionServer/server.xml
+++ b/dev/com.ibm.ws.cdi.extension_fat/publish/servers/cdi12RuntimeExtensionServer/server.xml
@@ -14,5 +14,17 @@
         <feature>cdi.internals-1.2</feature>
         <feature>usr:cdi.helloworld.extension-1.2</feature>
     </featureManager>
+    
+    <library id="enablementSharedLib">
+        <file name="enablementSharedLib.jar"/>
+    </library>
+    
+    <!-- enablement.war with no shared library -->
+    <webApplication location="enablement.war" name="enablement" />
+    
+    <!-- enablement.war with the shared library -->
+    <webApplication location="enablement.war" name="enablementSharedLib">
+        <classloader commonLibraryRef="enablementSharedLib"/>
+    </webApplication>
 
 </server>

--- a/dev/com.ibm.ws.cdi.internal/src/com/ibm/ws/cdi/internal/interfaces/WebSphereCDIDeployment.java
+++ b/dev/com.ibm.ws.cdi.internal/src/com/ibm/ws/cdi/internal/interfaces/WebSphereCDIDeployment.java
@@ -96,7 +96,7 @@ public interface WebSphereCDIDeployment extends CDI11Deployment {
     public WebSphereBeanDeploymentArchive getBeanDeploymentArchiveFromClass(Class<?> clazz);
 
     /**
-     * Get all BDAs relating only to this application. i.e. not Shared Libs or internal Runtime Extensions
+     * Get all BDAs which belong to this application. i.e. not internal Runtime Extensions
      *
      * @return all application BDAs
      */

--- a/dev/com.ibm.ws.cdi.visibility_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.visibility_fat/bnd.bnd
@@ -9,14 +9,16 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
-bVersion=1.0
 
+-sub: *.bnd
+
+bVersion=1.0
 # Define the bundle for this FAT
 
 src: \
-	fat/src,\
+	fat/src
 	
-test.project: true
+fat.project: true
 
 tested.features:\
 	cdi-2.0,\
@@ -55,6 +57,7 @@ tested.features:\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.websphere.org.osgi.service.component;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.websphere.javaee.jms.2.0;version=latest,\
 	com.ibm.websphere.javaee.connector.1.7;version=latest,\
 	com.ibm.websphere.javaee.validation.1.1;version=latest,\

--- a/dev/com.ibm.ws.cdi.visibility_fat/build.gradle
+++ b/dev/com.ibm.ws.cdi.visibility_fat/build.gradle
@@ -8,8 +8,6 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-apply from: '../wlp-gradle/subprojects/fat.gradle'
-
 configurations {
   jaxrsValidator
 }
@@ -24,8 +22,23 @@ task addjaxrsValidator(type: Copy) {
   into new File(autoFvtDir, 'lib/jaxrsvalidator')
 }
 
+//This task has a different output directory to the generic one in fat.gradle
+task copyCDIFeatureBundles {
+  doLast {
+    new File(project.buildDir, 'buildfiles').eachLine { String line ->
+      if (!line.contains(project.name + '.jar')) {
+        copy {
+          from line
+          into new File(autoFvtDir, 'publish/bundles')
+        }
+      }
+    }
+  }
+}
+
 addRequiredLibraries {
   dependsOn addjaxrsValidator
   dependsOn addJakartaTransformer
+  dependsOn copyCDIFeatureBundles
 }
 

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat.bnd
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat.bnd
@@ -1,0 +1,15 @@
+#*******************************************************************************
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+# Define the bundle for this FAT
+Bundle-SymbolicName: ${basename;${basedir}}

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/VisTest.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/VisTest.java
@@ -63,34 +63,10 @@ import com.ibm.ws.cdi.visibility.tests.vistest.ejbLib.EjbLibTargetBean;
 import com.ibm.ws.cdi.visibility.tests.vistest.ejbLib.EjbLibTestingBean;
 import com.ibm.ws.cdi.visibility.tests.vistest.ejbWarLib.EjbWarLibTargetBean;
 import com.ibm.ws.cdi.visibility.tests.vistest.ejbWarLib.EjbWarLibTestingBean;
-import com.ibm.ws.cdi.visibility.tests.vistest.framework.TargetBean;
-import com.ibm.ws.cdi.visibility.tests.vistest.framework.TestingBean;
-import com.ibm.ws.cdi.visibility.tests.vistest.framework.VisTester;
 import com.ibm.ws.cdi.visibility.tests.vistest.nonLib.NonLibTargetBean;
 import com.ibm.ws.cdi.visibility.tests.vistest.nonLib.NonLibTestingBean;
 import com.ibm.ws.cdi.visibility.tests.vistest.privateLib.PrivateLibTargetBean;
 import com.ibm.ws.cdi.visibility.tests.vistest.privateLib.PrivateLibTestingBean;
-import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InAppClient;
-import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InAppClientAsAppClientLib;
-import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InAppClientAsEjbLib;
-import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InAppClientAsWarLib;
-import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InAppClientLib;
-import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InCommonLib;
-import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InEarLib;
-import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InEjb;
-import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InEjbAppClientLib;
-import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InEjbAsAppClientLib;
-import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InEjbAsEjbLib;
-import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InEjbAsWarLib;
-import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InEjbLib;
-import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InEjbWarLib;
-import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InNonLib;
-import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InPrivateLib;
-import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InWar;
-import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InWar2;
-import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InWarAppClientLib;
-import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InWarLib;
-import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InWarWebinfLib;
 import com.ibm.ws.cdi.visibility.tests.vistest.war.WarTargetBean;
 import com.ibm.ws.cdi.visibility.tests.vistest.war.WarTestingBean;
 import com.ibm.ws.cdi.visibility.tests.vistest.war.servlet.VisibilityTestServlet;
@@ -140,6 +116,10 @@ import componenttest.topology.utils.HttpUtils;
  * <li>AppClientAsWarLib - an application client jar also referenced on the classpath of War</li>
  * <li>AppClientAsAppClientLib - an application client jar also referenced on the classpath of AppClient</li>
  * <li>War2 - another WAR, which does not reference anything else</li>
+ * <li>CommonLib - a shared library referenced with commonLibraryRef</li>
+ * <li>PrivateLib - a shared library referenced with privateLibraryRef</li>
+ * <li>RuntimeExtRegular - a regular runtime extension which can't see application beans</li>
+ * <li>RuntimeExtSeeApp - a runtime extension configured so that it can see application beans</li>
  * </ul>
  * <p>
  * The test is conducted by going through a servlet or application client main class, providing the location from which to test visibility. This class will load a
@@ -271,33 +251,6 @@ public class VisTest extends FATServletClient {
                                               .addClass(NonLibTargetBean.class)
                                               .addAsManifestResource(NonLibTestingBean.class.getResource("beans.xml"), "beans.xml");
 
-        JavaArchive visTestFramework = ShrinkWrap.create(JavaArchive.class, "visTestFramework.jar")
-                                                 .addClass(InWarWebinfLib.class)
-                                                 .addClass(InEjb.class)
-                                                 .addClass(InEarLib.class)
-                                                 .addClass(InEjbAsEjbLib.class)
-                                                 .addClass(InWarAppClientLib.class)
-                                                 .addClass(InAppClient.class)
-                                                 .addClass(InAppClientLib.class)
-                                                 .addClass(InNonLib.class)
-                                                 .addClass(InAppClientAsAppClientLib.class)
-                                                 .addClass(InEjbAppClientLib.class)
-                                                 .addClass(InEjbAsAppClientLib.class)
-                                                 .addClass(InAppClientAsWarLib.class)
-                                                 .addClass(InEjbAsWarLib.class)
-                                                 .addClass(InEjbLib.class)
-                                                 .addClass(InWar.class)
-                                                 .addClass(InWar2.class)
-                                                 .addClass(InAppClientAsEjbLib.class)
-                                                 .addClass(InWarLib.class)
-                                                 .addClass(InEjbWarLib.class)
-                                                 .addClass(InCommonLib.class)
-                                                 .addClass(InPrivateLib.class)
-                                                 .addClass(TargetBean.class)
-                                                 .addClass(VisTester.class)
-                                                 .addClass(TestingBean.class)
-                                                 .addAsManifestResource(VisTester.class.getResource("beans.xml"), "beans.xml");
-
         JavaArchive visTestEarLib = ShrinkWrap.create(JavaArchive.class, "visTestEarLib.jar")
                                               .addClass(EarLibTargetBean.class)
                                               .addClass(EarLibTestingBean.class)
@@ -337,12 +290,19 @@ public class VisTest extends FATServletClient {
         ShrinkHelper.exportAppToServer(server, visTest, DeployOptions.SERVER_ONLY);
         ShrinkHelper.exportToServer(server, "/", visTestPrivateLibrary, DeployOptions.SERVER_ONLY);
         ShrinkHelper.exportToServer(server, "/", visTestCommonLibrary, DeployOptions.SERVER_ONLY);
-        ShrinkHelper.exportToServer(server, "/", visTestFramework, DeployOptions.SERVER_ONLY);
 
         ShrinkHelper.exportAppToClient(client, visTest, DeployOptions.SERVER_ONLY);
         ShrinkHelper.exportToClient(client, "/", visTestPrivateLibrary, DeployOptions.SERVER_ONLY);
         ShrinkHelper.exportToClient(client, "/", visTestCommonLibrary, DeployOptions.SERVER_ONLY);
-        ShrinkHelper.exportToClient(client, "/", visTestFramework, DeployOptions.SERVER_ONLY);
+
+        server.installSystemBundle("visTest.framework");
+        server.installSystemBundle("visTest.framework-jakarta");
+        server.installSystemBundle("visTest.runtimeExtRegular");
+        server.installSystemBundle("visTest.runtimeExtRegular-jakarta");
+        server.installSystemBundle("visTest.runtimeExtSeeApp");
+        server.installSystemBundle("visTest.runtimeExtSeeApp-jakarta");
+        server.installSystemFeature("visTest-1.2");
+        server.installSystemFeature("visTest-3.0");
 
         server.startServer();
         getAppClientResults();
@@ -376,7 +336,9 @@ public class VisTest extends FATServletClient {
         InAppClientAsAppClientLib,
         InWar2,
         InCommonLib,
-        InPrivateLib
+        InPrivateLib,
+        InRuntimeExtRegular,
+        InRuntimeExtSeeApp,
     }
 
     /**
@@ -392,7 +354,9 @@ public class VisTest extends FATServletClient {
                                                                               Location.InEjbAsAppClientLib,
                                                                               Location.InAppClientAsEjbLib,
                                                                               Location.InCommonLib,
-                                                                              Location.InPrivateLib));
+                                                                              Location.InPrivateLib,
+                                                                              Location.InRuntimeExtRegular,
+                                                                              Location.InRuntimeExtSeeApp));
 
     /**
      * Set of locations that should be visible from WARs and their libraries
@@ -412,7 +376,9 @@ public class VisTest extends FATServletClient {
                                                                               Location.InAppClientAsEjbLib,
                                                                               Location.InAppClientAsWarLib,
                                                                               Location.InCommonLib,
-                                                                              Location.InPrivateLib));
+                                                                              Location.InPrivateLib,
+                                                                              Location.InRuntimeExtRegular,
+                                                                              Location.InRuntimeExtSeeApp));
 
     /**
      * Set of locations that should be visible from app clients and their libraries
@@ -425,12 +391,59 @@ public class VisTest extends FATServletClient {
                                                                                      Location.InEjbAsAppClientLib,
                                                                                      Location.InAppClientAsAppClientLib,
                                                                                      Location.InCommonLib,
-                                                                                     Location.InPrivateLib));
+                                                                                     Location.InPrivateLib,
+                                                                                     Location.InRuntimeExtRegular,
+                                                                                     Location.InRuntimeExtSeeApp));
 
     /**
      * Set of locations that should be visible from common server libraries
      */
-    Set<Location> COMMON_LIB_VISIBLE_LOCATIONS = new HashSet<Location>(Arrays.asList(Location.InCommonLib));
+    Set<Location> COMMON_LIB_VISIBLE_LOCATIONS = new HashSet<Location>(Arrays.asList(Location.InCommonLib,
+                                                                                     Location.InRuntimeExtRegular,
+                                                                                     Location.InRuntimeExtSeeApp));
+
+    /**
+     * Set of locations that should be visible from regular runtime extensions
+     */
+    Set<Location> RUNTIME_EXT_REGULAR_VISIBLE_LOCATIONS = new HashSet<Location>(Arrays.asList(Location.InRuntimeExtRegular));
+
+    /**
+     * Set of locations that should be visible from runtime extensions configured to see application beans
+     */
+    Set<Location> RUNTIME_EXT_SEE_ALL_VISIBLE_LOCATIONS = new HashSet<Location>(Arrays.asList(Location.InEjb,
+                                                                                              Location.InWar,
+                                                                                              Location.InEjbLib,
+                                                                                              Location.InWarLib,
+                                                                                              Location.InWarWebinfLib,
+                                                                                              Location.InEjbWarLib,
+                                                                                              Location.InEjbAppClientLib,
+                                                                                              Location.InWarAppClientLib,
+                                                                                              Location.InEarLib,
+                                                                                              Location.InEjbAsEjbLib,
+                                                                                              Location.InEjbAsWarLib,
+                                                                                              Location.InEjbAsAppClientLib,
+                                                                                              Location.InAppClientAsEjbLib,
+                                                                                              Location.InAppClientAsWarLib,
+                                                                                              Location.InCommonLib,
+                                                                                              Location.InPrivateLib,
+                                                                                              Location.InRuntimeExtRegular,
+                                                                                              Location.InRuntimeExtSeeApp,
+                                                                                              Location.InWar2));
+
+    /**
+     * Set of locations that should be visible from runtime extensions configured to see application beans when running as a client
+     * <p>
+     * This is a different list than on the server for two reasons:
+     * <ul>
+     * <li>EJB and Web modules are not started on the client, so they can't be visible
+     * <li>even when configured to see application beans, runtime extensions can't see application client module beans
+     * </ul>
+     */
+    Set<Location> RUNTIME_EXT_SEE_ALL_CLIENT_VISIBLE_LOCATIONS = new HashSet<Location>(Arrays.asList(Location.InEarLib,
+                                                                                                     Location.InCommonLib,
+                                                                                                     Location.InPrivateLib,
+                                                                                                     Location.InRuntimeExtRegular,
+                                                                                                     Location.InRuntimeExtSeeApp));
 
     private static Map<Location, String> appClientResults = null;
 
@@ -562,6 +575,18 @@ public class VisTest extends FATServletClient {
     @Test
     public void testVisibilityFromPrivateLib() throws Exception {
         doTestWithServlet(Location.InPrivateLib, EJB_VISIBLE_LOCATIONS);
+    }
+
+    @Test
+    public void testVisibilityFromRuntimeExtRegular() throws Exception {
+        doTestWithServlet(Location.InRuntimeExtRegular, RUNTIME_EXT_REGULAR_VISIBLE_LOCATIONS);
+        doTestWithAppClient(Location.InRuntimeExtRegular, RUNTIME_EXT_REGULAR_VISIBLE_LOCATIONS);
+    }
+
+    @Test
+    public void testVisibilityFromRuntimeExtSeeAll() throws Exception {
+        doTestWithServlet(Location.InRuntimeExtSeeApp, RUNTIME_EXT_SEE_ALL_VISIBLE_LOCATIONS);
+        doTestWithAppClient(Location.InRuntimeExtSeeApp, RUNTIME_EXT_SEE_ALL_CLIENT_VISIBLE_LOCATIONS);
     }
 
     /**
@@ -704,6 +729,12 @@ public class VisTest extends FATServletClient {
         if (server != null) {
             server.stopServer();
         }
+    }
+
+    @AfterClass
+    public static void cleanupFeatures() throws Exception {
+        server.uninstallSystemFeature("visTest-1.2");
+        server.uninstallSystemFeature("visTest-3.0");
     }
 
 }

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/appClient/main/Main.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/appClient/main/Main.java
@@ -15,6 +15,9 @@ import javax.inject.Inject;
 import com.ibm.ws.cdi.visibility.tests.vistest.appClient.AppClientTestingBean;
 import com.ibm.ws.cdi.visibility.tests.vistest.appClientAsAppClientLib.AppClientAsAppClientLibTestingBean;
 import com.ibm.ws.cdi.visibility.tests.vistest.appClientLib.AppClientLibTestingBean;
+import com.ibm.ws.cdi.visibility.tests.vistest.framework.TestingBean;
+import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InRuntimeExtRegular;
+import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InRuntimeExtSeeApp;
 
 /**
  * Called by the test client to test the visibility of beans from different BDAs which are only accessible in a client application.
@@ -30,9 +33,19 @@ public class Main {
     @Inject
     private static AppClientAsAppClientLibTestingBean appClientAsAppClientLibTestingBean;
 
+    // Using a qualifier to look this up so that we don't have to have the runtime extension export this package as API
+    @Inject
+    @InRuntimeExtRegular
+    private static TestingBean runtimeExtRegularTestingBean;
+
+    // Using a qualifier to look this up so that we don't have to have the runtime extension export this package as API
+    @Inject
+    @InRuntimeExtSeeApp
+    private static TestingBean runtimeExtSeeAppTestingBean;
+
     /**
      * Print the results of each testing bean in turn, separated by a line of "----"
-     * 
+     *
      * @param args ignored
      */
     public static void main(String[] args) {
@@ -52,6 +65,16 @@ public class Main {
 
         System.out.println("InAppClientAsAppClientLib");
         System.out.print(appClientAsAppClientLibTestingBean.doTest());
+
+        System.out.println("----");
+
+        System.out.println("InRuntimeExtRegular");
+        System.out.print(runtimeExtRegularTestingBean.doTest());
+
+        System.out.println("----");
+
+        System.out.println("InRuntimeExtSeeApp");
+        System.out.print(runtimeExtSeeAppTestingBean.doTest());
 
         // We need a final line to separate the results from the shutdown messages
         System.out.println("----");

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/framework/VisTester.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/framework/VisTester.java
@@ -36,6 +36,8 @@ import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InEjbLib;
 import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InEjbWarLib;
 import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InNonLib;
 import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InPrivateLib;
+import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InRuntimeExtRegular;
+import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InRuntimeExtSeeApp;
 import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InWar;
 import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InWar2;
 import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InWarAppClientLib;
@@ -124,6 +126,12 @@ public class VisTester {
 
         class InPrivateLibQualifier extends AnnotationLiteral<InPrivateLib> implements InPrivateLib {};
         qualifiers.add(new InPrivateLibQualifier());
+
+        class InRuntimeExtRegularQualifier extends AnnotationLiteral<InRuntimeExtRegular> implements InRuntimeExtRegular {};
+        qualifiers.add(new InRuntimeExtRegularQualifier());
+
+        class InRuntimeExtSeeAppQualifier extends AnnotationLiteral<InRuntimeExtSeeApp> implements InRuntimeExtSeeApp {};
+        qualifiers.add(new InRuntimeExtSeeAppQualifier());
 
         QUALIFIERS = Collections.unmodifiableSet(qualifiers);
     }

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/framework/package-info.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/framework/package-info.java
@@ -1,0 +1,12 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+@org.osgi.annotation.versioning.Version("1.0")
+package com.ibm.ws.cdi.visibility.tests.vistest.framework;

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/qualifiers/InRuntimeExtRegular.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/qualifiers/InRuntimeExtRegular.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.visibility.tests.vistest.qualifiers;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+@Qualifier
+@Retention(RUNTIME)
+@Target({ METHOD, FIELD, PARAMETER, TYPE })
+public @interface InRuntimeExtRegular {}

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/qualifiers/InRuntimeExtSeeApp.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/qualifiers/InRuntimeExtSeeApp.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.visibility.tests.vistest.qualifiers;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+@Qualifier
+@Retention(RUNTIME)
+@Target({ METHOD, FIELD, PARAMETER, TYPE })
+public @interface InRuntimeExtSeeApp {}

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/qualifiers/package-info.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/qualifiers/package-info.java
@@ -1,0 +1,12 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+@org.osgi.annotation.versioning.Version("1.0")
+package com.ibm.ws.cdi.visibility.tests.vistest.qualifiers;

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/runtimeExtRegular/RuntimeExtRegularMetadata.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/runtimeExtRegular/RuntimeExtRegularMetadata.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.visibility.tests.vistest.runtimeExtRegular;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+
+import io.openliberty.cdi.spi.CDIExtensionMetadata;
+
+@Component(configurationPolicy = ConfigurationPolicy.IGNORE)
+public class RuntimeExtRegularMetadata implements CDIExtensionMetadata {
+
+    /** {@inheritDoc} */
+    @Override
+    public Set<Class<?>> getBeanClasses() {
+        Set<Class<?>> result = new HashSet<>();
+        result.add(RuntimeExtRegularTargetBean.class);
+        result.add(RuntimeExtRegularTestingBean.class);
+        return result;
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/runtimeExtRegular/RuntimeExtRegularTargetBean.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/runtimeExtRegular/RuntimeExtRegularTargetBean.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.visibility.tests.vistest.runtimeExtRegular;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import com.ibm.ws.cdi.visibility.tests.vistest.framework.TargetBean;
+import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InRuntimeExtRegular;
+
+@ApplicationScoped
+@InRuntimeExtRegular
+public class RuntimeExtRegularTargetBean implements TargetBean {
+
+}

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/runtimeExtRegular/RuntimeExtRegularTestingBean.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/runtimeExtRegular/RuntimeExtRegularTestingBean.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.visibility.tests.vistest.runtimeExtRegular;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+
+import com.ibm.ws.cdi.visibility.tests.vistest.framework.TestingBean;
+import com.ibm.ws.cdi.visibility.tests.vistest.framework.VisTester;
+import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InRuntimeExtRegular;
+
+@ApplicationScoped
+@InRuntimeExtRegular
+public class RuntimeExtRegularTestingBean implements TestingBean {
+
+    @Inject
+    private BeanManager beanManager;
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see com.ibm.ws.cdi.visibility.tests.vistest.framework.TestingBean#doTest()
+     */
+    @Override
+    public String doTest() {
+        return VisTester.doTest(beanManager);
+    }
+}

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/runtimeExtRegular/beans.xml
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/runtimeExtRegular/beans.xml
@@ -4,3 +4,4 @@
        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
        version="1.1"
        bean-discovery-mode="none" />
+<!-- Note: discovery-mode=none so that we don't scan for beans at all. All beans should be provided by RuntimeExtRegularMetadata -->

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/runtimeExtSeeApp/RuntimeExtSeeAppMetadata.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/runtimeExtSeeApp/RuntimeExtSeeAppMetadata.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.visibility.tests.vistest.runtimeExtSeeApp;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+
+import com.ibm.ws.cdi.extension.CDIExtensionMetadataInternal;
+
+import io.openliberty.cdi.spi.CDIExtensionMetadata;
+
+@Component(configurationPolicy = ConfigurationPolicy.IGNORE)
+public class RuntimeExtSeeAppMetadata implements CDIExtensionMetadata, CDIExtensionMetadataInternal {
+
+    @Override
+    public Set<Class<?>> getBeanClasses() {
+        Set<Class<?>> result = new HashSet<>();
+        result.add(RuntimeExtSeeAppTargetBean.class);
+        result.add(RuntimeExtSeeAppTestingBean.class);
+        return result;
+    }
+
+    @Override
+    public boolean applicationBeansVisible() {
+        return true;
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/runtimeExtSeeApp/RuntimeExtSeeAppTargetBean.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/runtimeExtSeeApp/RuntimeExtSeeAppTargetBean.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.visibility.tests.vistest.runtimeExtSeeApp;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import com.ibm.ws.cdi.visibility.tests.vistest.framework.TargetBean;
+import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InRuntimeExtSeeApp;
+
+@ApplicationScoped
+@InRuntimeExtSeeApp
+public class RuntimeExtSeeAppTargetBean implements TargetBean {
+
+}

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/runtimeExtSeeApp/RuntimeExtSeeAppTestingBean.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/runtimeExtSeeApp/RuntimeExtSeeAppTestingBean.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.visibility.tests.vistest.runtimeExtSeeApp;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+
+import com.ibm.ws.cdi.visibility.tests.vistest.framework.TestingBean;
+import com.ibm.ws.cdi.visibility.tests.vistest.framework.VisTester;
+import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InRuntimeExtSeeApp;
+
+@ApplicationScoped
+@InRuntimeExtSeeApp
+public class RuntimeExtSeeAppTestingBean implements TestingBean {
+
+    @Inject
+    private BeanManager beanManager;
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see com.ibm.ws.cdi.visibility.tests.vistest.framework.TestingBean#doTest()
+     */
+    @Override
+    public String doTest() {
+        return VisTester.doTest(beanManager);
+    }
+}

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/runtimeExtSeeApp/beans.xml
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/runtimeExtSeeApp/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       version="1.1"
+       bean-discovery-mode="none" />
+<!-- Note: discovery-mode=none so that we don't scan for beans at all. All beans should be provided by RuntimeExtRegularMetadata -->

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/war/servlet/VisibilityTestServlet.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/war/servlet/VisibilityTestServlet.java
@@ -31,7 +31,10 @@ import com.ibm.ws.cdi.visibility.tests.vistest.ejbAsEjbLib.EjbAsEjbLibTestingBea
 import com.ibm.ws.cdi.visibility.tests.vistest.ejbAsWarLib.EjbAsWarLibTestingBean;
 import com.ibm.ws.cdi.visibility.tests.vistest.ejbLib.EjbLibTestingBean;
 import com.ibm.ws.cdi.visibility.tests.vistest.ejbWarLib.EjbWarLibTestingBean;
+import com.ibm.ws.cdi.visibility.tests.vistest.framework.TestingBean;
 import com.ibm.ws.cdi.visibility.tests.vistest.privateLib.PrivateLibTestingBean;
+import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InRuntimeExtRegular;
+import com.ibm.ws.cdi.visibility.tests.vistest.qualifiers.InRuntimeExtSeeApp;
 import com.ibm.ws.cdi.visibility.tests.vistest.war.WarTestingBean;
 import com.ibm.ws.cdi.visibility.tests.vistest.warAppClientLib.WarAppClientLibTestingBean;
 import com.ibm.ws.cdi.visibility.tests.vistest.warLib.WarLibTestingBean;
@@ -100,6 +103,16 @@ public class VisibilityTestServlet extends FATServlet {
     @Inject
     private Instance<PrivateLibTestingBean> privateLibTestingInstance;
 
+    // Using a qualifier to look this up so that we don't have to have the runtime extension export this package as API
+    @Inject
+    @InRuntimeExtRegular
+    private Instance<TestingBean> runtimeExtRegularTestingInstance;
+
+    // Using a qualifier to look this up so that we don't have to have the runtime extension export this package as API
+    @Inject
+    @InRuntimeExtSeeApp
+    private Instance<TestingBean> runtimeExtSeeAppTestingInstance;
+
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         String location = req.getParameter("location");
@@ -140,6 +153,10 @@ public class VisibilityTestServlet extends FATServlet {
                 result = commonLibTestingInstance.get().doTest();
             } else if (location.equals("InPrivateLib")) {
                 result = privateLibTestingInstance.get().doTest();
+            } else if (location.equals("InRuntimeExtRegular")) {
+                result = runtimeExtRegularTestingInstance.get().doTest();
+            } else if (location.equals("InRuntimeExtSeeApp")) {
+                result = runtimeExtSeeAppTestingInstance.get().doTest();
             } else {
                 result = "ERROR: unrecognised qualifier\n";
             }

--- a/dev/com.ibm.ws.cdi.visibility_fat/publish/clients/visTestClient/client.xml
+++ b/dev/com.ibm.ws.cdi.visibility_fat/publish/clients/visTestClient/client.xml
@@ -17,10 +17,6 @@
     
     <library id="visTestCommonLib">
        <fileset includes="visTestCommonLib.jar"/>
-       <fileset includes="visTestFramework.jar"/>
     </library>
-    
-    <!--Java2 security-->
-    <javaPermission codebase="${client.config.dir}/visTestFramework.jar" className="java.security.AllPermission"  name="*" actions="*" />
     
 </client>

--- a/dev/com.ibm.ws.cdi.visibility_fat/publish/features/visTest-1.2.mf
+++ b/dev/com.ibm.ws.cdi.visibility_fat/publish/features/visTest-1.2.mf
@@ -1,0 +1,17 @@
+Subsystem-ManifestVersion: 1
+Subsystem-SymbolicName: visTest-1.2
+Subsystem-Version: 1.0.0
+Subsystem-Content: 
+  visTest.framework;version="[1.0, 1.1)",
+  visTest.runtimeExtRegular;version="[1.0, 1.1)",
+  visTest.runtimeExtSeeApp;version="[1.0, 1.1)"
+Subsystem-Type: osgi.subsystem.feature
+
+X-Comment: This is an autofeature because there's a hardcoded limitation on what features you can list in a client.xml
+IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.cdi-1.2)(osgi.identity=com.ibm.websphere.appserver.cdi-2.0)))"
+
+IBM-API-Package: 
+  com.ibm.ws.cdi.visibility.tests.vistest.framework,
+  com.ibm.ws.cdi.visibility.tests.vistest.qualifiers
+IBM-Feature-Version: 2
+IBM-Process-Types: client,server

--- a/dev/com.ibm.ws.cdi.visibility_fat/publish/features/visTest-3.0.mf
+++ b/dev/com.ibm.ws.cdi.visibility_fat/publish/features/visTest-3.0.mf
@@ -1,0 +1,17 @@
+Subsystem-ManifestVersion: 1
+Subsystem-SymbolicName: visTest-3.0
+Subsystem-Version: 1.0.0
+Subsystem-Content: 
+  visTest.framework-jakarta;version="[1.0, 1.1)",
+  visTest.runtimeExtRegular-jakarta;version="[1.0, 1.1)",
+  visTest.runtimeExtSeeApp-jakarta;version="[1.0, 1.1)"
+Subsystem-Type: osgi.subsystem.feature
+
+X-Comment: This is an autofeature because there's a hardcoded limitation on what features you can list in a client.xml
+IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.cdi-3.0)(osgi.identity=io.openliberty.cdi-4.0)))"
+
+IBM-API-Package: 
+  com.ibm.ws.cdi.visibility.tests.vistest.framework,
+  com.ibm.ws.cdi.visibility.tests.vistest.qualifiers
+IBM-Feature-Version: 2
+IBM-Process-Types: client,server

--- a/dev/com.ibm.ws.cdi.visibility_fat/publish/servers/visTestServer/server.xml
+++ b/dev/com.ibm.ws.cdi.visibility_fat/publish/servers/visTestServer/server.xml
@@ -22,12 +22,8 @@
     
     <library id="visTestCommonLib">
        <fileset includes="visTestCommonLib.jar"/>
-       <fileset includes="visTestFramework.jar"/>
     </library>
     
     <orb id="defaultOrb" orbSSLInitTimeout="60"/>
     
-    <!--Java2 security-->
-    <javaPermission codebase="${server.config.dir}/visTestFramework.jar" className="java.security.AllPermission"  name="*" actions="*" />
-
 </server>

--- a/dev/com.ibm.ws.cdi.visibility_fat/visTest.framework-transformed.bnd
+++ b/dev/com.ibm.ws.cdi.visibility_fat/visTest.framework-transformed.bnd
@@ -1,0 +1,18 @@
+#*******************************************************************************
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/transform.props
+bVersion=1.0
+
+Bundle-SymbolicName: visTest.framework-jakarta
+
+Export-Package:\
+  com.ibm.ws.cdi.visibility.tests.vistest.framework;version="1.0",\
+  com.ibm.ws.cdi.visibility.tests.vistest.qualifiers;version="1.0"

--- a/dev/com.ibm.ws.cdi.visibility_fat/visTest.framework.bnd
+++ b/dev/com.ibm.ws.cdi.visibility_fat/visTest.framework.bnd
@@ -1,0 +1,24 @@
+#*******************************************************************************
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+Bundle-SymbolicName: visTest.framework
+
+Export-Package:\
+  com.ibm.ws.cdi.visibility.tests.vistest.framework;version="1.0",\
+  com.ibm.ws.cdi.visibility.tests.vistest.qualifiers;version="1.0"
+
+Import-Package:\
+  javax.enterprise.inject;version="[1.1,3)",\
+  javax.enterprise.inject.spi;version="[1.1,3)",\
+  javax.enterprise.util;version="[1.1,3)",\
+  ${defaultPackageImport}

--- a/dev/com.ibm.ws.cdi.visibility_fat/visTest.runtimeExtRegular-transformed.bnd
+++ b/dev/com.ibm.ws.cdi.visibility_fat/visTest.runtimeExtRegular-transformed.bnd
@@ -1,0 +1,18 @@
+#*******************************************************************************
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/transform.props
+bVersion=1.0
+
+Bundle-SymbolicName: visTest.runtimeExtRegular-jakarta
+
+Private-Package: com.ibm.ws.cdi.visibility.tests.vistest.runtimeExtRegular
+
+-dsannotations: com.ibm.ws.cdi.visibility.tests.vistest.runtimeExtRegular.RuntimeExtRegularMetadata

--- a/dev/com.ibm.ws.cdi.visibility_fat/visTest.runtimeExtRegular.bnd
+++ b/dev/com.ibm.ws.cdi.visibility_fat/visTest.runtimeExtRegular.bnd
@@ -1,0 +1,23 @@
+#*******************************************************************************
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+Bundle-SymbolicName: visTest.runtimeExtRegular
+
+Private-Package: com.ibm.ws.cdi.visibility.tests.vistest.runtimeExtRegular
+
+Import-Package: \
+  javax.enterprise.context;version="[1.1,3)",\
+  javax.enterprise.inject.spi;version="[1.1,3)",\
+  ${defaultPackageImport}
+
+-dsannotations: com.ibm.ws.cdi.visibility.tests.vistest.runtimeExtRegular.RuntimeExtRegularMetadata

--- a/dev/com.ibm.ws.cdi.visibility_fat/visTest.runtimeExtSeeApp-transformed.bnd
+++ b/dev/com.ibm.ws.cdi.visibility_fat/visTest.runtimeExtSeeApp-transformed.bnd
@@ -1,0 +1,18 @@
+#*******************************************************************************
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/transform.props
+bVersion=1.0
+
+Bundle-SymbolicName: visTest.runtimeExtSeeApp-jakarta
+
+Private-Package: com.ibm.ws.cdi.visibility.tests.vistest.runtimeExtSeeApp
+
+-dsannotations: com.ibm.ws.cdi.visibility.tests.vistest.runtimeExtSeeApp.RuntimeExtSeeAppMetadata

--- a/dev/com.ibm.ws.cdi.visibility_fat/visTest.runtimeExtSeeApp.bnd
+++ b/dev/com.ibm.ws.cdi.visibility_fat/visTest.runtimeExtSeeApp.bnd
@@ -1,0 +1,23 @@
+#*******************************************************************************
+# Copyright (c) 2022 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+Bundle-SymbolicName: visTest.runtimeExtSeeApp
+
+Private-Package: com.ibm.ws.cdi.visibility.tests.vistest.runtimeExtSeeApp
+
+Import-Package: \
+  javax.enterprise.context;version="[1.1,3)",\
+  javax.enterprise.inject.spi;version="[1.1,3)",\
+  ${defaultPackageImport}
+
+-dsannotations: com.ibm.ws.cdi.visibility.tests.vistest.runtimeExtSeeApp.RuntimeExtSeeAppMetadata

--- a/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/weld/WebSphereCDIDeploymentImpl.java
+++ b/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/weld/WebSphereCDIDeploymentImpl.java
@@ -181,7 +181,7 @@ public class WebSphereCDIDeploymentImpl implements WebSphereCDIDeployment {
     }
 
     /**
-     * Get all BDAs relating only to this application. i.e. not Shared Libs or internal Runtime Extensions
+     * Get all BDAs which belong to this application. i.e. not internal Runtime Extensions
      *
      * @return all application BDAs
      */
@@ -298,9 +298,13 @@ public class WebSphereCDIDeploymentImpl implements WebSphereCDIDeployment {
      * Create the ordered list for the bdas - extension bdas first and then followed by the application bdas
      *
      */
+    @Trivial
     public void initializeOrderedBeanDeploymentArchives() {
         orderedBDAs.addAll(extensionBDAs.values());
         orderedBDAs.addAll(applicationBDAs);
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(this, tc, "initializeOrderedBeanDeploymentArchives", orderedBDAs);
+        }
     }
 
     /** {@inheritDoc} */
@@ -592,8 +596,7 @@ public class WebSphereCDIDeploymentImpl implements WebSphereCDIDeployment {
         deploymentDBAs.put(bda.getId(), bda);
         extensionClassLoaders.add(bda.getClassLoader());
         ArchiveType type = bda.getType();
-        if (type != ArchiveType.SHARED_LIB &&
-            type != ArchiveType.RUNTIME_EXTENSION) {
+        if (type != ArchiveType.RUNTIME_EXTENSION) {
             applicationBDAs.add(bda);
         }
     }
@@ -648,7 +651,8 @@ public class WebSphereCDIDeploymentImpl implements WebSphereCDIDeployment {
         //first we need to initialize the injection service and collect the reference contexts and the injection classes
         for (WebSphereBeanDeploymentArchive bda : getApplicationBDAs()) {
             // Don't initialize child libraries, instead aggregate for the whole module
-            if (bda.getType() != ArchiveType.MANIFEST_CLASSPATH && bda.getType() != ArchiveType.WEB_INF_LIB) {
+            // No reference context for shared libs either
+            if (bda.getType() != ArchiveType.MANIFEST_CLASSPATH && bda.getType() != ArchiveType.WEB_INF_LIB && bda.getType() != ArchiveType.SHARED_LIB) {
                 ReferenceContext referenceContext = bda.initializeInjectionServices();
                 cdiReferenceContexts.add(referenceContext);
             }


### PR DESCRIPTION
This fixes two problems:
 - application BDAs are given visibility of runtime extensions. Shared libs should have this.
 - application BDAs are included in the the list of BDAs we search when looking up the BDA for a class. Shared libs should be included this list.

Add tests for:
- visibility of runtime extension BDAs
- calling CDI.current() from class in a shared library
- enablement of CDI in an application where the only visible CDI bean is in a shared library

Fixes #23748