### PR TITLE
Fix Defect 294367 (JSF22LocalizationTesterTests Failure )

### DIFF
--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22LocalizationTesterTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22LocalizationTesterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022 IBM Corporation and others.
+ * Copyright (c) 2015, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -67,10 +67,10 @@ public class JSF22LocalizationTesterTests {
                                                  "com/ibm/ws/jsf22/fat/localprops/messages.properties");
         JSF22LocalizationTesterWar.addAsResource(new File("test-applications/JSF22LocalizationTester.war/src/com/ibm/ws/jsf22/fat/localprops/messages_zh_CN.properties"),
                                                  "com/ibm/ws/jsf22/fat/localprops/messages_zh_CN.properties");
-        JSF22LocalizationTesterWar.addAsResource(new File("test-applications/JSF22LocalizationTester.war/src/com/ibm/ws/jsf22/fat/localprops/resources_zh_CN.properties"),
-                                                 "com/ibm/ws/jsf22/fat/localprops/resources_zh_CN.properties");
-        JSF22LocalizationTesterWar.addAsResource(new File("test-applications/JSF22LocalizationTester.war/src/com/ibm/ws/jsf22/fat/localprops/resources.properties"),
-                                                 "com/ibm/ws/jsf22/fat/localprops/resources.properties");
+        JSF22LocalizationTesterWar.addAsResource(new File("test-applications/JSF22LocalizationTester.war/src/com/ibm/ws/jsf22/fat/localprops/jsf22_localization_resources_zh_CN.properties"),
+                                                 "com/ibm/ws/jsf22/fat/localprops/jsf22_localization_resources_zh_CN.properties");
+        JSF22LocalizationTesterWar.addAsResource(new File("test-applications/JSF22LocalizationTester.war/src/com/ibm/ws/jsf22/fat/localprops/jsf22_localization_resources.properties"),
+                                                 "com/ibm/ws/jsf22/fat/localprops/jsf22_localization_resources.properties");
 
         ShrinkHelper.exportDropinAppToServer(jsfTestServer2, JSF22LocalizationTesterWar);
 
@@ -109,6 +109,8 @@ public class JSF22LocalizationTesterTests {
                 Assert.fail("JSF22LocalizationTester_TestLocalAndGlobalResources.xhtml did not render properly.");
             }
 
+            assertTrue(page.asXml().contains("country_flag.jpg.xhtml?ln=images&amp;loc=en"));
+
             assertTrue(page.asText().contains("Testing"));
         }
     }
@@ -132,6 +134,8 @@ public class JSF22LocalizationTesterTests {
             if (page == null) {
                 Assert.fail("JSF22LocalizationTester_TestCalculateLocale, default.xhtml did not render properly.");
             }
+
+            assertTrue(page.asXml().contains("country_flag.jpg.xhtml?ln=images&amp;loc=en"));
 
             assertTrue(page.asText().contains("Happy learning JSF 2.2"));
         }

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22LocalizationTester.war/resources/WEB-INF/faces-config.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22LocalizationTester.war/resources/WEB-INF/faces-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * Copyright (c) 2015 IBM Corporation and others.g
+ * Copyright (c) 2015, 2023 IBM Corporation and others.g
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -29,9 +29,8 @@
         </resource-bundle>
 
         <message-bundle>
-            com.ibm.ws.jsf22.fat.localprops.resources
+            com.ibm.ws.jsf22.fat.localprops.jsf22_localization_resources
         </message-bundle>
     </application>
 
 </faces-config>
-

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22LocalizationTester.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22LocalizationTester.war/resources/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * Copyright (c) 2015 IBM Corporation and others.g
+ * Copyright (c) 2015, 2023 IBM Corporation and others.g
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -39,6 +39,12 @@
     <context-param>
         <param-name>org.apache.myfaces.SERIALIZE_STATE_IN_SESSION</param-name>
         <param-value>false</param-value>
