### PR TITLE
decode initial request query parameters before the final redirection

### DIFF
--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/utils/HttpRequestInfo.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/utils/HttpRequestInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -260,6 +260,9 @@ public class HttpRequestInfo implements Serializable {
             if (encodedUrl != null && !encodedUrl.isEmpty()) {
                 this.requestURLWithFragments = URLDecoder.decode(encodedUrl, Constants.UTF8);
             } else {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc,  "OLGH23567, url with encoded query string = ", this.requestURL);
+                }
                 this.requestURLWithFragments = getRequestUrlWithDecodedQueryString();
             }
 
@@ -269,7 +272,7 @@ public class HttpRequestInfo implements Serializable {
         }
 
         if (tc.isDebugEnabled()) {
-            Tr.debug(tc, "Original RequestUrl:" + this.reqUrl + "\n  requestURLWithFragments:" + this.requestURLWithFragments);
+            Tr.debug(tc, "OLGH23567, Original RequestUrl:" + this.reqUrl + "\n  requestURLWithFragments:" + this.requestURLWithFragments);
         }
     }
 
@@ -317,7 +320,7 @@ public class HttpRequestInfo implements Serializable {
     }
 
     /**
-     * Encodes each parameter in the provided query. Expects the query argument to be the query string of a URL with parameters
+     * Encodes/Decodes each parameter in the provided query. Expects the query argument to be the query string of a URL with parameters
      * in the format: param=value(&param2=value2)*
      *
      * @param query

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/utils/HttpRequestInfo.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/utils/HttpRequestInfo.java
@@ -69,7 +69,8 @@ public class HttpRequestInfo implements Serializable {
     String redirectAfterSPLogout = null;
 
     // same package can access to it
-    HttpRequestInfo() {};
+    HttpRequestInfo() {
+    };
 
     /**
      * Constructor for any incoming http request on
@@ -102,26 +103,26 @@ public class HttpRequestInfo implements Serializable {
             }
         }
         //@AV999-092821
-        if(request.getAttribute("OIDC_END_SESSION_REDIRECT") != null) {
-            redirectAfterSPLogout = (String)request.getAttribute("OIDC_END_SESSION_REDIRECT");
+        if (request.getAttribute("OIDC_END_SESSION_REDIRECT") != null) {
+            redirectAfterSPLogout = (String) request.getAttribute("OIDC_END_SESSION_REDIRECT");
             if (tc.isDebugEnabled()) {
                 Tr.debug(tc, "SP Initiated SLO Request, save OIDC_END_SESSION_REDIRECT uri : " + redirectAfterSPLogout);
-            }        
+            }
         }
         if (tc.isDebugEnabled()) {
             Tr.debug(tc, "Request: method (" + this.method + ") savedParams:" + this.savedPostParams);
         }
     }
-    
+
     public HttpRequestInfo(String reqUrl, String requestURL, String method, String strInResponseToId, String formlogout, HashMap postParams) {
         this.reqUrl = reqUrl;
         this.requestURL = requestURL;
         this.method = method;
         this.strInResponseToId = strInResponseToId;
         this.formLogoutExitPage = formlogout;
-        
-        if (METHOD_POST.equalsIgnoreCase(this.method) && formLogoutExitPage == null) {  
-                this.savedPostParams = postParams;                
+
+        if (METHOD_POST.equalsIgnoreCase(this.method) && formLogoutExitPage == null) {
+            this.savedPostParams = postParams;
         }
         if (tc.isDebugEnabled()) {
             Tr.debug(tc, "Request: method (" + this.method + ") savedParams:" + this.savedPostParams);
@@ -135,7 +136,7 @@ public class HttpRequestInfo implements Serializable {
     public String getInResponseToId() {
         return this.strInResponseToId;
     }
-    
+
     public String getRedirectAfterSPLogout() {
         return this.redirectAfterSPLogout;
     }
@@ -172,11 +173,11 @@ public class HttpRequestInfo implements Serializable {
     public String getReqUrl() {
         return this.reqUrl;
     }
-    
+
     public String getRequestUrl() {
         return this.requestURL;
     }
-    
+
     public Map getSavedPostParams() {
         return this.savedPostParams;
     }
@@ -197,7 +198,7 @@ public class HttpRequestInfo implements Serializable {
      *
      * @param request
      * @param response
-     * @param cookieName --
+     * @param cookieName  --
      * @param cookieValue --
      * @throws SamlException
      */
