### PR TITLE
Increase token lifetime to handle slow test systems for refresh tests

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.refresh/fat/src/io/openliberty/security/jakartasec/fat/refresh/tests/BasicRefreshTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.refresh/fat/src/io/openliberty/security/jakartasec/fat/refresh/tests/BasicRefreshTests.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -341,7 +341,7 @@ public class BasicRefreshTests extends CommonLogoutAndRefreshTests {
         Page response1 = runGoodEndToEndTest(webClient, appName, baseAppName);
 
         // now logged in - wait for token to expire
-        actions.testLogAndSleep(20);
+        actions.testLogAndSleep(35);
         String url = rpHttpsBase + "/" + appName + "/" + baseAppName;
         Page response2 = invokeAppGetToAppWithRefreshedToken(webClient, url); // get to app not because either id or access token is good, but because the token was refreshed.
 
@@ -355,7 +355,7 @@ public class BasicRefreshTests extends CommonLogoutAndRefreshTests {
         validationUtils.validateResult(response2, expectations);
 
         // now logged in - wait for token to expire
-        actions.testLogAndSleep(20);
+        actions.testLogAndSleep(35);
         Page response3 = null;
         response3 = invokeAppGetToAppWithRefreshedToken(webClient, url); // get to app not because either id or access token is good, but because the token was refreshed, or we re-using a refreshed token
         if (refreshedSecondTime) {

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.refresh/publish/shared/config/oidcProvider.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.refresh/publish/shared/config/oidcProvider.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2022 IBM Corporation and others.
+    Copyright (c) 2022, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -132,7 +132,7 @@ https://localhost:${bvt.prop.security_2_HTTP_default.secure}/App_31/Callback"
 		signatureAlgorithm="RS256"
 		keyAliasName="rs256"
 		keystoreRef="key_allSigAlg"
-		idTokenLifetime="15s"
+		idTokenLifetime="30s"
 		oauthProviderRef="OAuth1" />
 
 	<oauthProvider
@@ -190,7 +190,7 @@ https://localhost:${bvt.prop.security_2_HTTP_default.secure}/App_31/Callback"
 		signatureAlgorithm="RS256"
 		keyAliasName="rs256"
 		keystoreRef="key_allSigAlg"
-		idTokenLifetime="15s"
+		idTokenLifetime="30s"
 		oauthProviderRef="OAuth1_noRefresh" />
 
 	<oauthProvider
@@ -255,7 +255,7 @@ https://localhost:${bvt.prop.security_2_HTTP_default.secure}/App_31/Callback"
 		id="OAuth2"
 		autoAuthorize="true"
 		tokenFormat="${opTokenFormat}"
-		accessTokenLifetime="15s"
+		accessTokenLifetime="30s"
 	>
 		<autoAuthorizeClient>client_1</autoAuthorizeClient>
 		
@@ -314,7 +314,7 @@ https://localhost:${bvt.prop.security_2_HTTP_default.secure}/App_31/Callback"
 		autoAuthorize="true"
 		tokenFormat="${opTokenFormat}"
 		issueRefreshToken="false"
-		accessTokenLifetime="15s"
+		accessTokenLifetime="30s"
 	>
 		<autoAuthorizeClient>client_1</autoAuthorizeClient>
 		
@@ -366,14 +366,14 @@ https://localhost:${bvt.prop.security_2_HTTP_default.secure}/App_31/Callback"
 		signatureAlgorithm="RS256"
 		keyAliasName="rs256"
 		keystoreRef="key_allSigAlg"
-		idTokenLifetime="15s"
+		idTokenLifetime="30s"
 		oauthProviderRef="OAuth3" />
 
 	<oauthProvider
 		id="OAuth3"
 		autoAuthorize="true"
 		tokenFormat="${opTokenFormat}"
-		accessTokenLifetime="15s"
+		accessTokenLifetime="30s"
 	>
 		<autoAuthorizeClient>client_1</autoAuthorizeClient>
 		
@@ -427,7 +427,7 @@ https://localhost:${bvt.prop.security_2_HTTP_default.secure}/BadRedirectUriToken
 		signatureAlgorithm="RS256"
 		keyAliasName="rs256"
 		keystoreRef="key_allSigAlg"
-		idTokenLifetime="15s"
+		idTokenLifetime="30s"
 		oauthProviderRef="OAuth3_noRefresh" />
 
 	<oauthProvider
@@ -435,7 +435,7 @@ https://localhost:${bvt.prop.security_2_HTTP_default.secure}/BadRedirectUriToken
 		autoAuthorize="true"
 		tokenFormat="${opTokenFormat}"
 		issueRefreshToken="false"
-		accessTokenLifetime="15s"
+		accessTokenLifetime="30s"
 	>
 		<autoAuthorizeClient>client_1</autoAuthorizeClient>
 		


### PR DESCRIPTION
Increase token lifetimes to account for slow test machines.
The refresh tests need tokens that do not live long since they'll be invoking refresh with/without expired tokens and we don't want to have to wait too long for them to expire. But, we've hit some slow machines where the tokens have expired before they're returned to the clients during a normal login process.