### PR TITLE
Issue 23875 Clean up artifactory artifacts

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -212,6 +212,11 @@
       <version>1.5.10</version>
     </dependency>
     <dependency>
+      <groupId>com.icegreen</groupId>
+      <artifactId>greenmail</artifactId>
+      <version>2.0.0-alpha1</version>
+    </dependency>
+    <dependency>
       <groupId>com.jcraft</groupId>
       <artifactId>jsch</artifactId>
       <version>0.1.54</version>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -38,6 +38,7 @@ com.ibm.db2:jcc:11.1.4.4
 com.ibm.ws.componenttest:mantis-collections:2.5.0
 com.ibm.ws.componenttest:mantis-nls-standalone:2.5.0
 com.icegreen:greenmail:1.5.10
+com.icegreen:greenmail:2.0.0-alpha1
 com.jcraft:jsch:0.1.54
 com.microsoft.sqlserver:mssql-jdbc:9.2.1.jre8
 com.nimbusds:nimbus-jose-jwt:4.23

--- a/dev/io.openliberty.mail.2.0.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.mail.2.0.internal_fat/bnd.bnd
@@ -34,4 +34,4 @@ tested.features:\
   io.openliberty.org.apache.commons.logging;version=latest, \
   com.ibm.ws.org.slf4j.api;version=latest, \
   com.ibm.ws.org.slf4j.jdk14;version=latest, \
-  com.ibm.ws.com.icegreen:greenmail;strategy=exact;version=2.0.0.fd826131f671b0d3230b0d0e1638d8c4
+  com.icegreen.greenmail;version=2.0.0.alpha-1

--- a/dev/io.openliberty.mail.2.0.internal_fat/build.gradle
+++ b/dev/io.openliberty.mail.2.0.internal_fat/build.gradle
@@ -16,7 +16,7 @@ dependencies {
                project(':com.ibm.websphere.javaee.jaxb.2.2'),
                'com.sun.mail:jakarta.mail:2.0.0-RC6',
                'com.ibm.ws.org.apache.yoko:yoko-spec-corba:1.5.+',
-               'com.ibm.ws.com.icegreen:greenmail:2.0.0.fd826131f671b0d3230b0d0e1638d8c4',
+               'com.icegreen:greenmail:2.0.0-alpha-1',
                // Deps needed for when running on Java 9 (EE-type APIs were removed from JDK)
                'com.sun.xml.bind:jaxb-core:2.2.+',
                'com.sun.xml.bind:jaxb-impl:2.2.+'


### PR DESCRIPTION
Update artifacts used by io.openliberty.mail.2.0.internal_fat so the maven version of the icegreen.greenmail server is used instead of the custom built one 