+    </context-param>
+
+    <!-- Temp solution for defect 294367; need to look into o.a.m.ALWAYS_FORCE_SESSION_CREATION for 4.0 -->
+    <context-param>
+        <param-name>jakarta.faces.FACELETS_BUFFER_SIZE</param-name>
+        <param-value>4096</param-value>
     </context-param>
 
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22LocalizationTester.war/src/com/ibm/ws/jsf22/fat/localprops/jsf22_localization_resources.properties
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22LocalizationTester.war/src/com/ibm/ws/jsf22/fat/localprops/jsf22_localization_resources.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015 IBM Corporation and others.
+# Copyright (c) 2015, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -10,4 +10,4 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-javax.faces.resource.localePrefix=zh_CN
+javax.faces.resource.localePrefix=en

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22LocalizationTester.war/src/com/ibm/ws/jsf22/fat/localprops/jsf22_localization_resources_zh_CN.properties
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22LocalizationTester.war/src/com/ibm/ws/jsf22/fat/localprops/jsf22_localization_resources_zh_CN.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015 IBM Corporation and others.
+# Copyright (c) 2015, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -10,4 +10,4 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-javax.faces.resource.localePrefix=en
+javax.faces.resource.localePrefix=zh_CN

--- a/dev/wlp-jakartaee-transform/rules/jakarta-direct.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-direct.properties
@@ -134,3 +134,4 @@ META-INF/services/javax.websocket=META-INF/services/jakarta.websocket
 META-INF/services/javax.ws.rs=META-INF/services/jakarta.ws.rs
 
 META-INF/services/javax.xml.ws=META-INF/services/jakarta.xml.ws
+

--- a/dev/wlp-jakartaee-transform/rules/jakarta-facelet.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-facelet.properties
@@ -2,3 +2,6 @@
 javax.faces.application.ResourceHandler=jakarta.faces.application.ResourceHandler
 javax.faces.component.behavior.ClientBehaviorContext=jakarta.faces.component.behavior.ClientBehaviorContext
 javax.faces.context.PartialViewContext=jakarta.faces.context.PartialViewContext
+
+# JSF 2.2 Localization Tester War
+javax.faces.resource.localePrefix=jakarta.faces.resource.localePrefix

--- a/dev/wlp-jakartaee-transform/rules/jakarta-text.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-text.properties
@@ -32,3 +32,8 @@ validatorCustomLoginModuleServer.xml=jakarta-metatype.properties
 
 #jpa FAT
 basic-constraints.xml=jakarta-renames.properties
+
+# JSF 2.2 Localization Tester War
+jsf22_localization_resources_zh_CN.properties=jakarta-facelet.properties
+jsf22_localization_resources.properties=jakarta-facelet.properties
+


### PR DESCRIPTION
for https://github.com/OpenLiberty/open-liberty/issues/22369
```
<br>[1/9/23, 10:17:59:801 PST] 00000039 com.ibm.ws.session.WASSessionCore                            W SESN0066E: The response is already committed to the client. The session cookie cannot be set.
<br>[1/9/23, 10:17:59:802 PST] 00000039 com.ibm.ws.webcontainer.srt                                  W SRVE8114W: WARNING: Cannot set session cookie. Response already committed.
<br>[1/9/23, 10:18:00:363 PST] 00000037 com.ibm.ws.session.WASSessionCore                            W SESN0066E: The response is already committed to the client. The session cookie cannot be set.
<br>[1/9/23, 10:18:00:363 PST] 00000037 com.ibm.ws.webcontainer.srt                                  W SRVE8114W: WARNING: Cannot set session cookie. Response already committed.
```

Increased the buffer size for a temporary solution. Will need to discuss o.am.ALWAYS_FORCE_SESSION_CREATION with the faces community as I think the default should change (and be consistent with earlier JSF versions). 

Also discovered that `javax.faces.resource.localePrefix` was not transformed which meant that the images weren't rendered on the page. That has been fixed, too. 