### PR TITLE
Add support for @Before @After to FatServlet

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/BasicSseApp/src/jaxrs21sse/basic/BasicSseTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/BasicSseApp/src/jaxrs21sse/basic/BasicSseTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,7 @@ package jaxrs21sse.basic;
 import static jaxrs21sse.basic.JaxbObject.JAXB_OBJECTS;
 import static jaxrs21sse.basic.JsonObject.JSON_OBJECTS;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -56,7 +56,7 @@ public class BasicSseTestServlet extends FATServlet {
                     msg += failure + "\n";
                 }
             }
-            assertNotNull("Detected failures in the SSE resource: " + msg, msg);
+            assertNull("Detected failures in the SSE resource: " + msg, msg);
         } finally {
             resourceFailures.clear();
         }

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/DelaySseApp/src/jaxrs21sse/delay/DelaySseTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/DelaySseApp/src/jaxrs21sse/delay/DelaySseTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,7 @@
 package jaxrs21sse.delay;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -49,7 +49,7 @@ public class DelaySseTestServlet extends FATServlet {
                     msg += failure + "\n";
                 }
             }
-            assertNotNull("Detected failures in the SSE resource: " + msg, msg);
+            assertNull("Detected failures in the SSE resource: " + msg, msg);
         } finally {
             resourceFailures.clear();
         }

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/SseClientBehaviorApp/src/jaxrs21sse/clientbehavior/SseClientBehaviorTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/SseClientBehaviorApp/src/jaxrs21sse/clientbehavior/SseClientBehaviorTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,7 @@
 package jaxrs21sse.clientbehavior;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -53,7 +53,7 @@ public class SseClientBehaviorTestServlet extends FATServlet {
                     msg += failure + "\n";
                 }
             }
-            assertNotNull("Detected failures in the SSE resource: " + msg, msg);
+            assertNull("Detected failures in the SSE resource: " + msg, msg);
         } finally {
             resourceFailures.clear();
         }

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/SseJaxbApp/src/jaxrs21sse/jaxb/SseJaxbTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/SseJaxbApp/src/jaxrs21sse/jaxb/SseJaxbTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package jaxrs21sse.jaxb;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -49,7 +49,7 @@ public class SseJaxbTestServlet extends FATServlet {
                     msg += failure + "\n";
                 }
             }
-            assertNotNull("Detected failures in the SSE resource: " + msg, msg);
+            assertNull("Detected failures in the SSE resource: " + msg, msg);
         } finally {
             resourceFailures.clear();
         }

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/SseJsonbApp/src/jaxrs21sse/jsonb/SseJsonbTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/SseJsonbApp/src/jaxrs21sse/jsonb/SseJsonbTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,7 @@ package jaxrs21sse.jsonb;
 import static jaxrs21sse.jsonb.JsonObject.JSON_OBJECTS;
 import static jaxrs21sse.jsonb.JsonbObject.JSONB_OBJECTS;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -52,7 +52,7 @@ public class SseJsonbTestServlet extends FATServlet {
                     msg += failure + "\n";
                 }
             }
-            assertNotNull("Detected failures in the SSE resource: " + msg, msg);
+            assertNull("Detected failures in the SSE resource: " + msg, msg);
         } finally {
             resourceFailures.clear();
         }

--- a/dev/fattest.simplicity/src/componenttest/annotation/processor/TestServletProcessor.java
+++ b/dev/fattest.simplicity/src/componenttest/annotation/processor/TestServletProcessor.java
@@ -18,6 +18,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runners.model.FrameworkField;
 import org.junit.runners.model.FrameworkMethod;
@@ -36,8 +38,6 @@ public class TestServletProcessor {
 
     public static List<FrameworkMethod> getServletTests(TestClass testClass) {
         final String m = "getServletTests";
-
-        List<FrameworkMethod> testMethods = new ArrayList<FrameworkMethod>();
 
         Set<FrameworkField> servers = new HashSet<FrameworkField>();
         servers.addAll(testClass.getAnnotatedFields(TestServlet.class));
@@ -59,18 +59,38 @@ public class TestServletProcessor {
             if (serverField.getAnnotation(TestServlets.class) != null)
                 testServlets.addAll(Arrays.asList(serverField.getAnnotation(TestServlets.class).value()));
 
+            List<FrameworkMethod> testMethods = new ArrayList<FrameworkMethod>();
+            List<FrameworkMethod> beforeMethods = new ArrayList<FrameworkMethod>();
+            List<FrameworkMethod> afterMethods = new ArrayList<FrameworkMethod>();
+
             // For each @TestServlet for this server, add all @Test methods
             for (TestServlet anno : testServlets) {
                 int initialSize = testMethods.size();
                 for (Method method : getTestServletMethods(anno)) {
                     if (method.isAnnotationPresent(Test.class)) {
                         testMethods.add(new SyntheticServletTest(anno.servlet(), serverField, getQueryPath(anno), method));
+                    } else if (method.isAnnotationPresent(Before.class)) {
+                        beforeMethods.add(new SyntheticServletTest(anno.servlet(), serverField, getQueryPath(anno), method));
+                    } else if (method.isAnnotationPresent(After.class)) {
+                        afterMethods.add(new SyntheticServletTest(anno.servlet(), serverField, getQueryPath(anno), method));
                     }
                 }
                 Log.info(c, m, "Added " + (testMethods.size() - initialSize) + " test methods from " + anno.servlet());
             }
+
+            List<FrameworkMethod> orderedTestMethods = new ArrayList<FrameworkMethod>();
+            for (int i = 0; i < testMethods.size(); i++) {
+                for (FrameworkMethod fm : beforeMethods)
+                    orderedTestMethods.add(fm);
+
+                orderedTestMethods.add(testMethods.get(i));
+
+                for (FrameworkMethod fm : afterMethods)
+                    orderedTestMethods.add(fm);
+            }
+            return orderedTestMethods;
         }
-        return testMethods;
+        return new ArrayList<FrameworkMethod>();
     }
 
     private static String getQueryPath(TestServlet anno) {


### PR DESCRIPTION
Adding support to `componenttest.app.FATServlet` for JUnit `@Before` and `@After`

Signed-off-by: Will Dazey <wadazey@us.ibm.com>

