### PR TITLE
Security 3.0: Add error message for TokenResponseValidator

### DIFF
--- a/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
+++ b/dev/io.openliberty.security.oidcclientcore.internal/resources/io/openliberty/security/oidcclientcore/internal/resources/OidcClientCoreMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -121,3 +121,7 @@ OIDC_CLIENT_INVALID_RESPONSE_TYPE.useraction=Specify one of the valid response t
 TOKEN_CLAIM_VALUE_MISMATCH=CWWKS2424E: The [{0}] value for the [{1}] claim in the token does not match the [{2}] expected value.
 TOKEN_CLAIM_VALUE_MISMATCH.explanation=The claim value is incorrect or malformed. The configuration for the OpenID Connect client might be incorrect, or the token was created with incorrect values.
 TOKEN_CLAIM_VALUE_MISMATCH.useraction=Ensure the attribute in the OpenID Connect client configuration that is related to the claim that is specified in the message is configured correctly.
+
+TOKEN_MISSING_CLAIMS=CWWKS2425E: The {0} OpenID Connect client token is invalid. The jwtClaims value on the JwtContext object is null or empty.
+TOKEN_MISSING_CLAIMS.explanation=Information is missing from the token and validation of the token cannot be completed.
+TOKEN_MISSING_CLAIMS.useraction=Review the log for any earlier errors for details on the failure. Check the format and content of the token that is returned from the OpenID Connect provider.

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenResponseValidator.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenResponseValidator.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -102,9 +102,9 @@ public class TokenResponseValidator {
         if (jwtContext != null) {
             jwtClaims = jwtContext.getJwtClaims();
         }
-        if (jwtContext == null || jwtClaims == null) {
-            // TODO - NLS message
-            throw new TokenValidationException(this.clientConfig.getClientId(), "not a valid token to continue the flow");
+        if (jwtClaims == null || jwtClaims.getClaimsMap().isEmpty()) {
+            String msg = Tr.formatMessage(tc, "TOKEN_MISSING_CLAIMS", new Object[] { this.clientConfig.getClientId() });
+            throw new TokenValidationException(this.clientConfig.getClientId(), msg);
         }
         return jwtClaims;
     }

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/token/TokenResponseValidatorTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/token/TokenResponseValidatorTest.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oidcclientcore.token;
+
+import static org.junit.Assert.assertTrue;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.consumer.JwtContext;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import io.openliberty.security.common.jwt.JwtParsingUtils;
+import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
+import test.common.SharedOutputManager;
+
+/**
+ *
+ */
+public class TokenResponseValidatorTest {
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    private final Mockery mock = new JUnit4Mockery() {
+        {
+            setImposteriser(ClassImposteriser.INSTANCE);
+        }
+    };
+    protected final OidcClientConfig oidcClientConfig = mock.mock(OidcClientConfig.class, "oidcClientConfig");
+    protected final JwtContext jwtContext = mock.mock(JwtContext.class, "jwtContext");
+    private static final String idToken = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwOi8vaGFybW9uaWM6ODAxMS9vYXV0aDIvZW5kcG9pbnQvT0F1dGhDb25maWdTYW1wbGUvdG9rZW4iLCJpYXQiOjEzODczODM5NTMsInN1YiI6InRlc3R1c2VyIiwiZXhwIjoxMzg3Mzg3NTUzLCJhdWQiOiJjbGllbnQwMSJ9.ottD3eYa6qrnItRpL_Q9UaKumAyo14LnlvwnyF3Kojk";
+
+    static JwtClaims jwtClaims = null;
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        jwtClaims = JwtParsingUtils.parseJwtWithoutValidation(idToken).getJwtClaims();
+
+    }
+
+    /**
+     * Make sure we do the correct error message for a null jwtContext
+     */
+    @Test
+    public void test_getJwtClaimsFromIdTokenContext_NullContext() {
+        final String methodName = "test_getJwtClaimsFromIdTokenContext_NullContext";
+        try {
+            mock.checking(new Expectations() {
+                {
+                    allowing(oidcClientConfig).getClientId();
+                    will(returnValue("oidcclientid"));
+                }
+            });
+
+            TokenResponseValidator validator = getTokenResponseValidotor();
+
+            validator.getJwtClaimsFromIdTokenContext(null);
+
+        } catch (TokenValidationException e) {
+            String error = e.getMessage();
+            assertTrue("message", error.contains("CWWKS2425E"));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(methodName, t);
+        }
+    }
+
+    /**
+     * Make sure we do the correct error message for a valid jwtContext with a null jwtClaims
+     */
+    @Test
+    public void test_getJwtClaimsFromIdTokenContext_NullClaims() {
+        final String methodName = "test_getJwtClaimsFromIdTokenContext_NullClaims";
+        try {
+            mock.checking(new Expectations() {
+                {
+                    allowing(oidcClientConfig).getClientId();
+                    will(returnValue("oidcclientid"));
+                    allowing(jwtContext).getJwtClaims();
+                    will(returnValue(null));
+                }
+            });
+
+            TokenResponseValidator validator = getTokenResponseValidotor();
+
+            validator.getJwtClaimsFromIdTokenContext(jwtContext);
+
+        } catch (TokenValidationException e) {
+            String error = e.getMessage();
+            assertTrue("message", error.contains("CWWKS2425E"));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(methodName, t);
+        }
+    }
+
+    /**
+     * No error message for an existing jwtContext with jwtClaims
+     */
+    @Test
+    public void test_getJwtClaimsFromIdTokenContext() {
+        final String methodName = "test_getJwtClaimsFromIdTokenContext";
+        try {
+            mock.checking(new Expectations() {
+                {
+                    allowing(oidcClientConfig).getClientId();
+                    will(returnValue("oidcclientid"));
+                    allowing(jwtContext).getJwtClaims();
+                    will(returnValue(jwtClaims));
+                }
+            });
+
+            TokenResponseValidator validator = getTokenResponseValidotor();
+
+            validator.getJwtClaimsFromIdTokenContext(jwtContext);
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(methodName, t);
+        }
+    }
+
+    private TokenResponseValidator getTokenResponseValidotor() {
+        return new TokenResponseValidator(oidcClientConfig, null, null);
+    }
+}


### PR DESCRIPTION
Addresses to-do to add an error message to TokenResponseValidator.

Created new unit test to test different failures of getJwtClaimsFromIdTokenContext()

Example message with variables: `CWWKS2425E: The oidcclientid OpenID Connect client token is invalid. The jwtContext field is null.`

In context when it's thrown to the user: `io.openliberty.security.oidcclientcore.token.TokenValidationException: CWWKS2415E: The oidcclientid OpenID Connect client encountered the following error during validation of the token that was received from the OpenID Connect provider: CWWKS2425E: The oidcclientid OpenID Connect client token is invalid. The jwtClaims value on the JwtContext object is null or empty.`