### PR TITLE
Update SAML fat repeat rules to reduce runtime

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/actions/LargeProjectRepeatActions.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/actions/LargeProjectRepeatActions.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.fat.common.actions;
+
+import com.ibm.websphere.simplicity.Machine;
+import com.ibm.websphere.simplicity.OperatingSystem;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.custom.junit.runner.TestModeFilter;
+import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.JakartaEE10Action;
+import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.JavaInfo;
+
+public class LargeProjectRepeatActions {
+
+    public static Class<?> thisClass = LargeProjectRepeatActions.class;
+
+    /**
+     * Create repeats for large security projects.
+     * On Windows, always run the default/empty/EE7/EE8 tests.
+     * On other Platforms:
+     * - if Java 8, run default/empty/EE7/EE8 tests.
+     * - All other Java versions
+     * -- If LITE mode, run EE9
+     * -- If FULL mode, run EE10
+     *
+     * @return repeat test instances
+     */
+    public static RepeatTests createEE9OrEE10Repeats() {
+
+        RepeatTests rTests = null;
+
+        OperatingSystem currentOS = null;
+        try {
+            currentOS = Machine.getLocalMachine().getOperatingSystem();
+        } catch (Exception e) {
+            Log.info(thisClass, "createLargeProjectRepeats", "Encountered and exception trying to determine OS type - assume we'll need to run: " + e.getMessage());
+        }
+        Log.info(thisClass, "createLargeProjectRepeats", "OS: " + currentOS.toString());
+
+        if (OperatingSystem.WINDOWS == currentOS) {
+            Log.info(thisClass, "createLargeProjectRepeats", "Enabling the default EE7/EE8 test instance since we're running on Windows");
+            rTests = addRepeat(rTests, new EmptyAction());
+        } else {
+            if (JavaInfo.forCurrentVM().majorVersion() > 8) {
+                if (TestModeFilter.FRAMEWORK_TEST_MODE == TestMode.LITE) {
+                    Log.info(thisClass, "createLargeProjectRepeats", "Enabling the EE9 test instance (Not on Windows, Java > 8, Lite Mode)");
+                    rTests = addRepeat(rTests, new JakartaEE9Action());
+                } else {
+                    Log.info(thisClass, "createLargeProjectRepeats", "Enabling the EE10 test instance (Not on Windows, Java > 8, FULL Mode)");
+                    rTests = addRepeat(rTests, new JakartaEE10Action());
+                }
+            } else {
+                Log.info(thisClass, "createLargeProjectRepeats", "Enabling the default EE7/EE8 test instance (Not on Windows, Java = 8, any Mode)");
+                rTests = addRepeat(rTests, new EmptyAction());
+            }
+        }
+
+        return rTests;
+    }
+
+    // We can add other methods for different complex rules
+
+    public static RepeatTests addRepeat(RepeatTests rTests, RepeatTestAction currentRepeat) {
+        if (rTests == null) {
+            return RepeatTests.with(currentRepeat);
+        } else {
+            return rTests.andWith(currentRepeat);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,14 +16,11 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
-import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
+import com.ibm.ws.security.fat.common.actions.LargeProjectRepeatActions;
 import com.ibm.ws.security.saml.fat.IDPInitiated.BasicIDPInitiatedTests;
 import com.ibm.ws.security.saml.fat.SPInitiated.BasicSolicitedSPInitiatedTests;
 import com.ibm.ws.security.saml.fat.SPInitiated.BasicUnsolicitedSPInitiatedTests;
 
-import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
@@ -36,13 +33,16 @@ import componenttest.rules.repeater.RepeatTests;
 })
 public class FATSuite {
     /*
-     * Run EE9 tests in LITE mode and run all tests in FULL mode.
+     * On Windows, always run the default/empty/EE7/EE8 tests.
+     * On other Platforms:
+     * - if Java 8, run default/empty/EE7/EE8 tests.
+     * - All other Java versions
+     * -- If LITE mode, run EE9
+     * -- If FULL mode, run EE10
+     *
      */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
-                    .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-                    .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly())
-                    .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().fullFATOnly());
+    public static RepeatTests repeat = LargeProjectRepeatActions.createEE9OrEE10Repeats();
 
     @BeforeClass
     public static void setup() throws Exception {


### PR DESCRIPTION
The SAML Fat project, com.ibm.ws.security.saml.sso_fat, is taking too long to run now that it runs a repeat for both EE9 and EE10.  I'm updating the rules to run:
On Windows, always run the default/empty/EE7/EE8 tests.
 On other Platforms:
 - if Java 8, run default/empty/EE7/EE8 tests.
 - All other Java versions
 -- If LITE mode, run EE9
 -- If FULL mode, run EE10