### PR TITLE
Ensure that a valid repeat is used for all Java versions

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/actions/LargeProjectRepeatActions.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/actions/LargeProjectRepeatActions.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.fat.common.actions;
+
+import com.ibm.websphere.simplicity.Machine;
+import com.ibm.websphere.simplicity.OperatingSystem;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.custom.junit.runner.TestModeFilter;
+import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.JakartaEE10Action;
+import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.JavaInfo;
+
+public class LargeProjectRepeatActions {
+
+    public static Class<?> thisClass = LargeProjectRepeatActions.class;
+
+    /**
+     * Create repeats for large security projects.
+     * On Windows, always run the default/empty/EE7/EE8 tests.
+     * On other Platforms:
+     * - if Java 8, run default/empty/EE7/EE8 tests.
+     * - All other Java versions
+     * -- If LITE mode, run EE9
+     * -- If FULL mode, run EE10
+     *
+     * @return repeat test instances
+     */
+    public static RepeatTests createEE9OrEE10Repeats() {
+
+        RepeatTests rTests = null;
+
+        OperatingSystem currentOS = null;
+        try {
+            currentOS = Machine.getLocalMachine().getOperatingSystem();
+        } catch (Exception e) {
+            Log.info(thisClass, "createLargeProjectRepeats", "Encountered and exception trying to determine OS type - assume we'll need to run: " + e.getMessage());
+        }
+        Log.info(thisClass, "createLargeProjectRepeats", "OS: " + currentOS.toString());
+
+        if (OperatingSystem.WINDOWS == currentOS) {
+            Log.info(thisClass, "createLargeProjectRepeats", "Enabling the default EE7/EE8 test instance since we're running on Windows");
+            rTests = addRepeat(rTests, new EmptyAction());
+        } else {
+            if (JavaInfo.forCurrentVM().majorVersion() > 8) {
+                if (TestModeFilter.FRAMEWORK_TEST_MODE == TestMode.LITE) {
+                    Log.info(thisClass, "createLargeProjectRepeats", "Enabling the EE9 test instance (Not on Windows, Java > 8, Lite Mode)");
+                    rTests = addRepeat(rTests, new JakartaEE9Action());
+                } else {
+                    Log.info(thisClass, "createLargeProjectRepeats", "Enabling the EE10 test instance (Not on Windows, Java > 8, FULL Mode)");
+                    rTests = addRepeat(rTests, new JakartaEE10Action());
+                }
+            } else {
+                Log.info(thisClass, "createLargeProjectRepeats", "Enabling the default EE7/EE8 test instance (Not on Windows, Java = 8, any Mode)");
+                rTests = addRepeat(rTests, new EmptyAction());
+            }
+        }
+
+        return rTests;
+    }
+
+    // We can add other methods for different complex rules
+
+    public static RepeatTests addRepeat(RepeatTests rTests, RepeatTestAction currentRepeat) {
+        if (rTests == null) {
+            return RepeatTests.with(currentRepeat);
+        } else {
+            return rTests.andWith(currentRepeat);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/FATSuite.java
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.security.fat.common.actions.LargeProjectRepeatActions;
 import com.ibm.ws.security.fat.common.utils.ldaputils.CommonLocalLDAPServerSuite;
 import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientBasicTests;
 import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientConsentTests;
@@ -30,8 +31,6 @@ import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientDiscoveryJVMPr
 import com.ibm.ws.security.openidconnect.client.fat.IBM.OidcClientDiscoveryJWTBasicTests;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
-import componenttest.rules.repeater.EmptyAction;
-import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
@@ -57,11 +56,15 @@ import componenttest.rules.repeater.RepeatTests;
  */
 public class FATSuite extends CommonLocalLDAPServerSuite {
     /*
-     * Run EE10 tests in only FULL mode and run EE7/EE8 tests only in LITE mode.
+     * On Windows, always run the default/empty/EE7/EE8 tests.
+     * On other Platforms:
+     * - if Java 8, run default/empty/EE7/EE8 tests.
+     * - All other Java versions
+     * -- If LITE mode, run EE9
+     * -- If FULL mode, run EE10
      *
-     * This was done to increase coverage of EE10 while not adding a large amount of test runtime.
      */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
-            .andWith(new JakartaEE10Action().fullFATOnly());
+    public static RepeatTests repeat = LargeProjectRepeatActions.createEE9OrEE10Repeats();
+
 }


### PR DESCRIPTION
The current repeat rules:
    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
            .andWith(new JakartaEE10Action().fullFATOnly());
            
EE10 requires Java11 or above, so, when we run with Java 8 in full mode, we end up running no tests, I'm updating the repeat to:

    public static RepeatTests repeat = LargeProjectRepeatActions.createEE9OrEE10Repeats();   

This results in
     * On Windows, always run the default/empty/EE7/EE8 tests.
     * On other Platforms:
     * - if Java 8, run default/empty/EE7/EE8 tests.
     * - All other Java versions
     * -- If LITE mode, run EE9
     * -- If FULL mode, run EE10
