### PR TITLE
Synchronized session attribute update method for JCache

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
@@ -454,6 +454,7 @@ public class CacheHashMap extends BackedHashMap {
 
                             FFDCFilter.processException(x, getClass().getName(), "91", sess,
                                                         new Object[] { hideValues ? "byte[" + b.length + "]" : TypeConversion.limitedBytesToString(b) });
+                            Tr.error(tc, "sessionAttributeCache attributeKey = ", attributeKey);
                             throw x;
                         }
                         if (value != null) {
@@ -503,6 +504,7 @@ public class CacheHashMap extends BackedHashMap {
 
             // we are not synchronized here - were not in old code either
             Hashtable tht = null;
+            synchronized (session) {
             if (_smc.writeAllProperties()) {
                 Map<?, ?> ht = session.getSwappableData();
                 propsToWrite = (Set<String>) ht.keySet();
@@ -583,7 +585,8 @@ public class CacheHashMap extends BackedHashMap {
                     }
                 }
             }
-
+            }
+            
             // see if any properties were REMOVED.
             // if so, process them
 


### PR DESCRIPTION
JCache session values being added to sessionAttributeCache is CacheHashMap.handlePropertyHits().  This method doesn't appear to be thread safe. It can lead to OptionalDataException when the returned byte array is being deserialized.