### PR TITLE
19911 - make getClassloader private

### DIFF
--- a/dev/io.openliberty.cdi.4.0.internal.weld/src/com/ibm/ws/cdi/proxy/ProxyServicesImpl.java
+++ b/dev/io.openliberty.cdi.4.0.internal.weld/src/com/ibm/ws/cdi/proxy/ProxyServicesImpl.java
@@ -90,9 +90,7 @@ public class ProxyServicesImpl implements ProxyServices {
         // This implementation requires no cleanup
     }
 
-    //TODO: this method was removed from the Weld 5 API - https://github.com/OpenLiberty/open-liberty/issues/19911
-    //@Override
-    public ClassLoader getClassLoader(final Class<?> proxiedBeanType) {
+    private ClassLoader getClassLoader(final Class<?> proxiedBeanType) {
         return AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
             @Override
             public ClassLoader run() {


### PR DESCRIPTION
This method was removed from the interface in EE10 but is still used by an method that remains in the interface

Part of #19911