### PR TITLE
Add compilePersonalRTC.properties

### DIFF
--- a/.ci-orchestrator/compile.properties
+++ b/.ci-orchestrator/compile.properties
@@ -27,7 +27,7 @@ fat.test.local.ldap.server=true
 # This is the base snapshot name compared by the fix list application
 fixlist.lastGMsnapshotName=85 Stabilization Release Build - Liberty_cl50520150305-2202
 # The server used to download git repository baseline
-git.clone.download.server=libfsfe06.hursley.ibm.com
+git.clone.download.server=libfsfe04.hursley.ibm.com
 # SSH URL of the git repository to clone - typically a fork of open-liberty (e.g. git@github.com:username/open-liberty.git).
 git.laos.clone.repository.sshUrl=git@github.com:${git.laos.clone.repository.username}/open-liberty.git
 # Your username or "OpenLiberty"
@@ -37,10 +37,10 @@ git.clone.checkout.branch=release
 git.launcher.clone.sshUrl=git@github.ibm.com:${git.launcher.clone.username}/rtc-build-launcher.git
 git.launcher.clone.username=websphere
 # OVERRIDE while libertyfs is down.  Remove libertyfs. from property name when libertyfs is working correctly.
-gsa.server=libfsfe06.hursley.ibm.com
+gsa.server=libfsfe04.hursley.ibm.com
 gsaUpload=true
 ignoreBuildStatusForAsyncLaunch=true
-image.gsa.server=libfsfe06.hursley.ibm.com
+image.gsa.server=libfsfe04.hursley.ibm.com
 liberty.fs.management=true
 nagios.monitoring=true
 # A hack to force 32-bit JVM. The EBC JBEs launch with 64-bit JREs, but some parts of our infrastructure, such as "will chkpii run ok" detection and jshint, work much better with 32-bit JVMs.

--- a/.ci-orchestrator/compile.properties
+++ b/.ci-orchestrator/compile.properties
@@ -1,3 +1,5 @@
+# Properties that are common and used by personal, release, continuous and platform builds.
+
 allowed.failing.suites=
 async.thread.count=3
 async.thread.count.for.bluemix=1

--- a/.ci-orchestrator/compilePersonal.properties
+++ b/.ci-orchestrator/compilePersonal.properties
@@ -25,7 +25,7 @@ fat.buckets.to.run=auto
 # Do not change, if you need to run full fat buckets please use the spawn.fullfat.buckets property instead
 fat.test.mode=lite
 ghe.build.type=CI Orchestrator Personal
-# Branch checked out before build launch (e.g. username/new.feature). Or "release" if you want
+# Branch checked out before build launch (e.g. username/new.feature), or "release".
 git.laos.clone.checkout.branch=${github_pr_branch}
 # Your username or "websphere"
 git.laos.clone.repository.username=${github_pr_user}

--- a/.ci-orchestrator/compilePersonal.properties
+++ b/.ci-orchestrator/compilePersonal.properties
@@ -1,3 +1,5 @@
+# Properties that are used by personal builds.
+
 # Whether the build should tolerate building with only some projects from the workspace loaded.
 allow.load.profiles=true
 # (Space-separated list) Any failures in the listed buckets will not cause the build to be red. Change history:

--- a/.ci-orchestrator/compilePersonal.properties
+++ b/.ci-orchestrator/compilePersonal.properties
@@ -6,7 +6,7 @@ allow.load.profiles=true
 async.target.name=Liberty Personal Async Tests - EBC
 async.thread.count.for.full=13
 # Prefix the build label with your username to find it easier
-buildLabelPrefix=${git.laos.clone.repository.username}-${github_pr_number}
+buildLabelPrefix=${git.laos.clone.repository.username}-${github_pr_number}-
 cognitive_auto_resolve_hung_builds=abandon
 # Setting create.im.repo to true will implicitly turn spawn.zos to true
 create.im.repo=false

--- a/.ci-orchestrator/compilePersonalRTC.properties
+++ b/.ci-orchestrator/compilePersonalRTC.properties
@@ -62,7 +62,7 @@ git.clone.update=true
 # Do not set this property.
 git.commit.sha=
 # The server used to download git repository baseline
