### PR TITLE
Change org.gradle.jvmargs to -Xmx6400m

### DIFF
--- a/dev/gradle.properties
+++ b/dev/gradle.properties
@@ -33,7 +33,7 @@ bnd_preCompileRefresh=false
 # By default Gradle will reserve 1GB of heap space.
 # Very large builds might need more memory to hold Gradle's model and caches.
 # Set file encoding to override the system encoding.
-org.gradle.jvmargs=-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx6400m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # Fix for the TLS protocol version used to communicate with Maven Central when using the IBM JVM.
 systemProp.com.ibm.jsse2.overrideDefaultTLS=true


### PR DESCRIPTION
- Increase Gradle's Java heap size to fix https://ibm-cloud.slack.com/archives/C30NGUQ9E/p1671660807837689.
```
1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':com.ibm.ws.webserver.plugin.utility:jar'.
> Java heap space
```