### PR TITLE
Prompt Internal Server Error instead of throw exception when persistence

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
@@ -902,8 +902,9 @@ public class CacheHashMap extends BackedHashMap {
             }
         } catch (Exception ex) {
             FFDCFilter.processException(ex, "com.ibm.ws.session.store.cache.CacheHashMap.overQualLastAccessTimeUpdate", "859", this, new Object[] { sess });
-            Tr.error(tc, "ERROR_CACHE_ACCESS", ex);
-            throw new RuntimeException(Tr.formatMessage(tc, "INTERNAL_SERVER_ERROR"));
+            Tr.error(tc, "ERROR_CACHE_ACCESS", id);
+            Tr.error(tc, "INTERNAL_SERVER_ERROR", ex);
+            // throw new RuntimeException(Tr.formatMessage(tc, "INTERNAL_SERVER_ERROR"));
         }
 
         return updateCount;

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
@@ -904,6 +904,7 @@ public class CacheHashMap extends BackedHashMap {
             FFDCFilter.processException(ex, "com.ibm.ws.session.store.cache.CacheHashMap.overQualLastAccessTimeUpdate", "859", this, new Object[] { sess });
             Tr.error(tc, "ERROR_CACHE_ACCESS", id);
             Tr.error(tc, "INTERNAL_SERVER_ERROR", ex);
+            updateCount = 0;
             // throw new RuntimeException(Tr.formatMessage(tc, "INTERNAL_SERVER_ERROR"));
         }
 


### PR DESCRIPTION
When JCache persistence stopped, request will log internal server error instead of return HTTP 500.