### PR TITLE
Fix security EE10 repeat rules

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/actions/SecurityTestFeatureEE10RepeatAction.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/actions/SecurityTestFeatureEE10RepeatAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,15 +30,18 @@ public class SecurityTestFeatureEE10RepeatAction extends JakartaEE10Action {
 
     public SecurityTestFeatureEE10RepeatAction() {
 
+        super();
         complexId = JakartaEE10Action.ID;
         Log.info(thisClass, "instance", complexId);
         testRunMode = TestModeFilter.FRAMEWORK_TEST_MODE;
         notAllowedOnWindows = false;
         withID(complexId);
+
     }
 
     public SecurityTestFeatureEE10RepeatAction(String inNameExtension) {
 
+        super();
         complexId = JakartaEE10Action.ID + "_" + inNameExtension;
         Log.info(thisClass, "instance", complexId);
         testRunMode = TestModeFilter.FRAMEWORK_TEST_MODE;
@@ -53,6 +56,7 @@ public class SecurityTestFeatureEE10RepeatAction extends JakartaEE10Action {
 
     @Override
     public boolean isEnabled() {
+
         Log.info(thisClass, "isEnabled", "testRunMode: " + testRunMode);
         Log.info(thisClass, "isEnabled", "complexId: " + complexId);
         Log.info(thisClass, "isEnabled", "Overall test mode: " + TestModeFilter.FRAMEWORK_TEST_MODE);
@@ -62,6 +66,13 @@ public class SecurityTestFeatureEE10RepeatAction extends JakartaEE10Action {
                     " is not valid for current mode " + TestModeFilter.FRAMEWORK_TEST_MODE);
             return false;
         }
+
+        // preform standard checks
+        if (!super.isEnabled()) {
+            return false;
+        }
+
+        // Some Security projects restrict some tests from running in certain modes on windows
         OperatingSystem currentOS = null;
         try {
             currentOS = Machine.getLocalMachine().getOperatingSystem();
@@ -73,7 +84,6 @@ public class SecurityTestFeatureEE10RepeatAction extends JakartaEE10Action {
             Log.info(thisClass, "isEnabled", "Skipping action '" + toString() + "' because the tests are disabled on Windows");
             return false;
         }
-
         return true;
     }
 

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/actions/SecurityTestFeatureEE9RepeatAction.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/actions/SecurityTestFeatureEE9RepeatAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,15 +30,18 @@ public class SecurityTestFeatureEE9RepeatAction extends JakartaEE9Action {
 
     public SecurityTestFeatureEE9RepeatAction() {
 
+        super();
         complexId = JakartaEE9Action.ID;
         Log.info(thisClass, "instance", complexId);
         testRunMode = TestModeFilter.FRAMEWORK_TEST_MODE;
         notAllowedOnWindows = false;
         withID(complexId);
+
     }
 
     public SecurityTestFeatureEE9RepeatAction(String inNameExtension) {
 
+        super();
         complexId = JakartaEE9Action.ID + "_" + inNameExtension;
         Log.info(thisClass, "instance", complexId);
         testRunMode = TestModeFilter.FRAMEWORK_TEST_MODE;
@@ -53,6 +56,7 @@ public class SecurityTestFeatureEE9RepeatAction extends JakartaEE9Action {
 
     @Override
     public boolean isEnabled() {
+
         Log.info(thisClass, "isEnabled", "testRunMode: " + testRunMode);
         Log.info(thisClass, "isEnabled", "complexId: " + complexId);
         Log.info(thisClass, "isEnabled", "Overall test mode: " + TestModeFilter.FRAMEWORK_TEST_MODE);
@@ -62,6 +66,13 @@ public class SecurityTestFeatureEE9RepeatAction extends JakartaEE9Action {
                     " is not valid for current mode " + TestModeFilter.FRAMEWORK_TEST_MODE);
             return false;
         }
+
+        // preform standard checks
+        if (!super.isEnabled()) {
+            return false;
+        }
+
+        // Some Security projects restrict some tests from running in certain modes on windows
         OperatingSystem currentOS = null;
         try {
             currentOS = Machine.getLocalMachine().getOperatingSystem();

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/publish/files/serversettings/samlTestApplication.xml
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/publish/files/serversettings/samlTestApplication.xml
@@ -1,6 +1,6 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,4 +30,8 @@
 			</security-role>
 		</application-bnd>
 	</application>
+	
+	<javaPermission className="java.util.PropertyPermission" actions="read" name="*"/>
+	<javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+	
 </server>    

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureReplacementAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -294,6 +294,10 @@ public class FeatureReplacementAction implements RepeatTestAction {
     public FeatureReplacementAction withMinJavaLevel(int javaLevel) {
         this.minJavaLevel = javaLevel;
         return this;
+    }
+
+    public int getMinJavaLevel() {
+        return this.minJavaLevel;
     }
 
     public FeatureReplacementAction fullFATOnly() {


### PR DESCRIPTION
Update Security EE10 Repeat tooling.  Use the base EE10 repeat tooling (which will skip running with Java 8) - keep the security specific checks.
Update the Security EE9 Repeat tooling to use the base EE9 tooling and keep the security specific checks.