### PR TITLE
Update the oAuth FAT repeat rules to reduce runtime

### DIFF
--- a/dev/com.ibm.ws.security.oauth_fat/build.gradle
+++ b/dev/com.ibm.ws.security.oauth_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -39,6 +39,7 @@ dependencies {
                   files('lib/jsse.jar'),
                   'rhino:js:1.6R5',
                   project(':com.ibm.ws.mongo_fat'),
+                  project(':com.ibm.ws.security.fat.common'),
                   'de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.0.0',
                   'de.flapdoodle.embed:de.flapdoodle.embed.process:3.0.1',
                   'org.apache.commons:commons-compress:1.21'

--- a/dev/com.ibm.ws.security.oauth_fat/fat/src/com/ibm/ws/security/oauth20/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.oauth_fat/fat/src/com/ibm/ws/security/oauth20/fat/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2022 IBM Corporation and others.
+ * Copyright (c) 2012, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -21,8 +21,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import componenttest.rules.repeater.EmptyAction;
-import componenttest.rules.repeater.FeatureReplacementAction;
+import com.ibm.ws.security.fat.common.actions.LargeProjectRepeatActions;
+
 import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
@@ -72,18 +72,22 @@ import componenttest.topology.impl.LibertyServer;
 public class FATSuite extends CommonLocalLDAPServerSuite {
 
     /*
-     * Run EE10 tests in LITE mode and run all tests in FULL mode.
+     * On Windows, always run the default/empty/EE7/EE8 tests.
+     * On other Platforms:
+     * - if Java 8, run default/empty/EE7/EE8 tests.
+     * - All other Java versions
+     * -- If LITE mode, run EE9
+     * -- If FULL mode, run EE10
+     *
      */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
-                    .andWith(new JakartaEE9Action().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
-                    .andWith(new JakartaEE10Action());
+    public static RepeatTests repeat = LargeProjectRepeatActions.createEE9OrEE10Repeats();
 
     /**
      * JakartaEE9 transform a list of applications.
      *
      * @param myServer The server to transform the applications on.
-     * @param apps     The names of the applications to transform. Should include the path from the server root directory.
+     * @param apps The names of the applications to transform. Should include the path from the server root directory.
      */
     public static void transformApps(LibertyServer myServer, String... apps) {
         if (JakartaEE10Action.isActive()) {


### PR DESCRIPTION
com.ibm.ws.security.oauth_fat  was taking too long to run after a repeat for EE10 was added.

I'm updating the rules to run:
On Windows, always run the default/empty/EE7/EE8 tests.
On other Platforms:

    if Java 8, run default/empty/EE7/EE8 tests.
    All other Java versions
    -- If LITE mode, run EE9
    -- If FULL mode, run EE10