-git.clone.download.server=libfsfe06.hursley.ibm.com
+git.clone.download.server=libfsfe04.hursley.ibm.com
 # Branch checked out before build launch (e.g. username/new.feature), or "release".
 git.laos.clone.checkout.branch=${github_pr_branch}
 # Your username or "OpenLiberty"
@@ -78,14 +78,14 @@ git.launcher.clone.username=websphere
 git.pr.number=${github_pr_number}
 # OVERRIDE while libertyfs is down.  Remove libertyfs. from property name when libertyfs is working correctly.
 gsa.base.dir=/liberty/personal/1
-gsa.server=libfsfe06.hursley.ibm.com
+gsa.server=libfsfe04.hursley.ibm.com
 gsaUpload=true
 # OVERRIDE while libertyfs is down.  Add hurgsa. to the start of the property name to disable this when libertyfs is back to working correctly.
 hurgsa.gsa.base.dir=/projects/a/aries.misc/builds/personal_builds/4
 # OVERRIDE while libertyfs is down.  Add hurgsa. to the start of the property name to disable this when libertyfs is working correctly.
 hurgsa.gsa.server=hurgsa.ibm.com
 ignoreBuildStatusForAsyncLaunch=true
-image.gsa.server=libfsfe06.hursley.ibm.com
+image.gsa.server=libfsfe04.hursley.ibm.com
 j8.target.name=Liberty - Java 8
 # PROD: 20170822-1355-LibertyProd
 # DEBUG: DebugSnapshot-AllLatest-NonProduction

--- a/.ci-orchestrator/compilePersonalRTC.properties
+++ b/.ci-orchestrator/compilePersonalRTC.properties
@@ -119,9 +119,9 @@ run.mvt=true
 run.packaging.verification=true
 run.unittest.async=false
 # When true, disables building Open Liberty from source if the branch is release and this is a Personal or Continuous type build.
-skip.open.liberty.build.if.possible=true
+skip.open.liberty.build.if.possible=false
 # If the Open Liberty build is being skipped (see skip.open.liberty.build.if.possible property), set this true to also skip executing the Open Liberty FATs.  Otherwise, if this is false the Open Liberty FATs will still be executed.
-skip.open.liberty.fats.if.possible=true
+skip.open.liberty.fats.if.possible=false
 soe.report.results=true
 soe.reporting.build.type=Personal
 soe.reporting.install.type=Archive

--- a/.ci-orchestrator/compilePersonalRTC.properties
+++ b/.ci-orchestrator/compilePersonalRTC.properties
@@ -1,3 +1,5 @@
+# Properties used by the personal builds that run the original RTC build.
+
 # Whether the build should tolerate building with only some projects from the workspace loaded.
 allow.load.profiles=true
 # (Space-separated list) Any failures in the listed buckets will not cause the build to be red. Change history:

