### PR TITLE
Increase short lived token times again for Jakarta logout tests.

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/tokens/AccessTokenImpl.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/tokens/AccessTokenImpl.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -20,12 +20,17 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
 import jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdConstant;
 import jakarta.security.enterprise.identitystore.openid.AccessToken;
 import jakarta.security.enterprise.identitystore.openid.JwtClaims;
 import jakarta.security.enterprise.identitystore.openid.Scope;
 
 public class AccessTokenImpl implements AccessToken, Serializable {
+
+    public static final TraceComponent tc = Tr.register(AccessTokenImpl.class);
 
     private static final long serialVersionUID = 1L;
 
@@ -97,8 +102,16 @@ public class AccessTokenImpl implements AccessToken, Serializable {
         if (expirationTimeInSeconds != null && !(expirationTimeInSeconds < 0) && !(tokenMinValidityInMillis < 0)) {
             Instant expirationInstant = responseGenerationTime.plusMillis(expirationTimeInSeconds * 1000);
             Instant nowInstant = Instant.now();
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Current time: " + nowInstant + ", expirationInstant: " + expirationInstant + " = when the token response was generated (" + responseGenerationTime
+                             + ") + expiration time (" + expirationTimeInSeconds + "), tokenMinValidityInMillis: " + tokenMinValidityInMillis);
+                Tr.debug(tc, "Token is considered expired if the current time is after expiration instant, or if the current time + tokenMinValidityInMillis is after the expiration instant");
+            }
             return nowInstant.isAfter(expirationInstant) || nowInstant.plusMillis(tokenMinValidityInMillis).isAfter(expirationInstant);
         } else if (Type.BEARER.equals(type)) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Access token is a bearer token");
+            }
             Optional<Instant> expirationOptionalInstant = jwtClaims.getExpirationTime();
             if (expirationOptionalInstant.isPresent()) {
                 Instant expirationInstant = expirationOptionalInstant.get();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/commonTests/CommonLogoutAndRefreshTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/commonTests/CommonLogoutAndRefreshTests.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -64,7 +64,7 @@ public class CommonLogoutAndRefreshTests extends CommonAnnotatedSecurityTests {
         Page response1 = runGoodEndToEndTest(webClient, appName, baseAppName);
 
         // now logged in - wait for token to expire
-        actions.testLogAndSleep(25);
+        actions.testLogAndSleep(35);
         String url = rpHttpsBase + "/" + appName + "/" + baseAppName;
         Page response2 = invokeAppGetToApp(webClient, url); // get to app not because either id or access token is good, but because the token was refreshed.
 
@@ -99,7 +99,7 @@ public class CommonLogoutAndRefreshTests extends CommonAnnotatedSecurityTests {
         runGoodEndToEndTest(webClient, appName, baseAppName);
 
         // now logged in - wait for token to expire
-        actions.testLogAndSleep(25);
+        actions.testLogAndSleep(35);
         String url = rpHttpsBase + "/" + appName + "/" + baseAppName;
         invokeAppReturnLogoutPage(webClient, url);
 
@@ -132,7 +132,7 @@ public class CommonLogoutAndRefreshTests extends CommonAnnotatedSecurityTests {
         Page response1 = runGoodEndToEndTest(webClient, appName, baseAppName);
 
         // now logged in - wait for token to expire
-        actions.testLogAndSleep(25);
+        actions.testLogAndSleep(35);
         String url = rpHttpsBase + "/" + appName + "/" + baseAppName;
         Page response2 = invokeAppGetToApp(webClient, url);
 
@@ -164,7 +164,7 @@ public class CommonLogoutAndRefreshTests extends CommonAnnotatedSecurityTests {
         runGoodEndToEndTest(webClient, appName, baseAppName);
 
         // now logged in - wait for token to expire
-        actions.testLogAndSleep(25);
+        actions.testLogAndSleep(35);
         String url = rpHttpsBase + "/" + appName + "/" + baseAppName;
         invokeAppGetToSplashPage(webClient, url);
 

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/publish/shared/config/oidcProvider.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/publish/shared/config/oidcProvider.xml
@@ -74,7 +74,7 @@ https://localhost:${bvt.prop.security_2_HTTP_default.secure}/App_31/Callback"
 		signatureAlgorithm="RS256"
 		keyAliasName="rs256"
 		keystoreRef="key_allSigAlg"
-		idTokenLifetime="20s"
+		idTokenLifetime="30s"
 		oauthProviderRef="OAuth1" />
 
 	<oauthProvider
@@ -138,7 +138,7 @@ https://localhost:${bvt.prop.security_2_HTTP_default.secure}/App_31/Callback"
 		id="OAuth2"
 		autoAuthorize="true"
 		tokenFormat="${opTokenFormat}"
-		accessTokenLifetime="20s"
+		accessTokenLifetime="30s"
 	>
 		<autoAuthorizeClient>client_1</autoAuthorizeClient>
 		
@@ -191,14 +191,14 @@ https://localhost:${bvt.prop.security_2_HTTP_default.secure}/App_31/Callback"
 		signatureAlgorithm="RS256"
 		keyAliasName="rs256"
 		keystoreRef="key_allSigAlg"
-		idTokenLifetime="20s"
+		idTokenLifetime="30s"
 		oauthProviderRef="OAuth3" />
 
 	<oauthProvider
 		id="OAuth3"
 		autoAuthorize="true"
 		tokenFormat="${opTokenFormat}"
-		accessTokenLifetime="20s"
+		accessTokenLifetime="30s"
 	>
 		<autoAuthorizeClient>client_1</autoAuthorizeClient>
 		
@@ -261,14 +261,14 @@ https://localhost:${bvt.prop.security_2_HTTP_default.secure}/GoodRedirectNotifyP
 		signatureAlgorithm="RS256"
 		keyAliasName="rs256"
 		keystoreRef="key_allSigAlg"
-		idTokenLifetime="20s"
+		idTokenLifetime="30s"
 		oauthProviderRef="OAuth4" />
 
 	<oauthProvider
 		id="OAuth4"
 		autoAuthorize="true"
 		tokenFormat="${opTokenFormat}"
-		accessTokenLifetime="20s"
+		accessTokenLifetime="30s"
 	>
 		<autoAuthorizeClient>client_1</autoAuthorizeClient>
 		


### PR DESCRIPTION
Increase token lifetimes even more to account for slow test machines.
The logout tests need tokens that do not live long since they'll be invoking logout with/without expired tokens and we don't want to have to wait too long for them to expire. But, we've hit some slow machines where the tokens have expired before they're returned to the clients during a normal login process.