@@ -249,15 +250,19 @@ public class HttpRequestInfo implements Serializable {
         String encodedUrl = RequestUtil.getCookieId((IExtendedRequest) request,
                                                     response,
                                                     encodedUrlCookieName);
- 
+
         if (encodedUrlCookieName != null) {
             RequestUtil.removeCookie(request, response, encodedUrlCookieName); // removing WASSamlReq_* cookie
         }
 
         // encodedURL is encoded since we called encodeURIComponent to get the cookie
         try {
-            if (encodedUrl != null && !encodedUrl.isEmpty())
+            if (encodedUrl != null && !encodedUrl.isEmpty()) {
                 this.requestURLWithFragments = URLDecoder.decode(encodedUrl, Constants.UTF8);
+            } else {
+                this.requestURLWithFragments = getRequestUrlWithDecodedQueryString();
+            }
+
         } catch (UnsupportedEncodingException e) {
             // this should not happen since we are calling with UTF8;
             throw new SamlException(e);
@@ -286,12 +291,27 @@ public class HttpRequestInfo implements Serializable {
         return birthTime;
     }
 
+    public String getRequestUrlWithDecodedQueryString() {
+        StringBuffer decoded = new StringBuffer();
+        int index = this.requestURL.indexOf("?");
+        if (index > 0) {
+            decoded.append(this.requestURL.substring(0, index));
+            String queryString = this.requestURL.substring(index + 1);
+            if (queryString != null) {
+                decoded.append("?");
+                decoded.append(encodeOrDecodeQuery(queryString, false));
+                return decoded.toString();
+            }
+        }
+        return null;
+    }
+
     static public String getRequestURL(HttpServletRequest req) {
         StringBuffer reqURL = req.getRequestURL();
         String queryString = req.getQueryString();
         if (queryString != null) {
             reqURL.append("?");
-            reqURL.append(encodeQuery(queryString));
+            reqURL.append(encodeOrDecodeQuery(queryString, true));
         }
         return reqURL.toString();
     }
@@ -303,7 +323,7 @@ public class HttpRequestInfo implements Serializable {
      * @param query
      * @return
      */
-    public static String encodeQuery(String query) {
+    public static String encodeOrDecodeQuery(String query, boolean encode) {
         if (query == null) {
             return null;
         }
@@ -313,12 +333,22 @@ public class HttpRequestInfo implements Serializable {
         // Encode parameters to mitigate XSS attacks
         String[] queryParams = query.split("&");
         for (String param : queryParams) {
-            String rebuiltParam = encode(param);
+            String rebuiltParam;
+            if (encode) {
+                rebuiltParam = encode(param);
+            } else {
+                rebuiltParam = decode(param);
+            }
+
             int equalIndex = param.indexOf("=");
             if (equalIndex > -1) {
                 String name = param.substring(0, equalIndex);
                 String value = (equalIndex < (param.length() - 1)) ? param.substring(equalIndex + 1) : "";
-                rebuiltParam = encode(name) + "=" + encode(value);
+                if (encode) {
+                    rebuiltParam = encode(name) + "=" + encode(value);
+                } else {
+                    rebuiltParam = decode(name) + "=" + decode(value);
+                }
             }
             if (!rebuiltParam.isEmpty()) {
                 rebuiltQuery.append(rebuiltParam + "&");
@@ -343,6 +373,24 @@ public class HttpRequestInfo implements Serializable {
         }
         try {
             value = URLEncoder.encode(value, Constants.UTF8);
+        } catch (UnsupportedEncodingException e) {
+            // Do nothing - UTF-8 should always be supported
+        }
+        return value;
+    }
+
+    /**
+     * Decodes the given string using URLDecoder and UTF-8 encoding.
+     *
+     * @param value
+     * @return
+     */
+    public static String decode(String value) {
+        if (value == null) {
+            return value;
+        }
+        try {
+            value = URLDecoder.decode(value, Constants.UTF8);
         } catch (UnsupportedEncodingException e) {
             // Do nothing - UTF-8 should always be supported
         }

--- a/dev/com.ibm.ws.security.saml.websso.2.0/test/com/ibm/ws/security/saml/sso20/internal/utils/InitialRequestUtilTest.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/test/com/ibm/ws/security/saml/sso20/internal/utils/InitialRequestUtilTest.java
@@ -1,0 +1,249 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.saml.sso20.internal.utils;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.security.KeyStoreException;
+import java.security.cert.CertificateException;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.rules.TestRule;
+
+import com.ibm.ws.security.common.jwk.utils.JsonUtils;
+import com.ibm.ws.security.saml.Constants;
+import com.ibm.ws.security.saml.SsoSamlService;
+import com.ibm.ws.security.saml.error.SamlException;
+import com.ibm.ws.webcontainer.srt.SRTServletRequest;
+
+import test.common.SharedOutputManager;
+
+/**
+ *
+ */
+public class InitialRequestUtilTest {
+    
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("com.ibm.ws.security.saml.sso20.*=all");
+    @Rule
+    public TestRule managerRule = outputMgr;
+
+    public final Mockery mockery = new JUnit4Mockery() {
+        {
+            setImposteriser(ClassImposteriser.INSTANCE);
+        }
+    };
+    
+    private final HttpServletRequest HTTP_SERVLET_REQUEST_MCK = mockery.mock(SRTServletRequest.class);
+    private final SsoSamlService ssoService = mockery.mock(SsoSamlService.class);
+    
+    @Rule
+    public final TestName testName = new TestName();
+    private InitialRequestUtil irUtil = null;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+        
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.resetStreams();
+        outputMgr.restoreStreams();
+    }
+
+    @Before
+    public void beforeTest() {
+        System.out.println("Entering test: " + testName.getMethodName());
+        irUtil  = new InitialRequestUtil();
+        //JwtUtils.setSSLSupportService(sslSupportRef);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        mockery.assertIsSatisfied();
+        System.out.println("Exiting test: " + testName.getMethodName());
+    }
+
+
+    /**
+     * Test method for {@link com.ibm.ws.security.saml.sso20.internal.utils.InitialRequestUtil#updateInitialRequestCookieNameWithRelayState(java.lang.String)}.
+     */
+    @Test
+    public void testUpdateInitialRequestCookieNameWithRelayState() {
+        String append = null;
+        String cookiename = irUtil.updateInitialRequestCookieNameWithRelayState(append);
+        assertNull("Result was not null when it should have been. Result: " + cookiename, cookiename);
+        append = "appendme";
+        String expect = Constants.WAS_IR_COOKIE + append;
+        cookiename = irUtil.updateInitialRequestCookieNameWithRelayState(append);
+        assertEquals("Did not find expected cookie name.", expect, cookiename);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.security.saml.sso20.internal.utils.InitialRequestUtil#digestInitialRequestCookieValue(java.lang.String, com.ibm.ws.security.saml.SsoSamlService)}.
+     */
+    @Test
+    public void testDigestInitialRequestCookieValue() {
+        String irBytesStr = getInitialRequestString();
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    allowing(ssoService).getPrivateKey();
+                    will(returnValue(null));
+                    allowing(ssoService).getDefaultKeyStorePassword();
+                    will(returnValue(null));      
+                }
+            });
+        } catch (KeyStoreException e) {
+
+        } catch (CertificateException e) {
+
+        }
+        String cookiedigest = irUtil.digestInitialRequestCookieValue(irBytesStr, ssoService);
+        String expect = "rO0ABXNyADxjb20uaWJtLndzLnNlY3VyaXR5LnNhbWwuc3NvMjAuaW50ZXJuYWwudXRpbHMuSW5pdGlhbFJlcXVlc3QAAAAAAAAAAQMACFoAFGlzRm9ybUxvZ291dEV4aXRQYWdlTAASZm9ybUxvZ291dEV4aXRQYWdldAASTGphdmEvbGFuZy9TdHJpbmc7TAAGbWV0aG9kcQB-AAFMAApwb3N0UGFyYW1zcQB-AAFMAAZyZXFVcmxxAH4AAUwACnJlcXVlc3RVUkxxAH4AAUwAD3NhdmVkUG9zdFBhcmFtc3QAE0xqYXZhL3V0aWwvSGFzaE1hcDtMABFzdHJJblJlc3BvbnNlVG9JZHEAfgABeHB3gwAraHR0cHM6Ly9sb2NhbGhvc3Q6ODAyMC9zYW1sY2xpZW50L3NwMS9zbm9vcAAraHR0cHM6Ly9sb2NhbGhvc3Q6ODAyMC9zYW1sY2xpZW50L3NwMS9zbm9vcAADR0VUACFfMG5EU2czOVc5TU1NUkpNMGc1MUM1b3RHbFdLOVV4V3oAeA_YQEzoMCRqkVb4orBZ8pgJT5EomZsyeOgFjnTHChNNCE=";
+        assertEquals("Did not find expected cookie digest.", expect, cookiedigest);
+    }
+
+    /**
+     * @return
+     */
+    private InitialRequest getInitialRequest() {
+        String requestUrl = "https://localhost:8020/samlclient/sp1/snoop";
+        String method = "GET";
+        String inResp = "_0nDSg39W9MMMRJM0g51C5otGlWK9UxWz";
+        String logoutPage = null;
+        InitialRequest ir = null;  
+        try {
+            ir = new InitialRequest(HTTP_SERVLET_REQUEST_MCK, requestUrl, requestUrl,method,inResp, logoutPage, null);
+        } catch (SamlException e) {
+
+        }
+        return ir;
+    }
+    
+    /**
+     * @return
+     */
+    private String getInitialRequestString() {
+        InitialRequest ir = null;
+        ir = getInitialRequest();
+        String irBytesStr = null; 
+        if (ir != null) {
+            byte[] irBytes = null;       
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ObjectOutputStream out = null;
+            try {
+              try {
+                out = new ObjectOutputStream(bos);
+                out.writeObject(ir);
+                out.flush();
+                irBytes = bos.toByteArray();
+                if (irBytes != null) {
+                    irBytesStr = JsonUtils.convertToBase64(irBytes);
+                }
+            } catch (IOException e) {
+               
+            }     
+             
+            } finally {
+              try {
+                bos.close();
+              } catch (IOException ex) {
+                
+              }
+            }
+        }
+        return irBytesStr;
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.security.saml.sso20.internal.utils.InitialRequestUtil#getInitialRequestCookie(java.lang.String, com.ibm.ws.security.saml.SsoSamlService)}.
+     */
+    @Test
+    public void testGetInitialRequestCookie() {
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    allowing(ssoService).getPrivateKey();
+                    will(returnValue(null));
+                    allowing(ssoService).getDefaultKeyStorePassword();
+                    will(returnValue(null));      
+                }
+            });
+        } catch (KeyStoreException e) {
+
+        } catch (CertificateException e) {
+
+        }
+        String ircookie = "rO0ABXNyADxjb20uaWJtLndzLnNlY3VyaXR5LnNhbWwuc3NvMjAuaW50ZXJuYWwudXRpbHMuSW5pdGlhbFJlcXVlc3QAAAAAAAAAAQMACFoAFGlzRm9ybUxvZ291dEV4aXRQYWdlTAASZm9ybUxvZ291dEV4aXRQYWdldAASTGphdmEvbGFuZy9TdHJpbmc7TAAGbWV0aG9kcQB-AAFMAApwb3N0UGFyYW1zcQB-AAFMAAZyZXFVcmxxAH4AAUwACnJlcXVlc3RVUkxxAH4AAUwAD3NhdmVkUG9zdFBhcmFtc3QAE0xqYXZhL3V0aWwvSGFzaE1hcDtMABFzdHJJblJlc3BvbnNlVG9JZHEAfgABeHB3gwAraHR0cHM6Ly9sb2NhbGhvc3Q6ODAyMC9zYW1sY2xpZW50L3NwMS9zbm9vcAAraHR0cHM6Ly9sb2NhbGhvc3Q6ODAyMC9zYW1sY2xpZW50L3NwMS9zbm9vcAADR0VUACFfMG5EU2czOVc5TU1NUkpNMGc1MUM1b3RHbFdLOVV4V3oAeA_YQEzoMCRqkVb4orBZ8pgJT5EomZsyeOgFjnTHChNNCE=";
+        String initial = irUtil.getInitialRequestCookie(ircookie, ssoService);
+        String expect = "rO0ABXNyADxjb20uaWJtLndzLnNlY3VyaXR5LnNhbWwuc3NvMjAuaW50ZXJuYWwudXRpbHMuSW5pdGlhbFJlcXVlc3QAAAAAAAAAAQMACFoAFGlzRm9ybUxvZ291dEV4aXRQYWdlTAASZm9ybUxvZ291dEV4aXRQYWdldAASTGphdmEvbGFuZy9TdHJpbmc7TAAGbWV0aG9kcQB-AAFMAApwb3N0UGFyYW1zcQB-AAFMAAZyZXFVcmxxAH4AAUwACnJlcXVlc3RVUkxxAH4AAUwAD3NhdmVkUG9zdFBhcmFtc3QAE0xqYXZhL3V0aWwvSGFzaE1hcDtMABFzdHJJblJlc3BvbnNlVG9JZHEAfgABeHB3gwAraHR0cHM6Ly9sb2NhbGhvc3Q6ODAyMC9zYW1sY2xpZW50L3NwMS9zbm9vcAAraHR0cHM6Ly9sb2NhbGhvc3Q6ODAyMC9zYW1sY2xpZW50L3NwMS9zbm9vcAADR0VUACFfMG5EU2czOVc5TU1NUkpNMGc1MUM1b3RHbFdLOVV4V3oAeA";
+        assertEquals("Did not find expected cookie.", expect, initial);  
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.security.saml.sso20.internal.utils.InitialRequestUtil#createHttpRequestInfoFromInitialRequest(com.ibm.ws.security.saml.sso20.internal.utils.InitialRequest)}.
+     */
+    @Test
+    public void testCreateHttpRequestInfoFromInitialRequest() {
+        InitialRequest ir = getInitialRequest();
+        HttpRequestInfo requestInfo = irUtil.createHttpRequestInfoFromInitialRequest(ir);
+        String url = requestInfo.getReqUrl();
+        String expect = ir.getRequestUrl();       
+        assertEquals("Did not find expected request url.", expect, url);
+        String inresp = requestInfo.getInResponseToId();
+        expect = ir.getInResponseToId();
+        assertEquals("Did not find expected in response to id.", expect, inresp);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.security.saml.sso20.internal.utils.InitialRequestUtil#handleDeserializingInitialRequest(java.lang.String)}.
+     */
+    @Test
+    public void testHandleDeserializingInitialRequest() {
+        String irBytesStr = getInitialRequestString();
+        InitialRequest ir = null;
+        try {
+            ir = irUtil.handleDeserializingInitialRequest(irBytesStr);
+        } catch (ClassNotFoundException e) {
+
+        } catch (IOException e) {
+
+        }
+        String url = null;
+        String method = null;
+        if (ir != null) {
+            method = ir.getMethod();
+            url = ir.getRequestUrl();
+        }
+        String expect = "GET";
+        assertEquals("Did not find expected request method.", expect, method);
+        expect = "https://localhost:8020/samlclient/sp1/snoop";
+        assertEquals("Did not find expected request url.", expect, url);
+    }
+}

--- a/dev/com.ibm.ws.security.saml.websso.2.0/test/com/ibm/ws/security/saml/sso20/internal/utils/InitialRequestUtilTest.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/test/com/ibm/ws/security/saml/sso20/internal/utils/InitialRequestUtilTest.java
@@ -1,12 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
  *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ *     IBM Corporation - initial implementation
  *******************************************************************************/
 package com.ibm.ws.security.saml.sso20.internal.utils;
 
@@ -74,6 +76,7 @@ public class InitialRequestUtilTest {
         outputMgr.dumpStreams();
         outputMgr.resetStreams();
         outputMgr.restoreStreams();
+        outputMgr.trace("*=all=disabled");
     }
 
     @Before

--- a/dev/com.ibm.ws.security.saml.websso.2.0/test/com/ibm/ws/security/saml/sso20/internal/utils/MsgCtxUtilTest.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/test/com/ibm/ws/security/saml/sso20/internal/utils/MsgCtxUtilTest.java
@@ -83,6 +83,7 @@ public class MsgCtxUtilTest {
     @BeforeClass
     public static void setUp() {
         //outputMgr.trace("*=all");
+        outputMgr.trace("*=all=disabled");
     }
 
     @Before


### PR DESCRIPTION
Update to handle the decoding of the initial request query in case the saml response is handled by different SP than the one initiated request to the IdP
fixes #23567