--- a/.ci-orchestrator/compilePersonalRTC.properties
+++ b/.ci-orchestrator/compilePersonalRTC.properties
@@ -1,0 +1,145 @@
+# Whether the build should tolerate building with only some projects from the workspace loaded.
+allow.load.profiles=true
+# (Space-separated list) Any failures in the listed buckets will not cause the build to be red. Change history:
+# 9th Apr=TE - Removed com.ibm.ws.logstash.collector_fat to see if it works better on Java 11
+# 25th April Added com.ibm.ws.install.jdk_fat due to ubuntu16 issue (Defect 262266)
+allowed.failing.suites=
+async.target.name=Liberty Personal Async Tests - EBC
+async.thread.count=3
+async.thread.count.for.bluemix=1
+async.thread.count.for.extended=1
+async.thread.count.for.full=13
+async.thread.count.for.nd=1
+# specify a non-standard build target
+build.stub.target=build.CachedWSCD.Combined
+# Prefix the build label with your username to find it easier
+buildLabelPrefix=${git.laos.clone.repository.username}-${github_pr_number}
+cognitive_auto_resolve_hung_builds=abandon
+# Remove the '.disabled' suffix to re-enable autofvt.zip creation
+create.autofvt.zip.disabled=true
+data.collection.commits.url=http://kerrigan.hursley.ibm.com:9093/analytics_dataCollection/changesetToDB/commit
+delete.fat.buckets=true
+# Delete output/results after FAT has run
+delete.run.fats=true
+delete.tests.from.GSA=true
+dhe.server=w3-transfer.boulder.ibm.com
+disable.run.buildSamples=true
+disable.run.createDocumentation=true
+disable.run.packagePII=false
+disable.run.runBvtTests=false
+disable.run.runUnitTests=false
+ebc.env.blueprint="[RTC][UBUNTU16.04][X86][Docker][Git+LibertyVolume]"
+ebc.env.groups=X86Cloud
+ebc.env.order=LIBERTY-ISOLATED-CLOUD-PROD-HDC,LIBERTY-ISOLATED-CLOUD-BACKUP-HDC,UCDFOREBC02
+# Normally 100. Used internally by the EBC to adjust the order builds are queued in.
+ebc.priority=100
+ebc.shortlist=parentbuild-personal.yml
+# Marvin will mail the requestor with his analysis of the build.
+enable.predelivery.checking=true
+extra.ant.options=-Dcom.ibm.team.repository.common.transport.TeamServerConfiguration.socketTimeout=3600000 -Dcom.ibm.team.repository.common.transport.TeamServerConfiguration.connectTimeout=1800000 -Dteam.build.retry=true
+fail.gradle.on.error=false
+# Simple ant exclude pattern, takes only a single value
+fat.buckets.to.exclude=
+# all, auto, none, or a comma-separated list of FAT project names.
+fat.buckets.to.run=auto
+fat.run.count=1
+fat.test.local.ldap.server=true
+# If you need to run full fat buckets please use the spawn.fullfat.buckets property instead. If needing to run FATs on SOE builds in full mode, then maybe change this--but I can't be certain (Wendy).
+fat.test.mode=lite
+# This is the base snapshot name compared by the fix list application
+fixlist.lastGMsnapshotName=85 Stabilization Release Build - Liberty_cl50520150305-2202
+ghe.build.type=Personal
+# Branch checked out before build launch (e.g. username/new.feature), or "release".
+git.clone.checkout.branch=release
+# Your username or "websphere"
+git.clone.repository.username=websphere
+# SSH URL of the git repository to clone - typically a fork of WS-CD-Open (e.g. git@github.ibm.com:username/WS-CD-Open.git).
+git.clone.repository.sshUrl=git@github.ibm.com:${git.clone.repository.username}/WS-CD-Open.git
+# Set to "true" if you wish to have your branch under test automatically merged with the latest master from the default repo. Default being WS-CD-Open for git.clone.update and open-liberty for git.laos.clone.update. Look in the build Activities tab to see how the branch is updated, where the SHA of your branch, latest master, and resulting merge are displayed. A resulting merge branch unique from both your branch SHA and the SHA of master means there was a successful merge of your older branch with the newer master branch.
+git.clone.update=true
+# Do not set this property.
+git.commit.sha=
+# The server used to download git repository baseline
+git.clone.download.server=libfsfe06.hursley.ibm.com
+# Branch checked out before build launch (e.g. username/new.feature), or "release".
+git.laos.clone.checkout.branch=${github_pr_branch}
+# Your username or "OpenLiberty"
+git.laos.clone.repository.username=${github_pr_user}
+# SSH URL of the git repository to clone - typically a fork of open-liberty (e.g. git@github.ibm.com:username/open-liberty.git).
+git.laos.clone.repository.sshUrl=git@github.com:${git.laos.clone.repository.username}/open-liberty.git
+# Set to "true" if you wish to have your branch under test automatically merged with the latest master from the default repo. Default being WS-CD-Open for git.clone.update and open-liberty for git.laos.clone.update. Look in the build Activities tab to see how the branch is updated, where the SHA of your branch, latest master, and resulting merge are displayed. A resulting merge branch unique from both your branch SHA and the SHA of master means there was a successful merge of your older branch with the newer master branch.
+git.laos.clone.update=true
+git.launcher.clone.branch=release
+git.launcher.clone.sshUrl=git@github.ibm.com:${git.launcher.clone.username}/rtc-build-launcher.git
+git.launcher.clone.username=websphere
+# Do not set this property. The pull request that triggered the build.
+git.pr.number=${github_pr_number}
+# OVERRIDE while libertyfs is down.  Remove libertyfs. from property name when libertyfs is working correctly.
+gsa.base.dir=/liberty/personal/1
+gsa.server=libfsfe06.hursley.ibm.com
+gsaUpload=true
+# OVERRIDE while libertyfs is down.  Add hurgsa. to the start of the property name to disable this when libertyfs is back to working correctly.
+hurgsa.gsa.base.dir=/projects/a/aries.misc/builds/personal_builds/4
+# OVERRIDE while libertyfs is down.  Add hurgsa. to the start of the property name to disable this when libertyfs is working correctly.
+hurgsa.gsa.server=hurgsa.ibm.com
+ignoreBuildStatusForAsyncLaunch=true
+image.gsa.server=libfsfe06.hursley.ibm.com
+j8.target.name=Liberty - Java 8
+# PROD: 20170822-1355-LibertyProd
+# DEBUG: DebugSnapshot-AllLatest-NonProduction
+LBS.deploy.snapshot=20170822-1355-LibertyProd
+liberty.fs.management=true
+nagios.monitoring=true
+# A hack to force 32-bit JVM. The EBC JBEs launch with 64-bit JREs, but some parts of our infrastructure, such as "will chkpii run ok" detection and jshint, work much better with 32-bit JVMs.
+os.arch=x86
+# The definition name for the packaging verification build.
+packaging.verification.build.name=Liberty Packaging Verification Build - NEW EBC
+# Whether the build should collect nmon data
+perf.nmon=true
+personal.async.target.name=Liberty Async Tests - EBC
+published.package.personal=personal
+# Report OS and JVM used for running tests
+report.testing.platform=true
+run.chkpii=true
+# Create zipped image
+run.createImage=true
+# create plugin for IBM workload deployer
+run.createIwdImage=true
+run.createSLE=false
+# If true, run FAT in async build
+run.fat.async=true
+# Run findbugs target
+run.findbugs=false
+# Whether or not kick off the fix list application
+run.fixlist=false
+run.jshint=false
+# If true run the media verification tests
+run.mvt=true
+# If true, run the async packaging verification build to check for install file changes.
+run.packaging.verification=true
+run.unittest.async=false
+# When true, disables building Open Liberty from source if the branch is release and this is a Personal or Continuous type build.
+skip.open.liberty.build.if.possible=true
+# If the Open Liberty build is being skipped (see skip.open.liberty.build.if.possible property), set this true to also skip executing the Open Liberty FATs.  Otherwise, if this is false the Open Liberty FATs will still be executed.
+skip.open.liberty.fats.if.possible=true
+soe.report.results=true
+soe.reporting.build.type=Personal
+soe.reporting.install.type=Archive
+soe.reporting.jdk=Personal
+soe.reporting.os=Personal
+soe.reporting.publish=false
+soe.reporting.release.version=9.0.0.0
+soe.reporting.topology=Standalone
+soe.target.stream=Liberty
+# Comma-separated list of FAT project names. Any FAT buckets listed here will be spawned in full mode, and also in normal mode (which is a good thing).
+spawn.fullfat.buckets=
+# If true, will build and test z-specific parts of Liberty. If you do set this, make sure there are no spaces in your workspace name! Under normal circumstances, there should be no need to set this to be true.
+spawn.zos=false
+test.coverage=false
+# Set to true to force all bvt and fat logs to be uploaded even if tests pass.
+upload.all.test.logs=false
+use.libertyfs.jvm.cache=true
+wait.for.async=true
+zos.aggregator.target.name=Liberty z/OS Test Build NEW EBC
+# The name of the z/OS build definition to use.
+zos.target.name=Liberty z/OS Packaging Build EBC

