### PR TITLE
fix for index out of bounds exception

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/FreePool.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/FreePool.java
@@ -638,7 +638,6 @@ public final class FreePool implements JCAPMIHelper {
 
                                 mcWrapperTemp2 = (MCWrapper) mcWrapperList.get(i);
                                 if (hashCode == mcWrapperTemp2.getSubjectCRIHashCode()) {
-                                    mcWrapper = getMCWrapperFromMatch(subject, cri, managedConnectionFactory, mcWrapperTemp2);
                                     if (((com.ibm.ejs.j2c.MCWrapper) mcWrapperTemp2).do_not_reuse_mcw) {
                                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                                             Tr.debug(this, tc, "Connection error occurred for this mcw " + mcWrapperTemp2 + ", mcw will not be reuse");
@@ -652,6 +651,8 @@ public final class FreePool implements JCAPMIHelper {
                                         if ((pm.waiterCount > 0) && (pm.waiterCount > pm.mcWrapperWaiterList.size())) {
                                             pm.waiterFreePoolLock.notify();
                                         }
+                                    } else {
+                                        mcWrapper = getMCWrapperFromMatch(subject, cri, managedConnectionFactory, mcWrapperTemp2);
                                     }
                                 }
                                 if (mcWrapper != null) {


### PR DESCRIPTION
Fix for index out of bounds exciton here, 

StackTrace=java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
	at java.util.ArrayList.rangeCheck(ArrayList.java:670)
	at java.util.ArrayList.remove(ArrayList.java:509)
	at com.ibm.ejs.j2c.FreePool.getFreeConnection(FreePool.java:658)

The main issue is a connection was marked not to be reused due to errors with the resource that were part of the customers test.   The error with the resource are expected, but the index out of bounds exception is not expected.

The code was changed to remove the connection if is should not be reused and only process the connection for matching after this check.