--- a/.ci-orchestrator/compilePersonalRTC.properties
+++ b/.ci-orchestrator/compilePersonalRTC.properties
@@ -13,7 +13,7 @@ async.thread.count.for.nd=1
 # specify a non-standard build target
 build.stub.target=build.CachedWSCD.Combined
 # Prefix the build label with your username to find it easier
-buildLabelPrefix=${git.laos.clone.repository.username}-${github_pr_number}
+buildLabelPrefix=${git.laos.clone.repository.username}-${github_pr_number}-
 cognitive_auto_resolve_hung_builds=abandon
 # Remove the '.disabled' suffix to re-enable autofvt.zip creation
 create.autofvt.zip.disabled=true

--- a/.ci-orchestrator/personalbuild.yml
+++ b/.ci-orchestrator/personalbuild.yml
@@ -116,7 +116,8 @@ steps:
     fat.test.mode: lite
     fats_to_omit: "com.ibm.ws.collective.controller.deploy_fat, com.ibm.ws.health.manager.odrlib_fat, com.ibm.ws.dynamic.routing_ihs_fat, com.ibm.ws.node.scaling_fat, com.ibm.ws.scaling.member_fat_multinode, com.ibm.ws.node.health_fat"
     fat_uploads_to_expect: ${compile:fat_uploads_to_expect}
-    outputServer: libertyfs.hursley.ibm.com
+    fileserver: libfsfe04.hursley.ibm.com
+    outputServer: libfsfe04.hursley.ibm.com
     outputPath: /liberty/personal/2/ciorchestrator
     command: ant -f build-test.xml localrun -propertyfile ../../../buildandbucket.properties -DhaltOnFailure=false -lib ../ant_build/lib.antClasspath
     aggregationId: ${compile:execution_id}

--- a/.ci-orchestrator/personalbuild.yml
+++ b/.ci-orchestrator/personalbuild.yml
@@ -1,5 +1,5 @@
 type: pipeline_definition
-product: OpenLiberty
+product: Liberty
 name: OpenLiberty Personal Build
 description: A build run against OpenLiberty Pull Requests
 triggers:

--- a/.ci-orchestrator/personalbuild.yml
+++ b/.ci-orchestrator/personalbuild.yml
@@ -26,6 +26,10 @@ triggers:
     defaultValue: true
     steps:
     - stepName: compile
+  - name: spawn.fullfat.buckets
+    defaultValue: ""
+    steps:
+    - stepName: pr-changes
 
 steps:
 - stepName: pr-changes
@@ -56,6 +60,7 @@ steps:
     disable.run.createDoc: ${pr-changes:disable.run.createDoc}
     skip.open.liberty.build.if.possible: ${pr-changes:skip.open.liberty.build.if.possible}
     skip.open.liberty.fats.if.possible: ${pr-changes:skip.open.liberty.fats.if.possible}
+    spawn.fullfat.buckets: ${pr-changes:spawn.fullfat.buckets}
   includeProperties:
   - file: compilePersonal.properties
   - file: compile.properties

--- a/.ci-orchestrator/rtcbuild.yml
+++ b/.ci-orchestrator/rtcbuild.yml
@@ -1,5 +1,5 @@
 type: pipeline_definition
-product: OpenLiberty
+product: Liberty
 name: OpenLiberty Personal Build RTC
 description: A build run against OpenLiberty Pull Requests
 triggers:

--- a/.ci-orchestrator/rtcbuild.yml
+++ b/.ci-orchestrator/rtcbuild.yml
@@ -31,6 +31,10 @@ triggers:
     defaultValue: true
     steps:
     - stepName: compile
+  - name: spawn.fullfat.buckets
+    defaultValue: ""
+    steps:
+    - stepName: pr-changes
   - name: fat.buckets.to.run
     defaultValue: all
     steps:
@@ -64,5 +68,7 @@ steps:
     disable.run.createDoc: ${pr-changes:disable.run.createDoc}
     skip.open.liberty.build.if.possible: ${pr-changes:skip.open.liberty.build.if.possible}
     skip.open.liberty.fats.if.possible: ${pr-changes:skip.open.liberty.fats.if.possible}
+    fat.run.count: ${pr-changes:fat.run.count}
+    spawn.fullfat.buckets: ${pr-changes:spawn.fullfat.buckets}
   includeProperties:
   - file: compilePersonalRTC.properties


### PR DESCRIPTION
- Add compilePersonalRTC.properties is used by personal builds launched in RTC and is imported by `.ci-orchestrator/rtcbuild.yml`.

The repository uses these existing properties files:
- compilePersonal.properties is used by personal builds launched via CI Orchestrator and is imported by `.ci-orchestrator/personalbuild.yml`.
- compile.properties is for common properties and is used by all builds launched via CI Orchestrator.